### PR TITLE
Gateway-native invite CRUD + redemption lifecycle (HTTP + IPC)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5270,6 +5270,9 @@ paths:
                     properties: {}
                     additionalProperties: {}
                     description: Created invite
+                  rawToken:
+                    description: One-time raw invite token (returned at creation only)
+                    type: string
                 required:
                   - ok
                   - invite

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -7,6 +7,39 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Mock the gateway IPC bridge used by the redemption service for the
+// authoritative pre-mutation claim (record_invite_redemption). Tests drive the
+// claim result via `gatewayIpc`.
+const gatewayIpc = {
+  claim: { ok: true, updated: true, mirrored: true } as {
+    ok: boolean;
+    updated: boolean;
+    mirrored: boolean;
+  },
+  claimThrows: false,
+  calls: [] as { method: string; params?: Record<string, unknown> }[],
+};
+
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    gatewayIpc.calls.push({ method, params });
+    if (method === "record_invite_redemption") {
+      if (gatewayIpc.claimThrows) throw new Error("gateway unreachable");
+      return gatewayIpc.claim;
+    }
+    return undefined;
+  },
+}));
+
+function resetGatewayIpc() {
+  gatewayIpc.claim = { ok: true, updated: true, mirrored: true };
+  gatewayIpc.claimThrows = false;
+  gatewayIpc.calls = [];
+}
+
 import {
   findContactChannel,
   getContact,
@@ -40,9 +73,12 @@ function createTargetContact(displayName = "Target Contact"): string {
 }
 
 describe("invite-redemption-service", () => {
-  beforeEach(resetTables);
+  beforeEach(() => {
+    resetTables();
+    resetGatewayIpc();
+  });
 
-  test("redeems a valid invite and returns typed outcome", () => {
+  test("redeems a valid invite and returns typed outcome", async () => {
     const targetContactId = createTargetContact();
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
@@ -50,7 +86,7 @@ describe("invite-redemption-service", () => {
       maxUses: 1,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "user-1",
@@ -65,7 +101,7 @@ describe("invite-redemption-service", () => {
     });
   });
 
-  test("marks channel as verified via invite on redemption", () => {
+  test("marks channel as verified via invite on redemption", async () => {
     const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
@@ -73,7 +109,7 @@ describe("invite-redemption-service", () => {
       maxUses: 1,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "user-1",
@@ -92,7 +128,7 @@ describe("invite-redemption-service", () => {
     expect(result!.channel.status).toBe("active");
   });
 
-  test("marks channel as verified via invite on 6-digit code redemption", () => {
+  test("marks channel as verified via invite on 6-digit code redemption", async () => {
     const targetContactId = createTargetContact();
     const inviteCode = "123456";
     createInvite({
@@ -102,7 +138,7 @@ describe("invite-redemption-service", () => {
       inviteCodeHash: hashVoiceCode(inviteCode),
     });
 
-    const outcome = redeemInviteByCode({
+    const outcome = await redeemInviteByCode({
       code: inviteCode,
       sourceChannel: "telegram",
       externalUserId: "code-user-1",
@@ -121,8 +157,8 @@ describe("invite-redemption-service", () => {
     expect(result!.channel.status).toBe("active");
   });
 
-  test("returns invalid_token for a bogus token", () => {
-    const outcome = redeemInvite({
+  test("returns invalid_token for a bogus token", async () => {
+    const outcome = await redeemInvite({
       rawToken: "totally-bogus-token",
       sourceChannel: "telegram",
       externalUserId: "user-1",
@@ -131,7 +167,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
   });
 
-  test("returns expired for an expired invite", () => {
+  test("returns expired for an expired invite", async () => {
     const targetContactId = createTargetContact();
     // Create an invite that expired 1 ms ago
     const { rawToken } = createInvite({
@@ -141,7 +177,7 @@ describe("invite-redemption-service", () => {
       expiresInMs: -1,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "user-1",
@@ -150,7 +186,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "expired" });
   });
 
-  test("returns revoked for a revoked invite", () => {
+  test("returns revoked for a revoked invite", async () => {
     const targetContactId = createTargetContact();
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
@@ -159,7 +195,7 @@ describe("invite-redemption-service", () => {
     });
     revokeStoreFn(invite.id);
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "user-1",
@@ -168,7 +204,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "revoked" });
   });
 
-  test("returns max_uses_reached when invite is fully consumed", () => {
+  test("returns max_uses_reached when invite is fully consumed", async () => {
     const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
@@ -177,7 +213,7 @@ describe("invite-redemption-service", () => {
     });
 
     // First redemption should succeed
-    const first = redeemInvite({
+    const first = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "user-1",
@@ -185,7 +221,7 @@ describe("invite-redemption-service", () => {
     expect(first.ok).toBe(true);
 
     // Second attempt should fail — the invite is now fully redeemed
-    const second = redeemInvite({
+    const second = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "user-2",
@@ -194,7 +230,7 @@ describe("invite-redemption-service", () => {
     expect(second).toEqual({ ok: false, reason: "max_uses_reached" });
   });
 
-  test("returns channel_mismatch when redeeming on wrong channel", () => {
+  test("returns channel_mismatch when redeeming on wrong channel", async () => {
     const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
@@ -202,7 +238,7 @@ describe("invite-redemption-service", () => {
       maxUses: 1,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "phone",
       externalUserId: "user-1",
@@ -211,7 +247,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "channel_mismatch" });
   });
 
-  test("returns missing_identity when no externalUserId or externalChatId", () => {
+  test("returns missing_identity when no externalUserId or externalChatId", async () => {
     const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
@@ -219,7 +255,7 @@ describe("invite-redemption-service", () => {
       maxUses: 1,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
     });
@@ -227,7 +263,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "missing_identity" });
   });
 
-  test("returns already_member when user is already an active member", () => {
+  test("returns already_member when user is already an active member", async () => {
     // Pre-create an active member and find their contact
     const member = upsertContactChannel({
       sourceChannel: "telegram",
@@ -242,7 +278,7 @@ describe("invite-redemption-service", () => {
       maxUses: 5,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "existing-user",
@@ -259,7 +295,7 @@ describe("invite-redemption-service", () => {
     ).toEqual(expect.any(String));
   });
 
-  test("returns invalid_token for a blocked member to avoid leaking membership status", () => {
+  test("returns invalid_token for a blocked member to avoid leaking membership status", async () => {
     // Pre-create a blocked member and find their contact
     const member = upsertContactChannel({
       sourceChannel: "telegram",
@@ -274,7 +310,7 @@ describe("invite-redemption-service", () => {
       maxUses: 5,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "blocked-user",
@@ -283,7 +319,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
   });
 
-  test("binds redeemer to the invite's target contact, not the guardian", () => {
+  test("binds redeemer to the invite's target contact, not the guardian", async () => {
     // Pre-create a guardian contact with a revoked telegram channel
     const guardianContact = upsertContact({
       displayName: "Guardian",
@@ -311,7 +347,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Redeem using the guardian's Telegram identity
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "guardian-tg-id",
@@ -336,7 +372,7 @@ describe("invite-redemption-service", () => {
     expect(guardian!.role).toBe("guardian");
   });
 
-  test("downgrades guardian to contact when redeeming invite targeting own contact", () => {
+  test("downgrades guardian to contact when redeeming invite targeting own contact", async () => {
     // Create a guardian contact with a revoked channel
     const guardianContact = upsertContact({
       displayName: "Guardian",
@@ -357,7 +393,7 @@ describe("invite-redemption-service", () => {
       maxUses: 5,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "guardian-own-id",
@@ -370,7 +406,7 @@ describe("invite-redemption-service", () => {
     expect(updated!.role).toBe("contact");
   });
 
-  test("binds redeemer to the invite's target contact via 6-digit code, not the guardian", () => {
+  test("binds redeemer to the invite's target contact via 6-digit code, not the guardian", async () => {
     // Pre-create a guardian contact with a revoked telegram channel
     const guardianContact = upsertContact({
       displayName: "Guardian",
@@ -401,7 +437,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Redeem using the guardian's Telegram identity
-    const outcome = redeemInviteByCode({
+    const outcome = await redeemInviteByCode({
       code,
       sourceChannel: "telegram",
       externalUserId: "guardian-code-id",
@@ -426,7 +462,7 @@ describe("invite-redemption-service", () => {
     expect(guardian!.role).toBe("guardian");
   });
 
-  test("does not return already_member for a revoked member", () => {
+  test("does not return already_member for a revoked member", async () => {
     const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
@@ -442,7 +478,7 @@ describe("invite-redemption-service", () => {
     });
     expect(member!.channel.status).toBe("revoked");
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "revoked-user",
@@ -455,7 +491,7 @@ describe("invite-redemption-service", () => {
     ).toBe("redeemed");
   });
 
-  test("raw token is not present in the outcome object", () => {
+  test("raw token is not present in the outcome object", async () => {
     const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
@@ -463,7 +499,7 @@ describe("invite-redemption-service", () => {
       maxUses: 1,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "user-1",
@@ -474,7 +510,7 @@ describe("invite-redemption-service", () => {
     expect(serialized).not.toContain(rawToken);
   });
 
-  test("channel enforcement blocks cross-channel redemption (voice invite via slack)", () => {
+  test("channel enforcement blocks cross-channel redemption (voice invite via slack)", async () => {
     const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "phone",
@@ -482,7 +518,7 @@ describe("invite-redemption-service", () => {
       maxUses: 1,
     });
 
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "slack",
       externalUserId: "user-1",
@@ -491,7 +527,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "channel_mismatch" });
   });
 
-  test("returns invalid_token for an active member with a bogus token (no membership probing)", () => {
+  test("returns invalid_token for an active member with a bogus token (no membership probing)", async () => {
     // Pre-create an active member
     upsertContactChannel({
       sourceChannel: "telegram",
@@ -500,7 +536,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Attempt to redeem with a bogus token — must NOT leak membership status
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken: "completely-bogus-token",
       sourceChannel: "telegram",
       externalUserId: "probed-user",
@@ -509,7 +545,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
   });
 
-  test("returns expired for an active member with an expired invite token", () => {
+  test("returns expired for an active member with an expired invite token", async () => {
     const targetContactId = createTargetContact();
     // Create an expired invite
     const { rawToken } = createInvite({
@@ -527,7 +563,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Expired token must return expired, not already_member
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "expired-token-user",
@@ -536,7 +572,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "expired" });
   });
 
-  test("returns channel_mismatch for an active member with a valid token for a different channel", () => {
+  test("returns channel_mismatch for an active member with a valid token for a different channel", async () => {
     const targetContactId = createTargetContact();
     // Create an invite for voice
     const { rawToken } = createInvite({
@@ -553,12 +589,177 @@ describe("invite-redemption-service", () => {
     });
 
     // Valid token for wrong channel must return channel_mismatch, not already_member
-    const outcome = redeemInvite({
+    const outcome = await redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "cross-channel-user",
     });
 
     expect(outcome).toEqual({ ok: false, reason: "channel_mismatch" });
+  });
+
+  // ── Gateway lifecycle pre-check + redemption mirror ────────────────────
+
+  test("rejects redemption when the gateway claim is not consumable (no assistant mutation)", async () => {
+    const targetContactId = createTargetContact();
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: targetContactId,
+      maxUses: 1,
+    });
+
+    // Gateway row exists but was NOT consumable (revoked/exhausted/raced).
+    gatewayIpc.claim = { ok: true, updated: false, mirrored: true };
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "gw-revoked-user",
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+
+    // No member was created — the assistant DB was never mutated.
+    expect(
+      findContactChannel({
+        channelType: "telegram",
+        address: "gw-revoked-user",
+      }),
+    ).toBeNull();
+  });
+
+  test("proceeds and mutates when the gateway claim is consumed (updated:true)", async () => {
+    const targetContactId = createTargetContact();
+    const { rawToken, invite } = createInvite({
+      sourceChannel: "telegram",
+      contactId: targetContactId,
+      maxUses: 1,
+    });
+
+    gatewayIpc.claim = { ok: true, updated: true, mirrored: true };
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "gw-active-user",
+    });
+
+    expect(outcome.ok).toBe(true);
+
+    // The claim was performed against the resolved invite id.
+    const claim = gatewayIpc.calls.find(
+      (c) => c.method === "record_invite_redemption",
+    );
+    expect(claim).toBeDefined();
+    expect(claim!.params).toMatchObject({ inviteId: invite.id });
+
+    // The assistant DB was mutated.
+    expect(
+      findContactChannel({ channelType: "telegram", address: "gw-active-user" }),
+    ).not.toBeNull();
+  });
+
+  test("proceeds for a legacy invite the gateway has never seen (mirrored:false)", async () => {
+    const targetContactId = createTargetContact();
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: targetContactId,
+      maxUses: 1,
+    });
+
+    gatewayIpc.claim = { ok: true, updated: false, mirrored: false };
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "legacy-user",
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(
+      findContactChannel({ channelType: "telegram", address: "legacy-user" }),
+    ).not.toBeNull();
+  });
+
+  test("fails open when the gateway claim throws (assistant-side checks still apply)", async () => {
+    const targetContactId = createTargetContact();
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: targetContactId,
+      maxUses: 1,
+    });
+
+    gatewayIpc.claimThrows = true;
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "failopen-user",
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(
+      findContactChannel({ channelType: "telegram", address: "failopen-user" }),
+    ).not.toBeNull();
+  });
+
+  test("does not claim the gateway row for an already-active member", async () => {
+    const targetContactId = createTargetContact();
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: targetContactId,
+      maxUses: 1,
+    });
+
+    // Seed an already-active member bound to the invite's target contact.
+    upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "already-member-user",
+      role: "contact",
+      status: "active",
+      policy: "allow",
+      contactId: targetContactId,
+    });
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "already-member-user",
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect((outcome as { type: string }).type).toBe("already_member");
+
+    // No gateway claim was made — no use must be consumed for a non-redemption.
+    expect(
+      gatewayIpc.calls.some((c) => c.method === "record_invite_redemption"),
+    ).toBe(false);
+  });
+
+  test("rejects 6-digit code redemption when the gateway claim is not consumable", async () => {
+    const targetContactId = createTargetContact();
+    const code = "654321";
+    createInvite({
+      sourceChannel: "telegram",
+      contactId: targetContactId,
+      maxUses: 1,
+      inviteCodeHash: hashVoiceCode(code),
+    });
+
+    gatewayIpc.claim = { ok: true, updated: false, mirrored: true };
+
+    const outcome = await redeemInviteByCode({
+      code,
+      sourceChannel: "telegram",
+      externalUserId: "gw-revoked-code-user",
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+    expect(
+      findContactChannel({
+        channelType: "telegram",
+        address: "gw-revoked-code-user",
+      }),
+    ).toBeNull();
   });
 });

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -37,22 +37,20 @@ mock.module("../calls/call-domain.js", () => ({
 import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { revokeInvite } from "../memory/invite-store.js";
 import {
   createIngressInvite,
-  listIngressInvites,
-  revokeIngressInvite,
   triggerInviteCall,
 } from "../runtime/invite-service.js";
 import { handleRedeemInvite as _handleRedeemInvite } from "../runtime/routes/contact-routes.js";
 import { RouteError } from "../runtime/routes/errors.js";
 
 /**
- * The CLI/HTTP create/list/revoke/trigger route handlers now relay to the
- * gateway (see invite-relay-routes.test.ts). The assistant-native invite logic
- * those handlers used to call directly — and which the gateway still invokes via
- * `invites_mint` + its native handlers — is exercised here against the assistant
- * DB through the `invite-service` functions. Redemption stays daemon-local and is
- * still driven through the route handler.
+ * The CLI/HTTP create/list/revoke/trigger route handlers relay to the gateway
+ * (see invite-relay-routes.test.ts). The assistant-native invite logic the
+ * gateway invokes via `invites_mint` + its native handlers is exercised here
+ * against the assistant DB through the `invite-service` functions. Redemption
+ * stays daemon-local and is driven through the route handler.
  */
 function fakeResponse(body: unknown, status = 200) {
   return { status, json: async () => body };
@@ -67,28 +65,12 @@ async function handleCreateInvite(req: Request) {
     expiresInMs: body.expiresInMs as number | undefined,
     contactName: body.contactName as string | undefined,
     expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
     friendName: body.friendName as string | undefined,
     guardianName: body.guardianName as string | undefined,
     contactId: body.contactId as string,
   });
   if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
   return fakeResponse({ ok: true, invite: result.data }, 201);
-}
-
-function handleListInvites(url: URL) {
-  const result = listIngressInvites({
-    sourceChannel: url.searchParams.get("sourceChannel") ?? undefined,
-    status: url.searchParams.get("status") ?? undefined,
-  });
-  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
-  return fakeResponse({ ok: true, invites: result.data });
-}
-
-function handleRevokeInvite(inviteId: string) {
-  const result = revokeIngressInvite(inviteId);
-  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 404);
-  return fakeResponse({ ok: true, invite: result.data });
 }
 
 async function handleRedeemInvite(req: Request) {
@@ -203,66 +185,6 @@ describe("ingress invite HTTP routes", () => {
     expect(body.error).toContain("sourceChannel");
   });
 
-  test("GET /v1/contacts/invites — lists invites", async () => {
-    // Create two invites
-    await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-    await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-
-    const url = new URL("http://localhost/v1/contacts/invites");
-    const res = handleListInvites(url);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(200);
-    expect(body.ok).toBe(true);
-    expect(Array.isArray(body.invites)).toBe(true);
-    expect((body.invites as unknown[]).length).toBe(2);
-  });
-
-  test("DELETE /v1/contacts/invites/:id — revokes an invite", async () => {
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as { invite: { id: string } };
-
-    const res = handleRevokeInvite(created.invite.id);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(200);
-    expect(body.ok).toBe(true);
-    const invite = body.invite as Record<string, unknown>;
-    expect(invite.status).toBe("revoked");
-  });
-
-  test("DELETE /v1/contacts/invites/:id — not found returns 404", () => {
-    const res = handleRevokeInvite("nonexistent-id");
-    expect(res.status).toBe(404);
-  });
-
   test("POST /v1/contacts/invites/redeem — redeems an invite", async () => {
     // Create an invite first
     const createRes = await handleCreateInvite(
@@ -352,12 +274,9 @@ describe("ingress service shared logic", () => {
     };
     expect(created.invite.status).toBe("active");
 
-    const revokeRes = handleRevokeInvite(created.invite.id);
-    const revoked = (await revokeRes.json()) as {
-      invite: { id: string; status: string };
-    };
-    expect(revoked.invite.status).toBe("revoked");
-    expect(revoked.invite.id).toBe(created.invite.id);
+    const revoked = revokeInvite(created.invite.id);
+    expect(revoked?.status).toBe("revoked");
+    expect(revoked?.id).toBe(created.invite.id);
   });
 });
 
@@ -709,7 +628,7 @@ describe("POST /v1/contacts/invites/:id/call", () => {
     const created = (await createRes.json()) as { invite: { id: string } };
 
     // Revoke the invite
-    handleRevokeInvite(created.invite.id);
+    revokeInvite(created.invite.id);
 
     const res = await handleTriggerInviteCall(created.invite.id);
     const body = (await res.json()) as Record<string, unknown>;

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -38,57 +38,57 @@ import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
-  handleCreateInvite as _handleCreateInvite,
-  handleListInvites as _handleListInvites,
-  handleRedeemInvite as _handleRedeemInvite,
-  handleRevokeInvite as _handleRevokeInvite,
-  handleTriggerInviteCall as _handleTriggerInviteCall,
-} from "../runtime/routes/contact-routes.js";
+  createIngressInvite,
+  listIngressInvites,
+  revokeIngressInvite,
+  triggerInviteCall,
+} from "../runtime/invite-service.js";
+import { handleRedeemInvite as _handleRedeemInvite } from "../runtime/routes/contact-routes.js";
 import { RouteError } from "../runtime/routes/errors.js";
 
 /**
- * Compatibility wrappers: translate old handler call signatures into the new
- * RouteHandlerArgs pattern and wrap the result in a Response-like object so
- * existing test assertions (res.status / res.json()) keep working.
+ * The CLI/HTTP create/list/revoke/trigger route handlers now relay to the
+ * gateway (see invite-relay-routes.test.ts). The assistant-native invite logic
+ * those handlers used to call directly — and which the gateway still invokes via
+ * `invites_mint` + its native handlers — is exercised here against the assistant
+ * DB through the `invite-service` functions. Redemption stays daemon-local and is
+ * still driven through the route handler.
  */
 function fakeResponse(body: unknown, status = 200) {
   return { status, json: async () => body };
 }
 
 async function handleCreateInvite(req: Request) {
-  const body = (await req.json()) as Record<string, unknown>;
-  try {
-    const result = await _handleCreateInvite({ body });
-    return fakeResponse(result, 201);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const body = (await req.json()) as Record<string, string | number>;
+  const result = await createIngressInvite({
+    sourceChannel: body.sourceChannel as string | undefined,
+    note: body.note as string | undefined,
+    maxUses: body.maxUses as number | undefined,
+    expiresInMs: body.expiresInMs as number | undefined,
+    contactName: body.contactName as string | undefined,
+    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
+    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
+    friendName: body.friendName as string | undefined,
+    guardianName: body.guardianName as string | undefined,
+    contactId: body.contactId as string,
+  });
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
+  return fakeResponse({ ok: true, invite: result.data }, 201);
 }
 
 function handleListInvites(url: URL) {
-  const queryParams: Record<string, string> = {};
-  for (const [k, v] of url.searchParams.entries()) queryParams[k] = v;
-  try {
-    const result = _handleListInvites({ queryParams });
-    return fakeResponse(result);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const result = listIngressInvites({
+    sourceChannel: url.searchParams.get("sourceChannel") ?? undefined,
+    status: url.searchParams.get("status") ?? undefined,
+  });
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
+  return fakeResponse({ ok: true, invites: result.data });
 }
 
 function handleRevokeInvite(inviteId: string) {
-  try {
-    const result = _handleRevokeInvite({ pathParams: { id: inviteId } });
-    return fakeResponse(result);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const result = revokeIngressInvite(inviteId);
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 404);
+  return fakeResponse({ ok: true, invite: result.data });
 }
 
 async function handleRedeemInvite(req: Request) {
@@ -104,16 +104,9 @@ async function handleRedeemInvite(req: Request) {
 }
 
 async function handleTriggerInviteCall(inviteId: string) {
-  try {
-    const result = await _handleTriggerInviteCall({
-      pathParams: { id: inviteId },
-    });
-    return fakeResponse(result);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const result = await triggerInviteCall(inviteId);
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
+  return fakeResponse({ ok: true, callSid: result.data.callSid });
 }
 
 await initializeDb();

--- a/assistant/src/__tests__/invite-service-ipc.test.ts
+++ b/assistant/src/__tests__/invite-service-ipc.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Prevent ensureTelegramBotUsernameResolved() from reading real credentials
+// and calling the Telegram API.
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => undefined,
+  setSecureKeyAsync: async () => {},
+  deleteSecureKeyAsync: async () => {},
+}));
+
+import { upsertContact } from "../contacts/contact-store.js";
+import { handleMintInvite } from "../ipc/routes/invite-ipc-routes.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import {
+  createInvite,
+  findById,
+  hashToken,
+} from "../memory/invite-store.js";
+import {
+  handleRedeemTokenInvite,
+  handleRedeemVoiceInvite,
+} from "../runtime/routes/contact-routes.js";
+import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
+
+await initializeDb();
+
+function resetTables() {
+  getSqlite().run("DELETE FROM assistant_ingress_invites");
+  getSqlite().run("DELETE FROM contact_channels");
+  getSqlite().run("DELETE FROM contacts");
+}
+
+/** Create a throwaway contact and return its ID, for use as the invite's contactId. */
+function createTargetContact(displayName = "Target Contact"): string {
+  return upsertContact({ displayName, role: "contact" }).id;
+}
+
+describe("handleMintInvite (invites_mint)", () => {
+  beforeEach(resetTables);
+
+  test("returns rawToken + gateway projection and persists the assistant row", async () => {
+    const contactId = createTargetContact();
+
+    const result = (await handleMintInvite({
+      body: { sourceChannel: "telegram", contactId, maxUses: 3 },
+    })) as {
+      ok: boolean;
+      invite: { id: string; token?: string };
+      rawToken?: string;
+      gateway: {
+        id: string;
+        inviteCodeHash: string;
+        sourceChannel: string;
+        contactId: string;
+        note: string | null;
+        maxUses: number;
+        expiresAt: number;
+      };
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.rawToken).toBeDefined();
+    expect(typeof result.rawToken).toBe("string");
+
+    // Gateway projection carries exactly the mirrored fields.
+    expect(result.gateway).toEqual({
+      id: result.invite.id,
+      inviteCodeHash: expect.any(String),
+      sourceChannel: "telegram",
+      contactId,
+      note: null,
+      maxUses: 3,
+      expiresAt: expect.any(Number),
+    });
+
+    // The assistant row is persisted and only the token hash is stored.
+    const row = findById(result.invite.id);
+    expect(row).not.toBeNull();
+    expect(row!.contactId).toBe(contactId);
+    expect(row!.tokenHash).toBe(hashToken(result.rawToken!));
+    expect(row!.inviteCodeHash).toBe(result.gateway.inviteCodeHash);
+  });
+
+  test("voice mint does not expose a raw token but persists voice fields", async () => {
+    const contactId = createTargetContact();
+
+    const result = (await handleMintInvite({
+      body: {
+        sourceChannel: "phone",
+        contactId,
+        expectedExternalUserId: "+12025550100",
+        friendName: "Alex",
+        guardianName: "Sam",
+      },
+    })) as {
+      ok: boolean;
+      invite: { id: string; voiceCode?: string };
+      rawToken?: string;
+      gateway: { sourceChannel: string; inviteCodeHash: string };
+    };
+
+    expect(result.ok).toBe(true);
+    // Voice invites never expose the generic redemption token.
+    expect(result.rawToken).toBeUndefined();
+    expect(result.gateway.sourceChannel).toBe("phone");
+
+    const row = findById(result.invite.id);
+    expect(row).not.toBeNull();
+    expect(row!.expectedExternalUserId).toBe("+12025550100");
+    expect(row!.voiceCodeHash).toBeTruthy();
+    // Voice invites have no non-voice inviteCodeHash; the gateway projection
+    // mirrors the voice code hash instead so the NOT NULL mirror constraint holds.
+    expect(row!.inviteCodeHash).toBeNull();
+    expect(row!.voiceCodeHash).toBe(result.gateway.inviteCodeHash);
+  });
+
+  test("returns a 400 when required params are missing", async () => {
+    await expect(
+      handleMintInvite({ body: { contactId: createTargetContact() } }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("handleRedeemTokenInvite (invites_redeem_token)", () => {
+  beforeEach(resetTables);
+
+  test("redeems a valid token and returns the invite shape", () => {
+    const contactId = createTargetContact();
+    const { rawToken, invite } = createInvite({
+      sourceChannel: "telegram",
+      contactId,
+      maxUses: 1,
+    });
+
+    const result = handleRedeemTokenInvite({
+      body: {
+        token: rawToken,
+        sourceChannel: "telegram",
+        externalUserId: "user-1",
+      },
+    }) as { ok: boolean; invite: { id: string } };
+
+    expect(result.ok).toBe(true);
+    expect(result.invite.id).toBe(invite.id);
+  });
+
+  test("rejects a bogus token with a 400", () => {
+    expect(() =>
+      handleRedeemTokenInvite({
+        body: {
+          token: "totally-bogus-token",
+          sourceChannel: "telegram",
+          externalUserId: "user-1",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects redemption on the wrong channel", () => {
+    const contactId = createTargetContact();
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId,
+      maxUses: 1,
+    });
+
+    expect(() =>
+      handleRedeemTokenInvite({
+        body: {
+          token: rawToken,
+          sourceChannel: "phone",
+          externalUserId: "user-1",
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("handleRedeemVoiceInvite (invites_redeem_voice)", () => {
+  beforeEach(resetTables);
+
+  /** Create a voice invite with a known code; return the invite + plaintext code. */
+  function createVoiceInvite(callerPhone = "+12025550100") {
+    const code = generateVoiceCode(6);
+    const { invite } = createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact(),
+      maxUses: 1,
+      expectedExternalUserId: callerPhone,
+      voiceCodeHash: hashVoiceCode(code),
+      voiceCodeDigits: 6,
+    });
+    return { invite, code };
+  }
+
+  test("redeems a valid voice code and returns the documented shape", () => {
+    const phone = "+12025550100";
+    const { invite, code } = createVoiceInvite(phone);
+
+    const result = handleRedeemVoiceInvite({
+      body: { callerExternalUserId: phone, code },
+    }) as {
+      ok: boolean;
+      type: string;
+      memberId: string;
+      inviteId?: string;
+    };
+
+    expect(result).toEqual({
+      ok: true,
+      type: "redeemed",
+      memberId: expect.any(String),
+      inviteId: invite.id,
+    });
+  });
+
+  test("wrong caller identity is rejected with a 400", () => {
+    const { code } = createVoiceInvite("+12025550100");
+
+    expect(() =>
+      handleRedeemVoiceInvite({
+        body: { callerExternalUserId: "+12025550101", code },
+      }),
+    ).toThrow();
+  });
+
+  test("missing callerExternalUserId or code is rejected with a 400", () => {
+    expect(() =>
+      handleRedeemVoiceInvite({ body: { code: "123456" } }),
+    ).toThrow();
+    expect(() =>
+      handleRedeemVoiceInvite({
+        body: { callerExternalUserId: "+12025550100" },
+      }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/__tests__/invite-service-ipc.test.ts
+++ b/assistant/src/__tests__/invite-service-ipc.test.ts
@@ -15,6 +15,18 @@ mock.module("../security/secure-keys.js", () => ({
   deleteSecureKeyAsync: async () => {},
 }));
 
+// The redemption service now claims the gateway-canonical row over IPC before
+// mutating. Default the claim to consumed (updated:true) so these assistant-side
+// handler tests exercise the happy redemption path.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (method: string) => {
+    if (method === "record_invite_redemption") {
+      return { ok: true, updated: true, mirrored: true };
+    }
+    return undefined;
+  },
+}));
+
 import { upsertContact } from "../contacts/contact-store.js";
 import { handleMintInvite } from "../ipc/routes/invite-ipc-routes.js";
 import { getSqlite } from "../memory/db-connection.js";
@@ -132,7 +144,7 @@ describe("handleMintInvite (invites_mint)", () => {
 describe("handleRedeemTokenInvite (invites_redeem_token)", () => {
   beforeEach(resetTables);
 
-  test("redeems a valid token and returns the invite shape", () => {
+  test("redeems a valid token and returns the invite shape", async () => {
     const contactId = createTargetContact();
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
@@ -140,20 +152,52 @@ describe("handleRedeemTokenInvite (invites_redeem_token)", () => {
       maxUses: 1,
     });
 
-    const result = handleRedeemTokenInvite({
+    const result = (await handleRedeemTokenInvite({
       body: {
         token: rawToken,
         sourceChannel: "telegram",
         externalUserId: "user-1",
       },
-    }) as { ok: boolean; invite: { id: string } };
+    })) as { ok: boolean; invite: { id: string }; type: string };
 
     expect(result.ok).toBe(true);
     expect(result.invite.id).toBe(invite.id);
+    expect(result.type).toBe("redeemed");
   });
 
-  test("rejects a bogus token with a 400", () => {
-    expect(() =>
+  test("surfaces type 'already_member' when an existing contact reopens the link", async () => {
+    const contactId = createTargetContact();
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId,
+      maxUses: 2,
+    });
+
+    // First redeem makes the caller an active contact.
+    await handleRedeemTokenInvite({
+      body: {
+        token: rawToken,
+        sourceChannel: "telegram",
+        externalUserId: "user-1",
+      },
+    });
+
+    // Second redeem by the SAME caller is a no-op membership-wise: it must
+    // surface type "already_member" so the gateway skips consuming a use.
+    const again = (await handleRedeemTokenInvite({
+      body: {
+        token: rawToken,
+        sourceChannel: "telegram",
+        externalUserId: "user-1",
+      },
+    })) as { ok: boolean; type: string };
+
+    expect(again.ok).toBe(true);
+    expect(again.type).toBe("already_member");
+  });
+
+  test("rejects a bogus token with a 400", async () => {
+    await expect(
       handleRedeemTokenInvite({
         body: {
           token: "totally-bogus-token",
@@ -161,10 +205,10 @@ describe("handleRedeemTokenInvite (invites_redeem_token)", () => {
           externalUserId: "user-1",
         },
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 
-  test("rejects redemption on the wrong channel", () => {
+  test("rejects redemption on the wrong channel", async () => {
     const contactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
@@ -172,7 +216,7 @@ describe("handleRedeemTokenInvite (invites_redeem_token)", () => {
       maxUses: 1,
     });
 
-    expect(() =>
+    await expect(
       handleRedeemTokenInvite({
         body: {
           token: rawToken,
@@ -180,7 +224,7 @@ describe("handleRedeemTokenInvite (invites_redeem_token)", () => {
           externalUserId: "user-1",
         },
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 });
 
@@ -201,13 +245,13 @@ describe("handleRedeemVoiceInvite (invites_redeem_voice)", () => {
     return { invite, code };
   }
 
-  test("redeems a valid voice code and returns the documented shape", () => {
+  test("redeems a valid voice code and returns the documented shape", async () => {
     const phone = "+12025550100";
     const { invite, code } = createVoiceInvite(phone);
 
-    const result = handleRedeemVoiceInvite({
+    const result = (await handleRedeemVoiceInvite({
       body: { callerExternalUserId: phone, code },
-    }) as {
+    })) as {
       ok: boolean;
       type: string;
       memberId: string;
@@ -222,24 +266,24 @@ describe("handleRedeemVoiceInvite (invites_redeem_voice)", () => {
     });
   });
 
-  test("wrong caller identity is rejected with a 400", () => {
+  test("wrong caller identity is rejected with a 400", async () => {
     const { code } = createVoiceInvite("+12025550100");
 
-    expect(() =>
+    await expect(
       handleRedeemVoiceInvite({
         body: { callerExternalUserId: "+12025550101", code },
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 
-  test("missing callerExternalUserId or code is rejected with a 400", () => {
-    expect(() =>
+  test("missing callerExternalUserId or code is rejected with a 400", async () => {
+    await expect(
       handleRedeemVoiceInvite({ body: { code: "123456" } }),
-    ).toThrow();
-    expect(() =>
+    ).rejects.toThrow();
+    await expect(
       handleRedeemVoiceInvite({
         body: { callerExternalUserId: "+12025550100" },
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -45,11 +45,21 @@ mock.module("../util/logger.js", () => ({
 // The voice redemption path now claims the gateway-canonical row over IPC
 // before mutating. Stub it so tests don't attempt a real socket connect; the
 // claim returns consumed (updated:true) so redemption proceeds.
+//
+// `inviteClaimCalls` counts gateway claims so concurrency tests can assert that
+// a repeated code does NOT launch a second claim. `inviteClaimGate`, when set,
+// holds the claim open mid-flight so a test can drive the race window where a
+// second code arrives while the first redemption is still awaiting the gateway.
+let inviteClaimCalls = 0;
+let inviteClaimGate: Promise<void> | null = null;
 mock.module("../ipc/gateway-client.js", () => ({
   ipcCall: async () => undefined,
   ipcCallPersistent: async (method: string) => {
-    if (method === "record_invite_redemption")
+    if (method === "record_invite_redemption") {
+      inviteClaimCalls += 1;
+      if (inviteClaimGate) await inviteClaimGate;
       return { ok: true, updated: true, mirrored: true };
+    }
     return undefined;
   },
 }));
@@ -503,6 +513,8 @@ describe("relay-server", () => {
       verifiedVia: "bootstrap",
     });
     activeRelayConnections.clear();
+    inviteClaimCalls = 0;
+    inviteClaimGate = null;
     mockUserReference = "my human";
     mockAssistantName = "Vellum";
     mockAdmissionPolicy = null;
@@ -2482,6 +2494,190 @@ describe("relay-server", () => {
     expect(endMessages.length).toBe(1);
 
     relay.destroy();
+  });
+
+  test("inbound voice invite redemption: repeated code during in-flight claim is deduped (no second redemption, no spurious failure)", async () => {
+    ensureConversation("conv-invite-dedup");
+    const session = createCallSession({
+      conversationId: "conv-invite-dedup",
+      provider: "twilio",
+      fromNumber: "+15558885555",
+      toNumber: "+15551111111",
+    });
+
+    const code = generateVoiceCode(6);
+    const codeHash = hashVoiceCode(code);
+    createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact(),
+      maxUses: 1,
+      expectedExternalUserId: "+15558885555",
+      voiceCodeHash: codeHash,
+      voiceCodeDigits: 6,
+      friendName: "Eve",
+      guardianName: "Frank",
+    });
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, how can I help?"]),
+    );
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_invite_dedup",
+        from: "+15558885555",
+        to: "+15551111111",
+      }),
+    );
+
+    expect(relay.getConnectionState()).toBe("verification_pending");
+
+    // Hold the gateway claim open so the first redemption stays in flight while
+    // the caller re-speaks the SAME code (the race this guard prevents).
+    let releaseClaim: () => void = () => {};
+    inviteClaimGate = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+
+    // First attempt: enter the full code via DTMF — dispatched fire-and-forget.
+    for (const digit of code) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    // Let the async handler reach the awaited gateway claim.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(inviteClaimCalls).toBe(1);
+
+    // Second attempt with the SAME code arrives while the first is in flight.
+    // It must be ignored — no second claim, no failure branch.
+    for (const digit of code) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(inviteClaimCalls).toBe(1);
+
+    // Now let the first redemption resolve.
+    releaseClaim();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Exactly one gateway claim ran across both attempts.
+    expect(inviteClaimCalls).toBe(1);
+
+    // Activation succeeded — call continued, never marked failed.
+    expect(relay.getConnectionState()).toBe("connected");
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).not.toBe("failed");
+
+    const events = getCallEvents(session.id);
+    expect(
+      events.some((e) => e.eventType === "invite_redemption_succeeded"),
+    ).toBe(true);
+    expect(events.some((e) => e.eventType === "invite_redemption_failed")).toBe(
+      false,
+    );
+
+    // No failure copy was sent for the deduped second attempt.
+    const failureCopy = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter(
+        (m) =>
+          m.type === "text" &&
+          (m.token ?? "").includes("incorrect or has since expired"),
+      );
+    expect(failureCopy.length).toBe(0);
+
+    relay.destroy();
+  });
+
+  test("inbound voice invite redemption: a fresh redemption after a prior attempt fully resolves still proceeds (guard cleared, no deadlock)", async () => {
+    // Prior attempt: a fully-resolved redemption on its own call.
+    ensureConversation("conv-invite-prior");
+    const priorSession = createCallSession({
+      conversationId: "conv-invite-prior",
+      provider: "twilio",
+      fromNumber: "+15558883333",
+      toNumber: "+15551111111",
+    });
+    const priorCode = generateVoiceCode(6);
+    createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact(),
+      maxUses: 1,
+      expectedExternalUserId: "+15558883333",
+      voiceCodeHash: hashVoiceCode(priorCode),
+      voiceCodeDigits: 6,
+      friendName: "Ivan",
+      guardianName: "Judy",
+    });
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, how can I help?"]),
+    );
+
+    const prior = createMockWs(priorSession.id);
+    await prior.relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_invite_prior",
+        from: "+15558883333",
+        to: "+15551111111",
+      }),
+    );
+    for (const digit of priorCode) {
+      await prior.relay.handleMessage(
+        JSON.stringify({ type: "dtmf", digit }),
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(prior.relay.getConnectionState()).toBe("connected");
+    expect(inviteClaimCalls).toBe(1);
+    prior.relay.destroy();
+
+    // Fresh attempt: a brand-new redemption proceeds (the in-flight guard from
+    // the resolved attempt does not block it — it was cleared in finally).
+    ensureConversation("conv-invite-fresh");
+    const freshSession = createCallSession({
+      conversationId: "conv-invite-fresh",
+      provider: "twilio",
+      fromNumber: "+15558882222",
+      toNumber: "+15551111111",
+    });
+    const freshCode = generateVoiceCode(6);
+    createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact(),
+      maxUses: 1,
+      expectedExternalUserId: "+15558882222",
+      voiceCodeHash: hashVoiceCode(freshCode),
+      voiceCodeDigits: 6,
+      friendName: "Kim",
+      guardianName: "Liam",
+    });
+
+    const fresh = createMockWs(freshSession.id);
+    await fresh.relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_invite_fresh",
+        from: "+15558882222",
+        to: "+15551111111",
+      }),
+    );
+    for (const digit of freshCode) {
+      await fresh.relay.handleMessage(
+        JSON.stringify({ type: "dtmf", digit }),
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // A second claim ran for the fresh attempt — guard did not deadlock it.
+    expect(inviteClaimCalls).toBe(2);
+    expect(fresh.relay.getConnectionState()).toBe("connected");
+
+    fresh.relay.destroy();
   });
 
   test("inbound voice: unknown caller with no active invite enters name capture flow", async () => {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -42,6 +42,18 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// The voice redemption path now claims the gateway-canonical row over IPC
+// before mutating. Stub it so tests don't attempt a real socket connect; the
+// claim returns consumed (updated:true) so redemption proceeds.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCall: async () => undefined,
+  ipcCallPersistent: async (method: string) => {
+    if (method === "record_invite_redemption")
+      return { ok: true, updated: true, mirrored: true };
+    return undefined;
+  },
+}));
+
 // ── Identity helpers mock ─────────────────────────────────────────────
 
 let mockAssistantName: string | null = "Vellum";
@@ -2428,7 +2440,11 @@ describe("relay-server", () => {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
 
-    // Call should be marked as failed immediately
+    // Redemption is dispatched async (it now consults the gateway lifecycle
+    // pre-check over IPC), so flush the microtask/timer queue before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Call should be marked as failed
     const updated = getCallSession(session.id);
     expect(updated).not.toBeNull();
     expect(updated!.status).toBe("failed");

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -7,6 +7,36 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+const gatewayIpc = {
+  claim: { ok: true, updated: true, mirrored: true } as {
+    ok: boolean;
+    updated: boolean;
+    mirrored: boolean;
+  },
+  claimThrows: false,
+  calls: [] as { method: string; params?: Record<string, unknown> }[],
+};
+
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    gatewayIpc.calls.push({ method, params });
+    if (method === "record_invite_redemption") {
+      if (gatewayIpc.claimThrows) throw new Error("gateway unreachable");
+      return gatewayIpc.claim;
+    }
+    return undefined;
+  },
+}));
+
+function resetGatewayIpc() {
+  gatewayIpc.claim = { ok: true, updated: true, mirrored: true };
+  gatewayIpc.claimThrows = false;
+  gatewayIpc.calls = [];
+}
+
 import {
   findContactChannel,
   getContact,
@@ -37,13 +67,13 @@ function createTargetContact(displayName = "Target Contact"): string {
 // ---------------------------------------------------------------------------
 
 describe("generateVoiceCode", () => {
-  test("generates a code with the default 6 digits", () => {
+  test("generates a code with the default 6 digits", async () => {
     const code = generateVoiceCode();
     expect(code.length).toBe(6);
     expect(/^\d{6}$/.test(code)).toBe(true);
   });
 
-  test("generates a code with the requested digit count", () => {
+  test("generates a code with the requested digit count", async () => {
     for (const digits of [4, 5, 6, 7, 8, 9, 10]) {
       const code = generateVoiceCode(digits);
       expect(code.length).toBe(digits);
@@ -51,15 +81,15 @@ describe("generateVoiceCode", () => {
     }
   });
 
-  test("throws for digit count below 4", () => {
+  test("throws for digit count below 4", async () => {
     expect(() => generateVoiceCode(3)).toThrow(/between 4 and 10/);
   });
 
-  test("throws for digit count above 10", () => {
+  test("throws for digit count above 10", async () => {
     expect(() => generateVoiceCode(11)).toThrow(/between 4 and 10/);
   });
 
-  test("produces different codes across multiple calls (randomness)", () => {
+  test("produces different codes across multiple calls (randomness)", async () => {
     // Generate many codes and check that we don't get the same one every time.
     // With 6 digits there are 900,000 possibilities, so getting 10 identical
     // codes would be astronomically unlikely.
@@ -71,7 +101,7 @@ describe("generateVoiceCode", () => {
     expect(codes.size).toBeGreaterThanOrEqual(2);
   });
 
-  test("generated code is within the valid numeric range", () => {
+  test("generated code is within the valid numeric range", async () => {
     for (let i = 0; i < 20; i++) {
       const code = generateVoiceCode(6);
       const num = parseInt(code, 10);
@@ -87,20 +117,20 @@ describe("generateVoiceCode", () => {
 // ---------------------------------------------------------------------------
 
 describe("hashVoiceCode", () => {
-  test("produces a deterministic hash", () => {
+  test("produces a deterministic hash", async () => {
     const code = "123456";
     const hash1 = hashVoiceCode(code);
     const hash2 = hashVoiceCode(code);
     expect(hash1).toBe(hash2);
   });
 
-  test("produces a hex-encoded SHA-256 hash (64 chars)", () => {
+  test("produces a hex-encoded SHA-256 hash (64 chars)", async () => {
     const hash = hashVoiceCode("654321");
     expect(hash.length).toBe(64);
     expect(/^[0-9a-f]{64}$/.test(hash)).toBe(true);
   });
 
-  test("different codes produce different hashes", () => {
+  test("different codes produce different hashes", async () => {
     const hash1 = hashVoiceCode("111111");
     const hash2 = hashVoiceCode("222222");
     expect(hash1).not.toBe(hash2);
@@ -112,7 +142,10 @@ describe("hashVoiceCode", () => {
 // ---------------------------------------------------------------------------
 
 describe("redeemVoiceInviteCode", () => {
-  beforeEach(resetTables);
+  beforeEach(() => {
+    resetTables();
+    resetGatewayIpc();
+  });
 
   /**
    * Helper: create a voice invite with a known code and return the
@@ -147,11 +180,11 @@ describe("redeemVoiceInviteCode", () => {
     return { invite, code };
   }
 
-  test("happy path: correct caller + correct code redeems successfully", () => {
+  test("happy path: correct caller + correct code redeems successfully", async () => {
     const phone = "+15551234567";
     const { code } = createVoiceInvite({ callerPhone: phone });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -164,13 +197,73 @@ describe("redeemVoiceInviteCode", () => {
       memberId: expect.any(String),
       inviteId: expect.any(String),
     });
+
+    // The redemption claimed the gateway-canonical row before mutating.
+    const claim = gatewayIpc.calls.find(
+      (c) => c.method === "record_invite_redemption",
+    );
+    expect(claim).toBeDefined();
+    expect(claim!.params).toMatchObject({ redeemedByExternalUserId: phone });
   });
 
-  test("marks channel as verified via invite on voice redemption", () => {
+  test("rejects voice redemption when the gateway claim is not consumable (no mutation)", async () => {
     const phone = "+15551234567";
     const { code } = createVoiceInvite({ callerPhone: phone });
 
-    const result = redeemVoiceInviteCode({
+    // Gateway row exists but was NOT consumable (revoked/exhausted/raced).
+    gatewayIpc.claim = { ok: true, updated: false, mirrored: true };
+
+    const result = await redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: "phone",
+      code,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
+    expect(findContactChannel({ channelType: "phone", address: phone })).toBeNull();
+  });
+
+  test("proceeds for a legacy voice invite the gateway has never seen (mirrored:false)", async () => {
+    const phone = "+15551234567";
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    gatewayIpc.claim = { ok: true, updated: false, mirrored: false };
+
+    const result = await redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: "phone",
+      code,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      findContactChannel({ channelType: "phone", address: phone }),
+    ).not.toBeNull();
+  });
+
+  test("fails open when the gateway claim throws on voice redemption", async () => {
+    const phone = "+15551234567";
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    gatewayIpc.claimThrows = true;
+
+    const result = await redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: "phone",
+      code,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      findContactChannel({ channelType: "phone", address: phone }),
+    ).not.toBeNull();
+  });
+
+  test("marks channel as verified via invite on voice redemption", async () => {
+    const phone = "+15551234567";
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -189,10 +282,10 @@ describe("redeemVoiceInviteCode", () => {
     expect(channelResult!.channel.status).toBe("active");
   });
 
-  test("wrong caller identity fails with generic error", () => {
+  test("wrong caller identity fails with generic error", async () => {
     const { code } = createVoiceInvite({ callerPhone: "+15551234567" });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: "+19999999999",
       sourceChannel: "phone",
       code,
@@ -201,10 +294,10 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("wrong code fails with generic error", () => {
+  test("wrong code fails with generic error", async () => {
     createVoiceInvite({ callerPhone: "+15551234567" });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: "+15551234567",
       sourceChannel: "phone",
       code: "000000",
@@ -213,11 +306,11 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("expired invite fails", () => {
+  test("expired invite fails", async () => {
     const phone = "+15551234567";
     const { code } = createVoiceInvite({ callerPhone: phone, expiresInMs: -1 });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -226,12 +319,12 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("max uses exhausted fails", () => {
+  test("max uses exhausted fails", async () => {
     const phone = "+15551234567";
     const { code } = createVoiceInvite({ callerPhone: phone, maxUses: 1 });
 
     // First redemption succeeds
-    const first = redeemVoiceInviteCode({
+    const first = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -239,7 +332,7 @@ describe("redeemVoiceInviteCode", () => {
     expect(first.ok).toBe(true);
 
     // Second redemption fails — max uses exhausted
-    const second = redeemVoiceInviteCode({
+    const second = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -247,13 +340,13 @@ describe("redeemVoiceInviteCode", () => {
     expect(second).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("revoked invite fails", () => {
+  test("revoked invite fails", async () => {
     const phone = "+15551234567";
     const { invite, code } = createVoiceInvite({ callerPhone: phone });
 
     revokeInvite(invite.id);
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -262,7 +355,7 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("voice-only invite cannot be redeemed if sourceChannel on invite is not voice", () => {
+  test("voice-only invite cannot be redeemed if sourceChannel on invite is not voice", async () => {
     // Create a non-voice invite with voice code metadata to simulate a
     // hypothetical misconfiguration. The redemption service filters by
     // sourceChannel='phone', so non-phone invites are invisible.
@@ -279,7 +372,7 @@ describe("redeemVoiceInviteCode", () => {
       voiceCodeDigits: 6,
     });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: "+15551234567",
       sourceChannel: "phone",
       code,
@@ -290,7 +383,7 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("already-member caller gets already_member outcome", () => {
+  test("already-member caller gets already_member outcome", async () => {
     const phone = "+15551234567";
 
     // Pre-create an active member for this phone on voice channel
@@ -307,7 +400,7 @@ describe("redeemVoiceInviteCode", () => {
       contactId: member!.contact.id,
     });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -319,9 +412,14 @@ describe("redeemVoiceInviteCode", () => {
       type: "already_member",
       memberId: expect.any(String),
     });
+
+    // No gateway claim — already_member must not consume a use.
+    expect(
+      gatewayIpc.calls.some((c) => c.method === "record_invite_redemption"),
+    ).toBe(false);
   });
 
-  test("blocked member gets generic failure to avoid leaking membership status", () => {
+  test("blocked member gets generic failure to avoid leaking membership status", async () => {
     const phone = "+15551234567";
 
     // Pre-create a blocked member and find their contact
@@ -338,7 +436,7 @@ describe("redeemVoiceInviteCode", () => {
       contactId: member!.contact.id,
     });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
@@ -347,8 +445,8 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("empty callerExternalUserId fails", () => {
-    const result = redeemVoiceInviteCode({
+  test("empty callerExternalUserId fails", async () => {
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: "",
       sourceChannel: "phone",
       code: "123456",
@@ -357,7 +455,7 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("binds redeemer to the invite's target contact, not the guardian, on voice redemption", () => {
+  test("binds redeemer to the invite's target contact, not the guardian, on voice redemption", async () => {
     const phone = "+15559998888";
 
     // Pre-create a guardian contact with a revoked phone channel
@@ -385,7 +483,7 @@ describe("redeemVoiceInviteCode", () => {
       contactId: momContact.id,
     });
 
-    const result = redeemVoiceInviteCode({
+    const result = await redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1620,7 +1620,7 @@ export class RelayConnection {
       return;
     }
 
-    const result = attemptInviteCodeRedemption({
+    const result = await attemptInviteCodeRedemption({
       inviteRedemptionAssistantId: this.inviteRedemptionAssistantId,
       inviteRedemptionFromNumber: this.inviteRedemptionFromNumber,
       enteredCode,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -213,6 +213,10 @@ export class RelayConnection {
 
   // Inbound voice invite redemption state
   private inviteRedemptionActive = false;
+  // In-flight guard: true while an async redemption attempt is awaiting the
+  // gateway-backed claim, so a rapidly-repeated code is deduped rather than
+  // launching a second concurrent redeemVoiceInviteCode.
+  private inviteRedemptionInFlight = false;
   private inviteRedemptionAssistantId: string | null = null;
   private inviteRedemptionFromNumber: string | null = null;
   private inviteRedemptionCodeLength = 6;
@@ -1200,6 +1204,7 @@ export class RelayConnection {
     isOutbound: boolean,
   ): void {
     this.inviteRedemptionActive = true;
+    this.inviteRedemptionInFlight = false;
     this.inviteRedemptionAssistantId = assistantId;
     this.inviteRedemptionFromNumber = fromNumber;
     this.inviteRedemptionFriendName = friendName;
@@ -1616,6 +1621,32 @@ export class RelayConnection {
   private async handleInviteCodeRedemptionResult(
     enteredCode: string,
   ): Promise<void> {
+    if (!this.inviteRedemptionAssistantId || !this.inviteRedemptionFromNumber) {
+      return;
+    }
+
+    // Dedup concurrent attempts: a repeated code (re-spoken / re-entered)
+    // arriving while the async gateway-backed claim is still in flight is
+    // ignored, so we never run a second redeemVoiceInviteCode that would see
+    // the invite already consumed and wrongly mark the call failed. The flag
+    // is set synchronously before awaiting and cleared in finally.
+    if (this.inviteRedemptionInFlight) {
+      log.info(
+        { callSessionId: this.callSessionId },
+        "Ignoring repeated invite code — redemption already in flight",
+      );
+      return;
+    }
+    this.inviteRedemptionInFlight = true;
+
+    try {
+      await this.runInviteCodeRedemption(enteredCode);
+    } finally {
+      this.inviteRedemptionInFlight = false;
+    }
+  }
+
+  private async runInviteCodeRedemption(enteredCode: string): Promise<void> {
     if (!this.inviteRedemptionAssistantId || !this.inviteRedemptionFromNumber) {
       return;
     }

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -244,9 +244,9 @@ type InviteRedemptionResult =
  * caller. Returns a structured result so the caller can handle state
  * mutations and session updates.
  */
-export function attemptInviteCodeRedemption(
+export async function attemptInviteCodeRedemption(
   params: InviteRedemptionParams,
-): InviteRedemptionResult {
+): Promise<InviteRedemptionResult> {
   const {
     inviteRedemptionAssistantId,
     inviteRedemptionFromNumber,
@@ -254,7 +254,7 @@ export function attemptInviteCodeRedemption(
     inviteRedemptionGuardianName,
   } = params;
 
-  const result = redeemVoiceInviteCode({
+  const result = await redeemVoiceInviteCode({
     assistantId: inviteRedemptionAssistantId,
     callerExternalUserId: inviteRedemptionFromNumber,
     sourceChannel: "phone",

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -55,6 +55,7 @@ import {
   type DbProxyTransactionParams,
   handleDbProxyTransaction,
 } from "./routes/db-proxy-transaction.js";
+import { INVITE_IPC_METHODS } from "./routes/invite-ipc-routes.js";
 import { routeDefinitionsToIpcMethods } from "./routes/route-adapter.js";
 import { ensureSocketPathFree } from "./socket-cleanup.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
@@ -201,6 +202,13 @@ export class AssistantIpcServer {
     this.methods.set("db_proxy_transaction", (params) =>
       handleDbProxyTransaction(params as unknown as DbProxyTransactionParams),
     );
+
+    // IPC-only invite methods (see ipc/routes/invite-ipc-routes.ts). The
+    // gateway calls these back over IPC to mint tokens / redeem voice + token
+    // invites (assistant-owned secrets). No HTTP surface; never in ROUTES.
+    for (const [operationId, handler] of Object.entries(INVITE_IPC_METHODS)) {
+      this.methods.set(operationId, handler);
+    }
 
     this.methods.set("$cancel", (params) => {
       const targetId = (params as { targetId?: string }).targetId;

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -62,6 +62,7 @@ let persistentClient: PackagePersistentIpcClient | null = null;
 export async function ipcCallPersistent(
   method: string,
   params?: Record<string, unknown>,
+  timeoutMs?: number,
 ): Promise<unknown> {
   if (!persistentClient) {
     persistentClient = new PackagePersistentIpcClient(
@@ -70,7 +71,7 @@ export async function ipcCallPersistent(
       log,
     );
   }
-  return persistentClient.call(method, params);
+  return persistentClient.call(method, params, timeoutMs);
 }
 
 /**

--- a/assistant/src/ipc/routes/__tests__/invite-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/invite-ipc-routes.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The three gateway-facing invite methods are IPC-only: registered on the
+ * assistant IPC server by operationId, and absent from the shared HTTP route
+ * set / `get_route_schema`. Relocating them out of `ROUTES` (per the
+ * documented IPC-only pattern) is what structurally guarantees they can never
+ * reach the gateway's HTTP IPC proxy route schema.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => undefined,
+  setSecureKeyAsync: async () => {},
+  deleteSecureKeyAsync: async () => {},
+}));
+
+import { ROUTES as contactRoutes } from "../../../runtime/routes/contact-routes.js";
+import { INVITE_IPC_METHODS } from "../invite-ipc-routes.js";
+import { routeDefinitionsToIpcMethods } from "../route-adapter.js";
+
+const INVITE_IPC_OPERATION_IDS = [
+  "invites_mint",
+  "invites_redeem_voice",
+  "invites_redeem_token",
+] as const;
+
+describe("invite IPC-only methods", () => {
+  test("are reachable on the IPC surface by operationId", () => {
+    for (const operationId of INVITE_IPC_OPERATION_IDS) {
+      expect(typeof INVITE_IPC_METHODS[operationId]).toBe("function");
+    }
+  });
+
+  test("are NOT in the shared contact ROUTES array", () => {
+    const sharedIds = new Set(contactRoutes.map((r) => r.operationId));
+    for (const operationId of INVITE_IPC_OPERATION_IDS) {
+      expect(sharedIds.has(operationId)).toBe(false);
+    }
+  });
+
+  test("are NOT in the gateway-facing get_route_schema", async () => {
+    const ipcMethods = routeDefinitionsToIpcMethods(contactRoutes);
+    const meta = ipcMethods.find((r) => r.operationId === "get_route_schema");
+    expect(meta).toBeDefined();
+    const schema = (await meta!.handler({})) as { operationId: string }[];
+    const schemaIds = new Set(schema.map((e) => e.operationId));
+    for (const operationId of INVITE_IPC_OPERATION_IDS) {
+      expect(schemaIds.has(operationId)).toBe(false);
+    }
+  });
+});

--- a/assistant/src/ipc/routes/invite-ipc-routes.ts
+++ b/assistant/src/ipc/routes/invite-ipc-routes.ts
@@ -1,0 +1,70 @@
+/**
+ * IPC-only invite methods called by the gateway's native invite HTTP
+ * handlers over the assistant IPC socket (`ipcCallAssistant`).
+ *
+ * Token secrecy + voice fields are assistant-owned, so the gateway mints
+ * tokens / redeems codes here and mirrors the canonical lifecycle into its
+ * own DB. These have no HTTP surface: they are registered directly on the
+ * IPC server and never enter the shared `ROUTES` array, so they can never
+ * reach the gateway's HTTP IPC proxy route schema (`get_route_schema`).
+ *
+ * Per `assistant/AGENTS.md`, IPC-only methods are registered here rather
+ * than flagged inside `ROUTES`.
+ */
+
+import { mintIngressInvite } from "../../runtime/invite-service.js";
+import {
+  handleRedeemTokenInvite,
+  handleRedeemVoiceInvite,
+} from "../../runtime/routes/contact-routes.js";
+import { BadRequestError } from "../../runtime/routes/errors.js";
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+
+/**
+ * Mint an invite for the gateway (`invites_mint`).
+ *
+ * Returns the raw token plus the minimal projection the gateway mirrors into
+ * its own store. Token generation/hashing and voice fields stay
+ * assistant-owned.
+ */
+export async function handleMintInvite({ body = {} }: RouteHandlerArgs) {
+  const result = await mintIngressInvite({
+    sourceChannel: body.sourceChannel as string | undefined,
+    note: body.note as string | undefined,
+    maxUses: body.maxUses as number | undefined,
+    expiresInMs: body.expiresInMs as number | undefined,
+    contactName: body.contactName as string | undefined,
+    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
+    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
+    friendName: body.friendName as string | undefined,
+    guardianName: body.guardianName as string | undefined,
+    contactId: body.contactId as string,
+  });
+
+  if (!result.ok) {
+    throw new BadRequestError(result.error);
+  }
+  return {
+    ok: true,
+    invite: result.data.invite,
+    rawToken: result.data.rawToken,
+    gateway: result.data.gateway,
+  };
+}
+
+/**
+ * IPC-only invite methods, keyed by IPC operationId. Registered directly on
+ * the assistant IPC server (see `assistant-server.ts`).
+ *
+ * `invites_redeem_voice` / `invites_redeem_token` reuse the same split
+ * handlers that back the shared HTTP `invites_redeem` route, so token/voice
+ * redemption behaves identically across both transports.
+ */
+export const INVITE_IPC_METHODS: Record<
+  string,
+  (args: RouteHandlerArgs) => unknown
+> = {
+  invites_mint: handleMintInvite,
+  invites_redeem_voice: handleRedeemVoiceInvite,
+  invites_redeem_token: handleRedeemTokenInvite,
+};

--- a/assistant/src/ipc/routes/invite-ipc-routes.ts
+++ b/assistant/src/ipc/routes/invite-ipc-routes.ts
@@ -35,7 +35,6 @@ export async function handleMintInvite({ body = {} }: RouteHandlerArgs) {
     expiresInMs: body.expiresInMs as number | undefined,
     contactName: body.contactName as string | undefined,
     expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
     friendName: body.friendName as string | undefined,
     guardianName: body.guardianName as string | undefined,
     contactId: body.contactId as string,

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -10,6 +10,7 @@
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel, getContact } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
+import { ipcCallPersistent } from "../ipc/gateway-client.js";
 import { getSqlite } from "../memory/db-connection.js";
 import {
   findActiveVoiceInvites,
@@ -20,7 +21,83 @@ import {
   recordInviteUse,
 } from "../memory/invite-store.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
+import { getLogger } from "../util/logger.js";
 import { hashVoiceCode } from "../util/voice-code.js";
+
+const log = getLogger("invite-redemption-service");
+
+// ---------------------------------------------------------------------------
+// Gateway lifecycle bridge (shared by all redemption paths)
+// ---------------------------------------------------------------------------
+//
+// The assistant is the authority on token/code → invite resolution (it holds
+// the hashes and caller scoping). Once it has resolved the EXACT invite and
+// passed its own validation, it CLAIMS the gateway-canonical row — BY ID, which
+// is unambiguous — as the AUTHORITATIVE lifecycle gate BEFORE mutating its own
+// DB. `record_invite_redemption` atomically checks status="active" and consumes
+// the row, so there is no check-then-act window: a guardian revoke or a racing
+// redemption that consumes the gateway row first makes this claim fail, and the
+// assistant never mutates. This keeps the gateway invite row the lifecycle
+// source of truth across every redemption path (token + 6-digit channel
+// intercepts, voice relay, HTTP).
+
+/**
+ * Atomically CLAIM the gateway-canonical invite row for `inviteId`.
+ *
+ * This is the single authoritative gateway gate, performed BEFORE the assistant
+ * mutation. Returns a decision the caller maps to behavior:
+ *   - "claimed": the gateway row existed and was consumed (active → redeemed) →
+ *     proceed to the assistant mutation.
+ *   - "rejected": the gateway row EXISTS but was NOT consumable
+ *     (revoked / exhausted / expired / already redeemed in a race) → REJECT the
+ *     redemption WITHOUT mutating the assistant DB.
+ *   - "legacy": no gateway row exists (pre-migration assistant-only invite) →
+ *     proceed (the assistant stays authoritative). Logged at warn.
+ *   - "unavailable": the gateway IPC threw (gateway unreachable). FAIL-OPEN —
+ *     proceed; the assistant-side checks still apply. Logged loudly.
+ */
+async function claimGatewayRedemption(
+  inviteId: string,
+  redeemedBy: {
+    redeemedByExternalUserId?: string | null;
+    redeemedByExternalChatId?: string | null;
+  },
+): Promise<"claimed" | "rejected" | "legacy" | "unavailable"> {
+  try {
+    const res = (await ipcCallPersistent("record_invite_redemption", {
+      inviteId,
+      redeemedByExternalUserId: redeemedBy.redeemedByExternalUserId ?? null,
+      redeemedByExternalChatId: redeemedBy.redeemedByExternalChatId ?? null,
+    })) as { ok?: boolean; updated?: boolean; mirrored?: boolean } | null;
+
+    if (!res || typeof res !== "object") {
+      log.warn(
+        { inviteId, res },
+        "record_invite_redemption: gateway returned malformed response — failing open",
+      );
+      return "unavailable";
+    }
+    if (res.mirrored === false) {
+      log.warn(
+        { inviteId },
+        "record_invite_redemption: no gateway invite row — treating as legacy assistant-only invite",
+      );
+      return "legacy";
+    }
+    // mirrored === true: a gateway row exists. `updated` reflects whether the
+    // atomic status="active" claim consumed it.
+    return res.updated ? "claimed" : "rejected";
+  } catch (err) {
+    // FAIL-OPEN: availability > strict gating. The assistant-side validation
+    // (status/expiry/use-count/channel) still applies; we just couldn't claim
+    // the gateway-canonical row.
+    log.error(
+      { err, inviteId },
+      "record_invite_redemption: gateway claim unavailable — failing open (assistant-side checks still apply)",
+    );
+    return "unavailable";
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Outcome type
@@ -67,7 +144,7 @@ const STORE_ERROR_TO_REASON: Record<
 // redeemInvite
 // ---------------------------------------------------------------------------
 
-export function redeemInvite(params: {
+export async function redeemInvite(params: {
   rawToken: string;
   sourceChannel: string;
   externalUserId?: string;
@@ -75,7 +152,7 @@ export function redeemInvite(params: {
   displayName?: string;
   username?: string;
   assistantId?: string;
-}): InviteRedemptionOutcome {
+}): Promise<InviteRedemptionOutcome> {
   const {
     rawToken,
     sourceChannel,
@@ -156,6 +233,20 @@ export function redeemInvite(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
+  // Authoritative gateway claim (by id — caller-scoped resolution already
+  // picked the exact invite). Consume the gateway-canonical row BEFORE mutating
+  // the assistant so a concurrent revoke/redemption that consumes it first
+  // rejects here, with no assistant mutation to roll back. No use is consumed
+  // for the already_member/blocked early returns above.
+  if (
+    (await claimGatewayRedemption(invite.id, {
+      redeemedByExternalUserId: externalUserId,
+      redeemedByExternalChatId: externalChatId,
+    })) === "rejected"
+  ) {
+    return { ok: false, reason: "invalid_token" };
+  }
+
   // Inactive member reactivation: when the user already has a member record
   // in a non-active state (revoked/pending), reactivate it via upsertContactChannel
   // and consume an invite use atomically. The fresh-member path below also
@@ -211,6 +302,13 @@ export function redeemInvite(params: {
       if (err === STALE_INVITE) {
         return { ok: false, reason: "invalid_token" };
       }
+      // Rare: the gateway claim already consumed the row but the assistant
+      // mutation failed — a recoverable wasted gateway use; no cross-process
+      // rollback is attempted.
+      log.error(
+        { err, inviteId: invite.id },
+        "redeemInvite: assistant mutation failed AFTER gateway claim consumed the row (wasted use)",
+      );
       throw err;
     }
 
@@ -267,6 +365,12 @@ export function redeemInvite(params: {
     if (err === STALE_INVITE_FRESH) {
       return { ok: false, reason: "invalid_token" };
     }
+    // Rare: gateway claim succeeded but the assistant mutation failed — a
+    // recoverable wasted gateway use; no cross-process rollback attempted.
+    log.error(
+      { err, inviteId: invite.id },
+      "redeemInvite: assistant mutation failed AFTER gateway claim consumed the row (wasted use)",
+    );
     throw err;
   }
 
@@ -298,12 +402,12 @@ export function redeemInvite(params: {
  * oracle attacks that could reveal which invites exist or which phone numbers
  * are bound.
  */
-export function redeemVoiceInviteCode(params: {
+export async function redeemVoiceInviteCode(params: {
   assistantId?: string;
   callerExternalUserId: string;
   sourceChannel: "phone";
   code: string;
-}): VoiceRedemptionOutcome {
+}): Promise<VoiceRedemptionOutcome> {
   const { callerExternalUserId, code } = params;
 
   if (!callerExternalUserId) {
@@ -378,6 +482,20 @@ export function redeemVoiceInviteCode(params: {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
+  // Authoritative gateway claim (by id). The candidate was already resolved
+  // caller-scoped (expectedExternalUserId == caller), so the id is unambiguous
+  // even when two phone invites share a 6-digit code — this closes the
+  // colliding-code gap that a code-hash-only gateway gate left open. Consuming
+  // the gateway row here, before the assistant mutation, closes the TOCTOU
+  // window: a concurrent revoke/redemption rejects with no assistant mutation.
+  if (
+    (await claimGatewayRedemption(invite.id, {
+      redeemedByExternalUserId: callerExternalUserId,
+    })) === "rejected"
+  ) {
+    return { ok: false, reason: "invalid_or_expired" };
+  }
+
   // Atomic redemption: upsert member + consume invite use in a transaction
   const STALE_INVITE = Symbol("stale_invite");
   let memberId: string | undefined;
@@ -424,6 +542,12 @@ export function redeemVoiceInviteCode(params: {
     if (err === STALE_INVITE) {
       return { ok: false, reason: "invalid_or_expired" };
     }
+    // Rare: gateway claim succeeded but the assistant mutation failed — a
+    // recoverable wasted gateway use; no cross-process rollback attempted.
+    log.error(
+      { err, inviteId: invite.id },
+      "redeemVoiceInviteCode: assistant mutation failed AFTER gateway claim consumed the row (wasted use)",
+    );
     throw err;
   }
 
@@ -449,7 +573,7 @@ export function redeemVoiceInviteCode(params: {
  * Validation: active status, not expired, uses remaining, channel match.
  * On success: upserts/reactivates a member with status 'active', policy 'allow'.
  */
-export function redeemInviteByCode(params: {
+export async function redeemInviteByCode(params: {
   code: string;
   sourceChannel: string;
   externalUserId?: string;
@@ -457,7 +581,7 @@ export function redeemInviteByCode(params: {
   displayName?: string;
   username?: string;
   assistantId?: string;
-}): InviteRedemptionOutcome {
+}): Promise<InviteRedemptionOutcome> {
   const {
     code,
     sourceChannel,
@@ -530,6 +654,19 @@ export function redeemInviteByCode(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
+  // Authoritative gateway claim (by id). Consume the gateway-canonical row
+  // before mutating the assistant, so a concurrent revoke/redemption that
+  // consumes it first rejects here with no assistant mutation to roll back. No
+  // use is consumed for the already_member/blocked early returns above.
+  if (
+    (await claimGatewayRedemption(invite.id, {
+      redeemedByExternalUserId: externalUserId,
+      redeemedByExternalChatId: externalChatId,
+    })) === "rejected"
+  ) {
+    return { ok: false, reason: "invalid_token" };
+  }
+
   // Inactive member reactivation: reactivate via upsertContactChannel and consume
   // an invite use atomically.
   if (existingChannel && !targetMismatch) {
@@ -577,6 +714,12 @@ export function redeemInviteByCode(params: {
       if (err === STALE_INVITE_REACTIVATE) {
         return { ok: false, reason: "invalid_token" };
       }
+      // Rare: gateway claim succeeded but the assistant mutation failed — a
+      // recoverable wasted gateway use; no cross-process rollback attempted.
+      log.error(
+        { err, inviteId: invite.id },
+        "redeemInviteByCode: assistant mutation failed AFTER gateway claim consumed the row (wasted use)",
+      );
       throw err;
     }
 
@@ -633,6 +776,12 @@ export function redeemInviteByCode(params: {
     if (err === STALE_INVITE_FRESH) {
       return { ok: false, reason: "invalid_token" };
     }
+    // Rare: gateway claim succeeded but the assistant mutation failed — a
+    // recoverable wasted gateway use; no cross-process rollback attempted.
+    log.error(
+      { err, inviteId: invite.id },
+      "redeemInviteByCode: assistant mutation failed AFTER gateway claim consumed the row (wasted use)",
+    );
     throw err;
   }
 

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -276,6 +276,73 @@ export async function createIngressInvite(params: {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Mint — gateway-facing projection
+//
+// The gateway owns the canonical invite lifecycle in its own DB, but token
+// generation/hashing and voice fields are assistant-owned. `mintIngressInvite`
+// runs the same `createIngressInvite` path and surfaces the raw token plus the
+// minimal projection the gateway mirrors. The raw token is returned exactly
+// once and never persisted in plaintext.
+// ---------------------------------------------------------------------------
+
+/** Minimal invite projection the gateway mirrors into its own store. */
+export interface GatewayInviteProjection {
+  id: string;
+  /** Hash of whatever code redeems this invite: token hash for token invites,
+   * voice code hash for voice/phone invites. Always non-null and mirrorable. */
+  inviteCodeHash: string;
+  sourceChannel: string;
+  contactId: string;
+  note: string | null;
+  maxUses: number;
+  expiresAt: number;
+}
+
+export interface MintInviteResult {
+  invite: InviteResponseData;
+  rawToken?: string;
+  gateway: GatewayInviteProjection;
+}
+
+export async function mintIngressInvite(
+  params: Parameters<typeof createIngressInvite>[0],
+): Promise<IngressResult<MintInviteResult>> {
+  const result = await createIngressInvite(params);
+  if (!result.ok) return result;
+
+  // The persisted row carries fields the response projection omits
+  // (inviteCodeHash); read it back to build the gateway projection.
+  const row = findById(result.data.id);
+  if (!row) {
+    return { ok: false, error: "Invite not found after mint" };
+  }
+
+  // The gateway mirrors the hash of whatever code redeems this invite. Token
+  // invites carry inviteCodeHash; voice/phone invites gate on voiceCodeHash.
+  const inviteCodeHash = row.inviteCodeHash ?? row.voiceCodeHash;
+  if (!inviteCodeHash) {
+    return { ok: false, error: "Invite is missing a redemption code hash" };
+  }
+
+  return {
+    ok: true,
+    data: {
+      invite: result.data,
+      rawToken: result.data.token,
+      gateway: {
+        id: row.id,
+        inviteCodeHash,
+        sourceChannel: row.sourceChannel,
+        contactId: row.contactId,
+        note: row.note,
+        maxUses: row.maxUses,
+        expiresAt: row.expiresAt,
+      },
+    },
+  };
+}
+
 export function listIngressInvites(params: {
   sourceChannel?: string;
   status?: string;

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -16,10 +16,7 @@ import {
   findByTokenHash,
   hashToken,
   type IngressInvite,
-  type InviteStatus,
-  listInvites,
   markInviteExpired,
-  revokeInvite,
 } from "../memory/invite-store.js";
 import {
   DECLINED_BY_USER_SENTINEL,
@@ -161,7 +158,6 @@ export async function createIngressInvite(params: {
   contactName?: string;
   // Voice invite parameters
   expectedExternalUserId?: string;
-  voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
   contactId: string;
@@ -347,33 +343,6 @@ export async function mintIngressInvite(
       },
     },
   };
-}
-
-export function listIngressInvites(params: {
-  sourceChannel?: string;
-  status?: string;
-}): IngressResult<InviteResponseData[]> {
-  const invites = listInvites({
-    sourceChannel: params.sourceChannel,
-    status: params.status as InviteStatus | undefined,
-  });
-  return {
-    ok: true,
-    data: invites.map((inv) => inviteToResponse(inv)),
-  };
-}
-
-export function revokeIngressInvite(
-  inviteId?: string,
-): IngressResult<InviteResponseData> {
-  if (!inviteId) {
-    return { ok: false, error: "inviteId is required for revoke" };
-  }
-  const revoked = revokeInvite(inviteId);
-  if (!revoked) {
-    return { ok: false, error: "Invite not found or already revoked" };
-  }
-  return { ok: true, data: inviteToResponse(revoked) };
 }
 
 export async function triggerInviteCall(

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -43,6 +43,12 @@ import {
 // Response shapes — used by both HTTP routes and message handlers
 // ---------------------------------------------------------------------------
 
+/**
+ * Redemption outcome type surfaced to callers. `already_member` consumes no
+ * invite use, so the gateway must not mirror it into recordInviteRedemption.
+ */
+export type RedemptionType = "redeemed" | "already_member";
+
 export interface InviteResponseData {
   id: string;
   sourceChannel: string;
@@ -400,19 +406,21 @@ export async function triggerInviteCall(
   return { ok: true, data: { callSid: result.callSid } };
 }
 
-export function redeemIngressInvite(params: {
+export async function redeemIngressInvite(params: {
   token?: string;
   externalUserId?: string;
   externalChatId?: string;
   sourceChannel?: string;
-}): IngressResult<InviteResponseData> {
+}): Promise<
+  IngressResult<{ invite: InviteResponseData; type: RedemptionType }>
+> {
   if (!params.token) {
     return { ok: false, error: "token is required for redeem" };
   }
   if (!params.sourceChannel) {
     return { ok: false, error: "sourceChannel is required for redeem" };
   }
-  const outcome = redeemInviteTyped({
+  const outcome = await redeemInviteTyped({
     rawToken: params.token,
     sourceChannel: params.sourceChannel,
     externalUserId: params.externalUserId,
@@ -421,21 +429,15 @@ export function redeemIngressInvite(params: {
   if (!outcome.ok) {
     return { ok: false, error: outcome.reason };
   }
-  // For already_member, look up the invite by token hash to build the response
-  if (outcome.type === "already_member") {
-    const inv = findByTokenHash(hashToken(params.token));
-    if (!inv) {
-      return { ok: false, error: "Invite not found after redemption" };
-    }
-    return { ok: true, data: inviteToResponse(inv) };
-  }
-  // Look up the invite by token hash — same approach as the already_member path
-  // above. Using findByTokenHash avoids the pagination limit of listInvites.
+  // Look up the invite by token hash for both outcomes (`redeemed` and
+  // `already_member`). Using findByTokenHash avoids the pagination limit of
+  // listInvites. The `type` is surfaced so the gateway can skip mirroring an
+  // `already_member` redemption (which consumes no use).
   const inv = findByTokenHash(hashToken(params.token));
   if (!inv) {
     return { ok: false, error: "Invite not found after redemption" };
   }
-  return { ok: true, data: inviteToResponse(inv) };
+  return { ok: true, data: { invite: inviteToResponse(inv), type: outcome.type } };
 }
 
 export function redeemVoiceInviteCode(params: {
@@ -443,6 +445,6 @@ export function redeemVoiceInviteCode(params: {
   callerExternalUserId: string;
   sourceChannel: "phone";
   code: string;
-}): VoiceRedemptionOutcome {
+}): Promise<VoiceRedemptionOutcome> {
   return redeemVoiceInviteCodeTyped(params);
 }

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for the CLI invite relay routes.
+ *
+ * Three CLI invite handlers (list/create/revoke) are thin relays to the gateway
+ * IPC methods via `ipcCallPersistent`. These tests assert each relays with the
+ * correct method + params, returns the parsed gateway response, never writes the
+ * assistant invite store directly, and surfaces a relayed IpcCallError with its
+ * statusCode. `invites_redeem` and `invites_trigger_call` stay daemon-local: the
+ * gateway delegates the actual provider call to the daemon-local handler, so
+ * relaying it back would loop gateway→assistant→gateway.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = {};
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if any relayed handler still writes the assistant invite
+// store directly. The relayed CLI paths must go through the gateway only, so we
+// spy on the store's write functions and assert they are never invoked.
+const actualInviteStore = await import("../../../memory/invite-store.js");
+
+const inviteStoreCall = mock(() => {
+  throw new Error("invite-store write must not happen on relayed CLI paths");
+});
+
+mock.module("../../../memory/invite-store.js", () => ({
+  ...actualInviteStore,
+  createInvite: inviteStoreCall,
+  listInvites: inviteStoreCall,
+  revokeInvite: inviteStoreCall,
+}));
+
+// `invites_trigger_call` is daemon-local: the handler invokes the local
+// `triggerInviteCall` provider logic directly (never `ipcCallPersistent`).
+let triggerInviteCallResult: unknown = { ok: true, data: { callSid: "CA000" } };
+const triggerInviteCallMock = mock(async (_id: string) => triggerInviteCallResult);
+
+const actualInviteService = await import("../../invite-service.js");
+
+mock.module("../../invite-service.js", () => ({
+  ...actualInviteService,
+  triggerInviteCall: triggerInviteCallMock,
+}));
+
+const {
+  handleListInvites,
+  handleCreateInvite,
+  handleRevokeInvite,
+  handleTriggerInviteCall,
+  ROUTES,
+} = await import("../contact-routes.js");
+
+describe("invite relay routes", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = {};
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    inviteStoreCall.mockClear();
+    triggerInviteCallResult = { ok: true, data: { callSid: "CA000" } };
+    triggerInviteCallMock.mockClear();
+  });
+
+  describe("handleListInvites", () => {
+    test("relays invites_list with filters from queryParams", async () => {
+      ipcResult = { invites: [{ id: "i1" }] };
+      const result = await handleListInvites({
+        queryParams: { sourceChannel: "telegram", status: "active" },
+      });
+
+      expect(ipcCalls).toEqual([
+        {
+          method: "invites_list",
+          params: { sourceChannel: "telegram", status: "active" },
+        },
+      ]);
+      expect(result).toEqual({ ok: true, invites: [{ id: "i1" }] });
+      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+
+    test("omits absent filters", async () => {
+      ipcResult = { invites: [] };
+      await handleListInvites({ queryParams: {} });
+
+      expect(ipcCalls).toEqual([{ method: "invites_list", params: {} }]);
+    });
+  });
+
+  describe("handleCreateInvite", () => {
+    test("relays invites_create with mapped body and returns invite + rawToken", async () => {
+      ipcResult = { invite: { id: "i9", token: "tok-9" }, rawToken: "tok-9" };
+      const result = await handleCreateInvite({
+        body: {
+          contactId: "c1",
+          sourceChannel: "telegram",
+          note: "hi",
+          maxUses: 2,
+        },
+      });
+
+      expect(ipcCalls).toEqual([
+        {
+          method: "invites_create",
+          params: {
+            contactId: "c1",
+            sourceChannel: "telegram",
+            note: "hi",
+            maxUses: 2,
+            expiresInMs: undefined,
+            contactName: undefined,
+            expectedExternalUserId: undefined,
+            voiceCodeDigits: undefined,
+            friendName: undefined,
+            guardianName: undefined,
+          },
+        },
+      ]);
+      expect(result).toEqual({
+        ok: true,
+        invite: { id: "i9", token: "tok-9" },
+        rawToken: "tok-9",
+      });
+      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+
+    test("omits rawToken when the gateway returns none", async () => {
+      ipcResult = { invite: { id: "i9" } };
+      const result = await handleCreateInvite({
+        body: { contactId: "c1", sourceChannel: "phone" },
+      });
+
+      expect(result).toEqual({ ok: true, invite: { id: "i9" } });
+    });
+  });
+
+  describe("handleRevokeInvite", () => {
+    test("relays invites_revoke with id from pathParams", async () => {
+      ipcResult = { invite: { id: "i3", status: "revoked" } };
+      const result = await handleRevokeInvite({ pathParams: { id: "i3" } });
+
+      expect(ipcCalls).toEqual([
+        { method: "invites_revoke", params: { id: "i3" } },
+      ]);
+      expect(result).toEqual({
+        ok: true,
+        invite: { id: "i3", status: "revoked" },
+      });
+      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleTriggerInviteCall (daemon-local carve-out)", () => {
+    test("invokes the local triggerInviteCall and does NOT relay to the gateway", async () => {
+      triggerInviteCallResult = { ok: true, data: { callSid: "CA123" } };
+      const result = await handleTriggerInviteCall({ pathParams: { id: "i7" } });
+
+      expect(triggerInviteCallMock).toHaveBeenCalledTimes(1);
+      expect(triggerInviteCallMock).toHaveBeenCalledWith("i7");
+      // Must NOT relay: relaying invites_trigger_call would loop
+      // gateway→assistant→gateway (the gateway calls THIS to place the call).
+      expect(ipcCalls).toEqual([]);
+      expect(result).toEqual({ ok: true, callSid: "CA123" });
+    });
+
+    test("surfaces a failed provider call as a 400", async () => {
+      triggerInviteCallResult = { ok: false, error: "Invite not eligible" };
+
+      try {
+        await handleTriggerInviteCall({ pathParams: { id: "i7" } });
+        throw new Error("expected handler to throw");
+      } catch (err) {
+        const e = err as { statusCode?: number; message: string };
+        expect(e.message).toBe("Invite not eligible");
+        expect(e.statusCode).toBe(400);
+      }
+      expect(ipcCalls).toEqual([]);
+    });
+  });
+
+  describe("error propagation", () => {
+    test("relayed IpcCallError surfaces with its statusCode/errorCode", async () => {
+      ipcError = new IpcCallError("Invite not found", {
+        statusCode: 404,
+        errorCode: "NOT_FOUND",
+      });
+
+      try {
+        await handleRevokeInvite({ pathParams: { id: "missing" } });
+        throw new Error("expected handler to throw");
+      } catch (err) {
+        const e = err as { statusCode?: number; code?: string; message: string };
+        expect(e.message).toBe("Invite not found");
+        expect(e.statusCode).toBe(404);
+        expect(e.code).toBe("NOT_FOUND");
+      }
+    });
+  });
+
+  describe("invites_redeem carve-out", () => {
+    test("redeem route is registered but NOT relayed to the gateway", () => {
+      const redeemRoute = ROUTES.find((r) => r.operationId === "invites_redeem");
+      expect(redeemRoute).toBeDefined();
+      // The redeem handler is daemon-local; it must not appear in the relayed
+      // operation set above. No gateway IPC call is made by registering it.
+      expect(ipcCalls).toEqual([]);
+    });
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -17,6 +17,7 @@ import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 type IpcCall = {
   method: string;
   params?: Record<string, unknown>;
+  timeoutMs?: number;
 };
 
 let ipcCalls: IpcCall[] = [];
@@ -24,8 +25,12 @@ let ipcResult: unknown = {};
 let ipcError: Error | undefined;
 
 const ipcCallPersistentMock = mock(
-  async (method: string, params?: Record<string, unknown>) => {
-    ipcCalls.push({ method, params });
+  async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCalls.push({ method, params, timeoutMs });
     if (ipcError) throw ipcError;
     return ipcResult;
   },
@@ -96,6 +101,8 @@ describe("invite relay routes", () => {
         {
           method: "invites_list",
           params: { sourceChannel: "telegram", status: "active" },
+          // List uses the default IPC timeout (no longer-timeout relay needed).
+          timeoutMs: undefined,
         },
       ]);
       expect(result).toEqual({ ok: true, invites: [{ id: "i1" }] });
@@ -106,7 +113,9 @@ describe("invite relay routes", () => {
       ipcResult = { invites: [] };
       await handleListInvites({ queryParams: {} });
 
-      expect(ipcCalls).toEqual([{ method: "invites_list", params: {} }]);
+      expect(ipcCalls).toEqual([
+        { method: "invites_list", params: {}, timeoutMs: undefined },
+      ]);
     });
   });
 
@@ -136,6 +145,9 @@ describe("invite relay routes", () => {
             friendName: undefined,
             guardianName: undefined,
           },
+          // The create relay uses a generous timeout (gateway invites_mint can
+          // spend ~5s in generateInviteInstruction); list/revoke use the default.
+          timeoutMs: 30_000,
         },
       ]);
       expect(result).toEqual({
@@ -162,7 +174,7 @@ describe("invite relay routes", () => {
       const result = await handleRevokeInvite({ pathParams: { id: "i3" } });
 
       expect(ipcCalls).toEqual([
-        { method: "invites_revoke", params: { id: "i3" } },
+        { method: "invites_revoke", params: { id: "i3" }, timeoutMs: undefined },
       ]);
       expect(result).toEqual({
         ok: true,

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -133,7 +133,6 @@ describe("invite relay routes", () => {
             expiresInMs: undefined,
             contactName: undefined,
             expectedExternalUserId: undefined,
-            voiceCodeDigits: undefined,
             friendName: undefined,
             guardianName: undefined,
           },

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -240,36 +240,48 @@ export function handleRevokeInvite({ pathParams = {} }: RouteHandlerArgs) {
   return { ok: true, invite: result.data };
 }
 
-export async function handleRedeemInvite({ body = {} }: RouteHandlerArgs) {
-  if (body.code != null) {
-    const callerExternalUserId = body.callerExternalUserId as
-      | string
-      | undefined;
-    const code = body.code as string | undefined;
+/**
+ * Redeem a voice invite code.
+ *
+ * Backs the HTTP `invites_redeem` route (voice path) and the IPC-only
+ * `invites_redeem_voice` method. Wraps the identity-bound
+ * `redeemVoiceInviteCode` path.
+ */
+export function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
+  const callerExternalUserId = body.callerExternalUserId as string | undefined;
+  const code = body.code as string | undefined;
 
-    if (!callerExternalUserId || !code) {
-      throw new BadRequestError("callerExternalUserId and code are required");
-    }
-
-    const result = redeemVoiceInviteCode({
-      assistantId: body.assistantId as string | undefined,
-      callerExternalUserId,
-      sourceChannel: "phone",
-      code,
-    });
-
-    if (!result.ok) {
-      throw new BadRequestError(result.reason);
-    }
-
-    return {
-      ok: true,
-      type: result.type,
-      memberId: result.memberId,
-      ...(result.type === "redeemed" ? { inviteId: result.inviteId } : {}),
-    };
+  if (!callerExternalUserId || !code) {
+    throw new BadRequestError("callerExternalUserId and code are required");
   }
 
+  const result = redeemVoiceInviteCode({
+    assistantId: body.assistantId as string | undefined,
+    callerExternalUserId,
+    sourceChannel: "phone",
+    code,
+  });
+
+  if (!result.ok) {
+    throw new BadRequestError(result.reason);
+  }
+
+  return {
+    ok: true,
+    type: result.type,
+    memberId: result.memberId,
+    ...(result.type === "redeemed" ? { inviteId: result.inviteId } : {}),
+  };
+}
+
+/**
+ * Redeem a token invite.
+ *
+ * Backs the HTTP `invites_redeem` route (token path) and the IPC-only
+ * `invites_redeem_token` method. Wraps the generic `redeemIngressInvite`
+ * token path.
+ */
+export function handleRedeemTokenInvite({ body = {} }: RouteHandlerArgs) {
   const result = redeemIngressInvite({
     token: body.token as string | undefined,
     externalUserId: body.externalUserId as string | undefined,
@@ -281,6 +293,14 @@ export async function handleRedeemInvite({ body = {} }: RouteHandlerArgs) {
     throw new BadRequestError(result.error);
   }
   return { ok: true, invite: result.data };
+}
+
+export async function handleRedeemInvite(args: RouteHandlerArgs) {
+  const body = args.body ?? {};
+  if (body.code != null) {
+    return handleRedeemVoiceInvite(args);
+  }
+  return handleRedeemTokenInvite(args);
 }
 
 export async function handleTriggerInviteCall({

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -248,7 +248,6 @@ export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
       expiresInMs: body.expiresInMs as number | undefined,
       contactName: body.contactName as string | undefined,
       expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-      voiceCodeDigits: body.voiceCodeDigits as number | undefined,
       friendName: body.friendName as string | undefined,
       guardianName: body.guardianName as string | undefined,
     })) as { invite: Record<string, unknown>; rawToken?: string };

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -224,6 +224,14 @@ function handleGetContact(contactId: string) {
 // to the gateway IPC methods via `ipcCallPersistent`; the assistant DB is
 // written only by the gateway. (Redemption stays daemon-local — see the redeem route.)
 
+// The invite-CREATE relay needs a generous timeout: the gateway's `invites_mint`
+// handler calls `createIngressInvite` → `generateInviteInstruction`, which can spend
+// up to GENERATION_TIMEOUT_MS (~5s) waiting on an LLM before falling back. The default
+// 5s persistent-IPC timeout can fire mid-mint, so the caller sees a spurious failure
+// even though the gateway is still writing the invite. 30s safely exceeds the inner
+// ~5s fallback plus IPC overhead on both nested hops. (List/revoke keep the default.)
+const INVITE_CREATE_RELAY_TIMEOUT_MS = 30_000;
+
 export async function handleListInvites({ queryParams = {} }: RouteHandlerArgs) {
   try {
     const result = (await ipcCallPersistent("invites_list", {
@@ -240,17 +248,23 @@ export async function handleListInvites({ queryParams = {} }: RouteHandlerArgs) 
 
 export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
   try {
-    const result = (await ipcCallPersistent("invites_create", {
-      contactId: body.contactId as string,
-      sourceChannel: body.sourceChannel as string | undefined,
-      note: body.note as string | undefined,
-      maxUses: body.maxUses as number | undefined,
-      expiresInMs: body.expiresInMs as number | undefined,
-      contactName: body.contactName as string | undefined,
-      expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-      friendName: body.friendName as string | undefined,
-      guardianName: body.guardianName as string | undefined,
-    })) as { invite: Record<string, unknown>; rawToken?: string };
+    const result = (await ipcCallPersistent(
+      "invites_create",
+      {
+        contactId: body.contactId as string,
+        sourceChannel: body.sourceChannel as string | undefined,
+        note: body.note as string | undefined,
+        maxUses: body.maxUses as number | undefined,
+        expiresInMs: body.expiresInMs as number | undefined,
+        contactName: body.contactName as string | undefined,
+        expectedExternalUserId: body.expectedExternalUserId as
+          | string
+          | undefined,
+        friendName: body.friendName as string | undefined,
+        guardianName: body.guardianName as string | undefined,
+      },
+      INVITE_CREATE_RELAY_TIMEOUT_MS,
+    )) as { invite: Record<string, unknown>; rawToken?: string };
     return {
       ok: true,
       invite: result.invite,

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -8,6 +8,7 @@
  * they don't shadow more-specific sub-paths like contacts/invites.
  */
 
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import {
@@ -25,18 +26,38 @@ import type {
   ContactRole,
   ContactType,
 } from "../../contacts/types.js";
+import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
-  createIngressInvite,
-  listIngressInvites,
   redeemIngressInvite,
   redeemVoiceInviteCode,
-  revokeIngressInvite,
   triggerInviteCall,
 } from "../invite-service.js";
-import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  RouteError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+/**
+ * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
+ * adapters honor its statusCode/errorCode (4xx surfaces as 4xx, not a generic
+ * 500). Non-IpcCallError throws propagate unchanged.
+ */
+function rethrowGatewayError(err: unknown): never {
+  if (err instanceof IpcCallError) {
+    throw new RouteError(
+      err.message,
+      err.errorCode ?? "INTERNAL_ERROR",
+      err.statusCode ?? 500,
+      err.errorDetails,
+    );
+  }
+  throw err;
+}
 
 function withGuardianNameOverride<
   T extends { role: string; displayName: string },
@@ -199,45 +220,57 @@ function handleGetContact(contactId: string) {
 // Invite handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
-export function handleListInvites({ queryParams = {} }: RouteHandlerArgs) {
-  const result = listIngressInvites({
-    sourceChannel: queryParams.sourceChannel,
-    status: queryParams.status,
-  });
+// The gateway owns the canonical invite write path. These CLI handlers relay
+// to the gateway IPC methods via `ipcCallPersistent`; the assistant DB is
+// written only by the gateway. (Redemption stays daemon-local — see the redeem route.)
 
-  if (!result.ok) {
-    throw new BadRequestError(result.error);
+export async function handleListInvites({ queryParams = {} }: RouteHandlerArgs) {
+  try {
+    const result = (await ipcCallPersistent("invites_list", {
+      ...(queryParams.sourceChannel
+        ? { sourceChannel: queryParams.sourceChannel }
+        : {}),
+      ...(queryParams.status ? { status: queryParams.status } : {}),
+    })) as { invites: Array<Record<string, unknown>> };
+    return { ok: true, invites: result.invites };
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-  return { ok: true, invites: result.data };
 }
 
 export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
-  const result = await createIngressInvite({
-    sourceChannel: body.sourceChannel as string | undefined,
-    note: body.note as string | undefined,
-    maxUses: body.maxUses as number | undefined,
-    expiresInMs: body.expiresInMs as number | undefined,
-    contactName: body.contactName as string | undefined,
-    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
-    friendName: body.friendName as string | undefined,
-    guardianName: body.guardianName as string | undefined,
-    contactId: body.contactId as string,
-  });
-
-  if (!result.ok) {
-    throw new BadRequestError(result.error);
+  try {
+    const result = (await ipcCallPersistent("invites_create", {
+      contactId: body.contactId as string,
+      sourceChannel: body.sourceChannel as string | undefined,
+      note: body.note as string | undefined,
+      maxUses: body.maxUses as number | undefined,
+      expiresInMs: body.expiresInMs as number | undefined,
+      contactName: body.contactName as string | undefined,
+      expectedExternalUserId: body.expectedExternalUserId as string | undefined,
+      voiceCodeDigits: body.voiceCodeDigits as number | undefined,
+      friendName: body.friendName as string | undefined,
+      guardianName: body.guardianName as string | undefined,
+    })) as { invite: Record<string, unknown>; rawToken?: string };
+    return {
+      ok: true,
+      invite: result.invite,
+      ...(result.rawToken ? { rawToken: result.rawToken } : {}),
+    };
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-  return { ok: true, invite: result.data };
 }
 
-export function handleRevokeInvite({ pathParams = {} }: RouteHandlerArgs) {
-  const result = revokeIngressInvite(pathParams.id);
-
-  if (!result.ok) {
-    throw new NotFoundError(result.error);
+export async function handleRevokeInvite({ pathParams = {} }: RouteHandlerArgs) {
+  try {
+    const result = (await ipcCallPersistent("invites_revoke", {
+      id: pathParams.id,
+    })) as { invite: Record<string, unknown> };
+    return { ok: true, invite: result.invite };
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-  return { ok: true, invite: result.data };
 }
 
 /**
@@ -309,6 +342,10 @@ export async function handleRedeemInvite(args: RouteHandlerArgs) {
   return handleRedeemTokenInvite(args);
 }
 
+// Stays daemon-local by design (like invites_redeem): the gateway's call path
+// validates its row then delegates the actual provider call to THIS handler via
+// ipcCallAssistant("invites_trigger_call"). Relaying back would loop
+// gateway→assistant→gateway. The provider call is a daemon capability.
 export async function handleTriggerInviteCall({
   pathParams = {},
 }: RouteHandlerArgs) {
@@ -445,6 +482,10 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       ok: z.boolean(),
       invite: z.object({}).passthrough().describe("Created invite"),
+      rawToken: z
+        .string()
+        .optional()
+        .describe("One-time raw invite token (returned at creation only)"),
     }),
     additionalResponses: {
       "400": {
@@ -453,6 +494,9 @@ export const ROUTES: RouteDefinition[] = [
     },
   },
   {
+    // Stays daemon-local by design: redemption is an inbound-channel path (not
+    // a CLI ACL surface), and the assistant redemption service already claims
+    // the gateway row by id via record_invite_redemption — relaying would loop.
     operationId: "invites_redeem",
     endpoint: "contacts/invites/redeem",
     method: "POST",

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -247,7 +247,9 @@ export function handleRevokeInvite({ pathParams = {} }: RouteHandlerArgs) {
  * `invites_redeem_voice` method. Wraps the identity-bound
  * `redeemVoiceInviteCode` path.
  */
-export function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
+export async function handleRedeemVoiceInvite({
+  body = {},
+}: RouteHandlerArgs) {
   const callerExternalUserId = body.callerExternalUserId as string | undefined;
   const code = body.code as string | undefined;
 
@@ -255,7 +257,7 @@ export function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
     throw new BadRequestError("callerExternalUserId and code are required");
   }
 
-  const result = redeemVoiceInviteCode({
+  const result = await redeemVoiceInviteCode({
     assistantId: body.assistantId as string | undefined,
     callerExternalUserId,
     sourceChannel: "phone",
@@ -281,8 +283,10 @@ export function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
  * `invites_redeem_token` method. Wraps the generic `redeemIngressInvite`
  * token path.
  */
-export function handleRedeemTokenInvite({ body = {} }: RouteHandlerArgs) {
-  const result = redeemIngressInvite({
+export async function handleRedeemTokenInvite({
+  body = {},
+}: RouteHandlerArgs) {
+  const result = await redeemIngressInvite({
     token: body.token as string | undefined,
     externalUserId: body.externalUserId as string | undefined,
     externalChatId: body.externalChatId as string | undefined,
@@ -292,7 +296,9 @@ export function handleRedeemTokenInvite({ body = {} }: RouteHandlerArgs) {
   if (!result.ok) {
     throw new BadRequestError(result.error);
   }
-  return { ok: true, invite: result.data };
+  // Surface the redemption `type` so the gateway can skip mirroring an
+  // `already_member` redeem (which consumes no invite use).
+  return { ok: true, invite: result.data.invite, type: result.data.type };
 }
 
 export async function handleRedeemInvite(args: RouteHandlerArgs) {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -875,7 +875,7 @@ async function handleInviteTokenIntercept(params: {
     };
   }
 
-  const outcome = redeemInvite({
+  const outcome = await redeemInvite({
     rawToken,
     sourceChannel,
     externalUserId: senderExternalUserId,
@@ -1077,9 +1077,9 @@ async function handleInviteCodeIntercept(params: {
     };
   }
 
-  let outcome: ReturnType<typeof redeemInviteByCode>;
+  let outcome: Awaited<ReturnType<typeof redeemInviteByCode>>;
   try {
-    outcome = redeemInviteByCode({
+    outcome = await redeemInviteByCode({
       code,
       sourceChannel,
       externalUserId: senderExternalUserId,

--- a/gateway/src/__tests__/contact-store-invites.test.ts
+++ b/gateway/src/__tests__/contact-store-invites.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for ContactStore's ingress_invites CRUD — the gateway-DB-only data
+ * access layer that the native HTTP invite handlers consume.
+ *
+ * These methods touch only the gateway DB (ingress_invites + contacts FK),
+ * so no assistant DB proxy is needed. We spin up the in-memory/temp gateway
+ * DB via the shared test preload and seed a contacts row to satisfy the
+ * invite's contact_id FK.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "./test-preload.js";
+
+import { ContactStore } from "../db/contact-store.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, ingressInvites } from "../db/schema.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(ingressInvites).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedContact(id: string) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: `name-${id}`,
+      role: "contact",
+      principalId: `prin-${id}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+describe("ContactStore ingress_invites", () => {
+  test("createInvite inserts an active invite with useCount 0 and returns the row", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    const before = Date.now();
+
+    const row = store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "hash-1",
+      contactId: "c1",
+      note: "hello",
+      maxUses: 3,
+      expiresAt: 9999,
+    });
+
+    expect(row.id).toBe("inv1");
+    expect(row.sourceChannel).toBe("vellum");
+    expect(row.inviteCodeHash).toBe("hash-1");
+    expect(row.note).toBe("hello");
+    expect(row.maxUses).toBe(3);
+    expect(row.useCount).toBe(0);
+    expect(row.expiresAt).toBe(9999);
+    expect(row.status).toBe("active");
+    expect(row.contactId).toBe("c1");
+    expect(row.redeemedAt).toBeNull();
+    expect(row.createdAt).toBeGreaterThanOrEqual(before);
+    expect(row.updatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  test("createInvite defaults note=null and maxUses=1", () => {
+    seedContact("c1");
+    const row = new ContactStore().createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "hash-1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+    expect(row.note).toBeNull();
+    expect(row.maxUses).toBe(1);
+  });
+
+  test("getInviteById returns the row or null", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "hash-1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+
+    expect(store.getInviteById("inv1")?.id).toBe("inv1");
+    expect(store.getInviteById("nope")).toBeNull();
+  });
+
+  test("listInvites filters by sourceChannel/status/contactId and orders by createdAt desc", () => {
+    seedContact("c1");
+    seedContact("c2");
+    const store = new ContactStore();
+
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+    store.createInvite({
+      id: "inv2",
+      sourceChannel: "sms",
+      inviteCodeHash: "h2",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+    store.createInvite({
+      id: "inv3",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h3",
+      contactId: "c2",
+      expiresAt: 9999,
+    });
+
+    // No filters → all three, newest first.
+    const all = store.listInvites({});
+    expect(all.map((r) => r.id)).toEqual(["inv3", "inv2", "inv1"]);
+
+    expect(
+      store.listInvites({ sourceChannel: "vellum" }).map((r) => r.id),
+    ).toEqual(["inv3", "inv1"]);
+    expect(store.listInvites({ contactId: "c1" }).map((r) => r.id)).toEqual([
+      "inv2",
+      "inv1",
+    ]);
+    expect(store.listInvites({ status: "active" }).length).toBe(3);
+
+    // Combined filters.
+    expect(
+      store
+        .listInvites({ sourceChannel: "vellum", contactId: "c1" })
+        .map((r) => r.id),
+    ).toEqual(["inv1"]);
+  });
+
+  test("listInvites honors limit and offset", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    for (const id of ["inv1", "inv2", "inv3"]) {
+      store.createInvite({
+        id,
+        sourceChannel: "vellum",
+        inviteCodeHash: `h-${id}`,
+        contactId: "c1",
+        expiresAt: 9999,
+      });
+    }
+    expect(store.listInvites({ limit: 2 }).map((r) => r.id)).toEqual([
+      "inv3",
+      "inv2",
+    ]);
+    expect(store.listInvites({ limit: 2, offset: 2 }).map((r) => r.id)).toEqual([
+      "inv1",
+    ]);
+  });
+
+  test("full lifecycle: create → redeem (maxUses=1) flips to redeemed → revoke is no-op", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      maxUses: 1,
+      expiresAt: 9999,
+    });
+
+    const redeem = store.recordInviteRedemption({
+      inviteId: "inv1",
+      redeemedByExternalUserId: "u-ext",
+      redeemedByExternalChatId: "chat-ext",
+    });
+    expect(redeem.updated).toBe(true);
+    expect(redeem.row!.useCount).toBe(1);
+    expect(redeem.row!.status).toBe("redeemed");
+    expect(redeem.row!.redeemedByExternalUserId).toBe("u-ext");
+    expect(redeem.row!.redeemedByExternalChatId).toBe("chat-ext");
+    expect(redeem.row!.redeemedAt).not.toBeNull();
+
+    // Revoking a redeemed (non-active) invite is a no-op but returns the row.
+    const revoked = store.revokeInvite("inv1");
+    expect(revoked).not.toBeNull();
+    expect(revoked!.status).toBe("redeemed");
+  });
+
+  test("maxUses>1: status stays active until useCount reaches maxUses", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      maxUses: 2,
+      expiresAt: 9999,
+    });
+
+    const r1 = store.recordInviteRedemption({ inviteId: "inv1" });
+    expect(r1.updated).toBe(true);
+    expect(r1.row!.useCount).toBe(1);
+    expect(r1.row!.status).toBe("active");
+
+    const r2 = store.recordInviteRedemption({ inviteId: "inv1" });
+    expect(r2.updated).toBe(true);
+    expect(r2.row!.useCount).toBe(2);
+    expect(r2.row!.status).toBe("redeemed");
+
+    // Exhausted (non-active) → further redemptions are gated out.
+    const r3 = store.recordInviteRedemption({ inviteId: "inv1" });
+    expect(r3.updated).toBe(false);
+    expect(r3.row!.useCount).toBe(2);
+    expect(r3.row!.status).toBe("redeemed");
+  });
+
+  test("revokeInvite flips active → revoked, is idempotent, and returns null for unknown id", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+
+    const revoked = store.revokeInvite("inv1");
+    expect(revoked!.status).toBe("revoked");
+
+    // Idempotent re-revoke returns the current (already revoked) row.
+    const again = store.revokeInvite("inv1");
+    expect(again!.status).toBe("revoked");
+
+    // Unknown id → null.
+    expect(store.revokeInvite("nope")).toBeNull();
+  });
+
+  test("status-gated redemption race: a revoked invite cannot be redeemed", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      maxUses: 5,
+      expiresAt: 9999,
+    });
+
+    store.revokeInvite("inv1");
+
+    const redeem = store.recordInviteRedemption({ inviteId: "inv1" });
+    expect(redeem.updated).toBe(false);
+    expect(redeem.row!.status).toBe("revoked");
+    expect(redeem.row!.useCount).toBe(0);
+  });
+
+  test("recordInviteRedemption returns updated=false and null row for unknown id", () => {
+    const redeem = new ContactStore().recordInviteRedemption({
+      inviteId: "nope",
+    });
+    expect(redeem.updated).toBe(false);
+    expect(redeem.row).toBeNull();
+  });
+});

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -2165,20 +2165,35 @@ describe("handleCallInvite (gateway-native)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("returns 404 when the invite does not exist", async () => {
+  test("relays to the assistant when no gateway row exists (assistant-only invite)", async () => {
+    // Legacy/assistant-only invite: no gateway row, but a live row in
+    // assistant_ingress_invites. Mirror the list/revoke assistant-only fallback
+    // — don't 404; relay and let the daemon-local trigger validate its own row.
     contactStoreGetInviteByIdMock = mock(() => null);
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_trigger_call") {
+        return { callSid: "CA456" };
+      }
+      return {};
+    });
 
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleCallInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/nope/call", {
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
         method: "POST",
       }),
-      "nope",
+      "inv_1",
     );
 
-    expect(res.status).toBe(404);
-    expect((await res.json()).error.code).toBe("NOT_FOUND");
-    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.callSid).toBe("CA456");
+    expect(ipcCallAssistantMock.mock.calls[0]).toEqual([
+      "invites_trigger_call",
+      { pathParams: { id: "inv_1" } },
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("returns 400 when the invite is not active", async () => {

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -33,8 +33,27 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 type IpcCallFn = (method: string, params: unknown) => Promise<unknown>;
 let ipcCallAssistantMock: ReturnType<typeof mock<IpcCallFn>> = mock(async () => ({}));
 
+class IpcHandlerError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+  constructor(message: string, statusCode: number, code: string) {
+    super(message);
+    this.name = "IpcHandlerError";
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+class IpcTransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IpcTransportError";
+  }
+}
+
 mock.module("../ipc/assistant-client.js", () => ({
   ipcCallAssistant: (...args: Parameters<IpcCallFn>) => ipcCallAssistantMock(...args),
+  IpcHandlerError,
+  IpcTransportError,
 }));
 
 // ── ContactStore mock ─────────────────────────────────────────────────────────
@@ -84,10 +103,89 @@ let contactStoreDualWriteChannelMock: ReturnType<typeof mock<DualWriteChannelFn>
 type MergeFn = (keepId: string, mergeId: string) => Promise<typeof DEFAULT_MOCK_CONTACT | null>;
 let contactStoreMergeMock: ReturnType<typeof mock<MergeFn>> = mock(async () => null);
 
+// ── Invite method mocks ───────────────────────────────────────────────────────
+type InviteRow = {
+  id: string;
+  sourceChannel: string;
+  inviteCodeHash: string;
+  contactId: string;
+  note: string | null;
+  maxUses: number;
+  useCount: number;
+  expiresAt: number;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+};
+const DEFAULT_INVITE: InviteRow = {
+  id: "inv_1",
+  sourceChannel: "telegram",
+  inviteCodeHash: "hash_1",
+  contactId: "ct_1",
+  note: null,
+  maxUses: 1,
+  useCount: 0,
+  // Far-future so the redeem pre-gate's expiry check treats it as still valid.
+  expiresAt: 4_000_000_000_000,
+  status: "active",
+  createdAt: 1000000,
+  updatedAt: 1000000,
+};
+
+type GetContactFn = (contactId: string) => { id: string } | undefined;
+let contactStoreGetContactMock: ReturnType<typeof mock<GetContactFn>> = mock(
+  () => ({ id: "ct_1" }),
+);
+
+type ListInvitesFn = (params: unknown) => InviteRow[];
+let contactStoreListInvitesMock: ReturnType<typeof mock<ListInvitesFn>> = mock(
+  () => [],
+);
+
+type CreateInviteFn = (params: unknown) => InviteRow;
+let contactStoreCreateInviteMock: ReturnType<typeof mock<CreateInviteFn>> = mock(
+  () => DEFAULT_INVITE,
+);
+
+type RevokeInviteFn = (inviteId: string) => InviteRow | null;
+let contactStoreRevokeInviteMock: ReturnType<typeof mock<RevokeInviteFn>> = mock(
+  () => DEFAULT_INVITE,
+);
+
+type RecordRedemptionFn = (params: unknown) => {
+  updated: boolean;
+  row: InviteRow | null;
+};
+let contactStoreRecordRedemptionMock: ReturnType<
+  typeof mock<RecordRedemptionFn>
+> = mock(() => ({ updated: true, row: DEFAULT_INVITE }));
+
+type GetInviteByIdFn = (inviteId: string) => InviteRow | null;
+let contactStoreGetInviteByIdMock: ReturnType<typeof mock<GetInviteByIdFn>> =
+  mock(() => DEFAULT_INVITE);
+
 mock.module("../db/contact-store.js", () => ({
   ContactStore: class MockContactStore {
     upsertContact(...args: Parameters<UpsertFn>) {
       return contactStoreUpsertMock(...args);
+    }
+    getContact(contactId: string) {
+      return contactStoreGetContactMock(contactId);
+    }
+    listInvites(params: unknown) {
+      return contactStoreListInvitesMock(params);
+    }
+    createInvite(params: unknown) {
+      return contactStoreCreateInviteMock(params);
+    }
+    revokeInvite(inviteId: string) {
+      return contactStoreRevokeInviteMock(inviteId);
+    }
+    recordInviteRedemption(params: unknown) {
+      return contactStoreRecordRedemptionMock(params);
+    }
+    getInviteById(inviteId: string) {
+      return contactStoreGetInviteByIdMock(inviteId);
     }
     async listContactsWithInfo(opts?: {
       limit?: number;
@@ -177,6 +275,15 @@ afterEach(() => {
   contactStoreUpdateChannelMock = mock(() => null);
   contactStoreDualWriteChannelMock = mock(async () => {});
   contactStoreMergeMock = mock(async () => null);
+  contactStoreGetContactMock = mock(() => ({ id: "ct_1" }));
+  contactStoreListInvitesMock = mock(() => []);
+  contactStoreCreateInviteMock = mock(() => DEFAULT_INVITE);
+  contactStoreRevokeInviteMock = mock(() => DEFAULT_INVITE);
+  contactStoreRecordRedemptionMock = mock(() => ({
+    updated: true,
+    row: DEFAULT_INVITE,
+  }));
+  contactStoreGetInviteByIdMock = mock(() => DEFAULT_INVITE);
 });
 
 describe("contacts control-plane proxy", () => {
@@ -212,16 +319,8 @@ describe("contacts control-plane proxy", () => {
     ]);
   });
 
-  test("forwards invite endpoints to the runtime", async () => {
-    const captured: string[] = [];
-    fetchMock = mock(async (input: string | URL | Request) => {
-      captured.push(String(input));
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    });
-
+  test("invite handlers never proxy to the runtime", async () => {
+    // All five invite handlers are gateway-native; none should call fetch.
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
 
     await handler.handleListInvites(
@@ -230,11 +329,15 @@ describe("contacts control-plane proxy", () => {
     await handler.handleCreateInvite(
       new Request("http://localhost:7830/v1/contacts/invites", {
         method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contactId: "ct_1", sourceChannel: "telegram" }),
       }),
     );
     await handler.handleRedeemInvite(
       new Request("http://localhost:7830/v1/contacts/invites/redeem", {
         method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "tok", sourceChannel: "telegram" }),
       }),
     );
     await handler.handleRevokeInvite(
@@ -243,86 +346,14 @@ describe("contacts control-plane proxy", () => {
       }),
       "inv_123",
     );
-
-    expect(captured).toEqual([
-      "http://localhost:7821/v1/contacts/invites?status=active",
-      "http://localhost:7821/v1/contacts/invites",
-      "http://localhost:7821/v1/contacts/invites/redeem",
-      "http://localhost:7821/v1/contacts/invites/inv_123",
-    ]);
-  });
-
-  test("replaces caller auth with runtime auth", async () => {
-    let capturedHeaders: Headers | undefined;
-    fetchMock = mock(
-      async (_input: string | URL | Request, init?: RequestInit) => {
-        capturedHeaders = init?.headers as unknown as Headers;
-        return new Response("ok", { status: 200 });
-      },
-    );
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleCreateInvite(
-      new Request("http://localhost:7830/v1/contacts/invites", {
-        method: "POST",
-        headers: {
-          authorization: "Bearer caller-token",
-          host: "localhost:7830",
-        },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          externalUserId: "u_1",
-        }),
-      }),
-    );
-
-    expect(res.status).toBe(200);
-    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
-    expect(capturedHeaders?.has("host")).toBe(false);
-  });
-
-  test("passes through upstream client errors", async () => {
-    fetchMock = mock(async () => {
-      return new Response(
-        JSON.stringify({ ok: false, error: "sourceChannel is required" }),
-        {
-          status: 400,
-          headers: { "content-type": "application/json" },
-        },
-      );
-    });
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleCreateInvite(
-      new Request("http://localhost:7830/v1/contacts/invites", {
+    await handler.handleCallInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_123/call", {
         method: "POST",
       }),
+      "inv_123",
     );
 
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
-      ok: false,
-      error: "sourceChannel is required",
-    });
-  });
-
-  test("returns 504 when upstream times out", async () => {
-    fetchMock = mock(async () => {
-      throw new DOMException(
-        "The operation was aborted due to timeout",
-        "TimeoutError",
-      );
-    });
-
-    const handler = createContactsControlPlaneProxyHandler(
-      makeConfig({ runtimeTimeoutMs: 100 }),
-    );
-    const res = await handler.handleListInvites(
-      new Request("http://localhost:7830/v1/contacts/invites"),
-    );
-
-    expect(res.status).toBe(504);
-    expect(await res.json()).toEqual({ error: "Gateway Timeout" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("returns 502 when runtime is unreachable", async () => {
@@ -1340,3 +1371,853 @@ describe("handleMergeContacts (gateway-native)", () => {
     expect(body.error.message).toMatch(/guardian/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+describe("handleCreateInvite (gateway-native)", () => {
+  test("returns the assistant's minted invite payload (one-time codes), not the gateway row", async () => {
+    // The minted payload carries creation-only fields (inviteCode/token/share)
+    // that the gateway row does NOT — these must reach the client.
+    const mintInvite = {
+      id: "inv_1",
+      sourceChannel: "telegram",
+      inviteCode: "123456",
+      guardianInstruction: "Share this code with them first.",
+      token: "raw-token-abc",
+      share: { url: "https://t.me/bot?start=abc", displayText: "Open invite" },
+      status: "active",
+    };
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_mint") {
+        return {
+          ok: true,
+          invite: mintInvite,
+          rawToken: "raw-token-abc",
+          gateway: {
+            id: "inv_1",
+            inviteCodeHash: "hash_1",
+            sourceChannel: "telegram",
+            contactId: "ct_1",
+            note: null,
+            maxUses: 1,
+            expiresAt: 2000000,
+          },
+        };
+      }
+      return {};
+    });
+    contactStoreCreateInviteMock = mock(() => DEFAULT_INVITE);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contactId: "ct_1", sourceChannel: "telegram" }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.rawToken).toBe("raw-token-abc");
+    expect(body.invite.id).toBe("inv_1");
+    // One-time creation fields must come from the mint payload — the gateway
+    // row (DEFAULT_INVITE) carries none of these.
+    expect(body.invite.inviteCode).toBe("123456");
+    expect(body.invite.token).toBe("raw-token-abc");
+    expect(body.invite.guardianInstruction).toBe(
+      "Share this code with them first.",
+    );
+    expect(body.invite.share).toEqual({
+      url: "https://t.me/bot?start=abc",
+      displayText: "Open invite",
+    });
+    // Gateway row is still written as the lifecycle source of truth.
+    expect(contactStoreCreateInviteMock).toHaveBeenCalledTimes(1);
+    const [createParams] = contactStoreCreateInviteMock.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(createParams.id).toBe("inv_1");
+    expect(createParams.inviteCodeHash).toBe("hash_1");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns the minted voiceCode for phone invites", async () => {
+    const mintInvite = {
+      id: "inv_phone",
+      sourceChannel: "phone",
+      voiceCode: "987654",
+      voiceCodeDigits: 6,
+      status: "active",
+    };
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_mint") {
+        return {
+          ok: true,
+          invite: mintInvite,
+          // Voice invites never expose a token.
+          rawToken: undefined,
+          gateway: {
+            id: "inv_phone",
+            inviteCodeHash: "voicehash_1",
+            sourceChannel: "phone",
+            contactId: "ct_1",
+            note: null,
+            maxUses: 1,
+            expiresAt: 2000000,
+          },
+        };
+      }
+      return {};
+    });
+    contactStoreCreateInviteMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      id: "inv_phone",
+      sourceChannel: "phone",
+    }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          contactId: "ct_1",
+          sourceChannel: "phone",
+          expectedExternalUserId: "+15551234567",
+          friendName: "Sam",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.invite.voiceCode).toBe("987654");
+    expect(body.invite.id).toBe("inv_phone");
+  });
+
+  test("returns 400 for invalid JSON body", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe("BAD_REQUEST");
+    expect(contactStoreCreateInviteMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when sourceChannel is missing", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contactId: "ct_1" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/sourceChannel/);
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when contact does not exist", async () => {
+    contactStoreGetContactMock = mock(() => undefined);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contactId: "ct_missing", sourceChannel: "telegram" }),
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("NOT_FOUND");
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when gateway DB write fails (no proxy fallback)", async () => {
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_mint") {
+        return {
+          ok: true,
+          invite: { id: "inv_1" },
+          rawToken: "raw",
+          gateway: {
+            id: "inv_1",
+            inviteCodeHash: "hash_1",
+            sourceChannel: "telegram",
+            contactId: "ct_1",
+            note: null,
+            maxUses: 1,
+            expiresAt: 2000000,
+          },
+        };
+      }
+      return {};
+    });
+    contactStoreCreateInviteMock = mock(() => {
+      throw new Error("gateway DB unavailable");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contactId: "ct_1", sourceChannel: "telegram" }),
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error.code).toBe("INTERNAL_ERROR");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("maps assistant mint 400 (IpcHandlerError) to a 400 response", async () => {
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_mint") {
+        throw new IpcHandlerError(
+          "expectedExternalUserId is required for voice invites",
+          400,
+          "BAD_REQUEST",
+        );
+      }
+      return {};
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contactId: "ct_1", sourceChannel: "phone" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/expectedExternalUserId/);
+    expect(contactStoreCreateInviteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleListInvites (gateway-native)", () => {
+  test("returns gateway rows joined with assistant voice fields", async () => {
+    contactStoreListInvitesMock = mock(() => [
+      { ...DEFAULT_INVITE, id: "inv_1", sourceChannel: "phone" },
+    ]);
+    assistantDbQueryMock = mock(async () => [
+      {
+        id: "inv_1",
+        voiceCodeDigits: 6,
+        friendName: "Alice",
+        guardianName: "Bob",
+        expectedExternalUserId: "+15551234567",
+      },
+    ]);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/contacts/invites?status=active"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.invites).toHaveLength(1);
+    expect(body.invites[0].id).toBe("inv_1");
+    expect(body.invites[0].voiceCodeDigits).toBe(6);
+    expect(body.invites[0].friendName).toBe("Alice");
+    // The brute-forceable code hash must never be exposed in list responses.
+    expect(body.invites[0]).not.toHaveProperty("inviteCodeHash");
+    // status filter passed through to the store query.
+    expect(contactStoreListInvitesMock.mock.calls[0][0]).toEqual({
+      status: "active",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("degrades gracefully when the assistant voice-field join throws", async () => {
+    contactStoreListInvitesMock = mock(() => [
+      { ...DEFAULT_INVITE, id: "inv_1" },
+    ]);
+    assistantDbQueryMock = mock(async () => {
+      throw new Error("assistant DB down");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/contacts/invites"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invites).toHaveLength(1);
+    expect(body.invites[0].id).toBe("inv_1");
+    expect(body.invites[0].friendName).toBeUndefined();
+    expect(body.invites[0]).not.toHaveProperty("inviteCodeHash");
+  });
+
+  test("merges assistant-only invites (no gateway row) into the list, sanitized", async () => {
+    contactStoreListInvitesMock = mock(() => [
+      { ...DEFAULT_INVITE, id: "inv_gateway", sourceChannel: "telegram" },
+    ]);
+    // The voice-join SELECT and the assistant-only merge SELECT both go through
+    // assistantDbQuery; branch on the query text to return the right shape.
+    assistantDbQueryMock = mock(async (sql: string) => {
+      if (/FROM assistant_ingress_invites/.test(sql) && /max_uses/.test(sql)) {
+        // The assistant-only merge query (selects full row + voice fields).
+        return [
+          {
+            id: "inv_assistant_only",
+            sourceChannel: "telegram",
+            note: null,
+            maxUses: 1,
+            useCount: 0,
+            expiresAt: 4_000_000_000_000,
+            status: "active",
+            redeemedByExternalUserId: null,
+            redeemedByExternalChatId: null,
+            redeemedAt: null,
+            contactId: "ct_1",
+            createdAt: 1000000,
+            updatedAt: 1000000,
+            voiceCodeDigits: 6,
+            friendName: "Carol",
+            guardianName: null,
+            expectedExternalUserId: null,
+            // Hash columns are NOT selected by the merge query; assert below.
+          },
+        ];
+      }
+      // The voice-join query for gateway rows.
+      return [];
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/contacts/invites?status=active"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    const ids = body.invites.map((i: { id: string }) => i.id);
+    expect(ids).toContain("inv_gateway");
+    expect(ids).toContain("inv_assistant_only");
+    const assistantOnly = body.invites.find(
+      (i: { id: string }) => i.id === "inv_assistant_only",
+    );
+    expect(assistantOnly.voiceCodeDigits).toBe(6);
+    expect(assistantOnly.friendName).toBe("Carol");
+    // Assistant-only rows must be sanitized too — never leak a code hash.
+    expect(assistantOnly).not.toHaveProperty("inviteCodeHash");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("does not duplicate an invite present in both stores (gateway wins)", async () => {
+    contactStoreListInvitesMock = mock(() => [
+      { ...DEFAULT_INVITE, id: "inv_dupe", status: "redeemed" },
+    ]);
+    // Assistant DB also has inv_dupe (e.g. as 'active'); the merge must drop it
+    // because the gateway row already covers that id.
+    assistantDbQueryMock = mock(async (sql: string) => {
+      if (/FROM assistant_ingress_invites/.test(sql) && /max_uses/.test(sql)) {
+        return [
+          {
+            id: "inv_dupe",
+            sourceChannel: "telegram",
+            note: null,
+            maxUses: 1,
+            useCount: 0,
+            expiresAt: 4_000_000_000_000,
+            status: "active",
+            redeemedByExternalUserId: null,
+            redeemedByExternalChatId: null,
+            redeemedAt: null,
+            contactId: "ct_1",
+            createdAt: 1000000,
+            updatedAt: 1000000,
+            voiceCodeDigits: null,
+            friendName: null,
+            guardianName: null,
+            expectedExternalUserId: null,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/contacts/invites"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const dupes = body.invites.filter(
+      (i: { id: string }) => i.id === "inv_dupe",
+    );
+    expect(dupes).toHaveLength(1);
+    // The gateway row (lifecycle truth) wins: status is 'redeemed', not 'active'.
+    expect(dupes[0].status).toBe("redeemed");
+  });
+
+  test("degrades to gateway-only rows when the assistant-only merge query throws", async () => {
+    contactStoreListInvitesMock = mock(() => [
+      { ...DEFAULT_INVITE, id: "inv_gateway" },
+    ]);
+    assistantDbQueryMock = mock(async () => {
+      throw new Error("assistant DB down");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/contacts/invites"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invites).toHaveLength(1);
+    expect(body.invites[0].id).toBe("inv_gateway");
+    expect(body.invites[0]).not.toHaveProperty("inviteCodeHash");
+  });
+
+  test("returns 500 when the gateway read throws", async () => {
+    contactStoreListInvitesMock = mock(() => {
+      throw new Error("gateway DB unavailable");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/contacts/invites"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleRevokeInvite (gateway-native)", () => {
+  test("revokes the invite and mirrors into the assistant DB", async () => {
+    contactStoreRevokeInviteMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      status: "revoked",
+    }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1", {
+        method: "DELETE",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.invite.status).toBe("revoked");
+    // Revoke responses must not leak the brute-forceable code hash.
+    expect(body.invite).not.toHaveProperty("inviteCodeHash");
+    expect(contactStoreRevokeInviteMock).toHaveBeenCalledWith("inv_1");
+    // Best-effort assistant DB mirror reflects the gateway row's actual status.
+    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
+    expect(assistantDbRunMock.mock.calls[0][0]).toMatch(
+      /assistant_ingress_invites/,
+    );
+    expect(assistantDbRunMock.mock.calls[0][1]?.[0]).toBe("revoked");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("mirrors the gateway row's actual status for an already-redeemed invite", async () => {
+    // revokeInvite() only flips an ACTIVE row to revoked; an already-redeemed
+    // invite is returned unchanged. The mirror must NOT force 'revoked' — it
+    // must reflect the gateway row's real status so the stores stay in sync.
+    contactStoreRevokeInviteMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      status: "redeemed",
+    }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1", {
+        method: "DELETE",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invite.status).toBe("redeemed");
+    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
+    expect(assistantDbRunMock.mock.calls[0][1]?.[0]).toBe("redeemed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when the invite is absent from both the gateway and assistant DBs", async () => {
+    // No gateway row AND no assistant row: the SELECT re-read returns empty,
+    // so the invite is genuinely absent everywhere.
+    contactStoreRevokeInviteMock = mock(() => null);
+    assistantDbQueryMock = mock(async () => []);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/nope", {
+        method: "DELETE",
+      }),
+      "nope",
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("NOT_FOUND");
+  });
+
+  test("falls back to revoking the assistant row when no gateway row exists", async () => {
+    // Assistant-only invite: gateway revoke returns null, but the row exists in
+    // the assistant DB and gets flipped active -> revoked via the fallback.
+    contactStoreRevokeInviteMock = mock(() => null);
+    assistantDbQueryMock = mock(async () => [
+      {
+        id: "inv_assistant_only",
+        sourceChannel: "telegram",
+        note: null,
+        maxUses: 1,
+        useCount: 0,
+        expiresAt: 4_000_000_000_000,
+        status: "revoked",
+        redeemedByExternalUserId: null,
+        redeemedByExternalChatId: null,
+        redeemedAt: null,
+        contactId: "ct_1",
+        createdAt: 1000000,
+        updatedAt: 2000000,
+        voiceCodeDigits: null,
+        friendName: null,
+        guardianName: null,
+        expectedExternalUserId: null,
+      },
+    ]);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request(
+        "http://localhost:7830/v1/contacts/invites/inv_assistant_only",
+        { method: "DELETE" },
+      ),
+      "inv_assistant_only",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.invite.id).toBe("inv_assistant_only");
+    expect(body.invite.status).toBe("revoked");
+    expect(body.invite).not.toHaveProperty("inviteCodeHash");
+    // The assistant fallback UPDATE ran against assistant_ingress_invites.
+    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
+    expect(assistantDbRunMock.mock.calls[0][0]).toMatch(
+      /UPDATE assistant_ingress_invites SET status='revoked'/,
+    );
+    expect(assistantDbRunMock.mock.calls[0][1]?.[1]).toBe("inv_assistant_only");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("revoking a gateway-known invite uses the gateway path (no assistant fallback)", async () => {
+    contactStoreRevokeInviteMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      status: "revoked",
+    }));
+    // assistantDbQuery would only be hit by the fallback; it must NOT run here.
+    const assistantQuerySpy = mock(async () => []);
+    assistantDbQueryMock = assistantQuerySpy;
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1", {
+        method: "DELETE",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invite.status).toBe("revoked");
+    expect(contactStoreRevokeInviteMock).toHaveBeenCalledWith("inv_1");
+    // Gateway path mirrors via assistantDbRun but never SELECTs via the fallback.
+    expect(assistantQuerySpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("still succeeds when the assistant DB mirror soft-fails", async () => {
+    contactStoreRevokeInviteMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      status: "revoked",
+    }));
+    assistantDbRunMock = mock(async () => {
+      throw new Error("assistant DB down");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1", {
+        method: "DELETE",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 on unexpected gateway error (no proxy fallback)", async () => {
+    contactStoreRevokeInviteMock = mock(() => {
+      throw new Error("gateway DB unavailable");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1", {
+        method: "DELETE",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(500);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleRedeemInvite (gateway-native, thin relay)", () => {
+  // The assistant redemption service now owns the authoritative gateway claim
+  // (record_invite_redemption, by id, caller-scoped) for ALL paths — including
+  // this HTTP one, which relays into the same assistant redeem handlers. So the
+  // gateway HTTP handler is a thin relay: it must NOT claim, resolve, or record
+  // itself.
+
+  test("voice path relays to invites_redeem_voice and returns the result", async () => {
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_redeem_voice") {
+        return { type: "redeemed", memberId: "mem_1", inviteId: "inv_1" };
+      }
+      return {};
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRedeemInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/redeem", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          code: "123456",
+          callerExternalUserId: "+15551234567",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.type).toBe("redeemed");
+    expect(body.memberId).toBe("mem_1");
+    expect(body.inviteId).toBe("inv_1");
+    // Voice path relayed; the handler does NOT re-gate or re-mirror.
+    expect(ipcCallAssistantMock.mock.calls[0][0]).toBe("invites_redeem_voice");
+    expect(contactStoreRecordRedemptionMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("token path relays to invites_redeem_token and returns the invite", async () => {
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_redeem_token") {
+        return { invite: { id: "inv_1" }, type: "redeemed" };
+      }
+      return {};
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRedeemInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/redeem", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          token: "tok",
+          sourceChannel: "telegram",
+          externalUserId: "u_1",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.invite.id).toBe("inv_1");
+    // Redemption type must be relayed so callers can tell a real redeem apart
+    // from a no-op already_member (mirrors the voice path's shape).
+    expect(body.type).toBe("redeemed");
+    // Only the redeem IPC runs — no resolve pre-step, no gateway-side record.
+    const methods = ipcCallAssistantMock.mock.calls.map((c) => c[0]);
+    expect(methods).toEqual(["invites_redeem_token"]);
+    expect(methods).not.toContain("invites_resolve_token");
+    expect(contactStoreRecordRedemptionMock).not.toHaveBeenCalled();
+    expect(contactStoreGetInviteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test("token path relays the already_member type unchanged", async () => {
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_redeem_token") {
+        return { invite: { id: "inv_1" }, type: "already_member" };
+      }
+      return {};
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRedeemInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/redeem", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          token: "tok",
+          sourceChannel: "telegram",
+          externalUserId: "u_1",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.invite.id).toBe("inv_1");
+    expect(body.type).toBe("already_member");
+  });
+
+  test("returns 400 when token redeem is missing sourceChannel", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRedeemInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/redeem", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "tok" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("maps assistant redeem 400 (IpcHandlerError) to 400", async () => {
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_redeem_token") {
+        throw new IpcHandlerError("Invite not found", 400, "BAD_REQUEST");
+      }
+      return {};
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRedeemInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/redeem", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "tok", sourceChannel: "telegram" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/not found/);
+  });
+});
+
+describe("handleCallInvite (gateway-native)", () => {
+  test("relays the call for an active invite", async () => {
+    contactStoreGetInviteByIdMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      status: "active",
+    }));
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "invites_trigger_call") {
+        return { callSid: "CA123" };
+      }
+      return {};
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCallInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
+        method: "POST",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.callSid).toBe("CA123");
+    // The id must land at pathParams.id on the assistant route handler
+    // (handleTriggerInviteCall reads pathParams.id, not body).
+    expect(ipcCallAssistantMock.mock.calls[0]).toEqual([
+      "invites_trigger_call",
+      { pathParams: { id: "inv_1" } },
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when the invite does not exist", async () => {
+    contactStoreGetInviteByIdMock = mock(() => null);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCallInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/nope/call", {
+        method: "POST",
+      }),
+      "nope",
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("NOT_FOUND");
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when the invite is not active", async () => {
+    contactStoreGetInviteByIdMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      status: "revoked",
+    }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCallInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
+        method: "POST",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/not active/);
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when the call relay throws unexpectedly", async () => {
+    contactStoreGetInviteByIdMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      status: "active",
+    }));
+    ipcCallAssistantMock = mock(async () => {
+      throw new Error("ipc transport failure");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCallInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
+        method: "POST",
+      }),
+      "inv_1",
+    );
+
+    expect(res.status).toBe(500);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -1928,6 +1928,97 @@ describe("handleRevokeInvite (gateway-native)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test("assistant-only revoke is idempotent on an already-terminal row (UPDATE no-ops, 200 terminal)", async () => {
+    // No gateway row. The UPDATE succeeds but affects 0 rows because the invite
+    // is already redeemed; the SELECT then returns the terminal row. This is the
+    // legitimate idempotent revoke — must stay 200 with the terminal state.
+    contactStoreRevokeInviteMock = mock(() => null);
+    assistantDbRunMock = mock(async () => ({ changes: 0, lastInsertRowid: 0 }));
+    assistantDbQueryMock = mock(async () => [
+      {
+        id: "inv_terminal",
+        sourceChannel: "telegram",
+        note: null,
+        maxUses: 1,
+        useCount: 1,
+        expiresAt: 4_000_000_000_000,
+        status: "redeemed",
+        redeemedByExternalUserId: "ext_1",
+        redeemedByExternalChatId: "chat_1",
+        redeemedAt: 3000000,
+        contactId: "ct_1",
+        createdAt: 1000000,
+        updatedAt: 2000000,
+        voiceCodeDigits: null,
+        friendName: null,
+        guardianName: null,
+        expectedExternalUserId: null,
+      },
+    ]);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_terminal", {
+        method: "DELETE",
+      }),
+      "inv_terminal",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.invite.id).toBe("inv_terminal");
+    expect(body.invite.status).toBe("redeemed");
+  });
+
+  test("assistant-only revoke surfaces 500 when the fallback UPDATE throws (no false success)", async () => {
+    // No gateway row, so assistant_ingress_invites is the only store that can
+    // revoke. If the UPDATE write throws, the handler must NOT swallow it and
+    // return 200 with the still-active row — a guardian would believe the
+    // invite was revoked while it stays redeemable via the legacy path.
+    contactStoreRevokeInviteMock = mock(() => null);
+    assistantDbRunMock = mock(async () => {
+      throw new Error("assistant DB write failed");
+    });
+    // The SELECT would still find the row active — proving the write didn't land.
+    const assistantQuerySpy = mock(async () => [
+      {
+        id: "inv_assistant_only",
+        sourceChannel: "telegram",
+        note: null,
+        maxUses: 1,
+        useCount: 0,
+        expiresAt: 4_000_000_000_000,
+        status: "active",
+        redeemedByExternalUserId: null,
+        redeemedByExternalChatId: null,
+        redeemedAt: null,
+        contactId: "ct_1",
+        createdAt: 1000000,
+        updatedAt: 2000000,
+        voiceCodeDigits: null,
+        friendName: null,
+        guardianName: null,
+        expectedExternalUserId: null,
+      },
+    ]);
+    assistantDbQueryMock = assistantQuerySpy;
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request(
+        "http://localhost:7830/v1/contacts/invites/inv_assistant_only",
+        { method: "DELETE" },
+      ),
+      "inv_assistant_only",
+    );
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error.code).toBe("INTERNAL_ERROR");
+    // The handler must not have read back and returned the still-active row.
+    expect(assistantQuerySpy).not.toHaveBeenCalled();
+  });
+
   test("revoking a gateway-known invite uses the gateway path (no assistant fallback)", async () => {
     contactStoreRevokeInviteMock = mock(() => ({
       ...DEFAULT_INVITE,

--- a/gateway/src/__tests__/data-migration-m0007-backfill-ingress-invites.test.ts
+++ b/gateway/src/__tests__/data-migration-m0007-backfill-ingress-invites.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for m0007-backfill-ingress-invites.
+ *
+ * Verifies that assistant ingress invites are copied into the gateway
+ * `ingress_invites` table with the SAME id and correct column mapping (incl.
+ * the inviteCodeHash COALESCE for voice invites), are FK-safe (rows whose
+ * contact is missing from the gateway are skipped), are idempotent
+ * (INSERT OR IGNORE never duplicates or clobbers), and never drop/alter the
+ * assistant table. Uses the same fake-assistant-DB + real in-memory gateway-DB
+ * pattern as the m0006 reconcile test.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+
+import "./test-preload.js";
+
+// ── Fake assistant DB ───────────────────────────────────────────────────────
+
+type FakeInvite = {
+  id: string;
+  source_channel: string;
+  invite_code_hash: string | null;
+  voice_code_hash: string | null;
+  token_hash: string | null;
+  note: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: number;
+  status: string;
+  redeemed_by_external_user_id: string | null;
+  redeemed_by_external_chat_id: string | null;
+  redeemed_at: number | null;
+  contact_id: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+const fakeAssistantDb = {
+  invites: new Map<string, FakeInvite>(),
+  hasInvitesTable: true,
+  reset(): void {
+    this.invites.clear();
+    this.hasInvitesTable = true;
+  },
+};
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(async (sql: string) => {
+    const lower = sql.toLowerCase();
+    if (
+      lower.includes("sqlite_master") &&
+      lower.includes("'assistant_ingress_invites'")
+    ) {
+      return fakeAssistantDb.hasInvitesTable ? [{ "1": 1 }] : [];
+    }
+    if (lower.includes("from assistant_ingress_invites")) {
+      return Array.from(fakeAssistantDb.invites.values());
+    }
+    return [];
+  }),
+  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
+  assistantDbExec: mock(async () => undefined),
+}));
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, ingressInvites } from "../db/schema.js";
+import {
+  up as m0007Up,
+  down as m0007Down,
+} from "../db/data-migrations/m0007-backfill-ingress-invites.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(ingressInvites).run();
+  db.delete(contacts).run();
+  fakeAssistantDb.reset();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function seedGatewayContact(id: string): void {
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: `gw-${id}`,
+      role: "contact",
+      principalId: null,
+      createdAt: 500,
+      updatedAt: 500,
+    })
+    .run();
+}
+
+function seedAssistantInvite(opts: Partial<FakeInvite> & { id: string }): void {
+  // Defaults via spread so explicit `null` overrides (e.g. invite_code_hash:
+  // null for voice/token-only invites) are preserved rather than coalesced.
+  fakeAssistantDb.invites.set(opts.id, {
+    source_channel: "telegram",
+    invite_code_hash: "code-hash",
+    voice_code_hash: null,
+    token_hash: null,
+    note: null,
+    max_uses: 1,
+    use_count: 0,
+    expires_at: 9_999_999,
+    status: "active",
+    redeemed_by_external_user_id: null,
+    redeemed_by_external_chat_id: null,
+    redeemed_at: null,
+    contact_id: null,
+    created_at: 100,
+    updated_at: 200,
+    ...opts,
+  });
+}
+
+function gatewayInviteIds(): string[] {
+  const rows = getGatewayDb().$client
+    .prepare("SELECT id FROM ingress_invites")
+    .all() as { id: string }[];
+  return rows.map((r) => r.id).sort();
+}
+
+function gatewayInvite(id: string): Record<string, unknown> | undefined {
+  return getGatewayDb().$client
+    .prepare("SELECT * FROM ingress_invites WHERE id = ?")
+    .get(id) as Record<string, unknown> | undefined;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("m0007-backfill-ingress-invites", () => {
+  test("copies an active invite with the same id and full column mapping", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({
+      id: "inv-1",
+      contact_id: "c1",
+      source_channel: "telegram",
+      invite_code_hash: "the-code-hash",
+      note: "hello",
+      max_uses: 3,
+      use_count: 1,
+      expires_at: 12345,
+      status: "active",
+      created_at: 111,
+      updated_at: 222,
+    });
+
+    const result = await m0007Up();
+
+    expect(result).toBe("done");
+    expect(gatewayInviteIds()).toEqual(["inv-1"]);
+
+    const row = gatewayInvite("inv-1")!;
+    expect(row.id).toBe("inv-1");
+    expect(row.source_channel).toBe("telegram");
+    expect(row.invite_code_hash).toBe("the-code-hash");
+    expect(row.note).toBe("hello");
+    expect(row.max_uses).toBe(3);
+    expect(row.use_count).toBe(1);
+    expect(row.expires_at).toBe(12345);
+    expect(row.status).toBe("active");
+    expect(row.contact_id).toBe("c1");
+    expect(row.created_at).toBe(111);
+    expect(row.updated_at).toBe(222);
+  });
+
+  test("inviteCodeHash COALESCE picks voice_code_hash for a voice invite", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({
+      id: "voice-1",
+      contact_id: "c1",
+      invite_code_hash: null,
+      voice_code_hash: "voice-hash",
+      token_hash: null,
+    });
+
+    await m0007Up();
+
+    expect(gatewayInvite("voice-1")!.invite_code_hash).toBe("voice-hash");
+  });
+
+  test("inviteCodeHash COALESCE falls back to token_hash when both others null", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({
+      id: "tok-1",
+      contact_id: "c1",
+      invite_code_hash: null,
+      voice_code_hash: null,
+      token_hash: "token-hash",
+    });
+
+    await m0007Up();
+
+    expect(gatewayInvite("tok-1")!.invite_code_hash).toBe("token-hash");
+  });
+
+  test("copies terminal (redeemed) invites with their real status", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({
+      id: "redeemed-1",
+      contact_id: "c1",
+      status: "redeemed",
+      use_count: 1,
+      redeemed_by_external_user_id: "u-9",
+      redeemed_by_external_chat_id: "chat-9",
+      redeemed_at: 7777,
+    });
+
+    await m0007Up();
+
+    const row = gatewayInvite("redeemed-1")!;
+    expect(row.status).toBe("redeemed");
+    expect(row.redeemed_by_external_user_id).toBe("u-9");
+    expect(row.redeemed_by_external_chat_id).toBe("chat-9");
+    expect(row.redeemed_at).toBe(7777);
+  });
+
+  test("skips an invite whose contactId is absent from gateway contacts", async () => {
+    // No gateway contact seeded for "ghost".
+    seedAssistantInvite({ id: "orphan", contact_id: "ghost" });
+    seedGatewayContact("c1");
+    seedAssistantInvite({ id: "ok", contact_id: "c1" });
+
+    const result = await m0007Up();
+
+    expect(result).toBe("done");
+    // Orphan skipped, valid one still copied — migration completes.
+    expect(gatewayInviteIds()).toEqual(["ok"]);
+  });
+
+  test("skips an invite with a null contactId", async () => {
+    seedAssistantInvite({ id: "nullc", contact_id: null });
+
+    const result = await m0007Up();
+
+    expect(result).toBe("done");
+    expect(gatewayInviteIds()).toEqual([]);
+  });
+
+  test("skips an invite with no resolvable code hash", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({
+      id: "nocode",
+      contact_id: "c1",
+      invite_code_hash: null,
+      voice_code_hash: null,
+      token_hash: null,
+    });
+
+    const result = await m0007Up();
+
+    expect(result).toBe("done");
+    expect(gatewayInviteIds()).toEqual([]);
+  });
+
+  test("idempotent: running twice does not duplicate", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({ id: "inv-1", contact_id: "c1" });
+
+    await m0007Up();
+    await m0007Up();
+
+    expect(gatewayInviteIds()).toEqual(["inv-1"]);
+  });
+
+  test("INSERT OR IGNORE does not clobber a gateway row that already exists", async () => {
+    seedGatewayContact("c1");
+    // Pre-existing gateway row created post-migration with a different hash.
+    getGatewayDb()
+      .insert(ingressInvites)
+      .values({
+        id: "inv-1",
+        sourceChannel: "telegram",
+        inviteCodeHash: "gateway-native-hash",
+        note: "gateway-native",
+        maxUses: 1,
+        useCount: 0,
+        expiresAt: 1,
+        status: "active",
+        contactId: "c1",
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      .run();
+
+    seedAssistantInvite({
+      id: "inv-1",
+      contact_id: "c1",
+      invite_code_hash: "assistant-hash",
+      note: "assistant-note",
+    });
+
+    await m0007Up();
+
+    const row = gatewayInvite("inv-1")!;
+    // Gateway's version is preserved, not overwritten.
+    expect(row.invite_code_hash).toBe("gateway-native-hash");
+    expect(row.note).toBe("gateway-native");
+  });
+
+  test("does not drop or alter the assistant table (copy, not move)", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({ id: "inv-1", contact_id: "c1" });
+
+    await m0007Up();
+
+    // The fake assistant table still has the invite — nothing was dropped.
+    expect(fakeAssistantDb.hasInvitesTable).toBe(true);
+    expect(fakeAssistantDb.invites.has("inv-1")).toBe(true);
+  });
+
+  test("returns done when assistant DB has no invites table", async () => {
+    fakeAssistantDb.hasInvitesTable = false;
+
+    const result = await m0007Up();
+
+    expect(result).toBe("done");
+    expect(gatewayInviteIds()).toEqual([]);
+  });
+
+  test("down is a no-op (returns done)", () => {
+    expect(m0007Down()).toBe("done");
+  });
+});

--- a/gateway/src/__tests__/ipc-invite-routes.test.ts
+++ b/gateway/src/__tests__/ipc-invite-routes.test.ts
@@ -1,0 +1,197 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+} from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { createConnection, type Socket } from "node:net";
+import { GatewayIpcServer } from "../ipc/server.js";
+import { inviteRoutes } from "../ipc/invite-handlers.js";
+import { ContactStore } from "../db/contact-store.js";
+import { contacts, contactChannels, ingressInvites } from "../db/schema.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { testWorkspaceDir } from "./test-preload.js";
+
+const socketPath = join(testWorkspaceDir, "gateway.sock");
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(ingressInvites).run();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function connectClient(path: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const client = createConnection(path, () => resolve(client));
+    client.on("error", reject);
+  });
+}
+
+function sendRequest(
+  client: Socket,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ id: string; result?: unknown; error?: string }> {
+  return new Promise((resolve, reject) => {
+    const id = randomBytes(4).toString("hex");
+    let buffer = "";
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        client.off("data", onData);
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      }
+    };
+    client.on("data", onData);
+    client.write(JSON.stringify({ id, method, params }) + "\n");
+  });
+}
+
+/** Seed a parent contact (FK target for invites). */
+function seedContact(): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: "c1",
+      displayName: "Target",
+      role: "contact",
+      principalId: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+/** Insert an invite row directly with the supplied lifecycle fields. */
+function seedInvite(overrides: {
+  id: string;
+  status?: string;
+  maxUses?: number;
+  useCount?: number;
+  expiresAt?: number;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(ingressInvites)
+    .values({
+      id: overrides.id,
+      sourceChannel: "telegram",
+      inviteCodeHash: "hash-" + overrides.id,
+      note: null,
+      maxUses: overrides.maxUses ?? 1,
+      useCount: overrides.useCount ?? 0,
+      expiresAt: overrides.expiresAt ?? now + 60_000,
+      status: overrides.status ?? "active",
+      contactId: "c1",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// IPC route tests
+// ---------------------------------------------------------------------------
+
+describe("IPC invite routes", () => {
+  let server: InstanceType<typeof GatewayIpcServer>;
+  let client: Socket;
+
+  beforeEach(async () => {
+    if (existsSync(socketPath)) rmSync(socketPath);
+  });
+
+  afterEach(() => {
+    client?.destroy();
+    server?.stop();
+  });
+
+  async function startServerAndConnect(): Promise<void> {
+    server = new GatewayIpcServer([...inviteRoutes]);
+    (server as unknown as { socketPath: string }).socketPath = socketPath;
+    server.start();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    client = await connectClient(socketPath);
+  }
+
+  // ── record_invite_redemption ───────────────────────────────────────────
+
+  test("record_invite_redemption: validates params", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "record_invite_redemption", {});
+    expect(res.error).toBeDefined();
+    expect(res.error).toContain("Invalid params");
+  });
+
+  test("record_invite_redemption: bumps useCount on an active row", async () => {
+    seedContact();
+    seedInvite({ id: "inv-rec", maxUses: 1, useCount: 0 });
+    await startServerAndConnect();
+
+    const res = await sendRequest(client, "record_invite_redemption", {
+      inviteId: "inv-rec",
+      redeemedByExternalUserId: "u1",
+    });
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({ ok: true, updated: true, mirrored: true });
+
+    const row = new ContactStore(getGatewayDb()).getInviteById("inv-rec");
+    expect(row!.useCount).toBe(1);
+    expect(row!.status).toBe("redeemed");
+    expect(row!.redeemedByExternalUserId).toBe("u1");
+  });
+
+  test("record_invite_redemption: no-ops on an absent legacy row", async () => {
+    await startServerAndConnect();
+
+    const res = await sendRequest(client, "record_invite_redemption", {
+      inviteId: "legacy-missing",
+    });
+    expect(res.error).toBeUndefined();
+    // Absent row is valid (legacy invite) — no error, just not updated/mirrored.
+    expect(res.result).toEqual({ ok: true, updated: false, mirrored: false });
+  });
+
+  test("record_invite_redemption: no-ops (updated:false) on a revoked row", async () => {
+    seedContact();
+    seedInvite({ id: "inv-revoked-rec", status: "revoked" });
+    await startServerAndConnect();
+
+    const res = await sendRequest(client, "record_invite_redemption", {
+      inviteId: "inv-revoked-rec",
+    });
+    // Row exists (mirrored:true) but the gated update matched nothing.
+    expect(res.result).toEqual({ ok: true, updated: false, mirrored: true });
+  });
+});

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -8,7 +8,7 @@ import {
   assistantDbRun,
 } from "./assistant-db-proxy.js";
 import { type GatewayDb, getGatewayDb } from "./connection.js";
-import { contacts, contactChannels } from "./schema.js";
+import { contacts, contactChannels, ingressInvites } from "./schema.js";
 import {
   type ContactInfoFields,
   emptyContactInfo,
@@ -21,6 +21,7 @@ const log = getLogger("contact-store");
 
 export type Contact = typeof contacts.$inferSelect;
 export type ContactChannel = typeof contactChannels.$inferSelect;
+export type IngressInviteRow = typeof ingressInvites.$inferSelect;
 
 export class ContactStore {
   private injectedDb?: GatewayDb;
@@ -702,6 +703,142 @@ export class ContactStore {
     }
 
     return { channel: after, didWrite };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ingress invites (gateway DB only)
+  // ---------------------------------------------------------------------------
+  //
+  // The gateway DB's ingress_invites table is the single source of truth for
+  // contact invites. These methods are pure gateway-DB data access — the
+  // assistant owns token generation/hashing (it supplies `id` and
+  // `inviteCodeHash`), and any soft-fail dual-write lives in the HTTP handlers.
+
+  listInvites(params: {
+    sourceChannel?: string;
+    status?: string;
+    contactId?: string;
+    limit?: number;
+    offset?: number;
+  }): IngressInviteRow[] {
+    const conditions = [];
+    if (params.sourceChannel !== undefined)
+      conditions.push(eq(ingressInvites.sourceChannel, params.sourceChannel));
+    if (params.status !== undefined)
+      conditions.push(eq(ingressInvites.status, params.status));
+    if (params.contactId !== undefined)
+      conditions.push(eq(ingressInvites.contactId, params.contactId));
+
+    return this.db
+      .select()
+      .from(ingressInvites)
+      .where(conditions.length ? and(...conditions) : undefined)
+      // Secondary sort on id keeps ordering (and offset pagination) stable when
+      // multiple invites share a createdAt millisecond.
+      .orderBy(desc(ingressInvites.createdAt), desc(ingressInvites.id))
+      .limit(params.limit ?? 100)
+      .offset(params.offset ?? 0)
+      .all();
+  }
+
+  createInvite(params: {
+    id: string;
+    sourceChannel: string;
+    inviteCodeHash: string;
+    contactId: string;
+    note?: string | null;
+    maxUses?: number;
+    expiresAt: number;
+  }): IngressInviteRow {
+    const now = Date.now();
+    return this.db
+      .insert(ingressInvites)
+      .values({
+        id: params.id,
+        sourceChannel: params.sourceChannel,
+        inviteCodeHash: params.inviteCodeHash,
+        note: params.note ?? null,
+        maxUses: params.maxUses ?? 1,
+        useCount: 0,
+        expiresAt: params.expiresAt,
+        status: "active",
+        contactId: params.contactId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+  }
+
+  /**
+   * Revoke an active invite. Idempotent: re-revoking a non-active invite
+   * returns the current row without error, and returns null only when the
+   * invite id doesn't exist.
+   */
+  revokeInvite(inviteId: string): IngressInviteRow | null {
+    const now = Date.now();
+    this.db
+      .update(ingressInvites)
+      .set({ status: "revoked", updatedAt: now })
+      .where(
+        and(
+          eq(ingressInvites.id, inviteId),
+          eq(ingressInvites.status, "active"),
+        ),
+      )
+      .run();
+
+    return this.getInviteById(inviteId);
+  }
+
+  /**
+   * Record a redemption against an active invite: bump useCount, stamp
+   * redeemedAt / redeemedBy*, and flip status to "redeemed" once useCount
+   * reaches maxUses. Gated on status="active" so a revoked (or already
+   * exhausted) invite can't be redeemed under a race — `updated` is false in
+   * that case.
+   */
+  recordInviteRedemption(params: {
+    inviteId: string;
+    redeemedByExternalUserId?: string | null;
+    redeemedByExternalChatId?: string | null;
+  }): { updated: boolean; row: IngressInviteRow | null } {
+    const now = Date.now();
+    // RETURNING lets us tell a gated-out update (no active row matched) from a
+    // successful one without depending on the driver's `changes` count.
+    const updated = this.db
+      .update(ingressInvites)
+      .set({
+        useCount: sql`${ingressInvites.useCount} + 1`,
+        redeemedAt: now,
+        redeemedByExternalUserId: params.redeemedByExternalUserId ?? null,
+        redeemedByExternalChatId: params.redeemedByExternalChatId ?? null,
+        status: sql`CASE WHEN ${ingressInvites.useCount} + 1 >= ${ingressInvites.maxUses} THEN 'redeemed' ELSE 'active' END`,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(ingressInvites.id, params.inviteId),
+          eq(ingressInvites.status, "active"),
+        ),
+      )
+      .returning()
+      .all();
+
+    return {
+      updated: updated.length > 0,
+      row: updated[0] ?? this.getInviteById(params.inviteId),
+    };
+  }
+
+  getInviteById(inviteId: string): IngressInviteRow | null {
+    return (
+      this.db
+        .select()
+        .from(ingressInvites)
+        .where(eq(ingressInvites.id, inviteId))
+        .get() ?? null
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/gateway/src/db/data-migrations/index.ts
+++ b/gateway/src/db/data-migrations/index.ts
@@ -25,6 +25,7 @@ import * as m0003 from "./m0003-recover-backup-key.js";
 import * as m0004 from "./m0004-actor-token-hash-index-unfiltered.js";
 import * as m0005 from "./m0005-normalize-contact-channel-addresses.js";
 import * as m0006 from "./m0006-reconcile-contacts-from-assistant.js";
+import * as m0007 from "./m0007-backfill-ingress-invites.js";
 
 const log = getLogger("data-migrations");
 
@@ -42,6 +43,7 @@ const MIGRATIONS: { key: string; mod: MigrationModule }[] = [
   { key: "m0004-actor-token-hash-index-unfiltered", mod: m0004 },
   { key: "m0005-normalize-contact-channel-addresses", mod: m0005 },
   { key: "m0006-reconcile-contacts-from-assistant", mod: m0006 },
+  { key: "m0007-backfill-ingress-invites", mod: m0007 },
 ];
 
 /**

--- a/gateway/src/db/data-migrations/m0007-backfill-ingress-invites.ts
+++ b/gateway/src/db/data-migrations/m0007-backfill-ingress-invites.ts
@@ -1,0 +1,167 @@
+/**
+ * One-time migration: backfill assistant-only ingress invites into the gateway
+ * `ingress_invites` table so the gateway-native list/revoke/redeem paths work
+ * for invites created before this migration (or via the assistant IPC/CLI
+ * `invites_create` path, which only writes the assistant DB).
+ *
+ * This is a COPY/RECONCILE, not a move: the assistant `assistant_ingress_invites`
+ * table remains the assistant-side store (voice UX fields etc.). We only INSERT
+ * missing rows into the gateway table.
+ *
+ * Idempotent: uses INSERT OR IGNORE so gateway rows created post-migration are
+ * never overwritten. Safe to re-run.
+ *
+ * FK safety: gateway `ingress_invites.contactId` is a NOT NULL FK to `contacts`
+ * (ON DELETE CASCADE). Only rows whose contactId exists in the gateway
+ * `contacts` table are inserted; rows with a missing/null contact are skipped
+ * and counted so one bad row can't abort the whole backfill.
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getGatewayDb } from "../connection.js";
+import { getLogger } from "../../logger.js";
+import { assistantDbQuery } from "../assistant-db-proxy.js";
+
+import type { MigrationResult } from "./index.js";
+
+const log = getLogger("m0007-backfill-ingress-invites");
+
+function getRawGatewayDb(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+interface AssistantInviteRow {
+  id: string;
+  source_channel: string;
+  invite_code_hash: string | null;
+  voice_code_hash: string | null;
+  token_hash: string | null;
+  note: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: number;
+  status: string;
+  redeemed_by_external_user_id: string | null;
+  redeemed_by_external_chat_id: string | null;
+  redeemed_at: number | null;
+  contact_id: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export async function up(): Promise<MigrationResult> {
+  const gwDb = getRawGatewayDb();
+
+  try {
+    // ── 1. Bail if the assistant table doesn't exist (fresh install) ───────
+    const hasTable = await assistantDbQuery<{ "1": number }>(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assistant_ingress_invites'`,
+    );
+    if (hasTable.length === 0) {
+      log.info(
+        "Assistant DB has no assistant_ingress_invites table — nothing to backfill",
+      );
+      return "done";
+    }
+
+    // ── 2. Read every assistant invite (active + terminal) ─────────────────
+    // Copying terminal invites with their real status keeps the gateway list
+    // history-complete; INSERT OR IGNORE keeps this idempotent.
+    const rows = await assistantDbQuery<AssistantInviteRow>(
+      `SELECT id, source_channel, invite_code_hash, voice_code_hash, token_hash,
+              note, max_uses, use_count, expires_at, status,
+              redeemed_by_external_user_id, redeemed_by_external_chat_id,
+              redeemed_at, contact_id, created_at, updated_at
+         FROM assistant_ingress_invites`,
+    );
+
+    if (rows.length === 0) {
+      log.info("No assistant ingress invites to backfill");
+      return "done";
+    }
+
+    // ── 3. Resolve which contacts exist in the gateway (FK safety) ─────────
+    const gatewayContactIds = new Set(
+      gwDb
+        .prepare("SELECT id FROM contacts")
+        .all()
+        .map((r) => (r as { id: string }).id),
+    );
+
+    const insert = gwDb.prepare(
+      `INSERT OR IGNORE INTO ingress_invites
+         (id, source_channel, invite_code_hash, note, max_uses, use_count,
+          expires_at, status, redeemed_by_external_user_id,
+          redeemed_by_external_chat_id, redeemed_at, contact_id,
+          created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    let backfilled = 0;
+    let skippedMissingContact = 0;
+    let skippedNoCodeHash = 0;
+
+    const txn = gwDb.transaction(() => {
+      for (const row of rows) {
+        // FK safety: skip rows whose contact is null or absent in gateway.
+        if (!row.contact_id || !gatewayContactIds.has(row.contact_id)) {
+          skippedMissingContact += 1;
+          continue;
+        }
+
+        // inviteCodeHash is NOT NULL in the gateway. Token invites carry
+        // invite_code_hash; voice invites carry voice_code_hash; older rows
+        // may only have token_hash. Pick the first non-null.
+        const inviteCodeHash =
+          row.invite_code_hash ?? row.voice_code_hash ?? row.token_hash;
+        if (inviteCodeHash == null) {
+          skippedNoCodeHash += 1;
+          continue;
+        }
+
+        insert.run(
+          row.id,
+          row.source_channel,
+          inviteCodeHash,
+          row.note,
+          row.max_uses,
+          row.use_count,
+          row.expires_at,
+          row.status,
+          row.redeemed_by_external_user_id,
+          row.redeemed_by_external_chat_id,
+          row.redeemed_at,
+          row.contact_id,
+          row.created_at,
+          row.updated_at,
+        );
+        backfilled += 1;
+      }
+    });
+    txn();
+
+    log.info(
+      {
+        total: rows.length,
+        backfilled,
+        skippedMissingContact,
+        skippedNoCodeHash,
+      },
+      "m0007: backfilled assistant ingress invites into gateway",
+    );
+
+    return "done";
+  } catch (err) {
+    log.error(
+      { err },
+      "m0007: ingress invite backfill failed — will retry on next startup",
+    );
+    return "skip";
+  }
+}
+
+export function down(): MigrationResult {
+  // No-op: backfilled rows are legitimate gateway data; never delete on rollback.
+  return "done";
+}

--- a/gateway/src/http/routes/__tests__/invite-validation.test.ts
+++ b/gateway/src/http/routes/__tests__/invite-validation.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  parseCreateInviteBody,
+  parseRedeemInviteBody,
+  parseListInviteQuery,
+} from "../invite-validation.js";
+
+describe("parseCreateInviteBody", () => {
+  it("accepts a minimal valid body", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "telegram",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.contactId).toBe("contact-1");
+      expect(result.value.sourceChannel).toBe("telegram");
+    }
+  });
+
+  it("rejects a missing sourceChannel", () => {
+    const result = parseCreateInviteBody({ contactId: "contact-1" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
+    }
+  });
+
+  it("rejects an empty/whitespace sourceChannel", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "   ",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
+    }
+  });
+
+  it("accepts the full set of optional fields", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "phone",
+      note: "hello",
+      maxUses: 3,
+      expiresInMs: 60_000,
+      contactName: "Alice",
+      expectedExternalUserId: "+12025550100",
+      voiceCodeDigits: 4,
+      friendName: "Bob",
+      guardianName: "Carol",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.sourceChannel).toBe("phone");
+      expect(result.value.maxUses).toBe(3);
+    }
+  });
+
+  it("rejects a missing contactId", () => {
+    const result = parseCreateInviteBody({ note: "no contact" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("contactId");
+    }
+  });
+
+  it("rejects an empty/whitespace contactId", () => {
+    const result = parseCreateInviteBody({ contactId: "   " });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a negative maxUses", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "telegram",
+      maxUses: -1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("maxUses");
+    }
+  });
+
+  it("rejects a zero expiresInMs", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "telegram",
+      expiresInMs: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("expiresInMs");
+    }
+  });
+
+  it("rejects a non-object body", () => {
+    const result = parseCreateInviteBody("nope");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseRedeemInviteBody", () => {
+  it("discriminates the voice-code path", () => {
+    const result = parseRedeemInviteBody({
+      code: "1234",
+      callerExternalUserId: "+12025550101",
+      assistantId: "asst-1",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("voice");
+      if (result.value.kind === "voice") {
+        expect(result.value.code).toBe("1234");
+        expect(result.value.callerExternalUserId).toBe("+12025550101");
+      }
+    }
+  });
+
+  it("rejects a voice-code body missing callerExternalUserId", () => {
+    const result = parseRedeemInviteBody({ code: "1234" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("callerExternalUserId");
+    }
+  });
+
+  it("discriminates the token path", () => {
+    const result = parseRedeemInviteBody({
+      token: "tok-abc",
+      externalUserId: "user-1",
+      sourceChannel: "telegram",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("token");
+      if (result.value.kind === "token") {
+        expect(result.value.token).toBe("tok-abc");
+        expect(result.value.sourceChannel).toBe("telegram");
+      }
+    }
+  });
+
+  it("rejects a token body missing sourceChannel", () => {
+    const result = parseRedeemInviteBody({ token: "tok-abc" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
+    }
+  });
+
+  it("rejects a token body with empty/whitespace sourceChannel", () => {
+    const result = parseRedeemInviteBody({
+      token: "tok-abc",
+      sourceChannel: "   ",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
+    }
+  });
+
+  it("rejects a body with neither code nor token", () => {
+    const result = parseRedeemInviteBody({ sourceChannel: "telegram" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("token");
+    }
+  });
+});
+
+describe("parseListInviteQuery", () => {
+  it("returns an empty object for an empty query", () => {
+    const result = parseListInviteQuery(new URLSearchParams());
+    expect(result).toEqual({});
+  });
+
+  it("extracts sourceChannel and status when present", () => {
+    const result = parseListInviteQuery(
+      new URLSearchParams({ sourceChannel: "phone", status: "active" }),
+    );
+    expect(result).toEqual({ sourceChannel: "phone", status: "active" });
+  });
+});

--- a/gateway/src/http/routes/__tests__/invite-validation.test.ts
+++ b/gateway/src/http/routes/__tests__/invite-validation.test.ts
@@ -47,7 +47,6 @@ describe("parseCreateInviteBody", () => {
       expiresInMs: 60_000,
       contactName: "Alice",
       expectedExternalUserId: "+12025550100",
-      voiceCodeDigits: 4,
       friendName: "Bob",
       guardianName: "Carol",
     });

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -23,8 +23,16 @@ import {
 } from "../../db/contact-store.js";
 import { contacts } from "../../db/schema.js";
 import { fetchImpl } from "../../fetch.js";
-import { ipcCallAssistant } from "../../ipc/assistant-client.js";
+import {
+  IpcHandlerError,
+  ipcCallAssistant,
+} from "../../ipc/assistant-client.js";
 import { getLogger } from "../../logger.js";
+import {
+  parseCreateInviteBody,
+  parseListInviteQuery,
+  parseRedeemInviteBody,
+} from "./invite-validation.js";
 
 const log = getLogger("contacts-control-plane-proxy");
 
@@ -33,6 +41,206 @@ const log = getLogger("contacts-control-plane-proxy");
 // ---------------------------------------------------------------------------
 
 const VALID_CONTACT_TYPES = ["human", "assistant"] as const;
+
+// ---------------------------------------------------------------------------
+// Invite hashing + response sanitization
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip code/token hashes from a gateway invite row before returning it over
+ * HTTP. `inviteCodeHash` is the unsalted SHA-256 of a 6-digit code; returning
+ * it lets any list-capable caller brute-force the ~10^6 keyspace offline and
+ * redeem an active invite. All invite responses MUST go through this.
+ */
+function sanitizeInviteRow<T extends { inviteCodeHash?: unknown }>(
+  row: T,
+): Omit<T, "inviteCodeHash"> {
+  const { inviteCodeHash: _omit, ...rest } = row;
+  return rest;
+}
+
+/**
+ * Row shape read from the assistant `assistant_ingress_invites` table for the
+ * list merge. Deliberately omits every *_hash column so a code/token hash can
+ * never reach the wire (the gateway list never returns hashes).
+ */
+interface AssistantOnlyInviteRow {
+  id: string;
+  sourceChannel: string;
+  note: string | null;
+  maxUses: number;
+  useCount: number;
+  expiresAt: number;
+  status: string;
+  redeemedByExternalUserId: string | null;
+  redeemedByExternalChatId: string | null;
+  redeemedAt: number | null;
+  contactId: string | null;
+  createdAt: number;
+  updatedAt: number;
+  voiceCodeDigits: number | null;
+  friendName: string | null;
+  guardianName: string | null;
+  expectedExternalUserId: string | null;
+}
+
+/**
+ * Query assistant-only ingress invites (those without a gateway row) for the
+ * list merge. Applies the SAME sourceChannel/status filters the gateway list
+ * uses and excludes any id already present in the gateway result set (gateway
+ * is the lifecycle source of truth and wins on dedupe). Returns rows mapped
+ * into the gateway list response shape, already sanitized (no hash columns are
+ * selected). Throws on DB error so the caller can soft-fail to gateway-only.
+ */
+async function listAssistantOnlyInvites(
+  query: { sourceChannel?: string; status?: string },
+  gatewayIds: Set<string>,
+): Promise<Array<Record<string, unknown>>> {
+  const conditions: string[] = [];
+  const params: Array<string | number> = [];
+  if (query.sourceChannel !== undefined) {
+    conditions.push("source_channel = ?");
+    params.push(query.sourceChannel);
+  }
+  if (query.status !== undefined) {
+    conditions.push("status = ?");
+    params.push(query.status);
+  }
+  const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  const rows = await assistantDbQuery<AssistantOnlyInviteRow>(
+    `SELECT id,
+            source_channel              AS sourceChannel,
+            note,
+            max_uses                    AS maxUses,
+            use_count                   AS useCount,
+            expires_at                  AS expiresAt,
+            status,
+            redeemed_by_external_user_id AS redeemedByExternalUserId,
+            redeemed_by_external_chat_id AS redeemedByExternalChatId,
+            redeemed_at                 AS redeemedAt,
+            contact_id                  AS contactId,
+            created_at                  AS createdAt,
+            updated_at                  AS updatedAt,
+            voice_code_digits           AS voiceCodeDigits,
+            friend_name                 AS friendName,
+            guardian_name               AS guardianName,
+            expected_external_user_id   AS expectedExternalUserId
+       FROM assistant_ingress_invites
+       ${where}`,
+    params,
+  );
+
+  return rows
+    .filter((r) => !gatewayIds.has(r.id))
+    .map((r) => {
+      const {
+        voiceCodeDigits,
+        friendName,
+        guardianName,
+        expectedExternalUserId,
+        ...invite
+      } = r;
+      // No *_hash column is selected, so there's no code hash to strip — the
+      // sanitizeInviteRow invariant is satisfied at the query boundary.
+      return {
+        ...invite,
+        ...(voiceCodeDigits != null ? { voiceCodeDigits } : {}),
+        ...(friendName ? { friendName } : {}),
+        ...(guardianName ? { guardianName } : {}),
+        ...(expectedExternalUserId ? { expectedExternalUserId } : {}),
+      };
+    });
+}
+
+/**
+ * Revoke an invite that exists only in the assistant DB (no gateway row).
+ *
+ * Flips an active row to revoked, then SELECTs the row to distinguish
+ * "absent" (→ 404) from "present but already terminal" (→ success with the
+ * row's resulting state). Returns the sanitized invite shape on success.
+ * Idempotent: re-revoking an already-terminal invite returns success.
+ */
+async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
+  const now = Date.now();
+  // Best-effort: flip an ACTIVE row to revoked. A terminal row is untouched.
+  try {
+    await assistantDbRun(
+      "UPDATE assistant_ingress_invites SET status='revoked', updated_at=? WHERE id=? AND status='active'",
+      [now, inviteId],
+    );
+  } catch (err) {
+    log.warn(
+      { err, inviteId },
+      "revoke_invite: assistant-only fallback UPDATE failed (best-effort)",
+    );
+  }
+
+  // Re-read to determine existence and the resulting status.
+  const found = await assistantDbQuery<AssistantOnlyInviteRow>(
+    `SELECT id,
+            source_channel              AS sourceChannel,
+            note,
+            max_uses                    AS maxUses,
+            use_count                   AS useCount,
+            expires_at                  AS expiresAt,
+            status,
+            redeemed_by_external_user_id AS redeemedByExternalUserId,
+            redeemed_by_external_chat_id AS redeemedByExternalChatId,
+            redeemed_at                 AS redeemedAt,
+            contact_id                  AS contactId,
+            created_at                  AS createdAt,
+            updated_at                  AS updatedAt,
+            voice_code_digits           AS voiceCodeDigits,
+            friend_name                 AS friendName,
+            guardian_name               AS guardianName,
+            expected_external_user_id   AS expectedExternalUserId
+       FROM assistant_ingress_invites
+      WHERE id = ?`,
+    [inviteId],
+  );
+
+  const row = found[0];
+  if (!row) {
+    // Absent from BOTH the gateway and the assistant DB.
+    return Response.json(
+      {
+        error: {
+          code: "NOT_FOUND",
+          message: `Invite "${inviteId}" not found`,
+        },
+      },
+      { status: 404 },
+    );
+  }
+
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  const {
+    voiceCodeDigits,
+    friendName,
+    guardianName,
+    expectedExternalUserId,
+    ...invite
+  } = row;
+  log.info(
+    { inviteId, status: row.status },
+    "revoke_invite: handled via assistant-only fallback",
+  );
+  return Response.json({
+    ok: true,
+    invite: {
+      // No *_hash column is selected, so there's no code hash to strip.
+      ...invite,
+      ...(voiceCodeDigits != null ? { voiceCodeDigits } : {}),
+      ...(friendName ? { friendName } : {}),
+      ...(guardianName ? { guardianName } : {}),
+      ...(expectedExternalUserId ? { expectedExternalUserId } : {}),
+    },
+  });
+}
 
 // ---------------------------------------------------------------------------
 // ContactWithInfo -> ContactPayload mapping (gateway-native read path)
@@ -850,29 +1058,465 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       return Response.json({ ok: true, channel: result.channel });
     },
 
-    // ── Invite routes ──
+    // ── Invite routes (gateway-native) ──
+    //
+    // The gateway DB's ingress_invites is the source of truth for invite
+    // lifecycle. Token mint, voice/token redemption, and outbound call relay
+    // to the assistant over IPC (token secrecy + voice UX are assistant-owned);
+    // the gateway records the canonical ACL-relevant lifecycle. None of these
+    // handlers fall back to `forward` on error — mutations 500 instead.
+
+    /**
+     * GET /v1/contacts/invites — gateway-native invite list.
+     *
+     * Reads invite rows from the gateway DB (source of truth) and best-effort
+     * joins voice UX fields (voiceCode digits, friendName, etc.) from the
+     * assistant DB keyed on invite id. If the assistant join throws, returns
+     * the gateway rows without voice fields (stale over lost).
+     */
     async handleListInvites(req: Request): Promise<Response> {
       const url = new URL(req.url);
-      return forward(req, "/v1/contacts/invites", url.search);
+      const query = parseListInviteQuery(url.searchParams);
+
+      try {
+        const rows = new ContactStore().listInvites(query);
+
+        // Best-effort: join voice UX fields from the assistant DB.
+        const voiceById = new Map<string, Record<string, unknown>>();
+        if (rows.length > 0) {
+          try {
+            const ids = rows.map((r) => r.id);
+            const placeholders = ids.map(() => "?").join(", ");
+            const voiceRows = await assistantDbQuery<{
+              id: string;
+              voiceCodeDigits: number | null;
+              friendName: string | null;
+              guardianName: string | null;
+              expectedExternalUserId: string | null;
+            }>(
+              `SELECT id,
+                      voice_code_digits        AS voiceCodeDigits,
+                      friend_name              AS friendName,
+                      guardian_name            AS guardianName,
+                      expected_external_user_id AS expectedExternalUserId
+                 FROM assistant_ingress_invites
+                WHERE id IN (${placeholders})`,
+              ids,
+            );
+            for (const v of voiceRows) {
+              voiceById.set(v.id, {
+                ...(v.voiceCodeDigits != null
+                  ? { voiceCodeDigits: v.voiceCodeDigits }
+                  : {}),
+                ...(v.friendName ? { friendName: v.friendName } : {}),
+                ...(v.guardianName ? { guardianName: v.guardianName } : {}),
+                ...(v.expectedExternalUserId
+                  ? { expectedExternalUserId: v.expectedExternalUserId }
+                  : {}),
+              });
+            }
+          } catch (err) {
+            log.warn(
+              { err, count: rows.length },
+              "list_invites: assistant DB voice-field join failed; returning gateway rows only",
+            );
+          }
+        }
+
+        const invites: Array<Record<string, unknown>> = rows.map((r) => ({
+          ...sanitizeInviteRow(r),
+          ...(voiceById.get(r.id) ?? {}),
+        }));
+
+        // Belt-and-suspenders for the transitional window: invites created via
+        // the assistant IPC/CLI `invites_create` path write only the assistant
+        // DB (no gateway row), so they're invisible to this list until the
+        // m0007 backfill (one-time) or the CLI create flip. Merge in any
+        // assistant-only rows the gateway hasn't seen, applying the SAME
+        // filters and sanitization. Gateway wins on id (lifecycle truth).
+        try {
+          const gatewayIds = new Set(rows.map((r) => r.id));
+          const assistantOnly = await listAssistantOnlyInvites(
+            query,
+            gatewayIds,
+          );
+          for (const inv of assistantOnly) invites.push(inv);
+        } catch (err) {
+          log.warn(
+            { err },
+            "list_invites: assistant-only merge query failed; returning gateway rows only",
+          );
+        }
+
+        log.info(
+          { count: invites.length, ...query },
+          "list_invites: handled natively",
+        );
+        return Response.json({ ok: true, invites });
+      } catch (err) {
+        log.error({ err }, "list_invites: gateway-native read failed");
+        return Response.json(
+          {
+            error: { code: "INTERNAL_ERROR", message: "Failed to list invites" },
+          },
+          { status: 500 },
+        );
+      }
     },
 
+    /**
+     * POST /v1/contacts/invites — gateway-native invite create.
+     *
+     * Inverted dual-write vs contacts: the assistant mints first (it owns
+     * token secrecy + voice UX, writes voice fields, returns the raw token +
+     * projection), then the gateway records the canonical lifecycle row in its
+     * own DB (source of truth for ACL). If the gateway write throws → 500, no
+     * fallback: the assistant row already existing is stale-over-lost.
+     */
     async handleCreateInvite(req: Request): Promise<Response> {
-      return forward(req, "/v1/contacts/invites");
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json(
+          { error: { code: "BAD_REQUEST", message: "Invalid JSON body" } },
+          { status: 400 },
+        );
+      }
+
+      const parsed = parseCreateInviteBody(body);
+      if (!parsed.ok) {
+        return Response.json(
+          { error: { code: "BAD_REQUEST", message: parsed.message } },
+          { status: 400 },
+        );
+      }
+      const input = parsed.value;
+      const store = new ContactStore();
+
+      // Verify the contact exists in the gateway DB before minting.
+      if (!store.getContact(input.contactId)) {
+        return Response.json(
+          {
+            error: {
+              code: "NOT_FOUND",
+              message: `Contact "${input.contactId}" not found`,
+            },
+          },
+          { status: 404 },
+        );
+      }
+
+      // ── Assistant mints (token/hash + voice fields) ──────────────────
+      let mint: {
+        invite: Record<string, unknown>;
+        rawToken?: string;
+        gateway: {
+          id: string;
+          inviteCodeHash: string;
+          sourceChannel: string;
+          contactId: string;
+          note: string | null;
+          maxUses: number;
+          expiresAt: number;
+        };
+      };
+      try {
+        mint = (await ipcCallAssistant("invites_mint", {
+          body: input,
+        } as unknown as Record<string, unknown>)) as typeof mint;
+      } catch (err) {
+        if (err instanceof IpcHandlerError) {
+          return Response.json(
+            {
+              error: {
+                code: err.code,
+                message: err.message,
+              },
+            },
+            { status: err.statusCode },
+          );
+        }
+        log.error({ err, contactId: input.contactId }, "create_invite: mint failed");
+        return Response.json(
+          {
+            error: { code: "INTERNAL_ERROR", message: "Failed to mint invite" },
+          },
+          { status: 500 },
+        );
+      }
+
+      // ── Gateway DB write (source of truth) ───────────────────────────
+      const gw = mint.gateway;
+      let invite;
+      try {
+        invite = store.createInvite({
+          id: gw.id,
+          inviteCodeHash: gw.inviteCodeHash,
+          sourceChannel: gw.sourceChannel,
+          contactId: gw.contactId,
+          note: gw.note,
+          maxUses: gw.maxUses,
+          expiresAt: gw.expiresAt,
+        });
+      } catch (err) {
+        // The assistant already minted a row; the gateway record is what
+        // gates ACL, so a missing gateway row is a hard failure. No fallback.
+        log.error(
+          { err, inviteId: gw?.id, contactId: input.contactId },
+          "create_invite: gateway DB write failed — assistant invite row is now orphaned (stale over lost)",
+        );
+        return Response.json(
+          {
+            error: { code: "INTERNAL_ERROR", message: "Failed to record invite" },
+          },
+          { status: 500 },
+        );
+      }
+
+      // Notify connected clients.
+      void ipcCallAssistant("emit_event", {
+        body: { kind: "contacts_changed" },
+      } as unknown as Record<string, unknown>).catch(() => {});
+
+      log.info(
+        { inviteId: invite.id, contactId: input.contactId },
+        "create_invite: handled natively",
+      );
+      // The gateway row is the lifecycle source of truth, but the HTTP response
+      // must carry the assistant's minted one-time fields (voiceCode for phone;
+      // inviteCode/guardianInstruction/share/token for non-phone) — these are
+      // returned only at creation time and can never be fetched later.
+      return Response.json(
+        { ok: true, invite: mint.invite, rawToken: mint.rawToken },
+        { status: 201 },
+      );
     },
 
+    /**
+     * POST /v1/contacts/invites/redeem — gateway-native invite redeem.
+     *
+     * Voice and token redemption relay to the assistant (it owns the
+     * identity-bound voice code path + token hash lookup); the gateway mirrors
+     * the canonical redemption into its own DB (best-effort) so the invite
+     * lifecycle stays consistent.
+     */
     async handleRedeemInvite(req: Request): Promise<Response> {
-      return forward(req, "/v1/contacts/invites/redeem");
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json(
+          { error: { code: "BAD_REQUEST", message: "Invalid JSON body" } },
+          { status: 400 },
+        );
+      }
+
+      const parsed = parseRedeemInviteBody(body);
+      if (!parsed.ok) {
+        return Response.json(
+          { error: { code: "BAD_REQUEST", message: parsed.message } },
+          { status: 400 },
+        );
+      }
+      const input = parsed.value;
+
+      // Thin relay: the assistant redemption service now owns the authoritative
+      // gateway claim (record_invite_redemption, by id, caller-scoped) for ALL
+      // paths — including this HTTP one, since it relays into the same assistant
+      // redeem handlers. Re-claiming here would double-count uses, so the gateway
+      // handler just parses, relays, and returns.
+      try {
+        if (input.kind === "voice") {
+          const result = (await ipcCallAssistant("invites_redeem_voice", {
+            body: {
+              code: input.code,
+              callerExternalUserId: input.callerExternalUserId,
+              ...(input.assistantId ? { assistantId: input.assistantId } : {}),
+            },
+          } as unknown as Record<string, unknown>)) as {
+            type: string;
+            memberId?: string;
+            inviteId?: string;
+          };
+
+          log.info(
+            { type: result.type, inviteId: result.inviteId },
+            "redeem_invite(voice): relayed to assistant",
+          );
+          return Response.json({
+            ok: true,
+            type: result.type,
+            memberId: result.memberId,
+            ...(result.inviteId ? { inviteId: result.inviteId } : {}),
+          });
+        }
+
+        const result = (await ipcCallAssistant("invites_redeem_token", {
+          body: {
+            token: input.token,
+            sourceChannel: input.sourceChannel,
+            ...(input.externalUserId
+              ? { externalUserId: input.externalUserId }
+              : {}),
+            ...(input.externalChatId
+              ? { externalChatId: input.externalChatId }
+              : {}),
+          },
+        } as unknown as Record<string, unknown>)) as {
+          invite: { id: string };
+          type?: string;
+        };
+
+        log.info(
+          { inviteId: result.invite.id },
+          "redeem_invite(token): relayed to assistant",
+        );
+        return Response.json({
+          ok: true,
+          invite: result.invite,
+          ...(result.type ? { type: result.type } : {}),
+        });
+      } catch (err) {
+        if (err instanceof IpcHandlerError) {
+          return Response.json(
+            { error: { code: err.code, message: err.message } },
+            { status: err.statusCode },
+          );
+        }
+        log.error({ err }, "redeem_invite: relay failed");
+        return Response.json(
+          {
+            error: {
+              code: "INTERNAL_ERROR",
+              message: "Failed to redeem invite",
+            },
+          },
+          { status: 500 },
+        );
+      }
     },
 
-    async handleCallInvite(req: Request, inviteId: string): Promise<Response> {
-      return forward(req, `/v1/contacts/invites/${inviteId}/call`);
+    /**
+     * POST /v1/contacts/invites/:id/call — gateway-native outbound call relay.
+     *
+     * Verifies the invite exists + is active in the gateway DB (source of
+     * truth for lifecycle), then relays the provider-specific call to the
+     * assistant. The gateway gates; the assistant places the call.
+     */
+    async handleCallInvite(_req: Request, inviteId: string): Promise<Response> {
+      const invite = new ContactStore().getInviteById(inviteId);
+      if (!invite) {
+        return Response.json(
+          {
+            error: {
+              code: "NOT_FOUND",
+              message: `Invite "${inviteId}" not found`,
+            },
+          },
+          { status: 404 },
+        );
+      }
+      if (invite.status !== "active") {
+        return Response.json(
+          {
+            error: {
+              code: "BAD_REQUEST",
+              message: `Invite "${inviteId}" is not active`,
+            },
+          },
+          { status: 400 },
+        );
+      }
+
+      try {
+        // `invites_trigger_call` is the shared assistant route handler
+        // (handleTriggerInviteCall), which reads the id from pathParams.id. The
+        // assistant IPC server spreads `params` directly into RouteHandlerArgs,
+        // so send it as pathParams — not body.
+        const result = (await ipcCallAssistant("invites_trigger_call", {
+          pathParams: { id: inviteId },
+        } as unknown as Record<string, unknown>)) as { callSid: string };
+        log.info(
+          { inviteId, callSid: result.callSid },
+          "call_invite: handled natively",
+        );
+        return Response.json({ ok: true, callSid: result.callSid });
+      } catch (err) {
+        if (err instanceof IpcHandlerError) {
+          return Response.json(
+            { error: { code: err.code, message: err.message } },
+            { status: err.statusCode },
+          );
+        }
+        log.error({ err, inviteId }, "call_invite: relay failed");
+        return Response.json(
+          {
+            error: {
+              code: "INTERNAL_ERROR",
+              message: "Failed to trigger invite call",
+            },
+          },
+          { status: 500 },
+        );
+      }
     },
 
+    /**
+     * DELETE /v1/contacts/invites/:id — gateway-native invite revoke.
+     *
+     * Revokes the invite in the gateway DB (source of truth). 404 if the id
+     * is unknown. Best-effort mirror of the revoke into the assistant DB.
+     */
     async handleRevokeInvite(
-      req: Request,
+      _req: Request,
       inviteId: string,
     ): Promise<Response> {
-      return forward(req, `/v1/contacts/invites/${inviteId}`);
+      try {
+        const invite = new ContactStore().revokeInvite(inviteId);
+        if (!invite) {
+          // No gateway row. The invite may still exist assistant-only (created
+          // via the IPC/CLI path before the m0007 backfill or the CLI flip).
+          // Fall back to revoking the assistant row directly so guardians can
+          // still manage it from the gateway surface. 404 only when the invite
+          // is absent from BOTH stores.
+          return await revokeAssistantOnlyInvite(inviteId);
+        }
+
+        // Best-effort mirror into the assistant DB. revokeInvite() only flips an
+        // ACTIVE row to revoked — an already redeemed/expired invite is returned
+        // unchanged. Mirror the gateway row's ACTUAL post-revoke status so the
+        // two lifecycle stores stay in sync instead of forcing 'revoked'.
+        try {
+          await assistantDbRun(
+            "UPDATE assistant_ingress_invites SET status=?, updated_at=? WHERE id=?",
+            [invite.status, Date.now(), inviteId],
+          );
+        } catch (err) {
+          log.warn(
+            { err, inviteId },
+            "revoke_invite: assistant DB mirror failed (best-effort)",
+          );
+        }
+
+        void ipcCallAssistant("emit_event", {
+          body: { kind: "contacts_changed" },
+        } as unknown as Record<string, unknown>).catch(() => {});
+
+        log.info({ inviteId }, "revoke_invite: handled natively");
+        return Response.json({ ok: true, invite: sanitizeInviteRow(invite) });
+      } catch (err) {
+        log.error({ err, inviteId }, "revoke_invite: gateway-native revoke failed");
+        return Response.json(
+          {
+            error: {
+              code: "INTERNAL_ERROR",
+              message: "Failed to revoke invite",
+            },
+          },
+          { status: 500 },
+        );
+      }
     },
   };
 }

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -32,9 +32,53 @@ import {
   parseCreateInviteBody,
   parseListInviteQuery,
   parseRedeemInviteBody,
+  type CreateInviteInput,
+  type ListInviteQuery,
 } from "./invite-validation.js";
 
 const log = getLogger("contacts-control-plane-proxy");
+
+// ---------------------------------------------------------------------------
+// Transport-agnostic invite native errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Error thrown by the transport-agnostic invite native functions to signal a
+ * client-facing failure with a stable code + status. The HTTP handlers map it
+ * to `Response.json`; the gateway IPC routes let it propagate (the IPC server
+ * stringifies thrown errors into the wire `error` field).
+ */
+export class InviteNativeError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+
+  constructor(message: string, statusCode: number, code: string) {
+    super(message);
+    this.name = "InviteNativeError";
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
+/** Map an InviteNativeError (or generic error) to the HTTP error Response. */
+function inviteErrorResponse(err: unknown): Response {
+  if (err instanceof InviteNativeError) {
+    return Response.json(
+      { error: { code: err.code, message: err.message } },
+      { status: err.statusCode },
+    );
+  }
+  if (err instanceof IpcHandlerError) {
+    return Response.json(
+      { error: { code: err.code, message: err.message } },
+      { status: err.statusCode },
+    );
+  }
+  return Response.json(
+    { error: { code: "INTERNAL_ERROR", message: "Internal error" } },
+    { status: 500 },
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Validation constants (mirrored from assistant/src/runtime/routes/contact-routes.ts)
@@ -157,11 +201,13 @@ async function listAssistantOnlyInvites(
  * Revoke an invite that exists only in the assistant DB (no gateway row).
  *
  * Flips an active row to revoked, then SELECTs the row to distinguish
- * "absent" (→ 404) from "present but already terminal" (→ success with the
- * row's resulting state). Returns the sanitized invite shape on success.
+ * "absent" (→ throw 404) from "present but already terminal" (→ success with
+ * the row's resulting state). Returns the sanitized invite shape on success.
  * Idempotent: re-revoking an already-terminal invite returns success.
  */
-async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
+async function revokeAssistantOnlyInviteNative(
+  inviteId: string,
+): Promise<{ invite: Record<string, unknown> }> {
   const now = Date.now();
   // Best-effort: flip an ACTIVE row to revoked. A terminal row is untouched.
   try {
@@ -203,14 +249,10 @@ async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
   const row = found[0];
   if (!row) {
     // Absent from BOTH the gateway and the assistant DB.
-    return Response.json(
-      {
-        error: {
-          code: "NOT_FOUND",
-          message: `Invite "${inviteId}" not found`,
-        },
-      },
-      { status: 404 },
+    throw new InviteNativeError(
+      `Invite "${inviteId}" not found`,
+      404,
+      "NOT_FOUND",
     );
   }
 
@@ -229,8 +271,7 @@ async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
     { inviteId, status: row.status },
     "revoke_invite: handled via assistant-only fallback",
   );
-  return Response.json({
-    ok: true,
+  return {
     invite: {
       // No *_hash column is selected, so there's no code hash to strip.
       ...invite,
@@ -239,7 +280,291 @@ async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
       ...(guardianName ? { guardianName } : {}),
       ...(expectedExternalUserId ? { expectedExternalUserId } : {}),
     },
-  });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transport-agnostic invite native functions
+//
+// These hold the ONE implementation shared by the gateway HTTP invite handlers
+// and the gateway IPC invite routes (gateway/src/ipc/invite-handlers.ts). They
+// return plain data (never a `Response`) and signal failures by throwing
+// InviteNativeError / IpcHandlerError so each transport can translate the
+// error into its own envelope (HTTP status code vs IPC error string). Behavior
+// here MUST stay identical to the prior inline HTTP handler bodies.
+// ---------------------------------------------------------------------------
+
+/**
+ * List invites (gateway rows + best-effort voice-field join + assistant-only
+ * merge), sanitized (no inviteCodeHash). Throws InviteNativeError(500) when the
+ * gateway read itself fails. The voice-join and assistant-only merge soft-fail.
+ */
+export async function listInvitesNative(
+  query: ListInviteQuery,
+): Promise<{ invites: Array<Record<string, unknown>> }> {
+  let rows;
+  try {
+    rows = new ContactStore().listInvites(query);
+  } catch (err) {
+    log.error({ err }, "list_invites: gateway-native read failed");
+    throw new InviteNativeError(
+      "Failed to list invites",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
+
+  // Best-effort: join voice UX fields from the assistant DB.
+  const voiceById = new Map<string, Record<string, unknown>>();
+  if (rows.length > 0) {
+    try {
+      const ids = rows.map((r) => r.id);
+      const placeholders = ids.map(() => "?").join(", ");
+      const voiceRows = await assistantDbQuery<{
+        id: string;
+        voiceCodeDigits: number | null;
+        friendName: string | null;
+        guardianName: string | null;
+        expectedExternalUserId: string | null;
+      }>(
+        `SELECT id,
+                voice_code_digits        AS voiceCodeDigits,
+                friend_name              AS friendName,
+                guardian_name            AS guardianName,
+                expected_external_user_id AS expectedExternalUserId
+           FROM assistant_ingress_invites
+          WHERE id IN (${placeholders})`,
+        ids,
+      );
+      for (const v of voiceRows) {
+        voiceById.set(v.id, {
+          ...(v.voiceCodeDigits != null
+            ? { voiceCodeDigits: v.voiceCodeDigits }
+            : {}),
+          ...(v.friendName ? { friendName: v.friendName } : {}),
+          ...(v.guardianName ? { guardianName: v.guardianName } : {}),
+          ...(v.expectedExternalUserId
+            ? { expectedExternalUserId: v.expectedExternalUserId }
+            : {}),
+        });
+      }
+    } catch (err) {
+      log.warn(
+        { err, count: rows.length },
+        "list_invites: assistant DB voice-field join failed; returning gateway rows only",
+      );
+    }
+  }
+
+  const invites: Array<Record<string, unknown>> = rows.map((r) => ({
+    ...sanitizeInviteRow(r),
+    ...(voiceById.get(r.id) ?? {}),
+  }));
+
+  // Belt-and-suspenders for the transitional window: merge in assistant-only
+  // rows (created via the IPC/CLI path with no gateway row), applying the SAME
+  // filters and sanitization. Gateway wins on id (lifecycle truth).
+  try {
+    const gatewayIds = new Set(rows.map((r) => r.id));
+    const assistantOnly = await listAssistantOnlyInvites(query, gatewayIds);
+    for (const inv of assistantOnly) invites.push(inv);
+  } catch (err) {
+    log.warn(
+      { err },
+      "list_invites: assistant-only merge query failed; returning gateway rows only",
+    );
+  }
+
+  log.info({ count: invites.length, ...query }, "list_invites: handled natively");
+  return { invites };
+}
+
+/**
+ * Create an invite: verify the contact exists, relay to the assistant mint
+ * (token/hash + voice fields), then write the canonical gateway lifecycle row.
+ * Returns the assistant's minted one-time payload + rawToken. Throws
+ * InviteNativeError(404) when the contact is unknown, InviteNativeError(500)
+ * when the mint or gateway write fails, and propagates an assistant mint
+ * IpcHandlerError unchanged so its status/code reach the caller.
+ */
+export async function createInviteNative(
+  input: CreateInviteInput,
+): Promise<{ invite: Record<string, unknown>; rawToken?: string }> {
+  const store = new ContactStore();
+
+  // Verify the contact exists in the gateway DB before minting.
+  if (!store.getContact(input.contactId)) {
+    throw new InviteNativeError(
+      `Contact "${input.contactId}" not found`,
+      404,
+      "NOT_FOUND",
+    );
+  }
+
+  // ── Assistant mints (token/hash + voice fields) ──────────────────
+  let mint: {
+    invite: Record<string, unknown>;
+    rawToken?: string;
+    gateway: {
+      id: string;
+      inviteCodeHash: string;
+      sourceChannel: string;
+      contactId: string;
+      note: string | null;
+      maxUses: number;
+      expiresAt: number;
+    };
+  };
+  try {
+    mint = (await ipcCallAssistant("invites_mint", {
+      body: input,
+    } as unknown as Record<string, unknown>)) as typeof mint;
+  } catch (err) {
+    if (err instanceof IpcHandlerError) {
+      // Propagate the assistant's status/code unchanged.
+      throw err;
+    }
+    log.error({ err, contactId: input.contactId }, "create_invite: mint failed");
+    throw new InviteNativeError("Failed to mint invite", 500, "INTERNAL_ERROR");
+  }
+
+  // ── Gateway DB write (source of truth) ───────────────────────────
+  const gw = mint.gateway;
+  let invite;
+  try {
+    invite = store.createInvite({
+      id: gw.id,
+      inviteCodeHash: gw.inviteCodeHash,
+      sourceChannel: gw.sourceChannel,
+      contactId: gw.contactId,
+      note: gw.note,
+      maxUses: gw.maxUses,
+      expiresAt: gw.expiresAt,
+    });
+  } catch (err) {
+    log.error(
+      { err, inviteId: gw?.id, contactId: input.contactId },
+      "create_invite: gateway DB write failed — assistant invite row is now orphaned (stale over lost)",
+    );
+    throw new InviteNativeError(
+      "Failed to record invite",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
+
+  // Notify connected clients.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  log.info(
+    { inviteId: invite.id, contactId: input.contactId },
+    "create_invite: handled natively",
+  );
+  // The gateway row is the lifecycle source of truth, but the response must
+  // carry the assistant's minted one-time fields (voiceCode for phone;
+  // inviteCode/guardianInstruction/share/token for non-phone) — returned only
+  // at creation time and never fetchable later.
+  return { invite: mint.invite, rawToken: mint.rawToken };
+}
+
+/**
+ * Revoke an invite: flip the gateway row (source of truth), best-effort mirror
+ * the actual post-revoke status into the assistant DB, and fall back to
+ * revoking the assistant-only row when no gateway row exists. Returns the
+ * sanitized invite. Throws InviteNativeError(404) only when the invite is
+ * absent from BOTH stores, InviteNativeError(500) on unexpected gateway error.
+ */
+export async function revokeInviteNative(
+  inviteId: string,
+): Promise<{ invite: Record<string, unknown> }> {
+  let invite;
+  try {
+    invite = new ContactStore().revokeInvite(inviteId);
+  } catch (err) {
+    log.error({ err, inviteId }, "revoke_invite: gateway-native revoke failed");
+    throw new InviteNativeError(
+      "Failed to revoke invite",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
+
+  if (!invite) {
+    // No gateway row. Fall back to revoking the assistant-only row; 404 only
+    // when absent from BOTH stores.
+    return await revokeAssistantOnlyInviteNative(inviteId);
+  }
+
+  // Best-effort mirror into the assistant DB — reflect the gateway row's ACTUAL
+  // post-revoke status (revokeInvite only flips ACTIVE rows) so the two stores
+  // stay in sync instead of forcing 'revoked'.
+  try {
+    await assistantDbRun(
+      "UPDATE assistant_ingress_invites SET status=?, updated_at=? WHERE id=?",
+      [invite.status, Date.now(), inviteId],
+    );
+  } catch (err) {
+    log.warn(
+      { err, inviteId },
+      "revoke_invite: assistant DB mirror failed (best-effort)",
+    );
+  }
+
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  log.info({ inviteId }, "revoke_invite: handled natively");
+  return { invite: sanitizeInviteRow(invite) };
+}
+
+/**
+ * Verify the invite exists + is active in the gateway DB (lifecycle source of
+ * truth) then relay the provider-specific outbound call to the assistant.
+ * Returns the provider call sid. Throws InviteNativeError(404) when the invite
+ * is unknown, InviteNativeError(400) when it isn't active, InviteNativeError(500)
+ * on relay failure, and propagates an assistant IpcHandlerError unchanged.
+ */
+export async function triggerInviteCallNative(
+  inviteId: string,
+): Promise<{ callSid: string }> {
+  const invite = new ContactStore().getInviteById(inviteId);
+  if (!invite) {
+    throw new InviteNativeError(
+      `Invite "${inviteId}" not found`,
+      404,
+      "NOT_FOUND",
+    );
+  }
+  if (invite.status !== "active") {
+    throw new InviteNativeError(
+      `Invite "${inviteId}" is not active`,
+      400,
+      "BAD_REQUEST",
+    );
+  }
+
+  try {
+    // `invites_trigger_call` reads the id from pathParams.id (the assistant IPC
+    // server spreads params into RouteHandlerArgs) — send pathParams, not body.
+    const result = (await ipcCallAssistant("invites_trigger_call", {
+      pathParams: { id: inviteId },
+    } as unknown as Record<string, unknown>)) as { callSid: string };
+    log.info({ inviteId, callSid: result.callSid }, "call_invite: handled natively");
+    return { callSid: result.callSid };
+  } catch (err) {
+    if (err instanceof IpcHandlerError) {
+      throw err;
+    }
+    log.error({ err, inviteId }, "call_invite: relay failed");
+    throw new InviteNativeError(
+      "Failed to trigger invite call",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1077,90 +1402,11 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     async handleListInvites(req: Request): Promise<Response> {
       const url = new URL(req.url);
       const query = parseListInviteQuery(url.searchParams);
-
       try {
-        const rows = new ContactStore().listInvites(query);
-
-        // Best-effort: join voice UX fields from the assistant DB.
-        const voiceById = new Map<string, Record<string, unknown>>();
-        if (rows.length > 0) {
-          try {
-            const ids = rows.map((r) => r.id);
-            const placeholders = ids.map(() => "?").join(", ");
-            const voiceRows = await assistantDbQuery<{
-              id: string;
-              voiceCodeDigits: number | null;
-              friendName: string | null;
-              guardianName: string | null;
-              expectedExternalUserId: string | null;
-            }>(
-              `SELECT id,
-                      voice_code_digits        AS voiceCodeDigits,
-                      friend_name              AS friendName,
-                      guardian_name            AS guardianName,
-                      expected_external_user_id AS expectedExternalUserId
-                 FROM assistant_ingress_invites
-                WHERE id IN (${placeholders})`,
-              ids,
-            );
-            for (const v of voiceRows) {
-              voiceById.set(v.id, {
-                ...(v.voiceCodeDigits != null
-                  ? { voiceCodeDigits: v.voiceCodeDigits }
-                  : {}),
-                ...(v.friendName ? { friendName: v.friendName } : {}),
-                ...(v.guardianName ? { guardianName: v.guardianName } : {}),
-                ...(v.expectedExternalUserId
-                  ? { expectedExternalUserId: v.expectedExternalUserId }
-                  : {}),
-              });
-            }
-          } catch (err) {
-            log.warn(
-              { err, count: rows.length },
-              "list_invites: assistant DB voice-field join failed; returning gateway rows only",
-            );
-          }
-        }
-
-        const invites: Array<Record<string, unknown>> = rows.map((r) => ({
-          ...sanitizeInviteRow(r),
-          ...(voiceById.get(r.id) ?? {}),
-        }));
-
-        // Belt-and-suspenders for the transitional window: invites created via
-        // the assistant IPC/CLI `invites_create` path write only the assistant
-        // DB (no gateway row), so they're invisible to this list until the
-        // m0007 backfill (one-time) or the CLI create flip. Merge in any
-        // assistant-only rows the gateway hasn't seen, applying the SAME
-        // filters and sanitization. Gateway wins on id (lifecycle truth).
-        try {
-          const gatewayIds = new Set(rows.map((r) => r.id));
-          const assistantOnly = await listAssistantOnlyInvites(
-            query,
-            gatewayIds,
-          );
-          for (const inv of assistantOnly) invites.push(inv);
-        } catch (err) {
-          log.warn(
-            { err },
-            "list_invites: assistant-only merge query failed; returning gateway rows only",
-          );
-        }
-
-        log.info(
-          { count: invites.length, ...query },
-          "list_invites: handled natively",
-        );
+        const { invites } = await listInvitesNative(query);
         return Response.json({ ok: true, invites });
       } catch (err) {
-        log.error({ err }, "list_invites: gateway-native read failed");
-        return Response.json(
-          {
-            error: { code: "INTERNAL_ERROR", message: "Failed to list invites" },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
     },
 
@@ -1191,106 +1437,16 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
           { status: 400 },
         );
       }
-      const input = parsed.value;
-      const store = new ContactStore();
 
-      // Verify the contact exists in the gateway DB before minting.
-      if (!store.getContact(input.contactId)) {
-        return Response.json(
-          {
-            error: {
-              code: "NOT_FOUND",
-              message: `Contact "${input.contactId}" not found`,
-            },
-          },
-          { status: 404 },
-        );
-      }
-
-      // ── Assistant mints (token/hash + voice fields) ──────────────────
-      let mint: {
-        invite: Record<string, unknown>;
-        rawToken?: string;
-        gateway: {
-          id: string;
-          inviteCodeHash: string;
-          sourceChannel: string;
-          contactId: string;
-          note: string | null;
-          maxUses: number;
-          expiresAt: number;
-        };
-      };
       try {
-        mint = (await ipcCallAssistant("invites_mint", {
-          body: input,
-        } as unknown as Record<string, unknown>)) as typeof mint;
-      } catch (err) {
-        if (err instanceof IpcHandlerError) {
-          return Response.json(
-            {
-              error: {
-                code: err.code,
-                message: err.message,
-              },
-            },
-            { status: err.statusCode },
-          );
-        }
-        log.error({ err, contactId: input.contactId }, "create_invite: mint failed");
+        const result = await createInviteNative(parsed.value);
         return Response.json(
-          {
-            error: { code: "INTERNAL_ERROR", message: "Failed to mint invite" },
-          },
-          { status: 500 },
+          { ok: true, invite: result.invite, rawToken: result.rawToken },
+          { status: 201 },
         );
-      }
-
-      // ── Gateway DB write (source of truth) ───────────────────────────
-      const gw = mint.gateway;
-      let invite;
-      try {
-        invite = store.createInvite({
-          id: gw.id,
-          inviteCodeHash: gw.inviteCodeHash,
-          sourceChannel: gw.sourceChannel,
-          contactId: gw.contactId,
-          note: gw.note,
-          maxUses: gw.maxUses,
-          expiresAt: gw.expiresAt,
-        });
       } catch (err) {
-        // The assistant already minted a row; the gateway record is what
-        // gates ACL, so a missing gateway row is a hard failure. No fallback.
-        log.error(
-          { err, inviteId: gw?.id, contactId: input.contactId },
-          "create_invite: gateway DB write failed — assistant invite row is now orphaned (stale over lost)",
-        );
-        return Response.json(
-          {
-            error: { code: "INTERNAL_ERROR", message: "Failed to record invite" },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
-
-      // Notify connected clients.
-      void ipcCallAssistant("emit_event", {
-        body: { kind: "contacts_changed" },
-      } as unknown as Record<string, unknown>).catch(() => {});
-
-      log.info(
-        { inviteId: invite.id, contactId: input.contactId },
-        "create_invite: handled natively",
-      );
-      // The gateway row is the lifecycle source of truth, but the HTTP response
-      // must carry the assistant's minted one-time fields (voiceCode for phone;
-      // inviteCode/guardianInstruction/share/token for non-phone) — these are
-      // returned only at creation time and can never be fetched later.
-      return Response.json(
-        { ok: true, invite: mint.invite, rawToken: mint.rawToken },
-        { status: 201 },
-      );
     },
 
     /**
@@ -1405,60 +1561,11 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
      * assistant. The gateway gates; the assistant places the call.
      */
     async handleCallInvite(_req: Request, inviteId: string): Promise<Response> {
-      const invite = new ContactStore().getInviteById(inviteId);
-      if (!invite) {
-        return Response.json(
-          {
-            error: {
-              code: "NOT_FOUND",
-              message: `Invite "${inviteId}" not found`,
-            },
-          },
-          { status: 404 },
-        );
-      }
-      if (invite.status !== "active") {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: `Invite "${inviteId}" is not active`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-
       try {
-        // `invites_trigger_call` is the shared assistant route handler
-        // (handleTriggerInviteCall), which reads the id from pathParams.id. The
-        // assistant IPC server spreads `params` directly into RouteHandlerArgs,
-        // so send it as pathParams — not body.
-        const result = (await ipcCallAssistant("invites_trigger_call", {
-          pathParams: { id: inviteId },
-        } as unknown as Record<string, unknown>)) as { callSid: string };
-        log.info(
-          { inviteId, callSid: result.callSid },
-          "call_invite: handled natively",
-        );
+        const result = await triggerInviteCallNative(inviteId);
         return Response.json({ ok: true, callSid: result.callSid });
       } catch (err) {
-        if (err instanceof IpcHandlerError) {
-          return Response.json(
-            { error: { code: err.code, message: err.message } },
-            { status: err.statusCode },
-          );
-        }
-        log.error({ err, inviteId }, "call_invite: relay failed");
-        return Response.json(
-          {
-            error: {
-              code: "INTERNAL_ERROR",
-              message: "Failed to trigger invite call",
-            },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
     },
 
@@ -1473,49 +1580,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       inviteId: string,
     ): Promise<Response> {
       try {
-        const invite = new ContactStore().revokeInvite(inviteId);
-        if (!invite) {
-          // No gateway row. The invite may still exist assistant-only (created
-          // via the IPC/CLI path before the m0007 backfill or the CLI flip).
-          // Fall back to revoking the assistant row directly so guardians can
-          // still manage it from the gateway surface. 404 only when the invite
-          // is absent from BOTH stores.
-          return await revokeAssistantOnlyInvite(inviteId);
-        }
-
-        // Best-effort mirror into the assistant DB. revokeInvite() only flips an
-        // ACTIVE row to revoked — an already redeemed/expired invite is returned
-        // unchanged. Mirror the gateway row's ACTUAL post-revoke status so the
-        // two lifecycle stores stay in sync instead of forcing 'revoked'.
-        try {
-          await assistantDbRun(
-            "UPDATE assistant_ingress_invites SET status=?, updated_at=? WHERE id=?",
-            [invite.status, Date.now(), inviteId],
-          );
-        } catch (err) {
-          log.warn(
-            { err, inviteId },
-            "revoke_invite: assistant DB mirror failed (best-effort)",
-          );
-        }
-
-        void ipcCallAssistant("emit_event", {
-          body: { kind: "contacts_changed" },
-        } as unknown as Record<string, unknown>).catch(() => {});
-
-        log.info({ inviteId }, "revoke_invite: handled natively");
-        return Response.json({ ok: true, invite: sanitizeInviteRow(invite) });
+        const { invite } = await revokeInviteNative(inviteId);
+        return Response.json({ ok: true, invite });
       } catch (err) {
-        log.error({ err, inviteId }, "revoke_invite: gateway-native revoke failed");
-        return Response.json(
-          {
-            error: {
-              code: "INTERNAL_ERROR",
-              message: "Failed to revoke invite",
-            },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
     },
   };

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -521,24 +521,23 @@ export async function revokeInviteNative(
 }
 
 /**
- * Verify the invite exists + is active in the gateway DB (lifecycle source of
- * truth) then relay the provider-specific outbound call to the assistant.
- * Returns the provider call sid. Throws InviteNativeError(404) when the invite
- * is unknown, InviteNativeError(400) when it isn't active, InviteNativeError(500)
- * on relay failure, and propagates an assistant IpcHandlerError unchanged.
+ * Trigger the provider-specific outbound call for an invite. When the gateway
+ * row exists (lifecycle source of truth) it gates on `active`. When it's absent
+ * — a legacy/assistant-only invite that lives only in `assistant_ingress_invites`
+ * (the same rows list/revoke handle via their assistant-only fallback) — it
+ * falls through and lets the daemon-local trigger validate its own row. Returns
+ * the provider call sid. Throws InviteNativeError(400) when a present gateway
+ * row isn't active, InviteNativeError(500) on relay failure, and propagates an
+ * assistant IpcHandlerError unchanged.
  */
 export async function triggerInviteCallNative(
   inviteId: string,
 ): Promise<{ callSid: string }> {
   const invite = new ContactStore().getInviteById(inviteId);
-  if (!invite) {
-    throw new InviteNativeError(
-      `Invite "${inviteId}" not found`,
-      404,
-      "NOT_FOUND",
-    );
-  }
-  if (invite.status !== "active") {
+  // Absent gateway row → legacy/assistant-only invite. Don't 404: fall through
+  // and relay; `handleTriggerInviteCall` validates its own assistant_ingress_invites
+  // row (active/inactive) and places the call or surfaces its own error.
+  if (invite && invite.status !== "active") {
     throw new InviteNativeError(
       `Invite "${inviteId}" is not active`,
       400,

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -209,16 +209,24 @@ async function revokeAssistantOnlyInviteNative(
   inviteId: string,
 ): Promise<{ invite: Record<string, unknown> }> {
   const now = Date.now();
-  // Best-effort: flip an ACTIVE row to revoked. A terminal row is untouched.
+  // Flip an ACTIVE row to revoked. A terminal row is untouched (0 rows
+  // affected, no throw → idempotent). A thrown write must NOT be swallowed:
+  // returning 200 with the still-active row would tell the guardian/CLI the
+  // invite was revoked while it stays redeemable via the legacy path.
   try {
     await assistantDbRun(
       "UPDATE assistant_ingress_invites SET status='revoked', updated_at=? WHERE id=? AND status='active'",
       [now, inviteId],
     );
   } catch (err) {
-    log.warn(
+    log.error(
       { err, inviteId },
-      "revoke_invite: assistant-only fallback UPDATE failed (best-effort)",
+      "revoke_invite: assistant-only fallback UPDATE failed",
+    );
+    throw new InviteNativeError(
+      `Failed to revoke invite "${inviteId}"`,
+      500,
+      "INTERNAL_ERROR",
     );
   }
 

--- a/gateway/src/http/routes/invite-validation.ts
+++ b/gateway/src/http/routes/invite-validation.ts
@@ -3,8 +3,8 @@
  *
  * These mirror the daemon's invite request shapes
  * (`assistant/src/runtime/routes/contact-routes.ts`, operations
- * `invites_create` / `invites_redeem`) so the native gateway HTTP handlers
- * (PR 3) and IPC callers can share a single source of validation truth.
+ * `invites_create` / `invites_redeem`) so the gateway HTTP handlers and IPC
+ * callers share a single source of validation truth.
  *
  * No DB, no IPC, no logging — just parse/validate. Keep it that way so any
  * caller (handler or test) can use these directly.
@@ -24,7 +24,6 @@ export interface CreateInviteInput {
   expiresInMs?: number;
   contactName?: string;
   expectedExternalUserId?: string;
-  voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
 }
@@ -33,11 +32,11 @@ export type ParseResult<T> =
   | { ok: true; value: T }
   | { ok: false; message: string };
 
-const positiveNumber = z
+export const positiveNumber = z
   .number()
   .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
 
-const createInviteSchema = z.object({
+export const createInviteSchema = z.object({
   contactId: z.string().trim().min(1, "contactId is required"),
   sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
   note: z.string().optional(),
@@ -45,7 +44,6 @@ const createInviteSchema = z.object({
   expiresInMs: positiveNumber.optional(),
   contactName: z.string().optional(),
   expectedExternalUserId: z.string().optional(),
-  voiceCodeDigits: positiveNumber.optional(),
   friendName: z.string().optional(),
   guardianName: z.string().optional(),
 });
@@ -148,6 +146,13 @@ export function parseRedeemInviteBody(
 // ---------------------------------------------------------------------------
 // List invites query
 // ---------------------------------------------------------------------------
+
+export const listInviteQueryShape = {
+  sourceChannel: z.string().optional(),
+  status: z.string().optional(),
+} as const;
+
+export const listInviteQuerySchema = z.object(listInviteQueryShape);
 
 export interface ListInviteQuery {
   sourceChannel?: string;

--- a/gateway/src/http/routes/invite-validation.ts
+++ b/gateway/src/http/routes/invite-validation.ts
@@ -1,0 +1,166 @@
+/**
+ * Pure, side-effect-free validation helpers for invite request bodies.
+ *
+ * These mirror the daemon's invite request shapes
+ * (`assistant/src/runtime/routes/contact-routes.ts`, operations
+ * `invites_create` / `invites_redeem`) so the native gateway HTTP handlers
+ * (PR 3) and IPC callers can share a single source of validation truth.
+ *
+ * No DB, no IPC, no logging — just parse/validate. Keep it that way so any
+ * caller (handler or test) can use these directly.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Create invite
+// ---------------------------------------------------------------------------
+
+export interface CreateInviteInput {
+  contactId: string;
+  sourceChannel: string;
+  note?: string;
+  maxUses?: number;
+  expiresInMs?: number;
+  contactName?: string;
+  expectedExternalUserId?: string;
+  voiceCodeDigits?: number;
+  friendName?: string;
+  guardianName?: string;
+}
+
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; message: string };
+
+const positiveNumber = z
+  .number()
+  .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
+
+const createInviteSchema = z.object({
+  contactId: z.string().trim().min(1, "contactId is required"),
+  sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
+  note: z.string().optional(),
+  maxUses: positiveNumber.optional(),
+  expiresInMs: positiveNumber.optional(),
+  contactName: z.string().optional(),
+  expectedExternalUserId: z.string().optional(),
+  voiceCodeDigits: positiveNumber.optional(),
+  friendName: z.string().optional(),
+  guardianName: z.string().optional(),
+});
+
+function firstIssueMessage(error: z.ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) {
+    return "Invalid request body";
+  }
+  const path = issue.path.join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+export function parseCreateInviteBody(
+  body: unknown,
+): ParseResult<CreateInviteInput> {
+  const parsed = createInviteSchema.safeParse(body ?? {});
+  if (!parsed.success) {
+    return { ok: false, message: firstIssueMessage(parsed.error) };
+  }
+  return { ok: true, value: parsed.data };
+}
+
+// ---------------------------------------------------------------------------
+// Redeem invite (voice-code vs token)
+// ---------------------------------------------------------------------------
+
+export interface VoiceRedeemInput {
+  kind: "voice";
+  code: string;
+  callerExternalUserId: string;
+  assistantId?: string;
+}
+
+export interface TokenRedeemInput {
+  kind: "token";
+  token: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  sourceChannel: string;
+}
+
+export type RedeemInviteInput = VoiceRedeemInput | TokenRedeemInput;
+
+export function parseRedeemInviteBody(
+  body: unknown,
+): ParseResult<RedeemInviteInput> {
+  const raw = (body ?? {}) as Record<string, unknown>;
+
+  // Voice-code path: presence of `code` selects voice redemption (matching the
+  // daemon, which branches on `body.code != null`).
+  if (raw.code != null) {
+    const code = typeof raw.code === "string" ? raw.code : "";
+    const callerExternalUserId =
+      typeof raw.callerExternalUserId === "string"
+        ? raw.callerExternalUserId
+        : "";
+    if (!code || !callerExternalUserId) {
+      return {
+        ok: false,
+        message: "callerExternalUserId and code are required",
+      };
+    }
+    return {
+      ok: true,
+      value: {
+        kind: "voice",
+        code,
+        callerExternalUserId,
+        assistantId:
+          typeof raw.assistantId === "string" ? raw.assistantId : undefined,
+      },
+    };
+  }
+
+  // Token path.
+  const token = typeof raw.token === "string" ? raw.token : "";
+  if (!token) {
+    return { ok: false, message: "token is required" };
+  }
+  const sourceChannel =
+    typeof raw.sourceChannel === "string" ? raw.sourceChannel.trim() : "";
+  if (!sourceChannel) {
+    return { ok: false, message: "sourceChannel is required" };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: "token",
+      token,
+      externalUserId:
+        typeof raw.externalUserId === "string" ? raw.externalUserId : undefined,
+      externalChatId:
+        typeof raw.externalChatId === "string" ? raw.externalChatId : undefined,
+      sourceChannel,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// List invites query
+// ---------------------------------------------------------------------------
+
+export interface ListInviteQuery {
+  sourceChannel?: string;
+  status?: string;
+}
+
+export function parseListInviteQuery(
+  searchParams: URLSearchParams,
+): ListInviteQuery {
+  const sourceChannel = searchParams.get("sourceChannel") ?? undefined;
+  const status = searchParams.get("status") ?? undefined;
+  return {
+    ...(sourceChannel ? { sourceChannel } : {}),
+    ...(status ? { status } : {}),
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -187,6 +187,7 @@ import {
 } from "./twilio/webhook-sync-trigger.js";
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
+import { inviteRoutes } from "./ipc/invite-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
 import { createLogTailRoutes } from "./ipc/log-tail-handlers.js";
@@ -2461,6 +2462,7 @@ async function main() {
   const ipcServer = new GatewayIpcServer([
     ...featureFlagRoutes,
     ...contactRoutes,
+    ...inviteRoutes,
     ...slackThreadRoutes,
     ...thresholdRoutes,
     ...admissionPolicyRoutes,

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -1,6 +1,11 @@
 /**
  * Tests for the gateway invite CRUD IPC routes (invites_list / invites_create /
- * invites_revoke / invites_trigger_call).
+ * invites_revoke).
+ *
+ * `invites_trigger_call` is intentionally NOT a gateway IPC route: it stays
+ * daemon-local on the assistant. The gateway HTTP call path validates its row
+ * then delegates the provider call to the assistant via triggerInviteCallNative;
+ * relaying it over IPC would loop gateway→assistant→gateway.
  *
  * Each route is driven directly through its handler. The shared native
  * functions from the HTTP module are mocked so these tests focus on the IPC
@@ -12,7 +17,7 @@
  * functions through the HTTP handlers).
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Native function mocks (the single shared implementation) ──────────────────
 type ListFn = (query: unknown) => Promise<{
@@ -35,11 +40,6 @@ let revokeInviteNativeMock: ReturnType<typeof mock<RevokeFn>> = mock(
   async () => ({ invite: { id: "inv_1", status: "revoked" } }),
 );
 
-type TriggerFn = (id: string) => Promise<{ callSid: string }>;
-let triggerInviteCallNativeMock: ReturnType<typeof mock<TriggerFn>> = mock(
-  async () => ({ callSid: "CA123" }),
-);
-
 mock.module("../../http/routes/contacts-control-plane-proxy.js", () => ({
   listInvitesNative: (...args: Parameters<ListFn>) =>
     listInvitesNativeMock(...args),
@@ -47,8 +47,6 @@ mock.module("../../http/routes/contacts-control-plane-proxy.js", () => ({
     createInviteNativeMock(...args),
   revokeInviteNative: (...args: Parameters<RevokeFn>) =>
     revokeInviteNativeMock(...args),
-  triggerInviteCallNative: (...args: Parameters<TriggerFn>) =>
-    triggerInviteCallNativeMock(...args),
 }));
 
 // ContactStore is only touched by the record_invite_redemption route; stub it
@@ -62,7 +60,8 @@ mock.module("../db/contact-store.js", () => ({
 }));
 
 const { inviteRoutes } = await import("../invite-handlers.js");
-const { buildErrorResponse } = await import("../server.js");
+const { buildErrorResponse, buildProtocolErrorResponse, GatewayIpcServer } =
+  await import("../server.js");
 
 function route(method: string) {
   const found = inviteRoutes.find((r) => r.method === method);
@@ -79,7 +78,6 @@ beforeEach(() => {
   revokeInviteNativeMock = mock(async () => ({
     invite: { id: "inv_1", status: "revoked" },
   }));
-  triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA123" }));
 });
 
 describe("buildErrorResponse — typed-error envelope preservation", () => {
@@ -142,25 +140,155 @@ describe("buildErrorResponse — typed-error envelope preservation", () => {
   });
 });
 
+describe("buildProtocolErrorResponse — early-return validation envelope", () => {
+  test("stamps statusCode + errorCode while preserving the error string", () => {
+    const res = buildProtocolErrorResponse(
+      "req-1",
+      "Invalid params: bad",
+      400,
+      "BAD_REQUEST",
+    );
+    expect(res).toEqual({
+      id: "req-1",
+      error: "Invalid params: bad",
+      statusCode: 400,
+      errorCode: "BAD_REQUEST",
+    });
+  });
+
+  test("supports a 404 for unknown methods", () => {
+    const res = buildProtocolErrorResponse(
+      "req-2",
+      "Unknown method: nope",
+      404,
+      "UNKNOWN_METHOD",
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.errorCode).toBe("UNKNOWN_METHOD");
+  });
+});
+
+describe("GatewayIpcServer — protocol/validation errors carry status codes", () => {
+  // Drive the server through a real Unix-domain-socket round-trip so the
+  // early-return validation paths (Invalid JSON / missing fields / unknown
+  // method / Zod rejection) are exercised exactly as the daemon relay hits
+  // them. The relay maps `statusCode` → RouteError, so these must NOT be 500.
+  let server: InstanceType<typeof GatewayIpcServer>;
+  let socketDir: string;
+  let prevEnv: string | undefined;
+
+  async function rpc(line: string): Promise<Record<string, unknown>> {
+    const { connect } = await import("node:net");
+    return await new Promise((resolve, reject) => {
+      const sock = connect(server.getSocketPath());
+      let buf = "";
+      sock.on("connect", () => sock.write(line + "\n"));
+      sock.on("data", (chunk) => {
+        buf += chunk.toString();
+        const nl = buf.indexOf("\n");
+        if (nl !== -1) {
+          sock.end();
+          resolve(JSON.parse(buf.slice(0, nl)));
+        }
+      });
+      sock.on("error", reject);
+    });
+  }
+
+  beforeEach(async () => {
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    socketDir = mkdtempSync(join(tmpdir(), "vellum-ipc-test-"));
+    prevEnv = process.env.GATEWAY_IPC_SOCKET_DIR;
+    process.env.GATEWAY_IPC_SOCKET_DIR = socketDir;
+    // Disable the watchdog so the test has a single deterministic listener.
+    server = new GatewayIpcServer(inviteRoutes, { watchdogIntervalMs: 0 });
+    server.start();
+    // Wait for the listener to bind.
+    const { existsSync } = await import("node:fs");
+    for (let i = 0; i < 100 && !existsSync(server.getSocketPath()); i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  });
+
+  afterEach(async () => {
+    server.stop();
+    if (prevEnv === undefined) delete process.env.GATEWAY_IPC_SOCKET_DIR;
+    else process.env.GATEWAY_IPC_SOCKET_DIR = prevEnv;
+    const { rmSync } = await import("node:fs");
+    rmSync(socketDir, { recursive: true, force: true });
+  });
+
+  test("Zod schema rejection → 400 BAD_REQUEST + 'Invalid params'", async () => {
+    // invites_create requires contactId + sourceChannel; omit sourceChannel.
+    const res = await rpc(
+      JSON.stringify({
+        id: "r1",
+        method: "invites_create",
+        params: { contactId: "ct_1" },
+      }),
+    );
+    expect(res.id).toBe("r1");
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("BAD_REQUEST");
+    expect(String(res.error)).toContain("Invalid params");
+    expect(createInviteNativeMock).not.toHaveBeenCalled();
+  });
+
+  test("maxUses: 0 fails the schema → 400, not 500", async () => {
+    const res = await rpc(
+      JSON.stringify({
+        id: "r2",
+        method: "invites_create",
+        params: { contactId: "ct_1", sourceChannel: "telegram", maxUses: 0 },
+      }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).not.toBe(500);
+  });
+
+  test("unknown method → 404 UNKNOWN_METHOD", async () => {
+    const res = await rpc(
+      JSON.stringify({ id: "r3", method: "does_not_exist" }),
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.errorCode).toBe("UNKNOWN_METHOD");
+    expect(String(res.error)).toContain("Unknown method");
+  });
+
+  test("invalid JSON → 400 BAD_REQUEST", async () => {
+    const res = await rpc("{not json");
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("BAD_REQUEST");
+    expect(res.error).toBe("Invalid JSON");
+  });
+
+  test("missing 'id'/'method' → 400 BAD_REQUEST", async () => {
+    const res = await rpc(JSON.stringify({ id: "r5" }));
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("BAD_REQUEST");
+    expect(res.error).toBe("Missing 'id' or 'method' field");
+  });
+});
+
 describe("invite CRUD IPC routes registration", () => {
-  test("registers all four CRUD methods alongside record_invite_redemption", () => {
+  test("registers the three CRUD methods alongside record_invite_redemption", () => {
     const methods = inviteRoutes.map((r) => r.method);
     expect(methods).toContain("record_invite_redemption");
     expect(methods).toContain("invites_list");
     expect(methods).toContain("invites_create");
     expect(methods).toContain("invites_revoke");
-    expect(methods).toContain("invites_trigger_call");
     // No redeem IPC method — redemption stays on record_invite_redemption.
     expect(methods).not.toContain("invites_redeem");
+    // invites_trigger_call stays daemon-local on the assistant; relaying it
+    // here would loop gateway→assistant→gateway.
+    expect(methods).not.toContain("invites_trigger_call");
+    expect(inviteRoutes).toHaveLength(4);
   });
 
   test("every CRUD route carries a Zod param schema", () => {
-    for (const m of [
-      "invites_list",
-      "invites_create",
-      "invites_revoke",
-      "invites_trigger_call",
-    ]) {
+    for (const m of ["invites_list", "invites_create", "invites_revoke"]) {
       expect(route(m).schema).toBeDefined();
     }
   });
@@ -298,29 +426,5 @@ describe("invites_revoke", () => {
   test("throws on missing id (no native call)", async () => {
     await expect(route("invites_revoke").handler({})).rejects.toThrow();
     expect(revokeInviteNativeMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("invites_trigger_call", () => {
-  test("requires a non-empty id", () => {
-    const schema = route("invites_trigger_call").schema;
-    expect(schema?.safeParse({ id: "inv_1" }).success).toBe(true);
-    expect(schema?.safeParse({}).success).toBe(false);
-  });
-
-  test("delegates to triggerInviteCallNative and returns { callSid }", async () => {
-    triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA999" }));
-    const result = await route("invites_trigger_call").handler({ id: "inv_1" });
-    expect(result).toEqual({ callSid: "CA999" });
-    expect(triggerInviteCallNativeMock.mock.calls[0][0]).toBe("inv_1");
-  });
-
-  test("propagates a native error (e.g. invite not active)", async () => {
-    triggerInviteCallNativeMock = mock(async () => {
-      throw new Error('Invite "inv_1" is not active');
-    });
-    await expect(
-      route("invites_trigger_call").handler({ id: "inv_1" }),
-    ).rejects.toThrow(/not active/);
   });
 });

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for the gateway invite CRUD IPC routes (invites_list / invites_create /
+ * invites_revoke / invites_trigger_call).
+ *
+ * Each route is driven directly through its handler. The shared native
+ * functions from the HTTP module are mocked so these tests focus on the IPC
+ * concerns: param validation (bad params throw) and that each route delegates
+ * to its native function with the right params + returns its result shape.
+ *
+ * Behavioral parity of the native functions themselves with the HTTP handlers
+ * is covered by contacts-control-plane-proxy.test.ts (which exercises the same
+ * functions through the HTTP handlers).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Native function mocks (the single shared implementation) ──────────────────
+type ListFn = (query: unknown) => Promise<{
+  invites: Array<Record<string, unknown>>;
+}>;
+let listInvitesNativeMock: ReturnType<typeof mock<ListFn>> = mock(async () => ({
+  invites: [],
+}));
+
+type CreateFn = (input: unknown) => Promise<{
+  invite: Record<string, unknown>;
+  rawToken?: string;
+}>;
+let createInviteNativeMock: ReturnType<typeof mock<CreateFn>> = mock(
+  async () => ({ invite: { id: "inv_1" }, rawToken: "raw" }),
+);
+
+type RevokeFn = (id: string) => Promise<{ invite: Record<string, unknown> }>;
+let revokeInviteNativeMock: ReturnType<typeof mock<RevokeFn>> = mock(
+  async () => ({ invite: { id: "inv_1", status: "revoked" } }),
+);
+
+type TriggerFn = (id: string) => Promise<{ callSid: string }>;
+let triggerInviteCallNativeMock: ReturnType<typeof mock<TriggerFn>> = mock(
+  async () => ({ callSid: "CA123" }),
+);
+
+mock.module("../../http/routes/contacts-control-plane-proxy.js", () => ({
+  listInvitesNative: (...args: Parameters<ListFn>) =>
+    listInvitesNativeMock(...args),
+  createInviteNative: (...args: Parameters<CreateFn>) =>
+    createInviteNativeMock(...args),
+  revokeInviteNative: (...args: Parameters<RevokeFn>) =>
+    revokeInviteNativeMock(...args),
+  triggerInviteCallNative: (...args: Parameters<TriggerFn>) =>
+    triggerInviteCallNativeMock(...args),
+}));
+
+// ContactStore is only touched by the record_invite_redemption route; stub it
+// so importing the module never opens a real DB.
+mock.module("../db/contact-store.js", () => ({
+  ContactStore: class MockContactStore {
+    recordInviteRedemption() {
+      return { updated: true, row: null };
+    }
+  },
+}));
+
+const { inviteRoutes } = await import("../invite-handlers.js");
+const { buildErrorResponse } = await import("../server.js");
+
+function route(method: string) {
+  const found = inviteRoutes.find((r) => r.method === method);
+  if (!found) throw new Error(`route not registered: ${method}`);
+  return found;
+}
+
+beforeEach(() => {
+  listInvitesNativeMock = mock(async () => ({ invites: [] }));
+  createInviteNativeMock = mock(async () => ({
+    invite: { id: "inv_1" },
+    rawToken: "raw",
+  }));
+  revokeInviteNativeMock = mock(async () => ({
+    invite: { id: "inv_1", status: "revoked" },
+  }));
+  triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA123" }));
+});
+
+describe("buildErrorResponse — typed-error envelope preservation", () => {
+  // Mirrors InviteNativeError / IpcHandlerError: both carry
+  // `statusCode: number` + `code: string`. The server duck-types these so any
+  // such typed error preserves its status/code over the IPC wire.
+  class TypedError extends Error {
+    readonly statusCode: number;
+    readonly code: string;
+    constructor(message: string, statusCode: number, code: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
+    }
+  }
+
+  test("includes statusCode + errorCode for a typed error (404)", () => {
+    const err = new TypedError("Contact not found", 404, "NOT_FOUND");
+    const res = buildErrorResponse("req-1", err);
+    expect(res).toEqual({
+      id: "req-1",
+      error: String(err),
+      statusCode: 404,
+      errorCode: "NOT_FOUND",
+    });
+  });
+
+  test("includes statusCode + errorCode for a 400 user-error", () => {
+    const err = new TypedError("Invite expired", 400, "INVALID_INVITE");
+    const res = buildErrorResponse("req-2", err);
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("INVALID_INVITE");
+    expect(res.error).toBe(String(err));
+  });
+
+  test("mirrors a structured `details` payload into errorDetails", () => {
+    const err = Object.assign(
+      new TypedError("Conflict", 409, "CONFLICT"),
+      { details: { reason: "already_revoked" } },
+    );
+    const res = buildErrorResponse("req-3", err);
+    expect(res.errorDetails).toEqual({ reason: "already_revoked" });
+  });
+
+  test("plain Error serializes as just { id, error } — no spurious fields", () => {
+    const res = buildErrorResponse("req-4", new Error("boom"));
+    expect(res).toEqual({ id: "req-4", error: "Error: boom" });
+    expect("statusCode" in res).toBe(false);
+    expect("errorCode" in res).toBe(false);
+    expect("errorDetails" in res).toBe(false);
+  });
+
+  test("ignores non-numeric statusCode / non-string code (backward compatible)", () => {
+    const err = Object.assign(new Error("weird"), {
+      statusCode: "503",
+      code: 42,
+    });
+    const res = buildErrorResponse("req-5", err);
+    expect(res).toEqual({ id: "req-5", error: "Error: weird" });
+  });
+});
+
+describe("invite CRUD IPC routes registration", () => {
+  test("registers all four CRUD methods alongside record_invite_redemption", () => {
+    const methods = inviteRoutes.map((r) => r.method);
+    expect(methods).toContain("record_invite_redemption");
+    expect(methods).toContain("invites_list");
+    expect(methods).toContain("invites_create");
+    expect(methods).toContain("invites_revoke");
+    expect(methods).toContain("invites_trigger_call");
+    // No redeem IPC method — redemption stays on record_invite_redemption.
+    expect(methods).not.toContain("invites_redeem");
+  });
+
+  test("every CRUD route carries a Zod param schema", () => {
+    for (const m of [
+      "invites_list",
+      "invites_create",
+      "invites_revoke",
+      "invites_trigger_call",
+    ]) {
+      expect(route(m).schema).toBeDefined();
+    }
+  });
+});
+
+describe("invites_list", () => {
+  test("accepts an empty filter and returns { invites }", async () => {
+    listInvitesNativeMock = mock(async () => ({
+      invites: [{ id: "inv_1" }],
+    }));
+    const r = route("invites_list");
+    expect(r.schema?.safeParse({}).success).toBe(true);
+
+    const result = await r.handler({});
+    expect(result).toEqual({ invites: [{ id: "inv_1" }] });
+    expect(listInvitesNativeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts omitted params (no-filter list) and calls native with {}", async () => {
+    listInvitesNativeMock = mock(async () => ({
+      invites: [{ id: "inv_1" }],
+    }));
+    const r = route("invites_list");
+    // The daemon relay's `ipcCallPersistent("invites_list")` sends no params,
+    // so the server validates `undefined` against the schema before the handler.
+    expect(r.schema?.safeParse(undefined).success).toBe(true);
+
+    const result = await r.handler(undefined);
+    expect(result).toEqual({ invites: [{ id: "inv_1" }] });
+    expect(listInvitesNativeMock).toHaveBeenCalledTimes(1);
+    expect(listInvitesNativeMock.mock.calls[0][0]).toEqual({});
+  });
+
+  test("passes sourceChannel + status through to the native function", async () => {
+    const r = route("invites_list");
+    expect(
+      r.schema?.safeParse({ sourceChannel: "telegram", status: "active" })
+        .success,
+    ).toBe(true);
+    await r.handler({ sourceChannel: "telegram", status: "active" });
+    expect(listInvitesNativeMock.mock.calls[0][0]).toEqual({
+      sourceChannel: "telegram",
+      status: "active",
+    });
+  });
+
+  test("rejects a non-string status param", () => {
+    expect(route("invites_list").schema?.safeParse({ status: 5 }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("invites_create", () => {
+  test("validates the create body shape", () => {
+    const schema = route("invites_create").schema;
+    expect(
+      schema?.safeParse({ contactId: "ct_1", sourceChannel: "telegram" })
+        .success,
+    ).toBe(true);
+    // contactId required.
+    expect(schema?.safeParse({ sourceChannel: "telegram" }).success).toBe(
+      false,
+    );
+    // sourceChannel required.
+    expect(schema?.safeParse({ contactId: "ct_1" }).success).toBe(false);
+    // maxUses must be positive.
+    expect(
+      schema?.safeParse({
+        contactId: "ct_1",
+        sourceChannel: "telegram",
+        maxUses: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("delegates to createInviteNative and returns the minted payload", async () => {
+    createInviteNativeMock = mock(async () => ({
+      invite: { id: "inv_1", inviteCode: "123456" },
+      rawToken: "raw-token-abc",
+    }));
+    const result = await route("invites_create").handler({
+      contactId: "ct_1",
+      sourceChannel: "telegram",
+      note: "hi",
+    });
+    expect(result).toEqual({
+      invite: { id: "inv_1", inviteCode: "123456" },
+      rawToken: "raw-token-abc",
+    });
+    expect(createInviteNativeMock.mock.calls[0][0]).toMatchObject({
+      contactId: "ct_1",
+      sourceChannel: "telegram",
+      note: "hi",
+    });
+  });
+
+  test("throws on invalid params (no native call)", async () => {
+    await expect(
+      route("invites_create").handler({ sourceChannel: "telegram" }),
+    ).rejects.toThrow();
+    expect(createInviteNativeMock).not.toHaveBeenCalled();
+  });
+
+  test("propagates a native error (e.g. contact not found)", async () => {
+    createInviteNativeMock = mock(async () => {
+      throw new Error('Contact "ct_x" not found');
+    });
+    await expect(
+      route("invites_create").handler({
+        contactId: "ct_x",
+        sourceChannel: "telegram",
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+describe("invites_revoke", () => {
+  test("requires a non-empty id", () => {
+    const schema = route("invites_revoke").schema;
+    expect(schema?.safeParse({ id: "inv_1" }).success).toBe(true);
+    expect(schema?.safeParse({ id: "" }).success).toBe(false);
+    expect(schema?.safeParse({}).success).toBe(false);
+  });
+
+  test("delegates to revokeInviteNative and returns the sanitized invite", async () => {
+    revokeInviteNativeMock = mock(async () => ({
+      invite: { id: "inv_9", status: "revoked" },
+    }));
+    const result = await route("invites_revoke").handler({ id: "inv_9" });
+    expect(result).toEqual({ invite: { id: "inv_9", status: "revoked" } });
+    expect(revokeInviteNativeMock.mock.calls[0][0]).toBe("inv_9");
+  });
+
+  test("throws on missing id (no native call)", async () => {
+    await expect(route("invites_revoke").handler({})).rejects.toThrow();
+    expect(revokeInviteNativeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("invites_trigger_call", () => {
+  test("requires a non-empty id", () => {
+    const schema = route("invites_trigger_call").schema;
+    expect(schema?.safeParse({ id: "inv_1" }).success).toBe(true);
+    expect(schema?.safeParse({}).success).toBe(false);
+  });
+
+  test("delegates to triggerInviteCallNative and returns { callSid }", async () => {
+    triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA999" }));
+    const result = await route("invites_trigger_call").handler({ id: "inv_1" });
+    expect(result).toEqual({ callSid: "CA999" });
+    expect(triggerInviteCallNativeMock.mock.calls[0][0]).toBe("inv_1");
+  });
+
+  test("propagates a native error (e.g. invite not active)", async () => {
+    triggerInviteCallNativeMock = mock(async () => {
+      throw new Error('Invite "inv_1" is not active');
+    });
+    await expect(
+      route("invites_trigger_call").handler({ id: "inv_1" }),
+    ).rejects.toThrow(/not active/);
+  });
+});

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -30,11 +30,12 @@
  *     params : { id: string }
  *     returns: { invite: Record<string, unknown> }            (sanitized)
  *
- *   invites_trigger_call
- *     params : { id: string }
- *     returns: { callSid: string }
+ * (Note: invites_trigger_call is NOT relayed here — it stays daemon-local on the
+ * assistant. The gateway HTTP call path validates its row then delegates the
+ * provider call to the assistant via triggerInviteCallNative; relaying it back
+ * over IPC would loop gateway→assistant→gateway.)
  *
- * All four delegate to the SAME native functions the gateway HTTP invite
+ * All three delegate to the SAME native functions the gateway HTTP invite
  * handlers use (gateway/src/http/routes/contacts-control-plane-proxy.ts), which
  * throw InviteNativeError / IpcHandlerError on failure. The IPC server
  * stringifies a thrown error into the wire `error` field.
@@ -48,7 +49,6 @@ import {
   createInviteNative,
   listInvitesNative,
   revokeInviteNative,
-  triggerInviteCallNative,
 } from "../http/routes/contacts-control-plane-proxy.js";
 import type { IpcRoute } from "./server.js";
 
@@ -155,15 +155,6 @@ export const inviteRoutes: IpcRoute[] = [
     handler: async (params?: Record<string, unknown>) => {
       const { id } = InviteIdParamsSchema.parse(params);
       return await revokeInviteNative(id);
-    },
-  },
-  {
-    // Gate on active gateway row → relay the outbound call to the assistant.
-    method: "invites_trigger_call",
-    schema: InviteIdParamsSchema,
-    handler: async (params?: Record<string, unknown>) => {
-      const { id } = InviteIdParamsSchema.parse(params);
-      return await triggerInviteCallNative(id);
     },
   },
 ];

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -21,8 +21,8 @@
  *   invites_create
  *     params : { contactId: string; sourceChannel: string; note?: string;
  *                maxUses?: number; expiresInMs?: number; contactName?: string;
- *                expectedExternalUserId?: string; voiceCodeDigits?: number;
- *                friendName?: string; guardianName?: string }
+ *                expectedExternalUserId?: string; friendName?: string;
+ *                guardianName?: string }
  *     returns: { invite: Record<string, unknown>; rawToken?: string }
  *              (the assistant's one-time minted payload)
  *
@@ -50,6 +50,10 @@ import {
   listInvitesNative,
   revokeInviteNative,
 } from "../http/routes/contacts-control-plane-proxy.js";
+import {
+  createInviteSchema,
+  listInviteQueryShape,
+} from "../http/routes/invite-validation.js";
 import type { IpcRoute } from "./server.js";
 
 let store: ContactStore | null = null;
@@ -67,36 +71,20 @@ const RecordInviteRedemptionParamsSchema = z.object({
   redeemedByExternalChatId: z.string().nullish(),
 });
 
-const positiveNumber = z
-  .number()
-  .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
-
 // The no-filter list is the common case; the daemon relay calls
 // `ipcCallPersistent("invites_list")` with no params (req.params === undefined).
 // The server validates req.params against this schema BEFORE the handler runs,
 // so the schema must accept omitted/undefined params and default them to {}.
-// Field validations stay intact for when params ARE provided.
+// Field validations stay intact for when params ARE provided. The omitted-params
+// tolerance is the IPC-layer concern; the field shape is shared with the HTTP
+// list-query validator.
 const ListInvitesParamsSchema = z.preprocess(
   (v) => v ?? {},
-  z.object({
-    sourceChannel: z.string().optional(),
-    status: z.string().optional(),
-  }),
+  z.object(listInviteQueryShape),
 );
 
-// Mirrors createInviteSchema in http/routes/invite-validation.ts.
-const CreateInviteParamsSchema = z.object({
-  contactId: z.string().trim().min(1, "contactId is required"),
-  sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
-  note: z.string().optional(),
-  maxUses: positiveNumber.optional(),
-  expiresInMs: positiveNumber.optional(),
-  contactName: z.string().optional(),
-  expectedExternalUserId: z.string().optional(),
-  voiceCodeDigits: positiveNumber.optional(),
-  friendName: z.string().optional(),
-  guardianName: z.string().optional(),
-});
+// The gateway HTTP handlers and IPC callers share a single create-invite schema.
+const CreateInviteParamsSchema = createInviteSchema;
 
 const InviteIdParamsSchema = z.object({
   id: z.string().min(1),

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -1,0 +1,57 @@
+/**
+ * IPC route definitions for gateway-canonical invite lifecycle.
+ *
+ * The assistant resolves the exact invite (caller-scoped) from a token/code,
+ * passes its own validation, then CLAIMS the gateway-canonical row — BY ID —
+ * via `record_invite_redemption` BEFORE mutating its own DB. That call
+ * atomically gates on status="active" and consumes the row, so it is the single
+ * authoritative lifecycle gate (no separate check-then-act window). This keeps
+ * the gateway invite row authoritative across every runtime redemption path
+ * (token + 6-digit channel intercepts, voice relay, HTTP).
+ */
+
+import { z } from "zod";
+
+import { ContactStore } from "../db/contact-store.js";
+import type { IpcRoute } from "./server.js";
+
+let store: ContactStore | null = null;
+
+function getStore(): ContactStore {
+  if (!store) {
+    store = new ContactStore();
+  }
+  return store;
+}
+
+const RecordInviteRedemptionParamsSchema = z.object({
+  inviteId: z.string().min(1),
+  redeemedByExternalUserId: z.string().nullish(),
+  redeemedByExternalChatId: z.string().nullish(),
+});
+
+export const inviteRoutes: IpcRoute[] = [
+  {
+    // Authoritative redemption claim against the gateway-canonical row: bumps
+    // useCount and flips status once exhausted, gated on status="active" so a
+    // revoked/exhausted row can't be consumed under a race. `updated:false` on a
+    // present row (`mirrored:true`) signals a rejected claim; `mirrored:false`
+    // means the row is absent (legacy invite) — which is valid and must NOT
+    // error.
+    method: "record_invite_redemption",
+    schema: RecordInviteRedemptionParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const parsed = RecordInviteRedemptionParamsSchema.parse(params);
+      const result = getStore().recordInviteRedemption({
+        inviteId: parsed.inviteId,
+        redeemedByExternalUserId: parsed.redeemedByExternalUserId ?? null,
+        redeemedByExternalChatId: parsed.redeemedByExternalChatId ?? null,
+      });
+      return {
+        ok: true,
+        updated: result.updated,
+        mirrored: result.row !== null,
+      };
+    },
+  },
+];

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -8,11 +8,48 @@
  * authoritative lifecycle gate (no separate check-then-act window). This keeps
  * the gateway invite row authoritative across every runtime redemption path
  * (token + 6-digit channel intercepts, voice relay, HTTP).
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * Invite CRUD IPC contract (the daemon CLI relay calls these via
+ * `ipcCallPersistent`; KEEP STABLE):
+ *
+ *   invites_list
+ *     params : { sourceChannel?: string; status?: string }
+ *     returns: { invites: Array<Record<string, unknown>> }   (sanitized — no
+ *              inviteCodeHash; gateway rows + voice join + assistant-only merge)
+ *
+ *   invites_create
+ *     params : { contactId: string; sourceChannel: string; note?: string;
+ *                maxUses?: number; expiresInMs?: number; contactName?: string;
+ *                expectedExternalUserId?: string; voiceCodeDigits?: number;
+ *                friendName?: string; guardianName?: string }
+ *     returns: { invite: Record<string, unknown>; rawToken?: string }
+ *              (the assistant's one-time minted payload)
+ *
+ *   invites_revoke
+ *     params : { id: string }
+ *     returns: { invite: Record<string, unknown> }            (sanitized)
+ *
+ *   invites_trigger_call
+ *     params : { id: string }
+ *     returns: { callSid: string }
+ *
+ * All four delegate to the SAME native functions the gateway HTTP invite
+ * handlers use (gateway/src/http/routes/contacts-control-plane-proxy.ts), which
+ * throw InviteNativeError / IpcHandlerError on failure. The IPC server
+ * stringifies a thrown error into the wire `error` field.
+ * ───────────────────────────────────────────────────────────────────────────
  */
 
 import { z } from "zod";
 
 import { ContactStore } from "../db/contact-store.js";
+import {
+  createInviteNative,
+  listInvitesNative,
+  revokeInviteNative,
+  triggerInviteCallNative,
+} from "../http/routes/contacts-control-plane-proxy.js";
 import type { IpcRoute } from "./server.js";
 
 let store: ContactStore | null = null;
@@ -28,6 +65,41 @@ const RecordInviteRedemptionParamsSchema = z.object({
   inviteId: z.string().min(1),
   redeemedByExternalUserId: z.string().nullish(),
   redeemedByExternalChatId: z.string().nullish(),
+});
+
+const positiveNumber = z
+  .number()
+  .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
+
+// The no-filter list is the common case; the daemon relay calls
+// `ipcCallPersistent("invites_list")` with no params (req.params === undefined).
+// The server validates req.params against this schema BEFORE the handler runs,
+// so the schema must accept omitted/undefined params and default them to {}.
+// Field validations stay intact for when params ARE provided.
+const ListInvitesParamsSchema = z.preprocess(
+  (v) => v ?? {},
+  z.object({
+    sourceChannel: z.string().optional(),
+    status: z.string().optional(),
+  }),
+);
+
+// Mirrors createInviteSchema in http/routes/invite-validation.ts.
+const CreateInviteParamsSchema = z.object({
+  contactId: z.string().trim().min(1, "contactId is required"),
+  sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
+  note: z.string().optional(),
+  maxUses: positiveNumber.optional(),
+  expiresInMs: positiveNumber.optional(),
+  contactName: z.string().optional(),
+  expectedExternalUserId: z.string().optional(),
+  voiceCodeDigits: positiveNumber.optional(),
+  friendName: z.string().optional(),
+  guardianName: z.string().optional(),
+});
+
+const InviteIdParamsSchema = z.object({
+  id: z.string().min(1),
 });
 
 export const inviteRoutes: IpcRoute[] = [
@@ -52,6 +124,46 @@ export const inviteRoutes: IpcRoute[] = [
         updated: result.updated,
         mirrored: result.row !== null,
       };
+    },
+  },
+  {
+    // Gateway rows (lifecycle truth) + best-effort voice-field join +
+    // assistant-only merge, sanitized (no inviteCodeHash). Shares the HTTP
+    // list native implementation.
+    method: "invites_list",
+    schema: ListInvitesParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const query = ListInvitesParamsSchema.parse(params ?? {});
+      return await listInvitesNative(query);
+    },
+  },
+  {
+    // Verify contact → relay assistant mint → write canonical gateway row.
+    // Returns the assistant's one-time minted payload + rawToken.
+    method: "invites_create",
+    schema: CreateInviteParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const input = CreateInviteParamsSchema.parse(params);
+      return await createInviteNative(input);
+    },
+  },
+  {
+    // Flip the gateway row (then mirror to assistant DB), or fall back to the
+    // assistant-only row. Returns the sanitized invite.
+    method: "invites_revoke",
+    schema: InviteIdParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { id } = InviteIdParamsSchema.parse(params);
+      return await revokeInviteNative(id);
+    },
+  },
+  {
+    // Gate on active gateway row → relay the outbound call to the assistant.
+    method: "invites_trigger_call",
+    schema: InviteIdParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { id } = InviteIdParamsSchema.parse(params);
+      return await triggerInviteCallNative(id);
     },
   },
 ];

--- a/gateway/src/ipc/server.ts
+++ b/gateway/src/ipc/server.ts
@@ -50,7 +50,7 @@ export type IpcRequest = {
  * `errorCode` (and `errorDetails` when present) ALONGSIDE the existing
  * `error` string. Errors without those fields serialize exactly as before
  * (just `{ id, error }`), so consumers reading only `error` keep working.
- * The PR 5 daemon relay (`PersistentIpcClient.call`) reads `statusCode`/
+ * The daemon relay (`PersistentIpcClient.call`) reads `statusCode`/
  * `errorCode`/`errorDetails` to surface invite user-errors (4xx) instead of
  * statusless IPC failures.
  */

--- a/gateway/src/ipc/server.ts
+++ b/gateway/src/ipc/server.ts
@@ -42,10 +42,28 @@ export type IpcRequest = {
   params?: Record<string, unknown>;
 };
 
+/**
+ * NDJSON IPC response envelope.
+ *
+ * Error responses are ADDITIVE: a thrown error that carries a numeric
+ * `statusCode` and/or a string error code is mirrored into `statusCode`/
+ * `errorCode` (and `errorDetails` when present) ALONGSIDE the existing
+ * `error` string. Errors without those fields serialize exactly as before
+ * (just `{ id, error }`), so consumers reading only `error` keep working.
+ * The PR 5 daemon relay (`PersistentIpcClient.call`) reads `statusCode`/
+ * `errorCode`/`errorDetails` to surface invite user-errors (4xx) instead of
+ * statusless IPC failures.
+ */
 export type IpcResponse = {
   id: string;
   result?: unknown;
   error?: string;
+  /** HTTP-style status code mirrored from a typed error's `statusCode`. */
+  statusCode?: number;
+  /** Machine-readable error code mirrored from a typed error's `code`. */
+  errorCode?: string;
+  /** Structured error payload mirrored from a typed error's `details`. */
+  errorDetails?: unknown;
 };
 
 export type IpcEvent = {
@@ -319,20 +337,14 @@ export class GatewayIpcServer {
           })
           .catch((err) => {
             log.warn({ err, method: req.method }, "IPC handler error");
-            this.sendResponse(socket, {
-              id: req.id,
-              error: String(err),
-            });
+            this.sendResponse(socket, buildErrorResponse(req.id, err));
           });
       } else {
         this.sendResponse(socket, { id: req.id, result });
       }
     } catch (err) {
       log.warn({ err, method: req.method }, "IPC handler error");
-      this.sendResponse(socket, {
-        id: req.id,
-        error: String(err),
-      });
+      this.sendResponse(socket, buildErrorResponse(req.id, err));
     }
   }
 
@@ -349,4 +361,26 @@ export class GatewayIpcServer {
 
 export function getDefaultSocketPath(): string {
   return resolveIpcSocketPath("gateway").path;
+}
+
+/**
+ * Build the IPC error envelope for a thrown handler error.
+ *
+ * Always includes `error: String(err)`. When the error DUCK-TYPES as a
+ * client-facing typed error — a numeric `statusCode` and/or a string `code`
+ * — those are mirrored ADDITIVELY into `statusCode`/`errorCode` (and
+ * `errorDetails` from `details` when present). This covers both
+ * `InviteNativeError` and the assistant `IpcHandlerError` (and any future
+ * typed error) without importing or requiring a specific class. Plain
+ * `Error`s serialize as before: just `{ id, error }`.
+ */
+export function buildErrorResponse(id: string, err: unknown): IpcResponse {
+  const response: IpcResponse = { id, error: String(err) };
+  if (err && typeof err === "object") {
+    const e = err as { statusCode?: unknown; code?: unknown; details?: unknown };
+    if (typeof e.statusCode === "number") response.statusCode = e.statusCode;
+    if (typeof e.code === "string") response.errorCode = e.code;
+    if (e.details !== undefined) response.errorDetails = e.details;
+  }
+  return response;
 }

--- a/gateway/src/ipc/server.ts
+++ b/gateway/src/ipc/server.ts
@@ -276,10 +276,10 @@ export class GatewayIpcServer {
     try {
       req = JSON.parse(line) as IpcRequest;
     } catch {
-      this.sendResponse(socket, {
-        id: "unknown",
-        error: "Invalid JSON",
-      });
+      this.sendResponse(
+        socket,
+        buildProtocolErrorResponse("unknown", "Invalid JSON", 400, "BAD_REQUEST"),
+      );
       return;
     }
 
@@ -297,19 +297,29 @@ export class GatewayIpcServer {
         typeof req.id === "string"
           ? req.id
           : "unknown";
-      this.sendResponse(socket, {
-        id,
-        error: "Missing 'id' or 'method' field",
-      });
+      this.sendResponse(
+        socket,
+        buildProtocolErrorResponse(
+          id,
+          "Missing 'id' or 'method' field",
+          400,
+          "BAD_REQUEST",
+        ),
+      );
       return;
     }
 
     const handler = this.methods.get(req.method);
     if (!handler) {
-      this.sendResponse(socket, {
-        id: req.id,
-        error: `Unknown method: ${req.method}`,
-      });
+      this.sendResponse(
+        socket,
+        buildProtocolErrorResponse(
+          req.id,
+          `Unknown method: ${req.method}`,
+          404,
+          "UNKNOWN_METHOD",
+        ),
+      );
       return;
     }
 
@@ -319,10 +329,15 @@ export class GatewayIpcServer {
     if (schema) {
       const result = schema.safeParse(req.params);
       if (!result.success) {
-        this.sendResponse(socket, {
-          id: req.id,
-          error: `Invalid params: ${result.error.message}`,
-        });
+        this.sendResponse(
+          socket,
+          buildProtocolErrorResponse(
+            req.id,
+            `Invalid params: ${result.error.message}`,
+            400,
+            "BAD_REQUEST",
+          ),
+        );
         return;
       }
       parsedParams = result.data as Record<string, unknown>;
@@ -374,6 +389,25 @@ export function getDefaultSocketPath(): string {
  * typed error) without importing or requiring a specific class. Plain
  * `Error`s serialize as before: just `{ id, error }`.
  */
+/**
+ * Build the IPC error envelope for an early-return PROTOCOL/VALIDATION
+ * failure — one detected before any handler runs (bad JSON, missing
+ * `id`/`method`, unknown method, Zod schema rejection).
+ *
+ * Stamps a `statusCode` + `errorCode` so the daemon relay
+ * (`PersistentIpcClient.call` → `IpcCallError` → `RouteError`) surfaces these
+ * as proper client 4xx instead of defaulting to 500. ADDITIVE: the `error`
+ * string is unchanged, so consumers reading only `error` keep working.
+ */
+export function buildProtocolErrorResponse(
+  id: string,
+  error: string,
+  statusCode: number,
+  errorCode: string,
+): IpcResponse {
+  return { id, error, statusCode, errorCode };
+}
+
 export function buildErrorResponse(id: string, err: unknown): IpcResponse {
   const response: IpcResponse = { id, error: String(err) };
   if (err && typeof err === "object") {

--- a/packages/gateway-client/src/ipc-client.ts
+++ b/packages/gateway-client/src/ipc-client.ts
@@ -219,11 +219,13 @@ export class PersistentIpcClient {
   async call(
     method: string,
     params?: Record<string, unknown>,
+    timeoutMs?: number,
   ): Promise<unknown> {
     await this.ensureConnected();
 
     const id = String(this.nextId++);
     const req: IpcRequest = { id, method, params };
+    const callTimeoutMs = timeoutMs ?? this.callTimeoutMs;
 
     return new Promise<unknown>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -232,11 +234,11 @@ export class PersistentIpcClient {
           this.pending.delete(id);
           entry.reject(
             new Error(
-              `IPC call "${method}" timed out after ${this.callTimeoutMs}ms`,
+              `IPC call "${method}" timed out after ${callTimeoutMs}ms`,
             ),
           );
         }
-      }, this.callTimeoutMs);
+      }, callTimeoutMs);
       timer.unref();
 
       this.pending.set(id, { resolve, reject, timer });


### PR DESCRIPTION
## Summary
Makes the gateway DB (`ingress_invites`) the single source of truth for contact-invite lifecycle across both the HTTP control plane and the IPC/CLI surface. The 5 invite HTTP routes are gateway-native (dual-write + soft-fail), the CLI invite handlers relay to the gateway, and — critically — invite **redemption** is now gateway-authoritative across every runtime path (channel intercepts, voice relay, HTTP), not just the HTTP redeem endpoint.

## What's included
- **Gateway-native HTTP invite CRUD** (`#35559`): list/create/revoke/redeem/call native, no proxy fallback on mutation (500 on error), assistant DB dual-write soft-fails.
- **Gateway IPC invite methods** (`#35562`): `invites_list/create/revoke` + `record_invite_redemption` sharing one native implementation with the HTTP handlers.
- **CLI relay** (`#35563`): daemon `invites_list/create/revoke` relay to the gateway via `ipcCallPersistent`; `invites_redeem` and `invites_trigger_call` stay daemon-local (documented carve-outs — provider/inbound paths the gateway delegates to).
- **Centralized redemption lifecycle**: the assistant redemption service claims the gateway-canonical invite row (`record_invite_redemption`, gated on `status=active`) **before** mutating the assistant DB, across token + 6-digit channel intercepts, voice relay, and HTTP — closing a TOCTOU trust-bypass where a revoked/exhausted invite could still grant trust.
- **Security**: invite code/voice/token hashes are sanitized out of all list/revoke responses (were brute-forceable).
- **Backward-compat**: `m0007` backfill migration copies pre-migration `assistant_ingress_invites` into the gateway table (same id, FK-safe, idempotent), plus query-time list/revoke fallback for any assistant-only invites.

## Self-review result
PASS on plan-faithfulness and repo-integration (async/await wiring, IPC contracts, migration safety all verified). Slop/reuse audit found 4 cleanups (schema dedup, dead-code removal, comment hygiene) — fixed in `#35564`.

## PRs merged into this feature branch
- #35557: ContactStore gateway-DB invite methods
- #35558: assistant invite mint/redeem IPC methods
- #35556: invite request validation helpers
- #35559: gateway-native invite CRUD over HTTP (+ redemption-lifecycle expansion)
- #35562: gateway IPC invite methods
- #35563: CLI invite relay
- #35564: self-review cleanup

## Known follow-ups (not blocking)
- A2A invite redemption (`claimA2AInvite`) still bypasses the gateway — separate peer-invite lifecycle, deliberately deferred.
- `tokenHash` remains in the one-time create response (pre-existing; create already returns the raw token, so no new exposure) — optional tightening.
- Gateway-unreachable redemption fails open (logged) — documented availability>gating tradeoff.

Part of plan: contacts-gw-native-invites.md