### PR TITLE
feat(gateway): parameterize verifiedVia on markChannelVerified

### DIFF
--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -279,6 +279,68 @@ describe("ContactStore.markChannelVerified", () => {
     expect(b!.channel.verifiedAt).toBe(a!.channel.verifiedAt);
   });
 
+  test("writes verifiedVia=challenge to gateway + assistant when passed", async () => {
+    seedContact("c1");
+    seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
+
+    const result = await new ContactStore().markChannelVerified(
+      "ch1",
+      "challenge",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.status).toBe("active");
+    expect(result!.channel.verifiedVia).toBe("challenge");
+
+    // The assistant DB dual-write bound the same verifiedVia.
+    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
+      c.sql.includes("UPDATE contact_channels"),
+    );
+    expect(dualWrite).toBeTruthy();
+    expect(dualWrite!.bind).toContain("challenge");
+    expect(dualWrite!.bind).not.toContain("manual");
+  });
+
+  test("is idempotent per-verifiedVia: a repeated challenge call is a no-op", async () => {
+    seedContact("c1");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedAt: 1000,
+      verifiedVia: "challenge",
+    });
+
+    const result = await new ContactStore().markChannelVerified(
+      "ch1",
+      "challenge",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(false);
+    expect(result!.channel.verifiedAt).toBe(1000);
+    expect(result!.channel.verifiedVia).toBe("challenge");
+    // No-op skips the assistant dual-write.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
+  });
+
+  test("default (no-arg) call still writes verifiedVia=manual", async () => {
+    seedContact("c1");
+    seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
+
+    const result = await new ContactStore().markChannelVerified("ch1");
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.verifiedVia).toBe("manual");
+
+    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
+      c.sql.includes("UPDATE contact_channels"),
+    );
+    expect(dualWrite!.bind).toContain("manual");
+  });
+
   test("mirrors channel + contact from assistant DB when gateway is empty, then verifies", async () => {
     seedAssistantContact("c1");
     seedAssistantChannel({

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -633,12 +633,13 @@ export class ContactStore {
   }
 
   /**
-   * Mark a channel as verified by guardian attestation, bypassing the
-   * standard challenge-code exchange. Sets `status="active"`, stamps
-   * `verifiedAt=now`, and sets `verifiedVia="manual"` for audit trail.
+   * Mark a channel as verified. Sets `status="active"`, stamps
+   * `verifiedAt=now`, and records `verifiedVia` (default `"manual"` for the
+   * guardian-attestation path; `"challenge"` for the code-exchange path) on
+   * the audit trail.
    *
    * Atomic + idempotent. The UPDATE is gated on the row not already being
-   * `(status="active" AND verified_via="manual")`, so two concurrent
+   * `(status="active" AND verified_via=verifiedVia)`, so two concurrent
    * verify requests can't both write — exactly one will see `changes=1`
    * and the other will see `changes=0`. Both still return the post-state
    * row.
@@ -650,7 +651,10 @@ export class ContactStore {
    * When the channel is missing on the gateway but present on the assistant,
    * it (plus its parent contact) is mirrored into the gateway first.
    */
-  async markChannelVerified(channelId: string): Promise<{
+  async markChannelVerified(
+    channelId: string,
+    verifiedVia: "challenge" | "manual" = "manual",
+  ): Promise<{
     channel: ContactChannel;
     didWrite: boolean;
   } | null> {
@@ -671,7 +675,7 @@ export class ContactStore {
          WHERE id = ?
            AND (status != ? OR verified_via != ? OR verified_via IS NULL)`,
       )
-      .run("active", now, "manual", now, channelId, "active", "manual");
+      .run("active", now, verifiedVia, now, channelId, "active", verifiedVia);
 
     const after = this.db
       .select()
@@ -690,9 +694,9 @@ export class ContactStore {
       try {
         await assistantDbRun(
           `UPDATE contact_channels
-             SET status = 'active', verified_at = ?, verified_via = 'manual', updated_at = ?
+             SET status = 'active', verified_at = ?, verified_via = ?, updated_at = ?
            WHERE id = ?`,
-          [now, now, channelId],
+          [now, verifiedVia, now, channelId],
         );
       } catch (err) {
         log.warn(


### PR DESCRIPTION
## Summary
- markChannelVerified accepts optional verifiedVia (default "manual", preserving HTTP caller)
- Gateway DB + assistant dual-write + idempotency guard all use the passed verifiedVia
- Tests cover challenge path, per-verifiedVia idempotency, and manual-default regression

Part of plan: contacts-gw-native-verification.md (PR 2 of 6)