### PR TITLE
feat(gateway-client): add contact read IPC contracts (list/get)

### DIFF
--- a/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
+++ b/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the contact read IPC contracts in gateway-ipc-contracts.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ContactReadSchema,
+  GetContactIpcParamsSchema,
+  ListContactsIpcParamsSchema,
+} from "../gateway-ipc-contracts.js";
+
+describe("contact read contracts", () => {
+  test("ContactReadSchema parses a fully-populated contact", () => {
+    const contact = {
+      id: "c1",
+      displayName: "Ada Lovelace",
+      role: "guardian",
+      notes: "primary guardian",
+      contactType: "human",
+      lastInteraction: 1700000000,
+      interactionCount: 12,
+      channels: [
+        {
+          id: "ch1",
+          contactId: "c1",
+          type: "imessage",
+          address: "+15551234567",
+          isPrimary: true,
+          externalUserId: "+15551234567",
+          status: "active",
+          policy: "allow",
+          verifiedAt: 1699999999,
+          verifiedVia: "voice",
+          lastSeenAt: 1700000001,
+          interactionCount: 12,
+          lastInteraction: 1700000000,
+          revokedReason: null,
+          blockedReason: null,
+        },
+      ],
+    };
+
+    expect(() => ContactReadSchema.parse(contact)).not.toThrow();
+  });
+
+  test("ListContactsIpcParamsSchema defaults to {} when given undefined", () => {
+    expect(ListContactsIpcParamsSchema.parse(undefined)).toEqual({});
+  });
+
+  test("GetContactIpcParamsSchema rejects an empty object", () => {
+    expect(() => GetContactIpcParamsSchema.parse({})).toThrow();
+  });
+});

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -85,3 +85,84 @@ export const TrustRulesListIpcResponseSchema = z.object({
 export type TrustRulesListIpcResponse = z.infer<
   typeof TrustRulesListIpcResponseSchema
 >;
+
+export const ContactReadChannelSchema = z.object({
+  id: z.string(),
+  contactId: z.string(),
+  type: z.string(),
+  address: z.string(),
+  isPrimary: z.boolean(),
+  externalUserId: z.string().nullable(),
+  status: z.string(),
+  policy: z.string(),
+  verifiedAt: z.number().nullable(),
+  verifiedVia: z.string().nullable(),
+  lastSeenAt: z.number().nullable(),
+  interactionCount: z.number(),
+  lastInteraction: z.number().nullable(),
+  revokedReason: z.string().nullable(),
+  blockedReason: z.string().nullable(),
+});
+
+export type ContactReadChannel = z.infer<typeof ContactReadChannelSchema>;
+
+export const ContactReadSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  role: z.string(),
+  notes: z.string().nullable().optional(),
+  contactType: z.string().nullable().optional(),
+  lastInteraction: z.number().nullable().optional(),
+  interactionCount: z.number(),
+  channels: z.array(ContactReadChannelSchema),
+});
+
+export type ContactRead = z.infer<typeof ContactReadSchema>;
+
+export const AssistantContactMetadataSchema = z.object({
+  contactId: z.string(),
+  species: z.string(),
+  metadata: z.object({}).passthrough().nullable(),
+});
+
+export type AssistantContactMetadata = z.infer<
+  typeof AssistantContactMetadataSchema
+>;
+
+export const ListContactsIpcParamsSchema = z
+  .object({
+    limit: z.number().optional(),
+    role: z.string().optional(),
+    contactType: z.string().optional(),
+  })
+  .strict()
+  .default({});
+
+export type ListContactsIpcParams = z.infer<
+  typeof ListContactsIpcParamsSchema
+>;
+
+export const ListContactsIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  contacts: z.array(ContactReadSchema),
+});
+
+export type ListContactsIpcResponse = z.infer<
+  typeof ListContactsIpcResponseSchema
+>;
+
+export const GetContactIpcParamsSchema = z
+  .object({ contactId: z.string() })
+  .strict();
+
+export type GetContactIpcParams = z.infer<typeof GetContactIpcParamsSchema>;
+
+export const GetContactIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  contact: ContactReadSchema,
+  assistantMetadata: AssistantContactMetadataSchema.optional(),
+});
+
+export type GetContactIpcResponse = z.infer<
+  typeof GetContactIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Add Zod IPC contracts for relaying daemon contact reads to the gateway: ContactReadChannelSchema, ContactReadSchema, AssistantContactMetadataSchema, list/get params + response schemas, and inferred types.
- Field-for-field compatible with the daemon's contactSchema/contactChannelSchema so relayed payloads validate unchanged.

Part of plan: contacts-relay-reads.md (PR 1 of 4)