### PR TITLE
fix(gateway): create_contact IPC handler dual-writes via ContactStore.upsertContact

### DIFF
--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -323,4 +323,124 @@ describe("IPC contact routes", () => {
     expect(res.error).toBeDefined();
     expect(res.error).toContain("Invalid params");
   });
+
+  // -------------------------------------------------------------------------
+  // create_contact (gateway DB source of truth via ContactStore.upsertContact)
+  // -------------------------------------------------------------------------
+  //
+  // No assistant daemon is running in these tests, so the best-effort
+  // assistant-DB dual-write inside upsertContact fails and is soft-failed —
+  // the gateway write still succeeds and { contactId, channelId } is still
+  // returned (invariant 2). This is exactly what we assert below.
+
+  test("create_contact writes the gateway DB contacts + contact_channels rows", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "new@example.com",
+      displayName: "New Person",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId, channelId } = res.result as {
+      contactId: string;
+      channelId: string;
+    };
+    expect(contactId).toBeTruthy();
+    expect(channelId).toBeTruthy();
+
+    // The gateway DB (source of truth) now has both rows — previously the
+    // raw-SQL handler wrote the assistant DB only.
+    const store = new ContactStore(getGatewayDb());
+    const contact = store.getContact(contactId);
+    expect(contact).toBeDefined();
+    expect(contact!.displayName).toBe("New Person");
+    // role is always "contact" — guardian binding is not settable here.
+    expect(contact!.role).toBe("contact");
+
+    const channels = store.getChannelsForContact(contactId);
+    expect(channels).toHaveLength(1);
+    expect(channels[0].id).toBe(channelId);
+    expect(channels[0].type).toBe("email");
+    expect(channels[0].address).toBe("new@example.com");
+    expect(channels[0].isPrimary).toBe(true);
+  });
+
+  test("create_contact returns { contactId, channelId } both present and non-empty", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "shape@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const result = res.result as { contactId: string; channelId: string };
+    expect(typeof result.contactId).toBe("string");
+    expect(typeof result.channelId).toBe("string");
+    expect(result.contactId.length).toBeGreaterThan(0);
+    expect(result.channelId.length).toBeGreaterThan(0);
+  });
+
+  test("create_contact ignores the role param (guardian binding not settable here)", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "wannabe-guardian@example.com",
+      role: "guardian",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    const store = new ContactStore(getGatewayDb());
+    expect(store.getContact(contactId)!.role).toBe("contact");
+  });
+
+  test("create_contact is idempotent for the same (channelType, address)", async () => {
+    await startServerAndConnect();
+    const first = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "dup@example.com",
+    });
+    const second = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "dup@example.com",
+    });
+
+    expect(first.error).toBeUndefined();
+    expect(second.error).toBeUndefined();
+    const a = first.result as { contactId: string; channelId: string };
+    const b = second.result as { contactId: string; channelId: string };
+    expect(b.contactId).toBe(a.contactId);
+    expect(b.channelId).toBe(a.channelId);
+
+    // No duplicate rows.
+    const store = new ContactStore(getGatewayDb());
+    expect(store.listContacts()).toHaveLength(1);
+    expect(store.getChannelsForContact(a.contactId)).toHaveLength(1);
+  });
+
+  test("create_contact canonicalizes the address so a non-canonical variant matches", async () => {
+    await startServerAndConnect();
+    // Phone numbers canonicalize to E.164; a variant with spacing/punctuation
+    // must resolve to the same channel on the second call.
+    const first = await sendRequest(client, "create_contact", {
+      channelType: "phone",
+      address: "+1 (555) 010-1234",
+    });
+    const second = await sendRequest(client, "create_contact", {
+      channelType: "phone",
+      address: "+15550101234",
+    });
+
+    expect(first.error).toBeUndefined();
+    expect(second.error).toBeUndefined();
+    const a = first.result as { contactId: string; channelId: string };
+    const b = second.result as { contactId: string; channelId: string };
+    expect(b.contactId).toBe(a.contactId);
+    expect(b.channelId).toBe(a.channelId);
+
+    const store = new ContactStore(getGatewayDb());
+    expect(store.getChannelsForContact(a.contactId)).toHaveLength(1);
+  });
 });

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -476,6 +476,115 @@ describe("IPC contact routes", () => {
     expect(channels[0].verifiedVia).toBe("manual");
   });
 
+  test("create_contact retry preserves existing displayName + external_chat_id when omitted", async () => {
+    // A retry / re-add for an existing contact that already has a custom
+    // displayName and a set external_chat_id, called WITHOUT a displayName,
+    // must not overwrite the name with the bare address nor clear the chat id.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "named-c1",
+        displayName: "Alice In Wonderland",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "named-ch1",
+        contactId: "named-c1",
+        type: "telegram",
+        address: "tg-alice-001",
+        isPrimary: true,
+        externalChatId: "chat-alice-001",
+        status: "active",
+        policy: "allow",
+        interactionCount: 2,
+        createdAt: now,
+      })
+      .run();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "telegram",
+      address: "tg-alice-001",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId, channelId } = res.result as {
+      contactId: string;
+      channelId: string;
+    };
+    expect(contactId).toBe("named-c1");
+    expect(channelId).toBe("named-ch1");
+
+    const store = new ContactStore(db);
+    // displayName preserved — NOT overwritten with the bare address.
+    expect(store.getContact("named-c1")!.displayName).toBe(
+      "Alice In Wonderland",
+    );
+    const channels = store.getChannelsForContact("named-c1");
+    expect(channels).toHaveLength(1);
+    // external_chat_id preserved — sparse upsert must not clear it.
+    expect(channels[0].externalChatId).toBe("chat-alice-001");
+  });
+
+  test("create_contact retry honors an explicitly supplied displayName", async () => {
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "rename-c1",
+        displayName: "Old Name",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "rename-ch1",
+        contactId: "rename-c1",
+        type: "email",
+        address: "rename@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+      })
+      .run();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "rename@example.com",
+      displayName: "New Name",
+    });
+
+    expect(res.error).toBeUndefined();
+    const store = new ContactStore(db);
+    expect(store.getContact("rename-c1")!.displayName).toBe("New Name");
+  });
+
+  test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "noname@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    const store = new ContactStore(getGatewayDb());
+    expect(store.getContact(contactId)!.displayName).toBe("noname@example.com");
+  });
+
   test("create_contact applies default unverified/allow to a brand-new channel", async () => {
     await startServerAndConnect();
     const res = await sendRequest(client, "create_contact", {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -328,10 +328,9 @@ describe("IPC contact routes", () => {
   // create_contact (gateway DB source of truth via ContactStore.upsertContact)
   // -------------------------------------------------------------------------
   //
-  // No assistant daemon is running in these tests, so the best-effort
-  // assistant-DB dual-write inside upsertContact fails and is soft-failed —
-  // the gateway write still succeeds and { contactId, channelId } is still
-  // returned (invariant 2). This is exactly what we assert below.
+  // No assistant daemon runs in these tests, so the best-effort assistant-DB
+  // dual-write inside upsertContact soft-fails. The gateway write still
+  // succeeds and { contactId, channelId } is returned regardless.
 
   test("create_contact writes the gateway DB contacts + contact_channels rows", async () => {
     await startServerAndConnect();
@@ -349,8 +348,7 @@ describe("IPC contact routes", () => {
     expect(contactId).toBeTruthy();
     expect(channelId).toBeTruthy();
 
-    // The gateway DB (source of truth) now has both rows — previously the
-    // raw-SQL handler wrote the assistant DB only.
+    // The gateway DB (source of truth) holds both the contact and channel rows.
     const store = new ContactStore(getGatewayDb());
     const contact = store.getContact(contactId);
     expect(contact).toBeDefined();

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -420,6 +420,79 @@ describe("IPC contact routes", () => {
     expect(store.getChannelsForContact(a.contactId)).toHaveLength(1);
   });
 
+  test("create_contact retry does not demote an existing active/verified channel", async () => {
+    // An already-trusted channel (active + non-allow policy) must survive a
+    // retry untouched — passing hard-coded unverified/allow would drop it below
+    // the trusted_contacts admission floor.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "trusted-c1",
+        displayName: "Trusted Person",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "trusted-ch1",
+        contactId: "trusted-c1",
+        type: "email",
+        address: "trusted@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "escalate",
+        verifiedAt: now,
+        verifiedVia: "manual",
+        interactionCount: 3,
+        createdAt: now,
+      })
+      .run();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "trusted@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId, channelId } = res.result as {
+      contactId: string;
+      channelId: string;
+    };
+    expect(contactId).toBe("trusted-c1");
+    expect(channelId).toBe("trusted-ch1");
+
+    const store = new ContactStore(db);
+    const channels = store.getChannelsForContact("trusted-c1");
+    expect(channels).toHaveLength(1);
+    // Status/policy/verification preserved — NOT overwritten to unverified/allow.
+    expect(channels[0].status).toBe("active");
+    expect(channels[0].policy).toBe("escalate");
+    expect(channels[0].verifiedAt).toBe(now);
+    expect(channels[0].verifiedVia).toBe("manual");
+  });
+
+  test("create_contact applies default unverified/allow to a brand-new channel", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "fresh@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    const store = new ContactStore(getGatewayDb());
+    const channels = store.getChannelsForContact(contactId);
+    expect(channels).toHaveLength(1);
+    expect(channels[0].status).toBe("unverified");
+    expect(channels[0].policy).toBe("allow");
+  });
+
   test("create_contact canonicalizes the address so a non-canonical variant matches", async () => {
     await startServerAndConnect();
     // Phone numbers canonicalize to E.164; a variant with spacing/punctuation

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1487,8 +1487,15 @@ export class ContactStore {
 
       if (existingCh.length) {
         const isBlocked = existingCh[0].status === "blocked";
-        const setParts: string[] = ["external_chat_id = ?", "updated_at = ?"];
-        const setParams: SqliteValue[] = [ch.externalChatId ?? null, now];
+        // Omit-to-preserve: only overwrite external_chat_id when the caller
+        // supplied one, mirroring syncChannels (gateway DB). A sparse upsert
+        // (no externalChatId) must not clear an existing delivery chat id.
+        const setParts: string[] = ["updated_at = ?"];
+        const setParams: SqliteValue[] = [now];
+        if (ch.externalChatId !== undefined) {
+          setParts.push("external_chat_id = ?");
+          setParams.push(ch.externalChatId);
+        }
         if (!isBlocked) {
           if (ch.status !== undefined) {
             setParts.push("status = ?");

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -2,13 +2,13 @@
  * IPC route definitions for contact reads and writes.
  *
  * Read methods expose gateway-owned contact data to the assistant daemon.
- * The `create_contact` write method upserts a contact+channel via the
- * assistant DB proxy (raw SQL), so the gateway owns the write path.
+ * The `create_contact` write method upserts a contact+channel via
+ * `ContactStore.upsertContact`, which writes the gateway DB (source of truth)
+ * and best-effort mirrors to the assistant DB.
  */
 
 import { z } from "zod";
 
-import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
 import { ContactStore } from "../db/contact-store.js";
 import { getLogger } from "../logger.js";
 import { canonicalizeInboundIdentity } from "../verification/identity.js";
@@ -81,74 +81,48 @@ export const contactRoutes: IpcRoute[] = [
     method: "create_contact",
     schema: CreateContactParamsSchema,
     handler: async (params?: Record<string, unknown>) => {
-      const { channelType, address, role, displayName } =
+      const { channelType, address, displayName } =
         CreateContactParamsSchema.parse(params);
 
-      const normalizedAddress =
+      // Canonicalize once here; upsertContact canonicalizes internally too, so
+      // passing the canonical form keeps a single source of truth.
+      // NOTE: `role` is intentionally not honored. Guardian binding is owned by
+      // guardian-bootstrap (see ContactStore.upsertContact SECURITY note); a
+      // contact created here always gets role="contact".
+      const canonicalAddress =
         canonicalizeInboundIdentity(channelType, address) ?? address.trim();
-      const effectiveDisplayName = displayName ?? normalizedAddress;
-      // Map prompt roles to valid ContactRole values ("guardian" | "contact").
-      const effectiveRole: string =
-        role === "guardian" ? "guardian" : "contact";
-      const now = Date.now();
+      const effectiveDisplayName = displayName ?? canonicalAddress;
 
-      // Check if a channel with this (type, address) already exists.
-      const existing = await assistantDbQuery<{
-        channelId: string;
-        contactId: string;
-      }>(
-        `SELECT cc.id AS channelId, cc.contact_id AS contactId
-         FROM contact_channels cc
-         WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-         LIMIT 1`,
-        [channelType, normalizedAddress],
-      );
+      const store = getStore();
+      const { contact } = await store.upsertContact({
+        displayName: effectiveDisplayName,
+        channels: [
+          {
+            type: channelType,
+            address: canonicalAddress,
+            isPrimary: true,
+            status: "unverified",
+            policy: "allow",
+          },
+        ],
+      });
 
-      if (existing.length > 0) {
-        const { channelId, contactId } = existing[0];
-        log.info(
-          { channelType, address: normalizedAddress, contactId, channelId },
-          "create_contact: channel already exists, returning existing record",
+      const contactId = contact.id;
+      // Resolve the channel id from the gateway DB (source of truth). The
+      // upsertContact result's channels can be empty when the assistant-DB
+      // read-back is unavailable (best-effort), so don't rely on it here.
+      const channel = store
+        .getChannelsForContact(contactId)
+        .find(
+          (ch) =>
+            ch.type === channelType &&
+            ch.address.toLowerCase() === canonicalAddress.toLowerCase(),
         );
-        return { contactId, channelId };
-      }
-
-      // Create a new contact + channel.
-      // Two separate INSERTs — use a compensating DELETE on channel failure.
-      const contactId = crypto.randomUUID();
-      const channelId = crypto.randomUUID();
-
-      await assistantDbRun(
-        `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-         VALUES (?, ?, ?, 'human', ?, ?)`,
-        [contactId, effectiveDisplayName, effectiveRole, now, now],
-      );
-
-      try {
-        await assistantDbRun(
-          `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-           VALUES (?, ?, ?, ?, 1, 'unverified', 'allow', 0, ?, ?)`,
-          [channelId, contactId, channelType, normalizedAddress, now, now],
-        );
-      } catch (channelErr) {
-        // Compensating delete — remove the orphaned contact row.
-        log.error(
-          { channelErr, contactId, channelType, address: normalizedAddress },
-          "create_contact: channel INSERT failed, rolling back contact row",
-        );
-        await assistantDbRun("DELETE FROM contacts WHERE id = ?", [contactId]);
-        throw channelErr;
-      }
+      const channelId = channel?.id ?? "";
 
       log.info(
-        {
-          channelType,
-          address: normalizedAddress,
-          contactId,
-          channelId,
-          role: effectiveRole,
-        },
-        "create_contact: created new contact + channel",
+        { channelType, address: canonicalAddress, contactId, channelId },
+        "create_contact: upserted contact + channel via ContactStore",
       );
 
       return { contactId, channelId };

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -91,13 +91,22 @@ export const contactRoutes: IpcRoute[] = [
       // contact created here always gets role="contact".
       const canonicalAddress =
         canonicalizeInboundIdentity(channelType, address) ?? address.trim();
-      const effectiveDisplayName = displayName ?? canonicalAddress;
 
       const store = getStore();
-      // Omit status/policy: syncChannels defaults a new channel to
-      // unverified/allow but preserves an existing channel's values on retry.
-      // Passing them here would demote a trusted channel below the
-      // trusted_contacts admission floor (mirrors verification/contact-helpers).
+      // Preserve an existing contact's displayName on retry: only the caller's
+      // explicit displayName overrides it. Falling back to the existing name
+      // (or the canonical address for a brand-new contact) avoids clobbering a
+      // custom name with the bare address, since upsertContact always writes
+      // displayName.
+      const existing = store.getContactByChannel(channelType, canonicalAddress);
+      const effectiveDisplayName =
+        displayName ?? existing?.displayName ?? canonicalAddress;
+
+      // Omit status/policy/externalChatId: syncChannels and the assistant-DB
+      // mirror default a new channel but preserve an existing channel's values
+      // on retry. Passing them here would demote a trusted channel below the
+      // trusted_contacts admission floor (mirrors verification/contact-helpers)
+      // or clear a delivery chat id.
       const { contact } = await store.upsertContact({
         displayName: effectiveDisplayName,
         channels: [

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -94,6 +94,10 @@ export const contactRoutes: IpcRoute[] = [
       const effectiveDisplayName = displayName ?? canonicalAddress;
 
       const store = getStore();
+      // Omit status/policy: syncChannels defaults a new channel to
+      // unverified/allow but preserves an existing channel's values on retry.
+      // Passing them here would demote a trusted channel below the
+      // trusted_contacts admission floor (mirrors verification/contact-helpers).
       const { contact } = await store.upsertContact({
         displayName: effectiveDisplayName,
         channels: [
@@ -101,8 +105,6 @@ export const contactRoutes: IpcRoute[] = [
             type: channelType,
             address: canonicalAddress,
             isPrimary: true,
-            status: "unverified",
-            policy: "allow",
           },
         ],
       });


### PR DESCRIPTION
## Summary
- Replace the assistant-DB-only raw-SQL `create_contact` IPC handler with `ContactStore.upsertContact`, dual-writing the gateway DB (source of truth) + assistant DB.
- `role` is no longer written through this surface; guardian binding stays owned by guardian-bootstrap (documented behavior change).

Part of plan: contacts-relay-writes-create-contact.md (PR 2 of 2)