### PR TITLE
feat(contacts): relay updateContactChannel IPC to gateway-native handler

### DIFF
--- a/assistant/src/runtime/routes/__tests__/contact-routes-update-channel-relay.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes-update-channel-relay.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the daemon updateContactChannel relay.
+ *
+ * `handleUpdateContactChannelRoute` is a thin relay to the gateway IPC method
+ * `update_contact_channel` via `ipcCallPersistent`. The gateway DB is the source
+ * of truth: the daemon writes NOTHING to the assistant DB directly. These tests
+ * assert the handler forwards `{ contactChannelId, status, policy, reason }`
+ * unchanged, returns the gateway response verbatim, never touches the assistant
+ * contact store, and propagates an unexpected relay rejection (no fallback).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = { ok: true };
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCalls.push({ method, params, timeoutMs });
+    if (ipcError) throw ipcError;
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if the relay still writes the assistant contact store
+// directly. The relayed update path must go through the gateway only.
+const actualContactStore = await import("../../../contacts/contact-store.js");
+
+const contactStoreWriteGuard = mock(() => {
+  throw new Error(
+    "assistant contact-store write must not happen on the relayed update path",
+  );
+});
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  updateChannelStatus: contactStoreWriteGuard,
+}));
+
+const { handleUpdateContactChannelRoute, ROUTES } = await import(
+  "../contact-routes.js"
+);
+
+describe("update contact channel relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = { ok: true };
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    contactStoreWriteGuard.mockClear();
+  });
+
+  test("forwards { contactChannelId, status, policy, reason } unchanged and returns the gateway response verbatim", async () => {
+    const gatewayResponse = {
+      ok: true,
+      contact: { id: "ct_1", displayName: "Alice", channels: [] },
+    };
+    ipcResult = gatewayResponse;
+
+    const result = await handleUpdateContactChannelRoute({
+      pathParams: { contactChannelId: "ch_1" },
+      body: { status: "revoked", policy: "deny", reason: "user request" },
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "update_contact_channel",
+        params: {
+          contactChannelId: "ch_1",
+          status: "revoked",
+          policy: "deny",
+          reason: "user request",
+        },
+        timeoutMs: undefined,
+      },
+    ]);
+    expect(result).toEqual(gatewayResponse);
+    // Must NOT write the assistant DB directly.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("omits absent body fields from the relayed params", async () => {
+    ipcResult = { ok: true };
+
+    await handleUpdateContactChannelRoute({
+      pathParams: { contactChannelId: "ch_2" },
+      body: { status: "active" },
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "update_contact_channel",
+        params: { contactChannelId: "ch_2", status: "active" },
+        timeoutMs: undefined,
+      },
+    ]);
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed IpcCallError surfaces with its statusCode/errorCode", async () => {
+    ipcError = new IpcCallError("Channel not found", {
+      statusCode: 404,
+      errorCode: "NOT_FOUND",
+    });
+
+    try {
+      await handleUpdateContactChannelRoute({
+        pathParams: { contactChannelId: "missing" },
+        body: { status: "active" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      const e = err as { statusCode?: number; code?: string; message: string };
+      expect(e.message).toBe("Channel not found");
+      expect(e.statusCode).toBe(404);
+      expect(e.code).toBe("NOT_FOUND");
+    }
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("an unexpected relay rejection propagates (no fallback, no second write)", async () => {
+    ipcError = new Error("ipc transport exploded");
+
+    try {
+      await handleUpdateContactChannelRoute({
+        pathParams: { contactChannelId: "ch_3" },
+        body: { status: "active" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      expect((err as Error).message).toBe("ipc transport exploded");
+    }
+    // No daemon-side fallback write.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+    expect(ipcCalls).toHaveLength(1);
+  });
+
+  test("the updateContactChannel route is registered and wired to the relay", () => {
+    const route = ROUTES.find((r) => r.operationId === "updateContactChannel");
+    expect(route).toBeDefined();
+    expect(route?.endpoint).toBe("contact-channels/:contactChannelId");
+    expect(route?.method).toBe("PATCH");
+  });
+});

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -8,24 +8,18 @@
  * they don't shadow more-specific sub-paths like contacts/invites.
  */
 
+import { UpdateContactChannelIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import {
   getAssistantContactMetadata,
-  getChannelById,
   getContact,
   listContacts,
   mergeContacts,
   searchContacts,
-  updateChannelStatus,
 } from "../../contacts/contact-store.js";
-import type {
-  ChannelPolicy,
-  ChannelStatus,
-  ContactRole,
-  ContactType,
-} from "../../contacts/types.js";
+import type { ContactRole, ContactType } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -34,12 +28,7 @@ import {
   redeemVoiceInviteCode,
   triggerInviteCall,
 } from "../invite-service.js";
-import {
-  BadRequestError,
-  ConflictError,
-  NotFoundError,
-  RouteError,
-} from "./errors.js";
+import { BadRequestError, NotFoundError, RouteError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 /**
@@ -97,29 +86,8 @@ function prepareContactResponse<
 
 const VALID_CONTACT_TYPES: readonly ContactType[] = ["human", "assistant"];
 
-const VALID_CHANNEL_STATUSES: readonly ChannelStatus[] = [
-  "active",
-  "pending",
-  "revoked",
-  "blocked",
-  "unverified",
-];
-const VALID_CHANNEL_POLICIES: readonly ChannelPolicy[] = [
-  "allow",
-  "deny",
-  "escalate",
-];
-
 function isContactType(value: string): value is ContactType {
   return (VALID_CONTACT_TYPES as readonly string[]).includes(value);
-}
-
-function isChannelStatus(value: string): value is ChannelStatus {
-  return (VALID_CHANNEL_STATUSES as readonly string[]).includes(value);
-}
-
-function isChannelPolicy(value: string): value is ChannelPolicy {
-  return (VALID_CHANNEL_POLICIES as readonly string[]).includes(value);
 }
 
 // ---------------------------------------------------------------------------
@@ -719,62 +687,33 @@ function handleMergeContactsRoute(args: RouteHandlerArgs) {
   }
 }
 
-function handleUpdateContactChannelRoute(args: RouteHandlerArgs) {
-  const channelId = args.pathParams!.contactChannelId;
+/**
+ * Relay the channel status/policy update to the gateway-native handler.
+ *
+ * The gateway DB is the source of truth: it owns validation, the
+ * revoke-of-blocked guard, the assistant-side channel-ID backward-compat
+ * resolution, the assistant-DB mirror, and the `contacts_changed` emit. This
+ * daemon handler writes NOTHING to the assistant DB directly — it forwards the
+ * raw channel ID + body and returns the gateway response verbatim. No fallback:
+ * an unexpected relay failure surfaces as an error (never a silent second
+ * write).
+ */
+export async function handleUpdateContactChannelRoute(args: RouteHandlerArgs) {
   const body = (args.body ?? {}) as {
     status?: string;
     policy?: string;
     reason?: string;
   };
 
-  if (body.status !== undefined && !isChannelStatus(body.status)) {
-    throw new BadRequestError(
-      `Invalid status "${body.status}". Must be one of: ${VALID_CHANNEL_STATUSES.join(", ")}`,
-    );
+  try {
+    const result = await ipcCallPersistent("update_contact_channel", {
+      contactChannelId: args.pathParams!.contactChannelId,
+      ...(body.status !== undefined ? { status: body.status } : {}),
+      ...(body.policy !== undefined ? { policy: body.policy } : {}),
+      ...(body.reason !== undefined ? { reason: body.reason } : {}),
+    });
+    return UpdateContactChannelIpcResponseSchema.parse(result);
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-
-  if (body.policy !== undefined && !isChannelPolicy(body.policy)) {
-    throw new BadRequestError(
-      `Invalid policy "${body.policy}". Must be one of: ${VALID_CHANNEL_POLICIES.join(", ")}`,
-    );
-  }
-
-  if (body.status === "revoked") {
-    const existing = getChannelById(channelId);
-    if (!existing) {
-      throw new NotFoundError(`Channel "${channelId}" not found`);
-    }
-    if (existing.status === "blocked") {
-      throw new ConflictError(
-        "Cannot revoke a blocked channel. Unblock it first or leave it blocked.",
-      );
-    }
-  }
-
-  const updated = updateChannelStatus(channelId, {
-    status: body.status,
-    policy: body.policy,
-    revokedReason:
-      body.status !== undefined
-        ? body.status === "revoked"
-          ? (body.reason ?? null)
-          : null
-        : undefined,
-    blockedReason:
-      body.status !== undefined
-        ? body.status === "blocked"
-          ? (body.reason ?? null)
-          : null
-        : undefined,
-  });
-
-  if (!updated) {
-    throw new NotFoundError(`Channel "${channelId}" not found`);
-  }
-
-  const parentContact = getContact(updated.contactId);
-  return {
-    ok: true,
-    contact: parentContact ? prepareContactResponse(parentContact) : undefined,
-  };
 }

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -6,12 +6,45 @@ import {
   beforeEach,
   afterAll,
   afterEach,
+  mock,
 } from "bun:test";
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { createConnection, type Socket } from "node:net";
 import { eq } from "drizzle-orm";
+
+// ── Assistant DB proxy + IPC mocks ──────────────────────────────────────────
+// The gateway-native channel write (updateContactChannelCore) resolves
+// assistant-side channel IDs and mirrors into the assistant DB over the IPC
+// proxy, and emits contacts_changed via ipcCallAssistant. None of that is
+// reachable in this unit test, so stub both modules. The gateway DB is the
+// source of truth and remains real.
+type DbQueryFn = (sql: string, bind?: unknown[]) => Promise<unknown[]>;
+let assistantDbQueryMock: ReturnType<typeof mock<DbQueryFn>> = mock(
+  async () => [],
+);
+type DbRunFn = (
+  sql: string,
+  bind?: unknown[],
+) => Promise<{ changes: number; lastInsertRowid: number }>;
+let assistantDbRunMock: ReturnType<typeof mock<DbRunFn>> = mock(async () => ({
+  changes: 1,
+  lastInsertRowid: 0,
+}));
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: (...args: Parameters<DbQueryFn>) =>
+    assistantDbQueryMock(...args),
+  assistantDbRun: (...args: Parameters<DbRunFn>) => assistantDbRunMock(...args),
+}));
+
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: mock(async () => ({})),
+  IpcHandlerError: class IpcHandlerError extends Error {},
+  IpcTransportError: class IpcTransportError extends Error {},
+}));
+
 import { GatewayIpcServer } from "../ipc/server.js";
 import { contactRoutes } from "../ipc/contact-handlers.js";
 import { ContactStore } from "../db/contact-store.js";
@@ -33,6 +66,10 @@ beforeEach(() => {
   const db = getGatewayDb();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
+  // Reset assistant-proxy stubs to their permissive defaults: no assistant-side
+  // channel resolution, dual-write succeeds.
+  assistantDbQueryMock = mock(async () => []);
+  assistantDbRunMock = mock(async () => ({ changes: 1, lastInsertRowid: 0 }));
 });
 
 afterAll(() => {
@@ -54,7 +91,13 @@ function sendRequest(
   client: Socket,
   method: string,
   params?: Record<string, unknown>,
-): Promise<{ id: string; result?: unknown; error?: string }> {
+): Promise<{
+  id: string;
+  result?: unknown;
+  error?: string;
+  statusCode?: number;
+  errorCode?: string;
+}> {
   return new Promise((resolve, reject) => {
     const id = randomBytes(4).toString("hex");
     let buffer = "";
@@ -322,5 +365,193 @@ describe("IPC contact routes", () => {
 
     expect(res.error).toBeDefined();
     expect(res.error).toContain("Invalid params");
+  });
+
+  // ── update_contact_channel (gateway-native write) ──────────────────────
+  describe("update_contact_channel", () => {
+    /** Insert a blocked channel so revoke-of-blocked can be exercised. */
+    function seedBlockedChannel(): void {
+      const db = getGatewayDb();
+      db.insert(contactChannels)
+        .values({
+          id: "ch_blocked",
+          contactId: "c2",
+          type: "telegram",
+          address: "tg-blocked-001",
+          isPrimary: false,
+          externalChatId: null,
+          status: "blocked",
+          policy: "deny",
+          interactionCount: 0,
+          createdAt: Date.now(),
+        })
+        .run();
+    }
+
+    test("status update succeeds and writes the gateway DB row", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        status: "active",
+      });
+
+      expect(res.error).toBeUndefined();
+      const body = res.result as { ok: boolean; contact?: { id: string } };
+      expect(body.ok).toBe(true);
+      expect(body.contact?.id).toBe("c2");
+
+      // Gateway DB is the source of truth — the row must reflect the new status.
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.status).toBe("active");
+    });
+
+    test("policy update succeeds and writes the gateway DB row", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        policy: "deny",
+      });
+
+      expect(res.error).toBeUndefined();
+      expect((res.result as { ok: boolean }).ok).toBe(true);
+
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.policy).toBe("deny");
+    });
+
+    test("invalid status is rejected as a 400", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        status: "deleted",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("BAD_REQUEST");
+      expect(res.error).toMatch(/status/);
+    });
+
+    test("invalid policy is rejected as a 400", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        policy: "maybe",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("BAD_REQUEST");
+      expect(res.error).toMatch(/policy/);
+    });
+
+    test("revoking a blocked channel returns the conflict error", async () => {
+      seedTestData();
+      seedBlockedChannel();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch_blocked",
+        status: "revoked",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(409);
+      expect(res.errorCode).toBe("CONFLICT");
+      expect(res.error).toMatch(/blocked/);
+
+      // The blocked row must be untouched.
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch_blocked"))
+        .get();
+      expect(row?.status).toBe("blocked");
+    });
+
+    test("unknown channel ID returns not-found", async () => {
+      seedTestData();
+      // No assistant-side resolution: the proxy query returns no rows.
+      assistantDbQueryMock = mock(async () => []);
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "does-not-exist",
+        status: "active",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(404);
+      expect(res.errorCode).toBe("NOT_FOUND");
+    });
+
+    test("assistant-side channel ID resolves via backward-compat path", async () => {
+      seedTestData();
+      // The given ID is unknown to the gateway DB; the assistant DB resolves it
+      // to the logical key (contactId, type, address) of the existing gateway
+      // channel ch3, which updateChannelStatus then matches.
+      assistantDbQueryMock = mock(async () => [
+        { contactId: "c2", type: "email", address: "test@example.com" },
+      ]);
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "assistant-side-id",
+        status: "active",
+      });
+
+      expect(res.error).toBeUndefined();
+      expect((res.result as { ok: boolean }).ok).toBe(true);
+
+      // The resolved gateway row (ch3) is the one that gets updated.
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.status).toBe("active");
+    });
+
+    test("tolerates assistant-DB dual-write failure (gateway write still succeeds)", async () => {
+      seedTestData();
+      // Dual-write to the assistant DB throws; the gateway write is the source
+      // of truth and must still succeed.
+      assistantDbRunMock = mock(async () => {
+        throw new Error("assistant DB down");
+      });
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        status: "revoked",
+        reason: "spam",
+      });
+
+      expect(res.error).toBeUndefined();
+      expect((res.result as { ok: boolean }).ok).toBe(true);
+
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.status).toBe("revoked");
+    });
   });
 });

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -60,6 +60,25 @@ export class InviteNativeError extends Error {
   }
 }
 
+/**
+ * Error thrown by the transport-agnostic contact-channel core to signal a
+ * client-facing failure with a stable code + status. The HTTP handler maps it
+ * to `Response.json`; the gateway IPC route lets it propagate (the IPC server
+ * stringifies thrown errors and mirrors `statusCode`/`code` into the wire
+ * envelope).
+ */
+export class ContactChannelNativeError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+
+  constructor(message: string, statusCode: number, code: string) {
+    super(message);
+    this.name = "ContactChannelNativeError";
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
 /** Map an InviteNativeError (or generic error) to the HTTP error Response. */
 function inviteErrorResponse(err: unknown): Response {
   if (err instanceof InviteNativeError) {
@@ -654,6 +673,120 @@ function isChannelPolicy(v: unknown): v is ChannelPolicy {
 }
 
 /**
+ * Transport-agnostic channel status/policy write.
+ *
+ * Shared by the HTTP `handleUpdateContactChannel` and the gateway IPC
+ * `update_contact_channel` route. Validates status/policy, performs the
+ * gateway DB write (source of truth) via `ContactStore.updateChannelStatus`
+ * — which preserves the revoke-of-blocked guard and resolves assistant-side
+ * channel IDs via the (contactId, type, address) backward-compat path —
+ * best-effort mirrors into the assistant DB, emits `contacts_changed`, and
+ * returns the parent contact payload.
+ *
+ * Throws `ContactChannelNativeError` for client-facing failures (400 bad
+ * status/policy, 404 unknown channel, 409 revoke-of-blocked). Unexpected
+ * errors propagate so each transport surfaces a 500-equivalent — never a
+ * silent fallback.
+ */
+export async function updateContactChannelCore(params: {
+  contactChannelId: string;
+  status?: string;
+  policy?: string;
+  reason?: string | null;
+}): Promise<{ ok: true; contact?: Record<string, unknown> }> {
+  const { contactChannelId } = params;
+  const status = params.status;
+  const policy = params.policy;
+  const reason = params.reason ?? null;
+
+  if (status !== undefined && !isChannelStatus(status)) {
+    throw new ContactChannelNativeError(
+      `Invalid status "${status}". Must be one of: ${VALID_CHANNEL_STATUSES.join(", ")}`,
+      400,
+      "BAD_REQUEST",
+    );
+  }
+  if (policy !== undefined && !isChannelPolicy(policy)) {
+    throw new ContactChannelNativeError(
+      `Invalid policy "${policy}". Must be one of: ${VALID_CHANNEL_POLICIES.join(", ")}`,
+      400,
+      "BAD_REQUEST",
+    );
+  }
+  if (status === undefined && policy === undefined) {
+    throw new ContactChannelNativeError(
+      "At least one of status or policy must be provided",
+      400,
+      "BAD_REQUEST",
+    );
+  }
+
+  const store = new ContactStore();
+  let updated;
+  try {
+    updated = await store.updateChannelStatus(contactChannelId, {
+      status,
+      policy,
+      reason,
+    });
+  } catch (err) {
+    if (err instanceof CannotRevokeBlockedError) {
+      throw new ContactChannelNativeError(err.message, 409, "CONFLICT");
+    }
+    throw err;
+  }
+
+  if (!updated) {
+    throw new ContactChannelNativeError(
+      `Channel "${contactChannelId}" not found`,
+      404,
+      "NOT_FOUND",
+    );
+  }
+
+  // Best-effort dual-write to assistant DB.
+  const dualWriteParams: {
+    status?: string;
+    policy?: string;
+    revokedReason?: string | null;
+    blockedReason?: string | null;
+  } = {};
+  if (status !== undefined) {
+    dualWriteParams.status = status;
+    dualWriteParams.revokedReason = status === "revoked" ? reason : null;
+    dualWriteParams.blockedReason = status === "blocked" ? reason : null;
+  }
+  if (policy !== undefined) dualWriteParams.policy = policy;
+
+  try {
+    await store.dualWriteChannelStatusToAssistantDb(
+      contactChannelId,
+      dualWriteParams,
+    );
+  } catch (err) {
+    log.warn(
+      { contactChannelId, err },
+      "update_channel: assistant DB dual-write failed (best-effort)",
+    );
+  }
+
+  // Emit contacts_changed so connected clients refresh.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  const contact = await store.getContactWithInfo(updated.contactId);
+  log.info(
+    { contactChannelId, contactId: updated.contactId, status, policy },
+    "update_channel: handled natively",
+  );
+  return {
+    ok: true,
+    contact: contact ? toContactPayload(contact) : undefined,
+  };
+}
+
+/**
  * Validate that metadata matches the expected shape for the given species.
  * Mirrors `validateSpeciesMetadata` in `assistant/src/contacts/contact-store.ts`.
  */
@@ -1217,116 +1350,19 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       const policy = body.policy as string | undefined;
       const reason = (body.reason as string | null | undefined) ?? null;
 
-      if (status !== undefined && !isChannelStatus(status)) {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: `Invalid status "${status}". Must be one of: ${VALID_CHANNEL_STATUSES.join(", ")}`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-
-      if (policy !== undefined && !isChannelPolicy(policy)) {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: `Invalid policy "${policy}". Must be one of: ${VALID_CHANNEL_POLICIES.join(", ")}`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-
-      if (status === undefined && policy === undefined) {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: "At least one of status or policy must be provided",
-            },
-          },
-          { status: 400 },
-        );
-      }
-
       try {
-        const store = new ContactStore();
-        const updated = await store.updateChannelStatus(contactChannelId, {
+        const result = await updateContactChannelCore({
+          contactChannelId,
           status,
           policy,
           reason,
         });
-
-        if (!updated) {
-          return Response.json(
-            {
-              error: {
-                code: "NOT_FOUND",
-                message: `Channel "${contactChannelId}" not found`,
-              },
-            },
-            { status: 404 },
-          );
-        }
-
-        // Best-effort dual-write to assistant DB.
-        const dualWriteParams: {
-          status?: string;
-          policy?: string;
-          revokedReason?: string | null;
-          blockedReason?: string | null;
-        } = {};
-        if (status !== undefined) {
-          dualWriteParams.status = status;
-          dualWriteParams.revokedReason =
-            status === "revoked" ? reason : null;
-          dualWriteParams.blockedReason =
-            status === "blocked" ? reason : null;
-        }
-        if (policy !== undefined) dualWriteParams.policy = policy;
-
-        try {
-          await store.dualWriteChannelStatusToAssistantDb(
-            contactChannelId,
-            dualWriteParams,
-          );
-        } catch (err) {
-          log.warn(
-            { contactChannelId, err },
-            "update_channel: assistant DB dual-write failed (best-effort)",
-          );
-        }
-
-        // Emit contacts_changed so connected clients refresh.
-        void ipcCallAssistant("emit_event", {
-          body: { kind: "contacts_changed" },
-        } as unknown as Record<string, unknown>).catch(() => {});
-
-        // Return the parent contact with info join, matching the daemon's
-        // response shape.
-        const contact = await store.getContactWithInfo(updated.contactId);
-        log.info(
-          { contactChannelId, contactId: updated.contactId, status, policy },
-          "update_channel: handled natively",
-        );
-        return Response.json({
-          ok: true,
-          contact: contact ? toContactPayload(contact) : undefined,
-        });
+        return Response.json(result);
       } catch (err) {
-        if (err instanceof CannotRevokeBlockedError) {
+        if (err instanceof ContactChannelNativeError) {
           return Response.json(
-            {
-              error: {
-                code: "CONFLICT",
-                message: err.message,
-              },
-            },
-            { status: 409 },
+            { error: { code: err.code, message: err.message } },
+            { status: err.statusCode },
           );
         }
         log.error(

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -6,10 +6,12 @@
  * assistant DB proxy (raw SQL), so the gateway owns the write path.
  */
 
+import { UpdateContactChannelIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
 import { ContactStore } from "../db/contact-store.js";
+import { updateContactChannelCore } from "../http/routes/contacts-control-plane-proxy.js";
 import { getLogger } from "../logger.js";
 import { canonicalizeInboundIdentity } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
@@ -152,6 +154,17 @@ export const contactRoutes: IpcRoute[] = [
       );
 
       return { contactId, channelId };
+    },
+  },
+  {
+    method: "update_contact_channel",
+    schema: UpdateContactChannelIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const parsed = UpdateContactChannelIpcParamsSchema.parse(params);
+      // Thrown ContactChannelNativeError carries statusCode/code, which the IPC
+      // server's buildErrorResponse mirrors into the wire envelope; unexpected
+      // errors propagate as a generic IPC error (no fallback).
+      return updateContactChannelCore(parsed);
     },
   },
 ];

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -85,3 +85,25 @@ export const TrustRulesListIpcResponseSchema = z.object({
 export type TrustRulesListIpcResponse = z.infer<
   typeof TrustRulesListIpcResponseSchema
 >;
+
+export const UpdateContactChannelIpcParamsSchema = z.object({
+  contactChannelId: z.string().min(1),
+  status: z.string().optional(),
+  policy: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+export type UpdateContactChannelIpcParams = z.infer<
+  typeof UpdateContactChannelIpcParamsSchema
+>;
+
+export const UpdateContactChannelIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  // The gateway-native handler owns the full contact payload shape; pass it
+  // through verbatim rather than re-declaring channel fields here.
+  contact: z.object({}).passthrough().optional(),
+});
+
+export type UpdateContactChannelIpcResponse = z.infer<
+  typeof UpdateContactChannelIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Add an `update_contact_channel` gateway IPC route backed by a shared transport-agnostic `updateContactChannelCore` (also used by HTTP `handleUpdateContactChannel`).
- Flip the daemon `handleUpdateContactChannelRoute` to relay via `ipcCallPersistent` instead of writing the assistant DB directly.

Part of plan: contacts-relay-writes-create-contact.md (PR 1 of 2)