### PR TITLE
feat(gateway): rich contact read helpers joining gateway ACL + assistant info fields

### DIFF
--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for the gateway-native rich contact reads:
+ *   - ContactStore.listContactsRich
+ *   - ContactStore.getContactRich
+ *
+ * These assemble the shared ContactRead shape (gateway ACL/identity + assistant
+ * info fields) so the daemon can relay its full contact read responses through
+ * the gateway IPC surface. The gateway DB is a real (file-backed) DB seeded per
+ * test; the assistant DB proxy is mocked behind `fakeAssistantDb` so no daemon
+ * is required. Mirrors the pattern in contacts-info-joiner.test.ts.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+
+import "./test-preload.js";
+
+// ── Fake assistant DB ───────────────────────────────────────────────────────
+// Honors the info-join query (SELECT ... FROM contacts LEFT JOIN
+// assistant_contact_metadata WHERE c.id IN (...)) and throws on demand.
+
+type FakeInfoRow = {
+  id: string;
+  notes: string | null;
+  user_file: string | null;
+  contact_type: string | null;
+  species: string | null;
+  metadata: string | null;
+};
+
+const fakeAssistantDb = {
+  info: new Map<string, FakeInfoRow>(),
+  throwOnQuery: false as boolean,
+  reset(): void {
+    this.info.clear();
+    this.throwOnQuery = false;
+  },
+};
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
+    if (fakeAssistantDb.throwOnQuery) {
+      throw new Error("simulated assistant DB outage");
+    }
+    const lower = sql.toLowerCase();
+    if (lower.includes("from contacts") && lower.includes("in (")) {
+      const ids = (bind ?? []) as string[];
+      const out: Array<{
+        id: string;
+        notes: string | null;
+        userFile: string | null;
+        contactType: string | null;
+        species: string | null;
+        metadata: string | null;
+      }> = [];
+      for (const id of ids) {
+        const row = fakeAssistantDb.info.get(id);
+        if (row) {
+          out.push({
+            id: row.id,
+            notes: row.notes,
+            userFile: row.user_file,
+            contactType: row.contact_type,
+            species: row.species,
+            metadata: row.metadata,
+          });
+        }
+      }
+      return out;
+    }
+    return [];
+  }),
+  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
+  assistantDbExec: mock(async () => undefined),
+}));
+
+import {
+  ContactReadSchema,
+  GetContactIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import { ContactStore } from "../db/contact-store.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  fakeAssistantDb.reset();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ── Seed helpers ─────────────────────────────────────────────────────────────
+
+function seedGatewayContact(opts: {
+  id: string;
+  displayName?: string;
+  role?: string;
+  updatedAt?: number;
+}): void {
+  const db = getGatewayDb();
+  db.insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: opts.displayName ?? `name-${opts.id}`,
+      role: opts.role ?? "contact",
+      principalId: null,
+      createdAt: opts.updatedAt ?? Date.now(),
+      updatedAt: opts.updatedAt ?? Date.now(),
+    })
+    .run();
+}
+
+function seedGatewayChannel(opts: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address?: string;
+  isPrimary?: boolean;
+  status?: string;
+  policy?: string;
+  verifiedAt?: number | null;
+  revokedReason?: string | null;
+  blockedReason?: string | null;
+  interactionCount?: number;
+  lastInteraction?: number | null;
+  createdAt?: number;
+}): void {
+  const db = getGatewayDb();
+  db.insert(contactChannels)
+    .values({
+      id: opts.id,
+      contactId: opts.contactId,
+      type: opts.type ?? "telegram",
+      address: opts.address ?? `addr-${opts.id}`,
+      isPrimary: opts.isPrimary ?? false,
+      externalChatId: null,
+      status: opts.status ?? "active",
+      policy: opts.policy ?? "allow",
+      verifiedAt: opts.verifiedAt ?? null,
+      verifiedVia: null,
+      inviteId: null,
+      revokedReason: opts.revokedReason ?? null,
+      blockedReason: opts.blockedReason ?? null,
+      lastSeenAt: null,
+      interactionCount: opts.interactionCount ?? 0,
+      lastInteraction: opts.lastInteraction ?? null,
+      createdAt: opts.createdAt ?? 100,
+      updatedAt: null,
+    })
+    .run();
+}
+
+function seedAssistantInfo(opts: {
+  id: string;
+  notes?: string | null;
+  contactType?: string | null;
+  species?: string | null;
+  metadata?: Record<string, unknown> | null;
+}): void {
+  fakeAssistantDb.info.set(opts.id, {
+    id: opts.id,
+    notes: opts.notes ?? null,
+    user_file: null,
+    contact_type: opts.contactType ?? null,
+    species: opts.species ?? null,
+    metadata: opts.metadata != null ? JSON.stringify(opts.metadata) : null,
+  });
+}
+
+// ── listContactsRich ─────────────────────────────────────────────────────────
+
+describe("ContactStore.listContactsRich", () => {
+  test("merges gateway ACL + assistant info and validates against ContactReadSchema", async () => {
+    seedGatewayContact({ id: "c1", role: "contact", updatedAt: 100 });
+    seedGatewayChannel({
+      id: "ch1",
+      contactId: "c1",
+      type: "telegram",
+      address: "tg-001",
+      status: "active",
+      policy: "escalate",
+      verifiedAt: 555,
+      revokedReason: "spam",
+      interactionCount: 4,
+      lastInteraction: 900,
+    });
+    seedAssistantInfo({ id: "c1", notes: "a friend", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toHaveLength(1);
+
+    // Every returned object validates against the shared contract.
+    for (const c of result) expect(ContactReadSchema.parse(c)).toEqual(c);
+
+    const c1 = result[0];
+    // Info fields from assistant DB.
+    expect(c1.notes).toBe("a friend");
+    expect(c1.contactType).toBe("human");
+    // Trust signals derived from gateway channels.
+    expect(c1.interactionCount).toBe(4);
+    expect(c1.lastInteraction).toBe(900);
+    // Channel ACL fields from gateway DB.
+    const ch = c1.channels[0];
+    expect(ch.status).toBe("active");
+    expect(ch.policy).toBe("escalate");
+    expect(ch.verifiedAt).toBe(555);
+    expect(ch.revokedReason).toBe("spam");
+    expect(ch.blockedReason).toBeNull();
+    // externalUserId echoes address (withChannelCompat).
+    expect(ch.externalUserId).toBe("tg-001");
+  });
+
+  test("orders guardian first, then updatedAt desc", async () => {
+    seedGatewayContact({ id: "old", updatedAt: 100 });
+    seedGatewayContact({ id: "new", updatedAt: 900 });
+    seedGatewayContact({ id: "guard", role: "guardian", updatedAt: 1 });
+    seedAssistantInfo({ id: "old", contactType: "human" });
+    seedAssistantInfo({ id: "new", contactType: "human" });
+    seedAssistantInfo({ id: "guard", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result.map((c) => c.id)).toEqual(["guard", "new", "old"]);
+  });
+
+  test("honors role filter (gateway DB)", async () => {
+    seedGatewayContact({ id: "g", role: "guardian" });
+    seedGatewayContact({ id: "c", role: "contact" });
+    seedAssistantInfo({ id: "g", contactType: "human" });
+    seedAssistantInfo({ id: "c", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich({
+      role: "guardian",
+    });
+    expect(result.map((c) => c.id)).toEqual(["g"]);
+  });
+
+  test("honors contactType filter against assistant-DB value", async () => {
+    seedGatewayContact({ id: "human", updatedAt: 200 });
+    seedGatewayContact({ id: "bot", updatedAt: 100 });
+    seedAssistantInfo({ id: "human", contactType: "human" });
+    seedAssistantInfo({
+      id: "bot",
+      contactType: "assistant",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+
+    const result = await new ContactStore().listContactsRich({
+      contactType: "assistant",
+    });
+    expect(result.map((c) => c.id)).toEqual(["bot"]);
+  });
+
+  test("honors limit (capped at 200)", async () => {
+    for (let i = 0; i < 5; i++) {
+      seedGatewayContact({ id: `c${i}`, updatedAt: i });
+      seedAssistantInfo({ id: `c${i}`, contactType: "human" });
+    }
+    const result = await new ContactStore().listContactsRich({ limit: 2 });
+    expect(result).toHaveLength(2);
+  });
+
+  test("missing assistant-DB row degrades gracefully (info null, no throw)", async () => {
+    seedGatewayContact({ id: "gap" });
+    seedGatewayChannel({ id: "ch-gap", contactId: "gap", interactionCount: 3 });
+    // No assistant info seeded.
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toHaveLength(1);
+    expect(result[0].notes).toBeNull();
+    expect(result[0].contactType).toBeNull();
+    // ACL/trust fields still populated from gateway.
+    expect(result[0].interactionCount).toBe(3);
+    expect(ContactReadSchema.parse(result[0])).toEqual(result[0]);
+  });
+
+  test("soft-fails on assistant DB outage: gateway-DB-only fields, no throw", async () => {
+    seedGatewayContact({ id: "c1" });
+    seedGatewayChannel({ id: "ch1", contactId: "c1", interactionCount: 2 });
+    seedAssistantInfo({ id: "c1", notes: "unseen", contactType: "human" });
+    fakeAssistantDb.throwOnQuery = true;
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toHaveLength(1);
+    expect(result[0].notes).toBeNull();
+    expect(result[0].contactType).toBeNull();
+    expect(result[0].interactionCount).toBe(2);
+  });
+
+  test("empty gateway DB returns empty array", async () => {
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toEqual([]);
+  });
+
+  test("primary channel appears first regardless of creation order", async () => {
+    seedGatewayContact({ id: "c1" });
+    seedGatewayChannel({ id: "ch-old", contactId: "c1", createdAt: 100 });
+    seedGatewayChannel({
+      id: "ch-primary",
+      contactId: "c1",
+      isPrimary: true,
+      createdAt: 200,
+    });
+    seedAssistantInfo({ id: "c1", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result[0].channels.map((c) => c.id)).toEqual([
+      "ch-primary",
+      "ch-old",
+    ]);
+  });
+});
+
+// ── getContactRich ───────────────────────────────────────────────────────────
+
+describe("ContactStore.getContactRich", () => {
+  test("returns null when contact not in gateway DB", async () => {
+    const result = await new ContactStore().getContactRich("nope");
+    expect(result).toBeNull();
+  });
+
+  test("returns merged ContactRead validating against the response contract", async () => {
+    seedGatewayContact({ id: "c1", role: "guardian" });
+    seedGatewayChannel({
+      id: "ch1",
+      contactId: "c1",
+      interactionCount: 7,
+      lastInteraction: 999,
+    });
+    seedAssistantInfo({ id: "c1", notes: "my guardian", contactType: "human" });
+
+    const result = await new ContactStore().getContactRich("c1");
+    expect(result).not.toBeNull();
+    expect(result!.contact.id).toBe("c1");
+    expect(result!.contact.role).toBe("guardian");
+    expect(result!.contact.notes).toBe("my guardian");
+    expect(result!.contact.interactionCount).toBe(7);
+    expect(result!.assistantMetadata).toBeUndefined();
+
+    // Validate against the get-contact IPC response contract.
+    const payload = { ok: true, contact: result!.contact };
+    expect(() => GetContactIpcResponseSchema.parse(payload)).not.toThrow();
+  });
+
+  test("includes assistantMetadata for assistant-species contacts", async () => {
+    seedGatewayContact({ id: "bot" });
+    seedGatewayChannel({ id: "ch-bot", contactId: "bot" });
+    seedAssistantInfo({
+      id: "bot",
+      contactType: "assistant",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+
+    const result = await new ContactStore().getContactRich("bot");
+    expect(result!.assistantMetadata).toEqual({
+      contactId: "bot",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+
+    const payload = {
+      ok: true,
+      contact: result!.contact,
+      assistantMetadata: result!.assistantMetadata,
+    };
+    expect(() => GetContactIpcResponseSchema.parse(payload)).not.toThrow();
+  });
+
+  test("missing assistant-DB row degrades gracefully (info null, no throw)", async () => {
+    seedGatewayContact({ id: "gap" });
+    seedGatewayChannel({ id: "ch-gap", contactId: "gap", interactionCount: 1 });
+
+    const result = await new ContactStore().getContactRich("gap");
+    expect(result).not.toBeNull();
+    expect(result!.contact.notes).toBeNull();
+    expect(result!.contact.contactType).toBeNull();
+    expect(result!.contact.interactionCount).toBe(1);
+    expect(result!.assistantMetadata).toBeUndefined();
+  });
+
+  test("soft-fails on assistant DB outage for single contact", async () => {
+    seedGatewayContact({ id: "c1" });
+    seedAssistantInfo({ id: "c1", notes: "lost", contactType: "human" });
+    fakeAssistantDb.throwOnQuery = true;
+
+    const result = await new ContactStore().getContactRich("c1");
+    expect(result).not.toBeNull();
+    expect(result!.contact.notes).toBeNull();
+    expect(result!.contact.contactType).toBeNull();
+  });
+});

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -3,6 +3,11 @@ import { type Database } from "bun:sqlite";
 import { and, desc, eq, ne, sql } from "drizzle-orm";
 
 import {
+  type AssistantContactMetadata,
+  type ContactRead,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import {
   type SqliteValue,
   assistantDbQuery,
   assistantDbRun,
@@ -179,6 +184,204 @@ export class ContactStore {
     if (rows.length === 0) return null;
     const joined = await this.joinInfoIntoContacts(rows);
     return joined[0] ?? null;
+  }
+
+  // ── Rich reads (gateway ACL + assistant info, ContactRead contract) ──────
+  //
+  // listContactsRich / getContactRich assemble the shared ContactRead shape
+  // (packages/gateway-client/src/gateway-ipc-contracts.ts) so the daemon can
+  // relay its full contact read responses through the gateway IPC surface.
+  // Identity + ACL/channel fields come from the gateway DB (source of truth);
+  // info fields (notes, contactType, interactionCount, lastInteraction) come
+  // from the assistant DB via assistantDbQuery. The assistant join is soft:
+  // a failed or missing read degrades to gateway-DB-only values + a warning.
+  //
+  // Guardian display-name override is intentionally NOT applied here — the
+  // daemon relay handler (PR 3) re-applies prepareContactResponse on the
+  // relayed payload, keeping prompt logic on the daemon side.
+
+  /**
+   * List contacts in the shared ContactRead shape: gateway-DB identity + ACL
+   * channels joined to assistant-DB info fields.
+   *
+   * Filters: `role` (gateway DB), `contactType` (assistant-owned — applied
+   * against the joined assistant value), `limit` (default 50, capped 200 to
+   * mirror the daemon's listContacts).
+   *
+   * Ordering mirrors the daemon's listContacts: guardian role first, then
+   * updatedAt desc.
+   */
+  async listContactsRich(opts?: {
+    limit?: number;
+    role?: string;
+    contactType?: string;
+  }): Promise<ContactRead[]> {
+    const effectiveLimit = Math.min(opts?.limit ?? 50, 200);
+
+    const contactRows = this.db
+      .select()
+      .from(contacts)
+      .where(opts?.role ? eq(contacts.role, opts.role) : undefined)
+      .orderBy(
+        sql`${contacts.role} = 'guardian' DESC`,
+        desc(contacts.updatedAt),
+      )
+      .limit(effectiveLimit)
+      .all();
+
+    if (contactRows.length === 0) return [];
+
+    const ids = contactRows.map((c) => c.id);
+    const channelsByContact = this.channelsForContacts(ids);
+    const infoMap = await this.fetchInfoSoft(ids);
+
+    const result: ContactRead[] = [];
+    for (const contact of contactRows) {
+      const info = infoMap.get(contact.id) ?? null;
+      // contactType is assistant-owned — filter against the joined value.
+      if (opts?.contactType && info?.contactType !== opts.contactType) continue;
+      result.push(
+        this.composeContactRead(
+          contact,
+          channelsByContact.get(contact.id) ?? [],
+          info,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Get a single contact in the shared ContactRead shape, plus the assistant
+   * metadata block for assistant-species contacts. Returns null if the
+   * contact is absent from the gateway DB.
+   */
+  async getContactRich(contactId: string): Promise<{
+    contact: ContactRead;
+    assistantMetadata?: AssistantContactMetadata;
+  } | null> {
+    const contact = this.db
+      .select()
+      .from(contacts)
+      .where(eq(contacts.id, contactId))
+      .get();
+    if (!contact) return null;
+
+    const channels = this.channelsForContacts([contactId]).get(contactId) ?? [];
+    const info = (await this.fetchInfoSoft([contactId])).get(contactId) ?? null;
+    const read = this.composeContactRead(contact, channels, info);
+
+    if (info?.contactType === "assistant" && info.assistantMetadata) {
+      return {
+        contact: read,
+        assistantMetadata: {
+          contactId,
+          species: info.assistantMetadata.species,
+          metadata: info.assistantMetadata.metadata,
+        },
+      };
+    }
+    return { contact: read };
+  }
+
+  /**
+   * Fetch channels for a set of contact IDs, grouped by contactId and ordered
+   * primary-first then by creation time (mirrors readAssistantContact and the
+   * daemon's withChannels ordering).
+   */
+  private channelsForContacts(
+    contactIds: string[],
+  ): Map<string, ContactChannel[]> {
+    const byId = new Map<string, ContactChannel[]>();
+    if (contactIds.length === 0) return byId;
+
+    const rows = this.db
+      .select()
+      .from(contactChannels)
+      .where(
+        sql`${contactChannels.contactId} IN (${sql.join(
+          contactIds.map((id) => sql`${id}`),
+          sql`, `,
+        )})`,
+      )
+      .orderBy(
+        sql`${contactChannels.isPrimary} DESC`,
+        contactChannels.createdAt,
+      )
+      .all();
+
+    for (const ch of rows) {
+      const list = byId.get(ch.contactId) ?? [];
+      list.push(ch);
+      byId.set(ch.contactId, list);
+    }
+    return byId;
+  }
+
+  /**
+   * Soft assistant-DB info fetch: on failure, log a warning and return an
+   * empty map so callers degrade to gateway-DB-only values.
+   */
+  private async fetchInfoSoft(
+    contactIds: string[],
+  ): Promise<Map<string, ContactInfoFields>> {
+    try {
+      return await fetchInfoForContacts(contactIds);
+    } catch (err) {
+      log.warn(
+        { err, count: contactIds.length },
+        "rich read: assistant DB info join failed; returning gateway-DB-only fields",
+      );
+      return new Map();
+    }
+  }
+
+  /**
+   * Compose the ContactRead shape: identity + ACL/channel fields from the
+   * gateway DB, info fields (notes, contactType, interactionCount,
+   * lastInteraction) from the assistant DB. interactionCount/lastInteraction
+   * are derived from gateway channels (trust signals live in gateway).
+   * `externalUserId` echoes `address` to match the daemon's withChannelCompat.
+   */
+  private composeContactRead(
+    contact: Contact,
+    channels: ContactChannel[],
+    info: ContactInfoFields | null,
+  ): ContactRead {
+    const interactionCount = channels.reduce(
+      (sum, ch) => sum + (ch.interactionCount ?? 0),
+      0,
+    );
+    const lastInteraction =
+      channels.reduce((max, ch) => Math.max(max, ch.lastInteraction ?? 0), 0) ||
+      null;
+
+    return {
+      id: contact.id,
+      displayName: contact.displayName,
+      role: contact.role,
+      notes: info?.notes ?? null,
+      contactType: info?.contactType ?? null,
+      interactionCount,
+      lastInteraction,
+      channels: channels.map((ch) => ({
+        id: ch.id,
+        contactId: ch.contactId,
+        type: ch.type,
+        address: ch.address,
+        isPrimary: ch.isPrimary,
+        externalUserId: ch.address,
+        status: ch.status ?? "unverified",
+        policy: ch.policy ?? "allow",
+        verifiedAt: ch.verifiedAt,
+        verifiedVia: ch.verifiedVia,
+        lastSeenAt: ch.lastSeenAt,
+        interactionCount: ch.interactionCount ?? 0,
+        lastInteraction: ch.lastInteraction,
+        revokedReason: ch.revokedReason,
+        blockedReason: ch.blockedReason,
+      })),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add listContactsRich/getContactRich to gateway ContactStore: gateway DB for identity + ACL/channel fields, assistant DB (via assistantDbQuery) for info fields (notes, contactType, interactionCount, lastInteraction).
- Soft assistant-DB join: missing/failed info degrades to gateway-DB-only values with a logged warning; ACL fields remain source of truth.
- Output validates against ContactReadSchema from the shared IPC contracts.

Part of plan: contacts-relay-reads.md (PR 2 of 4)