### PR TITLE
feat(daemon): relay trusted-contact verification outcome to gateway

### DIFF
--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the trusted-contact branch of the channel-verification create
+ * route.
+ *
+ * Investigation finding (PR 4 of contacts-gw-native-verification): the
+ * daemon/CLI trusted-contact path (`verifyTrustedContact` →
+ * `handleCreateVerificationSession`) has NO direct assistant-side activation
+ * write. Every branch only creates an outbound session, records delivery, and
+ * sends a code; the channel is flipped to `active` exclusively by the inbound
+ * code-match completion, which already runs through the gateway
+ * (`gateway/src/verification/text-verification.ts` →
+ * `applyTrustedContactSideEffects`). The `already_verified` check on this path
+ * is a read-only short-circuit that returns a 409, not a write.
+ *
+ * There is therefore no daemon-side outcome write to relay. These tests pin
+ * that invariant: the trusted-contact create path must NOT write the
+ * activation outcome assistant-side (no `updateChannelStatus`), so the outcome
+ * is never double-written against the inbound gateway path.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const verifyTrustedContactCalls: Array<[string, string]> = [];
+let verifyTrustedContactImpl: (
+  contactChannelId: string,
+  assistantId: string,
+) => Promise<Record<string, unknown>> = async () => ({ success: true });
+
+const updateChannelStatusCalls: unknown[] = [];
+const ipcCalls: Array<[string, unknown]> = [];
+
+mock.module("../../../daemon/handlers/config-channels.js", () => ({
+  verifyTrustedContact: async (contactChannelId: string, assistantId: string) => {
+    verifyTrustedContactCalls.push([contactChannelId, assistantId]);
+    return verifyTrustedContactImpl(contactChannelId, assistantId);
+  },
+  createInboundChallenge: () => ({ success: true }),
+  getVerificationStatus: () => ({ success: true }),
+  revokeVerificationForChannel: () => ({ success: true }),
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  updateChannelStatus: (...args: unknown[]) => {
+    updateChannelStatusCalls.push(args);
+    return null;
+  },
+}));
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (method: string, params: unknown) => {
+    ipcCalls.push([method, params]);
+    return { ok: true, didWrite: true, channel: {} };
+  },
+}));
+
+import { ConflictError, TooManyRequestsError } from "../errors.js";
+import { handleCreateVerificationSession } from "../channel-verification-routes.js";
+
+beforeEach(() => {
+  verifyTrustedContactCalls.length = 0;
+  updateChannelStatusCalls.length = 0;
+  ipcCalls.length = 0;
+  verifyTrustedContactImpl = async () => ({ success: true });
+});
+
+describe("handleCreateVerificationSession — trusted_contact", () => {
+  test("sends the verification session without writing the activation outcome assistant-side", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: true,
+      verificationSessionId: "sess-1",
+      expiresAt: Date.now() + 600_000,
+      sendCount: 1,
+      channel: "phone",
+    });
+
+    const result = (await handleCreateVerificationSession({
+      body: { purpose: "trusted_contact", contactChannelId: "cc-1" },
+    })) as Record<string, unknown>;
+
+    expect(result.success).toBe(true);
+    expect(result.verificationSessionId).toBe("sess-1");
+    expect(verifyTrustedContactCalls).toEqual([["cc-1", expect.any(String)]]);
+
+    // No assistant-side activation outcome write on the create path — the
+    // outcome flows through the inbound gateway code-match path instead.
+    expect(updateChannelStatusCalls).toEqual([]);
+  });
+
+  test("does not double-write the outcome via the gateway relay on the create path", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: true,
+      verificationSessionId: "sess-2",
+      channel: "telegram",
+    });
+
+    await handleCreateVerificationSession({
+      body: { purpose: "trusted_contact", contactChannelId: "cc-2" },
+    });
+
+    // The activation outcome is owned by the inbound gateway path; the create
+    // path must not relay a `mark_channel_verified` write (no double-write).
+    expect(
+      ipcCalls.filter(([method]) => method === "mark_channel_verified"),
+    ).toEqual([]);
+  });
+
+  test("propagates an already-verified short-circuit as a ConflictError (no silent success)", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: false,
+      error: "already_verified",
+      message: "Channel is already verified",
+    });
+
+    await expect(
+      handleCreateVerificationSession({
+        body: { purpose: "trusted_contact", contactChannelId: "cc-3" },
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(updateChannelStatusCalls).toEqual([]);
+  });
+
+  test("propagates a rate-limit failure rather than silently succeeding", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: false,
+      error: "rate_limited",
+      message: "Too many attempts",
+    });
+
+    await expect(
+      handleCreateVerificationSession({
+        body: { purpose: "trusted_contact", contactChannelId: "cc-4" },
+      }),
+    ).rejects.toBeInstanceOf(TooManyRequestsError);
+  });
+
+  test("a failure in the trusted-contact path propagates, never a silent success", async () => {
+    verifyTrustedContactImpl = async () => {
+      throw new Error("gateway relay failed");
+    };
+
+    await expect(
+      handleCreateVerificationSession({
+        body: { purpose: "trusted_contact", contactChannelId: "cc-5" },
+      }),
+    ).rejects.toThrow("gateway relay failed");
+
+    expect(updateChannelStatusCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Investigation finding: the daemon/CLI trusted-contact path (`verifyTrustedContact` → `handleCreateVerificationSession`) has NO direct assistant-side activation write. Every branch only creates an outbound session, records delivery, and sends a code; the channel is flipped to `active` exclusively by the inbound code-match completion, which already runs through the gateway (`gateway/src/verification/text-verification.ts` → `applyTrustedContactSideEffects`). The `already_verified` check is a read-only short-circuit that returns 409, not a write.
- Therefore there is no daemon-side outcome write to relay, and no `mark_channel_verified` call was added to the create path — doing so would double-write the outcome against the inbound gateway path (which the plan explicitly forbids). No production code change was needed.
- Scope per the plan's investigation-first directive: added a regression test pinning the invariant that the trusted-contact create path does NOT write the activation outcome assistant-side (no `updateChannelStatus`) and does NOT relay `mark_channel_verified`, so the outcome is never double-written.
- Session-state ops (code send/resend/consume/rate-limit) stay assistant-side and unchanged.

## Tests
- New `assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts` (5 cases, all passing): asserts the create path sends the session without an assistant-side outcome write, never relays `mark_channel_verified`, and propagates already-verified / rate-limited / thrown failures rather than silently succeeding.

Part of plan: contacts-gw-native-verification.md (PR 4 of 6)