### PR TITLE
feat(daemon): relay verification revoke/downgrade outcome to gateway

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -8,8 +8,8 @@ import {
   getChannelById,
   getContact,
 } from "../../contacts/contact-store.js";
-import { revokeMember } from "../../contacts/contacts-write.js";
 import type { ChannelStatus } from "../../contacts/types.js";
+import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { getBindingByChannelChat } from "../../memory/external-conversation-store.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
@@ -25,7 +25,6 @@ import {
   findActiveSession,
   getGuardianBinding,
   getPendingSession,
-  revokeBinding,
   revokePendingSessions,
   updateSessionDelivery,
 } from "../../runtime/channel-verification-service.js";
@@ -171,23 +170,21 @@ export function getVerificationStatus(
 // Revoke verification binding
 // ---------------------------------------------------------------------------
 
-export function revokeVerificationForChannel(
+export async function revokeVerificationForChannel(
   channel?: ChannelId,
-): ChannelVerificationSessionResult {
+): Promise<ChannelVerificationSessionResult> {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? "telegram";
 
-  // Cancel any active outbound session so revoke is a complete teardown.
+  // Session teardown stays assistant-side — it is session state, not the ACL
+  // outcome. Cancel any active outbound session and pending challenges first
+  // (the macOS app uses action: "revoke" to cancel an in-flight challenge even
+  // before a binding exists, e.g. during verification setup).
   cancelOutbound({ channel: resolvedChannel });
-
-  // Always revoke pending challenges first — the macOS app uses
-  // action: "revoke" to cancel an in-flight challenge even before
-  // a binding exists (e.g. during verification setup).
   revokePendingSessions(resolvedChannel);
 
-  // Capture binding before revoking so we can revoke the guardian's
-  // contact record — without this, the guardian would still pass
-  // the ACL check after unbinding.
+  // Capture binding before revoking so we can downgrade the guardian's
+  // channel — without this, the guardian would still pass the ACL check.
   const bindingBeforeRevoke = getGuardianBinding(assistantId, resolvedChannel);
   if (!bindingBeforeRevoke) {
     return {
@@ -197,17 +194,15 @@ export function revokeVerificationForChannel(
     };
   }
 
-  // Revoke the member BEFORE the guardian binding so that
-  // revokeMember sees the channel as active/pending and sets the
-  // correct revokedReason ("guardian_binding_revoked"). If the guardian binding
-  // is revoked first, the channel is already marked revoked and the member
-  // revocation becomes a no-op (wrong reason or skipped entirely).
   const contactResult = findContactChannel({
     channelType: resolvedChannel,
     address: bindingBeforeRevoke.guardianExternalUserId,
     externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
   });
 
+  // Relay the ACL downgrade to the gateway (source of truth). The gateway's
+  // mark_channel_revoked enforces the guardian guard and dual-writes the
+  // outcome back to the assistant DB; no assistant-side ACL fallback.
   if (contactResult) {
     const channelStatus: ChannelStatus = contactResult.channel.status;
     if (
@@ -215,11 +210,12 @@ export function revokeVerificationForChannel(
       channelStatus === "pending" ||
       channelStatus === "unverified"
     ) {
-      revokeMember(contactResult.channel.id, "guardian_binding_revoked");
+      await ipcCallPersistent("mark_channel_revoked", {
+        contactChannelId: contactResult.channel.id,
+        reason: "guardian_binding_revoked",
+      });
     }
   }
-
-  revokeBinding(assistantId, resolvedChannel);
 
   return {
     success: true,
@@ -590,7 +586,7 @@ export async function handleChannelVerificationSession(
         channel,
       });
     } else if (msg.action === "revoke") {
-      const result = revokeVerificationForChannel(channel);
+      const result = await revokeVerificationForChannel(channel);
       broadcastMessage({
         type: "channel_verification_session_response",
         ...result,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -25,6 +25,7 @@ import {
   findActiveSession,
   getGuardianBinding,
   getPendingSession,
+  revokeBinding,
   revokePendingSessions,
   updateSessionDelivery,
 } from "../../runtime/channel-verification-service.js";
@@ -202,7 +203,7 @@ export async function revokeVerificationForChannel(
 
   // Relay the ACL downgrade to the gateway (source of truth). The gateway's
   // mark_channel_revoked enforces the guardian guard and dual-writes the
-  // outcome back to the assistant DB; no assistant-side ACL fallback.
+  // contact-channel status back to the assistant DB.
   if (contactResult) {
     const channelStatus: ChannelStatus = contactResult.channel.status;
     if (
@@ -216,6 +217,11 @@ export async function revokeVerificationForChannel(
       });
     }
   }
+
+  // The guardian binding is assistant-owned state the gateway relay does not
+  // manage; tear it down here. revokeBinding also emits the contact-change
+  // invalidation so open client views stop showing the channel as active.
+  revokeBinding(assistantId, resolvedChannel);
 
   return {
     success: true,

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -53,6 +53,10 @@ mock.module("../../verification-outbound-actions.js", () => ({
 }));
 
 const revokePendingSessionsMock = mock((_channel: string) => {});
+const revokeBindingMock = mock((_assistantId: string, _channel: string) => {
+  revokeGuardianBindingMock();
+  return true;
+});
 let guardianBinding:
   | {
       guardianExternalUserId: string;
@@ -65,6 +69,7 @@ const actualVerificationService = await import(
 mock.module("../../channel-verification-service.js", () => ({
   ...actualVerificationService,
   revokePendingSessions: revokePendingSessionsMock,
+  revokeBinding: revokeBindingMock,
   getGuardianBinding: mock(() => guardianBinding),
 }));
 
@@ -78,15 +83,18 @@ mock.module("../../../contacts/contact-store.js", () => ({
   ),
 }));
 
-// Guard: the local ACL write paths must never run on the relayed revoke.
+// Guard: the contact-channel ACL write moves to the gateway relay and must
+// never run locally. The assistant-owned guardian-binding teardown
+// (revokeGuardianBinding) still runs locally — assert it is invoked.
 const localAclWrite = mock(() => {
   throw new Error("local ACL write must not happen on relayed revoke");
 });
+const revokeGuardianBindingMock = mock(() => true);
 const actualContactsWrite = await import("../../../contacts/contacts-write.js");
 mock.module("../../../contacts/contacts-write.js", () => ({
   ...actualContactsWrite,
   revokeMember: localAclWrite,
-  revokeGuardianBinding: localAclWrite,
+  revokeGuardianBinding: revokeGuardianBindingMock,
 }));
 
 const { ROUTES } = await import("../channel-verification-routes.js");
@@ -107,6 +115,8 @@ describe("verification revoke relay", () => {
     ipcCallPersistentMock.mockClear();
     cancelOutboundMock.mockClear();
     revokePendingSessionsMock.mockClear();
+    revokeBindingMock.mockClear();
+    revokeGuardianBindingMock.mockClear();
     localAclWrite.mockClear();
   });
 
@@ -130,7 +140,11 @@ describe("verification revoke relay", () => {
     expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
     expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
 
-    // No assistant-side ACL fallback.
+    // Assistant-owned guardian binding torn down locally.
+    expect(revokeBindingMock).toHaveBeenCalledTimes(1);
+    expect(revokeGuardianBindingMock).toHaveBeenCalledTimes(1);
+
+    // The contact-channel ACL write does not fall back to the assistant.
     expect(localAclWrite).not.toHaveBeenCalled();
 
     expect(result.success).toBe(true);
@@ -152,9 +166,11 @@ describe("verification revoke relay", () => {
 
     expect(thrown).toBeDefined();
     expect(thrown!.statusCode).toBe(409);
-    // Teardown still ran before the relay rejected.
+    // Session teardown ran before the relay rejected; the binding teardown
+    // does not run when the gateway refuses the downgrade.
     expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
     expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    expect(revokeBindingMock).not.toHaveBeenCalled();
     expect(localAclWrite).not.toHaveBeenCalled();
   });
 
@@ -168,6 +184,7 @@ describe("verification revoke relay", () => {
     expect(ipcCalls).toEqual([]);
     expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
     expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    expect(revokeBindingMock).not.toHaveBeenCalled();
     expect(result.success).toBe(true);
     expect(result.bound).toBe(false);
   });
@@ -180,5 +197,7 @@ describe("verification revoke relay", () => {
     expect(ipcCalls).toEqual([]);
     expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
     expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    // Binding teardown still runs even when the channel is already revoked.
+    expect(revokeBindingMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the verification-revoke route relay.
+ *
+ * The revoke route downgrades the channel's ACL status through the gateway
+ * (source of truth) via `ipcCallPersistent("mark_channel_revoked", ...)` while
+ * keeping session teardown (`cancelOutbound`, `revokePendingSessions`)
+ * assistant-side. The gateway enforces the guardian guard; a rejected guardian
+ * downgrade surfaces here as a relayed IpcCallError.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+let ipcCalls: IpcCall[] = [];
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
+    return {
+      ok: true,
+      didWrite: true,
+      channel: {
+        id: (params?.contactChannelId as string) ?? "ch1",
+        contactId: "c1",
+        type: "telegram",
+        address: "addr",
+        status: "revoked",
+        revokedReason: (params?.reason as string) ?? null,
+      },
+    };
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Session teardown — assert these still run locally on every revoke.
+const cancelOutboundMock = mock((_args: { channel: string }) => {});
+const actualOutboundActions = await import(
+  "../../verification-outbound-actions.js"
+);
+mock.module("../../verification-outbound-actions.js", () => ({
+  ...actualOutboundActions,
+  cancelOutbound: cancelOutboundMock,
+}));
+
+const revokePendingSessionsMock = mock((_channel: string) => {});
+let guardianBinding:
+  | {
+      guardianExternalUserId: string;
+      guardianDeliveryChatId?: string;
+    }
+  | null = null;
+const actualVerificationService = await import(
+  "../../channel-verification-service.js"
+);
+mock.module("../../channel-verification-service.js", () => ({
+  ...actualVerificationService,
+  revokePendingSessions: revokePendingSessionsMock,
+  getGuardianBinding: mock(() => guardianBinding),
+}));
+
+// Contact-store lookup that resolves the guardian's channel to downgrade.
+let contactChannel: { id: string; status: string } | null = null;
+const actualContactStore = await import("../../../contacts/contact-store.js");
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  findContactChannel: mock(() =>
+    contactChannel ? { channel: contactChannel, contact: { id: "c1" } } : null,
+  ),
+}));
+
+// Guard: the local ACL write paths must never run on the relayed revoke.
+const localAclWrite = mock(() => {
+  throw new Error("local ACL write must not happen on relayed revoke");
+});
+const actualContactsWrite = await import("../../../contacts/contacts-write.js");
+mock.module("../../../contacts/contacts-write.js", () => ({
+  ...actualContactsWrite,
+  revokeMember: localAclWrite,
+  revokeGuardianBinding: localAclWrite,
+}));
+
+const { ROUTES } = await import("../channel-verification-routes.js");
+
+const revokeHandler = ROUTES.find(
+  (r) => r.operationId === "channel_verification_sessions_revoke",
+)!.handler;
+
+describe("verification revoke relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcError = undefined;
+    guardianBinding = {
+      guardianExternalUserId: "guardian-user",
+      guardianDeliveryChatId: "chat-1",
+    };
+    contactChannel = { id: "ch1", status: "active" };
+    ipcCallPersistentMock.mockClear();
+    cancelOutboundMock.mockClear();
+    revokePendingSessionsMock.mockClear();
+    localAclWrite.mockClear();
+  });
+
+  test("relays the downgrade outcome to the gateway and tears down sessions locally", async () => {
+    const result = (await revokeHandler({
+      body: { channel: "telegram" },
+    })) as { success: boolean; bound: boolean; channel: string };
+
+    // ACL downgrade relayed to the gateway (source of truth).
+    expect(ipcCalls).toEqual([
+      {
+        method: "mark_channel_revoked",
+        params: {
+          contactChannelId: "ch1",
+          reason: "guardian_binding_revoked",
+        },
+      },
+    ]);
+
+    // Session teardown stays assistant-side.
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+
+    // No assistant-side ACL fallback.
+    expect(localAclWrite).not.toHaveBeenCalled();
+
+    expect(result.success).toBe(true);
+    expect(result.bound).toBe(false);
+  });
+
+  test("guardian guard rejection from the gateway surfaces as an error", async () => {
+    ipcError = new IpcCallError("Cannot downgrade a guardian channel.", {
+      statusCode: 409,
+      errorCode: "CONFLICT",
+    });
+
+    let thrown: { statusCode?: number; message: string } | undefined;
+    try {
+      await revokeHandler({ body: { channel: "telegram" } });
+    } catch (err) {
+      thrown = err as { statusCode?: number; message: string };
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown!.statusCode).toBe(409);
+    // Teardown still ran before the relay rejected.
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    expect(localAclWrite).not.toHaveBeenCalled();
+  });
+
+  test("no binding present: tears down sessions and skips the relay", async () => {
+    guardianBinding = null;
+
+    const result = (await revokeHandler({
+      body: { channel: "telegram" },
+    })) as { success: boolean; bound: boolean };
+
+    expect(ipcCalls).toEqual([]);
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    expect(result.bound).toBe(false);
+  });
+
+  test("skips the relay when the resolved channel is already revoked", async () => {
+    contactChannel = { id: "ch1", status: "revoked" };
+
+    await revokeHandler({ body: { channel: "telegram" } });
+
+    expect(ipcCalls).toEqual([]);
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -263,7 +263,7 @@ async function handleRevokeVerificationBinding({
 }: RouteHandlerArgs) {
   const { channel } = body as { channel?: ChannelId };
 
-  const result = revokeVerificationForChannel(channel);
+  const result = await revokeVerificationForChannel(channel);
   if (!result.success) {
     throw new BadRequestError(
       (result as { message?: string }).message ?? "Revocation failed",

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -86,6 +86,10 @@ const markChannelVerifiedHandler = contactRoutes.find(
   (r) => r.method === "mark_channel_verified",
 )!.handler;
 
+const markChannelRevokedHandler = contactRoutes.find(
+  (r) => r.method === "mark_channel_revoked",
+)!.handler;
+
 beforeAll(async () => {
   await initGatewayDb();
 });
@@ -245,5 +249,73 @@ describe("mark_channel_verified IPC handler", () => {
       .get();
     expect(channelInGateway).toBeTruthy();
     expect(channelInGateway!.contactId).toBe("c1");
+  });
+});
+
+describe("mark_channel_revoked IPC handler", () => {
+  test("downgrades a contact channel to revoked + reason and returns the envelope", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "active" });
+
+    const res = (await markChannelRevokedHandler({
+      contactChannelId: "ch1",
+      reason: "guardian_binding_revoked",
+    })) as {
+      ok: boolean;
+      didWrite: boolean;
+      channel: { status: string; revokedReason: string | null };
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.didWrite).toBe(true);
+    expect(res.channel.status).toBe("revoked");
+    expect(res.channel.revokedReason).toBe("guardian_binding_revoked");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("revoked");
+    expect(row!.revokedReason).toBe("guardian_binding_revoked");
+  });
+
+  test("guardian guard rejects a non-binding downgrade of a guardian channel", async () => {
+    seedContact("g1", "guardian");
+    seedChannel({ id: "gch1", contactId: "g1", status: "active" });
+
+    await expect(
+      markChannelRevokedHandler({
+        contactChannelId: "gch1",
+        reason: "some_other_reason",
+      }),
+    ).rejects.toThrow(/guardian channel/i);
+
+    // Row is untouched — the guard rejects before any write.
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "gch1"))
+      .get();
+    expect(row!.status).toBe("active");
+  });
+
+  test("allows the sanctioned guardian-binding teardown on a guardian channel", async () => {
+    seedContact("g1", "guardian");
+    seedChannel({ id: "gch1", contactId: "g1", status: "active" });
+
+    const res = (await markChannelRevokedHandler({
+      contactChannelId: "gch1",
+      reason: "guardian_binding_revoked",
+    })) as { ok: boolean; channel: { status: string } };
+
+    expect(res.ok).toBe(true);
+    expect(res.channel.status).toBe("revoked");
+  });
+
+  test("throws on a missing channel id (no silent success)", async () => {
+    await expect(
+      markChannelRevokedHandler({ contactChannelId: "nonexistent" }),
+    ).rejects.toThrow(/not found/);
   });
 });

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -313,6 +313,34 @@ describe("mark_channel_revoked IPC handler", () => {
     expect(res.channel.status).toBe("revoked");
   });
 
+  test("does not downgrade a blocked channel (preserves block + reason)", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "blocked" });
+    getGatewayDb()
+      .update(contactChannels)
+      .set({ blockedReason: "abuse" })
+      .where(eq(contactChannels.id, "ch1"))
+      .run();
+
+    const res = (await markChannelRevokedHandler({
+      contactChannelId: "ch1",
+      reason: "guardian_binding_revoked",
+    })) as { ok: boolean; didWrite: boolean; channel: { status: string } };
+
+    expect(res.ok).toBe(true);
+    expect(res.didWrite).toBe(false);
+    expect(res.channel.status).toBe("blocked");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("blocked");
+    expect(row!.blockedReason).toBe("abuse");
+    expect(row!.revokedReason).toBeNull();
+  });
+
   test("throws on a missing channel id (no silent success)", async () => {
     await expect(
       markChannelRevokedHandler({ contactChannelId: "nonexistent" }),

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -757,6 +757,14 @@ export class ContactStore {
       throw new CannotDowngradeGuardianError(channelId);
     }
 
+    // A blocked channel stays blocked: blocked is stricter than revoked, and
+    // downgrading it would clear blockedReason and make the actor re-claimable.
+    // Mirrors the blocked→revoked guard in updateChannelStatus; here it's a
+    // no-op so a guardian-binding teardown over a blocked channel doesn't fail.
+    if (channel.status === "blocked") {
+      return { channel, didWrite: false };
+    }
+
     // Idempotent: a row already revoked with this reason is a no-op — skip the
     // write + dual-write (matches markChannelVerified).
     const alreadyRevoked =

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -19,6 +19,13 @@ import { canonicalizeInboundIdentity } from "../verification/identity.js";
 
 const log = getLogger("contact-store");
 
+/**
+ * Reason that marks the sanctioned guardian-binding teardown. A guardian
+ * channel may only be downgraded with this reason; any other reason is
+ * rejected by the guardian guard (invariant 4).
+ */
+export const GUARDIAN_BINDING_REVOKE_REASON = "guardian_binding_revoked";
+
 export type Contact = typeof contacts.$inferSelect;
 export type ContactChannel = typeof contactChannels.$inferSelect;
 export type IngressInviteRow = typeof ingressInvites.$inferSelect;
@@ -707,6 +714,90 @@ export class ContactStore {
     }
 
     return { channel: after, didWrite };
+  }
+
+  /**
+   * Downgrade a channel to `revoked` (verification-revoke outcome), then
+   * best-effort dual-write to the assistant DB. Gateway DB is source of truth.
+   *
+   * Guardian guard (invariant 4): a guardian contact's channel may only be
+   * downgraded via the sanctioned guardian-binding teardown
+   * (`reason="guardian_binding_revoked"`). Any other reason on a guardian
+   * channel is rejected here at the boundary rather than silently applied.
+   *
+   * Mirrors `markChannelVerified`: when the channel is missing on the gateway
+   * but present on the assistant, it (plus its parent contact) is mirrored in
+   * first so a UI-visible channel id doesn't 404.
+   *
+   * Returns the channel after the write, or `null` if neither DB has the id.
+   */
+  async markChannelRevoked(
+    channelId: string,
+    reason?: string,
+  ): Promise<{ channel: ContactChannel; didWrite: boolean } | null> {
+    const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
+    if (!mirrored) return null;
+
+    const channel = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (!channel) return null;
+
+    const contact = this.getContact(channel.contactId);
+    if (
+      contact?.role === "guardian" &&
+      reason !== GUARDIAN_BINDING_REVOKE_REASON
+    ) {
+      log.warn(
+        { channelId, reason },
+        "markChannelRevoked: rejected guardian channel downgrade",
+      );
+      throw new CannotDowngradeGuardianError(channelId);
+    }
+
+    // Idempotent: a row already revoked with this reason is a no-op — skip the
+    // write + dual-write (matches markChannelVerified).
+    const alreadyRevoked =
+      channel.status === "revoked" &&
+      channel.revokedReason === (reason ?? null);
+    if (alreadyRevoked) {
+      return { channel, didWrite: false };
+    }
+
+    this.db
+      .update(contactChannels)
+      .set({
+        status: "revoked",
+        revokedReason: reason ?? null,
+        blockedReason: null,
+        updatedAt: Date.now(),
+      })
+      .where(eq(contactChannels.id, channelId))
+      .run();
+
+    const after = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (!after) return null;
+
+    try {
+      await this.dualWriteChannelStatusToAssistantDb(channelId, {
+        status: "revoked",
+        revokedReason: reason ?? null,
+        blockedReason: null,
+      });
+    } catch (err) {
+      log.warn(
+        { channelId, err },
+        "markChannelRevoked: assistant DB dual-write failed (best-effort)",
+      );
+    }
+
+    return { channel: after, didWrite: true };
   }
 
   // ---------------------------------------------------------------------------
@@ -1812,6 +1903,24 @@ export class CannotRevokeBlockedError extends Error {
       "Cannot revoke a blocked channel. Unblock it first or leave it blocked.",
     );
     this.name = "CannotRevokeBlockedError";
+    this.channelId = channelId;
+  }
+}
+
+/**
+ * Thrown by `markChannelRevoked` when a downgrade would strip a guardian
+ * contact's channel via anything other than the sanctioned guardian-binding
+ * teardown. The caller maps this to HTTP 409.
+ */
+export class CannotDowngradeGuardianError extends Error {
+  readonly channelId: string;
+  readonly statusCode = 409;
+  readonly code = "CONFLICT";
+  constructor(channelId: string) {
+    super(
+      "Cannot downgrade a guardian channel. Revoke the guardian binding instead.",
+    );
+    this.name = "CannotDowngradeGuardianError";
     this.channelId = channelId;
   }
 }

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -6,7 +6,10 @@
  * assistant DB proxy (raw SQL), so the gateway owns the write path.
  */
 
-import { MarkChannelVerifiedIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+import {
+  MarkChannelRevokedIpcParamsSchema,
+  MarkChannelVerifiedIpcParamsSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
@@ -180,6 +183,34 @@ export const contactRoutes: IpcRoute[] = [
           status: channel.status,
           verifiedAt: channel.verifiedAt,
           verifiedVia: channel.verifiedVia,
+        },
+      };
+    },
+  },
+  {
+    method: "mark_channel_revoked",
+    schema: MarkChannelRevokedIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { contactChannelId, reason } =
+        MarkChannelRevokedIpcParamsSchema.parse(params);
+      const result = await getStore().markChannelRevoked(
+        contactChannelId,
+        reason,
+      );
+      if (!result) {
+        throw new Error(`Channel "${contactChannelId}" not found`);
+      }
+      const { channel, didWrite } = result;
+      return {
+        ok: true,
+        didWrite,
+        channel: {
+          id: channel.id,
+          contactId: channel.contactId,
+          type: channel.type,
+          address: channel.address,
+          status: channel.status,
+          revokedReason: channel.revokedReason,
         },
       };
     },

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -114,3 +114,32 @@ export const MarkChannelVerifiedIpcResponseSchema = z.object({
 export type MarkChannelVerifiedIpcResponse = z.infer<
   typeof MarkChannelVerifiedIpcResponseSchema
 >;
+
+export const MarkChannelRevokedIpcParamsSchema = z.object({
+  contactChannelId: z.string().min(1),
+  // Audit reason for the downgrade. The verification-revoke flow passes
+  // "guardian_binding_revoked", the only reason allowed to downgrade a
+  // guardian channel (guardian guard, invariant 4).
+  reason: z.string().optional(),
+});
+
+export type MarkChannelRevokedIpcParams = z.infer<
+  typeof MarkChannelRevokedIpcParamsSchema
+>;
+
+export const MarkChannelRevokedIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  didWrite: z.boolean(),
+  channel: z.object({
+    id: z.string(),
+    contactId: z.string(),
+    type: z.string(),
+    address: z.string(),
+    status: z.string(),
+    revokedReason: z.string().nullable(),
+  }),
+});
+
+export type MarkChannelRevokedIpcResponse = z.infer<
+  typeof MarkChannelRevokedIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Route the verification revoke/downgrade outcome through the gateway (source of truth), keeping session teardown (cancelOutbound, revokePendingSessions) assistant-side
- Guardian guard rejects downgrading a guardian channel at the gateway boundary
- Relay target resolved: no `updateContactChannel` IPC method existed (only an HTTP handler), so added a thin gateway IPC method `mark_channel_revoked` (same pattern as PR 3's `mark_channel_verified`) delegating to a new `ContactStore.markChannelRevoked` that mirrors-if-missing, enforces the guardian guard, downgrades to `revoked`, and best-effort dual-writes to the assistant DB

Part of plan: contacts-gw-native-verification.md (PR 5 of 6)