### PR TITLE
feat(contacts): relay daemon listContacts/getContact IPC reads to the gateway

### DIFF
--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the daemon's contact read relay (PR 3).
+ *
+ * handleListContacts (non-search) and handleGetContact relay to the gateway
+ * via `ipcCallPersistent`. On the happy path they serve gateway-sourced data
+ * and do NOT read the assistant DB. On IPC failure they fall back to the
+ * assistant-DB read and log a warning. getContact still 404s for unknown ids.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const realLogger = await import("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Guardian display-name override → deterministic sentinel so we can assert it
+// is applied to relayed payloads.
+const realUserReference = await import("../prompts/user-reference.js");
+mock.module("../prompts/user-reference.js", () => ({
+  ...realUserReference,
+  resolveGuardianName: () => "Your Guardian",
+}));
+
+// IPC relay stub — each test sets the response/behavior.
+type IpcStub = (method: string, params?: Record<string, unknown>) => unknown;
+let ipcStub: IpcStub = () => undefined;
+const ipcCalls: Array<{ method: string; params?: Record<string, unknown> }> =
+  [];
+
+const realGatewayClient = await import("../ipc/gateway-client.js");
+mock.module("../ipc/gateway-client.js", () => ({
+  ...realGatewayClient,
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    ipcCalls.push({ method, params });
+    return ipcStub(method, params);
+  },
+}));
+
+// Assistant-DB fallback stubs — assert these are NOT hit on the happy path,
+// and that they ARE hit on the IPC-failure fallback path.
+const localCalls: string[] = [];
+const realContactStore = await import("../contacts/contact-store.js");
+mock.module("../contacts/contact-store.js", () => ({
+  ...realContactStore,
+  listContacts: () => {
+    localCalls.push("listContacts");
+    return [
+      {
+        id: "local-1",
+        displayName: "Local Contact",
+        role: "contact",
+        contactType: "human",
+        interactionCount: 0,
+        channels: [],
+      },
+    ];
+  },
+  getContact: (id: string) => {
+    localCalls.push("getContact");
+    if (id === "missing") return null;
+    return {
+      id,
+      displayName: "Local Contact",
+      role: "contact",
+      contactType: "human",
+      interactionCount: 0,
+      channels: [],
+    };
+  },
+  getAssistantContactMetadata: () => {
+    localCalls.push("getAssistantContactMetadata");
+    return undefined;
+  },
+}));
+
+const { handleListContacts, handleGetContact } = (await import(
+  "../runtime/routes/contact-routes.js"
+)) as typeof import("../runtime/routes/contact-routes.js") & {
+  handleListContacts: (q: Record<string, string>) => Promise<{
+    ok: boolean;
+    contacts: Array<{ id: string; displayName: string; role: string }>;
+  }>;
+  handleGetContact: (id: string) => Promise<{
+    ok: boolean;
+    contact: { id: string; displayName: string; role: string };
+    assistantMetadata?: unknown;
+  }>;
+};
+
+function gatewayContact(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "gw-1",
+    displayName: "Gateway Contact",
+    role: "contact",
+    notes: null,
+    contactType: "human",
+    interactionCount: 2,
+    lastInteraction: 100,
+    channels: [
+      {
+        id: "ch-1",
+        contactId: "gw-1",
+        type: "telegram",
+        address: "tg-001",
+        isPrimary: true,
+        externalUserId: "tg-001",
+        status: "active",
+        policy: "allow",
+        verifiedAt: null,
+        verifiedVia: null,
+        lastSeenAt: null,
+        interactionCount: 2,
+        lastInteraction: 100,
+        revokedReason: null,
+        blockedReason: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ipcStub = () => undefined;
+  ipcCalls.length = 0;
+  localCalls.length = 0;
+});
+
+describe("handleListContacts relay", () => {
+  test("non-search read serves gateway contacts and does NOT read assistant DB", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_list_rich") {
+        return { ok: true, contacts: [gatewayContact()] };
+      }
+      return undefined;
+    };
+
+    const result = await handleListContacts({ limit: "50" });
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(result.contacts).toHaveLength(1);
+    expect(result.contacts[0].id).toBe("gw-1");
+  });
+
+  test("applies guardian display-name override to relayed contacts", async () => {
+    ipcStub = () => ({
+      ok: true,
+      contacts: [gatewayContact({ role: "guardian", displayName: "Real Name" })],
+    });
+
+    const result = await handleListContacts({});
+    expect(result.contacts[0].displayName).toBe("Your Guardian");
+  });
+
+  test("falls back to the assistant DB on IPC failure", async () => {
+    ipcStub = () => {
+      throw new Error("gateway down");
+    };
+
+    const result = await handleListContacts({});
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toContain("listContacts");
+    expect(result.contacts[0].id).toBe("local-1");
+  });
+});
+
+describe("handleGetContact relay", () => {
+  test("serves the gateway contact and does NOT read the assistant DB", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_get_rich") {
+        return { ok: true, contact: gatewayContact() };
+      }
+      return undefined;
+    };
+
+    const result = await handleGetContact("gw-1");
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(result.contact.id).toBe("gw-1");
+    expect(result.assistantMetadata).toBeUndefined();
+  });
+
+  test("applies guardian display-name override", async () => {
+    ipcStub = () => ({
+      ok: true,
+      contact: gatewayContact({ role: "guardian", displayName: "Real Name" }),
+    });
+
+    const result = await handleGetContact("gw-1");
+    expect(result.contact.displayName).toBe("Your Guardian");
+  });
+
+  test("returns assistantMetadata when present", async () => {
+    ipcStub = () => ({
+      ok: true,
+      contact: gatewayContact(),
+      assistantMetadata: {
+        contactId: "gw-1",
+        species: "vellum",
+        metadata: { model: "opus" },
+      },
+    });
+
+    const result = await handleGetContact("gw-1");
+    expect(result.assistantMetadata).toEqual({
+      contactId: "gw-1",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+  });
+
+  test("throws NotFoundError on gateway not-found (no fallback)", async () => {
+    ipcStub = () => null;
+
+    await expect(handleGetContact("nope")).rejects.toThrow(
+      'Contact "nope" not found',
+    );
+    expect(localCalls).toEqual([]);
+  });
+
+  test("falls back to the assistant DB on IPC transport failure", async () => {
+    ipcStub = () => {
+      throw new Error("gateway down");
+    };
+
+    const result = await handleGetContact("gw-1");
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
+    expect(localCalls).toContain("getContact");
+    expect(result.contact.id).toBe("gw-1");
+  });
+
+  test("fallback path still 404s for unknown ids", async () => {
+    ipcStub = () => {
+      throw new Error("gateway down");
+    };
+
+    await expect(handleGetContact("missing")).rejects.toThrow(
+      'Contact "missing" not found',
+    );
+    expect(localCalls).toContain("getContact");
+  });
+});

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -8,6 +8,10 @@
  * they don't shadow more-specific sub-paths like contacts/invites.
  */
 
+import {
+  GetContactIpcResponseSchema,
+  ListContactsIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
@@ -28,6 +32,7 @@ import type {
 } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
+import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   redeemIngressInvite,
@@ -41,6 +46,8 @@ import {
   RouteError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("contact-routes");
 
 /**
  * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
@@ -160,7 +167,7 @@ const contactSchema = z.object({
 // Contact handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
-function handleListContacts(queryParams: Record<string, string>) {
+export async function handleListContacts(queryParams: Record<string, string>) {
   const limit = Number(queryParams.limit ?? 50);
   const role = (queryParams.role as ContactRole) || undefined;
   const contactTypeParam = queryParams.contactType;
@@ -178,6 +185,7 @@ function handleListContacts(queryParams: Record<string, string>) {
     ? (contactTypeParam as ContactType)
     : undefined;
 
+  // Search params still proxy to the local DB (PR 4 governs the search relay).
   if (query || channelAddress || channelType) {
     const contacts = searchContacts({
       query,
@@ -193,27 +201,66 @@ function handleListContacts(queryParams: Record<string, string>) {
     };
   }
 
-  const contacts = listContacts(limit, role, contactType);
-  return {
-    ok: true,
-    contacts: contacts.map(prepareContactResponse),
-  };
+  // Non-search reads relay to the gateway (source of truth for ACL fields).
+  try {
+    const result = await ipcCallPersistent("contacts_list_rich", {
+      limit,
+      ...(role ? { role } : {}),
+      ...(contactType ? { contactType } : {}),
+    });
+    const { contacts } = ListContactsIpcResponseSchema.parse(result);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  } catch (err) {
+    log.warn(
+      { err },
+      "handleListContacts: gateway relay failed; falling back to assistant DB",
+    );
+    const contacts = listContacts(limit, role, contactType);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  }
 }
 
-function handleGetContact(contactId: string) {
-  const contact = getContact(contactId);
-  if (!contact) {
-    throw new NotFoundError(`Contact "${contactId}" not found`);
+export async function handleGetContact(contactId: string) {
+  try {
+    const result = await ipcCallPersistent("contacts_get_rich", { contactId });
+    // The gateway returns null (no `contact`) on a clean not-found.
+    if (!result || (result as { contact?: unknown }).contact === undefined) {
+      throw new NotFoundError(`Contact "${contactId}" not found`);
+    }
+    const { contact, assistantMetadata } =
+      GetContactIpcResponseSchema.parse(result);
+    return {
+      ok: true,
+      contact: prepareContactResponse(contact),
+      assistantMetadata: assistantMetadata ?? undefined,
+    };
+  } catch (err) {
+    // A clean not-found is a real 404 — don't fall back or mask it.
+    if (err instanceof NotFoundError) throw err;
+    log.warn(
+      { err, contactId },
+      "handleGetContact: gateway relay failed; falling back to assistant DB",
+    );
+    const contact = getContact(contactId);
+    if (!contact) {
+      throw new NotFoundError(`Contact "${contactId}" not found`);
+    }
+    const assistantMeta =
+      contact.contactType === "assistant"
+        ? getAssistantContactMetadata(contact.id)
+        : undefined;
+    return {
+      ok: true,
+      contact: prepareContactResponse(contact),
+      assistantMetadata: assistantMeta ?? undefined,
+    };
   }
-  const assistantMeta =
-    contact.contactType === "assistant"
-      ? getAssistantContactMetadata(contact.id)
-      : undefined;
-  return {
-    ok: true,
-    contact: prepareContactResponse(contact),
-    assistantMetadata: assistantMeta ?? undefined,
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -323,4 +323,91 @@ describe("IPC contact routes", () => {
     expect(res.error).toBeDefined();
     expect(res.error).toContain("Invalid params");
   });
+
+  // ── Rich reads (contacts_list_rich / contacts_get_rich) ─────────────────
+  //
+  // The assistant DB proxy is not available in this test harness, so the rich
+  // reads soft-fail the info join (notes/contactType become null) and return
+  // the gateway-DB-only ACL shape. We assert the merged ContactRead structure
+  // end-to-end over the socket.
+
+  test("contacts_list_rich returns the merged ContactRead shape via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_list_rich", {});
+
+    expect(res.error).toBeUndefined();
+    const body = res.result as {
+      ok: boolean;
+      contacts: Array<{
+        id: string;
+        role: string;
+        interactionCount: number;
+        channels: Array<{ address: string; externalUserId: string | null }>;
+      }>;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.contacts).toHaveLength(2);
+    // Guardian first (ordering mirrors the daemon's listContacts).
+    expect(body.contacts[0].id).toBe("c1");
+    expect(body.contacts[0].role).toBe("guardian");
+    // Trust signals derived from gateway channels (5 + 10 for the guardian).
+    expect(body.contacts[0].interactionCount).toBe(15);
+    // externalUserId echoes address (withChannelCompat).
+    const ch = body.contacts[0].channels[0];
+    expect(ch.externalUserId).toBe(ch.address);
+  });
+
+  test("contacts_list_rich honors the role filter via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_list_rich", {
+      role: "guardian",
+    });
+
+    expect(res.error).toBeUndefined();
+    const body = res.result as { ok: boolean; contacts: Array<{ id: string }> };
+    expect(body.contacts.map((c) => c.id)).toEqual(["c1"]);
+  });
+
+  test("contacts_get_rich returns a merged contact via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_get_rich", {
+      contactId: "c1",
+    });
+
+    expect(res.error).toBeUndefined();
+    const body = res.result as {
+      ok: boolean;
+      contact: { id: string; displayName: string; channels: unknown[] };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.contact.id).toBe("c1");
+    expect(body.contact.displayName).toBe("Test Guardian");
+    expect(body.contact.channels).toHaveLength(2);
+  });
+
+  test("contacts_get_rich returns null for unknown contact via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_get_rich", {
+      contactId: "nonexistent",
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toBeNull();
+  });
+
+  test("contacts_get_rich validates params", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_get_rich", {});
+
+    expect(res.error).toBeDefined();
+    expect(res.error).toContain("Invalid params");
+  });
 });

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -6,6 +6,10 @@
  * assistant DB proxy (raw SQL), so the gateway owns the write path.
  */
 
+import {
+  GetContactIpcParamsSchema,
+  ListContactsIpcParamsSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
@@ -56,6 +60,36 @@ export const contactRoutes: IpcRoute[] = [
     handler: (params?: Record<string, unknown>) => {
       const contactId = params?.contactId as string;
       return getStore().getContact(contactId) ?? null;
+    },
+  },
+  // Rich reads expose the shared ContactRead shape (gateway ACL + assistant
+  // info) for the daemon's list/get relay. Additive — the lean list_contacts /
+  // get_contact methods above stay for gateway-internal callers.
+  {
+    method: "contacts_list_rich",
+    schema: ListContactsIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const parsed = ListContactsIpcParamsSchema.parse(params);
+      const contacts = await getStore().listContactsRich(parsed);
+      return { ok: true, contacts };
+    },
+  },
+  {
+    method: "contacts_get_rich",
+    schema: GetContactIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { contactId } = GetContactIpcParamsSchema.parse(params);
+      const result = await getStore().getContactRich(contactId);
+      // Return null on miss (mirrors get_contact); the daemon relay maps a
+      // null/not-found result to a 404.
+      if (!result) return null;
+      return {
+        ok: true,
+        contact: result.contact,
+        ...(result.assistantMetadata
+          ? { assistantMetadata: result.assistantMetadata }
+          : {}),
+      };
     },
   },
   {


### PR DESCRIPTION
## Summary
- Register gateway IPC methods contacts_list_rich / contacts_get_rich exposing the rich read helpers (additive; lean list_contacts/get_contact retained).
- Flip daemon handleListContacts (non-search) and handleGetContact to relay to the gateway via ipcCallPersistent, re-applying prepareContactResponse; gateway DB is now source of truth for ACL fields.
- Gateway-down reads fall back to the assistant DB with a logged warning; getContact still 404s for unknown ids.

Part of plan: contacts-relay-reads.md (PR 3 of 4)