### PR TITLE
feat(contacts): route search_contacts through the gateway list relay, keep search daemon-native

### DIFF
--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -9,12 +9,22 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Capture `log.debug(...)` calls so we can assert the daemon-native-search note
+// is emitted on the search path.
+const debugLogs: string[] = [];
 const realLogger = await import("../util/logger.js");
 mock.module("../util/logger.js", () => ({
   ...realLogger,
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
+      get:
+        (_target, prop: string) =>
+        (...args: unknown[]) => {
+          if (prop === "debug") {
+            const msg = args.find((a) => typeof a === "string");
+            if (typeof msg === "string") debugLogs.push(msg);
+          }
+        },
     }),
 }));
 
@@ -79,9 +89,22 @@ mock.module("../contacts/contact-store.js", () => ({
     localCalls.push("getAssistantContactMetadata");
     return undefined;
   },
+  searchContacts: () => {
+    localCalls.push("searchContacts");
+    return [
+      {
+        id: "search-1",
+        displayName: "Search Contact",
+        role: "contact",
+        contactType: "human",
+        interactionCount: 0,
+        channels: [],
+      },
+    ];
+  },
 }));
 
-const { handleListContacts, handleGetContact } = (await import(
+const { handleListContacts, handleGetContact, ROUTES } = (await import(
   "../runtime/routes/contact-routes.js"
 )) as typeof import("../runtime/routes/contact-routes.js") & {
   handleListContacts: (q: Record<string, string>) => Promise<{
@@ -94,6 +117,17 @@ const { handleListContacts, handleGetContact } = (await import(
     assistantMetadata?: unknown;
   }>;
 };
+
+/** Invoke the inline `search_contacts` POST route handler with a request body. */
+function searchContactsRoute(
+  body: Record<string, unknown>,
+): Promise<Array<{ id: string; displayName: string; role: string }>> {
+  const route = ROUTES.find((r) => r.operationId === "search_contacts");
+  if (!route) throw new Error("search_contacts route not found");
+  return route.handler({ body }) as Promise<
+    Array<{ id: string; displayName: string; role: string }>
+  >;
+}
 
 function gatewayContact(overrides: Record<string, unknown> = {}) {
   return {
@@ -131,6 +165,7 @@ beforeEach(() => {
   ipcStub = () => undefined;
   ipcCalls.length = 0;
   localCalls.length = 0;
+  debugLogs.length = 0;
 });
 
 describe("handleListContacts relay", () => {
@@ -170,6 +205,73 @@ describe("handleListContacts relay", () => {
     expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
     expect(localCalls).toContain("listContacts");
     expect(result.contacts[0].id).toBe("local-1");
+  });
+
+  test("search params stay daemon-native and log the boundary note", async () => {
+    const result = await handleListContacts({ query: "alice" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(result.contacts[0].id).toBe("search-1");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+});
+
+describe("search_contacts route relay boundary", () => {
+  test("real query stays daemon-native and logs the boundary note", async () => {
+    const contacts = await searchContactsRoute({ query: "alice" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(contacts[0].id).toBe("search-1");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+
+  test("real channelAddress stays daemon-native", async () => {
+    const contacts = await searchContactsRoute({ channelAddress: "tg-001" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(contacts[0].id).toBe("search-1");
+  });
+
+  test("real channelType stays daemon-native", async () => {
+    const contacts = await searchContactsRoute({ channelType: "telegram" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(contacts[0].id).toBe("search-1");
+  });
+
+  test("empty/whitespace query with no filters relays through the gateway", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_list_rich") {
+        return { ok: true, contacts: [gatewayContact()] };
+      }
+      return undefined;
+    };
+
+    const contacts = await searchContactsRoute({ query: "   " });
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(contacts[0].id).toBe("gw-1");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(false);
+  });
+
+  test("no params at all relays through the gateway", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_list_rich") {
+        return { ok: true, contacts: [gatewayContact()] };
+      }
+      return undefined;
+    };
+
+    const contacts = await searchContactsRoute({});
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(contacts[0].id).toBe("gw-1");
   });
 });
 

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -245,7 +245,7 @@ describe("contact_search tool", () => {
 describe("search_contacts route", () => {
   beforeEach(clearContacts);
 
-  test("includes externalUserId (= address) on channels for older clients", () => {
+  test("includes externalUserId (= address) on channels for older clients", async () => {
     const seeded = upsertFixture({
       display_name: "Dana",
       channels: [{ type: "slack", address: "U12345ABC" }],
@@ -255,9 +255,9 @@ describe("search_contacts route", () => {
     const searchRoute = ROUTES.find(
       (r) => r.operationId === "search_contacts",
     )!;
-    const contacts = searchRoute.handler({
+    const contacts = (await searchRoute.handler({
       body: { channelAddress: seededAddress },
-    }) as unknown as Array<{
+    })) as unknown as Array<{
       channels: Array<{ address: string; externalUserId?: string }>;
     }>;
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -167,6 +167,41 @@ const contactSchema = z.object({
 // Contact handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
+/**
+ * Relay a non-search contact list read to the gateway (source of truth for ACL
+ * fields), falling back to the assistant DB on IPC failure. Shared by the GET
+ * `contacts` list and the `search_contacts` no-filter case so both serve
+ * gateway-sourced data consistently.
+ */
+async function relayListContacts(
+  limit: number,
+  role: ContactRole | undefined,
+  contactType: ContactType | undefined,
+) {
+  try {
+    const result = await ipcCallPersistent("contacts_list_rich", {
+      limit,
+      ...(role ? { role } : {}),
+      ...(contactType ? { contactType } : {}),
+    });
+    const { contacts } = ListContactsIpcResponseSchema.parse(result);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  } catch (err) {
+    log.warn(
+      { err },
+      "relayListContacts: gateway relay failed; falling back to assistant DB",
+    );
+    const contacts = listContacts(limit, role, contactType);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  }
+}
+
 export async function handleListContacts(queryParams: Record<string, string>) {
   const limit = Number(queryParams.limit ?? 50);
   const role = (queryParams.role as ContactRole) || undefined;
@@ -185,8 +220,11 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     ? (contactTypeParam as ContactType)
     : undefined;
 
-  // Search params still proxy to the local DB (PR 4 governs the search relay).
+  // True search stays daemon-native pending gateway-native search (Tier 3 / PR 6).
   if (query || channelAddress || channelType) {
+    log.debug(
+      "handleListContacts: search served daemon-native (gateway-native search is design-blocked, Tier 3 / PR 6)",
+    );
     const contacts = searchContacts({
       query,
       channelAddress,
@@ -201,29 +239,7 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     };
   }
 
-  // Non-search reads relay to the gateway (source of truth for ACL fields).
-  try {
-    const result = await ipcCallPersistent("contacts_list_rich", {
-      limit,
-      ...(role ? { role } : {}),
-      ...(contactType ? { contactType } : {}),
-    });
-    const { contacts } = ListContactsIpcResponseSchema.parse(result);
-    return {
-      ok: true,
-      contacts: contacts.map(prepareContactResponse),
-    };
-  } catch (err) {
-    log.warn(
-      { err },
-      "handleListContacts: gateway relay failed; falling back to assistant DB",
-    );
-    const contacts = listContacts(limit, role, contactType);
-    return {
-      ok: true,
-      contacts: contacts.map(prepareContactResponse),
-    };
-  }
+  return relayListContacts(limit, role, contactType);
 }
 
 export async function handleGetContact(contactId: string) {
@@ -654,7 +670,7 @@ export const ROUTES: RouteDefinition[] = [
       limit: z.number().optional(),
     }),
     responseBody: z.array(contactSchema),
-    handler: ({ body = {} }: RouteHandlerArgs) => {
+    handler: async ({ body = {} }: RouteHandlerArgs) => {
       const parsed = z
         .object({
           query: z.string().optional(),
@@ -663,6 +679,27 @@ export const ROUTES: RouteDefinition[] = [
           limit: z.number().optional(),
         })
         .parse(body);
+
+      const hasFilter =
+        Boolean(parsed.query?.trim()) ||
+        Boolean(parsed.channelAddress) ||
+        Boolean(parsed.channelType);
+
+      // No-filter "search" is a list read — relay to the gateway so it returns
+      // the same source-of-truth data as `contacts list`.
+      if (!hasFilter) {
+        const { contacts } = await relayListContacts(
+          parsed.limit ?? 50,
+          undefined,
+          undefined,
+        );
+        return contacts;
+      }
+
+      // True search stays daemon-native pending gateway-native search (Tier 3 / PR 6).
+      log.debug(
+        "search_contacts: search served daemon-native (gateway-native search is design-blocked, Tier 3 / PR 6)",
+      );
       return searchContacts(parsed).map(prepareContactResponse);
     },
   },


### PR DESCRIPTION
## Summary
- Make the search boundary explicit: true search (query/channelAddress/channelType) stays daemon-native with a logged note; gateway-native search remains design-blocked (out of scope).
- Funnel no-filter/empty-param list-style reads (GET list + POST search-with-no-params) through the gateway contacts_list_rich relay for source-of-truth consistency.
- Boundary logged and covered by tests.

Part of plan: contacts-relay-reads.md (PR 4 of 4)