### PR TITLE
fix(gateway): preserve display name + reconcile existing contacts in create_contact

### DIFF
--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -612,6 +612,151 @@ describe("IPC contact routes", () => {
     expect(store.getContact("rename-c1")!.displayName).toBe("New Name");
   });
 
+  test("create_contact retry does not overwrite the assistant-DB display_name when omitted", async () => {
+    // Gap A: the gateway row exists with a stale name; the assistant DB holds
+    // the user's current (different) name. A retry WITHOUT displayName must
+    // leave the assistant-DB name untouched — the UPDATE must omit display_name.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "stale-c1",
+        displayName: "Stale Gateway Name",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "stale-ch1",
+        contactId: "stale-c1",
+        type: "email",
+        address: "stale@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+      })
+      .run();
+
+    // Assistant DB has the contact (so the mirror takes the UPDATE branch).
+    assistantDbQueryMock = mock(async (sql: string) => {
+      if (sql.includes("FROM contacts WHERE id = ?")) {
+        return [{ userFile: "current-name.md" }];
+      }
+      return [];
+    });
+    const runCalls: { sql: string; bind?: unknown[] }[] = [];
+    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
+      runCalls.push({ sql, bind });
+      return { changes: 1, lastInsertRowid: 0 };
+    });
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "stale@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+
+    // The assistant-DB contact UPDATE must NOT touch display_name.
+    const contactUpdate = runCalls.find(
+      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    );
+    expect(contactUpdate).toBeDefined();
+    expect(contactUpdate!.sql).not.toContain("display_name");
+
+    // The gateway row's stale name is likewise preserved (omit-to-preserve).
+    expect(new ContactStore(db).getContact("stale-c1")!.displayName).toBe(
+      "Stale Gateway Name",
+    );
+  });
+
+  test("create_contact reconciles an assistant-only contact instead of minting a duplicate", async () => {
+    // Gap B: a contact+channel exists in the assistant DB but NOT the gateway.
+    // upsertContact mints a new gateway id; the mirror must reconcile into the
+    // existing assistant contact (no duplicate INSERT, name preserved) and the
+    // gateway row must be created.
+    const assistantContactId = "assistant-only-c1";
+    const assistantChannelId = "assistant-only-ch1";
+
+    // Channel lookup by (type,address) returns the existing assistant contact;
+    // the contact-by-id lookup (keyed on the resolved id) reports it exists.
+    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      if (
+        sql.includes("FROM contact_channels") &&
+        sql.includes("WHERE type = ?")
+      ) {
+        return [{ contactId: assistantContactId, id: assistantChannelId }];
+      }
+      if (
+        sql.includes("FROM contact_channels") &&
+        sql.includes("WHERE contact_id = ?")
+      ) {
+        // existingCh lookup keyed on the resolved (assistant) contact id.
+        if (bind?.[0] === assistantContactId) {
+          return [{ id: assistantChannelId, status: "active" }];
+        }
+        return [];
+      }
+      if (sql.includes("FROM contacts WHERE id = ?")) {
+        if (bind?.[0] === assistantContactId) {
+          return [{ userFile: "existing-person.md" }];
+        }
+        return [];
+      }
+      return [];
+    });
+    const runCalls: { sql: string; bind?: unknown[] }[] = [];
+    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
+      runCalls.push({ sql, bind });
+      return { changes: 1, lastInsertRowid: 0 };
+    });
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "existing-person@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    // No duplicate assistant contact INSERT.
+    const contactInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT INTO contacts"),
+    );
+    expect(contactInsert).toBeUndefined();
+
+    // The assistant contact UPDATE targets the EXISTING assistant id, not the
+    // new gateway id, and preserves the name (no display_name in the SET).
+    const contactUpdate = runCalls.find(
+      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    );
+    expect(contactUpdate).toBeDefined();
+    expect(contactUpdate!.bind?.at(-1)).toBe(assistantContactId);
+    expect(contactUpdate!.sql).not.toContain("display_name");
+
+    // The existing assistant channel is updated, not re-inserted with the bare
+    // address.
+    const channelInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT INTO contact_channels"),
+    );
+    expect(channelInsert).toBeUndefined();
+
+    // The gateway DB now has the contact + channel (the split-brain heal).
+    const store = new ContactStore(getGatewayDb());
+    const gwContact = store.getContact(contactId);
+    expect(gwContact).toBeDefined();
+    const gwChannels = store.getChannelsForContact(contactId);
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].address).toBe("existing-person@example.com");
+  });
+
   test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {
     await startServerAndConnect();
     const res = await sendRequest(client, "create_contact", {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -873,10 +873,14 @@ export class ContactStore {
    * /v1/contacts rebind the guardian. On update, existing role/principalId
    * are preserved. On create, role defaults to "contact" and principalId
    * to null.
+   *
+   * `displayName` is omit-to-preserve: when undefined, an existing contact's
+   * name is left untouched (gateway DB + assistant mirror). A brand-new
+   * contact with no name falls back to the first channel's canonical address.
    */
   async upsertContact(params: {
     id?: string;
-    displayName: string;
+    displayName?: string;
     notes?: string | null;
     contactType?: string;
     assistantMetadata?: {
@@ -909,6 +913,25 @@ export class ContactStore {
       address: canonicalizeInboundIdentity(ch.type, ch.address) ?? ch.address,
     }));
 
+    // Fallback name for a brand-new contact created without an explicit
+    // displayName: the first channel's canonical address, else "Unknown".
+    const newContactName =
+      params.displayName ?? canonicalChannels?.[0]?.address ?? "Unknown";
+
+    // Omit-to-preserve: only overwrite an existing contact's displayName when
+    // the caller supplied one. Mirrors the role/principalId preservation.
+    const updateContactName = (id: string): void => {
+      const updateSet: Record<string, unknown> = { updatedAt: now };
+      if (params.displayName !== undefined) {
+        updateSet.displayName = params.displayName;
+      }
+      this.db
+        .update(contacts)
+        .set(updateSet)
+        .where(eq(contacts.id, id))
+        .run();
+    };
+
     // ── 1. Look up by id ──────────────────────────────────────────────
     if (contactId) {
       const existing = this.db
@@ -920,20 +943,13 @@ export class ContactStore {
       if (existing) {
         // Preserve existing role/principalId — they're never overwritten by
         // this code path. Guardian binding is owned by guardian-bootstrap.
-        this.db
-          .update(contacts)
-          .set({
-            displayName: params.displayName,
-            updatedAt: now,
-          })
-          .where(eq(contacts.id, contactId))
-          .run();
+        updateContactName(contactId);
       } else {
         this.db
           .insert(contacts)
           .values({
             id: contactId,
-            displayName: params.displayName,
+            displayName: newContactName,
             role: "contact",
             principalId: null,
             createdAt: now,
@@ -962,14 +978,7 @@ export class ContactStore {
 
         if (match) {
           contactId = match.contactId;
-          this.db
-            .update(contacts)
-            .set({
-              displayName: params.displayName,
-              updatedAt: now,
-            })
-            .where(eq(contacts.id, contactId))
-            .run();
+          updateContactName(contactId);
           break;
         }
       }
@@ -982,7 +991,7 @@ export class ContactStore {
         .insert(contacts)
         .values({
           id: contactId,
-          displayName: params.displayName,
+          displayName: newContactName,
           role: "contact",
           principalId: null,
           createdAt: now,
@@ -1002,12 +1011,7 @@ export class ContactStore {
       ? { ...params, channels: canonicalChannels }
       : params;
     try {
-      await this.dualWriteContactToAssistantDb(
-        contactId,
-        canonicalParams,
-        now,
-        created,
-      );
+      await this.dualWriteContactToAssistantDb(contactId, canonicalParams, now);
     } catch (err) {
       log.warn(
         { contactId, err },
@@ -1407,21 +1411,32 @@ export class ContactStore {
     contactId: string,
     params: Parameters<ContactStore["upsertContact"]>[0],
     now: number,
-    isNew: boolean,
   ): Promise<void> {
+    // Reconcile against an assistant-only contact: when the gateway minted a
+    // new id but the assistant DB already holds one of the provided channels
+    // (by (type, address)), adopt that existing assistant contact id instead
+    // of inserting a duplicate keyed by the new gateway id. Heals the
+    // split-brain case where the contact pre-dates the gateway dual-write.
+    const targetId = await this.resolveAssistantContactId(contactId, params);
+
     const existing = await assistantDbQuery<{ userFile: string | null }>(
       "SELECT user_file AS userFile FROM contacts WHERE id = ?",
-      [contactId],
+      [targetId],
     );
 
     if (existing.length) {
       // Dynamic SET clause: only touch fields the caller actually provided.
       // role / principal_id are intentionally never updated from this path —
       // they're not in the params surface and the assistant DB already holds
-      // the values written by guardian-bootstrap.
-      const setParts: string[] = ["display_name = ?", "updated_at = ?"];
-      const setParams: SqliteValue[] = [params.displayName, now];
+      // the values written by guardian-bootstrap. display_name is
+      // omit-to-preserve so a sparse upsert can't revert a custom name.
+      const setParts: string[] = ["updated_at = ?"];
+      const setParams: SqliteValue[] = [now];
 
+      if (params.displayName !== undefined) {
+        setParts.push("display_name = ?");
+        setParams.push(params.displayName);
+      }
       if (params.notes !== undefined) {
         setParts.push("notes = ?");
         setParams.push(params.notes ?? null);
@@ -1430,15 +1445,17 @@ export class ContactStore {
         setParts.push("contact_type = ?");
         setParams.push(params.contactType);
       }
-      setParams.push(contactId);
+      setParams.push(targetId);
 
       await assistantDbRun(
         `UPDATE contacts SET ${setParts.join(", ")} WHERE id = ?`,
         setParams,
       );
     } else {
+      const displayName =
+        params.displayName ?? params.channels?.[0]?.address ?? "Unknown";
       const userFile = await this.resolveAssistantUserFileSlug(
-        params.displayName,
+        displayName,
         null,
       );
       await assistantDbRun(
@@ -1447,8 +1464,8 @@ export class ContactStore {
             user_file, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
-          contactId,
-          params.displayName,
+          targetId,
+          displayName,
           params.notes ?? null,
           "contact",
           params.contactType ?? "human",
@@ -1469,7 +1486,7 @@ export class ContactStore {
            species  = excluded.species,
            metadata = excluded.metadata`,
         [
-          contactId,
+          targetId,
           params.assistantMetadata.species,
           params.assistantMetadata.metadata != null
             ? JSON.stringify(params.assistantMetadata.metadata)
@@ -1482,7 +1499,7 @@ export class ContactStore {
     for (const ch of params.channels ?? []) {
       const existingCh = await assistantDbQuery<{ id: string; status: string }>(
         "SELECT id, status FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
-        [contactId, ch.type, ch.address],
+        [targetId, ch.type, ch.address],
       );
 
       if (existingCh.length) {
@@ -1520,7 +1537,8 @@ export class ContactStore {
         if (conflict.length) continue;
 
         // Reuse the gateway channel ID so assistant and gateway channel
-        // rows share the same UUID for the same logical channel.
+        // rows share the same UUID for the same logical channel. The gateway
+        // row lives under the gateway contactId regardless of reconciliation.
         const gatewayChannel = this.db
           .select({ id: contactChannels.id })
           .from(contactChannels)
@@ -1542,7 +1560,7 @@ export class ContactStore {
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
           [
             channelId,
-            contactId,
+            targetId,
             ch.type,
             ch.address,
             ch.isPrimary ? 1 : 0,
@@ -1555,9 +1573,35 @@ export class ContactStore {
         );
       }
     }
+  }
 
-    // Touch the variable so the parameter isn't flagged unused.
-    void isNew;
+  /**
+   * Resolve which assistant-DB contact id the dual-write should target.
+   *
+   * Returns the gateway `contactId` unless one of the provided channels
+   * already exists in the assistant DB under a different contact (by (type,
+   * address)). In that split-brain case it returns the existing assistant
+   * contact id so the mirror reconciles into it instead of inserting a
+   * duplicate keyed by the gateway id.
+   *
+   * The lookup is by (type, address) — the same logical key the gateway uses
+   * — so a legacy assistant-only contact heals onto the gateway id at the
+   * channel layer while its assistant row/identity is preserved.
+   */
+  private async resolveAssistantContactId(
+    contactId: string,
+    params: Parameters<ContactStore["upsertContact"]>[0],
+  ): Promise<string> {
+    for (const ch of params.channels ?? []) {
+      const rows = await assistantDbQuery<{ contactId: string }>(
+        "SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
+        [ch.type, ch.address],
+      );
+      if (rows.length && rows[0].contactId !== contactId) {
+        return rows[0].contactId;
+      }
+    }
+    return contactId;
   }
 
   /**

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -95,22 +95,18 @@ export const contactRoutes: IpcRoute[] = [
         canonicalizeInboundIdentity(channelType, address) ?? address.trim();
 
       const store = getStore();
-      // Preserve an existing contact's displayName on retry: only the caller's
-      // explicit displayName overrides it. Falling back to the existing name
-      // (or the canonical address for a brand-new contact) avoids clobbering a
-      // custom name with the bare address, since upsertContact always writes
-      // displayName.
-      const existing = store.getContactByChannel(channelType, canonicalAddress);
-      const effectiveDisplayName =
-        displayName ?? existing?.displayName ?? canonicalAddress;
-
+      // Omit displayName when the caller didn't supply one: upsertContact is
+      // omit-to-preserve, so an existing contact keeps its current name and a
+      // brand-new contact falls back to the canonical address. Passing a
+      // synthesized name here would clobber a custom name on retry.
+      //
       // Omit status/policy/externalChatId: syncChannels and the assistant-DB
       // mirror default a new channel but preserve an existing channel's values
       // on retry. Passing them here would demote a trusted channel below the
       // trusted_contacts admission floor (mirrors verification/contact-helpers)
       // or clear a delivery chat id.
       const { contact } = await store.upsertContact({
-        displayName: effectiveDisplayName,
+        displayName,
         channels: [
           {
             type: channelType,


### PR DESCRIPTION
## Summary
Fixes two gaps found during plan review of contacts-relay-writes-create-contact.md:
- create_contact with no explicit displayName no longer overwrites an existing contact's display name (omit-to-preserve in upsertContact + assistant-DB mirror, matching the status/policy/external_chat_id pattern).
- create_contact reconciles an existing contact instead of minting a duplicate / renaming to the bare address.

Part of plan: contacts-relay-writes-create-contact.md (self-review remediation)