### PR TITLE
docs: record verification outcome source-of-truth split

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -157,6 +157,12 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 - Guardian approval records in `channelGuardianApprovalRequests` link via `requestId`.
 - The conversational approval engine classifies user intent and resolves via `conversation.handleConfirmationResponse(requestId, decision)`.
 
+### Channel verification source-of-truth split
+
+Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned (`channel-verification-routes.ts`, `channel-verification-service.ts`). The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned.
+
+The `channel_verification_sessions_*` daemon handlers are thin relays for the outcome write, following the trust-rules relay precedent. The gateway IPC methods `mark_channel_verified` / `mark_channel_revoked` (`ContactStore.markChannelVerified` / `markChannelRevoked`) are the single outcome write path for all callers: HTTP routes, inbound code-match completion (`gateway/src/verification/text-verification.ts`), and CLI/IPC.
+
 ## Rate Limiting & Diagnostics
 
 All `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middleware/rate-limiter.ts`):

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -6,6 +6,12 @@
  * DELETE /v1/channel-verification-sessions         — cancel all active sessions (inbound + outbound)
  * POST   /v1/channel-verification-sessions/revoke  — cancel all sessions and revoke binding
  * GET    /v1/channel-verification-sessions/status   — check guardian binding status
+ *
+ * Source-of-truth split:
+ * - Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned.
+ * - The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned, reached via
+ *   `ipcCallPersistent("mark_channel_verified", …)`; revoke/downgrade via
+ *   `ipcCallPersistent("mark_channel_revoked", …)`.
  */
 
 import { z } from "zod";


### PR DESCRIPTION
## Summary
- Document the verification source-of-truth split: session state assistant-owned, channel-verified/revoked OUTCOME gateway-owned via mark_channel_verified / mark_channel_revoked IPC
- File-header note in channel-verification-routes.ts + a CLAUDE.md subsection
- Docs only; no behavior change

Part of plan: contacts-gw-native-verification.md (PR 6 of 6)