### PR TITLE
fix(gateway): canonical contact id on create_contact heal; gate reconciliation to create-only

### DIFF
--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -676,36 +676,53 @@ describe("IPC contact routes", () => {
     );
   });
 
-  test("create_contact reconciles an assistant-only contact instead of minting a duplicate", async () => {
+  test("create_contact heals an assistant-only contact onto ONE shared canonical id", async () => {
     // Gap B: a contact+channel exists in the assistant DB but NOT the gateway.
-    // upsertContact mints a new gateway id; the mirror must reconcile into the
-    // existing assistant contact (no duplicate INSERT, name preserved) and the
-    // gateway row must be created.
+    // upsertContact adopts the existing assistant contact id as the gateway
+    // contact id (canonical-id heal), so BOTH DBs are keyed by the same id —
+    // the gateway row is created under it, no duplicate assistant INSERT, the
+    // name is preserved, and the gateway read join-by-id resolves info.
     const assistantContactId = "assistant-only-c1";
     const assistantChannelId = "assistant-only-ch1";
 
-    // Channel lookup by (type,address) returns the existing assistant contact;
-    // the contact-by-id lookup (keyed on the resolved id) reports it exists.
     assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      // Channel lookup by (type,address) → the existing assistant contact id.
       if (
         sql.includes("FROM contact_channels") &&
         sql.includes("WHERE type = ?")
       ) {
         return [{ contactId: assistantContactId, id: assistantChannelId }];
       }
+      // existingCh lookup keyed on the adopted (assistant) contact id.
       if (
         sql.includes("FROM contact_channels") &&
         sql.includes("WHERE contact_id = ?")
       ) {
-        // existingCh lookup keyed on the resolved (assistant) contact id.
         if (bind?.[0] === assistantContactId) {
           return [{ id: assistantChannelId, status: "active" }];
         }
         return [];
       }
+      // user_file lookup in the mirror (contact already exists in assistant DB).
       if (sql.includes("FROM contacts WHERE id = ?")) {
         if (bind?.[0] === assistantContactId) {
           return [{ userFile: "existing-person.md" }];
+        }
+        return [];
+      }
+      // Read-path info join keyed by the canonical id.
+      if (sql.includes("FROM contacts c") && sql.includes("IN (")) {
+        if (bind?.includes(assistantContactId)) {
+          return [
+            {
+              id: assistantContactId,
+              notes: "knows the family",
+              userFile: "existing-person.md",
+              contactType: "human",
+              species: null,
+              metadata: null,
+            },
+          ];
         }
         return [];
       }
@@ -726,14 +743,19 @@ describe("IPC contact routes", () => {
     expect(res.error).toBeUndefined();
     const { contactId } = res.result as { contactId: string };
 
-    // No duplicate assistant contact INSERT.
-    const contactInsert = runCalls.find((c) =>
-      c.sql.includes("INSERT INTO contacts"),
-    );
-    expect(contactInsert).toBeUndefined();
+    // The returned (gateway) id IS the existing assistant id — one canonical id.
+    expect(contactId).toBe(assistantContactId);
 
-    // The assistant contact UPDATE targets the EXISTING assistant id, not the
-    // new gateway id, and preserves the name (no display_name in the SET).
+    // No duplicate assistant contact INSERT; the existing channel is updated,
+    // not re-inserted.
+    expect(
+      runCalls.find((c) => c.sql.includes("INSERT INTO contacts")),
+    ).toBeUndefined();
+    expect(
+      runCalls.find((c) => c.sql.includes("INSERT INTO contact_channels")),
+    ).toBeUndefined();
+
+    // The assistant contact UPDATE targets the shared id, name preserved.
     const contactUpdate = runCalls.find(
       (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
     );
@@ -741,20 +763,77 @@ describe("IPC contact routes", () => {
     expect(contactUpdate!.bind?.at(-1)).toBe(assistantContactId);
     expect(contactUpdate!.sql).not.toContain("display_name");
 
-    // The existing assistant channel is updated, not re-inserted with the bare
-    // address.
-    const channelInsert = runCalls.find((c) =>
-      c.sql.includes("INSERT INTO contact_channels"),
-    );
-    expect(channelInsert).toBeUndefined();
-
-    // The gateway DB now has the contact + channel (the split-brain heal).
+    // The gateway DB has the contact + channel under the canonical id.
     const store = new ContactStore(getGatewayDb());
-    const gwContact = store.getContact(contactId);
-    expect(gwContact).toBeDefined();
+    expect(store.getContact(contactId)).toBeDefined();
     const gwChannels = store.getChannelsForContact(contactId);
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].address).toBe("existing-person@example.com");
+
+    // The gateway read join-by-id resolves the assistant info (NOT null) —
+    // proof the two DBs converged on one id.
+    const withInfo = await store.getContactWithInfo(contactId);
+    expect(withInfo).not.toBeNull();
+    expect(withInfo!.notes).toBe("knows the family");
+    expect(withInfo!.userFile).toBe("existing-person.md");
+    expect(withInfo!.contactType).toBe("human");
+  });
+
+  test("upsertContact with an explicit id does NOT retarget another contact's metadata", async () => {
+    // Update path (Problem 2): an edit carries a channel whose (type,address)
+    // is owned by a DIFFERENT assistant contact. The assistant mirror must
+    // target the provided id — never the other contact — matching the gateway
+    // syncChannels skip-on-cross-contact behavior.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "edit-me",
+        displayName: "Edit Me",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // The assistant DB reports the channel is owned by "other-contact" and the
+    // edited contact already exists by id.
+    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      if (
+        sql.includes("FROM contact_channels") &&
+        sql.includes("WHERE type = ?")
+      ) {
+        return [{ contactId: "other-contact" }];
+      }
+      if (sql.includes("FROM contacts WHERE id = ?")) {
+        if (bind?.[0] === "edit-me") return [{ userFile: "edit-me.md" }];
+        return [];
+      }
+      return [];
+    });
+    const runCalls: { sql: string; bind?: unknown[] }[] = [];
+    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
+      runCalls.push({ sql, bind });
+      return { changes: 1, lastInsertRowid: 0 };
+    });
+
+    const store = new ContactStore(db);
+    await store.upsertContact({
+      id: "edit-me",
+      displayName: "New Name",
+      channels: [{ type: "email", address: "shared@example.com" }],
+    });
+
+    // The assistant contact UPDATE targets the provided id, never "other-contact".
+    const contactUpdate = runCalls.find(
+      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    );
+    expect(contactUpdate).toBeDefined();
+    expect(contactUpdate!.bind?.at(-1)).toBe("edit-me");
+    expect(
+      runCalls.some((c) => c.bind?.includes("other-contact")),
+    ).toBe(false);
   });
 
   test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -851,8 +851,14 @@ export class ContactStore {
    *
    * Resolution order (mirrors the assistant's upsertContact):
    *  1. Match by `params.id` if provided.
-   *  2. Match by (type, address) on any provided channel.
-   *  3. Create a new contact with a generated id.
+   *  2. Match by (type, address) on a provided channel in the gateway DB.
+   *  3. Create: adopt an existing assistant-DB contact id for the same channel
+   *     (canonical-id heal), else mint a fresh id.
+   *
+   * Steps 2 and 3 (channel-match + assistant-id adoption) run on the create
+   * path only — when no explicit `id` is supplied. An explicit id is an update
+   * and keys the gateway row + assistant mirror to that id directly, so an edit
+   * can't retarget another contact's metadata.
    *
    * Channel sync follows the same no-reassignment path: existing channels
    * on the same contact are updated; conflicting channels on a different
@@ -985,20 +991,41 @@ export class ContactStore {
     }
 
     // ── 3. Create new ─────────────────────────────────────────────────
+    // Create-only canonical-id adoption: before minting a fresh id, check the
+    // assistant DB for an existing contact owning one of these channels (by
+    // (type, address)). Adopting that id keeps both DBs keyed by ONE canonical
+    // id — the gateway INSERT, syncChannels, and the assistant mirror all use
+    // it, so a "healed" assistant-only contact's info reads back via the
+    // join-by-id read path. Soft-fails to a minted id if the lookup throws
+    // (daemon down / tests) — the assistant-mirror best-effort invariant.
     if (!contactId) {
-      contactId = crypto.randomUUID();
-      this.db
-        .insert(contacts)
-        .values({
-          id: contactId,
-          displayName: newContactName,
-          role: "contact",
-          principalId: null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .run();
-      created = true;
+      const adoptedId = await this.adoptAssistantContactId(canonicalChannels);
+      contactId = adoptedId ?? crypto.randomUUID();
+      // An adopted id may already exist as a gateway row (different channels);
+      // preserve it (name omit-to-preserve) instead of a conflicting INSERT.
+      const existing = adoptedId
+        ? this.db
+            .select({ id: contacts.id })
+            .from(contacts)
+            .where(eq(contacts.id, contactId))
+            .get()
+        : undefined;
+      if (existing) {
+        updateContactName(contactId);
+      } else {
+        this.db
+          .insert(contacts)
+          .values({
+            id: contactId,
+            displayName: newContactName,
+            role: "contact",
+            principalId: null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run();
+        created = true;
+      }
     }
 
     // ── 4. Sync channels (gateway DB) ─────────────────────────────────
@@ -1412,16 +1439,14 @@ export class ContactStore {
     params: Parameters<ContactStore["upsertContact"]>[0],
     now: number,
   ): Promise<void> {
-    // Reconcile against an assistant-only contact: when the gateway minted a
-    // new id but the assistant DB already holds one of the provided channels
-    // (by (type, address)), adopt that existing assistant contact id instead
-    // of inserting a duplicate keyed by the new gateway id. Heals the
-    // split-brain case where the contact pre-dates the gateway dual-write.
-    const targetId = await this.resolveAssistantContactId(contactId, params);
-
+    // The mirror always targets the gateway contactId — the SAME id the gateway
+    // row + channels were written under. On create, any assistant-only contact
+    // was already adopted onto this id in upsertContact, so both DBs converge.
+    // On update (explicit id), this matches syncChannels' skip-on-cross-contact
+    // behavior so an edit can't retarget another contact's metadata.
     const existing = await assistantDbQuery<{ userFile: string | null }>(
       "SELECT user_file AS userFile FROM contacts WHERE id = ?",
-      [targetId],
+      [contactId],
     );
 
     if (existing.length) {
@@ -1445,7 +1470,7 @@ export class ContactStore {
         setParts.push("contact_type = ?");
         setParams.push(params.contactType);
       }
-      setParams.push(targetId);
+      setParams.push(contactId);
 
       await assistantDbRun(
         `UPDATE contacts SET ${setParts.join(", ")} WHERE id = ?`,
@@ -1464,7 +1489,7 @@ export class ContactStore {
             user_file, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
-          targetId,
+          contactId,
           displayName,
           params.notes ?? null,
           "contact",
@@ -1486,7 +1511,7 @@ export class ContactStore {
            species  = excluded.species,
            metadata = excluded.metadata`,
         [
-          targetId,
+          contactId,
           params.assistantMetadata.species,
           params.assistantMetadata.metadata != null
             ? JSON.stringify(params.assistantMetadata.metadata)
@@ -1499,7 +1524,7 @@ export class ContactStore {
     for (const ch of params.channels ?? []) {
       const existingCh = await assistantDbQuery<{ id: string; status: string }>(
         "SELECT id, status FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
-        [targetId, ch.type, ch.address],
+        [contactId, ch.type, ch.address],
       );
 
       if (existingCh.length) {
@@ -1536,9 +1561,8 @@ export class ContactStore {
         );
         if (conflict.length) continue;
 
-        // Reuse the gateway channel ID so assistant and gateway channel
-        // rows share the same UUID for the same logical channel. The gateway
-        // row lives under the gateway contactId regardless of reconciliation.
+        // Reuse the gateway channel ID so assistant and gateway channel rows
+        // share the same UUID for the same logical channel.
         const gatewayChannel = this.db
           .select({ id: contactChannels.id })
           .from(contactChannels)
@@ -1560,7 +1584,7 @@ export class ContactStore {
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
           [
             channelId,
-            targetId,
+            contactId,
             ch.type,
             ch.address,
             ch.isPrimary ? 1 : 0,
@@ -1576,32 +1600,37 @@ export class ContactStore {
   }
 
   /**
-   * Resolve which assistant-DB contact id the dual-write should target.
+   * Create-only canonical-id adoption.
    *
-   * Returns the gateway `contactId` unless one of the provided channels
-   * already exists in the assistant DB under a different contact (by (type,
-   * address)). In that split-brain case it returns the existing assistant
-   * contact id so the mirror reconciles into it instead of inserting a
-   * duplicate keyed by the gateway id.
+   * When creating a contact (no explicit id, no gateway (type, address) match),
+   * look up an existing contact in the ASSISTANT DB owning one of the provided
+   * channels (by the same logical key the gateway uses). If found, return its
+   * id so the gateway INSERT + channels + mirror all share ONE canonical id —
+   * healing a legacy assistant-only contact instead of forking the two DBs onto
+   * different ids. Returns null when there's no match or the lookup soft-fails
+   * (daemon down / tests), so the caller falls back to a freshly minted id.
    *
-   * The lookup is by (type, address) — the same logical key the gateway uses
-   * — so a legacy assistant-only contact heals onto the gateway id at the
-   * channel layer while its assistant row/identity is preserved.
+   * Never called on the explicit-id update path — an edit must not retarget
+   * another contact (the gateway syncChannels skips cross-contact channels).
    */
-  private async resolveAssistantContactId(
-    contactId: string,
-    params: Parameters<ContactStore["upsertContact"]>[0],
-  ): Promise<string> {
-    for (const ch of params.channels ?? []) {
-      const rows = await assistantDbQuery<{ contactId: string }>(
-        "SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
-        [ch.type, ch.address],
-      );
-      if (rows.length && rows[0].contactId !== contactId) {
-        return rows[0].contactId;
+  private async adoptAssistantContactId(
+    channels: Parameters<ContactStore["upsertContact"]>[0]["channels"],
+  ): Promise<string | null> {
+    try {
+      for (const ch of channels ?? []) {
+        const rows = await assistantDbQuery<{ contactId: string }>(
+          "SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
+          [ch.type, ch.address],
+        );
+        if (rows.length) return rows[0].contactId;
       }
+    } catch (err) {
+      log.warn(
+        { err },
+        "adoptAssistantContactId: assistant DB lookup failed; minting a new id",
+      );
     }
-    return contactId;
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Summary
Round-2 self-review remediation for contacts-relay-writes-create-contact.md:
- create_contact heals an assistant-only contact by adopting its existing id as the gateway contact id, so both DBs share one canonical id (gateway read join-by-id resolves info; no permanent divergence).
- Reconciliation/id-adoption is gated to the create path; explicit-id updates target the gateway id directly, fixing the misroute where an edit could move another contact's metadata.
- Preserves the omit-to-preserve displayName fix.

Part of plan: contacts-relay-writes-create-contact.md (self-review remediation, round 2)