### PR TITLE
test(gateway-client): generic fixtures in contact-read-contracts test

### DIFF
--- a/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
+++ b/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
@@ -14,7 +14,7 @@ describe("contact read contracts", () => {
   test("ContactReadSchema parses a fully-populated contact", () => {
     const contact = {
       id: "c1",
-      displayName: "Ada Lovelace",
+      displayName: "Example User",
       role: "guardian",
       notes: "primary guardian",
       contactType: "human",
@@ -25,9 +25,9 @@ describe("contact read contracts", () => {
           id: "ch1",
           contactId: "c1",
           type: "imessage",
-          address: "+15551234567",
+          address: "+15555550100",
           isPrimary: true,
-          externalUserId: "+15551234567",
+          externalUserId: "+15555550100",
           status: "active",
           policy: "allow",
           verifiedAt: 1699999999,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-relay-reads.md.

**Gap:** contact-read-contracts.test.ts used a real person's name (Ada Lovelace) and a non-reserved phone number (+15551234567), violating the AGENTS.md Generic Examples rule. Replaced with generic placeholders and a reserved-range (555-0100..555-0199) number.