### PR TITLE
fix(daemon): emit contact-change after revoke relay, validate IPC response

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -63,6 +63,26 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   },
 }));
 
+// Gateway relay mock — the revoke path relays the ACL downgrade over IPC and
+// validates the response; return a well-formed mark_channel_revoked result.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    _method: string,
+    params?: Record<string, unknown>,
+  ) => ({
+    ok: true,
+    didWrite: true,
+    channel: {
+      id: (params?.contactChannelId as string) ?? "ch1",
+      contactId: "c1",
+      type: "phone",
+      address: "addr",
+      status: "revoked",
+      revokedReason: (params?.reason as string) ?? null,
+    },
+  }),
+}));
+
 import { handleChannelVerificationSession } from "../daemon/handlers/config-channels.js";
 import type {
   ChannelVerificationSessionRequest,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,7 +1,10 @@
 import { createHash, randomBytes } from "node:crypto";
 
+import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import { startVerificationCall } from "../../calls/call-domain.js";
 import type { ChannelId } from "../../channels/types.js";
+import { emitContactChange } from "../../contacts/contact-events.js";
 import {
   findContactChannel,
   findGuardianForChannel,
@@ -211,16 +214,25 @@ export async function revokeVerificationForChannel(
       channelStatus === "pending" ||
       channelStatus === "unverified"
     ) {
-      await ipcCallPersistent("mark_channel_revoked", {
+      const result = await ipcCallPersistent("mark_channel_revoked", {
         contactChannelId: contactResult.channel.id,
         reason: "guardian_binding_revoked",
       });
+      const parsed = MarkChannelRevokedIpcResponseSchema.parse(result);
+      if (!parsed.ok) {
+        throw new Error("mark_channel_revoked relay returned ok: false");
+      }
+      // The gateway dual-write already set the assistant channel to "revoked",
+      // so the later revokeGuardianBinding lookup (active-only) finds nothing
+      // and won't fire the invalidation. Emit it here so open client views
+      // stop showing the channel as active.
+      emitContactChange();
     }
   }
 
   // The guardian binding is assistant-owned state the gateway relay does not
-  // manage; tear it down here. revokeBinding also emits the contact-change
-  // invalidation so open client views stop showing the channel as active.
+  // manage; tear it down here. The contact-change invalidation is emitted
+  // explicitly above on relay success.
   revokeBinding(assistantId, resolvedChannel);
 
   return {

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -97,6 +97,17 @@ mock.module("../../../contacts/contacts-write.js", () => ({
   revokeGuardianBinding: revokeGuardianBindingMock,
 }));
 
+// Contact-change invalidation — emitted explicitly on relay success so open
+// client views stop showing the channel as active (the gateway dual-write to
+// "revoked" precedes binding teardown, so revokeGuardianBinding no longer
+// fires it).
+const emitContactChangeMock = mock(() => {});
+const actualContactEvents = await import("../../../contacts/contact-events.js");
+mock.module("../../../contacts/contact-events.js", () => ({
+  ...actualContactEvents,
+  emitContactChange: emitContactChangeMock,
+}));
+
 const { ROUTES } = await import("../channel-verification-routes.js");
 
 const revokeHandler = ROUTES.find(
@@ -118,6 +129,7 @@ describe("verification revoke relay", () => {
     revokeBindingMock.mockClear();
     revokeGuardianBindingMock.mockClear();
     localAclWrite.mockClear();
+    emitContactChangeMock.mockClear();
   });
 
   test("relays the downgrade outcome to the gateway and tears down sessions locally", async () => {
@@ -147,8 +159,69 @@ describe("verification revoke relay", () => {
     // The contact-channel ACL write does not fall back to the assistant.
     expect(localAclWrite).not.toHaveBeenCalled();
 
+    // Invalidation emitted explicitly on relay success: the gateway dual-write
+    // to "revoked" precedes binding teardown, so revokeGuardianBinding's own
+    // emit no longer fires.
+    expect(emitContactChangeMock).toHaveBeenCalledTimes(1);
+
     expect(result.success).toBe(true);
     expect(result.bound).toBe(false);
+  });
+
+  test("emits the invalidation even when the gateway dual-write already revoked the channel", async () => {
+    // Simulate the gateway having dual-written the assistant row to "revoked"
+    // before binding teardown: findGuardianForChannel (active-only) now finds
+    // nothing, so revokeGuardianBinding is a no-op and never emits.
+    revokeGuardianBindingMock.mockImplementationOnce(() => false);
+
+    await revokeHandler({ body: { channel: "telegram" } });
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(emitContactChangeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("malformed gateway response surfaces as an error", async () => {
+    ipcCallPersistentMock.mockImplementationOnce(async () => ({
+      ok: "nope",
+    }));
+
+    let thrown: Error | undefined;
+    try {
+      await revokeHandler({ body: { channel: "telegram" } });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    // Invalidation must not fire when the relay response is invalid.
+    expect(emitContactChangeMock).not.toHaveBeenCalled();
+    expect(revokeBindingMock).not.toHaveBeenCalled();
+  });
+
+  test("ok: false gateway response surfaces as an error", async () => {
+    ipcCallPersistentMock.mockImplementationOnce(async (_m, params) => ({
+      ok: false,
+      didWrite: false,
+      channel: {
+        id: (params?.contactChannelId as string) ?? "ch1",
+        contactId: "c1",
+        type: "telegram",
+        address: "addr",
+        status: "active",
+        revokedReason: null,
+      },
+    }));
+
+    let thrown: Error | undefined;
+    try {
+      await revokeHandler({ body: { channel: "telegram" } });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(emitContactChangeMock).not.toHaveBeenCalled();
+    expect(revokeBindingMock).not.toHaveBeenCalled();
   });
 
   test("guardian guard rejection from the gateway surfaces as an error", async () => {

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -181,9 +181,10 @@ describe("verification revoke relay", () => {
   });
 
   test("malformed gateway response surfaces as an error", async () => {
-    ipcCallPersistentMock.mockImplementationOnce(async () => ({
-      ok: "nope",
-    }));
+    // Deliberately malformed shape: must fail schema validation, not pass.
+    ipcCallPersistentMock.mockImplementationOnce(
+      async () => ({ ok: "nope" }) as never,
+    );
 
     let thrown: Error | undefined;
     try {
@@ -208,7 +209,7 @@ describe("verification revoke relay", () => {
         type: "telegram",
         address: "addr",
         status: "active",
-        revokedReason: null,
+        revokedReason: "still_active",
       },
     }));
 


### PR DESCRIPTION
## Summary
- Emit emitContactChange explicitly after a successful mark_channel_revoked relay (the gateway dual-write to 'revoked' precedes binding teardown, so revokeGuardianBinding no longer fires the invalidation)
- Validate the mark_channel_revoked IPC response via MarkChannelRevokedIpcResponseSchema + assert ok, matching the trust-rules relay precedent

Fixes self-review gaps for plan contacts-gw-native-verification.md