### PR TITLE
fix(gateway): legacy channel-id fallback in markChannel verify/revoke

### DIFF
--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -123,12 +123,13 @@ function seedAssistantChannel(opts: {
   id: string;
   contactId: string;
   status?: string;
+  address?: string;
 }): void {
   fakeAssistantDb.channels.set(opts.id, {
     id: opts.id,
     contact_id: opts.contactId,
     type: "vellum",
-    address: `addr-${opts.id}`,
+    address: opts.address ?? `addr-${opts.id}`,
     is_primary: 0,
     external_user_id: null,
     external_chat_id: null,
@@ -172,6 +173,7 @@ function seedChannel(opts: {
   status?: string;
   verifiedAt?: number | null;
   verifiedVia?: string | null;
+  address?: string;
 }) {
   const now = Date.now();
   getGatewayDb()
@@ -180,7 +182,7 @@ function seedChannel(opts: {
       id: opts.id,
       contactId: opts.contactId,
       type: "vellum",
-      address: `addr-${opts.id}`,
+      address: opts.address ?? `addr-${opts.id}`,
       isPrimary: false,
       status: opts.status ?? "unverified",
       policy: "allow",
@@ -448,5 +450,84 @@ describe("ContactStore.markChannelVerified", () => {
       .where(eq(contacts.id, "c1"))
       .get();
     expect(contactRow!.displayName).toBe("gateway-name");
+  });
+
+  test("legacy channel: resolves a differing gateway id by (contactId,type,address) and verifies", async () => {
+    // Migrated user: gateway row lives under a different UUID than the
+    // assistant channel id, sharing the logical (contactId, type, address) key.
+    seedContact("c1");
+    seedChannel({
+      id: "gw-uuid",
+      contactId: "c1",
+      status: "unverified",
+      address: "shared-addr",
+    });
+    seedAssistantContact("c1");
+    seedAssistantChannel({
+      id: "assistant-uuid",
+      contactId: "c1",
+      status: "unverified",
+      address: "shared-addr",
+    });
+
+    const result = await new ContactStore().markChannelVerified(
+      "assistant-uuid",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.id).toBe("gw-uuid");
+    expect(result!.channel.status).toBe("active");
+    expect(result!.channel.verifiedVia).toBe("manual");
+
+    // Still exactly one gateway channel row — the mirror's ON CONFLICT
+    // DO NOTHING did not insert a duplicate.
+    expect(
+      getGatewayDb().select().from(contactChannels).all().length,
+    ).toBe(1);
+  });
+});
+
+describe("ContactStore.markChannelRevoked", () => {
+  test("revokes a channel by its gateway id", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "active" });
+
+    const result = await new ContactStore().markChannelRevoked("ch1", "spam");
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.status).toBe("revoked");
+    expect(result!.channel.revokedReason).toBe("spam");
+  });
+
+  test("legacy channel: resolves a differing gateway id by (contactId,type,address) and revokes", async () => {
+    seedContact("c1", "contact");
+    seedChannel({
+      id: "gw-uuid",
+      contactId: "c1",
+      status: "active",
+      address: "shared-addr",
+    });
+    seedAssistantContact("c1", "contact");
+    seedAssistantChannel({
+      id: "assistant-uuid",
+      contactId: "c1",
+      status: "active",
+      address: "shared-addr",
+    });
+
+    const result = await new ContactStore().markChannelRevoked(
+      "assistant-uuid",
+      "spam",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.id).toBe("gw-uuid");
+    expect(result!.channel.status).toBe("revoked");
+    expect(result!.channel.revokedReason).toBe("spam");
+
+    // No duplicate gateway row inserted by the mirror.
+    expect(
+      getGatewayDb().select().from(contactChannels).all().length,
+    ).toBe(1);
   });
 });

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -353,39 +353,7 @@ export class ContactStore {
       reason?: string | null;
     },
   ): Promise<ContactChannel | null> {
-    let gwChannel = this.db
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
-
-    // If not found in the gateway DB, resolve from the assistant DB by
-    // logical key (contactId, type, address) and find the matching gateway row.
-    if (!gwChannel) {
-      const assistantChannel = await assistantDbQuery<{
-        contactId: string;
-        type: string;
-        address: string;
-      }>(
-        "SELECT contact_id AS contactId, type, address FROM contact_channels WHERE id = ?",
-        [channelId],
-      );
-      if (assistantChannel.length > 0) {
-        const { contactId, type, address } = assistantChannel[0];
-        gwChannel = this.db
-          .select()
-          .from(contactChannels)
-          .where(
-            and(
-              eq(contactChannels.contactId, contactId),
-              eq(contactChannels.type, type),
-              sql`${contactChannels.address} = ${address} COLLATE NOCASE`,
-            ),
-          )
-          .get();
-      }
-    }
-
+    const gwChannel = await this.resolveGatewayChannel(channelId);
     if (!gwChannel) return null;
 
     // Guard: cannot revoke a blocked channel.
@@ -640,6 +608,46 @@ export class ContactStore {
   }
 
   /**
+   * Resolve a gateway channel row by id, falling back to its logical key
+   * (contactId, type, address) when the id-based lookup misses. Legacy
+   * channels can live under a different gateway UUID than the assistant id,
+   * so the id passed by callers may not be the gateway row's id.
+   */
+  private async resolveGatewayChannel(
+    channelId: string,
+  ): Promise<ContactChannel | undefined> {
+    const byId = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (byId) return byId;
+
+    const assistantChannel = await assistantDbQuery<{
+      contact_id: string;
+      type: string;
+      address: string;
+    }>(
+      "SELECT contact_id, type, address FROM contact_channels WHERE id = ?",
+      [channelId],
+    );
+    if (assistantChannel.length === 0) return undefined;
+
+    const { contact_id: contactId, type, address } = assistantChannel[0];
+    return this.db
+      .select()
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.contactId, contactId),
+          eq(contactChannels.type, type),
+          sql`${contactChannels.address} = ${address} COLLATE NOCASE`,
+        ),
+      )
+      .get();
+  }
+
+  /**
    * Mark a channel as verified. Sets `status="active"`, stamps
    * `verifiedAt=now`, and records `verifiedVia` (default `"manual"` for the
    * guardian-attestation path; `"challenge"` for the code-exchange path) on
@@ -673,6 +681,12 @@ export class ContactStore {
     const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
     if (!mirrored) return null;
 
+    // Legacy channels may live under a different gateway id than the assistant
+    // channel id passed in; resolve the gateway row before keying writes on it.
+    const gwChannel = await this.resolveGatewayChannel(channelId);
+    if (!gwChannel) return null;
+    const gwChannelId = gwChannel.id;
+
     const now = Date.now();
     const raw = (this.db as unknown as { $client: Database }).$client;
     const result = raw
@@ -682,12 +696,12 @@ export class ContactStore {
          WHERE id = ?
            AND (status != ? OR verified_via != ? OR verified_via IS NULL)`,
       )
-      .run("active", now, verifiedVia, now, channelId, "active", verifiedVia);
+      .run("active", now, verifiedVia, now, gwChannelId, "active", verifiedVia);
 
     const after = this.db
       .select()
       .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
+      .where(eq(contactChannels.id, gwChannelId))
       .get();
 
     if (!after) return null;
@@ -738,12 +752,11 @@ export class ContactStore {
     const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
     if (!mirrored) return null;
 
-    const channel = this.db
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
+    // Legacy channels may live under a different gateway id than the assistant
+    // channel id passed in; resolve the gateway row before keying writes on it.
+    const channel = await this.resolveGatewayChannel(channelId);
     if (!channel) return null;
+    const gwChannelId = channel.id;
 
     const contact = this.getContact(channel.contactId);
     if (
@@ -782,18 +795,18 @@ export class ContactStore {
         blockedReason: null,
         updatedAt: Date.now(),
       })
-      .where(eq(contactChannels.id, channelId))
+      .where(eq(contactChannels.id, gwChannelId))
       .run();
 
     const after = this.db
       .select()
       .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
+      .where(eq(contactChannels.id, gwChannelId))
       .get();
     if (!after) return null;
 
     try {
-      await this.dualWriteChannelStatusToAssistantDb(channelId, {
+      await this.dualWriteChannelStatusToAssistantDb(gwChannelId, {
         status: "revoked",
         revokedReason: reason ?? null,
         blockedReason: null,

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -8,7 +8,9 @@
 
 import {
   MarkChannelRevokedIpcParamsSchema,
+  MarkChannelRevokedIpcResponseSchema,
   MarkChannelVerifiedIpcParamsSchema,
+  MarkChannelVerifiedIpcResponseSchema,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
@@ -172,7 +174,7 @@ export const contactRoutes: IpcRoute[] = [
         throw new Error(`Channel "${contactChannelId}" not found`);
       }
       const { channel, didWrite } = result;
-      return {
+      return MarkChannelVerifiedIpcResponseSchema.parse({
         ok: true,
         didWrite,
         channel: {
@@ -184,7 +186,7 @@ export const contactRoutes: IpcRoute[] = [
           verifiedAt: channel.verifiedAt,
           verifiedVia: channel.verifiedVia,
         },
-      };
+      });
     },
   },
   {
@@ -201,7 +203,7 @@ export const contactRoutes: IpcRoute[] = [
         throw new Error(`Channel "${contactChannelId}" not found`);
       }
       const { channel, didWrite } = result;
-      return {
+      return MarkChannelRevokedIpcResponseSchema.parse({
         ok: true,
         didWrite,
         channel: {
@@ -212,7 +214,7 @@ export const contactRoutes: IpcRoute[] = [
           status: channel.status,
           revokedReason: channel.revokedReason,
         },
-      };
+      });
     },
   },
 ];


### PR DESCRIPTION
## Summary
- markChannelRevoked/markChannelVerified resolve a missing id-based gateway row by (contactId,type,address), matching updateChannelStatus, so migrated users with a differing gateway UUID can still verify/revoke
- mark_channel_verified/mark_channel_revoked IPC handlers validate their return through the response schemas (consumes previously-unused schemas)

Fixes self-review gaps for plan contacts-gw-native-verification.md