### PR TITLE
fix(contacts): contactType-filtered list reads daemon-native (no post-limit truncation)

### DIFF
--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -58,16 +58,24 @@ mock.module("../ipc/gateway-client.js", () => ({
 // and that they ARE hit on the IPC-failure fallback path.
 const localCalls: string[] = [];
 const realContactStore = await import("../contacts/contact-store.js");
+// Capture the args passed to the daemon-native listContacts so tests can assert
+// contactType is filtered in SQL (before the limit) rather than relayed.
+const listContactsArgs: Array<{
+  limit?: number;
+  role?: string;
+  contactType?: string;
+}> = [];
 mock.module("../contacts/contact-store.js", () => ({
   ...realContactStore,
-  listContacts: () => {
+  listContacts: (limit?: number, role?: string, contactType?: string) => {
     localCalls.push("listContacts");
+    listContactsArgs.push({ limit, role, contactType });
     return [
       {
         id: "local-1",
         displayName: "Local Contact",
-        role: "contact",
-        contactType: "human",
+        role: role ?? "contact",
+        contactType: contactType ?? "human",
         interactionCount: 0,
         channels: [],
       },
@@ -166,6 +174,7 @@ beforeEach(() => {
   ipcCalls.length = 0;
   localCalls.length = 0;
   debugLogs.length = 0;
+  listContactsArgs.length = 0;
 });
 
 describe("handleListContacts relay", () => {
@@ -214,6 +223,36 @@ describe("handleListContacts relay", () => {
     expect(localCalls).toContain("searchContacts");
     expect(result.contacts[0].id).toBe("search-1");
     expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+
+  test("contactType filter stays daemon-native and does NOT relay to the gateway", async () => {
+    // If contactType were relayed, the gateway would apply it AFTER its limit
+    // and could under-return. We serve it daemon-native instead (SQL filter
+    // before the limit). Assert no relay, local read, and the boundary note.
+    const result = await handleListContacts({
+      contactType: "assistant",
+      limit: "50",
+    });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toEqual(["listContacts"]);
+    // contactType + limit are pushed into the SQL-filtered daemon read (the
+    // daemon-native listContacts filters contactType BEFORE applying limit).
+    expect(listContactsArgs).toEqual([
+      { limit: 50, role: undefined, contactType: "assistant" },
+    ]);
+    expect(result.contacts[0].id).toBe("local-1");
+    expect(result.contacts[0].contactType).toBe("assistant");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+
+  test("contactType + role both flow into the daemon-native read", async () => {
+    await handleListContacts({ contactType: "human", role: "guardian" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(listContactsArgs).toEqual([
+      { limit: 50, role: "guardian", contactType: "human" },
+    ]);
   });
 });
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -176,13 +176,11 @@ const contactSchema = z.object({
 async function relayListContacts(
   limit: number,
   role: ContactRole | undefined,
-  contactType: ContactType | undefined,
 ) {
   try {
     const result = await ipcCallPersistent("contacts_list_rich", {
       limit,
       ...(role ? { role } : {}),
-      ...(contactType ? { contactType } : {}),
     });
     const { contacts } = ListContactsIpcResponseSchema.parse(result);
     return {
@@ -194,7 +192,7 @@ async function relayListContacts(
       { err },
       "relayListContacts: gateway relay failed; falling back to assistant DB",
     );
-    const contacts = listContacts(limit, role, contactType);
+    const contacts = listContacts(limit, role);
     return {
       ok: true,
       contacts: contacts.map(prepareContactResponse),
@@ -239,7 +237,22 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     };
   }
 
-  return relayListContacts(limit, role, contactType);
+  // contactType is assistant-owned: serve daemon-native so it's filtered in SQL
+  // BEFORE the limit. The gateway relay filtered it AFTER its limit, which
+  // under-returned (and returned empty on an assistant-DB outage, since the
+  // soft-fail map dropped every row). Mirrors the search boundary.
+  if (contactType) {
+    log.debug(
+      "handleListContacts: contactType-filtered read served daemon-native (gateway-native contactType filtering is design-blocked, pending ACL classification)",
+    );
+    const contacts = listContacts(limit, role, contactType);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  }
+
+  return relayListContacts(limit, role);
 }
 
 export async function handleGetContact(contactId: string) {
@@ -688,11 +701,7 @@ export const ROUTES: RouteDefinition[] = [
       // No-filter "search" is a list read — relay to the gateway so it returns
       // the same source-of-truth data as `contacts list`.
       if (!hasFilter) {
-        const { contacts } = await relayListContacts(
-          parsed.limit ?? 50,
-          undefined,
-          undefined,
-        );
+        const { contacts } = await relayListContacts(parsed.limit ?? 50, undefined);
         return contacts;
       }
 

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -271,6 +271,39 @@ describe("ContactStore.listContactsRich", () => {
     expect(result.map((c) => c.id)).toEqual(["bot"]);
   });
 
+  test("contactType filter with a MIX of types + tight limit (forward-compat path)", async () => {
+    // contactType filtering is no longer exercised on the daemon relay path
+    // (the daemon serves contactType-filtered reads natively). This test keeps
+    // the gateway-side filter behavior honest for forward-compat callers: with
+    // a mix of types and a limit, listContactsWithInfo applies the limit to
+    // CONTACTS first, then the contactType filter runs on the limited set — so
+    // a tight limit can still under-return here. The relay path avoids this by
+    // staying daemon-native (SQL contactType filter before the limit).
+    seedGatewayContact({ id: "h1", updatedAt: 500 });
+    seedGatewayContact({ id: "bot1", updatedAt: 400 });
+    seedGatewayContact({ id: "h2", updatedAt: 300 });
+    seedGatewayContact({ id: "bot2", updatedAt: 200 });
+    seedAssistantInfo({ id: "h1", contactType: "human" });
+    seedAssistantInfo({ id: "bot1", contactType: "assistant", species: "vellum" });
+    seedAssistantInfo({ id: "h2", contactType: "human" });
+    seedAssistantInfo({ id: "bot2", contactType: "assistant", species: "vellum" });
+
+    // No limit → all assistant contacts returned.
+    const all = await new ContactStore().listContactsRich({
+      contactType: "assistant",
+    });
+    expect(all.map((c) => c.id)).toEqual(["bot1", "bot2"]);
+
+    // limit 2 → contacts limited to [h1, bot1] first, then filtered to
+    // assistant → only bot1 survives (demonstrates the post-limit truncation
+    // the daemon-native relay path deliberately avoids).
+    const limited = await new ContactStore().listContactsRich({
+      contactType: "assistant",
+      limit: 2,
+    });
+    expect(limited.map((c) => c.id)).toEqual(["bot1"]);
+  });
+
   test("honors limit (capped at 200)", async () => {
     for (let i = 0; i < 5; i++) {
       seedGatewayContact({ id: `c${i}`, updatedAt: i });

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -204,9 +204,15 @@ export class ContactStore {
    * List contacts in the shared ContactRead shape: gateway-DB identity + ACL
    * channels joined to assistant-DB info fields.
    *
-   * Filters: `role` (gateway DB), `contactType` (assistant-owned — applied
-   * against the joined assistant value), `limit` (default 50, capped 200 to
-   * mirror the daemon's listContacts).
+   * Filters: `role` (gateway DB), `limit` (default 50, capped 200 to mirror
+   * the daemon's listContacts). `contactType` is assistant-owned and is NOT
+   * filtered here — the daemon serves contactType-filtered list reads natively
+   * (filtering in SQL before the limit) so a tight limit doesn't under-return
+   * and an assistant-DB outage degrades rather than dropping every row. The
+   * param is retained for forward-compat but not exercised on the relay path.
+   *
+   * Thin adapter over `listContactsWithInfo` (shared assembly/soft-fail logic),
+   * projected down to the ContactRead subset.
    *
    * Ordering mirrors the daemon's listContacts: guardian role first, then
    * updatedAt desc.
@@ -216,68 +222,37 @@ export class ContactStore {
     role?: string;
     contactType?: string;
   }): Promise<ContactRead[]> {
-    const effectiveLimit = Math.min(opts?.limit ?? 50, 200);
-
-    const contactRows = this.db
-      .select()
-      .from(contacts)
-      .where(opts?.role ? eq(contacts.role, opts.role) : undefined)
-      .orderBy(
-        sql`${contacts.role} = 'guardian' DESC`,
-        desc(contacts.updatedAt),
-      )
-      .limit(effectiveLimit)
-      .all();
-
-    if (contactRows.length === 0) return [];
-
-    const ids = contactRows.map((c) => c.id);
-    const channelsByContact = this.channelsForContacts(ids);
-    const infoMap = await this.fetchInfoSoft(ids);
-
-    const result: ContactRead[] = [];
-    for (const contact of contactRows) {
-      const info = infoMap.get(contact.id) ?? null;
-      // contactType is assistant-owned — filter against the joined value.
-      if (opts?.contactType && info?.contactType !== opts.contactType) continue;
-      result.push(
-        this.composeContactRead(
-          contact,
-          channelsByContact.get(contact.id) ?? [],
-          info,
-        ),
-      );
-    }
-    return result;
+    const withInfo = await this.listContactsWithInfo({
+      limit: opts?.limit,
+      role: opts?.role,
+    });
+    return withInfo
+      .filter((c) => !opts?.contactType || c.contactType === opts.contactType)
+      .map((c) => this.toContactRead(c));
   }
 
   /**
    * Get a single contact in the shared ContactRead shape, plus the assistant
    * metadata block for assistant-species contacts. Returns null if the
    * contact is absent from the gateway DB.
+   *
+   * Thin adapter over `getContactWithInfo`, projected down to ContactRead.
    */
   async getContactRich(contactId: string): Promise<{
     contact: ContactRead;
     assistantMetadata?: AssistantContactMetadata;
   } | null> {
-    const contact = this.db
-      .select()
-      .from(contacts)
-      .where(eq(contacts.id, contactId))
-      .get();
-    if (!contact) return null;
+    const withInfo = await this.getContactWithInfo(contactId);
+    if (!withInfo) return null;
 
-    const channels = this.channelsForContacts([contactId]).get(contactId) ?? [];
-    const info = (await this.fetchInfoSoft([contactId])).get(contactId) ?? null;
-    const read = this.composeContactRead(contact, channels, info);
-
-    if (info?.contactType === "assistant" && info.assistantMetadata) {
+    const read = this.toContactRead(withInfo);
+    if (withInfo.contactType === "assistant" && withInfo.assistantMetadata) {
       return {
         contact: read,
         assistantMetadata: {
           contactId,
-          species: info.assistantMetadata.species,
-          metadata: info.assistantMetadata.metadata,
+          species: withInfo.assistantMetadata.species,
+          metadata: withInfo.assistantMetadata.metadata,
         },
       };
     }
@@ -285,86 +260,22 @@ export class ContactStore {
   }
 
   /**
-   * Fetch channels for a set of contact IDs, grouped by contactId and ordered
-   * primary-first then by creation time (mirrors readAssistantContact and the
-   * daemon's withChannels ordering).
+   * Project a ContactWithInfo down to the ContactRead subset (drops the
+   * assistant-only/ACL-internal fields not on the shared contract). Channel
+   * `externalUserId` echoes `address` to match the daemon's withChannelCompat;
+   * status/policy default like the DB columns (notNull, so a no-op on real
+   * rows) to satisfy the non-null ContactRead channel contract.
    */
-  private channelsForContacts(
-    contactIds: string[],
-  ): Map<string, ContactChannel[]> {
-    const byId = new Map<string, ContactChannel[]>();
-    if (contactIds.length === 0) return byId;
-
-    const rows = this.db
-      .select()
-      .from(contactChannels)
-      .where(
-        sql`${contactChannels.contactId} IN (${sql.join(
-          contactIds.map((id) => sql`${id}`),
-          sql`, `,
-        )})`,
-      )
-      .orderBy(
-        sql`${contactChannels.isPrimary} DESC`,
-        contactChannels.createdAt,
-      )
-      .all();
-
-    for (const ch of rows) {
-      const list = byId.get(ch.contactId) ?? [];
-      list.push(ch);
-      byId.set(ch.contactId, list);
-    }
-    return byId;
-  }
-
-  /**
-   * Soft assistant-DB info fetch: on failure, log a warning and return an
-   * empty map so callers degrade to gateway-DB-only values.
-   */
-  private async fetchInfoSoft(
-    contactIds: string[],
-  ): Promise<Map<string, ContactInfoFields>> {
-    try {
-      return await fetchInfoForContacts(contactIds);
-    } catch (err) {
-      log.warn(
-        { err, count: contactIds.length },
-        "rich read: assistant DB info join failed; returning gateway-DB-only fields",
-      );
-      return new Map();
-    }
-  }
-
-  /**
-   * Compose the ContactRead shape: identity + ACL/channel fields from the
-   * gateway DB, info fields (notes, contactType, interactionCount,
-   * lastInteraction) from the assistant DB. interactionCount/lastInteraction
-   * are derived from gateway channels (trust signals live in gateway).
-   * `externalUserId` echoes `address` to match the daemon's withChannelCompat.
-   */
-  private composeContactRead(
-    contact: Contact,
-    channels: ContactChannel[],
-    info: ContactInfoFields | null,
-  ): ContactRead {
-    const interactionCount = channels.reduce(
-      (sum, ch) => sum + (ch.interactionCount ?? 0),
-      0,
-    );
-    const lastInteraction =
-      channels.reduce((max, ch) => Math.max(max, ch.lastInteraction ?? 0), 0) ||
-      null;
-
+  private toContactRead(c: ContactWithInfo): ContactRead {
     return {
-      id: contact.id,
-      displayName: contact.displayName,
-      role: contact.role,
-      notes: info?.notes ?? null,
-      contactType: info?.contactType ?? null,
-      interactionCount,
-      lastInteraction,
-      channels: channels.map((ch) => ({
+      id: c.id,
+      displayName: c.displayName,
+      role: c.role,
+      notes: c.notes,
+      contactType: c.contactType,
+      interactionCount: c.interactionCount,
+      lastInteraction: c.lastInteraction,
+      channels: c.channels.map((ch) => ({
         id: ch.id,
         contactId: ch.contactId,
         type: ch.type,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for contacts-relay-reads.md.

**Gap (correctness):** listContactsRich filtered contactType AFTER the gateway-DB limit, so contactType+limit could under-return (or return empty during an assistant-DB outage, since the empty soft-fail map dropped all rows without triggering the daemon fallback). Now contactType-filtered list reads are served daemon-native (mirroring the search boundary and the gateway HTTP precedent), filtering contactType in SQL before the limit; the boundary is logged. The relay path no longer sends contactType to the gateway; relayListContacts dropped its now-dead contactType parameter.

**Gap 3 (reuse consolidation): APPLIED.** listContactsRich/getContactRich are now thin adapters over the pre-existing listContactsWithInfo/getContactWithInfo plus a small ContactWithInfo -> ContactRead projector (toContactRead). The duplicated private helpers channelsForContacts, fetchInfoSoft, and composeContactRead were deleted. Behavior is preserved (same ordering, channel assembly, and soft-fail semantics, all inherited from the shared join path); all existing gateway tests stay green. The contactType param is retained on listContactsRich for forward-compat but is no longer exercised on the relay path.

## Tests
- assistant/contacts-relay-reads.test.ts: added two tests asserting contactType (and contactType+role) reads stay daemon-native — no gateway relay, args flow into the SQL-filtered listContacts before the limit, and the boundary note is logged.
- gateway/contact-rich-read.test.ts: added a mixed-type + tight-limit test documenting the forward-compat gateway-side filter behavior (limit applies to contacts first), which the daemon-native relay path deliberately avoids.
- gateway typecheck + contact-rich-read.test.ts (15) + ipc-contact-routes.test.ts (19): green.
- assistant typecheck + contacts-relay-reads.test.ts (17) + contacts-tools.test.ts (11): green.