### PR TITLE
Close Remaining Contact Write Split-Brain Gaps

### DIFF
--- a/assistant/src/runtime/routes/__tests__/contact-routes-update-channel-relay.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes-update-channel-relay.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the daemon updateContactChannel relay.
+ *
+ * `handleUpdateContactChannelRoute` is a thin relay to the gateway IPC method
+ * `update_contact_channel` via `ipcCallPersistent`. The gateway DB is the source
+ * of truth: the daemon writes NOTHING to the assistant DB directly. These tests
+ * assert the handler forwards `{ contactChannelId, status, policy, reason }`
+ * unchanged, returns the gateway response verbatim, never touches the assistant
+ * contact store, and propagates an unexpected relay rejection (no fallback).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = { ok: true };
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCalls.push({ method, params, timeoutMs });
+    if (ipcError) throw ipcError;
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if the relay still writes the assistant contact store
+// directly. The relayed update path must go through the gateway only.
+const actualContactStore = await import("../../../contacts/contact-store.js");
+
+const contactStoreWriteGuard = mock(() => {
+  throw new Error(
+    "assistant contact-store write must not happen on the relayed update path",
+  );
+});
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  updateChannelStatus: contactStoreWriteGuard,
+}));
+
+const { handleUpdateContactChannelRoute, ROUTES } = await import(
+  "../contact-routes.js"
+);
+
+describe("update contact channel relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = { ok: true };
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    contactStoreWriteGuard.mockClear();
+  });
+
+  test("forwards { contactChannelId, status, policy, reason } unchanged and returns the gateway response verbatim", async () => {
+    const gatewayResponse = {
+      ok: true,
+      contact: { id: "ct_1", displayName: "Alice", channels: [] },
+    };
+    ipcResult = gatewayResponse;
+
+    const result = await handleUpdateContactChannelRoute({
+      pathParams: { contactChannelId: "ch_1" },
+      body: { status: "revoked", policy: "deny", reason: "user request" },
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "update_contact_channel",
+        params: {
+          contactChannelId: "ch_1",
+          status: "revoked",
+          policy: "deny",
+          reason: "user request",
+        },
+        timeoutMs: undefined,
+      },
+    ]);
+    expect(result).toEqual(gatewayResponse);
+    // Must NOT write the assistant DB directly.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("omits absent body fields from the relayed params", async () => {
+    ipcResult = { ok: true };
+
+    await handleUpdateContactChannelRoute({
+      pathParams: { contactChannelId: "ch_2" },
+      body: { status: "active" },
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "update_contact_channel",
+        params: { contactChannelId: "ch_2", status: "active" },
+        timeoutMs: undefined,
+      },
+    ]);
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed IpcCallError surfaces with its statusCode/errorCode", async () => {
+    ipcError = new IpcCallError("Channel not found", {
+      statusCode: 404,
+      errorCode: "NOT_FOUND",
+    });
+
+    try {
+      await handleUpdateContactChannelRoute({
+        pathParams: { contactChannelId: "missing" },
+        body: { status: "active" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      const e = err as { statusCode?: number; code?: string; message: string };
+      expect(e.message).toBe("Channel not found");
+      expect(e.statusCode).toBe(404);
+      expect(e.code).toBe("NOT_FOUND");
+    }
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("an unexpected relay rejection propagates (no fallback, no second write)", async () => {
+    ipcError = new Error("ipc transport exploded");
+
+    try {
+      await handleUpdateContactChannelRoute({
+        pathParams: { contactChannelId: "ch_3" },
+        body: { status: "active" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      expect((err as Error).message).toBe("ipc transport exploded");
+    }
+    // No daemon-side fallback write.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+    expect(ipcCalls).toHaveLength(1);
+  });
+
+  test("the updateContactChannel route is registered and wired to the relay", () => {
+    const route = ROUTES.find((r) => r.operationId === "updateContactChannel");
+    expect(route).toBeDefined();
+    expect(route?.endpoint).toBe("contact-channels/:contactChannelId");
+    expect(route?.method).toBe("PATCH");
+  });
+});

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -8,24 +8,18 @@
  * they don't shadow more-specific sub-paths like contacts/invites.
  */
 
+import { UpdateContactChannelIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import {
   getAssistantContactMetadata,
-  getChannelById,
   getContact,
   listContacts,
   mergeContacts,
   searchContacts,
-  updateChannelStatus,
 } from "../../contacts/contact-store.js";
-import type {
-  ChannelPolicy,
-  ChannelStatus,
-  ContactRole,
-  ContactType,
-} from "../../contacts/types.js";
+import type { ContactRole, ContactType } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -34,12 +28,7 @@ import {
   redeemVoiceInviteCode,
   triggerInviteCall,
 } from "../invite-service.js";
-import {
-  BadRequestError,
-  ConflictError,
-  NotFoundError,
-  RouteError,
-} from "./errors.js";
+import { BadRequestError, NotFoundError, RouteError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 /**
@@ -97,29 +86,8 @@ function prepareContactResponse<
 
 const VALID_CONTACT_TYPES: readonly ContactType[] = ["human", "assistant"];
 
-const VALID_CHANNEL_STATUSES: readonly ChannelStatus[] = [
-  "active",
-  "pending",
-  "revoked",
-  "blocked",
-  "unverified",
-];
-const VALID_CHANNEL_POLICIES: readonly ChannelPolicy[] = [
-  "allow",
-  "deny",
-  "escalate",
-];
-
 function isContactType(value: string): value is ContactType {
   return (VALID_CONTACT_TYPES as readonly string[]).includes(value);
-}
-
-function isChannelStatus(value: string): value is ChannelStatus {
-  return (VALID_CHANNEL_STATUSES as readonly string[]).includes(value);
-}
-
-function isChannelPolicy(value: string): value is ChannelPolicy {
-  return (VALID_CHANNEL_POLICIES as readonly string[]).includes(value);
 }
 
 // ---------------------------------------------------------------------------
@@ -719,62 +687,33 @@ function handleMergeContactsRoute(args: RouteHandlerArgs) {
   }
 }
 
-function handleUpdateContactChannelRoute(args: RouteHandlerArgs) {
-  const channelId = args.pathParams!.contactChannelId;
+/**
+ * Relay the channel status/policy update to the gateway-native handler.
+ *
+ * The gateway DB is the source of truth: it owns validation, the
+ * revoke-of-blocked guard, the assistant-side channel-ID backward-compat
+ * resolution, the assistant-DB mirror, and the `contacts_changed` emit. This
+ * daemon handler writes NOTHING to the assistant DB directly — it forwards the
+ * raw channel ID + body and returns the gateway response verbatim. No fallback:
+ * an unexpected relay failure surfaces as an error (never a silent second
+ * write).
+ */
+export async function handleUpdateContactChannelRoute(args: RouteHandlerArgs) {
   const body = (args.body ?? {}) as {
     status?: string;
     policy?: string;
     reason?: string;
   };
 
-  if (body.status !== undefined && !isChannelStatus(body.status)) {
-    throw new BadRequestError(
-      `Invalid status "${body.status}". Must be one of: ${VALID_CHANNEL_STATUSES.join(", ")}`,
-    );
+  try {
+    const result = await ipcCallPersistent("update_contact_channel", {
+      contactChannelId: args.pathParams!.contactChannelId,
+      ...(body.status !== undefined ? { status: body.status } : {}),
+      ...(body.policy !== undefined ? { policy: body.policy } : {}),
+      ...(body.reason !== undefined ? { reason: body.reason } : {}),
+    });
+    return UpdateContactChannelIpcResponseSchema.parse(result);
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-
-  if (body.policy !== undefined && !isChannelPolicy(body.policy)) {
-    throw new BadRequestError(
-      `Invalid policy "${body.policy}". Must be one of: ${VALID_CHANNEL_POLICIES.join(", ")}`,
-    );
-  }
-
-  if (body.status === "revoked") {
-    const existing = getChannelById(channelId);
-    if (!existing) {
-      throw new NotFoundError(`Channel "${channelId}" not found`);
-    }
-    if (existing.status === "blocked") {
-      throw new ConflictError(
-        "Cannot revoke a blocked channel. Unblock it first or leave it blocked.",
-      );
-    }
-  }
-
-  const updated = updateChannelStatus(channelId, {
-    status: body.status,
-    policy: body.policy,
-    revokedReason:
-      body.status !== undefined
-        ? body.status === "revoked"
-          ? (body.reason ?? null)
-          : null
-        : undefined,
-    blockedReason:
-      body.status !== undefined
-        ? body.status === "blocked"
-          ? (body.reason ?? null)
-          : null
-        : undefined,
-  });
-
-  if (!updated) {
-    throw new NotFoundError(`Channel "${channelId}" not found`);
-  }
-
-  const parentContact = getContact(updated.contactId);
-  return {
-    ok: true,
-    contact: parentContact ? prepareContactResponse(parentContact) : undefined,
-  };
 }

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -388,3 +388,65 @@ describe("ContactStore.markChannelVerified", () => {
     expect(contactRow!.displayName).toBe("gateway-name");
   });
 });
+
+describe("ContactStore.updateChannelStatus (assistant-only backfill)", () => {
+  test("backfills a legacy assistant-only channel into the gateway, then revokes", async () => {
+    seedAssistantContact("c1", "contact");
+    seedAssistantChannel({ id: "ch1", contactId: "c1", status: "active" });
+
+    const updated = await new ContactStore().updateChannelStatus("ch1", {
+      status: "revoked",
+      reason: "spam",
+    });
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("revoked");
+    expect(updated!.revokedReason).toBe("spam");
+
+    // Channel + parent contact were materialized in the gateway DB.
+    const channelInGateway = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(channelInGateway!.status).toBe("revoked");
+    const contactInGateway = getGatewayDb()
+      .select()
+      .from(contacts)
+      .where(eq(contacts.id, "c1"))
+      .get();
+    expect(contactInGateway).toBeTruthy();
+  });
+
+  test("revoke-of-blocked still 409s after backfill", async () => {
+    seedAssistantContact("c1", "contact");
+    seedAssistantChannel({ id: "ch1", contactId: "c1", status: "blocked" });
+
+    await expect(
+      new ContactStore().updateChannelStatus("ch1", { status: "revoked" }),
+    ).rejects.toThrow("Cannot revoke a blocked channel");
+  });
+
+  test("returns null when neither DB has the channel", async () => {
+    const updated = await new ContactStore().updateChannelStatus("missing", {
+      status: "revoked",
+    });
+    expect(updated).toBeNull();
+  });
+
+  test("degrades to null when the assistant channel references a missing contact", async () => {
+    // Backfill can't complete (orphan channel) → soft-fail to 404, never throw.
+    seedAssistantChannel({ id: "ch1", contactId: "orphan", status: "active" });
+
+    const updated = await new ContactStore().updateChannelStatus("ch1", {
+      status: "revoked",
+    });
+    expect(updated).toBeNull();
+
+    const channelInGateway = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(channelInGateway).toBeUndefined();
+  });
+});

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -342,6 +342,17 @@ describe("ContactStore.markChannelVerified", () => {
         .where(eq(contactChannels.id, "asst-ch"))
         .get(),
     ).toBeUndefined();
+
+    // The assistant-side mirror targets the ORIGINAL assistant id, not the
+    // resolved gateway id — otherwise the UPDATE no-ops on the split-id path.
+    const mirror = fakeAssistantDb.runCalls.find(
+      (c) =>
+        c.sql.includes("UPDATE contact_channels") &&
+        c.sql.includes("WHERE id = ?"),
+    );
+    expect(mirror).toBeTruthy();
+    expect(mirror!.bind?.[mirror!.bind!.length - 1]).toBe("asst-ch");
+    expect(mirror!.bind).not.toContain("gw-ch");
   });
 
   test("refuses to mirror when assistant channel references a missing contact", async () => {

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -316,7 +316,11 @@ describe("ContactStore.markChannelVerified", () => {
 
   test("refuses to mirror when assistant channel references a missing contact", async () => {
     // Channel present, parent contact absent — broken state, refuse silently.
-    seedAssistantChannel({ id: "ch1", contactId: "orphan", status: "unverified" });
+    seedAssistantChannel({
+      id: "ch1",
+      contactId: "orphan",
+      status: "unverified",
+    });
 
     const result = await new ContactStore().markChannelVerified("ch1");
     expect(result).toBeNull();
@@ -345,9 +349,7 @@ describe("ContactStore.markChannelVerified", () => {
     expect(second!.didWrite).toBe(false);
     expect(second!.channel.verifiedAt).toBe(first!.channel.verifiedAt);
     // Mirror INSERT OR IGNORE: still exactly one channel row, one contact row.
-    expect(
-      getGatewayDb().select().from(contactChannels).all().length,
-    ).toBe(1);
+    expect(getGatewayDb().select().from(contactChannels).all().length).toBe(1);
     expect(getGatewayDb().select().from(contacts).all().length).toBe(1);
   });
 
@@ -415,6 +417,42 @@ describe("ContactStore.updateChannelStatus (assistant-only backfill)", () => {
       .where(eq(contacts.id, "c1"))
       .get();
     expect(contactInGateway).toBeTruthy();
+  });
+
+  test("updates the existing gateway row when (type,address) lives under a different contact id", async () => {
+    // Split-brain: the assistant resolves the id to a (type,address) that the
+    // gateway already holds under a DIFFERENT contact id. `(type,address)` is
+    // globally UNIQUE, so we must update that existing ACL row instead of
+    // re-mirroring (which would hit the constraint and 404).
+    seedContact("c-gw", "contact");
+    seedChannel({ id: "gw-ch", contactId: "c-gw", status: "active" });
+    // Assistant channel "asst-ch" shares addr (addr-gw-ch) under contact c-asst.
+    seedAssistantContact("c-asst", "contact");
+    seedAssistantChannel({
+      id: "asst-ch",
+      contactId: "c-asst",
+      status: "active",
+    });
+    fakeAssistantDb.channels.get("asst-ch")!.address = "addr-gw-ch";
+
+    const updated = await new ContactStore().updateChannelStatus("asst-ch", {
+      status: "revoked",
+      reason: "spam",
+    });
+
+    // Existing gateway row was updated; no 404, no unique-constraint failure.
+    expect(updated).not.toBeNull();
+    expect(updated!.id).toBe("gw-ch");
+    expect(updated!.status).toBe("revoked");
+
+    // No second channel row was mirrored under the assistant id.
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "asst-ch"))
+        .get(),
+    ).toBeUndefined();
   });
 
   test("revoke-of-blocked still 409s after backfill", async () => {

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -314,6 +314,36 @@ describe("ContactStore.markChannelVerified", () => {
     expect(contactInGateway!.role).toBe("guardian");
   });
 
+  test("verifies the existing gateway row when (type,address) lives under a different id", async () => {
+    // Split-brain: the caller's channelId is the assistant id, but the gateway
+    // already holds the same (type,address) under a DIFFERENT id (pre-canonical
+    // split). Resolve by (type,address) and verify that row instead of 404ing.
+    seedContact("c-gw", "contact");
+    seedChannel({ id: "gw-ch", contactId: "c-gw", status: "unverified" });
+    seedAssistantContact("c-asst", "contact");
+    seedAssistantChannel({
+      id: "asst-ch",
+      contactId: "c-asst",
+      status: "unverified",
+    });
+    fakeAssistantDb.channels.get("asst-ch")!.address = "addr-gw-ch";
+
+    const result = await new ContactStore().markChannelVerified("asst-ch");
+
+    // Existing gateway row was verified; no 404, no duplicate mirror.
+    expect(result).not.toBeNull();
+    expect(result!.channel.id).toBe("gw-ch");
+    expect(result!.channel.status).toBe("active");
+    expect(result!.channel.verifiedVia).toBe("manual");
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "asst-ch"))
+        .get(),
+    ).toBeUndefined();
+  });
+
   test("refuses to mirror when assistant channel references a missing contact", async () => {
     // Channel present, parent contact absent — broken state, refuse silently.
     seedAssistantChannel({

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -676,36 +676,53 @@ describe("IPC contact routes", () => {
     );
   });
 
-  test("create_contact reconciles an assistant-only contact instead of minting a duplicate", async () => {
+  test("create_contact heals an assistant-only contact onto ONE shared canonical id", async () => {
     // Gap B: a contact+channel exists in the assistant DB but NOT the gateway.
-    // upsertContact mints a new gateway id; the mirror must reconcile into the
-    // existing assistant contact (no duplicate INSERT, name preserved) and the
-    // gateway row must be created.
+    // upsertContact adopts the existing assistant contact id as the gateway
+    // contact id (canonical-id heal), so BOTH DBs are keyed by the same id —
+    // the gateway row is created under it, no duplicate assistant INSERT, the
+    // name is preserved, and the gateway read join-by-id resolves info.
     const assistantContactId = "assistant-only-c1";
     const assistantChannelId = "assistant-only-ch1";
 
-    // Channel lookup by (type,address) returns the existing assistant contact;
-    // the contact-by-id lookup (keyed on the resolved id) reports it exists.
     assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      // Channel lookup by (type,address) → the existing assistant contact id.
       if (
         sql.includes("FROM contact_channels") &&
         sql.includes("WHERE type = ?")
       ) {
         return [{ contactId: assistantContactId, id: assistantChannelId }];
       }
+      // existingCh lookup keyed on the adopted (assistant) contact id.
       if (
         sql.includes("FROM contact_channels") &&
         sql.includes("WHERE contact_id = ?")
       ) {
-        // existingCh lookup keyed on the resolved (assistant) contact id.
         if (bind?.[0] === assistantContactId) {
           return [{ id: assistantChannelId, status: "active" }];
         }
         return [];
       }
+      // user_file lookup in the mirror (contact already exists in assistant DB).
       if (sql.includes("FROM contacts WHERE id = ?")) {
         if (bind?.[0] === assistantContactId) {
           return [{ userFile: "existing-person.md" }];
+        }
+        return [];
+      }
+      // Read-path info join keyed by the canonical id.
+      if (sql.includes("FROM contacts c") && sql.includes("IN (")) {
+        if (bind?.includes(assistantContactId)) {
+          return [
+            {
+              id: assistantContactId,
+              notes: "knows the family",
+              userFile: "existing-person.md",
+              contactType: "human",
+              species: null,
+              metadata: null,
+            },
+          ];
         }
         return [];
       }
@@ -726,14 +743,19 @@ describe("IPC contact routes", () => {
     expect(res.error).toBeUndefined();
     const { contactId } = res.result as { contactId: string };
 
-    // No duplicate assistant contact INSERT.
-    const contactInsert = runCalls.find((c) =>
-      c.sql.includes("INSERT INTO contacts"),
-    );
-    expect(contactInsert).toBeUndefined();
+    // The returned (gateway) id IS the existing assistant id — one canonical id.
+    expect(contactId).toBe(assistantContactId);
 
-    // The assistant contact UPDATE targets the EXISTING assistant id, not the
-    // new gateway id, and preserves the name (no display_name in the SET).
+    // No duplicate assistant contact INSERT; the existing channel is updated,
+    // not re-inserted.
+    expect(
+      runCalls.find((c) => c.sql.includes("INSERT INTO contacts")),
+    ).toBeUndefined();
+    expect(
+      runCalls.find((c) => c.sql.includes("INSERT INTO contact_channels")),
+    ).toBeUndefined();
+
+    // The assistant contact UPDATE targets the shared id, name preserved.
     const contactUpdate = runCalls.find(
       (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
     );
@@ -741,20 +763,77 @@ describe("IPC contact routes", () => {
     expect(contactUpdate!.bind?.at(-1)).toBe(assistantContactId);
     expect(contactUpdate!.sql).not.toContain("display_name");
 
-    // The existing assistant channel is updated, not re-inserted with the bare
-    // address.
-    const channelInsert = runCalls.find((c) =>
-      c.sql.includes("INSERT INTO contact_channels"),
-    );
-    expect(channelInsert).toBeUndefined();
-
-    // The gateway DB now has the contact + channel (the split-brain heal).
+    // The gateway DB has the contact + channel under the canonical id.
     const store = new ContactStore(getGatewayDb());
-    const gwContact = store.getContact(contactId);
-    expect(gwContact).toBeDefined();
+    expect(store.getContact(contactId)).toBeDefined();
     const gwChannels = store.getChannelsForContact(contactId);
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].address).toBe("existing-person@example.com");
+
+    // The gateway read join-by-id resolves the assistant info (NOT null) —
+    // proof the two DBs converged on one id.
+    const withInfo = await store.getContactWithInfo(contactId);
+    expect(withInfo).not.toBeNull();
+    expect(withInfo!.notes).toBe("knows the family");
+    expect(withInfo!.userFile).toBe("existing-person.md");
+    expect(withInfo!.contactType).toBe("human");
+  });
+
+  test("upsertContact with an explicit id does NOT retarget another contact's metadata", async () => {
+    // Update path (Problem 2): an edit carries a channel whose (type,address)
+    // is owned by a DIFFERENT assistant contact. The assistant mirror must
+    // target the provided id — never the other contact — matching the gateway
+    // syncChannels skip-on-cross-contact behavior.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "edit-me",
+        displayName: "Edit Me",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // The assistant DB reports the channel is owned by "other-contact" and the
+    // edited contact already exists by id.
+    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      if (
+        sql.includes("FROM contact_channels") &&
+        sql.includes("WHERE type = ?")
+      ) {
+        return [{ contactId: "other-contact" }];
+      }
+      if (sql.includes("FROM contacts WHERE id = ?")) {
+        if (bind?.[0] === "edit-me") return [{ userFile: "edit-me.md" }];
+        return [];
+      }
+      return [];
+    });
+    const runCalls: { sql: string; bind?: unknown[] }[] = [];
+    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
+      runCalls.push({ sql, bind });
+      return { changes: 1, lastInsertRowid: 0 };
+    });
+
+    const store = new ContactStore(db);
+    await store.upsertContact({
+      id: "edit-me",
+      displayName: "New Name",
+      channels: [{ type: "email", address: "shared@example.com" }],
+    });
+
+    // The assistant contact UPDATE targets the provided id, never "other-contact".
+    const contactUpdate = runCalls.find(
+      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    );
+    expect(contactUpdate).toBeDefined();
+    expect(contactUpdate!.bind?.at(-1)).toBe("edit-me");
+    expect(
+      runCalls.some((c) => c.bind?.includes("other-contact")),
+    ).toBe(false);
   });
 
   test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -612,6 +612,151 @@ describe("IPC contact routes", () => {
     expect(store.getContact("rename-c1")!.displayName).toBe("New Name");
   });
 
+  test("create_contact retry does not overwrite the assistant-DB display_name when omitted", async () => {
+    // Gap A: the gateway row exists with a stale name; the assistant DB holds
+    // the user's current (different) name. A retry WITHOUT displayName must
+    // leave the assistant-DB name untouched — the UPDATE must omit display_name.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "stale-c1",
+        displayName: "Stale Gateway Name",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "stale-ch1",
+        contactId: "stale-c1",
+        type: "email",
+        address: "stale@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+      })
+      .run();
+
+    // Assistant DB has the contact (so the mirror takes the UPDATE branch).
+    assistantDbQueryMock = mock(async (sql: string) => {
+      if (sql.includes("FROM contacts WHERE id = ?")) {
+        return [{ userFile: "current-name.md" }];
+      }
+      return [];
+    });
+    const runCalls: { sql: string; bind?: unknown[] }[] = [];
+    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
+      runCalls.push({ sql, bind });
+      return { changes: 1, lastInsertRowid: 0 };
+    });
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "stale@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+
+    // The assistant-DB contact UPDATE must NOT touch display_name.
+    const contactUpdate = runCalls.find(
+      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    );
+    expect(contactUpdate).toBeDefined();
+    expect(contactUpdate!.sql).not.toContain("display_name");
+
+    // The gateway row's stale name is likewise preserved (omit-to-preserve).
+    expect(new ContactStore(db).getContact("stale-c1")!.displayName).toBe(
+      "Stale Gateway Name",
+    );
+  });
+
+  test("create_contact reconciles an assistant-only contact instead of minting a duplicate", async () => {
+    // Gap B: a contact+channel exists in the assistant DB but NOT the gateway.
+    // upsertContact mints a new gateway id; the mirror must reconcile into the
+    // existing assistant contact (no duplicate INSERT, name preserved) and the
+    // gateway row must be created.
+    const assistantContactId = "assistant-only-c1";
+    const assistantChannelId = "assistant-only-ch1";
+
+    // Channel lookup by (type,address) returns the existing assistant contact;
+    // the contact-by-id lookup (keyed on the resolved id) reports it exists.
+    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      if (
+        sql.includes("FROM contact_channels") &&
+        sql.includes("WHERE type = ?")
+      ) {
+        return [{ contactId: assistantContactId, id: assistantChannelId }];
+      }
+      if (
+        sql.includes("FROM contact_channels") &&
+        sql.includes("WHERE contact_id = ?")
+      ) {
+        // existingCh lookup keyed on the resolved (assistant) contact id.
+        if (bind?.[0] === assistantContactId) {
+          return [{ id: assistantChannelId, status: "active" }];
+        }
+        return [];
+      }
+      if (sql.includes("FROM contacts WHERE id = ?")) {
+        if (bind?.[0] === assistantContactId) {
+          return [{ userFile: "existing-person.md" }];
+        }
+        return [];
+      }
+      return [];
+    });
+    const runCalls: { sql: string; bind?: unknown[] }[] = [];
+    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
+      runCalls.push({ sql, bind });
+      return { changes: 1, lastInsertRowid: 0 };
+    });
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "existing-person@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    // No duplicate assistant contact INSERT.
+    const contactInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT INTO contacts"),
+    );
+    expect(contactInsert).toBeUndefined();
+
+    // The assistant contact UPDATE targets the EXISTING assistant id, not the
+    // new gateway id, and preserves the name (no display_name in the SET).
+    const contactUpdate = runCalls.find(
+      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    );
+    expect(contactUpdate).toBeDefined();
+    expect(contactUpdate!.bind?.at(-1)).toBe(assistantContactId);
+    expect(contactUpdate!.sql).not.toContain("display_name");
+
+    // The existing assistant channel is updated, not re-inserted with the bare
+    // address.
+    const channelInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT INTO contact_channels"),
+    );
+    expect(channelInsert).toBeUndefined();
+
+    // The gateway DB now has the contact + channel (the split-brain heal).
+    const store = new ContactStore(getGatewayDb());
+    const gwContact = store.getContact(contactId);
+    expect(gwContact).toBeDefined();
+    const gwChannels = store.getChannelsForContact(contactId);
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].address).toBe("existing-person@example.com");
+  });
+
   test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {
     await startServerAndConnect();
     const res = await sendRequest(client, "create_contact", {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -367,6 +367,306 @@ describe("IPC contact routes", () => {
     expect(res.error).toContain("Invalid params");
   });
 
+  // -------------------------------------------------------------------------
+  // create_contact (gateway DB source of truth via ContactStore.upsertContact)
+  // -------------------------------------------------------------------------
+  //
+  // No assistant daemon runs in these tests, so the best-effort assistant-DB
+  // dual-write inside upsertContact soft-fails. The gateway write still
+  // succeeds and { contactId, channelId } is returned regardless.
+
+  test("create_contact writes the gateway DB contacts + contact_channels rows", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "new@example.com",
+      displayName: "New Person",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId, channelId } = res.result as {
+      contactId: string;
+      channelId: string;
+    };
+    expect(contactId).toBeTruthy();
+    expect(channelId).toBeTruthy();
+
+    // The gateway DB (source of truth) holds both the contact and channel rows.
+    const store = new ContactStore(getGatewayDb());
+    const contact = store.getContact(contactId);
+    expect(contact).toBeDefined();
+    expect(contact!.displayName).toBe("New Person");
+    // role is always "contact" — guardian binding is not settable here.
+    expect(contact!.role).toBe("contact");
+
+    const channels = store.getChannelsForContact(contactId);
+    expect(channels).toHaveLength(1);
+    expect(channels[0].id).toBe(channelId);
+    expect(channels[0].type).toBe("email");
+    expect(channels[0].address).toBe("new@example.com");
+    expect(channels[0].isPrimary).toBe(true);
+  });
+
+  test("create_contact returns { contactId, channelId } both present and non-empty", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "shape@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const result = res.result as { contactId: string; channelId: string };
+    expect(typeof result.contactId).toBe("string");
+    expect(typeof result.channelId).toBe("string");
+    expect(result.contactId.length).toBeGreaterThan(0);
+    expect(result.channelId.length).toBeGreaterThan(0);
+  });
+
+  test("create_contact ignores the role param (guardian binding not settable here)", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "wannabe-guardian@example.com",
+      role: "guardian",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    const store = new ContactStore(getGatewayDb());
+    expect(store.getContact(contactId)!.role).toBe("contact");
+  });
+
+  test("create_contact is idempotent for the same (channelType, address)", async () => {
+    await startServerAndConnect();
+    const first = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "dup@example.com",
+    });
+    const second = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "dup@example.com",
+    });
+
+    expect(first.error).toBeUndefined();
+    expect(second.error).toBeUndefined();
+    const a = first.result as { contactId: string; channelId: string };
+    const b = second.result as { contactId: string; channelId: string };
+    expect(b.contactId).toBe(a.contactId);
+    expect(b.channelId).toBe(a.channelId);
+
+    // No duplicate rows.
+    const store = new ContactStore(getGatewayDb());
+    expect(store.listContacts()).toHaveLength(1);
+    expect(store.getChannelsForContact(a.contactId)).toHaveLength(1);
+  });
+
+  test("create_contact retry does not demote an existing active/verified channel", async () => {
+    // An already-trusted channel (active + non-allow policy) must survive a
+    // retry untouched — passing hard-coded unverified/allow would drop it below
+    // the trusted_contacts admission floor.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "trusted-c1",
+        displayName: "Trusted Person",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "trusted-ch1",
+        contactId: "trusted-c1",
+        type: "email",
+        address: "trusted@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "escalate",
+        verifiedAt: now,
+        verifiedVia: "manual",
+        interactionCount: 3,
+        createdAt: now,
+      })
+      .run();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "trusted@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId, channelId } = res.result as {
+      contactId: string;
+      channelId: string;
+    };
+    expect(contactId).toBe("trusted-c1");
+    expect(channelId).toBe("trusted-ch1");
+
+    const store = new ContactStore(db);
+    const channels = store.getChannelsForContact("trusted-c1");
+    expect(channels).toHaveLength(1);
+    // Status/policy/verification preserved — NOT overwritten to unverified/allow.
+    expect(channels[0].status).toBe("active");
+    expect(channels[0].policy).toBe("escalate");
+    expect(channels[0].verifiedAt).toBe(now);
+    expect(channels[0].verifiedVia).toBe("manual");
+  });
+
+  test("create_contact retry preserves existing displayName + external_chat_id when omitted", async () => {
+    // A retry / re-add for an existing contact that already has a custom
+    // displayName and a set external_chat_id, called WITHOUT a displayName,
+    // must not overwrite the name with the bare address nor clear the chat id.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "named-c1",
+        displayName: "Alice In Wonderland",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "named-ch1",
+        contactId: "named-c1",
+        type: "telegram",
+        address: "tg-alice-001",
+        isPrimary: true,
+        externalChatId: "chat-alice-001",
+        status: "active",
+        policy: "allow",
+        interactionCount: 2,
+        createdAt: now,
+      })
+      .run();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "telegram",
+      address: "tg-alice-001",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId, channelId } = res.result as {
+      contactId: string;
+      channelId: string;
+    };
+    expect(contactId).toBe("named-c1");
+    expect(channelId).toBe("named-ch1");
+
+    const store = new ContactStore(db);
+    // displayName preserved — NOT overwritten with the bare address.
+    expect(store.getContact("named-c1")!.displayName).toBe(
+      "Alice In Wonderland",
+    );
+    const channels = store.getChannelsForContact("named-c1");
+    expect(channels).toHaveLength(1);
+    // external_chat_id preserved — sparse upsert must not clear it.
+    expect(channels[0].externalChatId).toBe("chat-alice-001");
+  });
+
+  test("create_contact retry honors an explicitly supplied displayName", async () => {
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "rename-c1",
+        displayName: "Old Name",
+        role: "contact",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(contactChannels)
+      .values({
+        id: "rename-ch1",
+        contactId: "rename-c1",
+        type: "email",
+        address: "rename@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+      })
+      .run();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "rename@example.com",
+      displayName: "New Name",
+    });
+
+    expect(res.error).toBeUndefined();
+    const store = new ContactStore(db);
+    expect(store.getContact("rename-c1")!.displayName).toBe("New Name");
+  });
+
+  test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "noname@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    const store = new ContactStore(getGatewayDb());
+    expect(store.getContact(contactId)!.displayName).toBe("noname@example.com");
+  });
+
+  test("create_contact applies default unverified/allow to a brand-new channel", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "create_contact", {
+      channelType: "email",
+      address: "fresh@example.com",
+    });
+
+    expect(res.error).toBeUndefined();
+    const { contactId } = res.result as { contactId: string };
+
+    const store = new ContactStore(getGatewayDb());
+    const channels = store.getChannelsForContact(contactId);
+    expect(channels).toHaveLength(1);
+    expect(channels[0].status).toBe("unverified");
+    expect(channels[0].policy).toBe("allow");
+  });
+
+  test("create_contact canonicalizes the address so a non-canonical variant matches", async () => {
+    await startServerAndConnect();
+    // Phone numbers canonicalize to E.164; a variant with spacing/punctuation
+    // must resolve to the same channel on the second call.
+    const first = await sendRequest(client, "create_contact", {
+      channelType: "phone",
+      address: "+1 (555) 010-1234",
+    });
+    const second = await sendRequest(client, "create_contact", {
+      channelType: "phone",
+      address: "+15550101234",
+    });
+
+    expect(first.error).toBeUndefined();
+    expect(second.error).toBeUndefined();
+    const a = first.result as { contactId: string; channelId: string };
+    const b = second.result as { contactId: string; channelId: string };
+    expect(b.contactId).toBe(a.contactId);
+    expect(b.channelId).toBe(a.channelId);
+
+    const store = new ContactStore(getGatewayDb());
+    expect(store.getChannelsForContact(a.contactId)).toHaveLength(1);
+  });
+
   // ── update_contact_channel (gateway-native write) ──────────────────────
   describe("update_contact_channel", () => {
     /** Insert a blocked channel so revoke-of-blocked can be exercised. */

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -6,12 +6,45 @@ import {
   beforeEach,
   afterAll,
   afterEach,
+  mock,
 } from "bun:test";
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { createConnection, type Socket } from "node:net";
 import { eq } from "drizzle-orm";
+
+// ── Assistant DB proxy + IPC mocks ──────────────────────────────────────────
+// The gateway-native channel write (updateContactChannelCore) resolves
+// assistant-side channel IDs and mirrors into the assistant DB over the IPC
+// proxy, and emits contacts_changed via ipcCallAssistant. None of that is
+// reachable in this unit test, so stub both modules. The gateway DB is the
+// source of truth and remains real.
+type DbQueryFn = (sql: string, bind?: unknown[]) => Promise<unknown[]>;
+let assistantDbQueryMock: ReturnType<typeof mock<DbQueryFn>> = mock(
+  async () => [],
+);
+type DbRunFn = (
+  sql: string,
+  bind?: unknown[],
+) => Promise<{ changes: number; lastInsertRowid: number }>;
+let assistantDbRunMock: ReturnType<typeof mock<DbRunFn>> = mock(async () => ({
+  changes: 1,
+  lastInsertRowid: 0,
+}));
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: (...args: Parameters<DbQueryFn>) =>
+    assistantDbQueryMock(...args),
+  assistantDbRun: (...args: Parameters<DbRunFn>) => assistantDbRunMock(...args),
+}));
+
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: mock(async () => ({})),
+  IpcHandlerError: class IpcHandlerError extends Error {},
+  IpcTransportError: class IpcTransportError extends Error {},
+}));
+
 import { GatewayIpcServer } from "../ipc/server.js";
 import { contactRoutes } from "../ipc/contact-handlers.js";
 import { ContactStore } from "../db/contact-store.js";
@@ -33,6 +66,10 @@ beforeEach(() => {
   const db = getGatewayDb();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
+  // Reset assistant-proxy stubs to their permissive defaults: no assistant-side
+  // channel resolution, dual-write succeeds.
+  assistantDbQueryMock = mock(async () => []);
+  assistantDbRunMock = mock(async () => ({ changes: 1, lastInsertRowid: 0 }));
 });
 
 afterAll(() => {
@@ -54,7 +91,13 @@ function sendRequest(
   client: Socket,
   method: string,
   params?: Record<string, unknown>,
-): Promise<{ id: string; result?: unknown; error?: string }> {
+): Promise<{
+  id: string;
+  result?: unknown;
+  error?: string;
+  statusCode?: number;
+  errorCode?: string;
+}> {
   return new Promise((resolve, reject) => {
     const id = randomBytes(4).toString("hex");
     let buffer = "";
@@ -322,5 +365,193 @@ describe("IPC contact routes", () => {
 
     expect(res.error).toBeDefined();
     expect(res.error).toContain("Invalid params");
+  });
+
+  // ── update_contact_channel (gateway-native write) ──────────────────────
+  describe("update_contact_channel", () => {
+    /** Insert a blocked channel so revoke-of-blocked can be exercised. */
+    function seedBlockedChannel(): void {
+      const db = getGatewayDb();
+      db.insert(contactChannels)
+        .values({
+          id: "ch_blocked",
+          contactId: "c2",
+          type: "telegram",
+          address: "tg-blocked-001",
+          isPrimary: false,
+          externalChatId: null,
+          status: "blocked",
+          policy: "deny",
+          interactionCount: 0,
+          createdAt: Date.now(),
+        })
+        .run();
+    }
+
+    test("status update succeeds and writes the gateway DB row", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        status: "active",
+      });
+
+      expect(res.error).toBeUndefined();
+      const body = res.result as { ok: boolean; contact?: { id: string } };
+      expect(body.ok).toBe(true);
+      expect(body.contact?.id).toBe("c2");
+
+      // Gateway DB is the source of truth — the row must reflect the new status.
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.status).toBe("active");
+    });
+
+    test("policy update succeeds and writes the gateway DB row", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        policy: "deny",
+      });
+
+      expect(res.error).toBeUndefined();
+      expect((res.result as { ok: boolean }).ok).toBe(true);
+
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.policy).toBe("deny");
+    });
+
+    test("invalid status is rejected as a 400", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        status: "deleted",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("BAD_REQUEST");
+      expect(res.error).toMatch(/status/);
+    });
+
+    test("invalid policy is rejected as a 400", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        policy: "maybe",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("BAD_REQUEST");
+      expect(res.error).toMatch(/policy/);
+    });
+
+    test("revoking a blocked channel returns the conflict error", async () => {
+      seedTestData();
+      seedBlockedChannel();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch_blocked",
+        status: "revoked",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(409);
+      expect(res.errorCode).toBe("CONFLICT");
+      expect(res.error).toMatch(/blocked/);
+
+      // The blocked row must be untouched.
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch_blocked"))
+        .get();
+      expect(row?.status).toBe("blocked");
+    });
+
+    test("unknown channel ID returns not-found", async () => {
+      seedTestData();
+      // No assistant-side resolution: the proxy query returns no rows.
+      assistantDbQueryMock = mock(async () => []);
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "does-not-exist",
+        status: "active",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(404);
+      expect(res.errorCode).toBe("NOT_FOUND");
+    });
+
+    test("assistant-side channel ID resolves via backward-compat path", async () => {
+      seedTestData();
+      // The given ID is unknown to the gateway DB; the assistant DB resolves it
+      // to the logical key (contactId, type, address) of the existing gateway
+      // channel ch3, which updateChannelStatus then matches.
+      assistantDbQueryMock = mock(async () => [
+        { contactId: "c2", type: "email", address: "test@example.com" },
+      ]);
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "assistant-side-id",
+        status: "active",
+      });
+
+      expect(res.error).toBeUndefined();
+      expect((res.result as { ok: boolean }).ok).toBe(true);
+
+      // The resolved gateway row (ch3) is the one that gets updated.
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.status).toBe("active");
+    });
+
+    test("tolerates assistant-DB dual-write failure (gateway write still succeeds)", async () => {
+      seedTestData();
+      // Dual-write to the assistant DB throws; the gateway write is the source
+      // of truth and must still succeed.
+      assistantDbRunMock = mock(async () => {
+        throw new Error("assistant DB down");
+      });
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        status: "revoked",
+        reason: "spam",
+      });
+
+      expect(res.error).toBeUndefined();
+      expect((res.result as { ok: boolean }).ok).toBe(true);
+
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.status).toBe("revoked");
+    });
   });
 });

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -980,6 +980,80 @@ describe("IPC contact routes", () => {
     expect(fresh.policy).toBe("allow");
   });
 
+  test("multi-channel heal SKIPS a channel owned by a DIFFERENT assistant contact (gateway/assistant ownership stays in sync)", async () => {
+    // Channel A matches the adopted assistant-only contact; channel B is owned
+    // by ANOTHER assistant contact. B must NOT be inserted under the adopted
+    // gateway contact — the assistant mirror skips it as a cross-contact
+    // conflict, so claiming it gateway-side would diverge ACL ownership.
+    const adoptedId = "skip-c1";
+    const otherId = "skip-other";
+
+    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      // Adoption resolves the contact id from channel A.
+      if (
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.type = ?")
+      ) {
+        return [{ contactId: adoptedId, displayName: "Adopted" }];
+      }
+      // Adopted contact owns only channel A.
+      if (
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.contact_id = ?")
+      ) {
+        if (bind?.[0] !== adoptedId) return [];
+        return [
+          {
+            id: "ach-a",
+            type: "email",
+            address: "a@example.com",
+            isPrimary: 1,
+            externalChatId: null,
+            status: "active",
+            policy: "escalate",
+            verifiedAt: 1700000000000,
+            verifiedVia: "manual",
+            inviteId: null,
+            revokedReason: null,
+            blockedReason: null,
+          },
+        ];
+      }
+      // Cross-owner lookup (no `cc.` alias): channel B belongs to otherId.
+      if (
+        sql.includes("FROM contact_channels") &&
+        !sql.includes("cc") &&
+        sql.includes("WHERE type = ?")
+      ) {
+        if (bind?.[1] === "b@example.com") return [{ contactId: otherId }];
+        return [];
+      }
+      return [];
+    });
+    assistantDbRunMock = mock(async () => ({
+      changes: 1,
+      lastInsertRowid: 0,
+    }));
+
+    const store = new ContactStore(getGatewayDb());
+    const { contact } = await store.upsertContact({
+      channels: [
+        { type: "email", address: "a@example.com" },
+        { type: "email", address: "b@example.com" },
+      ],
+    });
+
+    expect(contact.id).toBe(adoptedId);
+    const gwChannels = store.getChannelsForContact(adoptedId);
+    // Only channel A is written under the adopted contact; B is skipped.
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].address).toBe("a@example.com");
+    expect(gwChannels[0].id).toBe("ach-a");
+    expect(
+      gwChannels.some((c) => c.address === "b@example.com"),
+    ).toBe(false);
+  });
+
   test("upsertContact with an explicit id does NOT retarget another contact's metadata", async () => {
     // Update path (Problem 2): an edit carries a channel whose (type,address)
     // is owned by a DIFFERENT assistant contact. The assistant mirror must

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -697,23 +697,33 @@ describe("IPC contact routes", () => {
         sql.includes("WHERE cc.type = ?")
       ) {
         return [
-          {
-            contactId: assistantContactId,
-            id: assistantChannelId,
-            displayName: "Existing Person",
-            type: "email",
-            address: "existing-person@example.com",
-            isPrimary: 0,
-            externalChatId: null,
-            status: "active",
-            policy: "escalate",
-            verifiedAt: 1700000000000,
-            verifiedVia: "manual",
-            inviteId: null,
-            revokedReason: null,
-            blockedReason: null,
-          },
+          { contactId: assistantContactId, displayName: "Existing Person" },
         ];
+      }
+      // Adoption ACL fetch: ALL of the adopted contact's channels by contact id.
+      if (
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.contact_id = ?")
+      ) {
+        if (bind?.[0] === assistantContactId) {
+          return [
+            {
+              id: assistantChannelId,
+              type: "email",
+              address: "existing-person@example.com",
+              isPrimary: 0,
+              externalChatId: null,
+              status: "active",
+              policy: "escalate",
+              verifiedAt: 1700000000000,
+              verifiedVia: "manual",
+              inviteId: null,
+              revokedReason: null,
+              blockedReason: null,
+            },
+          ];
+        }
+        return [];
       }
       // existingCh lookup keyed on the adopted (assistant) contact id.
       if (
@@ -822,6 +832,152 @@ describe("IPC contact routes", () => {
     expect(withInfo!.notes).toBe("knows the family");
     expect(withInfo!.userFile).toBe("existing-person.md");
     expect(withInfo!.contactType).toBe("human");
+  });
+
+  test("multi-channel heal adopts id+ACL for EVERY matched channel, not just the first", async () => {
+    // HTTP POST /v1/contacts heals an assistant-only contact that owns TWO
+    // existing channels, both active/verified with a non-default policy. The
+    // gateway INSERT must carry each channel's assistant id + ACL — a prior
+    // bug adopted only the first match and inserted the rest as fresh
+    // unverified/allow rows, downgrading trust and splitting channel ids.
+    const assistantContactId = "multi-c1";
+
+    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      if (
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.type = ?")
+      ) {
+        return [{ contactId: assistantContactId, displayName: "Two Channels" }];
+      }
+      if (
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.contact_id = ?")
+      ) {
+        if (bind?.[0] !== assistantContactId) return [];
+        return [
+          {
+            id: "ach-email",
+            type: "email",
+            address: "person@example.com",
+            isPrimary: 1,
+            externalChatId: null,
+            status: "active",
+            policy: "escalate",
+            verifiedAt: 1700000000000,
+            verifiedVia: "manual",
+            inviteId: null,
+            revokedReason: null,
+            blockedReason: null,
+          },
+          {
+            id: "ach-tg",
+            type: "telegram",
+            address: "555123",
+            isPrimary: 0,
+            externalChatId: "chat-99",
+            status: "active",
+            policy: "escalate",
+            verifiedAt: 1700000001000,
+            verifiedVia: "challenge",
+            inviteId: null,
+            revokedReason: null,
+            blockedReason: null,
+          },
+        ];
+      }
+      return [];
+    });
+    assistantDbRunMock = mock(async () => ({
+      changes: 1,
+      lastInsertRowid: 0,
+    }));
+
+    const store = new ContactStore(getGatewayDb());
+    const { contact } = await store.upsertContact({
+      channels: [
+        { type: "email", address: "person@example.com" },
+        { type: "telegram", address: "555123" },
+      ],
+    });
+
+    expect(contact.id).toBe(assistantContactId);
+    const gwChannels = store
+      .getChannelsForContact(assistantContactId)
+      .sort((a, b) => a.type.localeCompare(b.type));
+    expect(gwChannels).toHaveLength(2);
+
+    const email = gwChannels.find((c) => c.type === "email")!;
+    expect(email.id).toBe("ach-email");
+    expect(email.status).toBe("active");
+    expect(email.policy).toBe("escalate");
+    expect(email.verifiedVia).toBe("manual");
+
+    const tg = gwChannels.find((c) => c.type === "telegram")!;
+    expect(tg.id).toBe("ach-tg");
+    expect(tg.status).toBe("active");
+    expect(tg.policy).toBe("escalate");
+    expect(tg.verifiedVia).toBe("challenge");
+  });
+
+  test("mixed heal: matched channel adopts id+ACL, genuinely-new channel stays unverified/allow", async () => {
+    const assistantContactId = "mixed-c1";
+
+    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
+      if (
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.type = ?")
+      ) {
+        return [{ contactId: assistantContactId, displayName: "Mixed" }];
+      }
+      if (
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.contact_id = ?")
+      ) {
+        if (bind?.[0] !== assistantContactId) return [];
+        return [
+          {
+            id: "ach-known",
+            type: "email",
+            address: "known@example.com",
+            isPrimary: 1,
+            externalChatId: null,
+            status: "active",
+            policy: "escalate",
+            verifiedAt: 1700000000000,
+            verifiedVia: "manual",
+            inviteId: null,
+            revokedReason: null,
+            blockedReason: null,
+          },
+        ];
+      }
+      return [];
+    });
+    assistantDbRunMock = mock(async () => ({
+      changes: 1,
+      lastInsertRowid: 0,
+    }));
+
+    const store = new ContactStore(getGatewayDb());
+    await store.upsertContact({
+      channels: [
+        { type: "email", address: "known@example.com" },
+        { type: "email", address: "brand-new@example.com" },
+      ],
+    });
+
+    const gwChannels = store.getChannelsForContact(assistantContactId);
+    expect(gwChannels).toHaveLength(2);
+
+    const known = gwChannels.find((c) => c.address === "known@example.com")!;
+    expect(known.id).toBe("ach-known");
+    expect(known.status).toBe("active");
+    expect(known.policy).toBe("escalate");
+
+    const fresh = gwChannels.find((c) => c.address === "brand-new@example.com")!;
+    expect(fresh.id).not.toBe("ach-known");
+    expect(fresh.status).toBe("unverified");
+    expect(fresh.policy).toBe("allow");
   });
 
   test("upsertContact with an explicit id does NOT retarget another contact's metadata", async () => {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -697,6 +697,17 @@ describe("IPC contact routes", () => {
             contactId: assistantContactId,
             id: assistantChannelId,
             displayName: "Existing Person",
+            type: "email",
+            address: "existing-person@example.com",
+            isPrimary: 0,
+            externalChatId: null,
+            status: "active",
+            policy: "escalate",
+            verifiedAt: 1700000000000,
+            verifiedVia: "manual",
+            inviteId: null,
+            revokedReason: null,
+            blockedReason: null,
           },
         ];
       }
@@ -779,6 +790,16 @@ describe("IPC contact routes", () => {
     const gwChannels = store.getChannelsForContact(contactId);
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].address).toBe("existing-person@example.com");
+
+    // The heal must carry the assistant channel's ACL state into the new
+    // gateway row — NOT default it to unverified/allow. An active/verified
+    // assistant channel stays active/verified (status === "active" is what
+    // actor-trust-resolver classifies as trusted_contact), so default
+    // trusted_contacts admission keeps trusting the user post-heal.
+    expect(gwChannels[0].status).toBe("active");
+    expect(gwChannels[0].policy).toBe("escalate");
+    expect(gwChannels[0].verifiedAt).toBe(1700000000000);
+    expect(gwChannels[0].verifiedVia).toBe("manual");
 
     // The gateway read join-by-id resolves the assistant info (NOT null) —
     // proof the two DBs converged on one id.

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -686,12 +686,19 @@ describe("IPC contact routes", () => {
     const assistantChannelId = "assistant-only-ch1";
 
     assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
-      // Channel lookup by (type,address) → the existing assistant contact id.
+      // Channel lookup by (type,address) → the existing assistant contact id
+      // + its display_name (the adoption JOIN).
       if (
-        sql.includes("FROM contact_channels") &&
-        sql.includes("WHERE type = ?")
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.type = ?")
       ) {
-        return [{ contactId: assistantContactId, id: assistantChannelId }];
+        return [
+          {
+            contactId: assistantContactId,
+            id: assistantChannelId,
+            displayName: "Existing Person",
+          },
+        ];
       }
       // existingCh lookup keyed on the adopted (assistant) contact id.
       if (
@@ -763,9 +770,12 @@ describe("IPC contact routes", () => {
     expect(contactUpdate!.bind?.at(-1)).toBe(assistantContactId);
     expect(contactUpdate!.sql).not.toContain("display_name");
 
-    // The gateway DB has the contact + channel under the canonical id.
+    // The gateway DB has the contact + channel under the canonical id, and the
+    // adopted assistant contact's custom display_name is preserved on the
+    // gateway row (not renamed to the bare channel address).
     const store = new ContactStore(getGatewayDb());
     expect(store.getContact(contactId)).toBeDefined();
+    expect(store.getContact(contactId)!.displayName).toBe("Existing Person");
     const gwChannels = store.getChannelsForContact(contactId);
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].address).toBe("existing-person@example.com");
@@ -801,10 +811,10 @@ describe("IPC contact routes", () => {
     // edited contact already exists by id.
     assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
       if (
-        sql.includes("FROM contact_channels") &&
-        sql.includes("WHERE type = ?")
+        sql.includes("FROM contact_channels cc") &&
+        sql.includes("WHERE cc.type = ?")
       ) {
-        return [{ contactId: "other-contact" }];
+        return [{ contactId: "other-contact", displayName: "Other" }];
       }
       if (sql.includes("FROM contacts WHERE id = ?")) {
         if (bind?.[0] === "edit-me") return [{ userFile: "edit-me.md" }];

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -402,6 +402,10 @@ describe("IPC contact routes", () => {
     const channels = store.getChannelsForContact(contactId);
     expect(channels).toHaveLength(1);
     expect(channels[0].id).toBe(channelId);
+    // No assistant adoption match → a freshly minted UUID, not an adopted id.
+    expect(channels[0].id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
     expect(channels[0].type).toBe("email");
     expect(channels[0].address).toBe("new@example.com");
     expect(channels[0].isPrimary).toBe(true);
@@ -759,10 +763,17 @@ describe("IPC contact routes", () => {
     });
 
     expect(res.error).toBeUndefined();
-    const { contactId } = res.result as { contactId: string };
+    const { contactId, channelId } = res.result as {
+      contactId: string;
+      channelId: string;
+    };
 
     // The returned (gateway) id IS the existing assistant id — one canonical id.
     expect(contactId).toBe(assistantContactId);
+    // The gateway channel row adopts the assistant channel id (one canonical
+    // channel id), so the returned channelId equals it — a follow-up verify by
+    // this id can't 404 on a split-brain row.
+    expect(channelId).toBe(assistantChannelId);
 
     // No duplicate assistant contact INSERT; the existing channel is updated,
     // not re-inserted.
@@ -790,6 +801,9 @@ describe("IPC contact routes", () => {
     const gwChannels = store.getChannelsForContact(contactId);
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].address).toBe("existing-person@example.com");
+    // Canonical channel id: the gateway row shares the assistant channel's id
+    // (not a freshly minted UUID), so verify-by-id resolves the gateway row.
+    expect(gwChannels[0].id).toBe(assistantChannelId);
 
     // The heal must carry the assistant channel's ACL state into the new
     // gateway row — NOT default it to unverified/allow. An active/verified

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1104,10 +1104,12 @@ export class ContactStore {
     // join-by-id read path. Soft-fails to a minted id if the lookup throws
     // (daemon down / tests) — the assistant-mirror best-effort invariant.
     let adoptedChannelAcls: Map<string, AdoptedChannelAcl> | undefined;
+    let crossOwnedKeys: Set<string> | undefined;
     if (!contactId) {
       const adopted = await this.adoptAssistantContactId(canonicalChannels);
       contactId = adopted?.contactId ?? crypto.randomUUID();
       adoptedChannelAcls = adopted?.channelAcls;
+      crossOwnedKeys = adopted?.crossOwnedKeys;
       // An adopted id may already exist as a gateway row (different channels);
       // preserve it (name omit-to-preserve) instead of a conflicting INSERT.
       const existing = adopted
@@ -1143,11 +1145,29 @@ export class ContactStore {
     }
 
     // ── 4. Sync channels (gateway DB) ─────────────────────────────────
+    // Drop any requested channel owned by a DIFFERENT assistant contact: the
+    // gateway must not insert it under the adopted contact, because the
+    // assistant mirror skips it as a cross-contact conflict — claiming it
+    // gateway-side would diverge ACL ownership and risk routing the wrong
+    // contact. Genuinely-unowned channels stay and insert as new.
+    const healChannels = crossOwnedKeys?.size
+      ? canonicalChannels?.filter((ch) => {
+          const owned = crossOwnedKeys!.has(adoptedChannelKey(ch.type, ch.address));
+          if (owned) {
+            log.warn(
+              { contactId, type: ch.type, address: ch.address },
+              "upsertContact: skipping create-heal channel owned by another assistant contact (keeping gateway/assistant ownership in sync)",
+            );
+          }
+          return !owned;
+        })
+      : canonicalChannels;
+
     // Carry the adopted assistant channel's ACL state into the heal INSERT so
     // an active/verified contact isn't downgraded to unverified/allow.
     const channelsToSync = adoptedChannelAcls?.size
-      ? this.mergeAdoptedChannelAcl(canonicalChannels, adoptedChannelAcls)
-      : canonicalChannels;
+      ? this.mergeAdoptedChannelAcl(healChannels, adoptedChannelAcls)
+      : healChannels;
     if (channelsToSync?.length) {
       this.syncChannels(contactId, channelsToSync, now);
     }
@@ -1781,6 +1801,11 @@ export class ContactStore {
     contactId: string;
     displayName: string | null;
     channelAcls: Map<string, AdoptedChannelAcl>;
+    // (type,address) keys of requested channels owned by a DIFFERENT assistant
+    // contact than the adopted one. The gateway must not insert these under the
+    // adopted contact — the assistant mirror skips them as cross-contact
+    // conflicts, so claiming them gateway-side diverges ownership.
+    crossOwnedKeys: Set<string>;
   } | null> {
     try {
       for (const ch of channels ?? []) {
@@ -1850,7 +1875,26 @@ export class ContactStore {
             blockedReason: r.blockedReason,
           });
         }
-        return { contactId, displayName, channelAcls };
+
+        // For requested channels NOT owned by the adopted contact, flag any
+        // already owned by a DIFFERENT assistant contact so the create-heal
+        // path skips inserting them under the adopted gateway contact (the
+        // assistant mirror skips them too — keep ownership symmetric).
+        const crossOwnedKeys = new Set<string>();
+        for (const reqCh of channels ?? []) {
+          const key = adoptedChannelKey(reqCh.type, reqCh.address);
+          if (channelAcls.has(key)) continue;
+          const owner = await assistantDbQuery<{ contactId: string }>(
+            `SELECT contact_id AS contactId FROM contact_channels
+              WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1`,
+            [reqCh.type, reqCh.address],
+          );
+          if (owner.length && owner[0].contactId !== contactId) {
+            crossOwnedKeys.add(key);
+          }
+        }
+
+        return { contactId, displayName, channelAcls, crossOwnedKeys };
       }
     } catch (err) {
       log.warn(

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -352,8 +352,7 @@ export class ContactStore {
       .where(eq(contactChannels.id, channelId))
       .get();
 
-    // If not found in the gateway DB, resolve from the assistant DB by
-    // logical key (contactId, type, address) and find the matching gateway row.
+    // If not found in the gateway DB, resolve from the assistant DB by id.
     if (!gwChannel) {
       const assistantChannel = await assistantDbQuery<{
         contactId: string;
@@ -362,9 +361,12 @@ export class ContactStore {
       }>(
         "SELECT contact_id AS contactId, type, address FROM contact_channels WHERE id = ?",
         [channelId],
-      );
+      ).catch(() => []);
+
       if (assistantChannel.length > 0) {
         const { contactId, type, address } = assistantChannel[0];
+        // A gateway row may already exist under a DIFFERENT id (same logical
+        // channel) — resolve by logical key first.
         gwChannel = this.db
           .select()
           .from(contactChannels)
@@ -376,6 +378,30 @@ export class ContactStore {
             ),
           )
           .get();
+
+        // Still absent → legacy assistant-only channel. Mirror it (plus its
+        // parent contact) into the gateway DB so the status write resolves
+        // instead of 404ing — matching the verify path. The mirror reuses the
+        // assistant-side id; soft-fails to 404 when the assistant DB is
+        // unreachable.
+        if (!gwChannel) {
+          const mirrored = await this.mirrorChannelFromAssistantIfMissing(
+            channelId,
+          ).catch((err) => {
+            log.warn(
+              { channelId, err },
+              "updateChannelStatus: assistant-only backfill failed (best-effort)",
+            );
+            return false;
+          });
+          if (mirrored) {
+            gwChannel = this.db
+              .select()
+              .from(contactChannels)
+              .where(eq(contactChannels.id, channelId))
+              .get();
+          }
+        }
       }
     }
 
@@ -999,11 +1025,11 @@ export class ContactStore {
     // join-by-id read path. Soft-fails to a minted id if the lookup throws
     // (daemon down / tests) — the assistant-mirror best-effort invariant.
     if (!contactId) {
-      const adoptedId = await this.adoptAssistantContactId(canonicalChannels);
-      contactId = adoptedId ?? crypto.randomUUID();
+      const adopted = await this.adoptAssistantContactId(canonicalChannels);
+      contactId = adopted?.contactId ?? crypto.randomUUID();
       // An adopted id may already exist as a gateway row (different channels);
       // preserve it (name omit-to-preserve) instead of a conflicting INSERT.
-      const existing = adoptedId
+      const existing = adopted
         ? this.db
             .select({ id: contacts.id })
             .from(contacts)
@@ -1013,11 +1039,18 @@ export class ContactStore {
       if (existing) {
         updateContactName(contactId);
       } else {
+        // No displayName supplied → preserve the adopted assistant contact's
+        // existing name (a migrated custom name) so the gateway row doesn't
+        // get renamed to the bare channel address on the next refetch.
         this.db
           .insert(contacts)
           .values({
             id: contactId,
-            displayName: newContactName,
+            displayName:
+              params.displayName ??
+              adopted?.displayName ??
+              canonicalChannels?.[0]?.address ??
+              "Unknown",
             role: "contact",
             principalId: null,
             createdAt: now,
@@ -1605,24 +1638,37 @@ export class ContactStore {
    * When creating a contact (no explicit id, no gateway (type, address) match),
    * look up an existing contact in the ASSISTANT DB owning one of the provided
    * channels (by the same logical key the gateway uses). If found, return its
-   * id so the gateway INSERT + channels + mirror all share ONE canonical id —
-   * healing a legacy assistant-only contact instead of forking the two DBs onto
-   * different ids. Returns null when there's no match or the lookup soft-fails
-   * (daemon down / tests), so the caller falls back to a freshly minted id.
+   * id + existing display_name so the gateway INSERT + channels + mirror all
+   * share ONE canonical id — healing a legacy assistant-only contact instead of
+   * forking the two DBs onto different ids. The display_name lets the create
+   * path preserve a migrated custom name when the caller omits displayName.
+   * Returns null when there's no match or the lookup soft-fails (daemon down /
+   * tests), so the caller falls back to a freshly minted id.
    *
    * Never called on the explicit-id update path — an edit must not retarget
    * another contact (the gateway syncChannels skips cross-contact channels).
    */
   private async adoptAssistantContactId(
     channels: Parameters<ContactStore["upsertContact"]>[0]["channels"],
-  ): Promise<string | null> {
+  ): Promise<{ contactId: string; displayName: string | null } | null> {
     try {
       for (const ch of channels ?? []) {
-        const rows = await assistantDbQuery<{ contactId: string }>(
-          "SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
+        const rows = await assistantDbQuery<{
+          contactId: string;
+          displayName: string | null;
+        }>(
+          `SELECT cc.contact_id AS contactId, c.display_name AS displayName
+             FROM contact_channels cc
+             JOIN contacts c ON c.id = cc.contact_id
+            WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
+            LIMIT 1`,
           [ch.type, ch.address],
         );
-        if (rows.length) return rows[0].contactId;
+        if (rows.length)
+          return {
+            contactId: rows[0].contactId,
+            displayName: rows[0].displayName,
+          };
       }
     } catch (err) {
       log.warn(

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1487,8 +1487,15 @@ export class ContactStore {
 
       if (existingCh.length) {
         const isBlocked = existingCh[0].status === "blocked";
-        const setParts: string[] = ["external_chat_id = ?", "updated_at = ?"];
-        const setParams: SqliteValue[] = [ch.externalChatId ?? null, now];
+        // Omit-to-preserve: only overwrite external_chat_id when the caller
+        // supplied one, mirroring syncChannels (gateway DB). A sparse upsert
+        // (no externalChatId) must not clear an existing delivery chat id.
+        const setParts: string[] = ["updated_at = ?"];
+        const setParams: SqliteValue[] = [now];
+        if (ch.externalChatId !== undefined) {
+          setParts.push("external_chat_id = ?");
+          setParams.push(ch.externalChatId);
+        }
         if (!isBlocked) {
           if (ch.status !== undefined) {
             setParts.push("status = ?");

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -371,24 +371,24 @@ export class ContactStore {
     // If not found in the gateway DB, resolve from the assistant DB by id.
     if (!gwChannel) {
       const assistantChannel = await assistantDbQuery<{
-        contactId: string;
         type: string;
         address: string;
-      }>(
-        "SELECT contact_id AS contactId, type, address FROM contact_channels WHERE id = ?",
-        [channelId],
-      ).catch(() => []);
+      }>("SELECT type, address FROM contact_channels WHERE id = ?", [
+        channelId,
+      ]).catch(() => []);
 
       if (assistantChannel.length > 0) {
-        const { contactId, type, address } = assistantChannel[0];
+        const { type, address } = assistantChannel[0];
         // A gateway row may already exist under a DIFFERENT id (same logical
-        // channel) — resolve by logical key first.
+        // channel). `(type, address)` is globally UNIQUE, so resolve it
+        // globally — a split-brain row living under a different contact id is
+        // the existing gateway ACL we must update, not a row to re-mirror
+        // (which would hit the unique constraint and 404).
         gwChannel = this.db
           .select()
           .from(contactChannels)
           .where(
             and(
-              eq(contactChannels.contactId, contactId),
               eq(contactChannels.type, type),
               sql`${contactChannels.address} = ${address} COLLATE NOCASE`,
             ),
@@ -771,16 +771,18 @@ export class ContactStore {
     if (params.contactId !== undefined)
       conditions.push(eq(ingressInvites.contactId, params.contactId));
 
-    return this.db
-      .select()
-      .from(ingressInvites)
-      .where(conditions.length ? and(...conditions) : undefined)
-      // Secondary sort on id keeps ordering (and offset pagination) stable when
-      // multiple invites share a createdAt millisecond.
-      .orderBy(desc(ingressInvites.createdAt), desc(ingressInvites.id))
-      .limit(params.limit ?? 100)
-      .offset(params.offset ?? 0)
-      .all();
+    return (
+      this.db
+        .select()
+        .from(ingressInvites)
+        .where(conditions.length ? and(...conditions) : undefined)
+        // Secondary sort on id keeps ordering (and offset pagination) stable when
+        // multiple invites share a createdAt millisecond.
+        .orderBy(desc(ingressInvites.createdAt), desc(ingressInvites.id))
+        .limit(params.limit ?? 100)
+        .offset(params.offset ?? 0)
+        .all()
+    );
   }
 
   createInvite(params: {
@@ -973,11 +975,7 @@ export class ContactStore {
       if (params.displayName !== undefined) {
         updateSet.displayName = params.displayName;
       }
-      this.db
-        .update(contacts)
-        .set(updateSet)
-        .where(eq(contacts.id, id))
-        .run();
+      this.db.update(contacts).set(updateSet).where(eq(contacts.id, id)).run();
     };
 
     // ── 1. Look up by id ──────────────────────────────────────────────

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -873,10 +873,14 @@ export class ContactStore {
    * /v1/contacts rebind the guardian. On update, existing role/principalId
    * are preserved. On create, role defaults to "contact" and principalId
    * to null.
+   *
+   * `displayName` is omit-to-preserve: when undefined, an existing contact's
+   * name is left untouched (gateway DB + assistant mirror). A brand-new
+   * contact with no name falls back to the first channel's canonical address.
    */
   async upsertContact(params: {
     id?: string;
-    displayName: string;
+    displayName?: string;
     notes?: string | null;
     contactType?: string;
     assistantMetadata?: {
@@ -909,6 +913,25 @@ export class ContactStore {
       address: canonicalizeInboundIdentity(ch.type, ch.address) ?? ch.address,
     }));
 
+    // Fallback name for a brand-new contact created without an explicit
+    // displayName: the first channel's canonical address, else "Unknown".
+    const newContactName =
+      params.displayName ?? canonicalChannels?.[0]?.address ?? "Unknown";
+
+    // Omit-to-preserve: only overwrite an existing contact's displayName when
+    // the caller supplied one. Mirrors the role/principalId preservation.
+    const updateContactName = (id: string): void => {
+      const updateSet: Record<string, unknown> = { updatedAt: now };
+      if (params.displayName !== undefined) {
+        updateSet.displayName = params.displayName;
+      }
+      this.db
+        .update(contacts)
+        .set(updateSet)
+        .where(eq(contacts.id, id))
+        .run();
+    };
+
     // ── 1. Look up by id ──────────────────────────────────────────────
     if (contactId) {
       const existing = this.db
@@ -920,20 +943,13 @@ export class ContactStore {
       if (existing) {
         // Preserve existing role/principalId — they're never overwritten by
         // this code path. Guardian binding is owned by guardian-bootstrap.
-        this.db
-          .update(contacts)
-          .set({
-            displayName: params.displayName,
-            updatedAt: now,
-          })
-          .where(eq(contacts.id, contactId))
-          .run();
+        updateContactName(contactId);
       } else {
         this.db
           .insert(contacts)
           .values({
             id: contactId,
-            displayName: params.displayName,
+            displayName: newContactName,
             role: "contact",
             principalId: null,
             createdAt: now,
@@ -962,14 +978,7 @@ export class ContactStore {
 
         if (match) {
           contactId = match.contactId;
-          this.db
-            .update(contacts)
-            .set({
-              displayName: params.displayName,
-              updatedAt: now,
-            })
-            .where(eq(contacts.id, contactId))
-            .run();
+          updateContactName(contactId);
           break;
         }
       }
@@ -982,7 +991,7 @@ export class ContactStore {
         .insert(contacts)
         .values({
           id: contactId,
-          displayName: params.displayName,
+          displayName: newContactName,
           role: "contact",
           principalId: null,
           createdAt: now,
@@ -1002,12 +1011,7 @@ export class ContactStore {
       ? { ...params, channels: canonicalChannels }
       : params;
     try {
-      await this.dualWriteContactToAssistantDb(
-        contactId,
-        canonicalParams,
-        now,
-        created,
-      );
+      await this.dualWriteContactToAssistantDb(contactId, canonicalParams, now);
     } catch (err) {
       log.warn(
         { contactId, err },
@@ -1407,21 +1411,32 @@ export class ContactStore {
     contactId: string,
     params: Parameters<ContactStore["upsertContact"]>[0],
     now: number,
-    isNew: boolean,
   ): Promise<void> {
+    // Reconcile against an assistant-only contact: when the gateway minted a
+    // new id but the assistant DB already holds one of the provided channels
+    // (by (type, address)), adopt that existing assistant contact id instead
+    // of inserting a duplicate keyed by the new gateway id. Heals the
+    // split-brain case where the contact pre-dates the gateway dual-write.
+    const targetId = await this.resolveAssistantContactId(contactId, params);
+
     const existing = await assistantDbQuery<{ userFile: string | null }>(
       "SELECT user_file AS userFile FROM contacts WHERE id = ?",
-      [contactId],
+      [targetId],
     );
 
     if (existing.length) {
       // Dynamic SET clause: only touch fields the caller actually provided.
       // role / principal_id are intentionally never updated from this path —
       // they're not in the params surface and the assistant DB already holds
-      // the values written by guardian-bootstrap.
-      const setParts: string[] = ["display_name = ?", "updated_at = ?"];
-      const setParams: SqliteValue[] = [params.displayName, now];
+      // the values written by guardian-bootstrap. display_name is
+      // omit-to-preserve so a sparse upsert can't revert a custom name.
+      const setParts: string[] = ["updated_at = ?"];
+      const setParams: SqliteValue[] = [now];
 
+      if (params.displayName !== undefined) {
+        setParts.push("display_name = ?");
+        setParams.push(params.displayName);
+      }
       if (params.notes !== undefined) {
         setParts.push("notes = ?");
         setParams.push(params.notes ?? null);
@@ -1430,15 +1445,17 @@ export class ContactStore {
         setParts.push("contact_type = ?");
         setParams.push(params.contactType);
       }
-      setParams.push(contactId);
+      setParams.push(targetId);
 
       await assistantDbRun(
         `UPDATE contacts SET ${setParts.join(", ")} WHERE id = ?`,
         setParams,
       );
     } else {
+      const displayName =
+        params.displayName ?? params.channels?.[0]?.address ?? "Unknown";
       const userFile = await this.resolveAssistantUserFileSlug(
-        params.displayName,
+        displayName,
         null,
       );
       await assistantDbRun(
@@ -1447,8 +1464,8 @@ export class ContactStore {
             user_file, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
-          contactId,
-          params.displayName,
+          targetId,
+          displayName,
           params.notes ?? null,
           "contact",
           params.contactType ?? "human",
@@ -1469,7 +1486,7 @@ export class ContactStore {
            species  = excluded.species,
            metadata = excluded.metadata`,
         [
-          contactId,
+          targetId,
           params.assistantMetadata.species,
           params.assistantMetadata.metadata != null
             ? JSON.stringify(params.assistantMetadata.metadata)
@@ -1482,7 +1499,7 @@ export class ContactStore {
     for (const ch of params.channels ?? []) {
       const existingCh = await assistantDbQuery<{ id: string; status: string }>(
         "SELECT id, status FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
-        [contactId, ch.type, ch.address],
+        [targetId, ch.type, ch.address],
       );
 
       if (existingCh.length) {
@@ -1520,7 +1537,8 @@ export class ContactStore {
         if (conflict.length) continue;
 
         // Reuse the gateway channel ID so assistant and gateway channel
-        // rows share the same UUID for the same logical channel.
+        // rows share the same UUID for the same logical channel. The gateway
+        // row lives under the gateway contactId regardless of reconciliation.
         const gatewayChannel = this.db
           .select({ id: contactChannels.id })
           .from(contactChannels)
@@ -1542,7 +1560,7 @@ export class ContactStore {
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
           [
             channelId,
-            contactId,
+            targetId,
             ch.type,
             ch.address,
             ch.isPrimary ? 1 : 0,
@@ -1555,9 +1573,35 @@ export class ContactStore {
         );
       }
     }
+  }
 
-    // Touch the variable so the parameter isn't flagged unused.
-    void isNew;
+  /**
+   * Resolve which assistant-DB contact id the dual-write should target.
+   *
+   * Returns the gateway `contactId` unless one of the provided channels
+   * already exists in the assistant DB under a different contact (by (type,
+   * address)). In that split-brain case it returns the existing assistant
+   * contact id so the mirror reconciles into it instead of inserting a
+   * duplicate keyed by the gateway id.
+   *
+   * The lookup is by (type, address) — the same logical key the gateway uses
+   * — so a legacy assistant-only contact heals onto the gateway id at the
+   * channel layer while its assistant row/identity is preserved.
+   */
+  private async resolveAssistantContactId(
+    contactId: string,
+    params: Parameters<ContactStore["upsertContact"]>[0],
+  ): Promise<string> {
+    for (const ch of params.channels ?? []) {
+      const rows = await assistantDbQuery<{ contactId: string }>(
+        "SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
+        [ch.type, ch.address],
+      );
+      if (rows.length && rows[0].contactId !== contactId) {
+        return rows[0].contactId;
+      }
+    }
+    return contactId;
   }
 
   /**

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -42,6 +42,12 @@ type AdoptedChannelAcl = {
   blockedReason: string | null;
 };
 
+/** Canonical (type,address) key for matching adopted channels, COLLATE
+ * NOCASE-equivalent — same logical key the gateway uses to dedupe channels. */
+function adoptedChannelKey(type: string, address: string): string {
+  return `${type}\n${address.toLowerCase()}`;
+}
+
 export class ContactStore {
   private injectedDb?: GatewayDb;
 
@@ -1082,11 +1088,11 @@ export class ContactStore {
     // it, so a "healed" assistant-only contact's info reads back via the
     // join-by-id read path. Soft-fails to a minted id if the lookup throws
     // (daemon down / tests) — the assistant-mirror best-effort invariant.
-    let adoptedChannelAcl: AdoptedChannelAcl | undefined;
+    let adoptedChannelAcls: Map<string, AdoptedChannelAcl> | undefined;
     if (!contactId) {
       const adopted = await this.adoptAssistantContactId(canonicalChannels);
       contactId = adopted?.contactId ?? crypto.randomUUID();
-      adoptedChannelAcl = adopted?.channelAcl;
+      adoptedChannelAcls = adopted?.channelAcls;
       // An adopted id may already exist as a gateway row (different channels);
       // preserve it (name omit-to-preserve) instead of a conflicting INSERT.
       const existing = adopted
@@ -1124,8 +1130,8 @@ export class ContactStore {
     // ── 4. Sync channels (gateway DB) ─────────────────────────────────
     // Carry the adopted assistant channel's ACL state into the heal INSERT so
     // an active/verified contact isn't downgraded to unverified/allow.
-    const channelsToSync = adoptedChannelAcl
-      ? this.mergeAdoptedChannelAcl(canonicalChannels, adoptedChannelAcl)
+    const channelsToSync = adoptedChannelAcls?.size
+      ? this.mergeAdoptedChannelAcl(canonicalChannels, adoptedChannelAcls)
       : canonicalChannels;
     if (channelsToSync?.length) {
       this.syncChannels(contactId, channelsToSync, now);
@@ -1515,22 +1521,21 @@ export class ContactStore {
   }
 
   /**
-   * Merge an adopted assistant channel's ACL fields into the matching
-   * (type,address) channel of a create-heal upsert, omit-to-preserve so any
-   * field the caller explicitly supplied still wins. The enriched channel
+   * Merge adopted assistant channels' ACL fields into the matching
+   * (type,address) channels of a create-heal upsert, omit-to-preserve so any
+   * field the caller explicitly supplied still wins. Each enriched channel
    * carries the assistant row's real status/policy/verification into
    * syncChannels' INSERT — without this, the heal would default an active
-   * channel to unverified/allow and downgrade a trusted contact.
+   * channel to unverified/allow and downgrade a trusted contact. Requested
+   * channels with no assistant match stay genuinely-new (fresh id later).
    */
   private mergeAdoptedChannelAcl(
     channels: Parameters<ContactStore["upsertContact"]>[0]["channels"],
-    acl: AdoptedChannelAcl,
+    acls: Map<string, AdoptedChannelAcl>,
   ): Parameters<ContactStore["upsertContact"]>[0]["channels"] {
     return channels?.map((ch) => {
-      const sameAddress =
-        ch.type === acl.type &&
-        ch.address.toLowerCase() === acl.address.toLowerCase();
-      if (!sameAddress) return ch;
+      const acl = acls.get(adoptedChannelKey(ch.type, ch.address));
+      if (!acl) return ch;
       return {
         ...ch,
         // Adopt the assistant channel id so syncChannels' INSERT shares it.
@@ -1745,10 +1750,12 @@ export class ContactStore {
    * Returns null when there's no match or the lookup soft-fails (daemon down /
    * tests), so the caller falls back to a freshly minted id.
    *
-   * The matched channel's ACL fields (status/policy/verification) ride along so
-   * the create path can carry them into syncChannels' INSERT — without them the
-   * new gateway row would default to unverified/allow, DOWNGRADING an already
-   * active/trusted assistant channel below the trusted_contacts admission floor.
+   * Every adopted channel's ACL fields (status/policy/verification) ride along
+   * keyed by canonical (type,address) so the create path can carry them into
+   * syncChannels' INSERT — without them the new gateway rows would default to
+   * unverified/allow, DOWNGRADING already active/trusted assistant channels
+   * below the trusted_contacts admission floor. Multi-channel heals must adopt
+   * EVERY matched channel, not just the first one the contact id resolved on.
    *
    * Never called on the explicit-id update path — an edit must not retarget
    * another contact (the gateway syncChannels skips cross-contact channels).
@@ -1758,13 +1765,29 @@ export class ContactStore {
   ): Promise<{
     contactId: string;
     displayName: string | null;
-    channelAcl?: AdoptedChannelAcl;
+    channelAcls: Map<string, AdoptedChannelAcl>;
   } | null> {
     try {
       for (const ch of channels ?? []) {
         const rows = await assistantDbQuery<{
           contactId: string;
           displayName: string | null;
+        }>(
+          `SELECT cc.contact_id  AS contactId,
+                  c.display_name AS displayName
+             FROM contact_channels cc
+             JOIN contacts c ON c.id = cc.contact_id
+            WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
+            LIMIT 1`,
+          [ch.type, ch.address],
+        );
+        if (!rows.length) continue;
+
+        // Contact id resolved on the first match. Now fetch ALL of that
+        // contact's channels in one query so a multi-channel heal adopts each
+        // requested channel's id + ACL, not just the one that matched first.
+        const { contactId, displayName } = rows[0];
+        const aclRows = await assistantDbQuery<{
           id: string;
           type: string;
           address: string;
@@ -1778,9 +1801,7 @@ export class ContactStore {
           revokedReason: string | null;
           blockedReason: string | null;
         }>(
-          `SELECT cc.contact_id      AS contactId,
-                  c.display_name     AS displayName,
-                  cc.id,
+          `SELECT cc.id,
                   cc.type,
                   cc.address,
                   cc.is_primary      AS isPrimary,
@@ -1793,32 +1814,28 @@ export class ContactStore {
                   cc.revoked_reason  AS revokedReason,
                   cc.blocked_reason  AS blockedReason
              FROM contact_channels cc
-             JOIN contacts c ON c.id = cc.contact_id
-            WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-            LIMIT 1`,
-          [ch.type, ch.address],
+            WHERE cc.contact_id = ?`,
+          [contactId],
         );
-        if (rows.length) {
-          const r = rows[0];
-          return {
-            contactId: r.contactId,
-            displayName: r.displayName,
-            channelAcl: {
-              id: r.id,
-              type: r.type,
-              address: r.address,
-              isPrimary: Boolean(r.isPrimary),
-              externalChatId: r.externalChatId,
-              status: r.status,
-              policy: r.policy,
-              verifiedAt: r.verifiedAt,
-              verifiedVia: r.verifiedVia,
-              inviteId: r.inviteId,
-              revokedReason: r.revokedReason,
-              blockedReason: r.blockedReason,
-            },
-          };
+
+        const channelAcls = new Map<string, AdoptedChannelAcl>();
+        for (const r of aclRows) {
+          channelAcls.set(adoptedChannelKey(r.type, r.address), {
+            id: r.id,
+            type: r.type,
+            address: r.address,
+            isPrimary: Boolean(r.isPrimary),
+            externalChatId: r.externalChatId,
+            status: r.status,
+            policy: r.policy,
+            verifiedAt: r.verifiedAt,
+            verifiedVia: r.verifiedVia,
+            inviteId: r.inviteId,
+            revokedReason: r.revokedReason,
+            blockedReason: r.blockedReason,
+          });
         }
+        return { contactId, displayName, channelAcls };
       }
     } catch (err) {
       log.warn(

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -483,10 +483,12 @@ export class ContactStore {
       policy?: string;
       revokedReason?: string | null;
       blockedReason?: string | null;
+      verifiedAt?: number | null;
+      verifiedVia?: string | null;
     },
-  ): Promise<void> {
+  ): Promise<boolean> {
     const setClauses: string[] = [];
-    const bind: (string | null)[] = [];
+    const bind: (string | number | null)[] = [];
 
     if (params.status !== undefined) {
       setClauses.push("status = ?");
@@ -504,8 +506,16 @@ export class ContactStore {
       setClauses.push("blocked_reason = ?");
       bind.push(params.blockedReason);
     }
+    if (params.verifiedAt !== undefined) {
+      setClauses.push("verified_at = ?");
+      bind.push(params.verifiedAt);
+    }
+    if (params.verifiedVia !== undefined) {
+      setClauses.push("verified_via = ?");
+      bind.push(params.verifiedVia);
+    }
 
-    if (setClauses.length === 0) return;
+    if (setClauses.length === 0) return false;
 
     setClauses.push("updated_at = ?");
     bind.push(String(Date.now()));
@@ -515,26 +525,26 @@ export class ContactStore {
       `UPDATE contact_channels SET ${setClauses.join(", ")} WHERE id = ?`,
       bind,
     );
+    if (result.changes > 0) return true;
 
     // Legacy channels may have a different assistant-side ID. If the ID-keyed
     // update touched zero rows, resolve by (contactId, type, address) and
     // retry so the assistant mirror stays consistent.
-    if (result.changes === 0) {
-      const gwChannel = this.db
-        .select()
-        .from(contactChannels)
-        .where(eq(contactChannels.id, channelId))
-        .get();
-      if (!gwChannel) return;
+    const gwChannel = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (!gwChannel) return false;
 
-      const logicalBind = bind.slice(0, -1); // drop the channelId
-      logicalBind.push(gwChannel.contactId, gwChannel.type, gwChannel.address);
-      await assistantDbRun(
-        `UPDATE contact_channels SET ${setClauses.join(", ")}
+    const logicalBind = bind.slice(0, -1); // drop the channelId
+    logicalBind.push(gwChannel.contactId, gwChannel.type, gwChannel.address);
+    const retry = await assistantDbRun(
+      `UPDATE contact_channels SET ${setClauses.join(", ")}
          WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE`,
-        logicalBind,
-      );
-    }
+      logicalBind,
+    );
+    return retry.changes > 0;
   }
 
   /**
@@ -774,14 +784,19 @@ export class ContactStore {
     // wrote (best-effort dual-write). Skipping the no-op case prevents
     // spurious verified_at/updated_at drift in the assistant DB on idempotent
     // calls. The gateway DB remains source of truth.
+    //
+    // Key the mirror by the ORIGINAL assistant channel id, not the resolved
+    // gateway `targetId`: on the split-id path they differ and the assistant
+    // row is keyed by `channelId`, so mirroring by `targetId` would no-op.
+    // The dual-write's logical (contactId,type,address) fallback covers rows
+    // keyed differently from the id.
     if (didWrite) {
       try {
-        await assistantDbRun(
-          `UPDATE contact_channels
-             SET status = 'active', verified_at = ?, verified_via = 'manual', updated_at = ?
-           WHERE id = ?`,
-          [now, now, targetId],
-        );
+        await this.dualWriteChannelStatusToAssistantDb(channelId, {
+          status: "active",
+          verifiedAt: now,
+          verifiedVia: "manual",
+        });
       } catch (err) {
         log.warn(
           { channelId, targetId, err },

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -851,8 +851,14 @@ export class ContactStore {
    *
    * Resolution order (mirrors the assistant's upsertContact):
    *  1. Match by `params.id` if provided.
-   *  2. Match by (type, address) on any provided channel.
-   *  3. Create a new contact with a generated id.
+   *  2. Match by (type, address) on a provided channel in the gateway DB.
+   *  3. Create: adopt an existing assistant-DB contact id for the same channel
+   *     (canonical-id heal), else mint a fresh id.
+   *
+   * Steps 2 and 3 (channel-match + assistant-id adoption) run on the create
+   * path only — when no explicit `id` is supplied. An explicit id is an update
+   * and keys the gateway row + assistant mirror to that id directly, so an edit
+   * can't retarget another contact's metadata.
    *
    * Channel sync follows the same no-reassignment path: existing channels
    * on the same contact are updated; conflicting channels on a different
@@ -985,20 +991,41 @@ export class ContactStore {
     }
 
     // ── 3. Create new ─────────────────────────────────────────────────
+    // Create-only canonical-id adoption: before minting a fresh id, check the
+    // assistant DB for an existing contact owning one of these channels (by
+    // (type, address)). Adopting that id keeps both DBs keyed by ONE canonical
+    // id — the gateway INSERT, syncChannels, and the assistant mirror all use
+    // it, so a "healed" assistant-only contact's info reads back via the
+    // join-by-id read path. Soft-fails to a minted id if the lookup throws
+    // (daemon down / tests) — the assistant-mirror best-effort invariant.
     if (!contactId) {
-      contactId = crypto.randomUUID();
-      this.db
-        .insert(contacts)
-        .values({
-          id: contactId,
-          displayName: newContactName,
-          role: "contact",
-          principalId: null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .run();
-      created = true;
+      const adoptedId = await this.adoptAssistantContactId(canonicalChannels);
+      contactId = adoptedId ?? crypto.randomUUID();
+      // An adopted id may already exist as a gateway row (different channels);
+      // preserve it (name omit-to-preserve) instead of a conflicting INSERT.
+      const existing = adoptedId
+        ? this.db
+            .select({ id: contacts.id })
+            .from(contacts)
+            .where(eq(contacts.id, contactId))
+            .get()
+        : undefined;
+      if (existing) {
+        updateContactName(contactId);
+      } else {
+        this.db
+          .insert(contacts)
+          .values({
+            id: contactId,
+            displayName: newContactName,
+            role: "contact",
+            principalId: null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run();
+        created = true;
+      }
     }
 
     // ── 4. Sync channels (gateway DB) ─────────────────────────────────
@@ -1412,16 +1439,14 @@ export class ContactStore {
     params: Parameters<ContactStore["upsertContact"]>[0],
     now: number,
   ): Promise<void> {
-    // Reconcile against an assistant-only contact: when the gateway minted a
-    // new id but the assistant DB already holds one of the provided channels
-    // (by (type, address)), adopt that existing assistant contact id instead
-    // of inserting a duplicate keyed by the new gateway id. Heals the
-    // split-brain case where the contact pre-dates the gateway dual-write.
-    const targetId = await this.resolveAssistantContactId(contactId, params);
-
+    // The mirror always targets the gateway contactId — the SAME id the gateway
+    // row + channels were written under. On create, any assistant-only contact
+    // was already adopted onto this id in upsertContact, so both DBs converge.
+    // On update (explicit id), this matches syncChannels' skip-on-cross-contact
+    // behavior so an edit can't retarget another contact's metadata.
     const existing = await assistantDbQuery<{ userFile: string | null }>(
       "SELECT user_file AS userFile FROM contacts WHERE id = ?",
-      [targetId],
+      [contactId],
     );
 
     if (existing.length) {
@@ -1445,7 +1470,7 @@ export class ContactStore {
         setParts.push("contact_type = ?");
         setParams.push(params.contactType);
       }
-      setParams.push(targetId);
+      setParams.push(contactId);
 
       await assistantDbRun(
         `UPDATE contacts SET ${setParts.join(", ")} WHERE id = ?`,
@@ -1464,7 +1489,7 @@ export class ContactStore {
             user_file, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
-          targetId,
+          contactId,
           displayName,
           params.notes ?? null,
           "contact",
@@ -1486,7 +1511,7 @@ export class ContactStore {
            species  = excluded.species,
            metadata = excluded.metadata`,
         [
-          targetId,
+          contactId,
           params.assistantMetadata.species,
           params.assistantMetadata.metadata != null
             ? JSON.stringify(params.assistantMetadata.metadata)
@@ -1499,7 +1524,7 @@ export class ContactStore {
     for (const ch of params.channels ?? []) {
       const existingCh = await assistantDbQuery<{ id: string; status: string }>(
         "SELECT id, status FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
-        [targetId, ch.type, ch.address],
+        [contactId, ch.type, ch.address],
       );
 
       if (existingCh.length) {
@@ -1536,9 +1561,8 @@ export class ContactStore {
         );
         if (conflict.length) continue;
 
-        // Reuse the gateway channel ID so assistant and gateway channel
-        // rows share the same UUID for the same logical channel. The gateway
-        // row lives under the gateway contactId regardless of reconciliation.
+        // Reuse the gateway channel ID so assistant and gateway channel rows
+        // share the same UUID for the same logical channel.
         const gatewayChannel = this.db
           .select({ id: contactChannels.id })
           .from(contactChannels)
@@ -1560,7 +1584,7 @@ export class ContactStore {
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
           [
             channelId,
-            targetId,
+            contactId,
             ch.type,
             ch.address,
             ch.isPrimary ? 1 : 0,
@@ -1576,32 +1600,37 @@ export class ContactStore {
   }
 
   /**
-   * Resolve which assistant-DB contact id the dual-write should target.
+   * Create-only canonical-id adoption.
    *
-   * Returns the gateway `contactId` unless one of the provided channels
-   * already exists in the assistant DB under a different contact (by (type,
-   * address)). In that split-brain case it returns the existing assistant
-   * contact id so the mirror reconciles into it instead of inserting a
-   * duplicate keyed by the gateway id.
+   * When creating a contact (no explicit id, no gateway (type, address) match),
+   * look up an existing contact in the ASSISTANT DB owning one of the provided
+   * channels (by the same logical key the gateway uses). If found, return its
+   * id so the gateway INSERT + channels + mirror all share ONE canonical id —
+   * healing a legacy assistant-only contact instead of forking the two DBs onto
+   * different ids. Returns null when there's no match or the lookup soft-fails
+   * (daemon down / tests), so the caller falls back to a freshly minted id.
    *
-   * The lookup is by (type, address) — the same logical key the gateway uses
-   * — so a legacy assistant-only contact heals onto the gateway id at the
-   * channel layer while its assistant row/identity is preserved.
+   * Never called on the explicit-id update path — an edit must not retarget
+   * another contact (the gateway syncChannels skips cross-contact channels).
    */
-  private async resolveAssistantContactId(
-    contactId: string,
-    params: Parameters<ContactStore["upsertContact"]>[0],
-  ): Promise<string> {
-    for (const ch of params.channels ?? []) {
-      const rows = await assistantDbQuery<{ contactId: string }>(
-        "SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
-        [ch.type, ch.address],
-      );
-      if (rows.length && rows[0].contactId !== contactId) {
-        return rows[0].contactId;
+  private async adoptAssistantContactId(
+    channels: Parameters<ContactStore["upsertContact"]>[0]["channels"],
+  ): Promise<string | null> {
+    try {
+      for (const ch of channels ?? []) {
+        const rows = await assistantDbQuery<{ contactId: string }>(
+          "SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
+          [ch.type, ch.address],
+        );
+        if (rows.length) return rows[0].contactId;
       }
+    } catch (err) {
+      log.warn(
+        { err },
+        "adoptAssistantContactId: assistant DB lookup failed; minting a new id",
+      );
     }
-    return contactId;
+    return null;
   }
 
   /**

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -24,8 +24,11 @@ export type ContactChannel = typeof contactChannels.$inferSelect;
 export type IngressInviteRow = typeof ingressInvites.$inferSelect;
 
 /** ACL fields of an adopted assistant channel, carried through the create-heal
- * path so syncChannels' INSERT preserves them instead of defaulting. */
+ * path so syncChannels' INSERT preserves them instead of defaulting. `id` is the
+ * assistant channel's own id, adopted so the gateway row shares one canonical
+ * channel id (verify-by-id can't split). */
 type AdoptedChannelAcl = {
+  id: string;
   type: string;
   address: string;
   isPrimary: boolean;
@@ -696,13 +699,50 @@ export class ContactStore {
     channel: ContactChannel;
     didWrite: boolean;
   } | null> {
-    // Migration-window backfill: if the gateway DB has never seen this
-    // channel, but the assistant DB has it, mirror channel + parent contact
-    // into the gateway DB before attempting the verify write. Without this,
-    // any contact channel created before the dual-write was wired would
-    // 404 here even though the user can see the channel in their UI.
-    const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
-    if (!mirrored) return null;
+    // Resolve the gateway row id to write. The caller's `channelId` may be the
+    // assistant channel's id while the gateway row lives under a different id
+    // (pre-canonical-id split). Defense-in-depth mirroring updateChannelStatus:
+    // resolve by (type,address) before falling back to mirroring, so a verify
+    // by the assistant id hits the existing gateway ACL instead of 404ing.
+    let targetId = channelId;
+    const gwExisting = this.db
+      .select({ id: contactChannels.id })
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (!gwExisting) {
+      const assistantChannel = await assistantDbQuery<{
+        type: string;
+        address: string;
+      }>("SELECT type, address FROM contact_channels WHERE id = ?", [
+        channelId,
+      ]).catch(() => []);
+      const resolved = assistantChannel.length
+        ? this.db
+            .select({ id: contactChannels.id })
+            .from(contactChannels)
+            .where(
+              and(
+                eq(contactChannels.type, assistantChannel[0].type),
+                sql`${contactChannels.address} = ${assistantChannel[0].address} COLLATE NOCASE`,
+              ),
+            )
+            .get()
+        : undefined;
+      if (resolved) {
+        targetId = resolved.id;
+      } else {
+        // Migration-window backfill: the gateway DB has never seen this
+        // channel, but the assistant DB has it. Mirror channel + parent contact
+        // (reusing the assistant id) before the verify write. Without this, any
+        // contact channel created before the dual-write was wired would 404
+        // here even though the user can see the channel in their UI.
+        const mirrored = await this.mirrorChannelFromAssistantIfMissing(
+          channelId,
+        );
+        if (!mirrored) return null;
+      }
+    }
 
     const now = Date.now();
     const raw = (this.db as unknown as { $client: Database }).$client;
@@ -713,12 +753,12 @@ export class ContactStore {
          WHERE id = ?
            AND (status != ? OR verified_via != ? OR verified_via IS NULL)`,
       )
-      .run("active", now, "manual", now, channelId, "active", "manual");
+      .run("active", now, "manual", now, targetId, "active", "manual");
 
     const after = this.db
       .select()
       .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
+      .where(eq(contactChannels.id, targetId))
       .get();
 
     if (!after) return null;
@@ -734,11 +774,11 @@ export class ContactStore {
           `UPDATE contact_channels
              SET status = 'active', verified_at = ?, verified_via = 'manual', updated_at = ?
            WHERE id = ?`,
-          [now, now, channelId],
+          [now, now, targetId],
         );
       } catch (err) {
         log.warn(
-          { channelId, err },
+          { channelId, targetId, err },
           "markChannelVerified: assistant DB dual-write failed (best-effort)",
         );
       }
@@ -938,6 +978,10 @@ export class ContactStore {
       metadata?: Record<string, unknown> | null;
     };
     channels?: Array<{
+      // Internal: heal/adopt path sets this to the assistant channel's id so the
+      // gateway INSERT shares one canonical id. Public callers omit it (a fresh
+      // UUID is minted). Never honored on the existing-channel UPDATE path.
+      id?: string;
       type: string;
       address: string;
       isPrimary?: boolean;
@@ -1444,11 +1488,12 @@ export class ContactStore {
         .get();
       if (conflict) continue;
 
-      // New channel
+      // New channel. Honor an adopted assistant channel id (heal path) so both
+      // DBs share one canonical id; otherwise mint a fresh UUID.
       this.db
         .insert(contactChannels)
         .values({
-          id: crypto.randomUUID(),
+          id: ch.id ?? crypto.randomUUID(),
           contactId,
           type: ch.type,
           address: ch.address,
@@ -1488,6 +1533,8 @@ export class ContactStore {
       if (!sameAddress) return ch;
       return {
         ...ch,
+        // Adopt the assistant channel id so syncChannels' INSERT shares it.
+        id: ch.id ?? acl.id,
         isPrimary: ch.isPrimary ?? acl.isPrimary,
         externalChatId: ch.externalChatId ?? acl.externalChatId,
         status: ch.status ?? acl.status,
@@ -1718,6 +1765,7 @@ export class ContactStore {
         const rows = await assistantDbQuery<{
           contactId: string;
           displayName: string | null;
+          id: string;
           type: string;
           address: string;
           isPrimary: number;
@@ -1732,6 +1780,7 @@ export class ContactStore {
         }>(
           `SELECT cc.contact_id      AS contactId,
                   c.display_name     AS displayName,
+                  cc.id,
                   cc.type,
                   cc.address,
                   cc.is_primary      AS isPrimary,
@@ -1755,6 +1804,7 @@ export class ContactStore {
             contactId: r.contactId,
             displayName: r.displayName,
             channelAcl: {
+              id: r.id,
               type: r.type,
               address: r.address,
               isPrimary: Boolean(r.isPrimary),

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -23,6 +23,22 @@ export type Contact = typeof contacts.$inferSelect;
 export type ContactChannel = typeof contactChannels.$inferSelect;
 export type IngressInviteRow = typeof ingressInvites.$inferSelect;
 
+/** ACL fields of an adopted assistant channel, carried through the create-heal
+ * path so syncChannels' INSERT preserves them instead of defaulting. */
+type AdoptedChannelAcl = {
+  type: string;
+  address: string;
+  isPrimary: boolean;
+  externalChatId: string | null;
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+  verifiedVia: string | null;
+  inviteId: string | null;
+  revokedReason: string | null;
+  blockedReason: string | null;
+};
+
 export class ContactStore {
   private injectedDb?: GatewayDb;
 
@@ -1024,9 +1040,11 @@ export class ContactStore {
     // it, so a "healed" assistant-only contact's info reads back via the
     // join-by-id read path. Soft-fails to a minted id if the lookup throws
     // (daemon down / tests) — the assistant-mirror best-effort invariant.
+    let adoptedChannelAcl: AdoptedChannelAcl | undefined;
     if (!contactId) {
       const adopted = await this.adoptAssistantContactId(canonicalChannels);
       contactId = adopted?.contactId ?? crypto.randomUUID();
+      adoptedChannelAcl = adopted?.channelAcl;
       // An adopted id may already exist as a gateway row (different channels);
       // preserve it (name omit-to-preserve) instead of a conflicting INSERT.
       const existing = adopted
@@ -1062,8 +1080,13 @@ export class ContactStore {
     }
 
     // ── 4. Sync channels (gateway DB) ─────────────────────────────────
-    if (canonicalChannels?.length) {
-      this.syncChannels(contactId, canonicalChannels, now);
+    // Carry the adopted assistant channel's ACL state into the heal INSERT so
+    // an active/verified contact isn't downgraded to unverified/allow.
+    const channelsToSync = adoptedChannelAcl
+      ? this.mergeAdoptedChannelAcl(canonicalChannels, adoptedChannelAcl)
+      : canonicalChannels;
+    if (channelsToSync?.length) {
+      this.syncChannels(contactId, channelsToSync, now);
     }
 
     // ── 5. Dual-write to assistant DB (best-effort) ───────────────────
@@ -1448,6 +1471,38 @@ export class ContactStore {
     }
   }
 
+  /**
+   * Merge an adopted assistant channel's ACL fields into the matching
+   * (type,address) channel of a create-heal upsert, omit-to-preserve so any
+   * field the caller explicitly supplied still wins. The enriched channel
+   * carries the assistant row's real status/policy/verification into
+   * syncChannels' INSERT — without this, the heal would default an active
+   * channel to unverified/allow and downgrade a trusted contact.
+   */
+  private mergeAdoptedChannelAcl(
+    channels: Parameters<ContactStore["upsertContact"]>[0]["channels"],
+    acl: AdoptedChannelAcl,
+  ): Parameters<ContactStore["upsertContact"]>[0]["channels"] {
+    return channels?.map((ch) => {
+      const sameAddress =
+        ch.type === acl.type &&
+        ch.address.toLowerCase() === acl.address.toLowerCase();
+      if (!sameAddress) return ch;
+      return {
+        ...ch,
+        isPrimary: ch.isPrimary ?? acl.isPrimary,
+        externalChatId: ch.externalChatId ?? acl.externalChatId,
+        status: ch.status ?? acl.status,
+        policy: ch.policy ?? acl.policy,
+        verifiedAt: ch.verifiedAt ?? acl.verifiedAt,
+        verifiedVia: ch.verifiedVia ?? acl.verifiedVia,
+        inviteId: ch.inviteId ?? acl.inviteId,
+        revokedReason: ch.revokedReason ?? acl.revokedReason,
+        blockedReason: ch.blockedReason ?? acl.blockedReason,
+      };
+    });
+  }
+
   // ---------------------------------------------------------------------------
   // Assistant DB dual-write
   // ---------------------------------------------------------------------------
@@ -1645,30 +1700,77 @@ export class ContactStore {
    * Returns null when there's no match or the lookup soft-fails (daemon down /
    * tests), so the caller falls back to a freshly minted id.
    *
+   * The matched channel's ACL fields (status/policy/verification) ride along so
+   * the create path can carry them into syncChannels' INSERT — without them the
+   * new gateway row would default to unverified/allow, DOWNGRADING an already
+   * active/trusted assistant channel below the trusted_contacts admission floor.
+   *
    * Never called on the explicit-id update path — an edit must not retarget
    * another contact (the gateway syncChannels skips cross-contact channels).
    */
   private async adoptAssistantContactId(
     channels: Parameters<ContactStore["upsertContact"]>[0]["channels"],
-  ): Promise<{ contactId: string; displayName: string | null } | null> {
+  ): Promise<{
+    contactId: string;
+    displayName: string | null;
+    channelAcl?: AdoptedChannelAcl;
+  } | null> {
     try {
       for (const ch of channels ?? []) {
         const rows = await assistantDbQuery<{
           contactId: string;
           displayName: string | null;
+          type: string;
+          address: string;
+          isPrimary: number;
+          externalChatId: string | null;
+          status: string;
+          policy: string;
+          verifiedAt: number | null;
+          verifiedVia: string | null;
+          inviteId: string | null;
+          revokedReason: string | null;
+          blockedReason: string | null;
         }>(
-          `SELECT cc.contact_id AS contactId, c.display_name AS displayName
+          `SELECT cc.contact_id      AS contactId,
+                  c.display_name     AS displayName,
+                  cc.type,
+                  cc.address,
+                  cc.is_primary      AS isPrimary,
+                  cc.external_chat_id AS externalChatId,
+                  cc.status,
+                  cc.policy,
+                  cc.verified_at     AS verifiedAt,
+                  cc.verified_via    AS verifiedVia,
+                  cc.invite_id       AS inviteId,
+                  cc.revoked_reason  AS revokedReason,
+                  cc.blocked_reason  AS blockedReason
              FROM contact_channels cc
              JOIN contacts c ON c.id = cc.contact_id
             WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
             LIMIT 1`,
           [ch.type, ch.address],
         );
-        if (rows.length)
+        if (rows.length) {
+          const r = rows[0];
           return {
-            contactId: rows[0].contactId,
-            displayName: rows[0].displayName,
+            contactId: r.contactId,
+            displayName: r.displayName,
+            channelAcl: {
+              type: r.type,
+              address: r.address,
+              isPrimary: Boolean(r.isPrimary),
+              externalChatId: r.externalChatId,
+              status: r.status,
+              policy: r.policy,
+              verifiedAt: r.verifiedAt,
+              verifiedVia: r.verifiedVia,
+              inviteId: r.inviteId,
+              revokedReason: r.revokedReason,
+              blockedReason: r.blockedReason,
+            },
           };
+        }
       }
     } catch (err) {
       log.warn(

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -60,6 +60,25 @@ export class InviteNativeError extends Error {
   }
 }
 
+/**
+ * Error thrown by the transport-agnostic contact-channel core to signal a
+ * client-facing failure with a stable code + status. The HTTP handler maps it
+ * to `Response.json`; the gateway IPC route lets it propagate (the IPC server
+ * stringifies thrown errors and mirrors `statusCode`/`code` into the wire
+ * envelope).
+ */
+export class ContactChannelNativeError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+
+  constructor(message: string, statusCode: number, code: string) {
+    super(message);
+    this.name = "ContactChannelNativeError";
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
 /** Map an InviteNativeError (or generic error) to the HTTP error Response. */
 function inviteErrorResponse(err: unknown): Response {
   if (err instanceof InviteNativeError) {
@@ -654,6 +673,120 @@ function isChannelPolicy(v: unknown): v is ChannelPolicy {
 }
 
 /**
+ * Transport-agnostic channel status/policy write.
+ *
+ * Shared by the HTTP `handleUpdateContactChannel` and the gateway IPC
+ * `update_contact_channel` route. Validates status/policy, performs the
+ * gateway DB write (source of truth) via `ContactStore.updateChannelStatus`
+ * — which preserves the revoke-of-blocked guard and resolves assistant-side
+ * channel IDs via the (contactId, type, address) backward-compat path —
+ * best-effort mirrors into the assistant DB, emits `contacts_changed`, and
+ * returns the parent contact payload.
+ *
+ * Throws `ContactChannelNativeError` for client-facing failures (400 bad
+ * status/policy, 404 unknown channel, 409 revoke-of-blocked). Unexpected
+ * errors propagate so each transport surfaces a 500-equivalent — never a
+ * silent fallback.
+ */
+export async function updateContactChannelCore(params: {
+  contactChannelId: string;
+  status?: string;
+  policy?: string;
+  reason?: string | null;
+}): Promise<{ ok: true; contact?: Record<string, unknown> }> {
+  const { contactChannelId } = params;
+  const status = params.status;
+  const policy = params.policy;
+  const reason = params.reason ?? null;
+
+  if (status !== undefined && !isChannelStatus(status)) {
+    throw new ContactChannelNativeError(
+      `Invalid status "${status}". Must be one of: ${VALID_CHANNEL_STATUSES.join(", ")}`,
+      400,
+      "BAD_REQUEST",
+    );
+  }
+  if (policy !== undefined && !isChannelPolicy(policy)) {
+    throw new ContactChannelNativeError(
+      `Invalid policy "${policy}". Must be one of: ${VALID_CHANNEL_POLICIES.join(", ")}`,
+      400,
+      "BAD_REQUEST",
+    );
+  }
+  if (status === undefined && policy === undefined) {
+    throw new ContactChannelNativeError(
+      "At least one of status or policy must be provided",
+      400,
+      "BAD_REQUEST",
+    );
+  }
+
+  const store = new ContactStore();
+  let updated;
+  try {
+    updated = await store.updateChannelStatus(contactChannelId, {
+      status,
+      policy,
+      reason,
+    });
+  } catch (err) {
+    if (err instanceof CannotRevokeBlockedError) {
+      throw new ContactChannelNativeError(err.message, 409, "CONFLICT");
+    }
+    throw err;
+  }
+
+  if (!updated) {
+    throw new ContactChannelNativeError(
+      `Channel "${contactChannelId}" not found`,
+      404,
+      "NOT_FOUND",
+    );
+  }
+
+  // Best-effort dual-write to assistant DB.
+  const dualWriteParams: {
+    status?: string;
+    policy?: string;
+    revokedReason?: string | null;
+    blockedReason?: string | null;
+  } = {};
+  if (status !== undefined) {
+    dualWriteParams.status = status;
+    dualWriteParams.revokedReason = status === "revoked" ? reason : null;
+    dualWriteParams.blockedReason = status === "blocked" ? reason : null;
+  }
+  if (policy !== undefined) dualWriteParams.policy = policy;
+
+  try {
+    await store.dualWriteChannelStatusToAssistantDb(
+      contactChannelId,
+      dualWriteParams,
+    );
+  } catch (err) {
+    log.warn(
+      { contactChannelId, err },
+      "update_channel: assistant DB dual-write failed (best-effort)",
+    );
+  }
+
+  // Emit contacts_changed so connected clients refresh.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  const contact = await store.getContactWithInfo(updated.contactId);
+  log.info(
+    { contactChannelId, contactId: updated.contactId, status, policy },
+    "update_channel: handled natively",
+  );
+  return {
+    ok: true,
+    contact: contact ? toContactPayload(contact) : undefined,
+  };
+}
+
+/**
  * Validate that metadata matches the expected shape for the given species.
  * Mirrors `validateSpeciesMetadata` in `assistant/src/contacts/contact-store.ts`.
  */
@@ -1217,116 +1350,19 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       const policy = body.policy as string | undefined;
       const reason = (body.reason as string | null | undefined) ?? null;
 
-      if (status !== undefined && !isChannelStatus(status)) {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: `Invalid status "${status}". Must be one of: ${VALID_CHANNEL_STATUSES.join(", ")}`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-
-      if (policy !== undefined && !isChannelPolicy(policy)) {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: `Invalid policy "${policy}". Must be one of: ${VALID_CHANNEL_POLICIES.join(", ")}`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-
-      if (status === undefined && policy === undefined) {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: "At least one of status or policy must be provided",
-            },
-          },
-          { status: 400 },
-        );
-      }
-
       try {
-        const store = new ContactStore();
-        const updated = await store.updateChannelStatus(contactChannelId, {
+        const result = await updateContactChannelCore({
+          contactChannelId,
           status,
           policy,
           reason,
         });
-
-        if (!updated) {
-          return Response.json(
-            {
-              error: {
-                code: "NOT_FOUND",
-                message: `Channel "${contactChannelId}" not found`,
-              },
-            },
-            { status: 404 },
-          );
-        }
-
-        // Best-effort dual-write to assistant DB.
-        const dualWriteParams: {
-          status?: string;
-          policy?: string;
-          revokedReason?: string | null;
-          blockedReason?: string | null;
-        } = {};
-        if (status !== undefined) {
-          dualWriteParams.status = status;
-          dualWriteParams.revokedReason =
-            status === "revoked" ? reason : null;
-          dualWriteParams.blockedReason =
-            status === "blocked" ? reason : null;
-        }
-        if (policy !== undefined) dualWriteParams.policy = policy;
-
-        try {
-          await store.dualWriteChannelStatusToAssistantDb(
-            contactChannelId,
-            dualWriteParams,
-          );
-        } catch (err) {
-          log.warn(
-            { contactChannelId, err },
-            "update_channel: assistant DB dual-write failed (best-effort)",
-          );
-        }
-
-        // Emit contacts_changed so connected clients refresh.
-        void ipcCallAssistant("emit_event", {
-          body: { kind: "contacts_changed" },
-        } as unknown as Record<string, unknown>).catch(() => {});
-
-        // Return the parent contact with info join, matching the daemon's
-        // response shape.
-        const contact = await store.getContactWithInfo(updated.contactId);
-        log.info(
-          { contactChannelId, contactId: updated.contactId, status, policy },
-          "update_channel: handled natively",
-        );
-        return Response.json({
-          ok: true,
-          contact: contact ? toContactPayload(contact) : undefined,
-        });
+        return Response.json(result);
       } catch (err) {
-        if (err instanceof CannotRevokeBlockedError) {
+        if (err instanceof ContactChannelNativeError) {
           return Response.json(
-            {
-              error: {
-                code: "CONFLICT",
-                message: err.message,
-              },
-            },
-            { status: 409 },
+            { error: { code: err.code, message: err.message } },
+            { status: err.statusCode },
           );
         }
         log.error(

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -6,10 +6,12 @@
  * assistant DB proxy (raw SQL), so the gateway owns the write path.
  */
 
+import { UpdateContactChannelIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
 import { ContactStore } from "../db/contact-store.js";
+import { updateContactChannelCore } from "../http/routes/contacts-control-plane-proxy.js";
 import { getLogger } from "../logger.js";
 import { canonicalizeInboundIdentity } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
@@ -152,6 +154,17 @@ export const contactRoutes: IpcRoute[] = [
       );
 
       return { contactId, channelId };
+    },
+  },
+  {
+    method: "update_contact_channel",
+    schema: UpdateContactChannelIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const parsed = UpdateContactChannelIpcParamsSchema.parse(params);
+      // Thrown ContactChannelNativeError carries statusCode/code, which the IPC
+      // server's buildErrorResponse mirrors into the wire envelope; unexpected
+      // errors propagate as a generic IPC error (no fallback).
+      return updateContactChannelCore(parsed);
     },
   },
 ];

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -2,14 +2,14 @@
  * IPC route definitions for contact reads and writes.
  *
  * Read methods expose gateway-owned contact data to the assistant daemon.
- * The `create_contact` write method upserts a contact+channel via the
- * assistant DB proxy (raw SQL), so the gateway owns the write path.
+ * The `create_contact` write method upserts a contact+channel via
+ * `ContactStore.upsertContact`, which writes the gateway DB (source of truth)
+ * and best-effort mirrors to the assistant DB.
  */
 
 import { UpdateContactChannelIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
-import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
 import { ContactStore } from "../db/contact-store.js";
 import { updateContactChannelCore } from "../http/routes/contacts-control-plane-proxy.js";
 import { getLogger } from "../logger.js";
@@ -83,74 +83,59 @@ export const contactRoutes: IpcRoute[] = [
     method: "create_contact",
     schema: CreateContactParamsSchema,
     handler: async (params?: Record<string, unknown>) => {
-      const { channelType, address, role, displayName } =
+      const { channelType, address, displayName } =
         CreateContactParamsSchema.parse(params);
 
-      const normalizedAddress =
+      // Canonicalize once here; upsertContact canonicalizes internally too, so
+      // passing the canonical form keeps a single source of truth.
+      // NOTE: `role` is intentionally not honored. Guardian binding is owned by
+      // guardian-bootstrap (see ContactStore.upsertContact SECURITY note); a
+      // contact created here always gets role="contact".
+      const canonicalAddress =
         canonicalizeInboundIdentity(channelType, address) ?? address.trim();
-      const effectiveDisplayName = displayName ?? normalizedAddress;
-      // Map prompt roles to valid ContactRole values ("guardian" | "contact").
-      const effectiveRole: string =
-        role === "guardian" ? "guardian" : "contact";
-      const now = Date.now();
 
-      // Check if a channel with this (type, address) already exists.
-      const existing = await assistantDbQuery<{
-        channelId: string;
-        contactId: string;
-      }>(
-        `SELECT cc.id AS channelId, cc.contact_id AS contactId
-         FROM contact_channels cc
-         WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-         LIMIT 1`,
-        [channelType, normalizedAddress],
-      );
+      const store = getStore();
+      // Preserve an existing contact's displayName on retry: only the caller's
+      // explicit displayName overrides it. Falling back to the existing name
+      // (or the canonical address for a brand-new contact) avoids clobbering a
+      // custom name with the bare address, since upsertContact always writes
+      // displayName.
+      const existing = store.getContactByChannel(channelType, canonicalAddress);
+      const effectiveDisplayName =
+        displayName ?? existing?.displayName ?? canonicalAddress;
 
-      if (existing.length > 0) {
-        const { channelId, contactId } = existing[0];
-        log.info(
-          { channelType, address: normalizedAddress, contactId, channelId },
-          "create_contact: channel already exists, returning existing record",
+      // Omit status/policy/externalChatId: syncChannels and the assistant-DB
+      // mirror default a new channel but preserve an existing channel's values
+      // on retry. Passing them here would demote a trusted channel below the
+      // trusted_contacts admission floor (mirrors verification/contact-helpers)
+      // or clear a delivery chat id.
+      const { contact } = await store.upsertContact({
+        displayName: effectiveDisplayName,
+        channels: [
+          {
+            type: channelType,
+            address: canonicalAddress,
+            isPrimary: true,
+          },
+        ],
+      });
+
+      const contactId = contact.id;
+      // Resolve the channel id from the gateway DB (source of truth). The
+      // upsertContact result's channels can be empty when the assistant-DB
+      // read-back is unavailable (best-effort), so don't rely on it here.
+      const channel = store
+        .getChannelsForContact(contactId)
+        .find(
+          (ch) =>
+            ch.type === channelType &&
+            ch.address.toLowerCase() === canonicalAddress.toLowerCase(),
         );
-        return { contactId, channelId };
-      }
-
-      // Create a new contact + channel.
-      // Two separate INSERTs — use a compensating DELETE on channel failure.
-      const contactId = crypto.randomUUID();
-      const channelId = crypto.randomUUID();
-
-      await assistantDbRun(
-        `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-         VALUES (?, ?, ?, 'human', ?, ?)`,
-        [contactId, effectiveDisplayName, effectiveRole, now, now],
-      );
-
-      try {
-        await assistantDbRun(
-          `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-           VALUES (?, ?, ?, ?, 1, 'unverified', 'allow', 0, ?, ?)`,
-          [channelId, contactId, channelType, normalizedAddress, now, now],
-        );
-      } catch (channelErr) {
-        // Compensating delete — remove the orphaned contact row.
-        log.error(
-          { channelErr, contactId, channelType, address: normalizedAddress },
-          "create_contact: channel INSERT failed, rolling back contact row",
-        );
-        await assistantDbRun("DELETE FROM contacts WHERE id = ?", [contactId]);
-        throw channelErr;
-      }
+      const channelId = channel?.id ?? "";
 
       log.info(
-        {
-          channelType,
-          address: normalizedAddress,
-          contactId,
-          channelId,
-          role: effectiveRole,
-        },
-        "create_contact: created new contact + channel",
+        { channelType, address: canonicalAddress, contactId, channelId },
+        "create_contact: upserted contact + channel via ContactStore",
       );
 
       return { contactId, channelId };

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -95,22 +95,18 @@ export const contactRoutes: IpcRoute[] = [
         canonicalizeInboundIdentity(channelType, address) ?? address.trim();
 
       const store = getStore();
-      // Preserve an existing contact's displayName on retry: only the caller's
-      // explicit displayName overrides it. Falling back to the existing name
-      // (or the canonical address for a brand-new contact) avoids clobbering a
-      // custom name with the bare address, since upsertContact always writes
-      // displayName.
-      const existing = store.getContactByChannel(channelType, canonicalAddress);
-      const effectiveDisplayName =
-        displayName ?? existing?.displayName ?? canonicalAddress;
-
+      // Omit displayName when the caller didn't supply one: upsertContact is
+      // omit-to-preserve, so an existing contact keeps its current name and a
+      // brand-new contact falls back to the canonical address. Passing a
+      // synthesized name here would clobber a custom name on retry.
+      //
       // Omit status/policy/externalChatId: syncChannels and the assistant-DB
       // mirror default a new channel but preserve an existing channel's values
       // on retry. Passing them here would demote a trusted channel below the
       // trusted_contacts admission floor (mirrors verification/contact-helpers)
       // or clear a delivery chat id.
       const { contact } = await store.upsertContact({
-        displayName: effectiveDisplayName,
+        displayName,
         channels: [
           {
             type: channelType,

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -85,3 +85,25 @@ export const TrustRulesListIpcResponseSchema = z.object({
 export type TrustRulesListIpcResponse = z.infer<
   typeof TrustRulesListIpcResponseSchema
 >;
+
+export const UpdateContactChannelIpcParamsSchema = z.object({
+  contactChannelId: z.string().min(1),
+  status: z.string().optional(),
+  policy: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+export type UpdateContactChannelIpcParams = z.infer<
+  typeof UpdateContactChannelIpcParamsSchema
+>;
+
+export const UpdateContactChannelIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  // The gateway-native handler owns the full contact payload shape; pass it
+  // through verbatim rather than re-declaring channel fields here.
+  contact: z.object({}).passthrough().optional(),
+});
+
+export type UpdateContactChannelIpcResponse = z.infer<
+  typeof UpdateContactChannelIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
Makes the gateway DB the source of truth for the last two Tier-1 contact write paths that bypassed it:
- The daemon `updateContactChannel` IPC handler is now a thin relay to a gateway-native `update_contact_channel` route (shared `updateContactChannelCore` with the HTTP handler) — no direct assistant-DB write.
- The gateway `create_contact` IPC handler dual-writes via `ContactStore.upsertContact` (gateway DB source of truth + best-effort assistant-DB mirror) instead of assistant-DB-only raw SQL.

## Self-review result
PASS after 3 review rounds. 2 gaps found and fixed across 2 remediation PRs (#35577, #35579):
- create_contact no longer overwrites an existing contact's display name on retry (omit-to-preserve).
- create_contact heals an assistant-only contact by adopting its existing id as the gateway contact id (single canonical id; no gateway↔assistant id divergence); the reconciliation is gated to the create path so explicit-id updates can't misroute another contact's metadata.

## PRs merged into feature branch
- #35570: feat(contacts): relay updateContactChannel IPC to gateway-native handler
- #35569: fix(gateway): create_contact IPC handler dual-writes via ContactStore.upsertContact

### Fix PRs (self-review remediation)
- #35577: fix(gateway): preserve display name + reconcile existing contacts in create_contact
- #35579: fix(gateway): canonical contact id on create_contact heal; gate reconciliation to create-only

## Known follow-up (non-blocking)
Codex P2 on #35579: the HTTP `POST /v1/contacts` heal-path response can return transient stale ACL fields (assistant row) until a client refetch — a response-payload inconsistency, not a write bug; the `create_contact` IPC handler is unaffected (it re-reads channelId from the gateway DB).

Part of plan: contacts-relay-writes-create-contact.md