### PR TITLE
docs: correct verification outcome wiring description

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -161,7 +161,9 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 
 Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned (`channel-verification-routes.ts`, `channel-verification-service.ts`). The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned.
 
-The `channel_verification_sessions_*` daemon handlers are thin relays for the outcome write, following the trust-rules relay precedent. The gateway IPC methods `mark_channel_verified` / `mark_channel_revoked` (`ContactStore.markChannelVerified` / `markChannelRevoked`) are the single outcome write path for all callers: HTTP routes, inbound code-match completion (`gateway/src/verification/text-verification.ts`), and CLI/IPC.
+The verified outcome is written in-process by the gateway: the HTTP guardian-attest handler calls `ContactStore.markChannelVerified` directly (verifiedVia "manual"), and the inbound code-match path (`gateway/src/verification/text-verification.ts`) writes via `upsertVerifiedContactChannel` / `createGuardianBinding` (verifiedVia "challenge"). The revoke/downgrade outcome is relayed from the daemon via `ipcCallPersistent("mark_channel_revoked", …)` to `ContactStore.markChannelRevoked`.
+
+The `mark_channel_verified` IPC method exists as the daemon/CLI relay surface (symmetric with `mark_channel_revoked`) but has no caller: the trusted-contact CLI path sends codes only, and the outcome arrives via the inbound code-match path.
 
 ## Rate Limiting & Diagnostics
 

--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -2,20 +2,10 @@
  * Tests for the trusted-contact branch of the channel-verification create
  * route.
  *
- * Investigation finding (PR 4 of contacts-gw-native-verification): the
- * daemon/CLI trusted-contact path (`verifyTrustedContact` →
- * `handleCreateVerificationSession`) has NO direct assistant-side activation
- * write. Every branch only creates an outbound session, records delivery, and
- * sends a code; the channel is flipped to `active` exclusively by the inbound
- * code-match completion, which already runs through the gateway
- * (`gateway/src/verification/text-verification.ts` →
- * `applyTrustedContactSideEffects`). The `already_verified` check on this path
- * is a read-only short-circuit that returns a 409, not a write.
- *
- * There is therefore no daemon-side outcome write to relay. These tests pin
- * that invariant: the trusted-contact create path must NOT write the
- * activation outcome assistant-side (no `updateChannelStatus`), so the outcome
- * is never double-written against the inbound gateway path.
+ * Pins the invariant that the trusted-contact create path performs no
+ * assistant-side activation write (no `updateChannelStatus`): it only creates an
+ * outbound session and sends a code. The verified outcome flows exclusively
+ * through the inbound gateway code-match path, so it is never double-written.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -9,9 +9,14 @@
  *
  * Source-of-truth split:
  * - Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned.
- * - The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned, reached via
- *   `ipcCallPersistent("mark_channel_verified", …)`; revoke/downgrade via
- *   `ipcCallPersistent("mark_channel_revoked", …)`.
+ * - The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned, written
+ *   in-process by the HTTP guardian-attest handler (`ContactStore.markChannelVerified`) and by the
+ *   inbound code-match path (`gateway/src/verification/text-verification.ts`).
+ * - The revoke/downgrade OUTCOME is relayed from the daemon via
+ *   `ipcCallPersistent("mark_channel_revoked", …)` to `ContactStore.markChannelRevoked`.
+ * - The `mark_channel_verified` IPC method exists as the daemon/CLI relay surface (symmetric with
+ *   `mark_channel_revoked`) but has no caller: the trusted-contact CLI path sends codes only, and the
+ *   outcome arrives via the inbound code-match path.
  */
 
 import { z } from "zod";


### PR DESCRIPTION
## Summary
- Correct the channel-verification docs: the verified outcome is written in-process (HTTP attest) and by the inbound code-match path; mark_channel_verified IPC is an unused daemon/CLI relay surface; revoke relays via mark_channel_revoked
- Trim PR-history narration from the routes test header comment

Fixes self-review doc-accuracy gaps for plan contacts-gw-native-verification.md