### PR TITLE
refactor(contacts): drop dead contactType IPC param + single-source externalUserId compat

### DIFF
--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -153,7 +153,9 @@ function gatewayContact(overrides: Record<string, unknown> = {}) {
         type: "telegram",
         address: "tg-001",
         isPrimary: true,
-        externalUserId: "tg-001",
+        // The gateway leaves externalUserId null; the daemon's withChannelCompat
+        // re-derives it from address on the relayed payload.
+        externalUserId: null,
         status: "active",
         policy: "allow",
         verifiedAt: null,
@@ -192,6 +194,11 @@ describe("handleListContacts relay", () => {
     expect(localCalls).toEqual([]);
     expect(result.contacts).toHaveLength(1);
     expect(result.contacts[0].id).toBe("gw-1");
+    // The daemon's withChannelCompat re-derives externalUserId = address even
+    // though the gateway emits null — the client-facing guarantee holds.
+    const ch = (result.contacts[0] as { channels: { address: string; externalUserId: string | null }[] })
+      .channels[0];
+    expect(ch.externalUserId).toBe(ch.address);
   });
 
   test("applies guardian display-name override to relayed contacts", async () => {

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -226,8 +226,9 @@ describe("ContactStore.listContactsRich", () => {
     expect(ch.verifiedAt).toBe(555);
     expect(ch.revokedReason).toBe("spam");
     expect(ch.blockedReason).toBeNull();
-    // externalUserId echoes address (withChannelCompat).
-    expect(ch.externalUserId).toBe("tg-001");
+    // externalUserId is null here — the daemon's withChannelCompat is the sole
+    // producer of that compat field on the relayed payload.
+    expect(ch.externalUserId).toBeNull();
   });
 
   test("orders guardian first, then updatedAt desc", async () => {
@@ -252,56 +253,6 @@ describe("ContactStore.listContactsRich", () => {
       role: "guardian",
     });
     expect(result.map((c) => c.id)).toEqual(["g"]);
-  });
-
-  test("honors contactType filter against assistant-DB value", async () => {
-    seedGatewayContact({ id: "human", updatedAt: 200 });
-    seedGatewayContact({ id: "bot", updatedAt: 100 });
-    seedAssistantInfo({ id: "human", contactType: "human" });
-    seedAssistantInfo({
-      id: "bot",
-      contactType: "assistant",
-      species: "vellum",
-      metadata: { model: "opus" },
-    });
-
-    const result = await new ContactStore().listContactsRich({
-      contactType: "assistant",
-    });
-    expect(result.map((c) => c.id)).toEqual(["bot"]);
-  });
-
-  test("contactType filter with a MIX of types + tight limit (forward-compat path)", async () => {
-    // contactType filtering is no longer exercised on the daemon relay path
-    // (the daemon serves contactType-filtered reads natively). This test keeps
-    // the gateway-side filter behavior honest for forward-compat callers: with
-    // a mix of types and a limit, listContactsWithInfo applies the limit to
-    // CONTACTS first, then the contactType filter runs on the limited set — so
-    // a tight limit can still under-return here. The relay path avoids this by
-    // staying daemon-native (SQL contactType filter before the limit).
-    seedGatewayContact({ id: "h1", updatedAt: 500 });
-    seedGatewayContact({ id: "bot1", updatedAt: 400 });
-    seedGatewayContact({ id: "h2", updatedAt: 300 });
-    seedGatewayContact({ id: "bot2", updatedAt: 200 });
-    seedAssistantInfo({ id: "h1", contactType: "human" });
-    seedAssistantInfo({ id: "bot1", contactType: "assistant", species: "vellum" });
-    seedAssistantInfo({ id: "h2", contactType: "human" });
-    seedAssistantInfo({ id: "bot2", contactType: "assistant", species: "vellum" });
-
-    // No limit → all assistant contacts returned.
-    const all = await new ContactStore().listContactsRich({
-      contactType: "assistant",
-    });
-    expect(all.map((c) => c.id)).toEqual(["bot1", "bot2"]);
-
-    // limit 2 → contacts limited to [h1, bot1] first, then filtered to
-    // assistant → only bot1 survives (demonstrates the post-limit truncation
-    // the daemon-native relay path deliberately avoids).
-    const limited = await new ContactStore().listContactsRich({
-      contactType: "assistant",
-      limit: 2,
-    });
-    expect(limited.map((c) => c.id)).toEqual(["bot1"]);
   });
 
   test("honors limit (capped at 200)", async () => {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -354,9 +354,10 @@ describe("IPC contact routes", () => {
     expect(body.contacts[0].role).toBe("guardian");
     // Trust signals derived from gateway channels (5 + 10 for the guardian).
     expect(body.contacts[0].interactionCount).toBe(15);
-    // externalUserId echoes address (withChannelCompat).
+    // externalUserId is null on the gateway rich-read output — the daemon's
+    // withChannelCompat is the sole producer of that compat field.
     const ch = body.contacts[0].channels[0];
-    expect(ch.externalUserId).toBe(ch.address);
+    expect(ch.externalUserId).toBeNull();
   });
 
   test("contacts_list_rich honors the role filter via IPC", async () => {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -205,11 +205,10 @@ export class ContactStore {
    * channels joined to assistant-DB info fields.
    *
    * Filters: `role` (gateway DB), `limit` (default 50, capped 200 to mirror
-   * the daemon's listContacts). `contactType` is assistant-owned and is NOT
-   * filtered here — the daemon serves contactType-filtered list reads natively
-   * (filtering in SQL before the limit) so a tight limit doesn't under-return
-   * and an assistant-DB outage degrades rather than dropping every row. The
-   * param is retained for forward-compat but not exercised on the relay path.
+   * the daemon's listContacts). The daemon serves contactType-filtered list
+   * reads natively (filtering in SQL before the limit) so a tight limit doesn't
+   * under-return and an assistant-DB outage degrades rather than dropping every
+   * row — the relay never carries a contactType filter.
    *
    * Thin adapter over `listContactsWithInfo` (shared assembly/soft-fail logic),
    * projected down to the ContactRead subset.
@@ -220,15 +219,12 @@ export class ContactStore {
   async listContactsRich(opts?: {
     limit?: number;
     role?: string;
-    contactType?: string;
   }): Promise<ContactRead[]> {
     const withInfo = await this.listContactsWithInfo({
       limit: opts?.limit,
       role: opts?.role,
     });
-    return withInfo
-      .filter((c) => !opts?.contactType || c.contactType === opts.contactType)
-      .map((c) => this.toContactRead(c));
+    return withInfo.map((c) => this.toContactRead(c));
   }
 
   /**
@@ -262,9 +258,10 @@ export class ContactStore {
   /**
    * Project a ContactWithInfo down to the ContactRead subset (drops the
    * assistant-only/ACL-internal fields not on the shared contract). Channel
-   * `externalUserId` echoes `address` to match the daemon's withChannelCompat;
-   * status/policy default like the DB columns (notNull, so a no-op on real
-   * rows) to satisfy the non-null ContactRead channel contract.
+   * `externalUserId` is left null — the daemon's withChannelCompat is the sole
+   * producer of that compat field on the relayed payload. status/policy default
+   * like the DB columns (notNull, so a no-op on real rows) to satisfy the
+   * non-null ContactRead channel contract.
    */
   private toContactRead(c: ContactWithInfo): ContactRead {
     return {
@@ -281,7 +278,7 @@ export class ContactStore {
         type: ch.type,
         address: ch.address,
         isPrimary: ch.isPrimary,
-        externalUserId: ch.address,
+        externalUserId: null,
         status: ch.status ?? "unverified",
         policy: ch.policy ?? "allow",
         verifiedAt: ch.verifiedAt,

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -133,7 +133,6 @@ export const ListContactsIpcParamsSchema = z
   .object({
     limit: z.number().optional(),
     role: z.string().optional(),
-    contactType: z.string().optional(),
   })
   .strict()
   .default({});


### PR DESCRIPTION
## Summary
Cleanups identified during plan review for contacts-relay-reads.md.

- **Dead contactType param:** contactType-filtered list reads are served daemon-native, so the gateway relay never receives contactType. Removed it from ListContactsIpcParamsSchema, listContactsRich opts, and the no-op filter.
- **Single-source externalUserId:** the daemon's withChannelCompat already (re)derives externalUserId = address on every relayed channel, so the gateway no longer sets it (emits null). Client-facing output unchanged; end-to-end test still asserts externalUserId === address.