### PR TITLE
Gateway-native channel verification (+ IPC relay)

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -63,6 +63,26 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   },
 }));
 
+// Gateway relay mock — the revoke path relays the ACL downgrade over IPC and
+// validates the response; return a well-formed mark_channel_revoked result.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    _method: string,
+    params?: Record<string, unknown>,
+  ) => ({
+    ok: true,
+    didWrite: true,
+    channel: {
+      id: (params?.contactChannelId as string) ?? "ch1",
+      contactId: "c1",
+      type: "phone",
+      address: "addr",
+      status: "revoked",
+      revokedReason: (params?.reason as string) ?? null,
+    },
+  }),
+}));
+
 import { handleChannelVerificationSession } from "../daemon/handlers/config-channels.js";
 import type {
   ChannelVerificationSessionRequest,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -8,8 +8,8 @@ import {
   getChannelById,
   getContact,
 } from "../../contacts/contact-store.js";
-import { revokeMember } from "../../contacts/contacts-write.js";
 import type { ChannelStatus } from "../../contacts/types.js";
+import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { getBindingByChannelChat } from "../../memory/external-conversation-store.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
@@ -171,23 +171,21 @@ export function getVerificationStatus(
 // Revoke verification binding
 // ---------------------------------------------------------------------------
 
-export function revokeVerificationForChannel(
+export async function revokeVerificationForChannel(
   channel?: ChannelId,
-): ChannelVerificationSessionResult {
+): Promise<ChannelVerificationSessionResult> {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? "telegram";
 
-  // Cancel any active outbound session so revoke is a complete teardown.
+  // Session teardown stays assistant-side — it is session state, not the ACL
+  // outcome. Cancel any active outbound session and pending challenges first
+  // (the macOS app uses action: "revoke" to cancel an in-flight challenge even
+  // before a binding exists, e.g. during verification setup).
   cancelOutbound({ channel: resolvedChannel });
-
-  // Always revoke pending challenges first — the macOS app uses
-  // action: "revoke" to cancel an in-flight challenge even before
-  // a binding exists (e.g. during verification setup).
   revokePendingSessions(resolvedChannel);
 
-  // Capture binding before revoking so we can revoke the guardian's
-  // contact record — without this, the guardian would still pass
-  // the ACL check after unbinding.
+  // Capture binding before revoking so we can downgrade the guardian's
+  // channel — without this, the guardian would still pass the ACL check.
   const bindingBeforeRevoke = getGuardianBinding(assistantId, resolvedChannel);
   if (!bindingBeforeRevoke) {
     return {
@@ -197,17 +195,15 @@ export function revokeVerificationForChannel(
     };
   }
 
-  // Revoke the member BEFORE the guardian binding so that
-  // revokeMember sees the channel as active/pending and sets the
-  // correct revokedReason ("guardian_binding_revoked"). If the guardian binding
-  // is revoked first, the channel is already marked revoked and the member
-  // revocation becomes a no-op (wrong reason or skipped entirely).
   const contactResult = findContactChannel({
     channelType: resolvedChannel,
     address: bindingBeforeRevoke.guardianExternalUserId,
     externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
   });
 
+  // Relay the ACL downgrade to the gateway (source of truth). The gateway's
+  // mark_channel_revoked enforces the guardian guard and dual-writes the
+  // contact-channel status back to the assistant DB.
   if (contactResult) {
     const channelStatus: ChannelStatus = contactResult.channel.status;
     if (
@@ -215,10 +211,16 @@ export function revokeVerificationForChannel(
       channelStatus === "pending" ||
       channelStatus === "unverified"
     ) {
-      revokeMember(contactResult.channel.id, "guardian_binding_revoked");
+      await ipcCallPersistent("mark_channel_revoked", {
+        contactChannelId: contactResult.channel.id,
+        reason: "guardian_binding_revoked",
+      });
     }
   }
 
+  // The guardian binding is assistant-owned state the gateway relay does not
+  // manage; tear it down here. revokeBinding also emits the contact-change
+  // invalidation so open client views stop showing the channel as active.
   revokeBinding(assistantId, resolvedChannel);
 
   return {
@@ -590,7 +592,7 @@ export async function handleChannelVerificationSession(
         channel,
       });
     } else if (msg.action === "revoke") {
-      const result = revokeVerificationForChannel(channel);
+      const result = await revokeVerificationForChannel(channel);
       broadcastMessage({
         type: "channel_verification_session_response",
         ...result,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,7 +1,10 @@
 import { createHash, randomBytes } from "node:crypto";
 
+import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import { startVerificationCall } from "../../calls/call-domain.js";
 import type { ChannelId } from "../../channels/types.js";
+import { emitContactChange } from "../../contacts/contact-events.js";
 import {
   findContactChannel,
   findGuardianForChannel,
@@ -211,16 +214,25 @@ export async function revokeVerificationForChannel(
       channelStatus === "pending" ||
       channelStatus === "unverified"
     ) {
-      await ipcCallPersistent("mark_channel_revoked", {
+      const result = await ipcCallPersistent("mark_channel_revoked", {
         contactChannelId: contactResult.channel.id,
         reason: "guardian_binding_revoked",
       });
+      const parsed = MarkChannelRevokedIpcResponseSchema.parse(result);
+      if (!parsed.ok) {
+        throw new Error("mark_channel_revoked relay returned ok: false");
+      }
+      // The gateway dual-write already set the assistant channel to "revoked",
+      // so the later revokeGuardianBinding lookup (active-only) finds nothing
+      // and won't fire the invalidation. Emit it here so open client views
+      // stop showing the channel as active.
+      emitContactChange();
     }
   }
 
   // The guardian binding is assistant-owned state the gateway relay does not
-  // manage; tear it down here. revokeBinding also emits the contact-change
-  // invalidation so open client views stop showing the channel as active.
+  // manage; tear it down here. The contact-change invalidation is emitted
+  // explicitly above on relay success.
   revokeBinding(assistantId, resolvedChannel);
 
   return {

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -157,6 +157,12 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 - Guardian approval records in `channelGuardianApprovalRequests` link via `requestId`.
 - The conversational approval engine classifies user intent and resolves via `conversation.handleConfirmationResponse(requestId, decision)`.
 
+### Channel verification source-of-truth split
+
+Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned (`channel-verification-routes.ts`, `channel-verification-service.ts`). The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned.
+
+The `channel_verification_sessions_*` daemon handlers are thin relays for the outcome write, following the trust-rules relay precedent. The gateway IPC methods `mark_channel_verified` / `mark_channel_revoked` (`ContactStore.markChannelVerified` / `markChannelRevoked`) are the single outcome write path for all callers: HTTP routes, inbound code-match completion (`gateway/src/verification/text-verification.ts`), and CLI/IPC.
+
 ## Rate Limiting & Diagnostics
 
 All `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middleware/rate-limiter.ts`):

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -161,7 +161,9 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 
 Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned (`channel-verification-routes.ts`, `channel-verification-service.ts`). The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned.
 
-The `channel_verification_sessions_*` daemon handlers are thin relays for the outcome write, following the trust-rules relay precedent. The gateway IPC methods `mark_channel_verified` / `mark_channel_revoked` (`ContactStore.markChannelVerified` / `markChannelRevoked`) are the single outcome write path for all callers: HTTP routes, inbound code-match completion (`gateway/src/verification/text-verification.ts`), and CLI/IPC.
+The verified outcome is written in-process by the gateway: the HTTP guardian-attest handler calls `ContactStore.markChannelVerified` directly (verifiedVia "manual"), and the inbound code-match path (`gateway/src/verification/text-verification.ts`) writes via `upsertVerifiedContactChannel` / `createGuardianBinding` (verifiedVia "challenge"). The revoke/downgrade outcome is relayed from the daemon via `ipcCallPersistent("mark_channel_revoked", …)` to `ContactStore.markChannelRevoked`.
+
+The `mark_channel_verified` IPC method exists as the daemon/CLI relay surface (symmetric with `mark_channel_revoked`) but has no caller: the trusted-contact CLI path sends codes only, and the outcome arrives via the inbound code-match path.
 
 ## Rate Limiting & Diagnostics
 

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for the verification-revoke route relay.
+ *
+ * The revoke route downgrades the channel's ACL status through the gateway
+ * (source of truth) via `ipcCallPersistent("mark_channel_revoked", ...)` while
+ * keeping session teardown (`cancelOutbound`, `revokePendingSessions`)
+ * assistant-side. The gateway enforces the guardian guard; a rejected guardian
+ * downgrade surfaces here as a relayed IpcCallError.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+let ipcCalls: IpcCall[] = [];
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
+    return {
+      ok: true,
+      didWrite: true,
+      channel: {
+        id: (params?.contactChannelId as string) ?? "ch1",
+        contactId: "c1",
+        type: "telegram",
+        address: "addr",
+        status: "revoked",
+        revokedReason: (params?.reason as string) ?? null,
+      },
+    };
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Session teardown — assert these still run locally on every revoke.
+const cancelOutboundMock = mock((_args: { channel: string }) => {});
+const actualOutboundActions = await import(
+  "../../verification-outbound-actions.js"
+);
+mock.module("../../verification-outbound-actions.js", () => ({
+  ...actualOutboundActions,
+  cancelOutbound: cancelOutboundMock,
+}));
+
+const revokePendingSessionsMock = mock((_channel: string) => {});
+const revokeBindingMock = mock((_assistantId: string, _channel: string) => {
+  revokeGuardianBindingMock();
+  return true;
+});
+let guardianBinding:
+  | {
+      guardianExternalUserId: string;
+      guardianDeliveryChatId?: string;
+    }
+  | null = null;
+const actualVerificationService = await import(
+  "../../channel-verification-service.js"
+);
+mock.module("../../channel-verification-service.js", () => ({
+  ...actualVerificationService,
+  revokePendingSessions: revokePendingSessionsMock,
+  revokeBinding: revokeBindingMock,
+  getGuardianBinding: mock(() => guardianBinding),
+}));
+
+// Contact-store lookup that resolves the guardian's channel to downgrade.
+let contactChannel: { id: string; status: string } | null = null;
+const actualContactStore = await import("../../../contacts/contact-store.js");
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  findContactChannel: mock(() =>
+    contactChannel ? { channel: contactChannel, contact: { id: "c1" } } : null,
+  ),
+}));
+
+// Guard: the contact-channel ACL write moves to the gateway relay and must
+// never run locally. The assistant-owned guardian-binding teardown
+// (revokeGuardianBinding) still runs locally — assert it is invoked.
+const localAclWrite = mock(() => {
+  throw new Error("local ACL write must not happen on relayed revoke");
+});
+const revokeGuardianBindingMock = mock(() => true);
+const actualContactsWrite = await import("../../../contacts/contacts-write.js");
+mock.module("../../../contacts/contacts-write.js", () => ({
+  ...actualContactsWrite,
+  revokeMember: localAclWrite,
+  revokeGuardianBinding: revokeGuardianBindingMock,
+}));
+
+const { ROUTES } = await import("../channel-verification-routes.js");
+
+const revokeHandler = ROUTES.find(
+  (r) => r.operationId === "channel_verification_sessions_revoke",
+)!.handler;
+
+describe("verification revoke relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcError = undefined;
+    guardianBinding = {
+      guardianExternalUserId: "guardian-user",
+      guardianDeliveryChatId: "chat-1",
+    };
+    contactChannel = { id: "ch1", status: "active" };
+    ipcCallPersistentMock.mockClear();
+    cancelOutboundMock.mockClear();
+    revokePendingSessionsMock.mockClear();
+    revokeBindingMock.mockClear();
+    revokeGuardianBindingMock.mockClear();
+    localAclWrite.mockClear();
+  });
+
+  test("relays the downgrade outcome to the gateway and tears down sessions locally", async () => {
+    const result = (await revokeHandler({
+      body: { channel: "telegram" },
+    })) as { success: boolean; bound: boolean; channel: string };
+
+    // ACL downgrade relayed to the gateway (source of truth).
+    expect(ipcCalls).toEqual([
+      {
+        method: "mark_channel_revoked",
+        params: {
+          contactChannelId: "ch1",
+          reason: "guardian_binding_revoked",
+        },
+      },
+    ]);
+
+    // Session teardown stays assistant-side.
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+
+    // Assistant-owned guardian binding torn down locally.
+    expect(revokeBindingMock).toHaveBeenCalledTimes(1);
+    expect(revokeGuardianBindingMock).toHaveBeenCalledTimes(1);
+
+    // The contact-channel ACL write does not fall back to the assistant.
+    expect(localAclWrite).not.toHaveBeenCalled();
+
+    expect(result.success).toBe(true);
+    expect(result.bound).toBe(false);
+  });
+
+  test("guardian guard rejection from the gateway surfaces as an error", async () => {
+    ipcError = new IpcCallError("Cannot downgrade a guardian channel.", {
+      statusCode: 409,
+      errorCode: "CONFLICT",
+    });
+
+    let thrown: { statusCode?: number; message: string } | undefined;
+    try {
+      await revokeHandler({ body: { channel: "telegram" } });
+    } catch (err) {
+      thrown = err as { statusCode?: number; message: string };
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown!.statusCode).toBe(409);
+    // Session teardown ran before the relay rejected; the binding teardown
+    // does not run when the gateway refuses the downgrade.
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    expect(revokeBindingMock).not.toHaveBeenCalled();
+    expect(localAclWrite).not.toHaveBeenCalled();
+  });
+
+  test("no binding present: tears down sessions and skips the relay", async () => {
+    guardianBinding = null;
+
+    const result = (await revokeHandler({
+      body: { channel: "telegram" },
+    })) as { success: boolean; bound: boolean };
+
+    expect(ipcCalls).toEqual([]);
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    expect(revokeBindingMock).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.bound).toBe(false);
+  });
+
+  test("skips the relay when the resolved channel is already revoked", async () => {
+    contactChannel = { id: "ch1", status: "revoked" };
+
+    await revokeHandler({ body: { channel: "telegram" } });
+
+    expect(ipcCalls).toEqual([]);
+    expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
+    expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
+    // Binding teardown still runs even when the channel is already revoked.
+    expect(revokeBindingMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -97,6 +97,17 @@ mock.module("../../../contacts/contacts-write.js", () => ({
   revokeGuardianBinding: revokeGuardianBindingMock,
 }));
 
+// Contact-change invalidation — emitted explicitly on relay success so open
+// client views stop showing the channel as active (the gateway dual-write to
+// "revoked" precedes binding teardown, so revokeGuardianBinding no longer
+// fires it).
+const emitContactChangeMock = mock(() => {});
+const actualContactEvents = await import("../../../contacts/contact-events.js");
+mock.module("../../../contacts/contact-events.js", () => ({
+  ...actualContactEvents,
+  emitContactChange: emitContactChangeMock,
+}));
+
 const { ROUTES } = await import("../channel-verification-routes.js");
 
 const revokeHandler = ROUTES.find(
@@ -118,6 +129,7 @@ describe("verification revoke relay", () => {
     revokeBindingMock.mockClear();
     revokeGuardianBindingMock.mockClear();
     localAclWrite.mockClear();
+    emitContactChangeMock.mockClear();
   });
 
   test("relays the downgrade outcome to the gateway and tears down sessions locally", async () => {
@@ -147,8 +159,70 @@ describe("verification revoke relay", () => {
     // The contact-channel ACL write does not fall back to the assistant.
     expect(localAclWrite).not.toHaveBeenCalled();
 
+    // Invalidation emitted explicitly on relay success: the gateway dual-write
+    // to "revoked" precedes binding teardown, so revokeGuardianBinding's own
+    // emit no longer fires.
+    expect(emitContactChangeMock).toHaveBeenCalledTimes(1);
+
     expect(result.success).toBe(true);
     expect(result.bound).toBe(false);
+  });
+
+  test("emits the invalidation even when the gateway dual-write already revoked the channel", async () => {
+    // Simulate the gateway having dual-written the assistant row to "revoked"
+    // before binding teardown: findGuardianForChannel (active-only) now finds
+    // nothing, so revokeGuardianBinding is a no-op and never emits.
+    revokeGuardianBindingMock.mockImplementationOnce(() => false);
+
+    await revokeHandler({ body: { channel: "telegram" } });
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(emitContactChangeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("malformed gateway response surfaces as an error", async () => {
+    // Deliberately malformed shape: must fail schema validation, not pass.
+    ipcCallPersistentMock.mockImplementationOnce(
+      async () => ({ ok: "nope" }) as never,
+    );
+
+    let thrown: Error | undefined;
+    try {
+      await revokeHandler({ body: { channel: "telegram" } });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    // Invalidation must not fire when the relay response is invalid.
+    expect(emitContactChangeMock).not.toHaveBeenCalled();
+    expect(revokeBindingMock).not.toHaveBeenCalled();
+  });
+
+  test("ok: false gateway response surfaces as an error", async () => {
+    ipcCallPersistentMock.mockImplementationOnce(async (_m, params) => ({
+      ok: false,
+      didWrite: false,
+      channel: {
+        id: (params?.contactChannelId as string) ?? "ch1",
+        contactId: "c1",
+        type: "telegram",
+        address: "addr",
+        status: "active",
+        revokedReason: "still_active",
+      },
+    }));
+
+    let thrown: Error | undefined;
+    try {
+      await revokeHandler({ body: { channel: "telegram" } });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(emitContactChangeMock).not.toHaveBeenCalled();
+    expect(revokeBindingMock).not.toHaveBeenCalled();
   });
 
   test("guardian guard rejection from the gateway surfaces as an error", async () => {

--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the trusted-contact branch of the channel-verification create
+ * route.
+ *
+ * Investigation finding (PR 4 of contacts-gw-native-verification): the
+ * daemon/CLI trusted-contact path (`verifyTrustedContact` →
+ * `handleCreateVerificationSession`) has NO direct assistant-side activation
+ * write. Every branch only creates an outbound session, records delivery, and
+ * sends a code; the channel is flipped to `active` exclusively by the inbound
+ * code-match completion, which already runs through the gateway
+ * (`gateway/src/verification/text-verification.ts` →
+ * `applyTrustedContactSideEffects`). The `already_verified` check on this path
+ * is a read-only short-circuit that returns a 409, not a write.
+ *
+ * There is therefore no daemon-side outcome write to relay. These tests pin
+ * that invariant: the trusted-contact create path must NOT write the
+ * activation outcome assistant-side (no `updateChannelStatus`), so the outcome
+ * is never double-written against the inbound gateway path.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const verifyTrustedContactCalls: Array<[string, string]> = [];
+let verifyTrustedContactImpl: (
+  contactChannelId: string,
+  assistantId: string,
+) => Promise<Record<string, unknown>> = async () => ({ success: true });
+
+const updateChannelStatusCalls: unknown[] = [];
+const ipcCalls: Array<[string, unknown]> = [];
+
+mock.module("../../../daemon/handlers/config-channels.js", () => ({
+  verifyTrustedContact: async (contactChannelId: string, assistantId: string) => {
+    verifyTrustedContactCalls.push([contactChannelId, assistantId]);
+    return verifyTrustedContactImpl(contactChannelId, assistantId);
+  },
+  createInboundChallenge: () => ({ success: true }),
+  getVerificationStatus: () => ({ success: true }),
+  revokeVerificationForChannel: () => ({ success: true }),
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  updateChannelStatus: (...args: unknown[]) => {
+    updateChannelStatusCalls.push(args);
+    return null;
+  },
+}));
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (method: string, params: unknown) => {
+    ipcCalls.push([method, params]);
+    return { ok: true, didWrite: true, channel: {} };
+  },
+}));
+
+import { ConflictError, TooManyRequestsError } from "../errors.js";
+import { handleCreateVerificationSession } from "../channel-verification-routes.js";
+
+beforeEach(() => {
+  verifyTrustedContactCalls.length = 0;
+  updateChannelStatusCalls.length = 0;
+  ipcCalls.length = 0;
+  verifyTrustedContactImpl = async () => ({ success: true });
+});
+
+describe("handleCreateVerificationSession — trusted_contact", () => {
+  test("sends the verification session without writing the activation outcome assistant-side", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: true,
+      verificationSessionId: "sess-1",
+      expiresAt: Date.now() + 600_000,
+      sendCount: 1,
+      channel: "phone",
+    });
+
+    const result = (await handleCreateVerificationSession({
+      body: { purpose: "trusted_contact", contactChannelId: "cc-1" },
+    })) as Record<string, unknown>;
+
+    expect(result.success).toBe(true);
+    expect(result.verificationSessionId).toBe("sess-1");
+    expect(verifyTrustedContactCalls).toEqual([["cc-1", expect.any(String)]]);
+
+    // No assistant-side activation outcome write on the create path — the
+    // outcome flows through the inbound gateway code-match path instead.
+    expect(updateChannelStatusCalls).toEqual([]);
+  });
+
+  test("does not double-write the outcome via the gateway relay on the create path", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: true,
+      verificationSessionId: "sess-2",
+      channel: "telegram",
+    });
+
+    await handleCreateVerificationSession({
+      body: { purpose: "trusted_contact", contactChannelId: "cc-2" },
+    });
+
+    // The activation outcome is owned by the inbound gateway path; the create
+    // path must not relay a `mark_channel_verified` write (no double-write).
+    expect(
+      ipcCalls.filter(([method]) => method === "mark_channel_verified"),
+    ).toEqual([]);
+  });
+
+  test("propagates an already-verified short-circuit as a ConflictError (no silent success)", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: false,
+      error: "already_verified",
+      message: "Channel is already verified",
+    });
+
+    await expect(
+      handleCreateVerificationSession({
+        body: { purpose: "trusted_contact", contactChannelId: "cc-3" },
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(updateChannelStatusCalls).toEqual([]);
+  });
+
+  test("propagates a rate-limit failure rather than silently succeeding", async () => {
+    verifyTrustedContactImpl = async () => ({
+      success: false,
+      error: "rate_limited",
+      message: "Too many attempts",
+    });
+
+    await expect(
+      handleCreateVerificationSession({
+        body: { purpose: "trusted_contact", contactChannelId: "cc-4" },
+      }),
+    ).rejects.toBeInstanceOf(TooManyRequestsError);
+  });
+
+  test("a failure in the trusted-contact path propagates, never a silent success", async () => {
+    verifyTrustedContactImpl = async () => {
+      throw new Error("gateway relay failed");
+    };
+
+    await expect(
+      handleCreateVerificationSession({
+        body: { purpose: "trusted_contact", contactChannelId: "cc-5" },
+      }),
+    ).rejects.toThrow("gateway relay failed");
+
+    expect(updateChannelStatusCalls).toEqual([]);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -2,20 +2,10 @@
  * Tests for the trusted-contact branch of the channel-verification create
  * route.
  *
- * Investigation finding (PR 4 of contacts-gw-native-verification): the
- * daemon/CLI trusted-contact path (`verifyTrustedContact` →
- * `handleCreateVerificationSession`) has NO direct assistant-side activation
- * write. Every branch only creates an outbound session, records delivery, and
- * sends a code; the channel is flipped to `active` exclusively by the inbound
- * code-match completion, which already runs through the gateway
- * (`gateway/src/verification/text-verification.ts` →
- * `applyTrustedContactSideEffects`). The `already_verified` check on this path
- * is a read-only short-circuit that returns a 409, not a write.
- *
- * There is therefore no daemon-side outcome write to relay. These tests pin
- * that invariant: the trusted-contact create path must NOT write the
- * activation outcome assistant-side (no `updateChannelStatus`), so the outcome
- * is never double-written against the inbound gateway path.
+ * Pins the invariant that the trusted-contact create path performs no
+ * assistant-side activation write (no `updateChannelStatus`): it only creates an
+ * outbound session and sends a code. The verified outcome flows exclusively
+ * through the inbound gateway code-match path, so it is never double-written.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";

--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -53,8 +53,8 @@ mock.module("../../ipc/gateway-client.js", () => ({
   },
 }));
 
-import { ConflictError, TooManyRequestsError } from "../errors.js";
 import { handleCreateVerificationSession } from "../channel-verification-routes.js";
+import { ConflictError, TooManyRequestsError } from "../errors.js";
 
 beforeEach(() => {
   verifyTrustedContactCalls.length = 0;

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -263,7 +263,7 @@ async function handleRevokeVerificationBinding({
 }: RouteHandlerArgs) {
   const { channel } = body as { channel?: ChannelId };
 
-  const result = revokeVerificationForChannel(channel);
+  const result = await revokeVerificationForChannel(channel);
   if (!result.success) {
     throw new BadRequestError(
       (result as { message?: string }).message ?? "Revocation failed",

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -9,9 +9,14 @@
  *
  * Source-of-truth split:
  * - Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned.
- * - The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned, reached via
- *   `ipcCallPersistent("mark_channel_verified", …)`; revoke/downgrade via
- *   `ipcCallPersistent("mark_channel_revoked", …)`.
+ * - The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned, written
+ *   in-process by the HTTP guardian-attest handler (`ContactStore.markChannelVerified`) and by the
+ *   inbound code-match path (`gateway/src/verification/text-verification.ts`).
+ * - The revoke/downgrade OUTCOME is relayed from the daemon via
+ *   `ipcCallPersistent("mark_channel_revoked", …)` to `ContactStore.markChannelRevoked`.
+ * - The `mark_channel_verified` IPC method exists as the daemon/CLI relay surface (symmetric with
+ *   `mark_channel_revoked`) but has no caller: the trusted-contact CLI path sends codes only, and the
+ *   outcome arrives via the inbound code-match path.
  */
 
 import { z } from "zod";

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -6,6 +6,12 @@
  * DELETE /v1/channel-verification-sessions         — cancel all active sessions (inbound + outbound)
  * POST   /v1/channel-verification-sessions/revoke  — cancel all sessions and revoke binding
  * GET    /v1/channel-verification-sessions/status   — check guardian binding status
+ *
+ * Source-of-truth split:
+ * - Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned.
+ * - The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned, reached via
+ *   `ipcCallPersistent("mark_channel_verified", …)`; revoke/downgrade via
+ *   `ipcCallPersistent("mark_channel_revoked", …)`.
  */
 
 import { z } from "zod";

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for the mark_channel_verified IPC handler in contact-handlers.
+ *
+ * The handler delegates to ContactStore.markChannelVerified and projects the
+ * result into the contract-shaped envelope. The assistant DB proxy is mocked
+ * behind a per-test fake so the not-found and assistant-mirror paths can be
+ * exercised without a running daemon.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach, afterAll, mock } from "bun:test";
+
+import "./test-preload.js";
+
+type FakeChannelRow = {
+  id: string;
+  contact_id: string;
+  type: string;
+  address: string;
+  is_primary: number;
+  external_chat_id: string | null;
+  status: string;
+  policy: string;
+  verified_at: number | null;
+  verified_via: string | null;
+  invite_id: string | null;
+  revoked_reason: string | null;
+  blocked_reason: string | null;
+  last_seen_at: number | null;
+  interaction_count: number;
+  last_interaction: number | null;
+  created_at: number;
+  updated_at: number | null;
+};
+
+type FakeContactRow = {
+  id: string;
+  display_name: string;
+  role: string | null;
+  principal_id: string | null;
+  created_at: number;
+  updated_at: number | null;
+};
+
+const fakeAssistantDb = {
+  channels: new Map<string, FakeChannelRow>(),
+  contacts: new Map<string, FakeContactRow>(),
+  reset(): void {
+    this.channels.clear();
+    this.contacts.clear();
+  },
+};
+
+// Mock the assistant DB proxy before importing the handlers. The fake honors
+// `SELECT ... FROM contact_channels WHERE id = ?` and
+// `SELECT ... FROM contacts WHERE id = ?`; all other SELECTs return [].
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
+  assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
+    const lower = sql.toLowerCase();
+    if (lower.includes("from contact_channels")) {
+      const id = String(bind?.[0] ?? "");
+      const row = fakeAssistantDb.channels.get(id);
+      return row ? [row] : [];
+    }
+    if (lower.includes("from contacts")) {
+      const id = String(bind?.[0] ?? "");
+      const row = fakeAssistantDb.contacts.get(id);
+      return row ? [row] : [];
+    }
+    return [];
+  }),
+  assistantDbExec: mock(async () => undefined),
+}));
+
+import { eq } from "drizzle-orm";
+
+import { contactRoutes } from "../ipc/contact-handlers.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+
+const markChannelVerifiedHandler = contactRoutes.find(
+  (r) => r.method === "mark_channel_verified",
+)!.handler;
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  fakeAssistantDb.reset();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedContact(id: string, role: "guardian" | "contact" = "guardian") {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: `name-${id}`,
+      role,
+      principalId: `prin-${id}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedChannel(opts: { id: string; contactId: string; status?: string }) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: opts.id,
+      contactId: opts.contactId,
+      type: "vellum",
+      address: `addr-${opts.id}`,
+      isPrimary: false,
+      status: opts.status ?? "unverified",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedAssistantContact(id: string, role: string = "guardian"): void {
+  fakeAssistantDb.contacts.set(id, {
+    id,
+    display_name: `name-${id}`,
+    role,
+    principal_id: `prin-${id}`,
+    created_at: 100,
+    updated_at: 100,
+  });
+}
+
+function seedAssistantChannel(opts: {
+  id: string;
+  contactId: string;
+  status?: string;
+}): void {
+  fakeAssistantDb.channels.set(opts.id, {
+    id: opts.id,
+    contact_id: opts.contactId,
+    type: "vellum",
+    address: `addr-${opts.id}`,
+    is_primary: 0,
+    external_chat_id: null,
+    status: opts.status ?? "unverified",
+    policy: "allow",
+    verified_at: null,
+    verified_via: null,
+    invite_id: null,
+    revoked_reason: null,
+    blocked_reason: null,
+    last_seen_at: null,
+    interaction_count: 0,
+    last_interaction: null,
+    created_at: 100,
+    updated_at: 100,
+  });
+}
+
+describe("mark_channel_verified IPC handler", () => {
+  test("flips a seeded unverified channel to active + verified_via=challenge and returns the envelope", async () => {
+    seedContact("c1");
+    seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
+
+    const before = Date.now();
+    const res = (await markChannelVerifiedHandler({
+      contactChannelId: "ch1",
+    })) as {
+      ok: boolean;
+      didWrite: boolean;
+      channel: {
+        id: string;
+        contactId: string;
+        type: string;
+        address: string;
+        status: string;
+        verifiedAt: number | null;
+        verifiedVia: string | null;
+      };
+    };
+
+    // (b) response envelope is well-formed
+    expect(res.ok).toBe(true);
+    expect(res.didWrite).toBe(true);
+    expect(res.channel).toEqual({
+      id: "ch1",
+      contactId: "c1",
+      type: "vellum",
+      address: "addr-ch1",
+      status: "active",
+      verifiedAt: res.channel.verifiedAt,
+      verifiedVia: "challenge",
+    });
+
+    // (a) gateway DB row flipped to active / challenge / verified_at set
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("active");
+    expect(row!.verifiedVia).toBe("challenge");
+    expect(row!.verifiedAt!).toBeGreaterThanOrEqual(before);
+  });
+
+  test("throws on a missing channel id (no silent success)", async () => {
+    await expect(
+      markChannelVerifiedHandler({ contactChannelId: "nonexistent" }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  test("inherits assistant-mirror behavior: a gateway-absent channel is mirrored then verified", async () => {
+    seedAssistantContact("c1");
+    seedAssistantChannel({ id: "ch1", contactId: "c1", status: "unverified" });
+
+    const res = (await markChannelVerifiedHandler({
+      contactChannelId: "ch1",
+    })) as { ok: boolean; didWrite: boolean; channel: { status: string } };
+
+    expect(res.ok).toBe(true);
+    expect(res.didWrite).toBe(true);
+    expect(res.channel.status).toBe("active");
+
+    // Channel + parent contact were materialized into the gateway DB.
+    const channelInGateway = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(channelInGateway).toBeTruthy();
+    expect(channelInGateway!.contactId).toBe("c1");
+  });
+});

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -86,6 +86,10 @@ const markChannelVerifiedHandler = contactRoutes.find(
   (r) => r.method === "mark_channel_verified",
 )!.handler;
 
+const markChannelRevokedHandler = contactRoutes.find(
+  (r) => r.method === "mark_channel_revoked",
+)!.handler;
+
 beforeAll(async () => {
   await initGatewayDb();
 });
@@ -245,5 +249,101 @@ describe("mark_channel_verified IPC handler", () => {
       .get();
     expect(channelInGateway).toBeTruthy();
     expect(channelInGateway!.contactId).toBe("c1");
+  });
+});
+
+describe("mark_channel_revoked IPC handler", () => {
+  test("downgrades a contact channel to revoked + reason and returns the envelope", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "active" });
+
+    const res = (await markChannelRevokedHandler({
+      contactChannelId: "ch1",
+      reason: "guardian_binding_revoked",
+    })) as {
+      ok: boolean;
+      didWrite: boolean;
+      channel: { status: string; revokedReason: string | null };
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.didWrite).toBe(true);
+    expect(res.channel.status).toBe("revoked");
+    expect(res.channel.revokedReason).toBe("guardian_binding_revoked");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("revoked");
+    expect(row!.revokedReason).toBe("guardian_binding_revoked");
+  });
+
+  test("guardian guard rejects a non-binding downgrade of a guardian channel", async () => {
+    seedContact("g1", "guardian");
+    seedChannel({ id: "gch1", contactId: "g1", status: "active" });
+
+    await expect(
+      markChannelRevokedHandler({
+        contactChannelId: "gch1",
+        reason: "some_other_reason",
+      }),
+    ).rejects.toThrow(/guardian channel/i);
+
+    // Row is untouched — the guard rejects before any write.
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "gch1"))
+      .get();
+    expect(row!.status).toBe("active");
+  });
+
+  test("allows the sanctioned guardian-binding teardown on a guardian channel", async () => {
+    seedContact("g1", "guardian");
+    seedChannel({ id: "gch1", contactId: "g1", status: "active" });
+
+    const res = (await markChannelRevokedHandler({
+      contactChannelId: "gch1",
+      reason: "guardian_binding_revoked",
+    })) as { ok: boolean; channel: { status: string } };
+
+    expect(res.ok).toBe(true);
+    expect(res.channel.status).toBe("revoked");
+  });
+
+  test("does not downgrade a blocked channel (preserves block + reason)", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "blocked" });
+    getGatewayDb()
+      .update(contactChannels)
+      .set({ blockedReason: "abuse" })
+      .where(eq(contactChannels.id, "ch1"))
+      .run();
+
+    const res = (await markChannelRevokedHandler({
+      contactChannelId: "ch1",
+      reason: "guardian_binding_revoked",
+    })) as { ok: boolean; didWrite: boolean; channel: { status: string } };
+
+    expect(res.ok).toBe(true);
+    expect(res.didWrite).toBe(false);
+    expect(res.channel.status).toBe("blocked");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("blocked");
+    expect(row!.blockedReason).toBe("abuse");
+    expect(row!.revokedReason).toBeNull();
+  });
+
+  test("throws on a missing channel id (no silent success)", async () => {
+    await expect(
+      markChannelRevokedHandler({ contactChannelId: "nonexistent" }),
+    ).rejects.toThrow(/not found/);
   });
 });

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -123,12 +123,13 @@ function seedAssistantChannel(opts: {
   id: string;
   contactId: string;
   status?: string;
+  address?: string;
 }): void {
   fakeAssistantDb.channels.set(opts.id, {
     id: opts.id,
     contact_id: opts.contactId,
     type: "vellum",
-    address: `addr-${opts.id}`,
+    address: opts.address ?? `addr-${opts.id}`,
     is_primary: 0,
     external_user_id: null,
     external_chat_id: null,
@@ -172,6 +173,7 @@ function seedChannel(opts: {
   status?: string;
   verifiedAt?: number | null;
   verifiedVia?: string | null;
+  address?: string;
 }) {
   const now = Date.now();
   getGatewayDb()
@@ -180,7 +182,7 @@ function seedChannel(opts: {
       id: opts.id,
       contactId: opts.contactId,
       type: "vellum",
-      address: `addr-${opts.id}`,
+      address: opts.address ?? `addr-${opts.id}`,
       isPrimary: false,
       status: opts.status ?? "unverified",
       policy: "allow",
@@ -448,5 +450,84 @@ describe("ContactStore.markChannelVerified", () => {
       .where(eq(contacts.id, "c1"))
       .get();
     expect(contactRow!.displayName).toBe("gateway-name");
+  });
+
+  test("legacy channel: resolves a differing gateway id by (contactId,type,address) and verifies", async () => {
+    // Migrated user: gateway row lives under a different UUID than the
+    // assistant channel id, sharing the logical (contactId, type, address) key.
+    seedContact("c1");
+    seedChannel({
+      id: "gw-uuid",
+      contactId: "c1",
+      status: "unverified",
+      address: "shared-addr",
+    });
+    seedAssistantContact("c1");
+    seedAssistantChannel({
+      id: "assistant-uuid",
+      contactId: "c1",
+      status: "unverified",
+      address: "shared-addr",
+    });
+
+    const result = await new ContactStore().markChannelVerified(
+      "assistant-uuid",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.id).toBe("gw-uuid");
+    expect(result!.channel.status).toBe("active");
+    expect(result!.channel.verifiedVia).toBe("manual");
+
+    // Still exactly one gateway channel row — the mirror's ON CONFLICT
+    // DO NOTHING did not insert a duplicate.
+    expect(
+      getGatewayDb().select().from(contactChannels).all().length,
+    ).toBe(1);
+  });
+});
+
+describe("ContactStore.markChannelRevoked", () => {
+  test("revokes a channel by its gateway id", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "active" });
+
+    const result = await new ContactStore().markChannelRevoked("ch1", "spam");
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.status).toBe("revoked");
+    expect(result!.channel.revokedReason).toBe("spam");
+  });
+
+  test("legacy channel: resolves a differing gateway id by (contactId,type,address) and revokes", async () => {
+    seedContact("c1", "contact");
+    seedChannel({
+      id: "gw-uuid",
+      contactId: "c1",
+      status: "active",
+      address: "shared-addr",
+    });
+    seedAssistantContact("c1", "contact");
+    seedAssistantChannel({
+      id: "assistant-uuid",
+      contactId: "c1",
+      status: "active",
+      address: "shared-addr",
+    });
+
+    const result = await new ContactStore().markChannelRevoked(
+      "assistant-uuid",
+      "spam",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.id).toBe("gw-uuid");
+    expect(result!.channel.status).toBe("revoked");
+    expect(result!.channel.revokedReason).toBe("spam");
+
+    // No duplicate gateway row inserted by the mirror.
+    expect(
+      getGatewayDb().select().from(contactChannels).all().length,
+    ).toBe(1);
   });
 });

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -279,6 +279,68 @@ describe("ContactStore.markChannelVerified", () => {
     expect(b!.channel.verifiedAt).toBe(a!.channel.verifiedAt);
   });
 
+  test("writes verifiedVia=challenge to gateway + assistant when passed", async () => {
+    seedContact("c1");
+    seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
+
+    const result = await new ContactStore().markChannelVerified(
+      "ch1",
+      "challenge",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.status).toBe("active");
+    expect(result!.channel.verifiedVia).toBe("challenge");
+
+    // The assistant DB dual-write bound the same verifiedVia.
+    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
+      c.sql.includes("UPDATE contact_channels"),
+    );
+    expect(dualWrite).toBeTruthy();
+    expect(dualWrite!.bind).toContain("challenge");
+    expect(dualWrite!.bind).not.toContain("manual");
+  });
+
+  test("is idempotent per-verifiedVia: a repeated challenge call is a no-op", async () => {
+    seedContact("c1");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedAt: 1000,
+      verifiedVia: "challenge",
+    });
+
+    const result = await new ContactStore().markChannelVerified(
+      "ch1",
+      "challenge",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(false);
+    expect(result!.channel.verifiedAt).toBe(1000);
+    expect(result!.channel.verifiedVia).toBe("challenge");
+    // No-op skips the assistant dual-write.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
+  });
+
+  test("default (no-arg) call still writes verifiedVia=manual", async () => {
+    seedContact("c1");
+    seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
+
+    const result = await new ContactStore().markChannelVerified("ch1");
+    expect(result!.didWrite).toBe(true);
+    expect(result!.channel.verifiedVia).toBe("manual");
+
+    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
+      c.sql.includes("UPDATE contact_channels"),
+    );
+    expect(dualWrite!.bind).toContain("manual");
+  });
+
   test("mirrors channel + contact from assistant DB when gateway is empty, then verifies", async () => {
     seedAssistantContact("c1");
     seedAssistantChannel({

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -65,9 +65,17 @@ const fakeAssistantDb = {
 // Mock the assistant DB proxy before importing ContactStore. The fake
 // honors `SELECT ... FROM contact_channels WHERE id = ?` and
 // `SELECT ... FROM contacts WHERE id = ?`; all other SELECTs return [].
+// When set, the next id-keyed `UPDATE ... WHERE id = ?` reports 0 changes so
+// the logical-key fallback path is exercised. Cleared after one such update.
+let nextIdUpdateMisses = false;
+
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbRun: mock(async (sql: string, bind?: unknown[]) => {
     fakeAssistantDb.runCalls.push({ sql, bind });
+    if (nextIdUpdateMisses && /where id = \?/i.test(sql)) {
+      nextIdUpdateMisses = false;
+      return { changes: 0, lastInsertRowid: 0 };
+    }
     return { changes: 1, lastInsertRowid: 0 };
   }),
   assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
@@ -106,6 +114,7 @@ beforeEach(() => {
   db.delete(contactChannels).run();
   db.delete(contacts).run();
   fakeAssistantDb.reset();
+  nextIdUpdateMisses = false;
 });
 
 function seedAssistantContact(id: string, role: string = "guardian"): void {
@@ -484,6 +493,39 @@ describe("ContactStore.markChannelVerified", () => {
     expect(
       getGatewayDb().select().from(contactChannels).all().length,
     ).toBe(1);
+  });
+
+  test("assistant dual-write falls back to the logical key when the id-keyed update misses", async () => {
+    // Legacy mismatch: the caller's id resolves the gateway row, but the
+    // id-keyed assistant UPDATE affects 0 rows (the assistant mirror lives
+    // under a different UUID). The dual-write must then resolve by logical key.
+    seedContact("c1");
+    seedChannel({
+      id: "gw-uuid",
+      contactId: "c1",
+      status: "unverified",
+      address: "shared-addr",
+    });
+    nextIdUpdateMisses = true;
+
+    const result = await new ContactStore().markChannelVerified("gw-uuid");
+    expect(result!.didWrite).toBe(true);
+
+    const idUpdate = fakeAssistantDb.runCalls.find((c) =>
+      /UPDATE contact_channels[\s\S]*WHERE id = \?/i.test(c.sql),
+    );
+    expect(idUpdate).toBeTruthy();
+
+    const keyUpdate = fakeAssistantDb.runCalls.find((c) =>
+      /WHERE contact_id = \? AND type = \? AND address = \? COLLATE NOCASE/i.test(
+        c.sql,
+      ),
+    );
+    expect(keyUpdate).toBeTruthy();
+    // Logical-key update binds the resolved gateway row's (contactId,type,address).
+    expect(keyUpdate!.bind).toContain("c1");
+    expect(keyUpdate!.bind).toContain("vellum");
+    expect(keyUpdate!.bind).toContain("shared-addr");
   });
 });
 

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -23,6 +23,46 @@ type ExistingRow = {
 let queryRows: ExistingRow[] = [];
 const queryCalls: { sql: string; params: unknown[] }[] = [];
 const runCalls: { sql: string; params: unknown[] }[] = [];
+
+// Fake gateway DB: records update/insert calls and returns a configurable
+// `changes` count per update so the resilient dual-write fallback can be
+// exercised (id-keyed update → logical-key update → insert-mirror).
+type GwUpdate = { set: Record<string, unknown>; where: unknown };
+type GwInsert = { table: unknown; values: Record<string, unknown> };
+const gwUpdates: GwUpdate[] = [];
+const gwInserts: GwInsert[] = [];
+// Successive row-counts returned by `.update(...).returning().all()`, FIFO.
+// A non-zero count means the update matched an existing gateway row.
+let gwUpdateChanges: number[] = [];
+
+mock.module("../db/connection.js", () => ({
+  getGatewayDb: () => ({
+    update: (table: unknown) => ({
+      set: (set: Record<string, unknown>) => ({
+        where: (where: unknown) => ({
+          returning: () => ({
+            all: () => {
+              void table;
+              gwUpdates.push({ set, where });
+              const n = gwUpdateChanges.shift() ?? 0;
+              return Array.from({ length: n }, () => ({ id: "x" }));
+            },
+          }),
+        }),
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoNothing: () => ({
+          run: () => {
+            gwInserts.push({ table, values });
+          },
+        }),
+      }),
+    }),
+  }),
+}));
+
 const TEST_SOCKET_PATH = join(
   tmpdir(),
   `vellum-upsert-contact-channel-test-${process.pid}.sock`,
@@ -38,22 +78,19 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   },
 }));
 
-mock.module("../db/connection.js", () => ({
-  getGatewayDb: () => ({
-    update: () => ({ set: () => ({ where: () => ({ run: () => {} }) }) }),
-    insert: () => ({
-      values: () => ({ onConflictDoNothing: () => ({ run: () => {} }) }),
-    }),
-  }),
-}));
-
 mock.module("../db/schema.js", () => ({
-  contactChannels: "contactChannels",
+  contactChannels: { id: "id", type: "type", address: "address" },
   contacts: "contacts",
 }));
 
 mock.module("drizzle-orm", () => ({
-  eq: (col: unknown, val: unknown) => ({ col, val }),
+  eq: (col: unknown, val: unknown) => ({ op: "eq", col, val }),
+  and: (...conds: unknown[]) => ({ op: "and", conds }),
+  sql: (strings: TemplateStringsArray, ...vals: unknown[]) => ({
+    op: "sql",
+    strings: Array.from(strings),
+    vals,
+  }),
 }));
 
 mock.module("../verification/identity.js", () => ({
@@ -72,6 +109,10 @@ beforeEach(() => {
   queryRows = [];
   queryCalls.length = 0;
   runCalls.length = 0;
+  gwUpdates.length = 0;
+  gwInserts.length = 0;
+  // Default: the id-keyed gateway update lands on an existing row.
+  gwUpdateChanges = [1];
   writeFileSync(TEST_SOCKET_PATH, "");
 });
 
@@ -227,6 +268,59 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(channelInsert!.sql).toContain("verified_at");
     expect(channelInsert!.sql).toContain("verified_via");
     expect(channelInsert!.params).toContain("challenge");
+  });
+
+  test("resolves the gateway row by (type,address) when the id-keyed update misses", async () => {
+    queryRows = [
+      { channelId: "assistant-ch", contactId: "co-8", channelStatus: "active" },
+    ];
+    // id-keyed update misses (0 changes); logical-key update lands (1).
+    gwUpdateChanges = [0, 1];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550002222",
+      externalChatId: "+15550002222",
+    });
+
+    expect(gwUpdates).toHaveLength(2);
+    // Second update is keyed on the logical (type,address) key, not the id.
+    expect(gwUpdates[1]!.where).toMatchObject({ op: "and" });
+    expect(gwUpdates[1]!.set).toMatchObject({
+      status: "active",
+      verifiedVia: "challenge",
+    });
+    expect(gwUpdates[1]!.set.verifiedAt).toEqual(expect.any(Number));
+    // No insert-mirror needed — the logical-key update succeeded.
+    expect(gwInserts).toHaveLength(0);
+  });
+
+  test("inserts a verified gateway channel when no gateway row exists at all", async () => {
+    queryRows = [
+      { channelId: "assistant-ch", contactId: "co-9", channelStatus: "active" },
+    ];
+    // Both id-keyed and logical-key updates miss → insert-mirror.
+    gwUpdateChanges = [0, 0];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550003333",
+      externalChatId: "+15550003333",
+    });
+
+    expect(gwUpdates).toHaveLength(2);
+    const channelInsert = gwInserts.find(
+      (i) => i.values.type === "phone" && i.values.address === "+15550003333",
+    );
+    expect(channelInsert).toBeTruthy();
+    expect(channelInsert!.values).toMatchObject({
+      contactId: "co-9",
+      status: "active",
+      verifiedVia: "challenge",
+    });
+    expect(channelInsert!.values.verifiedAt).toEqual(expect.any(Number));
+    // Parent contact mirrored too.
+    expect(gwInserts.some((i) => i.values.id === "co-9")).toBe(true);
   });
 
   test("honors an explicit verifiedVia value on the update path", async () => {

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -323,6 +323,44 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(gwInserts.some((i) => i.values.id === "co-9")).toBe(true);
   });
 
+  test("guards both gateway update paths against blocked/revoked rows", async () => {
+    // Stale assistant mirror is active, so the caller's guard passes and we
+    // reach the gateway write; the authoritative gateway row may be
+    // blocked/revoked and must not be reactivated.
+    queryRows = [
+      { channelId: "assistant-ch", contactId: "co-10", channelStatus: "active" },
+    ];
+    gwUpdateChanges = [0, 0];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550004444",
+      externalChatId: "+15550004444",
+    });
+
+    const hasBlockedRevokedGuard = (whereRaw: unknown) => {
+      const where = whereRaw as { op?: string; conds?: unknown[] };
+      return (
+        where.op === "and" &&
+        (where.conds ?? []).some(
+          (c) =>
+            typeof c === "object" &&
+            c !== null &&
+            (c as { op?: string }).op === "sql" &&
+            ((c as { strings?: string[] }).strings ?? [])
+              .join("")
+              .includes("not in ('blocked', 'revoked')"),
+        )
+      );
+    };
+
+    expect(gwUpdates).toHaveLength(2);
+    // Both the id-keyed and logical-key updates carry the guard, so a
+    // blocked/revoked gateway row is excluded from reactivation.
+    expect(hasBlockedRevokedGuard(gwUpdates[0]!.where)).toBe(true);
+    expect(hasBlockedRevokedGuard(gwUpdates[1]!.where)).toBe(true);
+  });
+
   test("honors an explicit verifiedVia value on the update path", async () => {
     queryRows = [
       { channelId: "ch-7", contactId: "co-7", channelStatus: "active" },

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -186,6 +186,66 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     const inserts = runCalls.filter((c) => c.sql.includes("INSERT"));
     expect(inserts).toHaveLength(2);
   });
+
+  test("update path stamps verified_at + verified_via='challenge'", async () => {
+    queryRows = [
+      { channelId: "ch-6", contactId: "co-6", channelStatus: "active" },
+    ];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550001111",
+      externalChatId: "+15550001111",
+    });
+
+    const update = runCalls.find((c) =>
+      c.sql.includes("UPDATE contact_channels"),
+    );
+    expect(update).toBeTruthy();
+    expect(update!.sql).toContain("status = 'active'");
+    expect(update!.sql).toContain("verified_at = ?");
+    expect(update!.sql).toContain("verified_via = ?");
+    expect(update!.params).toContain("challenge");
+    // verified_at uses a numeric timestamp
+    expect(update!.params.some((p) => typeof p === "number")).toBe(true);
+  });
+
+  test("insert path stamps verified_at + verified_via='challenge'", async () => {
+    queryRows = [];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550009999",
+      externalChatId: "+15550009999",
+    });
+
+    const channelInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT OR IGNORE INTO contact_channels"),
+    );
+    expect(channelInsert).toBeTruthy();
+    expect(channelInsert!.sql).toContain("'active'");
+    expect(channelInsert!.sql).toContain("verified_at");
+    expect(channelInsert!.sql).toContain("verified_via");
+    expect(channelInsert!.params).toContain("challenge");
+  });
+
+  test("honors an explicit verifiedVia value on the update path", async () => {
+    queryRows = [
+      { channelId: "ch-7", contactId: "co-7", channelStatus: "active" },
+    ];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550001111",
+      externalChatId: "+15550001111",
+      verifiedVia: "manual",
+    });
+
+    const update = runCalls.find((c) =>
+      c.sql.includes("UPDATE contact_channels"),
+    );
+    expect(update!.params).toContain("manual");
+  });
 });
 
 describe("upsertContactChannel — channel address casing", () => {

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -256,6 +256,54 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(inserts).toHaveLength(2);
   });
 
+  test("new-insert path returns verified:false and writes nothing when gateway row is blocked", async () => {
+    // No existing assistant channel, but the authoritative gateway DB already
+    // has a blocked row for the same (type,address): no new active channel.
+    queryRows = [];
+    gwSelectStatus = "blocked";
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550009999",
+      externalChatId: "+15550009999",
+    });
+
+    expect(result).toEqual({ verified: false });
+    expect(runCalls.filter((c) => c.sql.includes("INSERT"))).toHaveLength(0);
+    expect(gwInserts).toHaveLength(0);
+    expect(gwUpdates).toHaveLength(0);
+  });
+
+  test("new-insert path returns verified:false and writes nothing when gateway row is revoked", async () => {
+    queryRows = [];
+    gwSelectStatus = "revoked";
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550009999",
+      externalChatId: "+15550009999",
+    });
+
+    expect(result).toEqual({ verified: false });
+    expect(runCalls.filter((c) => c.sql.includes("INSERT"))).toHaveLength(0);
+    expect(gwInserts).toHaveLength(0);
+    expect(gwUpdates).toHaveLength(0);
+  });
+
+  test("new-insert path returns verified:true when no gateway row exists", async () => {
+    queryRows = [];
+    gwSelectStatus = null;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550009999",
+      externalChatId: "+15550009999",
+    });
+
+    expect(result).toEqual({ verified: true });
+    expect(runCalls.filter((c) => c.sql.includes("INSERT"))).toHaveLength(2);
+  });
+
   test("update path stamps verified_at + verified_via='challenge'", async () => {
     queryRows = [
       { channelId: "ch-6", contactId: "co-6", channelStatus: "active" },

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -290,6 +290,38 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(gwUpdates).toHaveLength(0);
   });
 
+  test("new-insert path updates an existing non-blocked gateway row by logical key", async () => {
+    // Assistant lookup misses, but the gateway already has a NON-blocked
+    // (unverified) row for the same (type,address) — e.g. a gateway-created,
+    // unmirrored contact. The id-keyed update misses (different UUID); the
+    // logical-key update lands. The channel must end up active/verified, not a
+    // silent no-op, and the path returns verified:true.
+    queryRows = [];
+    gwSelectStatus = null;
+    gwUpdateChanges = [0, 1];
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550001212",
+      externalChatId: "+15550001212",
+    });
+
+    expect(result).toEqual({ verified: true });
+    // id-keyed update missed, logical-key update landed — no insert-mirror.
+    expect(gwUpdates).toHaveLength(2);
+    expect(gwUpdates[1]!.set).toMatchObject({
+      status: "active",
+      policy: "allow",
+      verifiedVia: "challenge",
+    });
+    // No channel insert-mirror: the existing row was updated in place.
+    expect(
+      gwInserts.some(
+        (i) => i.values.type === "phone" && i.values.address === "+15550001212",
+      ),
+    ).toBe(false);
+  });
+
   test("new-insert path returns verified:true when no gateway row exists", async () => {
     queryRows = [];
     gwSelectStatus = null;

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -34,9 +34,23 @@ const gwInserts: GwInsert[] = [];
 // Successive row-counts returned by `.update(...).returning().all()`, FIFO.
 // A non-zero count means the update matched an existing gateway row.
 let gwUpdateChanges: number[] = [];
+// Status returned by the authoritative gateway pre-check (`.select(...).get()`).
+// null models a missing gateway row (legacy/unmirrored happy path).
+let gwSelectStatus: string | null = null;
+// Whether the insert-mirror reports a written row (`.returning().all()`).
+// false models a (type,address) conflict with a blocked/revoked row.
+let gwInsertWrote = true;
 
 mock.module("../db/connection.js", () => ({
   getGatewayDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          get: () =>
+            gwSelectStatus === null ? undefined : { status: gwSelectStatus },
+        }),
+      }),
+    }),
     update: (table: unknown) => ({
       set: (set: Record<string, unknown>) => ({
         where: (where: unknown) => ({
@@ -57,6 +71,12 @@ mock.module("../db/connection.js", () => ({
           run: () => {
             gwInserts.push({ table, values });
           },
+          returning: () => ({
+            all: () => {
+              gwInserts.push({ table, values });
+              return gwInsertWrote ? [{ id: "x" }] : [];
+            },
+          }),
         }),
       }),
     }),
@@ -79,7 +99,12 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 }));
 
 mock.module("../db/schema.js", () => ({
-  contactChannels: { id: "id", type: "type", address: "address" },
+  contactChannels: {
+    id: "id",
+    type: "type",
+    address: "address",
+    status: "status",
+  },
   contacts: "contacts",
 }));
 
@@ -113,6 +138,9 @@ beforeEach(() => {
   gwInserts.length = 0;
   // Default: the id-keyed gateway update lands on an existing row.
   gwUpdateChanges = [1];
+  // Default: no authoritative gateway row (legacy/unmirrored happy path).
+  gwSelectStatus = null;
+  gwInsertWrote = true;
   writeFileSync(TEST_SOCKET_PATH, "");
 });
 
@@ -359,6 +387,90 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     // blocked/revoked gateway row is excluded from reactivation.
     expect(hasBlockedRevokedGuard(gwUpdates[0]!.where)).toBe(true);
     expect(hasBlockedRevokedGuard(gwUpdates[1]!.where)).toBe(true);
+  });
+
+  test("returns verified:false and skips assistant UPDATE when gateway row is blocked", async () => {
+    // Assistant mirror is active/claimable, but the authoritative gateway row
+    // is blocked: verification must be rejected without activating the mirror.
+    queryRows = [
+      { channelId: "ch-b", contactId: "co-b", channelStatus: "active" },
+    ];
+    gwSelectStatus = "blocked";
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550005555",
+      externalChatId: "+15550005555",
+    });
+
+    expect(result).toEqual({ verified: false });
+    expect(
+      runCalls.filter(
+        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+      ),
+    ).toHaveLength(0);
+    // Gateway write never attempted (returned before the dual-write).
+    expect(gwUpdates).toHaveLength(0);
+    expect(gwInserts).toHaveLength(0);
+  });
+
+  test("returns verified:false and skips assistant UPDATE when gateway row is revoked", async () => {
+    queryRows = [
+      { channelId: "ch-r", contactId: "co-r", channelStatus: "active" },
+    ];
+    gwSelectStatus = "revoked";
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550006666",
+      externalChatId: "+15550006666",
+    });
+
+    expect(result).toEqual({ verified: false });
+    expect(
+      runCalls.filter(
+        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+      ),
+    ).toHaveLength(0);
+    expect(gwUpdates).toHaveLength(0);
+    expect(gwInserts).toHaveLength(0);
+  });
+
+  test("returns verified:true when no authoritative gateway row exists", async () => {
+    queryRows = [
+      { channelId: "ch-ok", contactId: "co-ok", channelStatus: "active" },
+    ];
+    gwSelectStatus = null;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550007777",
+      externalChatId: "+15550007777",
+    });
+
+    expect(result).toEqual({ verified: true });
+    expect(
+      runCalls.filter((c) => c.sql.includes("UPDATE contact_channels")),
+    ).toHaveLength(1);
+  });
+
+  test("returns verified:false when the insert-mirror is no-op'd by a blocked/revoked row", async () => {
+    // Pre-check sees no row (race), updates both miss, and the insert-mirror
+    // conflicts with a blocked/revoked row landed concurrently.
+    queryRows = [
+      { channelId: "ch-race", contactId: "co-race", channelStatus: "active" },
+    ];
+    gwSelectStatus = null;
+    gwUpdateChanges = [0, 0];
+    gwInsertWrote = false;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550008888",
+      externalChatId: "+15550008888",
+    });
+
+    expect(result).toEqual({ verified: false });
   });
 
   test("honors an explicit verifiedVia value on the update path", async () => {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -353,39 +353,7 @@ export class ContactStore {
       reason?: string | null;
     },
   ): Promise<ContactChannel | null> {
-    let gwChannel = this.db
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
-
-    // If not found in the gateway DB, resolve from the assistant DB by
-    // logical key (contactId, type, address) and find the matching gateway row.
-    if (!gwChannel) {
-      const assistantChannel = await assistantDbQuery<{
-        contactId: string;
-        type: string;
-        address: string;
-      }>(
-        "SELECT contact_id AS contactId, type, address FROM contact_channels WHERE id = ?",
-        [channelId],
-      );
-      if (assistantChannel.length > 0) {
-        const { contactId, type, address } = assistantChannel[0];
-        gwChannel = this.db
-          .select()
-          .from(contactChannels)
-          .where(
-            and(
-              eq(contactChannels.contactId, contactId),
-              eq(contactChannels.type, type),
-              sql`${contactChannels.address} = ${address} COLLATE NOCASE`,
-            ),
-          )
-          .get();
-      }
-    }
-
+    const gwChannel = await this.resolveGatewayChannel(channelId);
     if (!gwChannel) return null;
 
     // Guard: cannot revoke a blocked channel.
@@ -640,6 +608,46 @@ export class ContactStore {
   }
 
   /**
+   * Resolve a gateway channel row by id, falling back to its logical key
+   * (contactId, type, address) when the id-based lookup misses. Legacy
+   * channels can live under a different gateway UUID than the assistant id,
+   * so the id passed by callers may not be the gateway row's id.
+   */
+  private async resolveGatewayChannel(
+    channelId: string,
+  ): Promise<ContactChannel | undefined> {
+    const byId = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (byId) return byId;
+
+    const assistantChannel = await assistantDbQuery<{
+      contact_id: string;
+      type: string;
+      address: string;
+    }>(
+      "SELECT contact_id, type, address FROM contact_channels WHERE id = ?",
+      [channelId],
+    );
+    if (assistantChannel.length === 0) return undefined;
+
+    const { contact_id: contactId, type, address } = assistantChannel[0];
+    return this.db
+      .select()
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.contactId, contactId),
+          eq(contactChannels.type, type),
+          sql`${contactChannels.address} = ${address} COLLATE NOCASE`,
+        ),
+      )
+      .get();
+  }
+
+  /**
    * Mark a channel as verified. Sets `status="active"`, stamps
    * `verifiedAt=now`, and records `verifiedVia` (default `"manual"` for the
    * guardian-attestation path; `"challenge"` for the code-exchange path) on
@@ -673,6 +681,12 @@ export class ContactStore {
     const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
     if (!mirrored) return null;
 
+    // Legacy channels may live under a different gateway id than the assistant
+    // channel id passed in; resolve the gateway row before keying writes on it.
+    const gwChannel = await this.resolveGatewayChannel(channelId);
+    if (!gwChannel) return null;
+    const gwChannelId = gwChannel.id;
+
     const now = Date.now();
     const raw = (this.db as unknown as { $client: Database }).$client;
     const result = raw
@@ -682,12 +696,12 @@ export class ContactStore {
          WHERE id = ?
            AND (status != ? OR verified_via != ? OR verified_via IS NULL)`,
       )
-      .run("active", now, verifiedVia, now, channelId, "active", verifiedVia);
+      .run("active", now, verifiedVia, now, gwChannelId, "active", verifiedVia);
 
     const after = this.db
       .select()
       .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
+      .where(eq(contactChannels.id, gwChannelId))
       .get();
 
     if (!after) return null;
@@ -738,12 +752,11 @@ export class ContactStore {
     const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
     if (!mirrored) return null;
 
-    const channel = this.db
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
+    // Legacy channels may live under a different gateway id than the assistant
+    // channel id passed in; resolve the gateway row before keying writes on it.
+    const channel = await this.resolveGatewayChannel(channelId);
     if (!channel) return null;
+    const gwChannelId = channel.id;
 
     const contact = this.getContact(channel.contactId);
     if (
@@ -782,18 +795,18 @@ export class ContactStore {
         blockedReason: null,
         updatedAt: Date.now(),
       })
-      .where(eq(contactChannels.id, channelId))
+      .where(eq(contactChannels.id, gwChannelId))
       .run();
 
     const after = this.db
       .select()
       .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
+      .where(eq(contactChannels.id, gwChannelId))
       .get();
     if (!after) return null;
 
     try {
-      await this.dualWriteChannelStatusToAssistantDb(channelId, {
+      await this.dualWriteChannelStatusToAssistantDb(gwChannelId, {
         status: "revoked",
         revokedReason: reason ?? null,
         blockedReason: null,

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -633,12 +633,13 @@ export class ContactStore {
   }
 
   /**
-   * Mark a channel as verified by guardian attestation, bypassing the
-   * standard challenge-code exchange. Sets `status="active"`, stamps
-   * `verifiedAt=now`, and sets `verifiedVia="manual"` for audit trail.
+   * Mark a channel as verified. Sets `status="active"`, stamps
+   * `verifiedAt=now`, and records `verifiedVia` (default `"manual"` for the
+   * guardian-attestation path; `"challenge"` for the code-exchange path) on
+   * the audit trail.
    *
    * Atomic + idempotent. The UPDATE is gated on the row not already being
-   * `(status="active" AND verified_via="manual")`, so two concurrent
+   * `(status="active" AND verified_via=verifiedVia)`, so two concurrent
    * verify requests can't both write — exactly one will see `changes=1`
    * and the other will see `changes=0`. Both still return the post-state
    * row.
@@ -650,7 +651,10 @@ export class ContactStore {
    * When the channel is missing on the gateway but present on the assistant,
    * it (plus its parent contact) is mirrored into the gateway first.
    */
-  async markChannelVerified(channelId: string): Promise<{
+  async markChannelVerified(
+    channelId: string,
+    verifiedVia: "challenge" | "manual" = "manual",
+  ): Promise<{
     channel: ContactChannel;
     didWrite: boolean;
   } | null> {
@@ -671,7 +675,7 @@ export class ContactStore {
          WHERE id = ?
            AND (status != ? OR verified_via != ? OR verified_via IS NULL)`,
       )
-      .run("active", now, "manual", now, channelId, "active", "manual");
+      .run("active", now, verifiedVia, now, channelId, "active", verifiedVia);
 
     const after = this.db
       .select()
@@ -690,9 +694,9 @@ export class ContactStore {
       try {
         await assistantDbRun(
           `UPDATE contact_channels
-             SET status = 'active', verified_at = ?, verified_via = 'manual', updated_at = ?
+             SET status = 'active', verified_at = ?, verified_via = ?, updated_at = ?
            WHERE id = ?`,
-          [now, now, channelId],
+          [now, verifiedVia, now, channelId],
         );
       } catch (err) {
         log.warn(

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -19,6 +19,13 @@ import { canonicalizeInboundIdentity } from "../verification/identity.js";
 
 const log = getLogger("contact-store");
 
+/**
+ * Reason that marks the sanctioned guardian-binding teardown. A guardian
+ * channel may only be downgraded with this reason; any other reason is
+ * rejected by the guardian guard (invariant 4).
+ */
+export const GUARDIAN_BINDING_REVOKE_REASON = "guardian_binding_revoked";
+
 export type Contact = typeof contacts.$inferSelect;
 export type ContactChannel = typeof contactChannels.$inferSelect;
 export type IngressInviteRow = typeof ingressInvites.$inferSelect;
@@ -707,6 +714,98 @@ export class ContactStore {
     }
 
     return { channel: after, didWrite };
+  }
+
+  /**
+   * Downgrade a channel to `revoked` (verification-revoke outcome), then
+   * best-effort dual-write to the assistant DB. Gateway DB is source of truth.
+   *
+   * Guardian guard (invariant 4): a guardian contact's channel may only be
+   * downgraded via the sanctioned guardian-binding teardown
+   * (`reason="guardian_binding_revoked"`). Any other reason on a guardian
+   * channel is rejected here at the boundary rather than silently applied.
+   *
+   * Mirrors `markChannelVerified`: when the channel is missing on the gateway
+   * but present on the assistant, it (plus its parent contact) is mirrored in
+   * first so a UI-visible channel id doesn't 404.
+   *
+   * Returns the channel after the write, or `null` if neither DB has the id.
+   */
+  async markChannelRevoked(
+    channelId: string,
+    reason?: string,
+  ): Promise<{ channel: ContactChannel; didWrite: boolean } | null> {
+    const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
+    if (!mirrored) return null;
+
+    const channel = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (!channel) return null;
+
+    const contact = this.getContact(channel.contactId);
+    if (
+      contact?.role === "guardian" &&
+      reason !== GUARDIAN_BINDING_REVOKE_REASON
+    ) {
+      log.warn(
+        { channelId, reason },
+        "markChannelRevoked: rejected guardian channel downgrade",
+      );
+      throw new CannotDowngradeGuardianError(channelId);
+    }
+
+    // A blocked channel stays blocked: blocked is stricter than revoked, and
+    // downgrading it would clear blockedReason and make the actor re-claimable.
+    // Mirrors the blocked→revoked guard in updateChannelStatus; here it's a
+    // no-op so a guardian-binding teardown over a blocked channel doesn't fail.
+    if (channel.status === "blocked") {
+      return { channel, didWrite: false };
+    }
+
+    // Idempotent: a row already revoked with this reason is a no-op — skip the
+    // write + dual-write (matches markChannelVerified).
+    const alreadyRevoked =
+      channel.status === "revoked" &&
+      channel.revokedReason === (reason ?? null);
+    if (alreadyRevoked) {
+      return { channel, didWrite: false };
+    }
+
+    this.db
+      .update(contactChannels)
+      .set({
+        status: "revoked",
+        revokedReason: reason ?? null,
+        blockedReason: null,
+        updatedAt: Date.now(),
+      })
+      .where(eq(contactChannels.id, channelId))
+      .run();
+
+    const after = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+    if (!after) return null;
+
+    try {
+      await this.dualWriteChannelStatusToAssistantDb(channelId, {
+        status: "revoked",
+        revokedReason: reason ?? null,
+        blockedReason: null,
+      });
+    } catch (err) {
+      log.warn(
+        { channelId, err },
+        "markChannelRevoked: assistant DB dual-write failed (best-effort)",
+      );
+    }
+
+    return { channel: after, didWrite: true };
   }
 
   // ---------------------------------------------------------------------------
@@ -1812,6 +1911,24 @@ export class CannotRevokeBlockedError extends Error {
       "Cannot revoke a blocked channel. Unblock it first or leave it blocked.",
     );
     this.name = "CannotRevokeBlockedError";
+    this.channelId = channelId;
+  }
+}
+
+/**
+ * Thrown by `markChannelRevoked` when a downgrade would strip a guardian
+ * contact's channel via anything other than the sanctioned guardian-binding
+ * teardown. The caller maps this to HTTP 409.
+ */
+export class CannotDowngradeGuardianError extends Error {
+  readonly channelId: string;
+  readonly statusCode = 409;
+  readonly code = "CONFLICT";
+  constructor(channelId: string) {
+    super(
+      "Cannot downgrade a guardian channel. Revoke the guardian binding instead.",
+    );
+    this.name = "CannotDowngradeGuardianError";
     this.channelId = channelId;
   }
 }

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -826,12 +826,23 @@ export class ContactStore {
     // calls. The gateway DB remains source of truth.
     if (didWrite) {
       try {
-        await assistantDbRun(
+        const result = await assistantDbRun(
           `UPDATE contact_channels
              SET status = 'active', verified_at = ?, verified_via = ?, updated_at = ?
            WHERE id = ?`,
           [now, verifiedVia, now, channelId],
         );
+        // Legacy mismatch: the caller's id may not be the assistant mirror's id
+        // (the gateway row lives under a different UUID). Fall back to the
+        // resolved row's logical key so the mirror isn't left stale.
+        if (result.changes === 0) {
+          await assistantDbRun(
+            `UPDATE contact_channels
+               SET status = 'active', verified_at = ?, verified_via = ?, updated_at = ?
+             WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE`,
+            [now, verifiedVia, now, after.contactId, after.type, after.address],
+          );
+        }
       } catch (err) {
         log.warn(
           { channelId, err },

--- a/gateway/src/http/routes/twilio-voice-verify-callback.ts
+++ b/gateway/src/http/routes/twilio-voice-verify-callback.ts
@@ -192,16 +192,24 @@ export function createTwilioVoiceVerifyCallbackHandler(
       }
     } else if (result.verificationType === "trusted_contact") {
       try {
-        await upsertVerifiedContactChannel({
+        const { verified } = await upsertVerifiedContactChannel({
           sourceChannel: "phone",
           externalUserId: fromNumber,
           externalChatId: fromNumber,
         });
 
-        log.info(
-          { callSid, fromNumber },
-          "Trusted contact phone channel activated by gateway",
-        );
+        if (verified) {
+          log.info(
+            { callSid, fromNumber },
+            "Trusted contact phone channel activated by gateway",
+          );
+        } else {
+          // Authoritative gateway row is blocked/revoked — activation skipped.
+          log.warn(
+            { callSid, fromNumber },
+            "Trusted contact activation skipped (channel blocked/revoked)",
+          );
+        }
       } catch (err) {
         log.error(
           { err, callSid, fromNumber },

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -6,6 +6,7 @@
  * assistant DB proxy (raw SQL), so the gateway owns the write path.
  */
 
+import { MarkChannelVerifiedIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
@@ -152,6 +153,35 @@ export const contactRoutes: IpcRoute[] = [
       );
 
       return { contactId, channelId };
+    },
+  },
+  {
+    method: "mark_channel_verified",
+    schema: MarkChannelVerifiedIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { contactChannelId, verifiedVia } =
+        MarkChannelVerifiedIpcParamsSchema.parse(params);
+      const result = await getStore().markChannelVerified(
+        contactChannelId,
+        verifiedVia,
+      );
+      if (!result) {
+        throw new Error(`Channel "${contactChannelId}" not found`);
+      }
+      const { channel, didWrite } = result;
+      return {
+        ok: true,
+        didWrite,
+        channel: {
+          id: channel.id,
+          contactId: channel.contactId,
+          type: channel.type,
+          address: channel.address,
+          status: channel.status,
+          verifiedAt: channel.verifiedAt,
+          verifiedVia: channel.verifiedVia,
+        },
+      };
     },
   },
 ];

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -8,7 +8,9 @@
 
 import {
   MarkChannelRevokedIpcParamsSchema,
+  MarkChannelRevokedIpcResponseSchema,
   MarkChannelVerifiedIpcParamsSchema,
+  MarkChannelVerifiedIpcResponseSchema,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
@@ -172,7 +174,7 @@ export const contactRoutes: IpcRoute[] = [
         throw new Error(`Channel "${contactChannelId}" not found`);
       }
       const { channel, didWrite } = result;
-      return {
+      return MarkChannelVerifiedIpcResponseSchema.parse({
         ok: true,
         didWrite,
         channel: {
@@ -184,7 +186,7 @@ export const contactRoutes: IpcRoute[] = [
           verifiedAt: channel.verifiedAt,
           verifiedVia: channel.verifiedVia,
         },
-      };
+      });
     },
   },
   {
@@ -201,7 +203,7 @@ export const contactRoutes: IpcRoute[] = [
         throw new Error(`Channel "${contactChannelId}" not found`);
       }
       const { channel, didWrite } = result;
-      return {
+      return MarkChannelRevokedIpcResponseSchema.parse({
         ok: true,
         didWrite,
         channel: {
@@ -212,7 +214,7 @@ export const contactRoutes: IpcRoute[] = [
           status: channel.status,
           revokedReason: channel.revokedReason,
         },
-      };
+      });
     },
   },
 ];

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -6,7 +6,10 @@
  * assistant DB proxy (raw SQL), so the gateway owns the write path.
  */
 
-import { MarkChannelVerifiedIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+import {
+  MarkChannelRevokedIpcParamsSchema,
+  MarkChannelVerifiedIpcParamsSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
@@ -180,6 +183,34 @@ export const contactRoutes: IpcRoute[] = [
           status: channel.status,
           verifiedAt: channel.verifiedAt,
           verifiedVia: channel.verifiedVia,
+        },
+      };
+    },
+  },
+  {
+    method: "mark_channel_revoked",
+    schema: MarkChannelRevokedIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { contactChannelId, reason } =
+        MarkChannelRevokedIpcParamsSchema.parse(params);
+      const result = await getStore().markChannelRevoked(
+        contactChannelId,
+        reason,
+      );
+      if (!result) {
+        throw new Error(`Channel "${contactChannelId}" not found`);
+      }
+      const { channel, didWrite } = result;
+      return {
+        ok: true,
+        didWrite,
+        channel: {
+          id: channel.id,
+          contactId: channel.contactId,
+          type: channel.type,
+          address: channel.address,
+          status: channel.status,
+          revokedReason: channel.revokedReason,
         },
       };
     },

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -354,10 +354,14 @@ export async function upsertVerifiedContactChannel(params: {
     ],
   );
 
-  // Dual-write to gateway DB
+  // Dual-write to gateway DB. The parent contact is conflict-tolerant (a
+  // pre-existing contact is fine). For the channel, resolve by logical key so
+  // an existing non-blocked gateway row (e.g. a gateway-created unverified
+  // contact) is UPDATED to active/verified rather than silently no-op'd by the
+  // (type,address) unique index — otherwise the authoritative gateway row stays
+  // unverified while the user gets a success reply.
   try {
-    const gwDb = getGatewayDb();
-    gwDb
+    getGatewayDb()
       .insert(gwContacts)
       .values({
         id: contactId,
@@ -369,25 +373,24 @@ export async function upsertVerifiedContactChannel(params: {
       .onConflictDoNothing()
       .run();
 
-    gwDb
-      .insert(gwContactChannels)
-      .values({
-        id: channelId,
-        contactId,
-        type: sourceChannel,
-        address,
-        isPrimary: false,
-        externalChatId,
-        status: "active",
-        policy: "allow",
-        verifiedAt: now,
-        verifiedVia,
-        interactionCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-      .run();
+    const wrote = writeVerifiedGatewayChannel({
+      assistantChannelId: channelId,
+      contactId,
+      type: sourceChannel,
+      address,
+      externalChatId,
+      verifiedVia,
+      now,
+    });
+    // A blocked/revoked gateway row appeared after the pre-check — reject so the
+    // caller suppresses the success reply rather than claiming a blocked actor.
+    if (!wrote) {
+      log.warn(
+        { sourceChannel, address },
+        "Gateway write ignored after pre-check: channel became blocked/revoked",
+      );
+      return { verified: false };
+    }
   } catch (gwErr) {
     log.warn({ err: gwErr }, "Gateway DB contact create dual-write failed");
   }

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -110,10 +110,15 @@ function writeVerifiedGatewayChannel(params: {
     updatedAt: now,
   };
 
+  // Never reactivate a blocked/revoked gateway row: the caller's guard only
+  // inspects the assistant mirror, which may be stale relative to the
+  // authoritative gateway status.
+  const notBlockedOrRevoked = sql`${gwContactChannels.status} not in ('blocked', 'revoked')`;
+
   const byId = gwDb
     .update(gwContactChannels)
     .set(verifiedSet)
-    .where(eq(gwContactChannels.id, assistantChannelId))
+    .where(and(eq(gwContactChannels.id, assistantChannelId), notBlockedOrRevoked))
     .returning({ id: gwContactChannels.id })
     .all();
   if (byId.length > 0) return;
@@ -126,13 +131,17 @@ function writeVerifiedGatewayChannel(params: {
       and(
         eq(gwContactChannels.type, type),
         sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+        notBlockedOrRevoked,
       ),
     )
     .returning({ id: gwContactChannels.id })
     .all();
   if (byKey.length > 0) return;
 
-  // No gateway row exists — mirror the verified channel (and parent contact).
+  // No gateway row exists, or the only match is blocked/revoked — mirror the
+  // verified channel. onConflictDoNothing preserves an existing blocked/revoked
+  // row (it conflicts on the (type,address) unique index), so this never
+  // reactivates a blocked actor.
   gwDb
     .insert(gwContacts)
     .values({

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -78,6 +78,9 @@ export async function findContactChannelByAddress(
  * insert-mirror. The gateway has a unique index on (type,address), so a
  * legacy/unmirrored channel may carry a different gateway id than the
  * assistant id, and a blind id-keyed update would silently affect 0 rows.
+ *
+ * Returns true if a gateway row was updated or inserted; false if the only
+ * matching row is blocked/revoked (so nothing was written).
  */
 function writeVerifiedGatewayChannel(params: {
   assistantChannelId: string;
@@ -87,7 +90,7 @@ function writeVerifiedGatewayChannel(params: {
   externalChatId: string;
   verifiedVia: string;
   now: number;
-}): void {
+}): boolean {
   const {
     assistantChannelId,
     contactId,
@@ -121,7 +124,7 @@ function writeVerifiedGatewayChannel(params: {
     .where(and(eq(gwContactChannels.id, assistantChannelId), notBlockedOrRevoked))
     .returning({ id: gwContactChannels.id })
     .all();
-  if (byId.length > 0) return;
+  if (byId.length > 0) return true;
 
   // Resolve by the gateway's logical key (type,address unique index).
   const byKey = gwDb
@@ -136,7 +139,7 @@ function writeVerifiedGatewayChannel(params: {
     )
     .returning({ id: gwContactChannels.id })
     .all();
-  if (byKey.length > 0) return;
+  if (byKey.length > 0) return true;
 
   // No gateway row exists, or the only match is blocked/revoked — mirror the
   // verified channel. onConflictDoNothing preserves an existing blocked/revoked
@@ -153,7 +156,7 @@ function writeVerifiedGatewayChannel(params: {
     })
     .onConflictDoNothing()
     .run();
-  gwDb
+  const inserted = gwDb
     .insert(gwContactChannels)
     .values({
       id: assistantChannelId,
@@ -165,7 +168,30 @@ function writeVerifiedGatewayChannel(params: {
       ...verifiedSet,
     })
     .onConflictDoNothing()
-    .run();
+    .returning({ id: gwContactChannels.id })
+    .all();
+  // An empty result means the (type,address) unique index conflicted with a
+  // blocked/revoked row, so nothing was written.
+  return inserted.length > 0;
+}
+
+/**
+ * Read the authoritative gateway row status for an actor by the logical key
+ * (type, address) COLLATE NOCASE. The gateway is the source of truth; the
+ * assistant mirror can lag behind a block/revoke landed gateway-side.
+ */
+function gatewayChannelStatus(type: string, address: string): string | null {
+  const row = getGatewayDb()
+    .select({ status: gwContactChannels.status })
+    .from(gwContactChannels)
+    .where(
+      and(
+        eq(gwContactChannels.type, type),
+        sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+      ),
+    )
+    .get();
+  return row?.status ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,6 +207,11 @@ function writeVerifiedGatewayChannel(params: {
  * This is intentionally simpler than the assistant's full upsertContact —
  * it handles the verification-specific case only (single channel, no
  * reassignment, no invite binding).
+ *
+ * Returns `{ verified: false }` when the verification is rejected because the
+ * authoritative gateway row (or the assistant mirror) is blocked/revoked, so
+ * the caller can suppress the success reply. Returns `{ verified: true }` on
+ * the normal activate/insert paths.
  */
 export async function upsertVerifiedContactChannel(params: {
   sourceChannel: string;
@@ -189,7 +220,7 @@ export async function upsertVerifiedContactChannel(params: {
   displayName?: string;
   username?: string;
   verifiedVia?: string;
-}): Promise<void> {
+}): Promise<{ verified: boolean }> {
   const now = Date.now();
   const { sourceChannel, externalChatId, displayName, username } = params;
   const verifiedVia = params.verifiedVia ?? "challenge";
@@ -222,13 +253,26 @@ export async function upsertVerifiedContactChannel(params: {
   if (existing.length > 0) {
     const row = existing[0];
 
-    // Don't overwrite blocked or revoked channels.
+    // Don't overwrite blocked or revoked channels (assistant mirror guard).
     if (row.channelStatus === "blocked" || row.channelStatus === "revoked") {
       log.warn(
         { sourceChannel, address, status: row.channelStatus },
         "Skipping upsert: channel is blocked or revoked",
       );
-      return;
+      return { verified: false };
+    }
+
+    // The gateway is the source of truth: a blocked/revoked gateway row rejects
+    // the verification even when the assistant mirror is still claimable. Don't
+    // activate the assistant mirror and signal the caller to suppress success.
+    // A missing gateway row is the legitimate happy path (legacy/unmirrored).
+    const gwStatus = gatewayChannelStatus(sourceChannel, address);
+    if (gwStatus === "blocked" || gwStatus === "revoked") {
+      log.warn(
+        { sourceChannel, address, status: gwStatus },
+        "Skipping upsert: authoritative gateway channel is blocked or revoked",
+      );
+      return { verified: false };
     }
 
     // Update existing channel
@@ -249,7 +293,7 @@ export async function upsertVerifiedContactChannel(params: {
     // channel id may not exist in the gateway DB (legacy/unmirrored channel)
     // or may live under a different gateway UUID, so resolve by logical key.
     try {
-      writeVerifiedGatewayChannel({
+      const wrote = writeVerifiedGatewayChannel({
         assistantChannelId: row.channelId,
         contactId: row.contactId,
         type: sourceChannel,
@@ -258,6 +302,16 @@ export async function upsertVerifiedContactChannel(params: {
         verifiedVia,
         now,
       });
+      // The gateway pre-check passed, so a write is expected. A false here means
+      // a blocked/revoked row appeared between the pre-check and the write —
+      // treat it as a rejection so the caller suppresses the success reply.
+      if (!wrote) {
+        log.warn(
+          { sourceChannel, address },
+          "Gateway write ignored after pre-check: channel became blocked/revoked",
+        );
+        return { verified: false };
+      }
     } catch (gwErr) {
       log.warn(
         { err: gwErr },
@@ -265,7 +319,7 @@ export async function upsertVerifiedContactChannel(params: {
       );
     }
 
-    return;
+    return { verified: true };
   }
 
   // Create new contact + channel. Both use OR IGNORE for idempotency under
@@ -337,6 +391,8 @@ export async function upsertVerifiedContactChannel(params: {
   } catch (gwErr) {
     log.warn({ err: gwErr }, "Gateway DB contact create dual-write failed");
   }
+
+  return { verified: true };
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -180,7 +180,7 @@ function writeVerifiedGatewayChannel(params: {
  * (type, address) COLLATE NOCASE. The gateway is the source of truth; the
  * assistant mirror can lag behind a block/revoke landed gateway-side.
  */
-function gatewayChannelStatus(type: string, address: string): string | null {
+export function gatewayChannelStatus(type: string, address: string): string | null {
   const row = getGatewayDb()
     .select({ status: gwContactChannels.status })
     .from(gwContactChannels)
@@ -250,6 +250,19 @@ export async function upsertVerifiedContactChannel(params: {
     [sourceChannel, address],
   );
 
+  // The gateway is the source of truth: a blocked/revoked gateway row rejects
+  // the verification, gating BOTH the existing-channel update and the
+  // new-insert path so no active mirror is created for a blocked actor. A
+  // missing gateway row is the legitimate happy path (legacy/unmirrored).
+  const gwStatus = gatewayChannelStatus(sourceChannel, address);
+  if (gwStatus === "blocked" || gwStatus === "revoked") {
+    log.warn(
+      { sourceChannel, address, status: gwStatus },
+      "Skipping upsert: authoritative gateway channel is blocked or revoked",
+    );
+    return { verified: false };
+  }
+
   if (existing.length > 0) {
     const row = existing[0];
 
@@ -258,19 +271,6 @@ export async function upsertVerifiedContactChannel(params: {
       log.warn(
         { sourceChannel, address, status: row.channelStatus },
         "Skipping upsert: channel is blocked or revoked",
-      );
-      return { verified: false };
-    }
-
-    // The gateway is the source of truth: a blocked/revoked gateway row rejects
-    // the verification even when the assistant mirror is still claimable. Don't
-    // activate the assistant mirror and signal the caller to suppress success.
-    // A missing gateway row is the legitimate happy path (legacy/unmirrored).
-    const gwStatus = gatewayChannelStatus(sourceChannel, address);
-    if (gwStatus === "blocked" || gwStatus === "revoked") {
-      log.warn(
-        { sourceChannel, address, status: gwStatus },
-        "Skipping upsert: authoritative gateway channel is blocked or revoked",
       );
       return { verified: false };
     }

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -12,7 +12,7 @@
 
 import { existsSync } from "node:fs";
 
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../db/connection.js";
@@ -63,6 +63,100 @@ export async function findContactChannelByAddress(
     [channelType, address],
   );
   return rows[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Gateway dual-write (verified outcome)
+// ---------------------------------------------------------------------------
+
+/**
+ * Land the verified outcome in the authoritative gateway DB for an existing
+ * channel, resilient to the assistant channel id being absent or living under
+ * a different gateway UUID.
+ *
+ * Resolution: id-keyed update → logical-key (type,address) update →
+ * insert-mirror. The gateway has a unique index on (type,address), so a
+ * legacy/unmirrored channel may carry a different gateway id than the
+ * assistant id, and a blind id-keyed update would silently affect 0 rows.
+ */
+function writeVerifiedGatewayChannel(params: {
+  assistantChannelId: string;
+  contactId: string;
+  type: string;
+  address: string;
+  externalChatId: string;
+  verifiedVia: string;
+  now: number;
+}): void {
+  const {
+    assistantChannelId,
+    contactId,
+    type,
+    address,
+    externalChatId,
+    verifiedVia,
+    now,
+  } = params;
+  const gwDb = getGatewayDb();
+  const verifiedSet = {
+    status: "active",
+    policy: "allow",
+    address,
+    externalChatId,
+    verifiedAt: now,
+    verifiedVia,
+    revokedReason: null,
+    blockedReason: null,
+    updatedAt: now,
+  };
+
+  const byId = gwDb
+    .update(gwContactChannels)
+    .set(verifiedSet)
+    .where(eq(gwContactChannels.id, assistantChannelId))
+    .returning({ id: gwContactChannels.id })
+    .all();
+  if (byId.length > 0) return;
+
+  // Resolve by the gateway's logical key (type,address unique index).
+  const byKey = gwDb
+    .update(gwContactChannels)
+    .set(verifiedSet)
+    .where(
+      and(
+        eq(gwContactChannels.type, type),
+        sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+      ),
+    )
+    .returning({ id: gwContactChannels.id })
+    .all();
+  if (byKey.length > 0) return;
+
+  // No gateway row exists — mirror the verified channel (and parent contact).
+  gwDb
+    .insert(gwContacts)
+    .values({
+      id: contactId,
+      displayName: address,
+      role: "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+    .run();
+  gwDb
+    .insert(gwContactChannels)
+    .values({
+      id: assistantChannelId,
+      contactId,
+      type,
+      isPrimary: false,
+      interactionCount: 0,
+      createdAt: now,
+      ...verifiedSet,
+    })
+    .onConflictDoNothing()
+    .run();
 }
 
 // ---------------------------------------------------------------------------
@@ -141,24 +235,20 @@ export async function upsertVerifiedContactChannel(params: {
       [address, externalChatId, now, verifiedVia, now, row.channelId],
     );
 
-    // Dual-write to gateway DB
+    // Dual-write to gateway DB. Best-effort: a gateway failure must not break
+    // inbound verification UX (the code already matched). The assistant
+    // channel id may not exist in the gateway DB (legacy/unmirrored channel)
+    // or may live under a different gateway UUID, so resolve by logical key.
     try {
-      const gwDb = getGatewayDb();
-      gwDb
-        .update(gwContactChannels)
-        .set({
-          status: "active",
-          policy: "allow",
-          address,
-          externalChatId,
-          verifiedAt: now,
-          verifiedVia,
-          revokedReason: null,
-          blockedReason: null,
-          updatedAt: now,
-        })
-        .where(eq(gwContactChannels.id, row.channelId))
-        .run();
+      writeVerifiedGatewayChannel({
+        assistantChannelId: row.channelId,
+        contactId: row.contactId,
+        type: sourceChannel,
+        address,
+        externalChatId,
+        verifiedVia,
+        now,
+      });
     } catch (gwErr) {
       log.warn(
         { err: gwErr },

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -85,9 +85,11 @@ export async function upsertVerifiedContactChannel(params: {
   externalChatId: string;
   displayName?: string;
   username?: string;
+  verifiedVia?: string;
 }): Promise<void> {
   const now = Date.now();
   const { sourceChannel, externalChatId, displayName, username } = params;
+  const verifiedVia = params.verifiedVia ?? "challenge";
 
   const address =
     canonicalizeInboundIdentity(sourceChannel, params.externalUserId) ??
@@ -132,10 +134,11 @@ export async function upsertVerifiedContactChannel(params: {
        SET address = ?,
            status = 'active', policy = 'allow',
            external_chat_id = ?,
+           verified_at = ?, verified_via = ?,
            revoked_reason = NULL, blocked_reason = NULL,
            updated_at = ?
        WHERE id = ?`,
-      [address, externalChatId, now, row.channelId],
+      [address, externalChatId, now, verifiedVia, now, row.channelId],
     );
 
     // Dual-write to gateway DB
@@ -148,6 +151,8 @@ export async function upsertVerifiedContactChannel(params: {
           policy: "allow",
           address,
           externalChatId,
+          verifiedAt: now,
+          verifiedVia,
           revokedReason: null,
           blockedReason: null,
           updatedAt: now,
@@ -180,9 +185,20 @@ export async function upsertVerifiedContactChannel(params: {
   await assistantDbRun(
     `INSERT OR IGNORE INTO contact_channels
        (id, contact_id, type, address, is_primary, external_chat_id,
-        status, policy, interaction_count, created_at, updated_at)
-     VALUES (?, ?, ?, ?, 0, ?, 'active', 'allow', 0, ?, ?)`,
-    [channelId, contactId, sourceChannel, address, externalChatId, now, now],
+        status, policy, verified_at, verified_via, interaction_count,
+        created_at, updated_at)
+     VALUES (?, ?, ?, ?, 0, ?, 'active', 'allow', ?, ?, 0, ?, ?)`,
+    [
+      channelId,
+      contactId,
+      sourceChannel,
+      address,
+      externalChatId,
+      now,
+      verifiedVia,
+      now,
+      now,
+    ],
   );
 
   // Dual-write to gateway DB
@@ -211,6 +227,8 @@ export async function upsertVerifiedContactChannel(params: {
         externalChatId,
         status: "active",
         policy: "allow",
+        verifiedAt: now,
+        verifiedVia,
         interactionCount: 0,
         createdAt: now,
         updatedAt: now,

--- a/gateway/src/verification/text-verification.ts
+++ b/gateway/src/verification/text-verification.ts
@@ -223,23 +223,43 @@ export async function tryTextVerificationIntercept(
       ? "trusted_contact"
       : "guardian";
 
-  // 7. Apply side effects
-  if (trustClass === "guardian") {
-    await applyGuardianSideEffects({
-      sourceChannel,
-      canonicalUserId,
+  // 7. Apply side effects. A blocked/revoked authoritative gateway row rejects
+  //    the verification: the actor must not regain trusted status nor see a
+  //    success reply, even though the code matched and the session consumed.
+  const sideEffectsVerified =
+    trustClass === "guardian"
+      ? await applyGuardianSideEffects({
+          sourceChannel,
+          canonicalUserId,
+          actorChatId,
+          actorDisplayName,
+          actorUsername,
+        })
+      : await applyTrustedContactSideEffects({
+          sourceChannel,
+          canonicalUserId,
+          actorChatId,
+          actorDisplayName,
+          actorUsername,
+        });
+
+  if (!sideEffectsVerified) {
+    log.warn(
+      { sourceChannel, actorExternalUserId: canonicalUserId, trustClass },
+      "Verification rejected: authoritative gateway channel is blocked/revoked",
+    );
+    const pendingReplyText = await replyWithFailure(
+      replyCallbackUrl,
       actorChatId,
-      actorDisplayName,
-      actorUsername,
-    });
-  } else {
-    await applyTrustedContactSideEffects({
-      sourceChannel,
-      canonicalUserId,
-      actorChatId,
-      actorDisplayName,
-      actorUsername,
-    });
+      assistantId,
+      "The verification code is invalid or has expired.",
+    );
+    return {
+      intercepted: true,
+      outcome: "failed",
+      trustClass,
+      pendingReplyText,
+    };
   }
 
   // 8. Deliver success reply
@@ -284,7 +304,7 @@ async function applyGuardianSideEffects(params: {
   actorChatId: string;
   actorDisplayName?: string;
   actorUsername?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const {
     sourceChannel,
     canonicalUserId,
@@ -306,14 +326,14 @@ async function applyGuardianSideEffects(params: {
     );
     // Still upsert the contact channel so the sender is a known contact,
     // but skip guardian binding creation.
-    await upsertVerifiedContactChannel({
+    const { verified } = await upsertVerifiedContactChannel({
       sourceChannel,
       externalUserId: canonicalUserId,
       externalChatId: actorChatId,
       displayName: actorDisplayName,
       username: actorUsername,
     });
-    return;
+    return verified;
   }
 
   // Revoke existing binding (same-user re-verification)
@@ -340,6 +360,7 @@ async function applyGuardianSideEffects(params: {
     displayName,
     verifiedVia: "challenge",
   });
+  return true;
 }
 
 async function applyTrustedContactSideEffects(params: {
@@ -348,7 +369,7 @@ async function applyTrustedContactSideEffects(params: {
   actorChatId: string;
   actorDisplayName?: string;
   actorUsername?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const {
     sourceChannel,
     canonicalUserId,
@@ -366,13 +387,14 @@ async function applyTrustedContactSideEffects(params: {
     ? existingContact.displayName
     : (actorDisplayName ?? actorUsername ?? canonicalUserId);
 
-  await upsertVerifiedContactChannel({
+  const { verified } = await upsertVerifiedContactChannel({
     sourceChannel,
     externalUserId: canonicalUserId,
     externalChatId: actorChatId,
     displayName,
     username: actorUsername,
   });
+  return verified;
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/verification/text-verification.ts
+++ b/gateway/src/verification/text-verification.ts
@@ -32,6 +32,7 @@ import {
 } from "./code-parsing.js";
 import {
   findContactChannelByAddress,
+  gatewayChannelStatus,
   upsertVerifiedContactChannel,
 } from "./contact-helpers.js";
 import { canonicalizeInboundIdentity } from "./identity.js";
@@ -334,6 +335,20 @@ async function applyGuardianSideEffects(params: {
       username: actorUsername,
     });
     return verified;
+  }
+
+  // The gateway is the source of truth: a blocked/revoked gateway row rejects
+  // the binding. Check BEFORE the same-user revoke below so a legitimately
+  // re-verifying guardian (whose current row is active) isn't blocked by their
+  // own about-to-be-revoked row. createGuardianBinding writes "active"
+  // unconditionally, so this guard is the only thing stopping a blocked actor.
+  const gwStatus = gatewayChannelStatus(sourceChannel, canonicalUserId);
+  if (gwStatus === "blocked" || gwStatus === "revoked") {
+    log.warn(
+      { sourceChannel, address: canonicalUserId, status: gwStatus },
+      "Skipping guardian binding: authoritative gateway channel is blocked or revoked",
+    );
+    return false;
   }
 
   // Revoke existing binding (same-user re-verification)

--- a/gateway/src/verification/voice-approval-sync.ts
+++ b/gateway/src/verification/voice-approval-sync.ts
@@ -92,12 +92,20 @@ async function syncVoiceApprovals(): Promise<void> {
     const chatId = (row.requester_chat_id as string | null) ?? fromNumber;
 
     try {
-      await upsertVerifiedContactChannel({
+      const { verified } = await upsertVerifiedContactChannel({
         sourceChannel: "phone",
         externalUserId: fromNumber,
         externalChatId: chatId,
       });
-      log.info({ fromNumber }, "Voice approval sync: contact activated");
+      if (verified) {
+        log.info({ fromNumber }, "Voice approval sync: contact activated");
+      } else {
+        // Authoritative gateway row is blocked/revoked — activation skipped.
+        log.warn(
+          { fromNumber },
+          "Voice approval sync: activation skipped (channel blocked/revoked)",
+        );
+      }
     } catch (err) {
       log.warn({ err, fromNumber }, "Voice approval sync: upsert failed");
     }

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -114,3 +114,32 @@ export const MarkChannelVerifiedIpcResponseSchema = z.object({
 export type MarkChannelVerifiedIpcResponse = z.infer<
   typeof MarkChannelVerifiedIpcResponseSchema
 >;
+
+export const MarkChannelRevokedIpcParamsSchema = z.object({
+  contactChannelId: z.string().min(1),
+  // Audit reason for the downgrade. The verification-revoke flow passes
+  // "guardian_binding_revoked", the only reason allowed to downgrade a
+  // guardian channel (guardian guard, invariant 4).
+  reason: z.string().optional(),
+});
+
+export type MarkChannelRevokedIpcParams = z.infer<
+  typeof MarkChannelRevokedIpcParamsSchema
+>;
+
+export const MarkChannelRevokedIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  didWrite: z.boolean(),
+  channel: z.object({
+    id: z.string(),
+    contactId: z.string(),
+    type: z.string(),
+    address: z.string(),
+    status: z.string(),
+    revokedReason: z.string().nullable(),
+  }),
+});
+
+export type MarkChannelRevokedIpcResponse = z.infer<
+  typeof MarkChannelRevokedIpcResponseSchema
+>;

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -85,3 +85,32 @@ export const TrustRulesListIpcResponseSchema = z.object({
 export type TrustRulesListIpcResponse = z.infer<
   typeof TrustRulesListIpcResponseSchema
 >;
+
+export const MarkChannelVerifiedIpcParamsSchema = z.object({
+  contactChannelId: z.string().min(1),
+  // Audit source for the verification. CLI/session-driven verifications
+  // pass "challenge"; manual guardian attest uses "manual" (HTTP path).
+  verifiedVia: z.enum(["challenge", "manual"]).default("challenge"),
+});
+
+export type MarkChannelVerifiedIpcParams = z.infer<
+  typeof MarkChannelVerifiedIpcParamsSchema
+>;
+
+export const MarkChannelVerifiedIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  didWrite: z.boolean(),
+  channel: z.object({
+    id: z.string(),
+    contactId: z.string(),
+    type: z.string(),
+    address: z.string(),
+    status: z.string(),
+    verifiedAt: z.number().nullable(),
+    verifiedVia: z.string().nullable(),
+  }),
+});
+
+export type MarkChannelVerifiedIpcResponse = z.infer<
+  typeof MarkChannelVerifiedIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
Makes the gateway DB the source of truth for the channel-verification OUTCOME (status / verifiedAt / verifiedVia). Verification SESSION state (pending sessions, codes, resend, rate-limit) stays assistant-owned; the verified outcome is written in-process by the HTTP guardian-attest handler and by the inbound code-match path, and the revoke/downgrade outcome is relayed from the daemon via `ipcCallPersistent("mark_channel_revoked", …)`.

## Self-review result
PASS (round 2). 5 gaps found and fixed across 3 fix PRs: legacy channel-id resolution fallback for migrated users, contact-change invalidation on revoke, IPC response validation, and docs accuracy.

## PRs merged into feature branch
- #35566: feat(contracts): add MarkChannelVerified gateway IPC contract
- #35567: feat(gateway): parameterize verifiedVia on markChannelVerified
- #35571: feat(gateway): expose mark_channel_verified IPC method
- #35573: feat(daemon): trusted-contact verification (investigation: no daemon-side outcome write exists; regression test pins no double-write)
- #35574: feat(daemon): relay verification revoke/downgrade outcome to gateway (mark_channel_revoked + ContactStore.markChannelRevoked, guardian guard)
- #35578 / #35586: docs: verification outcome source-of-truth split

### Fix PRs (self-review)
- #35583: fix(gateway): legacy channel-id fallback (resolveGatewayChannel) + validate IPC response shapes
- #35582: fix(daemon): emit contact-change after revoke relay + validate revoke IPC response
- #35586: docs: correct verification source-of-truth wiring; trim test comment

Part of plan: contacts-gw-native-verification.md