### PR TITLE
Relay contact read IPC handlers through the gateway

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4800,6 +4800,10 @@ paths:
                           - type: "null"
                       interactionCount:
                         type: number
+                      createdAt:
+                        type: number
+                      updatedAt:
+                        type: number
                       channels:
                         type: array
                         items:
@@ -4871,6 +4875,8 @@ paths:
                       - displayName
                       - role
                       - interactionCount
+                      - createdAt
+                      - updatedAt
                       - channels
                     additionalProperties: false
                 required:
@@ -4955,6 +4961,10 @@ paths:
                             - type: "null"
                         interactionCount:
                           type: number
+                        createdAt:
+                          type: number
+                        updatedAt:
+                          type: number
                         channels:
                           type: array
                           items:
@@ -5026,6 +5036,8 @@ paths:
                         - displayName
                         - role
                         - interactionCount
+                        - createdAt
+                        - updatedAt
                         - channels
                       additionalProperties: false
                     description: Contact objects with channels and metadata
@@ -5078,6 +5090,10 @@ paths:
                           - type: number
                           - type: "null"
                       interactionCount:
+                        type: number
+                      createdAt:
+                        type: number
+                      updatedAt:
                         type: number
                       channels:
                         type: array
@@ -5150,6 +5166,8 @@ paths:
                       - displayName
                       - role
                       - interactionCount
+                      - createdAt
+                      - updatedAt
                       - channels
                     additionalProperties: false
                   assistantMetadata:
@@ -5457,6 +5475,10 @@ paths:
                           - type: "null"
                       interactionCount:
                         type: number
+                      createdAt:
+                        type: number
+                      updatedAt:
+                        type: number
                       channels:
                         type: array
                         items:
@@ -5528,6 +5550,8 @@ paths:
                       - displayName
                       - role
                       - interactionCount
+                      - createdAt
+                      - updatedAt
                       - channels
                     additionalProperties: false
                     description: Merged contact
@@ -5646,6 +5670,10 @@ paths:
                         - type: "null"
                     interactionCount:
                       type: number
+                    createdAt:
+                      type: number
+                    updatedAt:
+                      type: number
                     channels:
                       type: array
                       items:
@@ -5717,6 +5745,8 @@ paths:
                     - displayName
                     - role
                     - interactionCount
+                    - createdAt
+                    - updatedAt
                     - channels
                   additionalProperties: false
   /v1/content-source:

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -9,12 +9,22 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Capture `log.debug(...)` calls so we can assert the daemon-native-search note
+// is emitted on the search path.
+const debugLogs: string[] = [];
 const realLogger = await import("../util/logger.js");
 mock.module("../util/logger.js", () => ({
   ...realLogger,
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
+      get:
+        (_target, prop: string) =>
+        (...args: unknown[]) => {
+          if (prop === "debug") {
+            const msg = args.find((a) => typeof a === "string");
+            if (typeof msg === "string") debugLogs.push(msg);
+          }
+        },
     }),
 }));
 
@@ -79,9 +89,22 @@ mock.module("../contacts/contact-store.js", () => ({
     localCalls.push("getAssistantContactMetadata");
     return undefined;
   },
+  searchContacts: () => {
+    localCalls.push("searchContacts");
+    return [
+      {
+        id: "search-1",
+        displayName: "Search Contact",
+        role: "contact",
+        contactType: "human",
+        interactionCount: 0,
+        channels: [],
+      },
+    ];
+  },
 }));
 
-const { handleListContacts, handleGetContact } = (await import(
+const { handleListContacts, handleGetContact, ROUTES } = (await import(
   "../runtime/routes/contact-routes.js"
 )) as typeof import("../runtime/routes/contact-routes.js") & {
   handleListContacts: (q: Record<string, string>) => Promise<{
@@ -94,6 +117,17 @@ const { handleListContacts, handleGetContact } = (await import(
     assistantMetadata?: unknown;
   }>;
 };
+
+/** Invoke the inline `search_contacts` POST route handler with a request body. */
+function searchContactsRoute(
+  body: Record<string, unknown>,
+): Promise<Array<{ id: string; displayName: string; role: string }>> {
+  const route = ROUTES.find((r) => r.operationId === "search_contacts");
+  if (!route) throw new Error("search_contacts route not found");
+  return route.handler({ body }) as Promise<
+    Array<{ id: string; displayName: string; role: string }>
+  >;
+}
 
 function gatewayContact(overrides: Record<string, unknown> = {}) {
   return {
@@ -131,6 +165,7 @@ beforeEach(() => {
   ipcStub = () => undefined;
   ipcCalls.length = 0;
   localCalls.length = 0;
+  debugLogs.length = 0;
 });
 
 describe("handleListContacts relay", () => {
@@ -170,6 +205,73 @@ describe("handleListContacts relay", () => {
     expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
     expect(localCalls).toContain("listContacts");
     expect(result.contacts[0].id).toBe("local-1");
+  });
+
+  test("search params stay daemon-native and log the boundary note", async () => {
+    const result = await handleListContacts({ query: "alice" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(result.contacts[0].id).toBe("search-1");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+});
+
+describe("search_contacts route relay boundary", () => {
+  test("real query stays daemon-native and logs the boundary note", async () => {
+    const contacts = await searchContactsRoute({ query: "alice" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(contacts[0].id).toBe("search-1");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+
+  test("real channelAddress stays daemon-native", async () => {
+    const contacts = await searchContactsRoute({ channelAddress: "tg-001" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(contacts[0].id).toBe("search-1");
+  });
+
+  test("real channelType stays daemon-native", async () => {
+    const contacts = await searchContactsRoute({ channelType: "telegram" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toContain("searchContacts");
+    expect(contacts[0].id).toBe("search-1");
+  });
+
+  test("empty/whitespace query with no filters relays through the gateway", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_list_rich") {
+        return { ok: true, contacts: [gatewayContact()] };
+      }
+      return undefined;
+    };
+
+    const contacts = await searchContactsRoute({ query: "   " });
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(contacts[0].id).toBe("gw-1");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(false);
+  });
+
+  test("no params at all relays through the gateway", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_list_rich") {
+        return { ok: true, contacts: [gatewayContact()] };
+      }
+      return undefined;
+    };
+
+    const contacts = await searchContactsRoute({});
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(contacts[0].id).toBe("gw-1");
   });
 });
 

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the daemon's contact read relay (PR 3).
+ * Tests for the daemon's contact read relay.
  *
  * handleListContacts (non-search) and handleGetContact relay to the gateway
  * via `ipcCallPersistent`. On the happy path they serve gateway-sourced data
@@ -146,6 +146,8 @@ function gatewayContact(overrides: Record<string, unknown> = {}) {
     contactType: "human",
     interactionCount: 2,
     lastInteraction: 100,
+    createdAt: 1699000000,
+    updatedAt: 1700000000,
     channels: [
       {
         id: "ch-1",
@@ -336,6 +338,12 @@ describe("handleGetContact relay", () => {
     expect(localCalls).toEqual([]);
     expect(result.contact.id).toBe("gw-1");
     expect(result.assistantMetadata).toBeUndefined();
+    // Relayed reads must carry contact-level timestamps — the CLI's detail
+    // formatter calls new Date(createdAt/updatedAt) unconditionally, so dropping
+    // them surfaces as a RangeError ("Invalid time value").
+    const contact = result.contact as { createdAt?: number; updatedAt?: number };
+    expect(contact.createdAt).toBe(1699000000);
+    expect(contact.updatedAt).toBe(1700000000);
   });
 
   test("applies guardian display-name override", async () => {

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the daemon's contact read relay (PR 3).
+ *
+ * handleListContacts (non-search) and handleGetContact relay to the gateway
+ * via `ipcCallPersistent`. On the happy path they serve gateway-sourced data
+ * and do NOT read the assistant DB. On IPC failure they fall back to the
+ * assistant-DB read and log a warning. getContact still 404s for unknown ids.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const realLogger = await import("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Guardian display-name override → deterministic sentinel so we can assert it
+// is applied to relayed payloads.
+const realUserReference = await import("../prompts/user-reference.js");
+mock.module("../prompts/user-reference.js", () => ({
+  ...realUserReference,
+  resolveGuardianName: () => "Your Guardian",
+}));
+
+// IPC relay stub — each test sets the response/behavior.
+type IpcStub = (method: string, params?: Record<string, unknown>) => unknown;
+let ipcStub: IpcStub = () => undefined;
+const ipcCalls: Array<{ method: string; params?: Record<string, unknown> }> =
+  [];
+
+const realGatewayClient = await import("../ipc/gateway-client.js");
+mock.module("../ipc/gateway-client.js", () => ({
+  ...realGatewayClient,
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    ipcCalls.push({ method, params });
+    return ipcStub(method, params);
+  },
+}));
+
+// Assistant-DB fallback stubs — assert these are NOT hit on the happy path,
+// and that they ARE hit on the IPC-failure fallback path.
+const localCalls: string[] = [];
+const realContactStore = await import("../contacts/contact-store.js");
+mock.module("../contacts/contact-store.js", () => ({
+  ...realContactStore,
+  listContacts: () => {
+    localCalls.push("listContacts");
+    return [
+      {
+        id: "local-1",
+        displayName: "Local Contact",
+        role: "contact",
+        contactType: "human",
+        interactionCount: 0,
+        channels: [],
+      },
+    ];
+  },
+  getContact: (id: string) => {
+    localCalls.push("getContact");
+    if (id === "missing") return null;
+    return {
+      id,
+      displayName: "Local Contact",
+      role: "contact",
+      contactType: "human",
+      interactionCount: 0,
+      channels: [],
+    };
+  },
+  getAssistantContactMetadata: () => {
+    localCalls.push("getAssistantContactMetadata");
+    return undefined;
+  },
+}));
+
+const { handleListContacts, handleGetContact } = (await import(
+  "../runtime/routes/contact-routes.js"
+)) as typeof import("../runtime/routes/contact-routes.js") & {
+  handleListContacts: (q: Record<string, string>) => Promise<{
+    ok: boolean;
+    contacts: Array<{ id: string; displayName: string; role: string }>;
+  }>;
+  handleGetContact: (id: string) => Promise<{
+    ok: boolean;
+    contact: { id: string; displayName: string; role: string };
+    assistantMetadata?: unknown;
+  }>;
+};
+
+function gatewayContact(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "gw-1",
+    displayName: "Gateway Contact",
+    role: "contact",
+    notes: null,
+    contactType: "human",
+    interactionCount: 2,
+    lastInteraction: 100,
+    channels: [
+      {
+        id: "ch-1",
+        contactId: "gw-1",
+        type: "telegram",
+        address: "tg-001",
+        isPrimary: true,
+        externalUserId: "tg-001",
+        status: "active",
+        policy: "allow",
+        verifiedAt: null,
+        verifiedVia: null,
+        lastSeenAt: null,
+        interactionCount: 2,
+        lastInteraction: 100,
+        revokedReason: null,
+        blockedReason: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ipcStub = () => undefined;
+  ipcCalls.length = 0;
+  localCalls.length = 0;
+});
+
+describe("handleListContacts relay", () => {
+  test("non-search read serves gateway contacts and does NOT read assistant DB", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_list_rich") {
+        return { ok: true, contacts: [gatewayContact()] };
+      }
+      return undefined;
+    };
+
+    const result = await handleListContacts({ limit: "50" });
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(result.contacts).toHaveLength(1);
+    expect(result.contacts[0].id).toBe("gw-1");
+  });
+
+  test("applies guardian display-name override to relayed contacts", async () => {
+    ipcStub = () => ({
+      ok: true,
+      contacts: [gatewayContact({ role: "guardian", displayName: "Real Name" })],
+    });
+
+    const result = await handleListContacts({});
+    expect(result.contacts[0].displayName).toBe("Your Guardian");
+  });
+
+  test("falls back to the assistant DB on IPC failure", async () => {
+    ipcStub = () => {
+      throw new Error("gateway down");
+    };
+
+    const result = await handleListContacts({});
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+    expect(localCalls).toContain("listContacts");
+    expect(result.contacts[0].id).toBe("local-1");
+  });
+});
+
+describe("handleGetContact relay", () => {
+  test("serves the gateway contact and does NOT read the assistant DB", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_get_rich") {
+        return { ok: true, contact: gatewayContact() };
+      }
+      return undefined;
+    };
+
+    const result = await handleGetContact("gw-1");
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
+    expect(localCalls).toEqual([]);
+    expect(result.contact.id).toBe("gw-1");
+    expect(result.assistantMetadata).toBeUndefined();
+  });
+
+  test("applies guardian display-name override", async () => {
+    ipcStub = () => ({
+      ok: true,
+      contact: gatewayContact({ role: "guardian", displayName: "Real Name" }),
+    });
+
+    const result = await handleGetContact("gw-1");
+    expect(result.contact.displayName).toBe("Your Guardian");
+  });
+
+  test("returns assistantMetadata when present", async () => {
+    ipcStub = () => ({
+      ok: true,
+      contact: gatewayContact(),
+      assistantMetadata: {
+        contactId: "gw-1",
+        species: "vellum",
+        metadata: { model: "opus" },
+      },
+    });
+
+    const result = await handleGetContact("gw-1");
+    expect(result.assistantMetadata).toEqual({
+      contactId: "gw-1",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+  });
+
+  test("throws NotFoundError on gateway not-found (no fallback)", async () => {
+    ipcStub = () => null;
+
+    await expect(handleGetContact("nope")).rejects.toThrow(
+      'Contact "nope" not found',
+    );
+    expect(localCalls).toEqual([]);
+  });
+
+  test("falls back to the assistant DB on IPC transport failure", async () => {
+    ipcStub = () => {
+      throw new Error("gateway down");
+    };
+
+    const result = await handleGetContact("gw-1");
+
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
+    expect(localCalls).toContain("getContact");
+    expect(result.contact.id).toBe("gw-1");
+  });
+
+  test("fallback path still 404s for unknown ids", async () => {
+    ipcStub = () => {
+      throw new Error("gateway down");
+    };
+
+    await expect(handleGetContact("missing")).rejects.toThrow(
+      'Contact "missing" not found',
+    );
+    expect(localCalls).toContain("getContact");
+  });
+});

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -153,7 +153,9 @@ function gatewayContact(overrides: Record<string, unknown> = {}) {
         type: "telegram",
         address: "tg-001",
         isPrimary: true,
-        externalUserId: "tg-001",
+        // The gateway leaves externalUserId null; the daemon's withChannelCompat
+        // re-derives it from address on the relayed payload.
+        externalUserId: null,
         status: "active",
         policy: "allow",
         verifiedAt: null,
@@ -192,6 +194,11 @@ describe("handleListContacts relay", () => {
     expect(localCalls).toEqual([]);
     expect(result.contacts).toHaveLength(1);
     expect(result.contacts[0].id).toBe("gw-1");
+    // The daemon's withChannelCompat re-derives externalUserId = address even
+    // though the gateway emits null — the client-facing guarantee holds.
+    const ch = (result.contacts[0] as { channels: { address: string; externalUserId: string | null }[] })
+      .channels[0];
+    expect(ch.externalUserId).toBe(ch.address);
   });
 
   test("applies guardian display-name override to relayed contacts", async () => {

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -58,16 +58,24 @@ mock.module("../ipc/gateway-client.js", () => ({
 // and that they ARE hit on the IPC-failure fallback path.
 const localCalls: string[] = [];
 const realContactStore = await import("../contacts/contact-store.js");
+// Capture the args passed to the daemon-native listContacts so tests can assert
+// contactType is filtered in SQL (before the limit) rather than relayed.
+const listContactsArgs: Array<{
+  limit?: number;
+  role?: string;
+  contactType?: string;
+}> = [];
 mock.module("../contacts/contact-store.js", () => ({
   ...realContactStore,
-  listContacts: () => {
+  listContacts: (limit?: number, role?: string, contactType?: string) => {
     localCalls.push("listContacts");
+    listContactsArgs.push({ limit, role, contactType });
     return [
       {
         id: "local-1",
         displayName: "Local Contact",
-        role: "contact",
-        contactType: "human",
+        role: role ?? "contact",
+        contactType: contactType ?? "human",
         interactionCount: 0,
         channels: [],
       },
@@ -166,6 +174,7 @@ beforeEach(() => {
   ipcCalls.length = 0;
   localCalls.length = 0;
   debugLogs.length = 0;
+  listContactsArgs.length = 0;
 });
 
 describe("handleListContacts relay", () => {
@@ -214,6 +223,36 @@ describe("handleListContacts relay", () => {
     expect(localCalls).toContain("searchContacts");
     expect(result.contacts[0].id).toBe("search-1");
     expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+
+  test("contactType filter stays daemon-native and does NOT relay to the gateway", async () => {
+    // If contactType were relayed, the gateway would apply it AFTER its limit
+    // and could under-return. We serve it daemon-native instead (SQL filter
+    // before the limit). Assert no relay, local read, and the boundary note.
+    const result = await handleListContacts({
+      contactType: "assistant",
+      limit: "50",
+    });
+
+    expect(ipcCalls).toEqual([]);
+    expect(localCalls).toEqual(["listContacts"]);
+    // contactType + limit are pushed into the SQL-filtered daemon read (the
+    // daemon-native listContacts filters contactType BEFORE applying limit).
+    expect(listContactsArgs).toEqual([
+      { limit: 50, role: undefined, contactType: "assistant" },
+    ]);
+    expect(result.contacts[0].id).toBe("local-1");
+    expect(result.contacts[0].contactType).toBe("assistant");
+    expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
+  });
+
+  test("contactType + role both flow into the daemon-native read", async () => {
+    await handleListContacts({ contactType: "human", role: "guardian" });
+
+    expect(ipcCalls).toEqual([]);
+    expect(listContactsArgs).toEqual([
+      { limit: 50, role: "guardian", contactType: "human" },
+    ]);
   });
 });
 

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -245,7 +245,7 @@ describe("contact_search tool", () => {
 describe("search_contacts route", () => {
   beforeEach(clearContacts);
 
-  test("includes externalUserId (= address) on channels for older clients", () => {
+  test("includes externalUserId (= address) on channels for older clients", async () => {
     const seeded = upsertFixture({
       display_name: "Dana",
       channels: [{ type: "slack", address: "U12345ABC" }],
@@ -255,9 +255,9 @@ describe("search_contacts route", () => {
     const searchRoute = ROUTES.find(
       (r) => r.operationId === "search_contacts",
     )!;
-    const contacts = searchRoute.handler({
+    const contacts = (await searchRoute.handler({
       body: { channelAddress: seededAddress },
-    }) as unknown as Array<{
+    })) as unknown as Array<{
       channels: Array<{ address: string; externalUserId?: string }>;
     }>;
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -176,13 +176,11 @@ const contactSchema = z.object({
 async function relayListContacts(
   limit: number,
   role: ContactRole | undefined,
-  contactType: ContactType | undefined,
 ) {
   try {
     const result = await ipcCallPersistent("contacts_list_rich", {
       limit,
       ...(role ? { role } : {}),
-      ...(contactType ? { contactType } : {}),
     });
     const { contacts } = ListContactsIpcResponseSchema.parse(result);
     return {
@@ -194,7 +192,7 @@ async function relayListContacts(
       { err },
       "relayListContacts: gateway relay failed; falling back to assistant DB",
     );
-    const contacts = listContacts(limit, role, contactType);
+    const contacts = listContacts(limit, role);
     return {
       ok: true,
       contacts: contacts.map(prepareContactResponse),
@@ -239,7 +237,22 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     };
   }
 
-  return relayListContacts(limit, role, contactType);
+  // contactType is assistant-owned: serve daemon-native so it's filtered in SQL
+  // BEFORE the limit. The gateway relay filtered it AFTER its limit, which
+  // under-returned (and returned empty on an assistant-DB outage, since the
+  // soft-fail map dropped every row). Mirrors the search boundary.
+  if (contactType) {
+    log.debug(
+      "handleListContacts: contactType-filtered read served daemon-native (gateway-native contactType filtering is design-blocked, pending ACL classification)",
+    );
+    const contacts = listContacts(limit, role, contactType);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  }
+
+  return relayListContacts(limit, role);
 }
 
 export async function handleGetContact(contactId: string) {
@@ -688,11 +701,7 @@ export const ROUTES: RouteDefinition[] = [
       // No-filter "search" is a list read — relay to the gateway so it returns
       // the same source-of-truth data as `contacts list`.
       if (!hasFilter) {
-        const { contacts } = await relayListContacts(
-          parsed.limit ?? 50,
-          undefined,
-          undefined,
-        );
+        const { contacts } = await relayListContacts(parsed.limit ?? 50, undefined);
         return contacts;
       }
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -167,6 +167,41 @@ const contactSchema = z.object({
 // Contact handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
+/**
+ * Relay a non-search contact list read to the gateway (source of truth for ACL
+ * fields), falling back to the assistant DB on IPC failure. Shared by the GET
+ * `contacts` list and the `search_contacts` no-filter case so both serve
+ * gateway-sourced data consistently.
+ */
+async function relayListContacts(
+  limit: number,
+  role: ContactRole | undefined,
+  contactType: ContactType | undefined,
+) {
+  try {
+    const result = await ipcCallPersistent("contacts_list_rich", {
+      limit,
+      ...(role ? { role } : {}),
+      ...(contactType ? { contactType } : {}),
+    });
+    const { contacts } = ListContactsIpcResponseSchema.parse(result);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  } catch (err) {
+    log.warn(
+      { err },
+      "relayListContacts: gateway relay failed; falling back to assistant DB",
+    );
+    const contacts = listContacts(limit, role, contactType);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  }
+}
+
 export async function handleListContacts(queryParams: Record<string, string>) {
   const limit = Number(queryParams.limit ?? 50);
   const role = (queryParams.role as ContactRole) || undefined;
@@ -185,8 +220,11 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     ? (contactTypeParam as ContactType)
     : undefined;
 
-  // Search params still proxy to the local DB (PR 4 governs the search relay).
+  // True search stays daemon-native pending gateway-native search (Tier 3 / PR 6).
   if (query || channelAddress || channelType) {
+    log.debug(
+      "handleListContacts: search served daemon-native (gateway-native search is design-blocked, Tier 3 / PR 6)",
+    );
     const contacts = searchContacts({
       query,
       channelAddress,
@@ -201,29 +239,7 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     };
   }
 
-  // Non-search reads relay to the gateway (source of truth for ACL fields).
-  try {
-    const result = await ipcCallPersistent("contacts_list_rich", {
-      limit,
-      ...(role ? { role } : {}),
-      ...(contactType ? { contactType } : {}),
-    });
-    const { contacts } = ListContactsIpcResponseSchema.parse(result);
-    return {
-      ok: true,
-      contacts: contacts.map(prepareContactResponse),
-    };
-  } catch (err) {
-    log.warn(
-      { err },
-      "handleListContacts: gateway relay failed; falling back to assistant DB",
-    );
-    const contacts = listContacts(limit, role, contactType);
-    return {
-      ok: true,
-      contacts: contacts.map(prepareContactResponse),
-    };
-  }
+  return relayListContacts(limit, role, contactType);
 }
 
 export async function handleGetContact(contactId: string) {
@@ -654,7 +670,7 @@ export const ROUTES: RouteDefinition[] = [
       limit: z.number().optional(),
     }),
     responseBody: z.array(contactSchema),
-    handler: ({ body = {} }: RouteHandlerArgs) => {
+    handler: async ({ body = {} }: RouteHandlerArgs) => {
       const parsed = z
         .object({
           query: z.string().optional(),
@@ -663,6 +679,27 @@ export const ROUTES: RouteDefinition[] = [
           limit: z.number().optional(),
         })
         .parse(body);
+
+      const hasFilter =
+        Boolean(parsed.query?.trim()) ||
+        Boolean(parsed.channelAddress) ||
+        Boolean(parsed.channelType);
+
+      // No-filter "search" is a list read — relay to the gateway so it returns
+      // the same source-of-truth data as `contacts list`.
+      if (!hasFilter) {
+        const { contacts } = await relayListContacts(
+          parsed.limit ?? 50,
+          undefined,
+          undefined,
+        );
+        return contacts;
+      }
+
+      // True search stays daemon-native pending gateway-native search (Tier 3 / PR 6).
+      log.debug(
+        "search_contacts: search served daemon-native (gateway-native search is design-blocked, Tier 3 / PR 6)",
+      );
       return searchContacts(parsed).map(prepareContactResponse);
     },
   },

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -8,6 +8,10 @@
  * they don't shadow more-specific sub-paths like contacts/invites.
  */
 
+import {
+  GetContactIpcResponseSchema,
+  ListContactsIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
@@ -28,6 +32,7 @@ import type {
 } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
+import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   redeemIngressInvite,
@@ -41,6 +46,8 @@ import {
   RouteError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("contact-routes");
 
 /**
  * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
@@ -160,7 +167,7 @@ const contactSchema = z.object({
 // Contact handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
-function handleListContacts(queryParams: Record<string, string>) {
+export async function handleListContacts(queryParams: Record<string, string>) {
   const limit = Number(queryParams.limit ?? 50);
   const role = (queryParams.role as ContactRole) || undefined;
   const contactTypeParam = queryParams.contactType;
@@ -178,6 +185,7 @@ function handleListContacts(queryParams: Record<string, string>) {
     ? (contactTypeParam as ContactType)
     : undefined;
 
+  // Search params still proxy to the local DB (PR 4 governs the search relay).
   if (query || channelAddress || channelType) {
     const contacts = searchContacts({
       query,
@@ -193,27 +201,66 @@ function handleListContacts(queryParams: Record<string, string>) {
     };
   }
 
-  const contacts = listContacts(limit, role, contactType);
-  return {
-    ok: true,
-    contacts: contacts.map(prepareContactResponse),
-  };
+  // Non-search reads relay to the gateway (source of truth for ACL fields).
+  try {
+    const result = await ipcCallPersistent("contacts_list_rich", {
+      limit,
+      ...(role ? { role } : {}),
+      ...(contactType ? { contactType } : {}),
+    });
+    const { contacts } = ListContactsIpcResponseSchema.parse(result);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  } catch (err) {
+    log.warn(
+      { err },
+      "handleListContacts: gateway relay failed; falling back to assistant DB",
+    );
+    const contacts = listContacts(limit, role, contactType);
+    return {
+      ok: true,
+      contacts: contacts.map(prepareContactResponse),
+    };
+  }
 }
 
-function handleGetContact(contactId: string) {
-  const contact = getContact(contactId);
-  if (!contact) {
-    throw new NotFoundError(`Contact "${contactId}" not found`);
+export async function handleGetContact(contactId: string) {
+  try {
+    const result = await ipcCallPersistent("contacts_get_rich", { contactId });
+    // The gateway returns null (no `contact`) on a clean not-found.
+    if (!result || (result as { contact?: unknown }).contact === undefined) {
+      throw new NotFoundError(`Contact "${contactId}" not found`);
+    }
+    const { contact, assistantMetadata } =
+      GetContactIpcResponseSchema.parse(result);
+    return {
+      ok: true,
+      contact: prepareContactResponse(contact),
+      assistantMetadata: assistantMetadata ?? undefined,
+    };
+  } catch (err) {
+    // A clean not-found is a real 404 — don't fall back or mask it.
+    if (err instanceof NotFoundError) throw err;
+    log.warn(
+      { err, contactId },
+      "handleGetContact: gateway relay failed; falling back to assistant DB",
+    );
+    const contact = getContact(contactId);
+    if (!contact) {
+      throw new NotFoundError(`Contact "${contactId}" not found`);
+    }
+    const assistantMeta =
+      contact.contactType === "assistant"
+        ? getAssistantContactMetadata(contact.id)
+        : undefined;
+    return {
+      ok: true,
+      contact: prepareContactResponse(contact),
+      assistantMetadata: assistantMeta ?? undefined,
+    };
   }
-  const assistantMeta =
-    contact.contactType === "assistant"
-      ? getAssistantContactMetadata(contact.id)
-      : undefined;
-  return {
-    ok: true,
-    contact: prepareContactResponse(contact),
-    assistantMetadata: assistantMeta ?? undefined,
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -160,6 +160,8 @@ const contactSchema = z.object({
   contactType: z.string().nullable().optional(),
   lastInteraction: z.number().nullable().optional(),
   interactionCount: z.number(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
   channels: z.array(contactChannelSchema),
 });
 
@@ -218,10 +220,10 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     ? (contactTypeParam as ContactType)
     : undefined;
 
-  // True search stays daemon-native pending gateway-native search (Tier 3 / PR 6).
+  // True search stays daemon-native: gateway-native search is design-blocked.
   if (query || channelAddress || channelType) {
     log.debug(
-      "handleListContacts: search served daemon-native (gateway-native search is design-blocked, Tier 3 / PR 6)",
+      "handleListContacts: search served daemon-native (gateway-native search is design-blocked)",
     );
     const contacts = searchContacts({
       query,
@@ -705,9 +707,9 @@ export const ROUTES: RouteDefinition[] = [
         return contacts;
       }
 
-      // True search stays daemon-native pending gateway-native search (Tier 3 / PR 6).
+      // True search stays daemon-native: gateway-native search is design-blocked.
       log.debug(
-        "search_contacts: search served daemon-native (gateway-native search is design-blocked, Tier 3 / PR 6)",
+        "search_contacts: search served daemon-native (gateway-native search is design-blocked)",
       );
       return searchContacts(parsed).map(prepareContactResponse);
     },

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -226,8 +226,9 @@ describe("ContactStore.listContactsRich", () => {
     expect(ch.verifiedAt).toBe(555);
     expect(ch.revokedReason).toBe("spam");
     expect(ch.blockedReason).toBeNull();
-    // externalUserId echoes address (withChannelCompat).
-    expect(ch.externalUserId).toBe("tg-001");
+    // externalUserId is null here — the daemon's withChannelCompat is the sole
+    // producer of that compat field on the relayed payload.
+    expect(ch.externalUserId).toBeNull();
   });
 
   test("orders guardian first, then updatedAt desc", async () => {
@@ -252,56 +253,6 @@ describe("ContactStore.listContactsRich", () => {
       role: "guardian",
     });
     expect(result.map((c) => c.id)).toEqual(["g"]);
-  });
-
-  test("honors contactType filter against assistant-DB value", async () => {
-    seedGatewayContact({ id: "human", updatedAt: 200 });
-    seedGatewayContact({ id: "bot", updatedAt: 100 });
-    seedAssistantInfo({ id: "human", contactType: "human" });
-    seedAssistantInfo({
-      id: "bot",
-      contactType: "assistant",
-      species: "vellum",
-      metadata: { model: "opus" },
-    });
-
-    const result = await new ContactStore().listContactsRich({
-      contactType: "assistant",
-    });
-    expect(result.map((c) => c.id)).toEqual(["bot"]);
-  });
-
-  test("contactType filter with a MIX of types + tight limit (forward-compat path)", async () => {
-    // contactType filtering is no longer exercised on the daemon relay path
-    // (the daemon serves contactType-filtered reads natively). This test keeps
-    // the gateway-side filter behavior honest for forward-compat callers: with
-    // a mix of types and a limit, listContactsWithInfo applies the limit to
-    // CONTACTS first, then the contactType filter runs on the limited set — so
-    // a tight limit can still under-return here. The relay path avoids this by
-    // staying daemon-native (SQL contactType filter before the limit).
-    seedGatewayContact({ id: "h1", updatedAt: 500 });
-    seedGatewayContact({ id: "bot1", updatedAt: 400 });
-    seedGatewayContact({ id: "h2", updatedAt: 300 });
-    seedGatewayContact({ id: "bot2", updatedAt: 200 });
-    seedAssistantInfo({ id: "h1", contactType: "human" });
-    seedAssistantInfo({ id: "bot1", contactType: "assistant", species: "vellum" });
-    seedAssistantInfo({ id: "h2", contactType: "human" });
-    seedAssistantInfo({ id: "bot2", contactType: "assistant", species: "vellum" });
-
-    // No limit → all assistant contacts returned.
-    const all = await new ContactStore().listContactsRich({
-      contactType: "assistant",
-    });
-    expect(all.map((c) => c.id)).toEqual(["bot1", "bot2"]);
-
-    // limit 2 → contacts limited to [h1, bot1] first, then filtered to
-    // assistant → only bot1 survives (demonstrates the post-limit truncation
-    // the daemon-native relay path deliberately avoids).
-    const limited = await new ContactStore().listContactsRich({
-      contactType: "assistant",
-      limit: 2,
-    });
-    expect(limited.map((c) => c.id)).toEqual(["bot1"]);
   });
 
   test("honors limit (capped at 200)", async () => {

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for the gateway-native rich contact reads:
+ *   - ContactStore.listContactsRich
+ *   - ContactStore.getContactRich
+ *
+ * These assemble the shared ContactRead shape (gateway ACL/identity + assistant
+ * info fields) so the daemon can relay its full contact read responses through
+ * the gateway IPC surface. The gateway DB is a real (file-backed) DB seeded per
+ * test; the assistant DB proxy is mocked behind `fakeAssistantDb` so no daemon
+ * is required. Mirrors the pattern in contacts-info-joiner.test.ts.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+
+import "./test-preload.js";
+
+// ── Fake assistant DB ───────────────────────────────────────────────────────
+// Honors the info-join query (SELECT ... FROM contacts LEFT JOIN
+// assistant_contact_metadata WHERE c.id IN (...)) and throws on demand.
+
+type FakeInfoRow = {
+  id: string;
+  notes: string | null;
+  user_file: string | null;
+  contact_type: string | null;
+  species: string | null;
+  metadata: string | null;
+};
+
+const fakeAssistantDb = {
+  info: new Map<string, FakeInfoRow>(),
+  throwOnQuery: false as boolean,
+  reset(): void {
+    this.info.clear();
+    this.throwOnQuery = false;
+  },
+};
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
+    if (fakeAssistantDb.throwOnQuery) {
+      throw new Error("simulated assistant DB outage");
+    }
+    const lower = sql.toLowerCase();
+    if (lower.includes("from contacts") && lower.includes("in (")) {
+      const ids = (bind ?? []) as string[];
+      const out: Array<{
+        id: string;
+        notes: string | null;
+        userFile: string | null;
+        contactType: string | null;
+        species: string | null;
+        metadata: string | null;
+      }> = [];
+      for (const id of ids) {
+        const row = fakeAssistantDb.info.get(id);
+        if (row) {
+          out.push({
+            id: row.id,
+            notes: row.notes,
+            userFile: row.user_file,
+            contactType: row.contact_type,
+            species: row.species,
+            metadata: row.metadata,
+          });
+        }
+      }
+      return out;
+    }
+    return [];
+  }),
+  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
+  assistantDbExec: mock(async () => undefined),
+}));
+
+import {
+  ContactReadSchema,
+  GetContactIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import { ContactStore } from "../db/contact-store.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  fakeAssistantDb.reset();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ── Seed helpers ─────────────────────────────────────────────────────────────
+
+function seedGatewayContact(opts: {
+  id: string;
+  displayName?: string;
+  role?: string;
+  updatedAt?: number;
+}): void {
+  const db = getGatewayDb();
+  db.insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: opts.displayName ?? `name-${opts.id}`,
+      role: opts.role ?? "contact",
+      principalId: null,
+      createdAt: opts.updatedAt ?? Date.now(),
+      updatedAt: opts.updatedAt ?? Date.now(),
+    })
+    .run();
+}
+
+function seedGatewayChannel(opts: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address?: string;
+  isPrimary?: boolean;
+  status?: string;
+  policy?: string;
+  verifiedAt?: number | null;
+  revokedReason?: string | null;
+  blockedReason?: string | null;
+  interactionCount?: number;
+  lastInteraction?: number | null;
+  createdAt?: number;
+}): void {
+  const db = getGatewayDb();
+  db.insert(contactChannels)
+    .values({
+      id: opts.id,
+      contactId: opts.contactId,
+      type: opts.type ?? "telegram",
+      address: opts.address ?? `addr-${opts.id}`,
+      isPrimary: opts.isPrimary ?? false,
+      externalChatId: null,
+      status: opts.status ?? "active",
+      policy: opts.policy ?? "allow",
+      verifiedAt: opts.verifiedAt ?? null,
+      verifiedVia: null,
+      inviteId: null,
+      revokedReason: opts.revokedReason ?? null,
+      blockedReason: opts.blockedReason ?? null,
+      lastSeenAt: null,
+      interactionCount: opts.interactionCount ?? 0,
+      lastInteraction: opts.lastInteraction ?? null,
+      createdAt: opts.createdAt ?? 100,
+      updatedAt: null,
+    })
+    .run();
+}
+
+function seedAssistantInfo(opts: {
+  id: string;
+  notes?: string | null;
+  contactType?: string | null;
+  species?: string | null;
+  metadata?: Record<string, unknown> | null;
+}): void {
+  fakeAssistantDb.info.set(opts.id, {
+    id: opts.id,
+    notes: opts.notes ?? null,
+    user_file: null,
+    contact_type: opts.contactType ?? null,
+    species: opts.species ?? null,
+    metadata: opts.metadata != null ? JSON.stringify(opts.metadata) : null,
+  });
+}
+
+// ── listContactsRich ─────────────────────────────────────────────────────────
+
+describe("ContactStore.listContactsRich", () => {
+  test("merges gateway ACL + assistant info and validates against ContactReadSchema", async () => {
+    seedGatewayContact({ id: "c1", role: "contact", updatedAt: 100 });
+    seedGatewayChannel({
+      id: "ch1",
+      contactId: "c1",
+      type: "telegram",
+      address: "tg-001",
+      status: "active",
+      policy: "escalate",
+      verifiedAt: 555,
+      revokedReason: "spam",
+      interactionCount: 4,
+      lastInteraction: 900,
+    });
+    seedAssistantInfo({ id: "c1", notes: "a friend", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toHaveLength(1);
+
+    // Every returned object validates against the shared contract.
+    for (const c of result) expect(ContactReadSchema.parse(c)).toEqual(c);
+
+    const c1 = result[0];
+    // Info fields from assistant DB.
+    expect(c1.notes).toBe("a friend");
+    expect(c1.contactType).toBe("human");
+    // Trust signals derived from gateway channels.
+    expect(c1.interactionCount).toBe(4);
+    expect(c1.lastInteraction).toBe(900);
+    // Channel ACL fields from gateway DB.
+    const ch = c1.channels[0];
+    expect(ch.status).toBe("active");
+    expect(ch.policy).toBe("escalate");
+    expect(ch.verifiedAt).toBe(555);
+    expect(ch.revokedReason).toBe("spam");
+    expect(ch.blockedReason).toBeNull();
+    // externalUserId echoes address (withChannelCompat).
+    expect(ch.externalUserId).toBe("tg-001");
+  });
+
+  test("orders guardian first, then updatedAt desc", async () => {
+    seedGatewayContact({ id: "old", updatedAt: 100 });
+    seedGatewayContact({ id: "new", updatedAt: 900 });
+    seedGatewayContact({ id: "guard", role: "guardian", updatedAt: 1 });
+    seedAssistantInfo({ id: "old", contactType: "human" });
+    seedAssistantInfo({ id: "new", contactType: "human" });
+    seedAssistantInfo({ id: "guard", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result.map((c) => c.id)).toEqual(["guard", "new", "old"]);
+  });
+
+  test("honors role filter (gateway DB)", async () => {
+    seedGatewayContact({ id: "g", role: "guardian" });
+    seedGatewayContact({ id: "c", role: "contact" });
+    seedAssistantInfo({ id: "g", contactType: "human" });
+    seedAssistantInfo({ id: "c", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich({
+      role: "guardian",
+    });
+    expect(result.map((c) => c.id)).toEqual(["g"]);
+  });
+
+  test("honors contactType filter against assistant-DB value", async () => {
+    seedGatewayContact({ id: "human", updatedAt: 200 });
+    seedGatewayContact({ id: "bot", updatedAt: 100 });
+    seedAssistantInfo({ id: "human", contactType: "human" });
+    seedAssistantInfo({
+      id: "bot",
+      contactType: "assistant",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+
+    const result = await new ContactStore().listContactsRich({
+      contactType: "assistant",
+    });
+    expect(result.map((c) => c.id)).toEqual(["bot"]);
+  });
+
+  test("honors limit (capped at 200)", async () => {
+    for (let i = 0; i < 5; i++) {
+      seedGatewayContact({ id: `c${i}`, updatedAt: i });
+      seedAssistantInfo({ id: `c${i}`, contactType: "human" });
+    }
+    const result = await new ContactStore().listContactsRich({ limit: 2 });
+    expect(result).toHaveLength(2);
+  });
+
+  test("missing assistant-DB row degrades gracefully (info null, no throw)", async () => {
+    seedGatewayContact({ id: "gap" });
+    seedGatewayChannel({ id: "ch-gap", contactId: "gap", interactionCount: 3 });
+    // No assistant info seeded.
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toHaveLength(1);
+    expect(result[0].notes).toBeNull();
+    expect(result[0].contactType).toBeNull();
+    // ACL/trust fields still populated from gateway.
+    expect(result[0].interactionCount).toBe(3);
+    expect(ContactReadSchema.parse(result[0])).toEqual(result[0]);
+  });
+
+  test("soft-fails on assistant DB outage: gateway-DB-only fields, no throw", async () => {
+    seedGatewayContact({ id: "c1" });
+    seedGatewayChannel({ id: "ch1", contactId: "c1", interactionCount: 2 });
+    seedAssistantInfo({ id: "c1", notes: "unseen", contactType: "human" });
+    fakeAssistantDb.throwOnQuery = true;
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toHaveLength(1);
+    expect(result[0].notes).toBeNull();
+    expect(result[0].contactType).toBeNull();
+    expect(result[0].interactionCount).toBe(2);
+  });
+
+  test("empty gateway DB returns empty array", async () => {
+    const result = await new ContactStore().listContactsRich();
+    expect(result).toEqual([]);
+  });
+
+  test("primary channel appears first regardless of creation order", async () => {
+    seedGatewayContact({ id: "c1" });
+    seedGatewayChannel({ id: "ch-old", contactId: "c1", createdAt: 100 });
+    seedGatewayChannel({
+      id: "ch-primary",
+      contactId: "c1",
+      isPrimary: true,
+      createdAt: 200,
+    });
+    seedAssistantInfo({ id: "c1", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich();
+    expect(result[0].channels.map((c) => c.id)).toEqual([
+      "ch-primary",
+      "ch-old",
+    ]);
+  });
+});
+
+// ── getContactRich ───────────────────────────────────────────────────────────
+
+describe("ContactStore.getContactRich", () => {
+  test("returns null when contact not in gateway DB", async () => {
+    const result = await new ContactStore().getContactRich("nope");
+    expect(result).toBeNull();
+  });
+
+  test("returns merged ContactRead validating against the response contract", async () => {
+    seedGatewayContact({ id: "c1", role: "guardian" });
+    seedGatewayChannel({
+      id: "ch1",
+      contactId: "c1",
+      interactionCount: 7,
+      lastInteraction: 999,
+    });
+    seedAssistantInfo({ id: "c1", notes: "my guardian", contactType: "human" });
+
+    const result = await new ContactStore().getContactRich("c1");
+    expect(result).not.toBeNull();
+    expect(result!.contact.id).toBe("c1");
+    expect(result!.contact.role).toBe("guardian");
+    expect(result!.contact.notes).toBe("my guardian");
+    expect(result!.contact.interactionCount).toBe(7);
+    expect(result!.assistantMetadata).toBeUndefined();
+
+    // Validate against the get-contact IPC response contract.
+    const payload = { ok: true, contact: result!.contact };
+    expect(() => GetContactIpcResponseSchema.parse(payload)).not.toThrow();
+  });
+
+  test("includes assistantMetadata for assistant-species contacts", async () => {
+    seedGatewayContact({ id: "bot" });
+    seedGatewayChannel({ id: "ch-bot", contactId: "bot" });
+    seedAssistantInfo({
+      id: "bot",
+      contactType: "assistant",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+
+    const result = await new ContactStore().getContactRich("bot");
+    expect(result!.assistantMetadata).toEqual({
+      contactId: "bot",
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+
+    const payload = {
+      ok: true,
+      contact: result!.contact,
+      assistantMetadata: result!.assistantMetadata,
+    };
+    expect(() => GetContactIpcResponseSchema.parse(payload)).not.toThrow();
+  });
+
+  test("missing assistant-DB row degrades gracefully (info null, no throw)", async () => {
+    seedGatewayContact({ id: "gap" });
+    seedGatewayChannel({ id: "ch-gap", contactId: "gap", interactionCount: 1 });
+
+    const result = await new ContactStore().getContactRich("gap");
+    expect(result).not.toBeNull();
+    expect(result!.contact.notes).toBeNull();
+    expect(result!.contact.contactType).toBeNull();
+    expect(result!.contact.interactionCount).toBe(1);
+    expect(result!.assistantMetadata).toBeUndefined();
+  });
+
+  test("soft-fails on assistant DB outage for single contact", async () => {
+    seedGatewayContact({ id: "c1" });
+    seedAssistantInfo({ id: "c1", notes: "lost", contactType: "human" });
+    fakeAssistantDb.throwOnQuery = true;
+
+    const result = await new ContactStore().getContactRich("c1");
+    expect(result).not.toBeNull();
+    expect(result!.contact.notes).toBeNull();
+    expect(result!.contact.contactType).toBeNull();
+  });
+});

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -213,6 +213,9 @@ describe("ContactStore.listContactsRich", () => {
     for (const c of result) expect(ContactReadSchema.parse(c)).toEqual(c);
 
     const c1 = result[0];
+    // Contact-level timestamps projected from the gateway DB.
+    expect(c1.createdAt).toBe(100);
+    expect(c1.updatedAt).toBe(100);
     // Info fields from assistant DB.
     expect(c1.notes).toBe("a friend");
     expect(c1.contactType).toBe("human");
@@ -324,7 +327,7 @@ describe("ContactStore.getContactRich", () => {
   });
 
   test("returns merged ContactRead validating against the response contract", async () => {
-    seedGatewayContact({ id: "c1", role: "guardian" });
+    seedGatewayContact({ id: "c1", role: "guardian", updatedAt: 321 });
     seedGatewayChannel({
       id: "ch1",
       contactId: "c1",
@@ -339,6 +342,8 @@ describe("ContactStore.getContactRich", () => {
     expect(result!.contact.role).toBe("guardian");
     expect(result!.contact.notes).toBe("my guardian");
     expect(result!.contact.interactionCount).toBe(7);
+    expect(result!.contact.createdAt).toBe(321);
+    expect(result!.contact.updatedAt).toBe(321);
     expect(result!.assistantMetadata).toBeUndefined();
 
     // Validate against the get-contact IPC response contract.

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -271,6 +271,39 @@ describe("ContactStore.listContactsRich", () => {
     expect(result.map((c) => c.id)).toEqual(["bot"]);
   });
 
+  test("contactType filter with a MIX of types + tight limit (forward-compat path)", async () => {
+    // contactType filtering is no longer exercised on the daemon relay path
+    // (the daemon serves contactType-filtered reads natively). This test keeps
+    // the gateway-side filter behavior honest for forward-compat callers: with
+    // a mix of types and a limit, listContactsWithInfo applies the limit to
+    // CONTACTS first, then the contactType filter runs on the limited set — so
+    // a tight limit can still under-return here. The relay path avoids this by
+    // staying daemon-native (SQL contactType filter before the limit).
+    seedGatewayContact({ id: "h1", updatedAt: 500 });
+    seedGatewayContact({ id: "bot1", updatedAt: 400 });
+    seedGatewayContact({ id: "h2", updatedAt: 300 });
+    seedGatewayContact({ id: "bot2", updatedAt: 200 });
+    seedAssistantInfo({ id: "h1", contactType: "human" });
+    seedAssistantInfo({ id: "bot1", contactType: "assistant", species: "vellum" });
+    seedAssistantInfo({ id: "h2", contactType: "human" });
+    seedAssistantInfo({ id: "bot2", contactType: "assistant", species: "vellum" });
+
+    // No limit → all assistant contacts returned.
+    const all = await new ContactStore().listContactsRich({
+      contactType: "assistant",
+    });
+    expect(all.map((c) => c.id)).toEqual(["bot1", "bot2"]);
+
+    // limit 2 → contacts limited to [h1, bot1] first, then filtered to
+    // assistant → only bot1 survives (demonstrates the post-limit truncation
+    // the daemon-native relay path deliberately avoids).
+    const limited = await new ContactStore().listContactsRich({
+      contactType: "assistant",
+      limit: 2,
+    });
+    expect(limited.map((c) => c.id)).toEqual(["bot1"]);
+  });
+
   test("honors limit (capped at 200)", async () => {
     for (let i = 0; i < 5; i++) {
       seedGatewayContact({ id: `c${i}`, updatedAt: i });

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -354,9 +354,10 @@ describe("IPC contact routes", () => {
     expect(body.contacts[0].role).toBe("guardian");
     // Trust signals derived from gateway channels (5 + 10 for the guardian).
     expect(body.contacts[0].interactionCount).toBe(15);
-    // externalUserId echoes address (withChannelCompat).
+    // externalUserId is null on the gateway rich-read output — the daemon's
+    // withChannelCompat is the sole producer of that compat field.
     const ch = body.contacts[0].channels[0];
-    expect(ch.externalUserId).toBe(ch.address);
+    expect(ch.externalUserId).toBeNull();
   });
 
   test("contacts_list_rich honors the role filter via IPC", async () => {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -323,4 +323,91 @@ describe("IPC contact routes", () => {
     expect(res.error).toBeDefined();
     expect(res.error).toContain("Invalid params");
   });
+
+  // ── Rich reads (contacts_list_rich / contacts_get_rich) ─────────────────
+  //
+  // The assistant DB proxy is not available in this test harness, so the rich
+  // reads soft-fail the info join (notes/contactType become null) and return
+  // the gateway-DB-only ACL shape. We assert the merged ContactRead structure
+  // end-to-end over the socket.
+
+  test("contacts_list_rich returns the merged ContactRead shape via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_list_rich", {});
+
+    expect(res.error).toBeUndefined();
+    const body = res.result as {
+      ok: boolean;
+      contacts: Array<{
+        id: string;
+        role: string;
+        interactionCount: number;
+        channels: Array<{ address: string; externalUserId: string | null }>;
+      }>;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.contacts).toHaveLength(2);
+    // Guardian first (ordering mirrors the daemon's listContacts).
+    expect(body.contacts[0].id).toBe("c1");
+    expect(body.contacts[0].role).toBe("guardian");
+    // Trust signals derived from gateway channels (5 + 10 for the guardian).
+    expect(body.contacts[0].interactionCount).toBe(15);
+    // externalUserId echoes address (withChannelCompat).
+    const ch = body.contacts[0].channels[0];
+    expect(ch.externalUserId).toBe(ch.address);
+  });
+
+  test("contacts_list_rich honors the role filter via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_list_rich", {
+      role: "guardian",
+    });
+
+    expect(res.error).toBeUndefined();
+    const body = res.result as { ok: boolean; contacts: Array<{ id: string }> };
+    expect(body.contacts.map((c) => c.id)).toEqual(["c1"]);
+  });
+
+  test("contacts_get_rich returns a merged contact via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_get_rich", {
+      contactId: "c1",
+    });
+
+    expect(res.error).toBeUndefined();
+    const body = res.result as {
+      ok: boolean;
+      contact: { id: string; displayName: string; channels: unknown[] };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.contact.id).toBe("c1");
+    expect(body.contact.displayName).toBe("Test Guardian");
+    expect(body.contact.channels).toHaveLength(2);
+  });
+
+  test("contacts_get_rich returns null for unknown contact via IPC", async () => {
+    seedTestData();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_get_rich", {
+      contactId: "nonexistent",
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toBeNull();
+  });
+
+  test("contacts_get_rich validates params", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "contacts_get_rich", {});
+
+    expect(res.error).toBeDefined();
+    expect(res.error).toContain("Invalid params");
+  });
 });

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -204,9 +204,15 @@ export class ContactStore {
    * List contacts in the shared ContactRead shape: gateway-DB identity + ACL
    * channels joined to assistant-DB info fields.
    *
-   * Filters: `role` (gateway DB), `contactType` (assistant-owned — applied
-   * against the joined assistant value), `limit` (default 50, capped 200 to
-   * mirror the daemon's listContacts).
+   * Filters: `role` (gateway DB), `limit` (default 50, capped 200 to mirror
+   * the daemon's listContacts). `contactType` is assistant-owned and is NOT
+   * filtered here — the daemon serves contactType-filtered list reads natively
+   * (filtering in SQL before the limit) so a tight limit doesn't under-return
+   * and an assistant-DB outage degrades rather than dropping every row. The
+   * param is retained for forward-compat but not exercised on the relay path.
+   *
+   * Thin adapter over `listContactsWithInfo` (shared assembly/soft-fail logic),
+   * projected down to the ContactRead subset.
    *
    * Ordering mirrors the daemon's listContacts: guardian role first, then
    * updatedAt desc.
@@ -216,68 +222,37 @@ export class ContactStore {
     role?: string;
     contactType?: string;
   }): Promise<ContactRead[]> {
-    const effectiveLimit = Math.min(opts?.limit ?? 50, 200);
-
-    const contactRows = this.db
-      .select()
-      .from(contacts)
-      .where(opts?.role ? eq(contacts.role, opts.role) : undefined)
-      .orderBy(
-        sql`${contacts.role} = 'guardian' DESC`,
-        desc(contacts.updatedAt),
-      )
-      .limit(effectiveLimit)
-      .all();
-
-    if (contactRows.length === 0) return [];
-
-    const ids = contactRows.map((c) => c.id);
-    const channelsByContact = this.channelsForContacts(ids);
-    const infoMap = await this.fetchInfoSoft(ids);
-
-    const result: ContactRead[] = [];
-    for (const contact of contactRows) {
-      const info = infoMap.get(contact.id) ?? null;
-      // contactType is assistant-owned — filter against the joined value.
-      if (opts?.contactType && info?.contactType !== opts.contactType) continue;
-      result.push(
-        this.composeContactRead(
-          contact,
-          channelsByContact.get(contact.id) ?? [],
-          info,
-        ),
-      );
-    }
-    return result;
+    const withInfo = await this.listContactsWithInfo({
+      limit: opts?.limit,
+      role: opts?.role,
+    });
+    return withInfo
+      .filter((c) => !opts?.contactType || c.contactType === opts.contactType)
+      .map((c) => this.toContactRead(c));
   }
 
   /**
    * Get a single contact in the shared ContactRead shape, plus the assistant
    * metadata block for assistant-species contacts. Returns null if the
    * contact is absent from the gateway DB.
+   *
+   * Thin adapter over `getContactWithInfo`, projected down to ContactRead.
    */
   async getContactRich(contactId: string): Promise<{
     contact: ContactRead;
     assistantMetadata?: AssistantContactMetadata;
   } | null> {
-    const contact = this.db
-      .select()
-      .from(contacts)
-      .where(eq(contacts.id, contactId))
-      .get();
-    if (!contact) return null;
+    const withInfo = await this.getContactWithInfo(contactId);
+    if (!withInfo) return null;
 
-    const channels = this.channelsForContacts([contactId]).get(contactId) ?? [];
-    const info = (await this.fetchInfoSoft([contactId])).get(contactId) ?? null;
-    const read = this.composeContactRead(contact, channels, info);
-
-    if (info?.contactType === "assistant" && info.assistantMetadata) {
+    const read = this.toContactRead(withInfo);
+    if (withInfo.contactType === "assistant" && withInfo.assistantMetadata) {
       return {
         contact: read,
         assistantMetadata: {
           contactId,
-          species: info.assistantMetadata.species,
-          metadata: info.assistantMetadata.metadata,
+          species: withInfo.assistantMetadata.species,
+          metadata: withInfo.assistantMetadata.metadata,
         },
       };
     }
@@ -285,86 +260,22 @@ export class ContactStore {
   }
 
   /**
-   * Fetch channels for a set of contact IDs, grouped by contactId and ordered
-   * primary-first then by creation time (mirrors readAssistantContact and the
-   * daemon's withChannels ordering).
+   * Project a ContactWithInfo down to the ContactRead subset (drops the
+   * assistant-only/ACL-internal fields not on the shared contract). Channel
+   * `externalUserId` echoes `address` to match the daemon's withChannelCompat;
+   * status/policy default like the DB columns (notNull, so a no-op on real
+   * rows) to satisfy the non-null ContactRead channel contract.
    */
-  private channelsForContacts(
-    contactIds: string[],
-  ): Map<string, ContactChannel[]> {
-    const byId = new Map<string, ContactChannel[]>();
-    if (contactIds.length === 0) return byId;
-
-    const rows = this.db
-      .select()
-      .from(contactChannels)
-      .where(
-        sql`${contactChannels.contactId} IN (${sql.join(
-          contactIds.map((id) => sql`${id}`),
-          sql`, `,
-        )})`,
-      )
-      .orderBy(
-        sql`${contactChannels.isPrimary} DESC`,
-        contactChannels.createdAt,
-      )
-      .all();
-
-    for (const ch of rows) {
-      const list = byId.get(ch.contactId) ?? [];
-      list.push(ch);
-      byId.set(ch.contactId, list);
-    }
-    return byId;
-  }
-
-  /**
-   * Soft assistant-DB info fetch: on failure, log a warning and return an
-   * empty map so callers degrade to gateway-DB-only values.
-   */
-  private async fetchInfoSoft(
-    contactIds: string[],
-  ): Promise<Map<string, ContactInfoFields>> {
-    try {
-      return await fetchInfoForContacts(contactIds);
-    } catch (err) {
-      log.warn(
-        { err, count: contactIds.length },
-        "rich read: assistant DB info join failed; returning gateway-DB-only fields",
-      );
-      return new Map();
-    }
-  }
-
-  /**
-   * Compose the ContactRead shape: identity + ACL/channel fields from the
-   * gateway DB, info fields (notes, contactType, interactionCount,
-   * lastInteraction) from the assistant DB. interactionCount/lastInteraction
-   * are derived from gateway channels (trust signals live in gateway).
-   * `externalUserId` echoes `address` to match the daemon's withChannelCompat.
-   */
-  private composeContactRead(
-    contact: Contact,
-    channels: ContactChannel[],
-    info: ContactInfoFields | null,
-  ): ContactRead {
-    const interactionCount = channels.reduce(
-      (sum, ch) => sum + (ch.interactionCount ?? 0),
-      0,
-    );
-    const lastInteraction =
-      channels.reduce((max, ch) => Math.max(max, ch.lastInteraction ?? 0), 0) ||
-      null;
-
+  private toContactRead(c: ContactWithInfo): ContactRead {
     return {
-      id: contact.id,
-      displayName: contact.displayName,
-      role: contact.role,
-      notes: info?.notes ?? null,
-      contactType: info?.contactType ?? null,
-      interactionCount,
-      lastInteraction,
-      channels: channels.map((ch) => ({
+      id: c.id,
+      displayName: c.displayName,
+      role: c.role,
+      notes: c.notes,
+      contactType: c.contactType,
+      interactionCount: c.interactionCount,
+      lastInteraction: c.lastInteraction,
+      channels: c.channels.map((ch) => ({
         id: ch.id,
         contactId: ch.contactId,
         type: ch.type,

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -197,8 +197,8 @@ export class ContactStore {
   // a failed or missing read degrades to gateway-DB-only values + a warning.
   //
   // Guardian display-name override is intentionally NOT applied here — the
-  // daemon relay handler (PR 3) re-applies prepareContactResponse on the
-  // relayed payload, keeping prompt logic on the daemon side.
+  // daemon relay handler re-applies prepareContactResponse on the relayed
+  // payload, keeping prompt logic on the daemon side.
 
   /**
    * List contacts in the shared ContactRead shape: gateway-DB identity + ACL
@@ -272,6 +272,8 @@ export class ContactStore {
       contactType: c.contactType,
       interactionCount: c.interactionCount,
       lastInteraction: c.lastInteraction,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
       channels: c.channels.map((ch) => ({
         id: ch.id,
         contactId: ch.contactId,

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -3,6 +3,11 @@ import { type Database } from "bun:sqlite";
 import { and, desc, eq, ne, sql } from "drizzle-orm";
 
 import {
+  type AssistantContactMetadata,
+  type ContactRead,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import {
   type SqliteValue,
   assistantDbQuery,
   assistantDbRun,
@@ -179,6 +184,204 @@ export class ContactStore {
     if (rows.length === 0) return null;
     const joined = await this.joinInfoIntoContacts(rows);
     return joined[0] ?? null;
+  }
+
+  // ── Rich reads (gateway ACL + assistant info, ContactRead contract) ──────
+  //
+  // listContactsRich / getContactRich assemble the shared ContactRead shape
+  // (packages/gateway-client/src/gateway-ipc-contracts.ts) so the daemon can
+  // relay its full contact read responses through the gateway IPC surface.
+  // Identity + ACL/channel fields come from the gateway DB (source of truth);
+  // info fields (notes, contactType, interactionCount, lastInteraction) come
+  // from the assistant DB via assistantDbQuery. The assistant join is soft:
+  // a failed or missing read degrades to gateway-DB-only values + a warning.
+  //
+  // Guardian display-name override is intentionally NOT applied here — the
+  // daemon relay handler (PR 3) re-applies prepareContactResponse on the
+  // relayed payload, keeping prompt logic on the daemon side.
+
+  /**
+   * List contacts in the shared ContactRead shape: gateway-DB identity + ACL
+   * channels joined to assistant-DB info fields.
+   *
+   * Filters: `role` (gateway DB), `contactType` (assistant-owned — applied
+   * against the joined assistant value), `limit` (default 50, capped 200 to
+   * mirror the daemon's listContacts).
+   *
+   * Ordering mirrors the daemon's listContacts: guardian role first, then
+   * updatedAt desc.
+   */
+  async listContactsRich(opts?: {
+    limit?: number;
+    role?: string;
+    contactType?: string;
+  }): Promise<ContactRead[]> {
+    const effectiveLimit = Math.min(opts?.limit ?? 50, 200);
+
+    const contactRows = this.db
+      .select()
+      .from(contacts)
+      .where(opts?.role ? eq(contacts.role, opts.role) : undefined)
+      .orderBy(
+        sql`${contacts.role} = 'guardian' DESC`,
+        desc(contacts.updatedAt),
+      )
+      .limit(effectiveLimit)
+      .all();
+
+    if (contactRows.length === 0) return [];
+
+    const ids = contactRows.map((c) => c.id);
+    const channelsByContact = this.channelsForContacts(ids);
+    const infoMap = await this.fetchInfoSoft(ids);
+
+    const result: ContactRead[] = [];
+    for (const contact of contactRows) {
+      const info = infoMap.get(contact.id) ?? null;
+      // contactType is assistant-owned — filter against the joined value.
+      if (opts?.contactType && info?.contactType !== opts.contactType) continue;
+      result.push(
+        this.composeContactRead(
+          contact,
+          channelsByContact.get(contact.id) ?? [],
+          info,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Get a single contact in the shared ContactRead shape, plus the assistant
+   * metadata block for assistant-species contacts. Returns null if the
+   * contact is absent from the gateway DB.
+   */
+  async getContactRich(contactId: string): Promise<{
+    contact: ContactRead;
+    assistantMetadata?: AssistantContactMetadata;
+  } | null> {
+    const contact = this.db
+      .select()
+      .from(contacts)
+      .where(eq(contacts.id, contactId))
+      .get();
+    if (!contact) return null;
+
+    const channels = this.channelsForContacts([contactId]).get(contactId) ?? [];
+    const info = (await this.fetchInfoSoft([contactId])).get(contactId) ?? null;
+    const read = this.composeContactRead(contact, channels, info);
+
+    if (info?.contactType === "assistant" && info.assistantMetadata) {
+      return {
+        contact: read,
+        assistantMetadata: {
+          contactId,
+          species: info.assistantMetadata.species,
+          metadata: info.assistantMetadata.metadata,
+        },
+      };
+    }
+    return { contact: read };
+  }
+
+  /**
+   * Fetch channels for a set of contact IDs, grouped by contactId and ordered
+   * primary-first then by creation time (mirrors readAssistantContact and the
+   * daemon's withChannels ordering).
+   */
+  private channelsForContacts(
+    contactIds: string[],
+  ): Map<string, ContactChannel[]> {
+    const byId = new Map<string, ContactChannel[]>();
+    if (contactIds.length === 0) return byId;
+
+    const rows = this.db
+      .select()
+      .from(contactChannels)
+      .where(
+        sql`${contactChannels.contactId} IN (${sql.join(
+          contactIds.map((id) => sql`${id}`),
+          sql`, `,
+        )})`,
+      )
+      .orderBy(
+        sql`${contactChannels.isPrimary} DESC`,
+        contactChannels.createdAt,
+      )
+      .all();
+
+    for (const ch of rows) {
+      const list = byId.get(ch.contactId) ?? [];
+      list.push(ch);
+      byId.set(ch.contactId, list);
+    }
+    return byId;
+  }
+
+  /**
+   * Soft assistant-DB info fetch: on failure, log a warning and return an
+   * empty map so callers degrade to gateway-DB-only values.
+   */
+  private async fetchInfoSoft(
+    contactIds: string[],
+  ): Promise<Map<string, ContactInfoFields>> {
+    try {
+      return await fetchInfoForContacts(contactIds);
+    } catch (err) {
+      log.warn(
+        { err, count: contactIds.length },
+        "rich read: assistant DB info join failed; returning gateway-DB-only fields",
+      );
+      return new Map();
+    }
+  }
+
+  /**
+   * Compose the ContactRead shape: identity + ACL/channel fields from the
+   * gateway DB, info fields (notes, contactType, interactionCount,
+   * lastInteraction) from the assistant DB. interactionCount/lastInteraction
+   * are derived from gateway channels (trust signals live in gateway).
+   * `externalUserId` echoes `address` to match the daemon's withChannelCompat.
+   */
+  private composeContactRead(
+    contact: Contact,
+    channels: ContactChannel[],
+    info: ContactInfoFields | null,
+  ): ContactRead {
+    const interactionCount = channels.reduce(
+      (sum, ch) => sum + (ch.interactionCount ?? 0),
+      0,
+    );
+    const lastInteraction =
+      channels.reduce((max, ch) => Math.max(max, ch.lastInteraction ?? 0), 0) ||
+      null;
+
+    return {
+      id: contact.id,
+      displayName: contact.displayName,
+      role: contact.role,
+      notes: info?.notes ?? null,
+      contactType: info?.contactType ?? null,
+      interactionCount,
+      lastInteraction,
+      channels: channels.map((ch) => ({
+        id: ch.id,
+        contactId: ch.contactId,
+        type: ch.type,
+        address: ch.address,
+        isPrimary: ch.isPrimary,
+        externalUserId: ch.address,
+        status: ch.status ?? "unverified",
+        policy: ch.policy ?? "allow",
+        verifiedAt: ch.verifiedAt,
+        verifiedVia: ch.verifiedVia,
+        lastSeenAt: ch.lastSeenAt,
+        interactionCount: ch.interactionCount ?? 0,
+        lastInteraction: ch.lastInteraction,
+        revokedReason: ch.revokedReason,
+        blockedReason: ch.blockedReason,
+      })),
+    };
   }
 
   /**

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -205,11 +205,10 @@ export class ContactStore {
    * channels joined to assistant-DB info fields.
    *
    * Filters: `role` (gateway DB), `limit` (default 50, capped 200 to mirror
-   * the daemon's listContacts). `contactType` is assistant-owned and is NOT
-   * filtered here — the daemon serves contactType-filtered list reads natively
-   * (filtering in SQL before the limit) so a tight limit doesn't under-return
-   * and an assistant-DB outage degrades rather than dropping every row. The
-   * param is retained for forward-compat but not exercised on the relay path.
+   * the daemon's listContacts). The daemon serves contactType-filtered list
+   * reads natively (filtering in SQL before the limit) so a tight limit doesn't
+   * under-return and an assistant-DB outage degrades rather than dropping every
+   * row — the relay never carries a contactType filter.
    *
    * Thin adapter over `listContactsWithInfo` (shared assembly/soft-fail logic),
    * projected down to the ContactRead subset.
@@ -220,15 +219,12 @@ export class ContactStore {
   async listContactsRich(opts?: {
     limit?: number;
     role?: string;
-    contactType?: string;
   }): Promise<ContactRead[]> {
     const withInfo = await this.listContactsWithInfo({
       limit: opts?.limit,
       role: opts?.role,
     });
-    return withInfo
-      .filter((c) => !opts?.contactType || c.contactType === opts.contactType)
-      .map((c) => this.toContactRead(c));
+    return withInfo.map((c) => this.toContactRead(c));
   }
 
   /**
@@ -262,9 +258,10 @@ export class ContactStore {
   /**
    * Project a ContactWithInfo down to the ContactRead subset (drops the
    * assistant-only/ACL-internal fields not on the shared contract). Channel
-   * `externalUserId` echoes `address` to match the daemon's withChannelCompat;
-   * status/policy default like the DB columns (notNull, so a no-op on real
-   * rows) to satisfy the non-null ContactRead channel contract.
+   * `externalUserId` is left null — the daemon's withChannelCompat is the sole
+   * producer of that compat field on the relayed payload. status/policy default
+   * like the DB columns (notNull, so a no-op on real rows) to satisfy the
+   * non-null ContactRead channel contract.
    */
   private toContactRead(c: ContactWithInfo): ContactRead {
     return {
@@ -281,7 +278,7 @@ export class ContactStore {
         type: ch.type,
         address: ch.address,
         isPrimary: ch.isPrimary,
-        externalUserId: ch.address,
+        externalUserId: null,
         status: ch.status ?? "unverified",
         policy: ch.policy ?? "allow",
         verifiedAt: ch.verifiedAt,

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -6,6 +6,10 @@
  * assistant DB proxy (raw SQL), so the gateway owns the write path.
  */
 
+import {
+  GetContactIpcParamsSchema,
+  ListContactsIpcParamsSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
@@ -56,6 +60,36 @@ export const contactRoutes: IpcRoute[] = [
     handler: (params?: Record<string, unknown>) => {
       const contactId = params?.contactId as string;
       return getStore().getContact(contactId) ?? null;
+    },
+  },
+  // Rich reads expose the shared ContactRead shape (gateway ACL + assistant
+  // info) for the daemon's list/get relay. Additive — the lean list_contacts /
+  // get_contact methods above stay for gateway-internal callers.
+  {
+    method: "contacts_list_rich",
+    schema: ListContactsIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const parsed = ListContactsIpcParamsSchema.parse(params);
+      const contacts = await getStore().listContactsRich(parsed);
+      return { ok: true, contacts };
+    },
+  },
+  {
+    method: "contacts_get_rich",
+    schema: GetContactIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { contactId } = GetContactIpcParamsSchema.parse(params);
+      const result = await getStore().getContactRich(contactId);
+      // Return null on miss (mirrors get_contact); the daemon relay maps a
+      // null/not-found result to a 404.
+      if (!result) return null;
+      return {
+        ok: true,
+        contact: result.contact,
+        ...(result.assistantMetadata
+          ? { assistantMetadata: result.assistantMetadata }
+          : {}),
+      };
     },
   },
   {

--- a/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
+++ b/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the contact read IPC contracts in gateway-ipc-contracts.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ContactReadSchema,
+  GetContactIpcParamsSchema,
+  ListContactsIpcParamsSchema,
+} from "../gateway-ipc-contracts.js";
+
+describe("contact read contracts", () => {
+  test("ContactReadSchema parses a fully-populated contact", () => {
+    const contact = {
+      id: "c1",
+      displayName: "Ada Lovelace",
+      role: "guardian",
+      notes: "primary guardian",
+      contactType: "human",
+      lastInteraction: 1700000000,
+      interactionCount: 12,
+      channels: [
+        {
+          id: "ch1",
+          contactId: "c1",
+          type: "imessage",
+          address: "+15551234567",
+          isPrimary: true,
+          externalUserId: "+15551234567",
+          status: "active",
+          policy: "allow",
+          verifiedAt: 1699999999,
+          verifiedVia: "voice",
+          lastSeenAt: 1700000001,
+          interactionCount: 12,
+          lastInteraction: 1700000000,
+          revokedReason: null,
+          blockedReason: null,
+        },
+      ],
+    };
+
+    expect(() => ContactReadSchema.parse(contact)).not.toThrow();
+  });
+
+  test("ListContactsIpcParamsSchema defaults to {} when given undefined", () => {
+    expect(ListContactsIpcParamsSchema.parse(undefined)).toEqual({});
+  });
+
+  test("GetContactIpcParamsSchema rejects an empty object", () => {
+    expect(() => GetContactIpcParamsSchema.parse({})).toThrow();
+  });
+});

--- a/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
+++ b/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
@@ -14,7 +14,7 @@ describe("contact read contracts", () => {
   test("ContactReadSchema parses a fully-populated contact", () => {
     const contact = {
       id: "c1",
-      displayName: "Ada Lovelace",
+      displayName: "Example User",
       role: "guardian",
       notes: "primary guardian",
       contactType: "human",
@@ -25,9 +25,9 @@ describe("contact read contracts", () => {
           id: "ch1",
           contactId: "c1",
           type: "imessage",
-          address: "+15551234567",
+          address: "+15555550100",
           isPrimary: true,
-          externalUserId: "+15551234567",
+          externalUserId: "+15555550100",
           status: "active",
           policy: "allow",
           verifiedAt: 1699999999,

--- a/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
+++ b/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
@@ -20,6 +20,8 @@ describe("contact read contracts", () => {
       contactType: "human",
       lastInteraction: 1700000000,
       interactionCount: 12,
+      createdAt: 1699000000,
+      updatedAt: 1700000000,
       channels: [
         {
           id: "ch1",
@@ -41,7 +43,20 @@ describe("contact read contracts", () => {
       ],
     };
 
-    expect(() => ContactReadSchema.parse(contact)).not.toThrow();
+    const parsed = ContactReadSchema.parse(contact);
+    expect(parsed.createdAt).toBe(1699000000);
+    expect(parsed.updatedAt).toBe(1700000000);
+  });
+
+  test("ContactReadSchema requires createdAt/updatedAt", () => {
+    const withoutTimestamps = {
+      id: "c1",
+      displayName: "Example User",
+      role: "contact",
+      interactionCount: 0,
+      channels: [],
+    };
+    expect(() => ContactReadSchema.parse(withoutTimestamps)).toThrow();
   });
 
   test("ListContactsIpcParamsSchema defaults to {} when given undefined", () => {

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -114,6 +114,8 @@ export const ContactReadSchema = z.object({
   contactType: z.string().nullable().optional(),
   lastInteraction: z.number().nullable().optional(),
   interactionCount: z.number(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
   channels: z.array(ContactReadChannelSchema),
 });
 

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -85,3 +85,84 @@ export const TrustRulesListIpcResponseSchema = z.object({
 export type TrustRulesListIpcResponse = z.infer<
   typeof TrustRulesListIpcResponseSchema
 >;
+
+export const ContactReadChannelSchema = z.object({
+  id: z.string(),
+  contactId: z.string(),
+  type: z.string(),
+  address: z.string(),
+  isPrimary: z.boolean(),
+  externalUserId: z.string().nullable(),
+  status: z.string(),
+  policy: z.string(),
+  verifiedAt: z.number().nullable(),
+  verifiedVia: z.string().nullable(),
+  lastSeenAt: z.number().nullable(),
+  interactionCount: z.number(),
+  lastInteraction: z.number().nullable(),
+  revokedReason: z.string().nullable(),
+  blockedReason: z.string().nullable(),
+});
+
+export type ContactReadChannel = z.infer<typeof ContactReadChannelSchema>;
+
+export const ContactReadSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  role: z.string(),
+  notes: z.string().nullable().optional(),
+  contactType: z.string().nullable().optional(),
+  lastInteraction: z.number().nullable().optional(),
+  interactionCount: z.number(),
+  channels: z.array(ContactReadChannelSchema),
+});
+
+export type ContactRead = z.infer<typeof ContactReadSchema>;
+
+export const AssistantContactMetadataSchema = z.object({
+  contactId: z.string(),
+  species: z.string(),
+  metadata: z.object({}).passthrough().nullable(),
+});
+
+export type AssistantContactMetadata = z.infer<
+  typeof AssistantContactMetadataSchema
+>;
+
+export const ListContactsIpcParamsSchema = z
+  .object({
+    limit: z.number().optional(),
+    role: z.string().optional(),
+    contactType: z.string().optional(),
+  })
+  .strict()
+  .default({});
+
+export type ListContactsIpcParams = z.infer<
+  typeof ListContactsIpcParamsSchema
+>;
+
+export const ListContactsIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  contacts: z.array(ContactReadSchema),
+});
+
+export type ListContactsIpcResponse = z.infer<
+  typeof ListContactsIpcResponseSchema
+>;
+
+export const GetContactIpcParamsSchema = z
+  .object({ contactId: z.string() })
+  .strict();
+
+export type GetContactIpcParams = z.infer<typeof GetContactIpcParamsSchema>;
+
+export const GetContactIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  contact: ContactReadSchema,
+  assistantMetadata: AssistantContactMetadataSchema.optional(),
+});
+
+export type GetContactIpcResponse = z.infer<
+  typeof GetContactIpcResponseSchema
+>;

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -133,7 +133,6 @@ export const ListContactsIpcParamsSchema = z
   .object({
     limit: z.number().optional(),
     role: z.string().optional(),
-    contactType: z.string().optional(),
   })
   .strict()
   .default({});


### PR DESCRIPTION
## Summary
Converts the assistant CLI's daemon contact read handlers (`listContacts` / `getContact` / `search_contacts`) into thin relays to the gateway IPC surface (`contacts_list_rich` / `contacts_get_rich`), so the CLI reads the gateway DB as the source of truth for ACL fields instead of the assistant DB. The daemon re-applies `prepareContactResponse` (guardian display-name override + channel compat), falls back to the assistant DB with a logged warning on gateway IPC transport failure, and preserves 404 behavior. True search and `contactType`-filtered list reads stay daemon-native (design-blocked gateway-native work); the boundary is explicit and logged.

## Self-review result
GAPS FOUND → all fixed across 2 remediation rounds (3 fix PRs); final re-review PASS on all passes.

## PRs merged into feature branch
- #35568: feat(gateway-client): add contact read IPC contracts (list/get)
- #35572: feat(gateway): rich contact read helpers joining gateway ACL + assistant info fields
- #35575: feat(contacts): relay daemon listContacts/getContact IPC reads to the gateway
- #35576: feat(contacts): route search_contacts through the gateway list relay, keep search daemon-native

### Fix PRs (self-review remediation)
- #35584: fix(contacts): contactType-filtered list reads daemon-native (no post-limit truncation) + reuse `*WithInfo` stack
- #35580: test(gateway-client): generic fixtures in contact-read-contracts test per AGENTS.md
- #35587: refactor(contacts): drop dead contactType IPC param + single-source externalUserId compat

Part of plan: contacts-relay-reads.md