### PR TITLE
feat(memory): let remember() batch multiple facts in one call

### DIFF
--- a/assistant/src/memory/graph/__tests__/handle-remember-v2.test.ts
+++ b/assistant/src/memory/graph/__tests__/handle-remember-v2.test.ts
@@ -227,3 +227,95 @@ describe("handleRemember — memory.v2.enabled off (v1 PKB path)", () => {
     }
   });
 });
+
+describe("handleRemember — batch (array) content", () => {
+  test("v2: writes every fact from an array in a single call", () => {
+    const result = handleRemember(
+      { content: ["fact one", "fact two", "fact three"] },
+      "conv-batch-1",
+      "default",
+      CONFIG,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("3");
+
+    const memoryDir = join(tmpWorkspace, "memory");
+    const buffer = readFileSync(join(memoryDir, "buffer.md"), "utf-8");
+    expect(buffer).toContain("fact one");
+    expect(buffer).toContain("fact two");
+    expect(buffer).toContain("fact three");
+    // Three independent timestamped bullets from the one call.
+    expect(buffer.match(/^- /gm)?.length).toBe(3);
+
+    const archive = readFileSync(
+      join(memoryDir, "archive", todaysArchiveBasename()),
+      "utf-8",
+    );
+    expect(archive).toContain("fact one");
+    expect(archive).toContain("fact three");
+  });
+
+  test("v1: a batched call still enqueues exactly two re-index jobs (per file, not per fact)", () => {
+    const result = handleRemember(
+      { content: ["alpha", "beta", "gamma"] },
+      "conv-batch-2",
+      "default",
+      CONFIG_V2_OFF,
+    );
+
+    expect(result.success).toBe(true);
+
+    const pkbDir = join(tmpWorkspace, "pkb");
+    const buffer = readFileSync(join(pkbDir, "buffer.md"), "utf-8");
+    expect(buffer).toContain("alpha");
+    expect(buffer).toContain("beta");
+    expect(buffer).toContain("gamma");
+    expect(buffer.match(/^- /gm)?.length).toBe(3);
+
+    // One enqueue per written file (buffer + archive), regardless of fact count.
+    expect(enqueueCalls).toHaveLength(2);
+  });
+
+  test("drops blank entries and rejects an all-empty array", () => {
+    const ok = handleRemember(
+      { content: ["   ", "kept fact", ""] },
+      "conv-batch-3",
+      "default",
+      CONFIG,
+    );
+    expect(ok.success).toBe(true);
+    const buffer = readFileSync(
+      join(tmpWorkspace, "memory", "buffer.md"),
+      "utf-8",
+    );
+    expect(buffer).toContain("kept fact");
+    expect(buffer.match(/^- /gm)?.length).toBe(1);
+
+    const empty = handleRemember(
+      { content: ["   ", ""] },
+      "conv-batch-4",
+      "default",
+      CONFIG,
+    );
+    expect(empty.success).toBe(false);
+    expect(empty.message).toContain("content is required");
+  });
+
+  test("single-string content still records exactly one fact", () => {
+    const result = handleRemember(
+      { content: "lone fact" },
+      "conv-batch-5",
+      "default",
+      CONFIG,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Saved to knowledge base.");
+    const buffer = readFileSync(
+      join(tmpWorkspace, "memory", "buffer.md"),
+      "utf-8",
+    );
+    expect(buffer).toContain("lone fact");
+    expect(buffer.match(/^- /gm)?.length).toBe(1);
+  });
+});

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -22,7 +22,13 @@ const log = getLogger("graph-tool-handlers");
 // ---------------------------------------------------------------------------
 
 export interface RememberInput {
-  content: string;
+  /**
+   * The fact(s) to remember. A single string records one fact; an array
+   * records several independent facts in one call (each becomes its own
+   * timestamped entry), so a single turn can batch unrelated facts instead of
+   * calling `remember` once per fact.
+   */
+  content: string | string[];
   finish_turn?: boolean;
 }
 
@@ -31,13 +37,33 @@ export interface RememberResult {
   message: string;
 }
 
+/**
+ * Normalize the `remember` content input to a list of non-empty facts.
+ * Accepts the single-string form or the batch array form, trims each fact, and
+ * drops blanks so an empty or whitespace-only input yields no facts.
+ */
+function normalizeFacts(content: string | string[]): string[] {
+  const raw = Array.isArray(content) ? content : [content];
+  return raw
+    .filter((fact): fact is string => typeof fact === "string")
+    .map((fact) => fact.trim())
+    .filter((fact) => fact.length > 0);
+}
+
+function rememberSuccessMessage(count: number): string {
+  return count === 1
+    ? "Saved to knowledge base."
+    : `Saved ${count} facts to knowledge base.`;
+}
+
 export function handleRemember(
   input: RememberInput,
   _conversationId: string,
   _scopeId: string,
   config: AssistantConfig,
 ): RememberResult {
-  if (!input.content || input.content.trim().length === 0) {
+  const facts = normalizeFacts(input.content);
+  if (facts.length === 0) {
     return { success: false, message: "content is required" };
   }
   if (config.memory.enabled === false) {
@@ -46,7 +72,10 @@ export function handleRemember(
 
   const workspaceDir = getWorkspaceDir();
   const now = new Date();
-  const entry = formatRememberEntry(input.content.trim(), now);
+  // Each fact becomes its own timestamped bullet; a batched call writes them
+  // all in a single append so one turn can record several independent facts.
+  const entry = facts.map((fact) => formatRememberEntry(fact, now)).join("");
+  const message = rememberSuccessMessage(facts.length);
 
   if (config.memory.v2.enabled) {
     appendBufferAndArchive({
@@ -57,7 +86,7 @@ export function handleRemember(
     // v2 path skips the PKB re-index queue — embedding for memory v2 happens
     // via the dedicated `embed_concept_page` job after consolidation, not on
     // every remember() write.
-    return { success: true, message: "Saved to knowledge base." };
+    return { success: true, message };
   }
 
   const pkbDir = join(workspaceDir, "pkb");
@@ -69,7 +98,7 @@ export function handleRemember(
   enqueuePkbReindex(pkbDir, bufferPath);
   enqueuePkbReindex(pkbDir, archivePath);
 
-  return { success: true, message: "Saved to knowledge base." };
+  return { success: true, message };
 }
 
 /**

--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -77,9 +77,12 @@ export const graphRememberDefinition = {
     type: "object",
     properties: {
       content: {
-        type: "string",
+        anyOf: [
+          { type: "string" },
+          { type: "array", items: { type: "string" }, minItems: 1 },
+        ],
         description:
-          "The fact to remember. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize.",
+          "The fact(s) to remember. Pass a single string for one fact, or an array of strings to record several independent facts in one call. When a turn surfaces multiple unrelated facts, pass them all as an array in one call rather than calling `remember` once per fact. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize.",
       },
       finish_turn: {
         type: "boolean",

--- a/assistant/src/tools/memory/register.test.ts
+++ b/assistant/src/tools/memory/register.test.ts
@@ -348,3 +348,35 @@ describe("rememberTool.execute — PKB re-index enqueue", () => {
     expect(archiveContents).toContain("enqueue will throw");
   });
 });
+
+describe("rememberTool.execute — batch (array) content", () => {
+  beforeEach(() => {
+    enqueueCalls.length = 0;
+    enqueueShouldThrow = false;
+  });
+
+  test("records every fact from an array and enqueues per file, not per fact", async () => {
+    const result = await rememberTool.execute(
+      { content: ["batch fact A", "batch fact B"] },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+
+    const pkbRoot = join(tmpWorkspace, "pkb");
+    const bufferContents = readFileSync(join(pkbRoot, "buffer.md"), "utf-8");
+    expect(bufferContents).toContain("batch fact A");
+    expect(bufferContents).toContain("batch fact B");
+
+    // buffer + archive, regardless of how many facts the call carried.
+    expect(enqueueCalls).toHaveLength(2);
+  });
+
+  test("rejects an all-blank array without writing or enqueueing", async () => {
+    const result = await rememberTool.execute(
+      { content: ["  ", ""] },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(enqueueCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `remember` now accepts `content` as either a single string (unchanged) **or** an array of strings, so one call can record several independent facts. Each fact still becomes its own timestamped `buffer.md` / daily-archive entry — persisted shape is unchanged, no migration, and the single-string form is fully backward compatible.
- The tool description now tells the model to pass multiple independent facts as an array in one call rather than calling `remember` once per fact. The v1 PKB path still enqueues exactly two re-index jobs (buffer + archive) regardless of fact count; the v2 path is unchanged.
- `finish_turn` / `activity` semantics are untouched: one `activity` describes the batch, and `finish_turn` applies after the whole call.

**Motivation:** a background memory-retrospective pass was observed writing 6 independent facts as 6 sequential single-`remember` turns — each turn re-sends the full (~470KB) conversation context, ~920K input tokens / ~$1.81 for one pass. The main agent also rarely batches tool calls. This is the structural batch-form fix that removes the one-fact-per-call friction regardless of the model's parallel-tool-use behavior; it complements the `<use_parallel_tool_calls>` prompt guidance (handled separately).

## Original prompt

While diagnosing why the assistant wasn't making parallel tool calls — a memory-retrospective turn that serialized six independent `remember` writes — we found that `remember`'s single-fact `content` plus its `finish_turn` yield flag encode a one-fact-per-turn cadence. The ask was to give `remember` a batch form so a single call can record multiple facts, keeping it backward compatible (single string still works), persisting each fact identically, and leaving `finish_turn` / `activity` semantics unchanged.

## Test plan

- `bun test src/memory/graph/__tests__/handle-remember-v2.test.ts` — 12 pass (incl. new batch tests: v2 multi-fact write, v1 batch still enqueues 2 jobs, blank-drop + all-empty rejection, single-string still records one fact).
- `bun test src/tools/memory/register.test.ts` — 16 pass (incl. new executor-level array tests).
- `bun test src/memory/__tests__/memory-retrospective-job.test.ts` — 51 pass.
- `bunx tsc --noEmit` — clean for the changed files. (One pre-existing, unrelated error in `src/ipc/gateway-client.ts:74` exists on `main` and is untouched here.)