### PR TITLE
fix(memory): make the retrospective pass use the remember() batch form

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -497,6 +497,28 @@ describe("memoryRetrospectiveJob", () => {
     expect(instructionText).not.toContain("(none)");
   });
 
+  test("subsequent run: <already_remembered> flattens a prior batched (array) remember call", async () => {
+    priorRetroId = "prior-retro-conv-1";
+    priorRetroMessages = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "remember",
+            input: { content: ["Bob switched teams", "Launch slipped to Q3"] },
+          },
+        ]),
+      },
+    ];
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    const instructionText = persistedInstructionText();
+    expect(instructionText).toContain("- Bob switched teams");
+    expect(instructionText).toContain("- Launch slipped to Q3");
+    expect(instructionText).not.toContain("(none)");
+  });
+
   test("malformed prior-retrospective messages are skipped, run still proceeds", async () => {
     priorRetroId = "prior-retro-conv-1";
     priorRetroMessages = [

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -775,9 +775,14 @@ function extractRememberContents(messages: MessageLike[]): string[] {
       const input = b.input;
       if (!input || typeof input !== "object") continue;
       const content = (input as Record<string, unknown>).content;
-      if (typeof content !== "string") continue;
-      const trimmed = content.trim();
-      if (trimmed.length > 0) contents.push(trimmed);
+      // `remember` accepts a single string or an array of facts (batch form);
+      // flatten both so batched saves still feed the dedup baseline.
+      const facts = Array.isArray(content) ? content : [content];
+      for (const fact of facts) {
+        if (typeof fact !== "string") continue;
+        const trimmed = fact.trim();
+        if (trimmed.length > 0) contents.push(trimmed);
+      }
     }
   }
   return contents;
@@ -863,6 +868,6 @@ Two dedup sources to skip:
 1. Anything semantically captured in <already_remembered> above (from prior retrospective passes).
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
-For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. One \`remember\` call per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
 `;
 }


### PR DESCRIPTION
## Summary

Follow-up to #35591 addressing its two P2 Codex review comments — both in `assistant/src/memory/memory-retrospective-job.ts`:

- **Dedup baseline now handles batched saves.** `extractRememberContents()` only recorded `input.content` when it was a string, so array-form (batched) `remember` calls were written to buffer/archive but dropped from the persisted `rememberedLog` — meaning the next pass's `<already_remembered>` baseline omitted them and could re-save duplicates. It now flattens non-empty strings from both the single-string and array forms.
- **Prompt no longer contradicts batching.** The retrospective kickoff prompt instructed *"One `remember` call per fact"*, which directly fought the new batch form (and the workflow that motivated #35591). It now tells the pass to pass several facts as an array to a single `remember` call.

## Original prompt

Codex's review of #35591 (the `remember` batch form) flagged that the memory-retrospective pass — the very workflow #35591 was meant to speed up — still (a) carried a hard "one call per fact" instruction in its prompt and (b) dropped array-form saves from its dedup baseline because the extractor only handled strings. This PR closes both gaps so the retrospective actually benefits from batching.

## Test plan

- `bun test src/memory/__tests__/memory-retrospective-job.test.ts` — 52 pass (incl. new test: a prior batched/array `remember` call is flattened into `<already_remembered>`).
- `bunx tsc --noEmit` — clean.