### PR TITLE
fix(anthropic): bridge prompt cache across the first two calls of a turn after a long autonomous tail

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -698,10 +698,12 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   // -----------------------------------------------------------------------
   // mutableLatestUserMessage — volatile trailing user message cache anchor
   // -----------------------------------------------------------------------
-  test("mutableLatestUserMessage: first-of-turn skips the volatile turn-start anchor and anchors the previous stable user message", async () => {
+  test("mutableLatestUserMessage: first-of-turn moves the 1h anchor off the volatile latest message and bridges it with a 5m tail", async () => {
     // The latest user message carries per-turn-volatile content (e.g. an
-    // injected memory block). The long-TTL anchor must move off it onto the
-    // most recent stable user message so the cached prefix stays reusable.
+    // injected memory block). The 1h anchor must move off it onto the most
+    // recent stable user message so the cached prefix stays reusable across
+    // turns; the volatile message still gets a cheap 5m tail breakpoint so the
+    // next request in the same turn has an exact, reachable boundary.
     const messages: Message[] = [
       userMsg("Turn 1"),
       assistantMsg("Response 1"),
@@ -721,13 +723,13 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     }>;
     const userMessages = sent.filter((m) => m.role === "user");
 
-    // Latest (turn-start) user message gets NO long-TTL breakpoint — it's volatile.
+    // Latest (turn-start) user message gets the cheap 5m tail bridge, never the
+    // 1h anchor — it's volatile.
     const latest = userMessages[userMessages.length - 1];
-    for (const block of latest.content) {
-      expect(block.cache_control).toBeUndefined();
-    }
+    const latestLast = latest.content[latest.content.length - 1];
+    expect(latestLast.cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
 
-    // Previous stable user message (Turn 1) becomes the primary anchor.
+    // Previous stable user message (Turn 1) becomes the primary 1h anchor.
     const prev = userMessages[userMessages.length - 2];
     const prevLast = prev.content[prev.content.length - 1];
     expect(prevLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
@@ -803,9 +805,104 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       }>;
     }>;
     // Only user message is volatile and there is no prior stable one, so no
-    // long-TTL breakpoint lands on any user message — graceful, no throw.
+    // 1h anchor and no 5m tail bridge land on any user message — there is no
+    // previous-turn anchor to bridge to. Graceful, no throw.
     const lastBlock = sent[0].content[sent[0].content.length - 1];
     expect(lastBlock.cache_control).toBeUndefined();
+  });
+
+  test("mutableLatestUserMessage: first-of-turn after a long autonomous tail bridges the volatile latest message so the next call stays within the lookback window", async () => {
+    // Reproduces the memory-retrospective / heartbeat case: a long run of
+    // autonomous assistant + tool turns sits between the previous user message
+    // and the volatile latest one. The 1h anchor moves back onto the previous
+    // user message (now >20 content blocks away); without a breakpoint on the
+    // latest message the next request's anchor would land beyond Anthropic's
+    // ~20-block lookback and re-create the whole prefix. The 5m tail bridge
+    // gives the next call an exact, reachable boundary.
+    const tail: Message[] = [];
+    for (let i = 0; i < 8; i++) {
+      tail.push(
+        assistantMsg(`heartbeat ${i}`),
+        toolUseMsg(`hb_${i}`, "bash"),
+        toolResultMsg(`hb_${i}`, "wake"),
+      );
+    }
+    // End the tail on an assistant message so the latest user message is not
+    // merged with a preceding tool_result (both user role).
+    tail.push(assistantMsg("still here"));
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      ...tail,
+      userMsg("Turn 2 (volatile)"),
+    ];
+    await provider.sendMessage(messages, {
+      config: { mutableLatestUserMessage: true },
+    });
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        text?: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    const findUser = (text: string) =>
+      sent.find(
+        (m) => m.role === "user" && m.content.some((b) => b.text === text),
+      )!;
+
+    // The volatile latest message gets the 5m tail bridge.
+    const turn2 = findUser("Turn 2 (volatile)");
+    const turn2Last = turn2.content[turn2.content.length - 1];
+    expect(turn2Last.cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
+
+    // The previous stable user message — across the whole autonomous tail —
+    // is the 1h anchor.
+    const turn1 = findUser("Turn 1");
+    const turn1Last = turn1.content[turn1.content.length - 1];
+    expect(turn1Last.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("mutableLatestUserMessage absent: the same long autonomous tail gets no extra tail bridge (placement unchanged)", async () => {
+    // Regression guard: the tail bridge is gated on the volatile-latest flag,
+    // not on tail length. With the flag off, the latest message keeps the
+    // ordinary 1h turn-start anchor and no 5m bridge is added.
+    const tail: Message[] = [];
+    for (let i = 0; i < 8; i++) {
+      tail.push(
+        assistantMsg(`heartbeat ${i}`),
+        toolUseMsg(`hb_${i}`, "bash"),
+        toolResultMsg(`hb_${i}`, "wake"),
+      );
+    }
+    // End the tail on an assistant message so the latest user message is not
+    // merged with a preceding tool_result (both user role).
+    tail.push(assistantMsg("still here"));
+    const messages: Message[] = [userMsg("Turn 1"), ...tail, userMsg("Turn 2")];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        text?: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    const findUser = (text: string) =>
+      sent.find(
+        (m) => m.role === "user" && m.content.some((b) => b.text === text),
+      )!;
+
+    // Latest message keeps the 1h turn-start anchor — no 5m bridge.
+    const turn2 = findUser("Turn 2");
+    const turn2Last = turn2.content[turn2.content.length - 1];
+    expect(turn2Last.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    // Previous-turn anchor keeps 1h.
+    const turn1 = findUser("Turn 1");
+    const turn1Last = turn1.content[turn1.content.length - 1];
+    expect(turn1Last.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   test("mutableLatestUserMessage is not forwarded to the Anthropic API", async () => {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1022,15 +1022,23 @@ export class AnthropicProvider implements Provider {
       }
 
       // Advancing tail: place a short-lived 5m cache breakpoint on the last
-      // block of the last message when it falls after the turn-starting user
-      // message (i.e. tool-use loop content). This caches the growing tail
-      // cheaply without conflicting with the 1h breakpoints above.
-      // Skip thinking/redacted_thinking blocks — Anthropic doesn't allow
+      // block of the last message. This caches the growing tail cheaply
+      // without conflicting with the 1h breakpoints above. It fires during
+      // tool-use loops (the tail falls after the turn-starting user message)
+      // and also on a first-of-turn request whose volatile turn-start anchor
+      // was skipped while a previous-turn anchor exists: there the latest
+      // message would otherwise carry no breakpoint, so the next request's
+      // anchor can land far ahead of the previous-turn anchor and Anthropic's
+      // ~20-block cache lookback can't bridge the gap — forcing a full
+      // re-creation of the prefix. The 5m breakpoint gives the next call an
+      // exact, reachable boundary; cross-turn it expires harmlessly. Skip
+      // thinking/redacted_thinking blocks — Anthropic doesn't allow
       // cache_control on those types.
       if (
         !disableCache &&
         turnStartIdx >= 0 &&
-        turnStartIdx < sentMessages.length - 1
+        (turnStartIdx < sentMessages.length - 1 ||
+          (skipVolatileTurnStartAnchor && turnStartIdx > 0))
       ) {
         const lastMsg = sentMessages[sentMessages.length - 1];
         if (Array.isArray(lastMsg.content) && lastMsg.content.length > 0) {
@@ -1057,11 +1065,13 @@ export class AnthropicProvider implements Provider {
       }
 
       // Cache-breakpoint accounting: system(≤2) + tools(1, only when the
-      // system is a single block or absent) + turn-start(1) +
-      // (tail OR prev-turn-anchor)(1) ≤ 4 — Anthropic's per-request cap.
-      // Tail and prev-turn-anchor are mutually exclusive (the latter only
-      // fires when turn-start is the last message, which suppresses the
-      // tail), so the total can't drift past 4.
+      // system is a single block or absent) + at most two message anchors
+      // ≤ 4 — Anthropic's per-request cap. The two message anchors are
+      // turn-start + prev-turn-anchor (first-of-turn), turn-start + tail
+      // (tool-use loop), or prev-turn-anchor + tail (first-of-turn with the
+      // volatile turn-start anchor skipped — the freed turn-start slot covers
+      // the tail). At most two message-level breakpoints are placed, so the
+      // total can't drift past 4.
 
       // Strip orphaned UTF-16 surrogates so the Anthropic JSON parser never
       // sees invalid strings produced by upstream surrogate-splitting `.slice()` calls.


### PR DESCRIPTION
## Summary

- When memory-v3 is live, the Anthropic provider skips the long-TTL turn-start cache anchor on the *volatile* latest user message and falls back to the previous-turn anchor. If a long autonomous/assistant-only tail (a heartbeat chain, or **every memory-retrospective fork**) sits between the two user messages, that previous-turn anchor lands **>20 content blocks back**, so the next call's anchor jumps past Anthropic's ~20-block prefix-cache lookback and re-creates the entire conversation prefix (~100K+ `cache_creation` tokens on the first two calls of the turn).
- Fix: place the cheap 5m advancing-tail breakpoint on the latest message **even on a first-of-turn request** when the volatile turn-start anchor was skipped and a previous-turn anchor exists — giving the next call an exact, reachable boundary to chain off. Cross-turn the 5m tail expires harmlessly; within-turn the tool loop chains off it. Byte-identical when the volatile-latest flag is off (gated on `skipVolatileTurnStartAnchor`).
- Breakpoint budget stays ≤4 — skipping the turn-start anchor frees exactly the slot the tail now uses (2 system + prev-anchor + tail). Adds a characterization test for the long-autonomous-tail bridge and a flag-off regression guard; updates the existing first-of-turn test to expect the 5m bridge on the volatile message.

## Original prompt

While diagnosing one of Velissa's memory-retrospective turns, we found the first two LLM calls each rewrote ~100K+ tokens of prompt cache instead of reading them. The root cause is cache-breakpoint placement: the volatile-anchor skip (memory-v3-live) drops the stable anchor 69 content-blocks back across an autonomous heartbeat chain, past Anthropic's 20-block prefix-cache lookback, so the next call can't reuse the prior cache. This implements the targeted fix — keep a cheap 5m tail breakpoint on the latest message when the volatile turn-start anchor is skipped — so the within-turn tool loop chains off a reachable boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)