### PR TITLE
fix(anthropic): honor disableTurnStartCache in the first-of-turn cache tail bridge

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -905,6 +905,43 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(turn1Last.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
+  test("mutableLatestUserMessage + disableTurnStartCache: the first-of-turn tail bridge is suppressed on the volatile latest block", async () => {
+    // The volatile-latest tail bridge lands on the turn-start block, so it must
+    // honor disableTurnStartCache (the explicit opt-out from paid cache writes
+    // on volatile turn-start content) just like the long-TTL anchor does. The
+    // previous-turn anchor is unaffected — it targets a stable prior block.
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      assistantMsg("Response 1"),
+      userMsg("Turn 2 (volatile)"),
+    ];
+    await provider.sendMessage(messages, {
+      config: { mutableLatestUserMessage: true, disableTurnStartCache: true },
+    });
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        text: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    const userMessages = sent.filter((m) => m.role === "user");
+
+    // Latest (turn-start) user message gets NO breakpoint — disableTurnStartCache
+    // suppresses the 5m bridge.
+    const latest = userMessages[userMessages.length - 1];
+    for (const block of latest.content) {
+      expect(block.cache_control).toBeUndefined();
+    }
+
+    // Previous stable user message (Turn 1) still gets the 1h anchor.
+    const prev = userMessages[userMessages.length - 2];
+    const prevLast = prev.content[prev.content.length - 1];
+    expect(prevLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
   test("mutableLatestUserMessage is not forwarded to the Anthropic API", async () => {
     await provider.sendMessage([userMsg("Hi")], {
       config: { mutableLatestUserMessage: true },

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1031,14 +1031,18 @@ export class AnthropicProvider implements Provider {
       // anchor can land far ahead of the previous-turn anchor and Anthropic's
       // ~20-block cache lookback can't bridge the gap — forcing a full
       // re-creation of the prefix. The 5m breakpoint gives the next call an
-      // exact, reachable boundary; cross-turn it expires harmlessly. Skip
+      // exact, reachable boundary; cross-turn it expires harmlessly. The
+      // first-of-turn bridge lands on the turn-start block, so it honors
+      // `disableTurnStartCache` like the long-TTL anchor above. Skip
       // thinking/redacted_thinking blocks — Anthropic doesn't allow
       // cache_control on those types.
       if (
         !disableCache &&
         turnStartIdx >= 0 &&
         (turnStartIdx < sentMessages.length - 1 ||
-          (skipVolatileTurnStartAnchor && turnStartIdx > 0))
+          (skipVolatileTurnStartAnchor &&
+            turnStartIdx > 0 &&
+            !disableTurnStartCache))
       ) {
         const lastMsg = sentMessages[sentMessages.length - 1];
         if (Array.isArray(lastMsg.content) && lastMsg.content.length > 0) {


### PR DESCRIPTION
## Summary

- Follow-up to #35593. The first-of-turn cache **tail bridge** lands on the turn-start (latest) user block, but — unlike the sibling long-TTL turn-start anchor — it did not gate on `disableTurnStartCache`. A caller combining `mutableLatestUserMessage: true` + `disableTurnStartCache: true` with a prior user turn would therefore get an unwanted paid 5m cache write on the exact block the flag opts out of.
- Gate the bridge's first-of-turn disjunct on `!disableTurnStartCache`, matching the long-TTL anchor. No-op for every current caller (the `disableTurnStartCache` callers — `memoryRouter`, v3 shadow `pool-select` — are single-message and don't set `mutableLatestUserMessage`); the tool-loop tail disjunct is unchanged.
- Adds a test: with both flags set on a multi-turn request, the volatile latest block gets no breakpoint while the stable previous-turn anchor is unaffected.

## Original prompt

Codex left a P2 review comment on #35593 (the prompt-cache tail-bridge fix) noting that the new first-of-turn bridge stamps a 5m `cache_control` on the turn-start block without honoring `disableTurnStartCache`, defeating that opt-out's intent. It isn't reachable by any current caller, but it's a correct, zero-risk consistency guard that aligns the bridge with the existing turn-start anchor. This applies the guard and locks it with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)