### PR TITLE
feat(logs): add "Yesterday" option to usage date range picker

### DIFF
--- a/clients/web/src/domains/logs/components/usage-tab.tsx
+++ b/clients/web/src/domains/logs/components/usage-tab.tsx
@@ -75,6 +75,7 @@ type UsageBreakdownState = {
 
 const RANGE_OPTIONS: { value: UsageTimeRange; label: string }[] = [
   { value: "today", label: "Today" },
+  { value: "yesterday", label: "Yesterday" },
   { value: "7d", label: "Last 7 days" },
   { value: "30d", label: "Last 30 days" },
   { value: "90d", label: "Last 90 days" },

--- a/clients/web/src/domains/logs/usage-tab-state.test.ts
+++ b/clients/web/src/domains/logs/usage-tab-state.test.ts
@@ -8,6 +8,7 @@ import {
   buildUsageSearchParams,
   readUsageUrlState,
   resolveRangeWindow,
+  resolveUsageGranularity,
 } from "@/domains/logs/usage-tab-state";
 
 const UTC = "UTC";
@@ -92,6 +93,14 @@ describe("resolveRangeWindow", () => {
     expect(from).toBe(Date.UTC(2026, 5, 2, 0, 0, 0));
   });
 
+  test("'yesterday' spans the prior calendar day; 'to' is today's midnight", () => {
+    const now = Date.UTC(2026, 5, 2, 18, 30, 0);
+    const { from, to } = resolveRangeWindow("yesterday", UTC, now);
+    // UTC midnight of 2026-06-01 .. UTC midnight of 2026-06-02
+    expect(from).toBe(Date.UTC(2026, 5, 1, 0, 0, 0));
+    expect(to).toBe(Date.UTC(2026, 5, 2, 0, 0, 0));
+  });
+
   test("'7d' from is six zone-local days before today (UTC)", () => {
     const now = Date.UTC(2026, 5, 2, 18, 30, 0);
     const { from } = resolveRangeWindow("7d", UTC, now);
@@ -136,6 +145,15 @@ describe("resolveRangeWindow", () => {
   });
 });
 
+describe("resolveUsageGranularity", () => {
+  test("single-day ranges are hourly, multi-day ranges are daily", () => {
+    expect(resolveUsageGranularity("today")).toBe("hourly");
+    expect(resolveUsageGranularity("yesterday")).toBe("hourly");
+    expect(resolveUsageGranularity("7d")).toBe("daily");
+    expect(resolveUsageGranularity("all")).toBe("daily");
+  });
+});
+
 describe("usage URL state", () => {
   test("reads valid range, group-by, and schedule id params", () => {
     const params = new URLSearchParams(
@@ -151,7 +169,7 @@ describe("usage URL state", () => {
 
   test("falls back for invalid range and group-by params", () => {
     const params = new URLSearchParams(
-      "range=yesterday&groupBy=not-real&scheduleId=",
+      "range=not-real&groupBy=not-real&scheduleId=",
     );
 
     expect(readUsageUrlState(params)).toEqual({

--- a/clients/web/src/domains/logs/usage-tab-state.ts
+++ b/clients/web/src/domains/logs/usage-tab-state.ts
@@ -16,6 +16,7 @@ const UNSUPPORTED_GROUP_BY_STATUSES = new Set([400, 404, 422]);
 const MAX_RETRY_COUNT = 3;
 const USAGE_TIME_RANGES = new Set<UsageTimeRange>([
   "today",
+  "yesterday",
   "7d",
   "30d",
   "90d",
@@ -223,5 +224,6 @@ export function resolveRangeWindow(
 export function resolveUsageGranularity(
   range: UsageTimeRange,
 ): UsageGranularity {
-  return range === "today" ? "hourly" : "daily";
+  // Single-calendar-day ranges read best at hourly resolution.
+  return range === "today" || range === "yesterday" ? "hourly" : "daily";
 }

--- a/clients/web/src/domains/logs/usage-types.ts
+++ b/clients/web/src/domains/logs/usage-types.ts
@@ -13,7 +13,13 @@ import type {
   UsageTotalsGetResponse,
 } from "@/generated/daemon/types.gen";
 
-export type UsageTimeRange = "today" | "7d" | "30d" | "90d" | "all";
+export type UsageTimeRange =
+  | "today"
+  | "yesterday"
+  | "7d"
+  | "30d"
+  | "90d"
+  | "all";
 
 export type UsageGranularity = "daily" | "hourly";
 

--- a/clients/web/src/utils/usage-window.ts
+++ b/clients/web/src/utils/usage-window.ts
@@ -3,10 +3,16 @@ import {
   toTimezoneDateString,
 } from "@/components/charts/format-date-label";
 
-export type UsageRangeWindowId = "today" | "7d" | "30d" | "90d" | "all";
+export type UsageRangeWindowId =
+  | "today"
+  | "yesterday"
+  | "7d"
+  | "30d"
+  | "90d"
+  | "all";
 
 const RANGE_START_DAY_OFFSETS: Record<
-  Exclude<UsageRangeWindowId, "all">,
+  Exclude<UsageRangeWindowId, "all" | "yesterday">,
   number
 > = {
   today: 0,
@@ -31,6 +37,17 @@ export function resolveUsageRangeWindow(
   const to = typeof now === "number" ? now : now.getTime();
   if (range === "all") {
     return { from: 0, to };
+  }
+
+  // "Yesterday" is the only bounded-on-both-ends preset: its window spans the
+  // full prior calendar day in `tz`, so `to` is zone-local midnight of today
+  // (i.e. the end of yesterday) rather than the current instant.
+  if (range === "yesterday") {
+    const { fromDate, toDate } = resolveLastTimezoneCalendarDays(2, tz, to);
+    return {
+      from: timezoneDayStartEpoch(fromDate, tz),
+      to: timezoneDayStartEpoch(toDate, tz),
+    };
   }
 
   const dayOffset = RANGE_START_DAY_OFFSETS[range];


### PR DESCRIPTION
## Why

The date range dropdown on `/assistant/logs/usage` offers Today, Last 7/30/90 days, and All time. There was no way to look at *just yesterday's* usage — a common ask when checking whether a spike or change from the prior day's activity. This adds a **Yesterday** preset between "Today" and "Last 7 days".

## What changed

- **`usage-tab.tsx`** — adds `{ value: "yesterday", label: "Yesterday" }` to the range dropdown options.
- **`usage-types.ts` / `usage-window.ts` / `usage-tab-state.ts`** — extends the `UsageTimeRange` / `UsageRangeWindowId` unions and the valid-range set with `"yesterday"`.
- **Window resolution** — unlike the other relative presets, "Yesterday" is bounded on *both* ends: its window spans the full prior calendar day in the effective timezone, so `to` is zone-local midnight of today (end of yesterday) rather than the current instant. Boundaries are computed in the effective `tz` to stay aligned with the backend's zone-aware buckets.
- **Granularity** — like "Today", "Yesterday" renders at hourly resolution since it covers a single calendar day.

## Tests

- Added `resolveRangeWindow("yesterday", ...)` coverage asserting the window spans the prior calendar day with `to` at today's midnight.
- Added `resolveUsageGranularity` coverage for single-day vs multi-day ranges.
- Updated the URL-state fallback test that previously used `range=yesterday` as an *invalid* value (now valid) to use a genuinely invalid value.

`bun test` (usage-tab-state) and `tsc --noEmit` both pass. The `usage-tab.test.tsx` suite is blocked locally by a pre-existing missing `@radix-ui/react-slot` dependency in the design-library workspace, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmWUsxtPM36ciEugWFujQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmWUsxtPM36ciEugWFujQ)_