### PR TITLE
fix(onboarding): warn that Local hosting won't sync across devices

### DIFF
--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -55,7 +55,7 @@ function useHostingOptions(): HostingOption[] {
       mode: "local",
       label: "Local",
       subtitle:
-        "Runs directly on your machine. Your data never leaves your computer.",
+        "Runs on this computer only. Your data stays private and won't sync to the web app or your phone.",
       icon: <Laptop className={ICON_CLASS} />,
     },
   ];


### PR DESCRIPTION
## Why

Triaging a customer feedback report (Chrome extension diagnostics + complaint). The user's #1 functional complaint:

> Even though I signed in with the same account on the Mac app, the Chrome website, and my iPhone, none of the data is syncing together. I set up the personality and everything for my bot on my Mac app, but it doesn't transfer over to the Chrome one or my phone.

### Root cause
The onboarding **Hosting** step lets desktop/web users choose between **Vellum Cloud** and **Local**. The Local option was described only as:

> "Runs directly on your machine. Your data never leaves your computer."

That reads as a pure privacy *benefit* and never mentions the tradeoff: a local-mode assistant runs in an on-device workspace that never reaches the platform, so it **cannot** sync to cloud clients. The Chrome extension and iOS app are cloud-mode clients (the uploaded diagnostics confirm the extension is in `mode: "cloud"`). So a user who picks Local on their Mac, configures their assistant's personality, then opens Chrome/iOS, sees none of it — same account, different (local vs cloud) backend.

This is working as architected, but the copy actively misleads users into the trap.

## What

Update the Local hosting card subtitle to state the cross-device tradeoff up front:

- **Before:** "Runs directly on your machine. Your data never leaves your computer."
- **After:** "Runs on this computer only. Your data stays private and won't sync to the web app or your phone."

Copy-only change to a single shared onboarding screen (web + Electron); no behavior change, no tests reference the old string.

## Not addressed here
The same report also describes the macOS app "freezing / force-logging out." I investigated the auth/session and SSE paths and found them already hardened against transient-failure logout (session teardown is limited to settled 401/403/410; 429/5xx/network are explicitly treated as non-authoritative, plus offline-restore handling), and SSE reconnect already refreshes tokens. I did **not** find a clear, low-risk bug to fix there. The uploaded diagnostics are from the *Chrome* client (which is healthy — SSE connected), so we have no macOS-side telemetry to localize the freeze/logout. Recommend capturing diagnostics from the macOS app to triage that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv3mx4Lk4T66YuLd175zBN)_