### PR TITLE
fix(migrations): fix Type Check failure in async 'started' marker test

### DIFF
--- a/assistant/src/memory/migrations/__tests__/run-migrations.test.ts
+++ b/assistant/src/memory/migrations/__tests__/run-migrations.test.ts
@@ -358,7 +358,7 @@ describe("runMigrationSteps — checkpointing", () => {
     const db = createTestDb();
     const raw = getSqliteFrom(db);
 
-    let markerSeenDuringAwait: string | null = null;
+    const seen: { marker: string | null } = { marker: null };
     const steps: MigrationStep[] = [
       async function asyncWithInspection() {
         // Read the checkpoint while the step is "in flight" — the
@@ -368,7 +368,7 @@ describe("runMigrationSteps — checkpointing", () => {
             `SELECT value FROM memory_checkpoints WHERE key = 'step:asyncWithInspection'`,
           )
           .get();
-        markerSeenDuringAwait = row?.value ?? null;
+        seen.marker = row?.value ?? null;
         await Promise.resolve();
       },
     ];
@@ -376,7 +376,7 @@ describe("runMigrationSteps — checkpointing", () => {
     await runMigrationSteps(db, steps);
 
     // The 'started' marker was visible during the async step's execution
-    expect(markerSeenDuringAwait).toBe("started");
+    expect(seen.marker).toBe("started");
 
     // After completion, the checkpoint is '1'
     const final = raw


### PR DESCRIPTION
## Summary
- Fixes the `Type Check` CI failure on main (`run-migrations.test.ts(379,40): error TS2769`).
- The test declared `markerSeenDuringAwait: string | null` but only reassigned it inside an async closure; TS control-flow analysis ignores closure assignments, narrowing the variable to `null` at the assertion site so `.toBe("started")` matched only the `(expected: null)` overload.
- Captures the value in a holder object (`seen.marker`), matching the existing `calls = { flaky: 0 }` convention in the same file, so the declared union type survives to the assertion. Type check is clean and all 11 tests pass.

## Original prompt
Fix the failing CI Type Check job on main (run 27951410014, introduced by #35560's 'started' crash-recovery lifecycle work and still red on the current main tip). The single error was a TS2769 overload mismatch in the async migration step test, caused by control-flow narrowing collapsing the captured marker variable to `null`.