### PR TITLE
security(plugin-api): stop exposing unrestricted plaintext secret reads (ATL-829)

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -222,7 +222,13 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/platform-routes.ts", // CLI platform connect/disconnect/status routes (CLI-migrated to IPC)
       "ipc/skill-routes/providers.ts", // host.providers.secureKeys.getProviderKey IPC route (out-of-process SkillHost companion)
       "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path
-      "plugin-api/index.ts", // public @vellumai/plugin-api surface re-exports getSecureKeyAsync to dynamically-imported workspace plugins via the boot-time shim (compiled-binary plugin loading)
+      // NOTE: plugin-api/index.ts is intentionally NOT allowlisted. The public
+      // @vellumai/plugin-api surface must never re-export a raw credential-store
+      // reader to dynamically-imported workspace plugins — that exposed an
+      // unrestricted plaintext read over the whole vault (ATL-829). Plugins
+      // receive only their declared `manifest.requiresCredential` values via
+      // PluginInitContext.credentials, resolved host-side in
+      // external-plugins-bootstrap.ts.
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup

--- a/assistant/src/__tests__/fixtures/credential-security-fixtures.ts
+++ b/assistant/src/__tests__/fixtures/credential-security-fixtures.ts
@@ -60,6 +60,15 @@ export const directReadCases: DirectReadCase[] = [
     modulePath: "tools/credentials/broker",
     exportName: "getCredentialValue",
   },
+  {
+    // ATL-829: the public @vellumai/plugin-api surface must not hand workspace
+    // plugins a generic plaintext reader over the whole credential vault.
+    // Plugins get only their declared `manifest.requiresCredential` values via
+    // PluginInitContext.credentials.
+    label: "plugin-api re-exports getSecureKeyAsync",
+    modulePath: "plugin-api/index",
+    exportName: "getSecureKeyAsync",
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -21,7 +21,7 @@
  *
  * Alongside those types, the module exposes a small set of **runtime
  * handles** for plugins that need to reach the assistant's live singletons
- * (subscribe to runtime events, read secrets). These resolve to the
+ * (e.g. subscribe to runtime events, run inference). These resolve to the
  * assistant's own instances: the host parks the loaded plugin-api namespace
  * on `globalThis` at boot, and the workspace-level shim re-binds each
  * runtime export from there — so a plugin's
@@ -31,7 +31,6 @@
  * disjoint module copy.
  *
  * - {@link assistantEventHub} — the assistant's pub/sub hub for runtime events
- * - {@link getSecureKeyAsync} — read a secret from secure storage
  * - {@link getModelProfiles} — list the workspace inference profiles a plugin
  *   can route to (e.g. a model router building its category → profile map)
  * - {@link getConfiguredProvider} — resolve a {@link Provider} for a call site
@@ -130,7 +129,17 @@ export type {
   AssistantEventSubscription,
 } from "../runtime/assistant-event-hub.js";
 export { assistantEventHub } from "../runtime/assistant-event-hub.js";
-export { getSecureKeyAsync } from "../security/secure-keys.js";
+// NOTE: `getSecureKeyAsync` (and any other raw credential-store reader) is
+// deliberately NOT re-exported here. Doing so would hand every loaded plugin
+// an unrestricted, plaintext read over the *entire* credential vault — provider
+// API keys, OAuth tokens, the managed `vellum:assistant_api_key`, etc. — with
+// no declaration or scoping (ATL-829). Plugins declare the specific credentials
+// they need via `manifest.requiresCredential`; the host resolves exactly those
+// and injects them into `init()` as `PluginInitContext.credentials`. That
+// declared, per-plugin path is the only supported way for a plugin to obtain a
+// secret. See the credential-store import boundary enforced by
+// `credential-security-invariants.test.ts` (Invariant 2: no generic plaintext
+// secret read API).
 export { getModelProfiles } from "./model-profiles.js";
 // Check whether a profile's resolved model can process image input. Resolves
 // the effective (provider, model) by merging over the workspace default and

--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -222,7 +222,8 @@ What to import:
 - Hook context types and the `HOOKS` constant, when you need to refer to event names inside a hook body.
 - `ToolDefinition`, `ToolContext`, `ToolExecutionResult`, `RiskLevel`.
 - `PluginLogger` (Pino-compatible, scoped to your plugin, threaded onto contexts).
-- Runtime handles: `assistantEventHub` (the pub/sub hub for runtime events) and `getSecureKeyAsync` (read a secret by key). Both rebind to the assistant's live singletons via a boot-time shim; do not wrap them.
+- Runtime handles: `assistantEventHub` (the pub/sub hub for runtime events) and `getConfiguredProvider` / `getModelProfiles` (run inference through the workspace's configured profiles). These rebind to the assistant's live singletons via a boot-time shim; do not wrap them.
+- Credentials are **not** read through a generic getter. Declare the specific keys your plugin needs in `manifest.requiresCredential`; the host resolves exactly those and hands them to your `init` hook as `ctx.credentials[key]`. There is no API to read arbitrary secrets from the vault — that is by design (a plugin must never be able to read credentials it didn't declare).
 
 What not to import:
 


### PR DESCRIPTION
## Why

The public `@vellumai/plugin-api` surface re-exported the raw credential-store reader `getSecureKeyAsync`, and the boot-time shim re-binds it to the assistant's live singleton. That meant **any loaded workspace plugin** could call `getSecureKeyAsync(<any account>)` and read **any** secret in the vault in plaintext — provider API keys, OAuth tokens, the managed `vellum:assistant_api_key`, etc. — with no declaration and no scoping.

This is ATL-829: *Plugin API exposes unrestricted plaintext secret reads.*

## What changed

- **Remove the `getSecureKeyAsync` re-export** from `assistant/src/plugin-api/index.ts` (the shim derives its export list dynamically, so it's automatically dropped from the workspace shim too). A rationale comment is left in its place so it isn't reintroduced.
- Plugins keep the scoped, declared credential path they already had: list the specific keys in `manifest.requiresCredential` → the host resolves exactly those host-side → they arrive in `init()` as `PluginInitContext.credentials`. A plugin can no longer read a credential it didn't declare.
- **Align with the existing credential security model** (Invariant 2 — "no generic plaintext secret read API"):
  - Drop `plugin-api/index.ts` from the `secure-keys` import allowlist in `credential-security-invariants.test.ts`.
  - Add a direct-read invariant case asserting the plugin API does not export `getSecureKeyAsync`.
- Update the `plugin-builder` skill docs to point authors at `manifest.requiresCredential` instead of the removed runtime handle.

The host-side resolution path is unaffected: `external-plugins-bootstrap.ts` imports `getSecureKeyAsync` directly from `security/secure-keys`, not via the plugin API.

## Compatibility

No first-party plugin imports `getSecureKeyAsync` from `@vellumai/plugin-api`. External plugins that relied on the raw reader must migrate to declaring `manifest.requiresCredential` — which is the documented, supported path.

## Testing

- `bun test credential-security-invariants.test.ts` — 30 pass (incl. new invariant case + import-boundary check)
- `bun test plugin-api-shim.test.ts plugin-api-provider.test.ts plugin-bootstrap.test.ts` — 27 pass
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWbFQvQRqdUq6KVVivgp8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWbFQvQRqdUq6KVVivgp8F)_