### PR TITLE
fix(ces): authenticate managed bootstrap handshake to prevent socket hijack (ATL-728)

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -230,7 +230,9 @@ async function startCesProcess(
       // the env var, so we pass it via the handshake.
       const proxyCtx = await resolveManagedProxyContext();
       const assistantId = getPlatformAssistantId();
+      const cesAuthToken = process.env["CES_SERVICE_TOKEN"];
       const { accepted, reason } = await client.handshake({
+        ...(cesAuthToken ? { authToken: cesAuthToken } : {}),
         ...(proxyCtx.assistantApiKey
           ? { assistantApiKey: proxyCtx.assistantApiKey }
           : {}),
@@ -776,7 +778,9 @@ export async function runDaemon(): Promise<void> {
           await pm.stop();
           const transport = await pm.start();
           const newClient = createCesClient(transport);
+          const reconnectAuthToken = process.env["CES_SERVICE_TOKEN"];
           const { accepted, reason } = await newClient.handshake({
+            ...(reconnectAuthToken ? { authToken: reconnectAuthToken } : {}),
             ...(startupProxyCtx.assistantApiKey
               ? { assistantApiKey: startupProxyCtx.assistantApiKey }
               : {}),

--- a/credential-executor/src/__tests__/managed-reconnect.test.ts
+++ b/credential-executor/src/__tests__/managed-reconnect.test.ts
@@ -107,8 +107,15 @@ function connectToSocket(
   });
 }
 
+/** The shared service token CES is configured with for these tests. */
+const SERVICE_TOKEN = "test-ces-service-token";
+
 /** Send a handshake and resolve the resulting ack. */
-function handshake(sock: Socket, sessionId: string): Promise<HandshakeAck> {
+function handshake(
+  sock: Socket,
+  sessionId: string,
+  authToken: string | undefined = SERVICE_TOKEN,
+): Promise<HandshakeAck> {
   return new Promise((resolveAck, reject) => {
     let buffer = "";
     const timer = setTimeout(() => {
@@ -139,6 +146,7 @@ function handshake(sock: Socket, sessionId: string): Promise<HandshakeAck> {
         type: "handshake_request",
         protocolVersion: CES_PROTOCOL_VERSION,
         sessionId,
+        ...(authToken ? { authToken } : {}),
       }) + "\n",
     );
   });
@@ -190,6 +198,7 @@ describe("managed CES reconnection (real entrypoint)", () => {
         CES_BOOTSTRAP_SOCKET: socketPath,
         CES_HEALTH_PORT: String(healthPort),
         CES_ASSISTANT_DATA_MOUNT: assistantDataMount,
+        CES_SERVICE_TOKEN: SERVICE_TOKEN,
       },
       stdout: "ignore",
       stderr: "ignore",
@@ -240,5 +249,69 @@ describe("managed CES reconnection (real entrypoint)", () => {
     expect(await readyzRpcConnected(healthPort)).toBe(true);
 
     second.destroy();
+  }, 30_000);
+
+  test("rejects an unauthenticated hijack after reconnect, then accepts the real client", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ces-hijack-"));
+    const dataDir = join(tmpDir, "ces-data");
+    const socketDir = join(tmpDir, "bootstrap");
+    const socketPath = join(socketDir, "ces.sock");
+    const assistantDataMount = join(tmpDir, "assistant-data-ro");
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(socketDir, { recursive: true });
+    mkdirSync(join(assistantDataMount, ".vellum"), { recursive: true });
+
+    const healthPort = await pickFreePort();
+    const managedMain = resolve(__dirname, "..", "managed-main.ts");
+
+    proc = Bun.spawn({
+      cmd: [process.execPath, managedMain],
+      env: {
+        ...process.env,
+        CES_MODE: "managed",
+        CES_DATA_DIR: dataDir,
+        CES_BOOTSTRAP_SOCKET: socketPath,
+        CES_HEALTH_PORT: String(healthPort),
+        CES_ASSISTANT_DATA_MOUNT: assistantDataMount,
+        CES_SERVICE_TOKEN: SERVICE_TOKEN,
+      },
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    await waitForHealth(healthPort);
+    await waitForSocket(socketPath);
+
+    // Legitimate assistant connects, then crashes — opening the reconnect window.
+    const legit = await connectToSocket(socketPath);
+    expect((await handshake(legit, "session-1")).accepted).toBe(true);
+    await delay(200);
+    legit.destroy();
+    await waitForSocket(socketPath);
+
+    // An attacker races into the reconnect window with no service token. CES
+    // must reject the handshake AND tear the session down so the socket
+    // re-binds — the attacker must not be able to hold the only slot.
+    const attacker = await connectToSocket(socketPath);
+    const attackerAck = await handshake(attacker, "evil-session", undefined);
+    expect(attackerAck.accepted).toBe(false);
+    expect(attackerAck.reason).toBe("Authentication failed");
+    expect(proc.killed).toBe(false);
+
+    // A second attacker with a wrong token is likewise rejected.
+    await waitForSocket(socketPath);
+    const attacker2 = await connectToSocket(socketPath);
+    const attacker2Ack = await handshake(attacker2, "evil-session-2", "wrong");
+    expect(attacker2Ack.accepted).toBe(false);
+
+    // The real assistant — holding the shared token — reconnects successfully.
+    await waitForSocket(socketPath);
+    const real = await connectToSocket(socketPath);
+    const realAck = await handshake(real, "session-2");
+    expect(realAck.accepted).toBe(true);
+    await delay(200);
+    expect(await readyzRpcConnected(healthPort)).toBe(true);
+
+    real.destroy();
   }, 30_000);
 });

--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -33,7 +33,10 @@ import { CesRpcServer, type RpcHandlerRegistry } from "../server.js";
 /**
  * Create a CesRpcServer wired to in-memory PassThrough streams for testing.
  */
-function createTestServer(handlers: RpcHandlerRegistry = {}) {
+function createTestServer(
+  handlers: RpcHandlerRegistry = {},
+  options: { expectedAuthToken?: string } = {},
+) {
   const input = new PassThrough();
   const output = new PassThrough();
   const logs: string[] = [];
@@ -42,6 +45,9 @@ function createTestServer(handlers: RpcHandlerRegistry = {}) {
     input,
     output,
     handlers,
+    ...(options.expectedAuthToken
+      ? { expectedAuthToken: options.expectedAuthToken }
+      : {}),
     logger: {
       log: (msg: string) => logs.push(`LOG: ${msg}`),
       warn: (msg: string) => logs.push(`WARN: ${msg}`),
@@ -69,11 +75,15 @@ function createTestServer(handlers: RpcHandlerRegistry = {}) {
   /**
    * Send a handshake request and read the response.
    */
-  async function handshake(sessionId = "test-session"): Promise<HandshakeAck> {
+  async function handshake(
+    sessionId = "test-session",
+    authToken?: string,
+  ): Promise<HandshakeAck> {
     send({
       type: "handshake_request",
       protocolVersion: CES_PROTOCOL_VERSION,
       sessionId,
+      ...(authToken ? { authToken } : {}),
     });
     // Give the server a tick to process
     await new Promise((r) => setTimeout(r, 10));
@@ -335,6 +345,109 @@ describe("CesRpcServer", () => {
     const payload = resp.payload as { success: boolean; error: { code: string; message: string } };
     expect(payload.error.code).toBe("HANDLER_ERROR");
     expect(payload.error.message).toMatch(/Intentional test failure/);
+
+    server.close();
+    input.end();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4b. Handshake authentication (managed bootstrap socket hijack defense)
+// ---------------------------------------------------------------------------
+
+describe("CesRpcServer handshake authentication", () => {
+  const TOKEN = "s3cret-service-token";
+
+  test("accepts a handshake that presents the correct token", async () => {
+    const { server, handshake, input } = createTestServer(
+      {},
+      { expectedAuthToken: TOKEN },
+    );
+    const _servePromise = server.serve();
+
+    const ack = await handshake("authed-session", TOKEN);
+    expect(ack.accepted).toBe(true);
+    expect(server.isHandshakeComplete).toBe(true);
+
+    server.close();
+    input.end();
+  });
+
+  test("rejects a handshake that omits the token", async () => {
+    const { server, handshake, input } = createTestServer(
+      {},
+      { expectedAuthToken: TOKEN },
+    );
+    const servePromise = server.serve();
+
+    const ack = await handshake("no-token-session");
+    expect(ack.accepted).toBe(false);
+    expect(ack.reason).toBe("Authentication failed");
+    expect(server.isHandshakeComplete).toBe(false);
+
+    // The rejected session is torn down so the bootstrap socket can re-bind
+    // for a legitimate client rather than being held by the rejected peer.
+    expect(await servePromise).toBe("handshake_unauthenticated");
+
+    input.end();
+  });
+
+  test("rejects a handshake that presents a wrong token without leaking why", async () => {
+    const { server, handshake, input } = createTestServer(
+      {},
+      { expectedAuthToken: TOKEN },
+    );
+    const servePromise = server.serve();
+
+    const ack = await handshake("wrong-token-session", "not-the-token");
+    expect(ack.accepted).toBe(false);
+    // Reason must be generic — it must not reveal whether the token or the
+    // protocol version was the problem.
+    expect(ack.reason).toBe("Authentication failed");
+    expect(server.isHandshakeComplete).toBe(false);
+
+    expect(await servePromise).toBe("handshake_unauthenticated");
+
+    input.end();
+  });
+
+  test("an unauthenticated peer cannot send RPC after a rejected handshake", async () => {
+    const { server, handshake, send, collectOutputLines, input } =
+      createTestServer(
+        { list_grants: async () => ({ grants: [] }) },
+        { expectedAuthToken: TOKEN },
+      );
+    const _servePromise = server.serve();
+
+    const ack = await handshake("attacker", "wrong");
+    expect(ack.accepted).toBe(false);
+    expect(server.isHandshakeComplete).toBe(false);
+
+    // The session was torn down on the rejected handshake, so a follow-up RPC
+    // the attacker tries to push gets no response at all — the handler never
+    // runs.
+    send({
+      type: "rpc",
+      id: "1",
+      kind: "request",
+      method: "list_grants",
+      payload: {},
+      timestamp: new Date().toISOString(),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(collectOutputLines()).toEqual([]);
+
+    input.end();
+  });
+
+  test("does not enforce authentication when no expected token is configured", async () => {
+    // Local stdio mode: no socket to hijack, so the handshake stays open.
+    const { server, handshake, input } = createTestServer();
+    const _servePromise = server.serve();
+
+    const ack = await handshake("local-session");
+    expect(ack.accepted).toBe(true);
+    expect(server.isHandshakeComplete).toBe(true);
 
     server.close();
     input.end();

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -656,6 +656,20 @@ async function main(): Promise<void> {
     );
   }
 
+  // The same shared secret authenticates the bootstrap RPC handshake. The
+  // bootstrap socket re-binds after every assistant session, so without an
+  // authenticated handshake any local process could hijack the socket during
+  // the reconnect window and impersonate the assistant. When the token is
+  // configured every handshake must present it; when it is absent the socket
+  // is left unauthenticated — log loudly so the misconfiguration is visible.
+  if (!serviceToken) {
+    log.error(
+      "CES_SERVICE_TOKEN not set — the bootstrap RPC socket will accept " +
+        "UNAUTHENTICATED connections. Set CES_SERVICE_TOKEN so CES can verify " +
+        "the assistant during the handshake and prevent socket hijacking.",
+    );
+  }
+
   // Start health server on dedicated port. The returned handle isn't
   // needed because the server lifetime is bound to controller.signal,
   // which fires on shutdown and triggers Bun.serve's stop().
@@ -720,6 +734,9 @@ async function main(): Promise<void> {
       input: connection.readable,
       output: connection.writable,
       handlers,
+      // Authenticate the handshake against the shared service token so a
+      // process that races the socket re-bind cannot impersonate the assistant.
+      expectedAuthToken: serviceToken || undefined,
       logger: {
         log: (msg: string, ...args: unknown[]) => rpcLog.info({ args }, msg),
         warn: (msg: string, ...args: unknown[]) => rpcLog.warn({ args }, msg),
@@ -781,9 +798,22 @@ async function main(): Promise<void> {
         { err, uptime: process.uptime(), pid: process.pid },
         "RPC transport errored — treating as session end",
       );
+    } finally {
+      // Drop the underlying socket so a peer whose session ended (including a
+      // handshake we rejected as unauthenticated) cannot keep the connection
+      // open. The next loop iteration re-binds the bootstrap socket for a
+      // legitimate client.
+      connection.socket.destroy();
     }
 
     rpcConnected = false;
+
+    if (endReason === "handshake_unauthenticated") {
+      log.warn(
+        { uptime: process.uptime(), pid: process.pid },
+        "Rejected an unauthenticated bootstrap handshake — awaiting a new connection",
+      );
+    }
 
     // Drop all ephemeral approvals when the session ends. `allow_once` /
     // `allow_10m` grants are keyed by proposal hash only, so reusing the

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -16,6 +16,8 @@
 
 import type { Readable, Writable } from "node:stream";
 
+import { createHash, timingSafeEqual } from "node:crypto";
+
 import {
   CES_PROTOCOL_VERSION,
   CesRpcMethod,
@@ -88,6 +90,15 @@ export interface CesServerOptions {
   logger?: Pick<Console, "log" | "warn" | "error">;
   /** Optional abort signal to shut down the server. */
   signal?: AbortSignal;
+  /**
+   * Optional shared secret the connecting peer must present in its handshake
+   * `authToken` to be accepted. When set (managed sidecar mode), a handshake
+   * that omits the token or presents a non-matching one is rejected and the
+   * session is torn down so the bootstrap socket re-binds for a legitimate
+   * client. When unset (local stdio mode), no authentication is enforced —
+   * the parent process owns the child's pipes and there is no socket to hijack.
+   */
+  expectedAuthToken?: string;
   /** Callback invoked when the handshake completes with the negotiated session ID and optional API key / assistant ID. */
   onHandshakeComplete?: (sessionId: string, assistantApiKey?: string, assistantId?: string) => void;
   /** Callback invoked when the assistant pushes an updated API key (and optionally assistant ID) after hatch. */
@@ -97,7 +108,8 @@ export interface CesServerOptions {
 export type ServeEndReason =
   | "input_stream_ended"
   | "signal_aborted"
-  | "signal_aborted_before_start";
+  | "signal_aborted_before_start"
+  | "handshake_unauthenticated";
 
 // ---------------------------------------------------------------------------
 // Server implementation
@@ -109,12 +121,17 @@ export class CesRpcServer {
   private readonly handlers: RpcHandlerRegistry;
   private readonly logger: Pick<Console, "log" | "warn" | "error">;
   private readonly signal?: AbortSignal;
+  private readonly expectedAuthToken?: string;
   private readonly onHandshakeComplete?: (sessionId: string, assistantApiKey?: string, assistantId?: string) => void;
 
   private handshakeComplete = false;
   private sessionId: string | null = null;
   private buffer = "";
   private closed = false;
+  /** Resolver for the in-flight `serve()` promise, so the handshake path can
+   *  end the session (e.g. on an authentication failure) and let the managed
+   *  loop re-bind the bootstrap socket for a legitimate client. */
+  private serveResolve: ((reason: ServeEndReason) => void) | null = null;
 
   constructor(options: CesServerOptions) {
     this.input = options.input;
@@ -122,6 +139,7 @@ export class CesRpcServer {
     this.handlers = options.handlers;
     this.logger = options.logger ?? console;
     this.signal = options.signal;
+    this.expectedAuthToken = options.expectedAuthToken;
     this.onHandshakeComplete = options.onHandshakeComplete;
 
     // Auto-register the update_managed_credential handler if a callback is provided.
@@ -147,9 +165,18 @@ export class CesRpcServer {
         return;
       }
 
+      const settle = (reason: ServeEndReason) => {
+        this.serveResolve = null;
+        if (this.signal) {
+          this.signal.removeEventListener("abort", onAbort);
+        }
+        resolve(reason);
+      };
+      this.serveResolve = settle;
+
       const onAbort = () => {
         this.close();
-        resolve("signal_aborted");
+        settle("signal_aborted");
       };
 
       if (this.signal) {
@@ -163,14 +190,12 @@ export class CesRpcServer {
       });
 
       this.input.on("end", () => {
-        if (this.signal) {
-          this.signal.removeEventListener("abort", onAbort);
-        }
         this.close();
-        resolve("input_stream_ended");
+        settle("input_stream_ended");
       });
 
       this.input.on("error", (err) => {
+        this.serveResolve = null;
         if (this.signal) {
           this.signal.removeEventListener("abort", onAbort);
         }
@@ -259,6 +284,31 @@ export class CesRpcServer {
   }
 
   private handleHandshake(req: HandshakeRequest): void {
+    // Authenticate the peer before anything else. When an expected token is
+    // configured (managed sidecar mode), a missing or non-matching token is a
+    // hijack attempt: the bootstrap socket re-binds after each session, so an
+    // unauthenticated peer racing the reconnect window must never be accepted.
+    // The error reason is deliberately generic so it does not reveal whether
+    // the token or the protocol version was wrong.
+    if (this.expectedAuthToken && !this.isAuthorized(req.authToken)) {
+      this.logger.warn(
+        "[ces-server] Handshake rejected: authentication failed — tearing down session",
+      );
+      this.sendMessage({
+        type: "handshake_ack",
+        protocolVersion: CES_PROTOCOL_VERSION,
+        sessionId: req.sessionId,
+        accepted: false,
+        reason: "Authentication failed",
+      } satisfies HandshakeAck);
+      // End the session so the managed loop re-binds the bootstrap socket for
+      // a legitimate client instead of leaving the slot held by the rejected
+      // peer (which would otherwise be a denial of service).
+      this.close();
+      this.serveResolve?.("handshake_unauthenticated");
+      return;
+    }
+
     const accepted = req.protocolVersion === CES_PROTOCOL_VERSION;
     const ack: HandshakeAck = {
       type: "handshake_ack",
@@ -280,6 +330,20 @@ export class CesRpcServer {
     }
 
     this.sendMessage(ack);
+  }
+
+  /**
+   * Constant-time comparison of the presented handshake token against the
+   * expected shared secret. Both sides are SHA-256 hashed first so the compare
+   * runs over fixed-length buffers — this avoids leaking the secret length and
+   * sidesteps `timingSafeEqual`'s equal-length requirement.
+   */
+  private isAuthorized(presented: string | undefined): boolean {
+    if (!this.expectedAuthToken) return true;
+    if (!presented) return false;
+    const expectedHash = createHash("sha256").update(this.expectedAuthToken).digest();
+    const presentedHash = createHash("sha256").update(presented).digest();
+    return timingSafeEqual(expectedHash, presentedHash);
   }
 
   private async handleRpcEnvelope(envelope: RpcEnvelope): Promise<void> {

--- a/docs/service-communication-matrix.md
+++ b/docs/service-communication-matrix.md
@@ -42,7 +42,7 @@ This document enumerates every observed communication permutation between the th
 | 30 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Risk classification IPC |
 | 31 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Threshold IPC |
 | 32 | Assistant -> CES | `stdio-ndjson` | none (child process) | CES RPC (local mode) |
-| 33 | Assistant -> CES | `unix-socket-ndjson` | none (bootstrap socket) | CES RPC (managed mode) |
+| 33 | Assistant -> CES | `unix-socket-ndjson` | CES_SERVICE_TOKEN (handshake) | CES RPC (managed mode) |
 | 34 | Assistant -> CES | `http` | CES_SERVICE_TOKEN Bearer | CES credential CRUD (HTTP) |
 | 35 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway credential reads (HTTP) |
 | 36 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway CES log export (HTTP) |
@@ -451,8 +451,8 @@ This document enumerates every observed communication permutation between the th
 ### CES RPC (managed mode)
 
 - **Protocol:** `unix-socket-ndjson`
-- **Auth:** none (bootstrap socket)
-- **Description:** Assistant connects to the CES sidecar's bootstrap Unix socket (CES_BOOTSTRAP_SOCKET) for RPC in managed/Docker mode.
+- **Auth:** CES_SERVICE_TOKEN (handshake)
+- **Description:** Assistant connects to the CES sidecar's bootstrap Unix socket (CES_BOOTSTRAP_SOCKET) for RPC in managed/Docker mode. The socket re-binds after each session, so CES verifies the shared CES_SERVICE_TOKEN (constant-time) during the handshake before accepting the session — without this, a local process racing the reconnect window could hijack the socket and impersonate the assistant.
 
 **Caller files:**
 - `assistant/src/credential-execution/process-manager.ts`

--- a/packages/ces-client/src/rpc-client.ts
+++ b/packages/ces-client/src/rpc-client.ts
@@ -85,6 +85,16 @@ const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 
 export interface CesRpcHandshakeOptions {
   /**
+   * Optional shared-secret token authenticating this client to CES.
+   *
+   * In managed (sidecar) mode CES requires the assistant to present the shared
+   * `CES_SERVICE_TOKEN` so it can verify the peer before accepting the session
+   * — the bootstrap Unix socket re-binds after each session and is otherwise
+   * vulnerable to being hijacked by another local process during the reconnect
+   * window. Omitted in local stdio mode, where there is no socket to hijack.
+   */
+  authToken?: string;
+  /**
    * Optional assistant API key to pass to CES during the handshake.
    * In managed (sidecar) mode the API key is provisioned after hatch,
    * so the assistant forwards it here so CES can use it for platform
@@ -360,6 +370,7 @@ export function createCesRpcClient(
             type: "handshake_request",
             protocolVersion: CES_PROTOCOL_VERSION,
             sessionId,
+            ...(options?.authToken ? { authToken: options.authToken } : {}),
             ...(options?.assistantApiKey
               ? { assistantApiKey: options.assistantApiKey }
               : {}),

--- a/packages/service-contracts/src/transport.ts
+++ b/packages/service-contracts/src/transport.ts
@@ -26,6 +26,20 @@ export const HandshakeRequestSchema = z.object({
   /** Opaque session identifier chosen by the initiator. */
   sessionId: z.string(),
   /**
+   * Optional shared-secret token authenticating the initiator.
+   *
+   * In managed (sidecar) mode the CES bootstrap Unix socket re-binds after
+   * each assistant session ends, so the connection is unauthenticated at the
+   * transport layer — any local process that reaches the socket path during
+   * the reconnect window could otherwise impersonate the assistant. The
+   * assistant forwards the shared `CES_SERVICE_TOKEN` here so CES can verify
+   * the peer before accepting the session (constant-time comparison).
+   *
+   * Omitted in local stdio mode, where the parent process owns the child's
+   * pipes and there is no socket to hijack.
+   */
+  authToken: z.string().optional(), // nosemgrep: not-a-secret
+  /**
    * Optional assistant API key passed from the assistant runtime.
    * In managed (sidecar) mode the API key is provisioned after hatch,
    * so the assistant forwards it during the bootstrap handshake so CES

--- a/scripts/service-communication/matrix-source.ts
+++ b/scripts/service-communication/matrix-source.ts
@@ -465,9 +465,9 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
     caller: "assistant",
     callee: "ces",
     protocol: "unix-socket-ndjson",
-    auth: "none (bootstrap socket)",
+    auth: "CES_SERVICE_TOKEN (handshake)",
     description:
-      "Assistant connects to the CES sidecar's bootstrap Unix socket (CES_BOOTSTRAP_SOCKET) for RPC in managed/Docker mode.",
+      "Assistant connects to the CES sidecar's bootstrap Unix socket (CES_BOOTSTRAP_SOCKET) for RPC in managed/Docker mode. The socket re-binds after each session, so CES verifies the shared CES_SERVICE_TOKEN (constant-time) during the handshake before accepting the session — without this, a local process racing the reconnect window could hijack the socket and impersonate the assistant.",
     callerGlobs: ["assistant/src/credential-execution/process-manager.ts"],
     calleeGlobs: [
       "credential-executor/src/managed-main.ts",


### PR DESCRIPTION
## Why

[ATL-728](https://linear.app/vellum/issue/ATL-728/security-unauthenticated-ces-socket-can-be-hijacked-after-reconnect): **the managed CES bootstrap Unix socket can be hijacked after a reconnect.**

CES is a long-lived sidecar that outlives any single assistant session. When the assistant disconnects (e.g. its container crashes and restarts), CES **re-binds** the bootstrap socket and accepts the *next* connection. The handshake (`credential-executor/src/server.ts`) only validated the **protocol version** — it never authenticated *who* connected:

```ts
const accepted = req.protocolVersion === CES_PROTOCOL_VERSION;
```

So during the reconnect window, any local process that can reach the socket path could complete a handshake and become "the assistant" — gaining full access to:

- platform credential **materialization** (`run_authenticated_command`, `make_authenticated_request`)
- authenticated **command execution**
- credential **CRUD** (get/set/delete/list/bulk-set)

Unlinking the socket while a session is live (the existing mitigation) only prevents *concurrent* connections; it does nothing to authenticate the peer that grabs the socket after a re-bind.

## What

Gate the bootstrap handshake on the **already-shared `CES_SERVICE_TOKEN`** — the same secret injected into both the assistant container and the CES sidecar via the `cesServiceToken` secret (see `cli/src/lib/statefulset.ts`), already used to authenticate the CES HTTP credential API.

- **Contract** (`service-contracts/transport.ts`): add optional `authToken` to `HandshakeRequestSchema`.
- **Client** (`ces-client/rpc-client.ts`): add `authToken` to handshake options and send it.
- **Assistant** (`lifecycle.ts`): present `CES_SERVICE_TOKEN` on both the initial and reconnect handshakes.
- **CES server** (`server.ts`): when an `expectedAuthToken` is configured, verify the presented token with a **constant-time SHA-256 comparison** before accepting. On a missing/wrong token, reject with a generic `"Authentication failed"` reason and **tear the session down** so the socket re-binds for a legitimate client instead of being held open by the rejected peer (otherwise a DoS).
- **CES entrypoint** (`managed-main.ts`): pass `CES_SERVICE_TOKEN` as the expected token per session, destroy the underlying socket at each session end, and log loudly if the token is unset.

**Local stdio mode is unaffected** — the parent owns the child's pipes, there's no socket to hijack, no expected token is configured, and authentication is not enforced (backward compatible).

## Threat model note

Enforcement is driven by whether an expected token is configured, mirroring the existing HTTP-route pattern in `managed-main.ts`. In every real managed deployment the statefulset guarantees `CES_SERVICE_TOKEN` is present, so the hijack window is closed; when it is absent CES now logs an error-level security warning.

## Testing

- `credential-executor/src/__tests__/transport.test.ts` — new auth matrix: correct token accepted; missing/wrong token rejected with a generic reason and no handshake completion; rejected peer cannot send RPC; no enforcement when no token is configured. **All pass.**
- `credential-executor/src/__tests__/managed-reconnect.test.ts` — new end-to-end hijack test: an attacker racing the reconnect window (no token / wrong token) is rejected and the socket re-binds; the real assistant (holding the token) then reconnects successfully. *(This and the existing reconnect/integration e2e tests bind a TCP health port, which this sandbox can't do — they run in CI.)*
- `service-communication` matrix doc regenerated from `matrix-source.ts` to reflect the new auth posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L66zBoxxPiWqHkAYmpW4QF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L66zBoxxPiWqHkAYmpW4QF)_