### PR TITLE
fix(runtime): strip caller-supplied actor/principal headers in HTTP adapter (ATL-863)

### DIFF
--- a/assistant/src/runtime/routes/__tests__/http-adapter-actor-header.test.ts
+++ b/assistant/src/runtime/routes/__tests__/http-adapter-actor-header.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for actor/principal header sanitization in the HTTP
+ * adapter.
+ *
+ * The HTTP adapter must derive the actor identity headers
+ * (`x-vellum-actor-principal-id`, `x-vellum-principal-type`) exclusively from
+ * the verified AuthContext, never from caller-supplied request headers. A
+ * caller whose token carries no actorPrincipalId (svc_gateway / svc_daemon /
+ * local principals) must not be able to spoof another principal — e.g. the
+ * guardian — by setting the header explicitly. This protects principal-gated
+ * handlers (surface action `apr:*` guardian decisions, guardian actions, host
+ * proxies) from approval-token bypass via a forged actor principal.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { resolveScopeProfile } from "../../auth/scopes.js";
+import type { AuthContext } from "../../auth/types.js";
+import { routeDefinitionsToHTTPRoutes } from "../http-adapter.js";
+import type { RouteDefinition } from "../types.js";
+
+// Echo route: returns the identity headers the handler actually observed.
+const ECHO_ROUTE: RouteDefinition = {
+  operationId: "echo_identity_headers",
+  endpoint: "test/echo-identity",
+  method: "POST",
+  policy: null,
+  handler: ({ headers }) => ({
+    actorPrincipalId: headers?.["x-vellum-actor-principal-id"] ?? null,
+    principalType: headers?.["x-vellum-principal-type"] ?? null,
+  }),
+};
+
+function buildAuthContext(overrides: Partial<AuthContext>): AuthContext {
+  return {
+    subject: "svc:gateway:self",
+    principalType: "svc_gateway",
+    assistantId: "self",
+    scopeProfile: "gateway_service_v1",
+    scopes: resolveScopeProfile("gateway_service_v1"),
+    policyEpoch: 0,
+    ...overrides,
+  };
+}
+
+async function invokeEcho(params: {
+  spoofedPrincipalId?: string;
+  spoofedPrincipalType?: string;
+  authContext: AuthContext;
+}): Promise<{ actorPrincipalId: string | null; principalType: string | null }> {
+  const [httpRoute] = routeDefinitionsToHTTPRoutes([ECHO_ROUTE]);
+
+  const reqHeaders: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (params.spoofedPrincipalId !== undefined) {
+    reqHeaders["x-vellum-actor-principal-id"] = params.spoofedPrincipalId;
+  }
+  if (params.spoofedPrincipalType !== undefined) {
+    reqHeaders["x-vellum-principal-type"] = params.spoofedPrincipalType;
+  }
+
+  const req = new Request("http://daemon.local/v1/test/echo-identity", {
+    method: "POST",
+    headers: reqHeaders,
+    body: JSON.stringify({}),
+  });
+
+  const response = await httpRoute.handler({
+    req,
+    url: new URL(req.url),
+    // The echo handler doesn't touch `server`; a stub is fine.
+    server: undefined as never,
+    authContext: params.authContext,
+    params: {},
+  });
+
+  return (await response.json()) as {
+    actorPrincipalId: string | null;
+    principalType: string | null;
+  };
+}
+
+describe("http-adapter actor/principal header sanitization", () => {
+  test("drops a spoofed actor-principal header when the context has no actorPrincipalId", async () => {
+    // A service token (svc_gateway) has no actorPrincipalId. The forged header
+    // must be stripped, not passed through to the handler.
+    const result = await invokeEcho({
+      spoofedPrincipalId: "guardian-principal-victim",
+      authContext: buildAuthContext({ actorPrincipalId: undefined }),
+    });
+
+    expect(result.actorPrincipalId).toBeNull();
+    // principalType is always re-derived from the verified context.
+    expect(result.principalType).toBe("svc_gateway");
+  });
+
+  test("overrides a spoofed actor-principal header with the verified context value", async () => {
+    const result = await invokeEcho({
+      spoofedPrincipalId: "guardian-principal-victim",
+      spoofedPrincipalType: "actor",
+      authContext: buildAuthContext({
+        subject: "actor:self:real-actor",
+        principalType: "actor",
+        scopeProfile: "actor_client_v1",
+        scopes: resolveScopeProfile("actor_client_v1"),
+        actorPrincipalId: "real-actor",
+      }),
+    });
+
+    expect(result.actorPrincipalId).toBe("real-actor");
+    expect(result.principalType).toBe("actor");
+  });
+
+  test("passes through the genuine actor identity when no spoof is present", async () => {
+    const result = await invokeEcho({
+      authContext: buildAuthContext({
+        subject: "actor:self:real-actor",
+        principalType: "actor",
+        scopeProfile: "actor_client_v1",
+        scopes: resolveScopeProfile("actor_client_v1"),
+        actorPrincipalId: "real-actor",
+      }),
+    });
+
+    expect(result.actorPrincipalId).toBe("real-actor");
+    expect(result.principalType).toBe("actor");
+  });
+});

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -96,6 +96,21 @@ export function routeDefinitionsToHTTPRoutes(
           headers[key] = value;
         });
 
+        // Strip any caller-supplied identity headers before deriving them
+        // from the verified AuthContext. On the HTTP path the actor identity
+        // always comes from the validated JWT — never from inbound headers —
+        // so a request that carries these headers is either confused or
+        // hostile. Without this, a caller whose token carries no
+        // actorPrincipalId (svc_gateway / svc_daemon / local principals) could
+        // spoof another principal — e.g. the guardian — by setting the header
+        // explicitly, because the override below only fires when the context
+        // supplies a value. Handlers that gate on principal identity (surface
+        // action `apr:*` guardian decisions, guardian actions, host proxies)
+        // would then apply a decision as the impersonated principal. Mirrors
+        // the gateway IPC proxy (gateway/src/http/routes/ipc-runtime-proxy.ts).
+        delete headers["x-vellum-actor-principal-id"];
+        delete headers["x-vellum-principal-type"];
+
         // Inject auth context fields so transport-agnostic handlers can
         // resolve trust context without importing auth internals.
         if (authContext?.actorPrincipalId) {


### PR DESCRIPTION
## Summary

Fixes the surface-actions approval-token bypass via actor/principal (ATL-863).

The daemon's HTTP adapter (`assistant/src/runtime/routes/http-adapter.ts`) copied **all** inbound request headers into the transport-agnostic handler args, then only *overrode* `x-vellum-actor-principal-id` when the verified `AuthContext` supplied an `actorPrincipalId`. For tokens whose principal type carries no actor id — `svc_gateway`, `svc_daemon`, `local` (all permitted by `ACTOR_PRINCIPALS`) — the override never fired, so a **caller-supplied** `x-vellum-actor-principal-id` header survived into the handler.

### Why this is exploitable

Principal-gated handlers read that header as the deciding actor's identity. The most direct impact is `POST /v1/surface-actions`:

- The `apr:<requestId>:<action>` branch forwards the header straight into the canonical guardian-decision primitive as the `guardianPrincipalId`, whose sole authorization gate is `actor.guardianPrincipalId === request.guardianPrincipalId`.
- A forged header set to the guardian's principal therefore lets a non-guardian **apply a guardian approval decision** (approve/reject an access request) — an approval-token bypass.
- Unlike the dedicated `POST /v1/guardian-actions/decision` endpoint, `surface-actions` has **no** `requireGuardian` gate, so the spoofable canonical principal check was the only line of defense — and it consumed the spoofable value. Other principal-gated handlers (host bash/file/CU/browser/app-control, client same-user filter) read the same header.

On the HTTP path the actor identity always comes from the validated JWT — never from inbound headers. The gateway IPC proxy (`gateway/src/http/routes/ipc-runtime-proxy.ts`) already `delete`s these inbound identity headers before re-deriving them from verified claims, and its comment even claims the HTTP adapter does the same — but it did not.

### Fix

Strip `x-vellum-actor-principal-id` and `x-vellum-principal-type` from the copied inbound headers **before** setting the `AuthContext`-derived values. This makes the HTTP adapter match the invariant the IPC proxy already enforces. No legitimate flow is affected: identity on the HTTP path is JWT-derived, and the gateway-proxy/local-IPC paths set identity via `injectLocalActorHeader` (IPC server), not via this adapter.

## Testing

- New regression test `assistant/src/runtime/routes/__tests__/http-adapter-actor-header.test.ts` (3 cases):
  - spoofed header dropped when the context has no `actorPrincipalId` (the bypass case),
  - spoofed header overridden by the verified context value,
  - genuine actor identity passes through unchanged.
- Verified the spoof case **fails without the fix** and passes with it.
- Surrounding runtime-route suites show no new failures attributable to this change (pre-existing/environmental failures only).

> Note: the repo's pre-commit typecheck hook could not run cleanly in the ephemeral build container because the sibling `packages/*` workspaces weren't dependency-installed (so `zod` doesn't resolve there); those errors are pre-existing on `main` and unrelated to this change. Lint and formatting passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qe4PVMSsuJKJuYynN4GKEf)_