### PR TITLE
fix(gateway): stop routing STT stream WS through the Velay tunnel (ATL-713)

### DIFF
--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -7,6 +7,7 @@ import {
   getSttStreamWebsocketHandlers,
   type SttStreamSocketData,
 } from "../http/routes/stt-stream-websocket.js";
+import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
@@ -291,6 +292,67 @@ describe("createSttStreamWebsocketHandler", () => {
     expect(opts.data.provider).toBe("deepgram");
     expect(opts.data.mimeType).toBe("audio/webm");
     expect(opts.data.sampleRate).toBe(16000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Velay tunnel guard (ATL-713)
+  //
+  // STT authenticates only with the local actor edge JWT, which must never
+  // transit the platform's velay edge. The endpoint is excluded from the velay
+  // path allowlist; this in-process guard rejects anything that nonetheless
+  // arrives over the gateway's own velay bridge (identified by the unspoofable
+  // per-process bridge proof), regardless of allowlist drift.
+  // -------------------------------------------------------------------------
+
+  test("rejects a velay-bridged request with 403 even with a valid token", () => {
+    const handler = createSttStreamWebsocketHandler(makeConfig());
+    const headers = new Headers({
+      upgrade: "websocket",
+    });
+    setVelayBridgeAuthHeader(headers);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&mimeType=audio/webm`,
+      { headers },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("velay-bridge guard short-circuits before auth/param checks", () => {
+    // No token, no mimeType: the guard must still return 403 rather than
+    // falling through to the 401/400 paths.
+    const handler = createSttStreamWebsocketHandler(makeConfig());
+    const headers = new Headers({ upgrade: "websocket" });
+    setVelayBridgeAuthHeader(headers);
+    const req = new Request("http://localhost:7830/v1/stt/stream", { headers });
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("velay-bridge guard applies even when auth is disabled (dev bypass)", () => {
+    const handler = createSttStreamWebsocketHandler(
+      makeConfig({ runtimeProxyRequireAuth: false }),
+    );
+    const headers = new Headers({ upgrade: "websocket" });
+    setVelayBridgeAuthHeader(headers);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?mimeType=audio/webm",
+      { headers },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
   });
 });
 

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -8,6 +8,7 @@ import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
+import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
 
 const log = getLogger("stt-stream-ws");
 
@@ -51,6 +52,23 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
   ): Response | undefined {
     if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return new Response("Upgrade Required", { status: 426 });
+    }
+
+    // ── Velay tunnel guard (defense in depth) ──
+    // STT streaming authenticates only with the local actor edge JWT, which
+    // must never transit the platform's velay edge (it would be observable in
+    // the `?token=` query string / Authorization header of the bridged frame,
+    // letting the platform exfiltrate the long-lived, full-access token).
+    // `/v1/stt/stream` is excluded from the velay path allowlist
+    // (`velay/allowed-paths.ts`); this in-process check is the belt to that
+    // suspenders — reject anything opened over this gateway's own velay bridge
+    // regardless of allowlist drift. The bridge proof cannot be spoofed by a
+    // direct caller. Mirrors the live-voice bridge-proof model (ATL-713).
+    if (requestHasVelayBridgeAuth(req)) {
+      log.warn(
+        "STT stream WS: rejected velay-bridged request (local-only path)",
+      );
+      return new Response("Forbidden", { status: 403 });
     }
 
     const url = new URL(req.url);

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -33,7 +33,7 @@ describe("VELAY_ALLOWED_PATHS", () => {
     }
   });
 
-  it("matches the four gateway public-surface route shapes", () => {
+  it("matches the three gateway public-surface route shapes", () => {
     // Allowlist coverage check — if you add a public route in
     // `gateway/src/index.ts` that needs to be reachable through the Velay
     // tunnel, add a matching regex to VELAY_ALLOWED_PATHS and a sample here.
@@ -50,8 +50,11 @@ describe("VELAY_ALLOWED_PATHS", () => {
       "/webhooks/oauth/callback": true,
       "/v1/audio/some-uuid.mp3": true,
       "/v1/live-voice": true,
-      "/v1/stt/stream": true,
       // Negative samples — paths that must NOT be tunnel-public.
+      // `/v1/stt/stream` authenticates only with the local actor edge JWT and
+      // has no velay-attested auth path, so it must never be reachable through
+      // the tunnel (ATL-713).
+      "/v1/stt/stream": false,
       "/v1/contacts/abc": false,
       "/v1/health": false,
       "/v1/pair": false,

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -19,9 +19,20 @@
  *     Velay.
  *   - `^/v1/audio/` — Twilio fetches generated audio URLs directly on the
  *     public surface (see comment at `gateway/src/index.ts` audio route).
- *   - `^/v1/live-voice` — exact match for the Twilio media-stream WebSocket
- *     used for live voice calls.
- *   - `^/v1/stt/stream` — exact match for the public STT streaming WebSocket.
+ *   - `^/v1/live-voice` — exact match for the live-voice WebSocket. Its cloud
+ *     path authenticates with a short-lived, org+assistant-scoped velay WS
+ *     token (validated by velay, attested to the gateway via the per-process
+ *     bridge proof — see `live-voice-websocket.ts`), so the long-lived local
+ *     actor edge JWT is never carried across the velay edge.
+ *
+ * `/v1/stt/stream` is intentionally NOT tunnel-public. Unlike live-voice, the
+ * STT streaming WebSocket has no velay-attested auth path — it authenticates
+ * only with the local actor edge JWT. Routing it through velay would force
+ * that long-lived, full-access token across the cross-origin platform edge
+ * (in the `?token=` query string), letting the platform exfiltrate it. STT
+ * streaming is therefore self-hosted-only (the client connects straight to the
+ * user's own gateway ingress); cloud STT, if ever wired, must adopt the
+ * live-voice token-exchange model instead of being added back here (ATL-713).
  *
  * If you add a new public route to `gateway/src/index.ts` that must be
  * reachable through the Velay tunnel (i.e. anything an external provider
@@ -33,7 +44,6 @@ export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
   "^/webhooks/",
   "^/v1/audio/",
   "^/v1/live-voice$",
-  "^/v1/stt/stream$",
 ]);
 
 /**
@@ -48,6 +58,5 @@ export const VELAY_ALLOWED_PATHS_HEADER = "X-Vellum-Velay-Allowed-Paths";
  * module load — the allowlist is static for the lifetime of the gateway
  * process.
  */
-export const VELAY_ALLOWED_PATHS_HEADER_VALUE = JSON.stringify(
-  VELAY_ALLOWED_PATHS,
-);
+export const VELAY_ALLOWED_PATHS_HEADER_VALUE =
+  JSON.stringify(VELAY_ALLOWED_PATHS);

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -7,10 +7,10 @@ import type { VelayHeaders } from "./protocol.js";
 const MAX_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 
 const VELAY_ALLOWED_HTTP_PATH_PREFIXES = ["/webhooks/twilio/"] as const;
-const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
-  "/v1/live-voice",
-  "/v1/stt/stream",
-] as const;
+// `/v1/stt/stream` is intentionally absent: it authenticates only with the
+// local actor edge JWT, which must never traverse the velay edge. Keep this in
+// sync with `VELAY_ALLOWED_PATHS` in ./allowed-paths.ts (ATL-713).
+const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = ["/v1/live-voice"] as const;
 
 /**
  * Injected unconditionally by the HTTP bridge on every request forwarded to

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -340,10 +340,18 @@ describe("VelayWebSocketBridge", () => {
     ]);
   });
 
-  test("allows live voice and STT websocket paths declared in the tunnel allowlist", () => {
+  test("allows the live-voice websocket path declared in the tunnel allowlist", () => {
     bridge.open(
       makeOpenFrame({ path: "/v1/live-voice", raw_query: "token=t" }),
     );
+
+    expect(WebSocketMock).toHaveBeenCalledTimes(1);
+    expect((WebSocketMock.mock.calls[0] as [string])[0]).toBe(
+      "ws://127.0.0.1:7830/v1/live-voice?token=t",
+    );
+  });
+
+  test("rejects the STT stream websocket path (not tunnel-public — ATL-713)", () => {
     bridge.open(
       makeOpenFrame({
         connection_id: "conn-stt",
@@ -352,13 +360,16 @@ describe("VelayWebSocketBridge", () => {
       }),
     );
 
-    expect(WebSocketMock).toHaveBeenCalledTimes(2);
-    expect((WebSocketMock.mock.calls[0] as [string])[0]).toBe(
-      "ws://127.0.0.1:7830/v1/live-voice?token=t",
-    );
-    expect((WebSocketMock.mock.calls[1] as [string])[0]).toBe(
-      "ws://127.0.0.1:7830/v1/stt/stream?token=t",
-    );
+    // STT authenticates only with the local actor edge JWT, which must never
+    // traverse the velay edge, so the bridge refuses to open the connection.
+    expect(WebSocketMock).not.toHaveBeenCalled();
+    expect(sentFrames).toEqual([
+      {
+        type: VELAY_FRAME_TYPES.websocketOpenError,
+        connection_id: "conn-stt",
+        reason: "Invalid WebSocket path",
+      },
+    ]);
   });
 
   test("forwards local close frames back to Velay and cleans up", () => {


### PR DESCRIPTION
## Why

**Security: platform API keys can exfiltrate local gateway actor tokens (ATL-713).**

The `/v1/stt/stream` WebSocket authenticates **only** with the long-lived local **actor edge JWT** (presented via `?token=` or `Authorization`), and it was listed in the Velay tunnel path allowlist (`VELAY_ALLOWED_PATHS` + the gateway-side `VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS`).

In managed/cloud deployments the gateway reaches the platform through a Velay tunnel authenticated with the assistant/platform API key. Any request routed over that tunnel is bridged to the gateway's loopback listener by the platform's cross-origin velay edge (`velay.vellum.ai`). Because STT's only credential is the actor edge JWT, routing STT through velay forces that high-privilege, ~30-day, full-access token across the platform edge — where it is observable (it rides in the `?token=` query string / `Authorization` header of the bridged frame). That lets the platform **exfiltrate local gateway actor tokens**.

This is exactly the failure mode the **live-voice** design deliberately avoided: a spike disproved sending the actor JWT through velay, so cloud live-voice instead mints a short-lived, **org+assistant-scoped** velay WS token and relies on the gateway's per-process **bridge proof** (`requestHasVelayBridgeAuth`) to attest velay-validated context — the actor JWT never leaves the local trust boundary. STT was never migrated to that model and shouldn't be tunnel-reachable at all: STT streaming is **self-hosted-only** (the web dictation client connects straight to the user's own gateway ingress; cloud STT is deliberately unwired).

## What

- **Remove `/v1/stt/stream` from the Velay allowlists** — both the list declared to the platform (`velay/allowed-paths.ts`) and the gateway-side WebSocket bridge enforcement (`velay/bridge-utils.ts`). The bridge now refuses to open an STT connection over the tunnel.
- **Defense in depth in the STT upgrade handler** — reject any request carrying the unspoofable per-process velay bridge proof, independent of allowlist drift. Mirrors the live-voice bridge-proof model.
- **Tests** — allowlist coverage now treats `/v1/stt/stream` as not-tunnel-public; the WS bridge sends `websocket_open_error` for the STT path; and the STT handler returns `403` for velay-bridged upgrades (including before auth/param checks and under the dev auth bypass).

## Scope / non-impact

STT remains a normal local route (still in the OpenAPI schema, still served to loopback/self-hosted clients with the actor edge JWT). The only capability removed is reaching STT **through the platform's velay tunnel**, which had no legitimate caller.

## Verification

- `bun test` (gateway): velay suite + STT/live-voice WS handler tests — 106 passing.
- `tsc --noEmit`: clean. `eslint` + `prettier --check`: clean. Pre-commit/pre-push hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpF7Y2vgHHEJ7VdVQ9aSmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpF7Y2vgHHEJ7VdVQ9aSmN)_