### PR TITLE
refactor(web): load attachment preview content via React Query [LUM-2513]

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+
+import * as daemonSdk from "@/generated/daemon/sdk.gen";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+type ContentResult = { data: Blob | null; error: { message: string } | null };
+
+// Mock only the daemon content endpoint; keep the rest of the generated SDK
+// real so any other consumer in the module graph is unaffected.
+const attachmentsByIdContentGet = mock(
+  async (): Promise<ContentResult> => ({
+    data: new Blob(["content"]),
+    error: null,
+  }),
+);
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  attachmentsByIdContentGet,
+}));
+
+// happy-dom doesn't implement object URLs.
+globalThis.URL.createObjectURL = mock(
+  (_obj: Blob | MediaSource): string => "blob:preview-mock",
+);
+globalThis.URL.revokeObjectURL = mock((_url: string): void => undefined);
+
+const { AttachmentPreviewModal } = await import(
+  "@/domains/chat/components/chat-attachments/attachment-preview-modal"
+);
+
+const ATTACHMENT: DisplayAttachment = {
+  id: "att-1",
+  filename: "photo.png",
+  mimeType: "image/png",
+  sizeBytes: 1024,
+  previewUrl: null,
+};
+
+function renderModal(attachment: DisplayAttachment): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const ui: ReactElement = (
+    <QueryClientProvider client={client}>
+      <AttachmentPreviewModal
+        open
+        onClose={() => undefined}
+        attachment={attachment}
+        assistantId="asst-1"
+      />
+    </QueryClientProvider>
+  );
+  render(ui);
+}
+
+afterEach(() => {
+  cleanup();
+  attachmentsByIdContentGet.mockClear();
+});
+
+describe("AttachmentPreviewModal content loading", () => {
+  test("renders an inline previewUrl without hitting the daemon", () => {
+    renderModal({ ...ATTACHMENT, previewUrl: "data:image/png;base64,AAAA" });
+
+    expect(screen.getByAltText("photo.png").getAttribute("src")).toBe(
+      "data:image/png;base64,AAAA",
+    );
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
+
+  test("shows a clear message for rehydrated attachments and never fetches", () => {
+    renderModal({ ...ATTACHMENT, id: "rehydrated:abc" });
+
+    expect(
+      screen.getByText(
+        "Preview unavailable — file content was not preserved in chat history.",
+      ),
+    ).toBeDefined();
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
+
+  test("fetches from the daemon and renders the resulting object URL", async () => {
+    renderModal(ATTACHMENT);
+
+    const img = await screen.findByAltText("photo.png");
+    expect(img.getAttribute("src")).toBe("blob:preview-mock");
+    expect(attachmentsByIdContentGet).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows the failure fallback when the daemon fetch fails", async () => {
+    attachmentsByIdContentGet.mockImplementationOnce(async () => ({
+      data: null,
+      error: { message: "boom" },
+    }));
+    renderModal(ATTACHMENT);
+
+    expect(await screen.findByText("Failed to load preview.")).toBeDefined();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { Download, FileIcon, Loader2, X } from "lucide-react";
 import type { FC, KeyboardEvent, MouseEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -10,6 +11,7 @@ import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-previ
 import { PreviewMessageCard } from "@/domains/chat/components/chat-attachments/preview-message-card";
 import { TextPreview } from "@/domains/chat/components/chat-attachments/text-preview";
 import { formatAttachmentSize } from "@/domains/chat/components/chat-attachments/utils";
+import type { DisplayAttachment } from "@/types/attachment-types";
 
 // File extensions routed to the inline text preview even when the upstream
 // MIME type is generic (e.g. application/octet-stream).
@@ -45,13 +47,7 @@ const getExtension = (filename: string): string => {
 interface AttachmentPreviewModalProps {
   open: boolean;
   onClose: () => void;
-  attachment: {
-    id: string;
-    filename: string;
-    mimeType: string;
-    sizeBytes: number;
-    previewUrl: string | null;
-  };
+  attachment: DisplayAttachment;
   /** When set, the modal will fetch missing content from
    *  /v1/assistants/{assistantId}/attachments/{attachment.id}/content. */
   assistantId?: string | null;
@@ -74,9 +70,6 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
 }) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
-  const [previewError, setPreviewError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -84,66 +77,69 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     }
   }, [open]);
 
-  // Lazily fetch attachment content as a blob when no previewUrl is supplied.
-  useEffect(() => {
-    if (!open) return;
-    if (attachment.previewUrl) return;
-    if (!assistantId || !attachment.id) return;
+  // Synthetic IDs from the text-parsing history fallback
+  // (parseAttachmentSummariesFromContent) can never resolve against the
+  // daemon's content endpoint, so we never fetch them — we show a clear message
+  // instead of a misleading network error.
+  const isRehydrated =
+    !attachment.previewUrl && attachment.id.startsWith("rehydrated:");
 
-    // Synthetic IDs created by the text-parsing fallback
-    // (parseAttachmentSummariesFromContent) can never resolve against
-    // the daemon's content endpoint. Skip the doomed fetch and show a
-    // clear message instead of a misleading network error.
-    if (attachment.id.startsWith("rehydrated:")) {
-      setPreviewError(
-        "Preview unavailable — file content was not preserved in chat history.",
-      );
+  // Fetch content from the daemon only when there's no inline previewUrl and we
+  // have a real, resolvable id to fetch with.
+  const shouldFetch =
+    open &&
+    !attachment.previewUrl &&
+    !!assistantId &&
+    !!attachment.id &&
+    !isRehydrated;
+
+  const { data: blob, isError } = useQuery({
+    // The attachment id is stable and unique, so it is the cache key — reopening
+    // the same attachment reuses the fetched blob instead of refetching.
+    queryKey: ["attachmentContent", assistantId, attachment.id],
+    queryFn: async () => {
+      const { data, error } = await attachmentsByIdContentGet({
+        path: { assistant_id: assistantId!, id: attachment.id },
+        parseAs: "blob",
+        throwOnError: false,
+      });
+      if (error || !(data instanceof Blob)) {
+        throw new Error("Failed to load file");
+      }
+      return data;
+    },
+    enabled: shouldFetch,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  // Hold the fetched blob as an object URL for the media/text renderers, and
+  // revoke it when the blob changes or the modal unmounts.
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (!blob) {
+      setObjectUrl(null);
       return;
     }
-
-    let revoked = false;
-
-    const loadPreview = async () => {
-      setIsLoadingPreview(true);
-      setPreviewError(null);
-      setObjectUrl(null);
-
-      try {
-        const { data, error } = await attachmentsByIdContentGet({
-          path: { assistant_id: assistantId, id: attachment.id },
-          parseAs: "blob",
-          throwOnError: false,
-        });
-        if (error || !(data instanceof Blob)) {
-          throw new Error("Failed to load file");
-        }
-        if (revoked) return;
-
-        const url = URL.createObjectURL(data);
-        setObjectUrl(url);
-      } catch {
-        if (!revoked) {
-          setPreviewError("Failed to load preview.");
-        }
-      } finally {
-        if (!revoked) {
-          setIsLoadingPreview(false);
-        }
-      }
-    };
-
-    void loadPreview();
-
+    const url = URL.createObjectURL(blob);
+    setObjectUrl(url);
     return () => {
-      revoked = true;
-      setObjectUrl((prev) => {
-        if (prev) URL.revokeObjectURL(prev);
-        return null;
-      });
-      setIsLoadingPreview(false);
-      setPreviewError(null);
+      URL.revokeObjectURL(url);
+      setObjectUrl(null);
     };
-  }, [open, attachment.previewUrl, attachment.id, assistantId]);
+  }, [blob]);
+
+  const effectiveUrl = attachment.previewUrl ?? objectUrl;
+
+  // Loading until there's a usable URL: covers the fetch and the one-render gap
+  // between the blob arriving and its object URL being created.
+  const isLoadingPreview = shouldFetch && !objectUrl && !isError;
+
+  const previewError = isRehydrated
+    ? "Preview unavailable — file content was not preserved in chat history."
+    : isError
+      ? "Failed to load preview."
+      : null;
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -165,8 +161,6 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     },
     [onClose],
   );
-
-  const effectiveUrl = attachment.previewUrl ?? objectUrl;
 
   const handleDownload = useCallback(async () => {
     if (!effectiveUrl) return;


### PR DESCRIPTION
Closes **LUM-2513**. Follow-up to #35369 (which removed React Query from `TextPreview` because it was caching a *local* read) — this puts the **genuinely server-side** fetch in the same area onto React Query, where it belongs.

## What this changes

The preview modal fetched daemon `/content` with a **hand-rolled `fetch`-in-`useEffect`**, manually juggling `isLoadingPreview` / `previewError` / `objectUrl` state, a `revoked` latch, and the object-URL lifecycle. This moves it to **`useQuery`**, mirroring the codebase's own file viewers (`workspace-file-viewer.tsx`, `use-skill-detail-files.ts`):

- **Keyed by the stable attachment `id`** (`["attachmentContent", assistantId, id]`). File-backed attachments have real, unique ids, so the cache key is correct **by construction** — no URL/content-hash gymnastics — and reopening the same attachment reuses the fetched blob.
- The blob → object-URL conversion + **revoke on unmount/blob-change** lives in a small `useEffect` (the workspace-viewer pattern).
- Loading/error are **derived**, not imperative state.

## Also in scope (audit findings from #35369)

- **Type dedup:** the modal re-declared `DisplayAttachment`'s shape inline as the `attachment` prop type; it now uses the named type.

## One deliberate behavior refinement

A **rehydrated** attachment (synthetic `id`, content not preserved in history) now shows the "content not preserved" message **regardless of whether `assistantId` is present**. Previously the `!assistantId` guard short-circuited *before* that branch, so an assistant-less rehydrated attachment fell through to the generic fallback card. The message is always the correct thing for a synthetic id, so this is a small fix, not a regression. Flagging it explicitly.

## Tests

Adds **`attachment-preview-modal.test.tsx`** (the modal had **zero** tests) covering the four content paths:
- inline `previewUrl` → renders without hitting the daemon;
- `rehydrated:` id → clear message, never fetches;
- daemon success → fetches, renders the resulting object URL;
- daemon failure → "Failed to load preview." fallback.

## Risk
Low–medium. It touches the **shared** content path (image / video / PDF / text all consume the resulting URL), but behavior is preserved and now test-covered. `retry: false` preserves the prior single-attempt fail-fast UX. The image/video/PDF/text *renderers* are untouched.

## Verification
- `eslint` clean; modal test 4/4; full chat-attachments folder 15/15; `tsc` clean for the changed files.
- A full local `tsc` shows pre-existing, unrelated `DisplayMessage` stale-dep drift in the dev container (none in these files, no consumer breakage from the type change) — cleared by CI's clean build.
- **Not** verified on a device/packaged build (this env can't) — the daemon `blob:` path is reasoned + unit-tested, not clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzBCQ9QFqa9Tw9pqv4PtPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzBCQ9QFqa9Tw9pqv4PtPb)_