### PR TITLE
fix(gateway): resolve legacy verification rows by (type,address) + gateway-first activation

### DIFF
--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -517,15 +517,44 @@ describe("ContactStore.markChannelVerified", () => {
     expect(idUpdate).toBeTruthy();
 
     const keyUpdate = fakeAssistantDb.runCalls.find((c) =>
-      /WHERE contact_id = \? AND type = \? AND address = \? COLLATE NOCASE/i.test(
-        c.sql,
-      ),
+      /WHERE type = \? AND address = \? COLLATE NOCASE/i.test(c.sql),
     );
     expect(keyUpdate).toBeTruthy();
-    // Logical-key update binds the resolved gateway row's (contactId,type,address).
-    expect(keyUpdate!.bind).toContain("c1");
+    // Logical-key update binds the gateway unique key (type, address) — not
+    // contactId, since the assistant row may sit under a different contact.
     expect(keyUpdate!.bind).toContain("vellum");
     expect(keyUpdate!.bind).toContain("shared-addr");
+  });
+
+  test("legacy cross-contact: resolves the gateway row by (type,address) even under a different contact", async () => {
+    // m0006 can leave the gateway row under a DIFFERENT contact than the
+    // assistant mirror. Keying the fallback on (type,address) — the gateway
+    // unique key — must still resolve it (no 404), and the write keys on the
+    // gateway row's own contact.
+    seedContact("gw-contact", "contact");
+    seedChannel({
+      id: "gw-uuid",
+      contactId: "gw-contact",
+      status: "unverified",
+      address: "shared-addr",
+    });
+    seedAssistantContact("asst-contact", "contact");
+    seedAssistantChannel({
+      id: "assistant-uuid",
+      contactId: "asst-contact",
+      status: "unverified",
+      address: "shared-addr",
+    });
+
+    const result = await new ContactStore().markChannelVerified(
+      "assistant-uuid",
+      "challenge",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.channel.id).toBe("gw-uuid");
+    expect(result!.channel.contactId).toBe("gw-contact");
+    expect(result!.channel.status).toBe("active");
+    expect(result!.channel.verifiedVia).toBe("challenge");
   });
 });
 

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -553,6 +553,33 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(result).toEqual({ verified: false });
   });
 
+  test("gateway-first: skips assistant activation when the gateway write is rejected after the pre-check", async () => {
+    // An existing assistant channel + a gateway pre-check that passes, but the
+    // guarded gateway write is rejected (row became blocked/revoked in the
+    // race). The assistant mirror must NOT be activated, so a blocked actor is
+    // never left active locally.
+    queryRows = [
+      { channelId: "ch-race", contactId: "co-race", channelStatus: "unverified" },
+    ];
+    gwSelectStatus = "unverified"; // pre-check passes
+    gwUpdateChanges = [0, 0]; // guarded gateway updates miss
+    gwInsertWrote = false; // insert-mirror no-op → write rejected
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550009999",
+      externalChatId: "+15550009999",
+    });
+
+    expect(result).toEqual({ verified: false });
+    const assistantActivate = runCalls.find(
+      (c) =>
+        /UPDATE contact_channels/i.test(c.sql) &&
+        c.sql.includes("status = 'active'"),
+    );
+    expect(assistantActivate).toBeUndefined();
+  });
+
   test("honors an explicit verifiedVia value on the update path", async () => {
     queryRows = [
       { channelId: "ch-7", contactId: "co-7", channelStatus: "active" },

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -554,8 +554,9 @@ export class ContactStore {
     );
 
     // Legacy channels may have a different assistant-side ID. If the ID-keyed
-    // update touched zero rows, resolve by (contactId, type, address) and
-    // retry so the assistant mirror stays consistent.
+    // update touched zero rows, resolve by the unique (type, address) key and
+    // retry so the assistant mirror stays consistent. The assistant row may sit
+    // under a different contact than the gateway row, so contactId is excluded.
     if (result.changes === 0) {
       const gwChannel = this.db
         .select()
@@ -565,10 +566,10 @@ export class ContactStore {
       if (!gwChannel) return;
 
       const logicalBind = bind.slice(0, -1); // drop the channelId
-      logicalBind.push(gwChannel.contactId, gwChannel.type, gwChannel.address);
+      logicalBind.push(gwChannel.type, gwChannel.address);
       await assistantDbRun(
         `UPDATE contact_channels SET ${setClauses.join(", ")}
-         WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE`,
+         WHERE type = ? AND address = ? COLLATE NOCASE`,
         logicalBind,
       );
     }
@@ -737,22 +738,24 @@ export class ContactStore {
     if (byId) return byId;
 
     const assistantChannel = await assistantDbQuery<{
-      contact_id: string;
       type: string;
       address: string;
     }>(
-      "SELECT contact_id, type, address FROM contact_channels WHERE id = ?",
+      "SELECT type, address FROM contact_channels WHERE id = ?",
       [channelId],
     );
     if (assistantChannel.length === 0) return undefined;
 
-    const { contact_id: contactId, type, address } = assistantChannel[0];
+    // Resolve by the gateway's unique key (type, address). The gateway row may
+    // live under a different contact than the assistant mirror — m0006 reconcile
+    // skips mirroring when (type, address) already exists under any contact — so
+    // contactId is not part of the lookup; the resolved row's contact is trusted.
+    const { type, address } = assistantChannel[0];
     return this.db
       .select()
       .from(contactChannels)
       .where(
         and(
-          eq(contactChannels.contactId, contactId),
           eq(contactChannels.type, type),
           sql`${contactChannels.address} = ${address} COLLATE NOCASE`,
         ),
@@ -834,13 +837,14 @@ export class ContactStore {
         );
         // Legacy mismatch: the caller's id may not be the assistant mirror's id
         // (the gateway row lives under a different UUID). Fall back to the
-        // resolved row's logical key so the mirror isn't left stale.
+        // unique (type, address) key so the mirror isn't left stale — the
+        // assistant row may sit under a different contact than the gateway row.
         if (result.changes === 0) {
           await assistantDbRun(
             `UPDATE contact_channels
                SET status = 'active', verified_at = ?, verified_via = ?, updated_at = ?
-             WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE`,
-            [now, verifiedVia, now, after.contactId, after.type, after.address],
+             WHERE type = ? AND address = ? COLLATE NOCASE`,
+            [now, verifiedVia, now, after.type, after.address],
           );
         }
       } catch (err) {

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -275,7 +275,47 @@ export async function upsertVerifiedContactChannel(params: {
       return { verified: false };
     }
 
-    // Update existing channel
+    // Gateway is source of truth: write it FIRST, then activate the assistant
+    // mirror only if the gateway accepted the write. The assistant channel id
+    // may not exist in the gateway DB (legacy/unmirrored) or live under a
+    // different gateway UUID, so the helper resolves by logical key.
+    let gatewayRejected = false;
+    try {
+      const wrote = writeVerifiedGatewayChannel({
+        assistantChannelId: row.channelId,
+        contactId: row.contactId,
+        type: sourceChannel,
+        address,
+        externalChatId,
+        verifiedVia,
+        now,
+      });
+      // The pre-check passed, so a write is expected. A false means a
+      // blocked/revoked row appeared between the pre-check and the write —
+      // reject WITHOUT activating the assistant mirror so a blocked actor is
+      // never left active locally.
+      if (!wrote) {
+        log.warn(
+          { sourceChannel, address },
+          "Gateway write ignored after pre-check: channel became blocked/revoked",
+        );
+        gatewayRejected = true;
+      }
+    } catch (gwErr) {
+      // A thrown gateway DB error is an infra failure, not a rejection: the
+      // code already matched, so fall through and activate the assistant mirror
+      // best-effort rather than failing a legitimate verification.
+      log.warn(
+        { err: gwErr },
+        "Gateway DB contact channel update dual-write failed",
+      );
+    }
+
+    if (gatewayRejected) {
+      return { verified: false };
+    }
+
+    // Activate the assistant mirror.
     await assistantDbRun(
       `UPDATE contact_channels
        SET address = ?,
@@ -288,47 +328,64 @@ export async function upsertVerifiedContactChannel(params: {
       [address, externalChatId, now, verifiedVia, now, row.channelId],
     );
 
-    // Dual-write to gateway DB. Best-effort: a gateway failure must not break
-    // inbound verification UX (the code already matched). The assistant
-    // channel id may not exist in the gateway DB (legacy/unmirrored channel)
-    // or may live under a different gateway UUID, so resolve by logical key.
-    try {
-      const wrote = writeVerifiedGatewayChannel({
-        assistantChannelId: row.channelId,
-        contactId: row.contactId,
-        type: sourceChannel,
-        address,
-        externalChatId,
-        verifiedVia,
-        now,
-      });
-      // The gateway pre-check passed, so a write is expected. A false here means
-      // a blocked/revoked row appeared between the pre-check and the write —
-      // treat it as a rejection so the caller suppresses the success reply.
-      if (!wrote) {
-        log.warn(
-          { sourceChannel, address },
-          "Gateway write ignored after pre-check: channel became blocked/revoked",
-        );
-        return { verified: false };
-      }
-    } catch (gwErr) {
-      log.warn(
-        { err: gwErr },
-        "Gateway DB contact channel update dual-write failed",
-      );
-    }
-
     return { verified: true };
   }
 
-  // Create new contact + channel. Both use OR IGNORE for idempotency under
-  // retries. If the channel insert fails mid-flight, the orphan contact row
-  // is harmless (no channels → invisible in UI, cleaned up by next upsert
-  // for the same identity which will find-by-address and reuse it).
+  // No existing channel: create contact + channel. Gateway is source of truth,
+  // so write it FIRST and create the assistant mirror only if the gateway
+  // accepted the write — never leave an active assistant channel for an actor
+  // the gateway has blocked/revoked.
   const contactId = crypto.randomUUID();
   const channelId = crypto.randomUUID();
 
+  // The parent contact is conflict-tolerant (a pre-existing contact is fine).
+  // For the channel, resolve by logical key so an existing non-blocked gateway
+  // row (e.g. a gateway-created unverified contact) is UPDATED to active/verified
+  // rather than silently no-op'd by the (type,address) unique index.
+  let gatewayRejected = false;
+  try {
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({
+        id: contactId,
+        displayName: contactDisplayName,
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+      .run();
+
+    const wrote = writeVerifiedGatewayChannel({
+      assistantChannelId: channelId,
+      contactId,
+      type: sourceChannel,
+      address,
+      externalChatId,
+      verifiedVia,
+      now,
+    });
+    // A blocked/revoked gateway row appeared after the pre-check — reject
+    // without creating an active assistant mirror for a blocked actor.
+    if (!wrote) {
+      log.warn(
+        { sourceChannel, address },
+        "Gateway write ignored after pre-check: channel became blocked/revoked",
+      );
+      gatewayRejected = true;
+    }
+  } catch (gwErr) {
+    // A thrown gateway DB error is an infra failure, not a rejection: fall
+    // through and create the assistant mirror best-effort.
+    log.warn({ err: gwErr }, "Gateway DB contact create dual-write failed");
+  }
+
+  if (gatewayRejected) {
+    return { verified: false };
+  }
+
+  // Create the assistant mirror. OR IGNORE for idempotency under retries; if the
+  // channel insert fails mid-flight, the orphan contact row is harmless.
   await assistantDbRun(
     `INSERT OR IGNORE INTO contacts (id, display_name, role, created_at, updated_at)
      VALUES (?, ?, 'contact', ?, ?)`,
@@ -353,47 +410,6 @@ export async function upsertVerifiedContactChannel(params: {
       now,
     ],
   );
-
-  // Dual-write to gateway DB. The parent contact is conflict-tolerant (a
-  // pre-existing contact is fine). For the channel, resolve by logical key so
-  // an existing non-blocked gateway row (e.g. a gateway-created unverified
-  // contact) is UPDATED to active/verified rather than silently no-op'd by the
-  // (type,address) unique index — otherwise the authoritative gateway row stays
-  // unverified while the user gets a success reply.
-  try {
-    getGatewayDb()
-      .insert(gwContacts)
-      .values({
-        id: contactId,
-        displayName: contactDisplayName,
-        role: "contact",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-      .run();
-
-    const wrote = writeVerifiedGatewayChannel({
-      assistantChannelId: channelId,
-      contactId,
-      type: sourceChannel,
-      address,
-      externalChatId,
-      verifiedVia,
-      now,
-    });
-    // A blocked/revoked gateway row appeared after the pre-check — reject so the
-    // caller suppresses the success reply rather than claiming a blocked actor.
-    if (!wrote) {
-      log.warn(
-        { sourceChannel, address },
-        "Gateway write ignored after pre-check: channel became blocked/revoked",
-      );
-      return { verified: false };
-    }
-  } catch (gwErr) {
-    log.warn({ err: gwErr }, "Gateway DB contact create dual-write failed");
-  }
 
   return { verified: true };
 }


### PR DESCRIPTION
## Summary
- `resolveGatewayChannel` and the two assistant-mirror dual-write fallbacks now resolve legacy channels by the gateway unique key `(type, address)` instead of `(contactId, type, address)`. m0006 reconcile can leave the gateway row under a *different* contact than the assistant mirror, so requiring contactId made manual verify/revoke 404 for migrated actors. Guard logic uses the resolved gateway row's contact.
- `upsertVerifiedContactChannel` now writes the gateway row FIRST and activates the assistant mirror only when the gateway accepted the write (both the existing-channel and new-insert paths). Previously the assistant row was activated before the gateway write, so a blocked/revoked actor could be left `active` in the assistant mirror when the gateway rejected the write in a pre-check→write race. A thrown gateway DB error (infra failure, not a rejection) still falls through and activates the mirror best-effort.
- Tests: cross-contact resolution (gateway row under a different contact resolves, no 404) and gateway-first ordering (no assistant activation when the gateway write is rejected).

## Original prompt
Two Codex P2 correctness bugs were surfaced on the now-merged feature PR #35588 (gateway-as-source-of-truth for channel verification). (1) The legacy-row fallback in resolveGatewayChannel keyed on (contactId, type, address) but the gateway's actual unique key is (type, address), so post-m0006 actors whose gateway row sits under a different contact got null/404 on manual verify/revoke. (2) upsertVerifiedContactChannel activated the assistant mirror before confirming the authoritative gateway write, so a blocked/revoked actor could remain active locally on a TOCTOU. Fix both off origin/main, add tests, present the PR for manual merge (no auto-merge).