### PR TITLE
fix(notifications): gate source-active suppression before the decision engine (LUM-2520)

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -57,6 +57,21 @@ mock.module("../notifications/decisions-store.js", () => ({
 mock.module("../notifications/deterministic-checks.js", () => ({
   runDeterministicChecks: (...args: unknown[]) =>
     runDeterministicChecksMock(...args),
+  // emit-signal also imports checkSourceActiveSuppression for the pre-decision
+  // gate. Mirror its real signal-only contract here so the gate behaves under
+  // the mock without depending on bun's export-merge semantics. The real
+  // implementation is unit-tested in
+  // notifications/__tests__/deterministic-checks.test.ts.
+  checkSourceActiveSuppression: (signal: {
+    attentionHints: { visibleInSourceNow?: boolean };
+  }) =>
+    signal.attentionHints.visibleInSourceNow
+      ? {
+          passed: false,
+          reason:
+            "Source-active suppression: user is already viewing the source context",
+        }
+      : { passed: true },
 }));
 
 mock.module("../notifications/events-store.js", () => ({
@@ -213,5 +228,73 @@ describe("emitNotificationSignal routing intent re-persistence", () => {
     const callArgs = evaluateSignalMock.mock.calls[0];
     expect(callArgs).toBeDefined();
     expect(callArgs?.[1]).toEqual(["vellum"]);
+  });
+});
+
+describe("emitNotificationSignal source-active pre-gate", () => {
+  beforeEach(() => {
+    evaluateSignalMock.mockReset();
+    runDeterministicChecksMock.mockReset();
+    createEventMock.mockReset();
+    dispatchDecisionMock.mockReset();
+
+    createEventMock.mockReturnValue({ id: "evt-src-active" });
+    runDeterministicChecksMock.mockResolvedValue({ passed: true });
+    dispatchDecisionMock.mockResolvedValue({
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    });
+  });
+
+  test("suppresses visibleInSourceNow signals before the decision engine runs", async () => {
+    const result = await emitNotificationSignal({
+      sourceEventName: "ingress.trusted_contact.verification_sent",
+      sourceChannel: "slack",
+      sourceContextId: "conv-1",
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: true,
+        visibleInSourceNow: true,
+      },
+      contextPayload: { verificationSessionId: "vs-1" },
+    });
+
+    // The event row is still persisted (audit trail), but the signal
+    // short-circuits before the LLM-backed decision stage and never dispatches.
+    expect(createEventMock).toHaveBeenCalledTimes(1);
+    expect(evaluateSignalMock).not.toHaveBeenCalled();
+    expect(runDeterministicChecksMock).not.toHaveBeenCalled();
+    expect(dispatchDecisionMock).not.toHaveBeenCalled();
+    expect(result.dispatched).toBe(false);
+    expect(result.reason).toContain("Source-active suppression");
+  });
+
+  test("does not short-circuit when visibleInSourceNow is false", async () => {
+    evaluateSignalMock.mockResolvedValue({
+      shouldNotify: false,
+      selectedChannels: [],
+      reasoningSummary: "no notify",
+      renderedCopy: {},
+      dedupeKey: "dk-not-source-active",
+      confidence: 0.5,
+      fallbackUsed: false,
+    });
+
+    await emitNotificationSignal({
+      sourceEventName: "schedule.notify",
+      sourceChannel: "scheduler",
+      sourceContextId: "conv-2",
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {},
+    });
+
+    expect(evaluateSignalMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -20,6 +20,7 @@ import { getDb } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import { notificationEvents } from "../../memory/schema.js";
 import {
+  checkSourceActiveSuppression,
   type DeterministicCheckContext,
   runDeterministicChecks,
 } from "../deterministic-checks.js";
@@ -282,5 +283,46 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     const result = await runDeterministicChecks(signal, decision, context);
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("fallback leak");
+  });
+});
+
+describe("checkSourceActiveSuppression (pre-decision gate)", () => {
+  test("fails when visibleInSourceNow is set", () => {
+    const result = checkSourceActiveSuppression(
+      makeSignal({
+        attentionHints: {
+          requiresAction: false,
+          urgency: "low",
+          isAsyncBackground: true,
+          visibleInSourceNow: true,
+        },
+      }),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("Source-active suppression");
+  });
+
+  test("passes when visibleInSourceNow is false", () => {
+    expect(checkSourceActiveSuppression(makeSignal()).passed).toBe(true);
+  });
+
+  test("runDeterministicChecks does not suppress source-active signals (handled by the pre-decision gate)", async () => {
+    // Source-active suppression is enforced by the pre-decision gate in
+    // emitNotificationSignal, not by this stage. A source-active signal
+    // evaluated here therefore passes — this stage only validates the decision.
+    const signal = makeSignal({
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: true,
+        visibleInSourceNow: true,
+      },
+    });
+    const result = await runDeterministicChecks(
+      signal,
+      makeDecision(),
+      context,
+    );
+    expect(result.passed).toBe(true);
   });
 });

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -3,8 +3,13 @@
  *
  * These checks run after the decision engine produces a NotificationDecision
  * and before the broadcaster dispatches. They enforce hard invariants that
- * the LLM cannot override: channel availability, source-active suppression,
- * deduplication, and schema validity.
+ * the LLM cannot override: channel availability, deduplication, schema
+ * validity, and rendered-copy quality.
+ *
+ * Source-active suppression is also a hard invariant, but it depends only on
+ * the signal — not on the decision — so `emitNotificationSignal` runs it as a
+ * pre-decision gate, short-circuiting before the expensive LLM stage rather
+ * than discarding the decision after it. See `checkSourceActiveSuppression`.
  */
 
 import { and, eq } from "drizzle-orm";
@@ -52,17 +57,7 @@ export async function runDeterministicChecks(
     return schemaCheck;
   }
 
-  // Check 2: Source-active suppression
-  const sourceActiveCheck = checkSourceActiveSuppression(signal);
-  if (!sourceActiveCheck.passed) {
-    log.info(
-      { signalId: signal.signalId, reason: sourceActiveCheck.reason },
-      "Deterministic check failed: source active",
-    );
-    return sourceActiveCheck;
-  }
-
-  // Check 3: Channel availability
+  // Check 2: Channel availability
   const channelCheck = checkChannelAvailability(
     decision,
     context.connectedChannels,
@@ -75,7 +70,7 @@ export async function runDeterministicChecks(
     return channelCheck;
   }
 
-  // Check 4: Dedupe
+  // Check 3: Dedupe
   const dedupeCheck = checkDedupe(
     signal,
     decision,
@@ -89,7 +84,7 @@ export async function runDeterministicChecks(
     return dedupeCheck;
   }
 
-  // Check 5: Rendered copy quality (fail-closed)
+  // Check 4: Rendered copy quality (fail-closed)
   const copyCheck = checkRenderedCopyQuality(signal, decision);
   if (!copyCheck.passed) {
     log.info(
@@ -151,8 +146,16 @@ function checkDecisionSchema(decision: NotificationDecision): CheckResult {
 /**
  * If the user is already looking at the source context (visibleInSourceNow),
  * suppress the notification to avoid redundant alerts.
+ *
+ * This depends only on the signal, not on the decision, so the outcome is
+ * knowable before the decision engine runs. `emitNotificationSignal` calls it
+ * as a pre-decision gate to short-circuit statically-suppressed signals
+ * (e.g. trusted-contact `verification_sent`) before paying for an LLM
+ * inference whose result would be discarded. Exported for that caller.
  */
-function checkSourceActiveSuppression(signal: NotificationSignal): CheckResult {
+export function checkSourceActiveSuppression(
+  signal: NotificationSignal,
+): CheckResult {
   if (signal.attentionHints.visibleInSourceNow) {
     return {
       passed: false,

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -27,6 +27,7 @@ import {
 import { enforceRoutingIntent, evaluateSignal } from "./decision-engine.js";
 import { updateDecision } from "./decisions-store.js";
 import {
+  checkSourceActiveSuppression,
   type DeterministicCheckContext,
   runDeterministicChecks,
 } from "./deterministic-checks.js";
@@ -209,7 +210,12 @@ export interface EmitSignalResult {
 
 /**
  * Emit a notification signal through the full pipeline:
- * createEvent -> evaluateSignal -> runDeterministicChecks -> dispatchDecision.
+ * createEvent -> (source-active pre-gate) -> evaluateSignal ->
+ * runDeterministicChecks -> dispatchDecision.
+ *
+ * Source-active suppression runs before the decision engine: it depends only
+ * on the signal, so a statically-suppressed signal short-circuits here without
+ * paying for an LLM inference whose result would be discarded downstream.
  *
  * Fire-and-forget safe by default: errors are caught and logged unless
  * `throwOnError` is enabled by the caller.
@@ -257,6 +263,28 @@ export async function emitNotificationSignal<TEventName extends string>(
         deduplicated: true,
         dispatched: false,
         reason: "Signal deduplicated at event store level",
+        deliveryResults: [],
+      };
+    }
+
+    // Step 1.5: Source-active pre-gate. visibleInSourceNow is a hard invariant
+    // the decision engine cannot override, and it depends only on the signal —
+    // so when it is set, the outcome is predetermined: suppress. Short-circuit
+    // before the (LLM-backed) decision stage so statically-suppressed signals
+    // (e.g. trusted-contact verification_sent) never incur an inference, a
+    // discarded decision row, or an LLM-dependent home-feed mirror. The event
+    // row persisted above preserves the lifecycle/audit trail.
+    const sourceActiveCheck = checkSourceActiveSuppression(signal);
+    if (!sourceActiveCheck.passed) {
+      log.info(
+        { signalId, reason: sourceActiveCheck.reason },
+        "Signal suppressed before decision stage (source-active)",
+      );
+      return {
+        signalId,
+        deduplicated: false,
+        dispatched: false,
+        reason: `Signal suppressed: ${sourceActiveCheck.reason}`,
         deliveryResults: [],
       };
     }


### PR DESCRIPTION
## What

`visibleInSourceNow` is a hard, signal-only invariant the notification decision engine cannot override — yet it was enforced as a **post-decision** deterministic check (`runDeterministicChecks` → "source-active suppression"), which runs *after* the LLM-backed `evaluateSignal`.

So every statically-suppressed signal:
- paid for an LLM notification-decision inference whose result was then unconditionally discarded, and
- reached the home-feed mirror or not **depending on the LLM's `shouldNotify` output** (the mirror runs on the `shouldNotify:false` fall-through, bypassing the post-decision suppression check) — rather than on the invariant itself.

A cheap, deterministic, signal-only gate has no business running after the expensive probabilistic stage.

## Change

Lift `checkSourceActiveSuppression` to a **pre-decision gate** in `emitNotificationSignal`, right after event persistence and before `evaluateSignal`:
- The event row (lifecycle/audit anchor — the trusted-contacts runbook queries `notification_events`) is **still written**.
- The LLM inference, the discarded decision row, and the LLM-dependent home-feed mirror are **all skipped**.
- Source-active is **removed** from `runDeterministicChecks` (moved, not duplicated), whose remaining checks are all decision-dependent — matching its docstring.

## Blast radius / safety

The only production signal with `visibleInSourceNow: true` is the trusted-contact `verification_sent` lifecycle event, and nothing reads decision rows for never-delivered signals (readers reach decisions through `notification_deliveries`, which a suppressed signal never has; the runbook's `LEFT JOIN` tolerates the absence). No security/caching/LLM-correctness regression — verification-code minting/identity-binding/delivery is untouched. **No user-facing change** — just no wasted inference and deterministic suppression.

## Tests

- New `emitNotificationSignal` test: a `visibleInSourceNow` signal short-circuits **before** `evaluateSignal` (no LLM call, no dispatch) while the event row is still persisted; a `visibleInSourceNow: false` control still hits the decision engine.
- New unit tests for the exported `checkSourceActiveSuppression`, plus a regression that `runDeterministicChecks` does not apply source-active suppression (it's handled by the pre-gate).

`tsc`, `eslint`, and both affected suites pass.

## Context

Split out of #35358 / LUM-2507 (the trusted-contact `verification_sent` emit), where this surfaced during a first-principles audit. It's a separate concern — core notification pipeline, broader blast radius than the approvals-scoped verification_sent fix — so it gets its own focused review and revert unit.

Closes LUM-2520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015B2dK2YjCb5E5Yz7XmnWAB)_