### PR TITLE
fix(web): never strand the user on a stale confirmation prompt

### DIFF
--- a/clients/web/src/domains/chat/confirmation-actions.test.ts
+++ b/clients/web/src/domains/chat/confirmation-actions.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Reactive safety net for stale confirmation prompts.
+ *
+ * When the daemon has already discarded a pending interaction (the turn
+ * ended, the tool call timed out, the prompt was superseded, or a daemon
+ * restart dropped it), `POST /v1/confirm` returns 404. The matching
+ * `interaction_resolved` SSE event that would normally retire the card can be
+ * missed entirely (the web / iOS SSE stream tears down on app background and
+ * has no replay), so the prompt lingers. Tapping Allow/Deny must not strand
+ * the user on an un-actionable card.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { SubmitSecretResponseResult } from "@/domains/chat/api/interactions";
+
+let submitConfirmationResult: SubmitSecretResponseResult = { ok: true };
+const submitConfirmationCalls: Array<{ requestId: string; decision: string }> =
+  [];
+
+mock.module("@/domains/chat/api/interactions", () => ({
+  submitConfirmation: async (
+    _assistantId: string,
+    requestId: string,
+    decision: string,
+  ): Promise<SubmitSecretResponseResult> => {
+    submitConfirmationCalls.push({ requestId, decision });
+    return submitConfirmationResult;
+  },
+}));
+
+const { handleConfirmationSubmit } = await import(
+  "@/domains/chat/confirmation-actions"
+);
+const { useInteractionStore } = await import(
+  "@/domains/chat/interaction-store"
+);
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
+const { useStreamStore } = await import("@/domains/chat/stream-store");
+
+function seedPendingConfirmation(requestId: string): void {
+  useStreamStore.getState().setStreamContext({
+    assistantId: "ast-1",
+    conversationId: "conv-1",
+  });
+  useInteractionStore.getState().showConfirmation({
+    requestId,
+    toolName: "acp_spawn",
+    riskLevel: "high",
+    input: {},
+  });
+}
+
+beforeEach(() => {
+  submitConfirmationCalls.length = 0;
+  submitConfirmationResult = { ok: true };
+  useInteractionStore.getState().resetAll();
+  useChatSessionStore.getState().setError(null);
+  useStreamStore.getState().setStreamContext(null);
+});
+
+describe("handleConfirmationSubmit — stale (404) interaction", () => {
+  it("retires the prompt without surfacing a blocking error", async () => {
+    submitConfirmationResult = {
+      ok: false,
+      status: 404,
+      error: "No pending interaction found for this requestId",
+    };
+    seedPendingConfirmation("cr-stale");
+
+    await handleConfirmationSubmit("allow");
+
+    expect(submitConfirmationCalls).toHaveLength(1);
+    expect(useInteractionStore.getState().pendingConfirmation).toBeNull();
+    expect(useInteractionStore.getState().isSubmittingConfirmation).toBe(false);
+    // No error banner — the user is not stranded on an un-actionable card.
+    expect(useChatSessionStore.getState().error).toBeNull();
+  });
+
+  it("still surfaces an error for non-404 failures", async () => {
+    submitConfirmationResult = {
+      ok: false,
+      status: 500,
+      error: "Internal error",
+    };
+    seedPendingConfirmation("cr-500");
+
+    await handleConfirmationSubmit("deny");
+
+    // The prompt stays so the user can retry a transient failure.
+    expect(useInteractionStore.getState().pendingConfirmation?.requestId).toBe(
+      "cr-500",
+    );
+    expect(useChatSessionStore.getState().error?.message).toBe("Internal error");
+  });
+});

--- a/clients/web/src/domains/chat/confirmation-actions.ts
+++ b/clients/web/src/domains/chat/confirmation-actions.ts
@@ -109,6 +109,39 @@ function cleanupAfterConfirmationDecision(
   useInteractionStore.getState().submitConfirmationEnd();
 }
 
+/**
+ * Clear a confirmation prompt the daemon has already discarded.
+ *
+ * A confirmation POST comes back 404 ("No pending interaction found for this
+ * requestId") when the server-side pending interaction is gone — the turn
+ * ended, the tool call timed out, the prompt was superseded, or a daemon
+ * restart dropped it. This is terminal and non-retryable: the decision is moot
+ * because the server has moved on. The matching `interaction_resolved` SSE
+ * event that would normally retire the card can be missed entirely (the web /
+ * iOS SSE stream tears down on app background and has no replay), so the stale
+ * prompt lingers — leaving the user tapping Allow/Deny into the same 404.
+ *
+ * Retire the prompt without surfacing a blocking error so the user is never
+ * stranded. No decision is stamped on the tool call — none was applied; the
+ * transcript already reflects the tool call's own outcome.
+ */
+function clearStaleConfirmation(snapshot: PendingConfirmationState): void {
+  useInteractionStore.getState().dismissConfirmation();
+  useInteractionStore.getState().setInlineConfirmationToolCallId(null);
+  const convKey = useConversationStore.getState().activeConversationId;
+  if (convKey) {
+    useConversationStore.getState().removeAttentionConversationId(convKey);
+  }
+  useChatSessionStore
+    .getState()
+    .setMessages((prev: DisplayMessage[]) =>
+      clearConfirmationByRequestId(prev, snapshot.requestId),
+    );
+  useChatSessionStore.getState().deleteConfirmationToolCall(snapshot.requestId);
+  useChatSessionStore.getState().setError(null);
+  useInteractionStore.getState().submitConfirmationEnd();
+}
+
 // ---------------------------------------------------------------------------
 // Public actions
 // ---------------------------------------------------------------------------
@@ -162,6 +195,12 @@ export async function handleConfirmationSubmit(
     );
 
     if (!result.ok) {
+      if (result.status === 404) {
+        // Pending interaction already gone server-side — retire the stale
+        // prompt instead of stranding the user on an un-actionable card.
+        clearStaleConfirmation(snapshot);
+        return;
+      }
       useChatSessionStore.getState().setError({ message: result.error });
       useInteractionStore.getState().submitConfirmationEnd();
       return;
@@ -229,7 +268,12 @@ export async function handleAllowAndCreateRule(toolCall?: ChatMessageToolCall): 
     );
 
     if (!result.ok) {
-      useChatSessionStore.getState().setError({ message: result.error });
+      // A 404 means the pending interaction is already gone server-side; the
+      // user can still create a rule, so retire the prompt quietly rather than
+      // surfacing a blocking "No pending interaction" error they can't act on.
+      useChatSessionStore
+        .getState()
+        .setError(result.status === 404 ? null : { message: result.error });
       useInteractionStore.getState().submitConfirmationEnd();
       useInteractionStore.getState().setInlineConfirmationToolCallId(null);
       useChatSessionStore.getState().setMessages((prev: DisplayMessage[]) => clearConfirmationByRequestId(prev, snapshot.requestId));

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -38,6 +38,7 @@ import {
   handleSecretRequest,
   handleConfirmationRequest,
   handleContactRequest,
+  handleInteractionResolved,
   handleQuestionRequest,
 } from "@/domains/chat/utils/stream-handlers/interaction-handlers";
 import {
@@ -409,7 +410,13 @@ export function useStreamEventHandler(
         case "document_comment_resolved":
         case "document_comment_reopened":
         case "document_comment_deleted":
+          break;
+        // The daemon resolved a pending interaction for the active
+        // conversation. Attention tracking handles non-active conversations
+        // and defers the active one here, so retire any matching confirmation
+        // card before the user can tap a prompt the server has discarded.
         case "interaction_resolved":
+          handleInteractionResolved(event, ctx);
           break;
         // Diagnostic timeline events. The logs domain fetches these from
         // the daemon's trace-events endpoint on demand; the chat stream

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it, beforeEach } from "bun:test";
 
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import {
   handleSecretRequest,
   handleConfirmationRequest,
   handleContactRequest,
+  handleInteractionResolved,
 } from "@/domains/chat/utils/stream-handlers/interaction-handlers";
 
 beforeEach(() => {
   useInteractionStore.getState().resetAll();
+  useChatSessionStore.getState().deleteConfirmationToolCall("cr-1");
 });
 
 describe("handleSecretRequest", () => {
@@ -53,6 +56,91 @@ describe("handleConfirmationRequest", () => {
     const state = useInteractionStore.getState();
     expect(state.pendingConfirmation).toMatchObject({ requestId: "cr-1" });
     expect(ctx.setMessages).toHaveBeenCalled();
+  });
+});
+
+describe("handleInteractionResolved", () => {
+  it("retires the active confirmation card when its interaction resolves", () => {
+    const ctx = makeCtx();
+    useInteractionStore.getState().showConfirmation({
+      requestId: "cr-1",
+      toolName: "acp_spawn",
+      riskLevel: "high",
+      input: {},
+    });
+    useInteractionStore.getState().setInlineConfirmationToolCallId("tc-1");
+    useChatSessionStore.getState().setConfirmationToolCall("cr-1", "tc-1");
+
+    handleInteractionResolved(
+      {
+        type: "interaction_resolved",
+        requestId: "cr-1",
+        conversationId: "conv-1",
+        kind: "confirmation",
+        state: "cancelled",
+      },
+      ctx,
+    );
+
+    const interaction = useInteractionStore.getState();
+    expect(interaction.pendingConfirmation).toBeNull();
+    expect(interaction.inlineConfirmationToolCallId).toBeNull();
+    expect(ctx.setMessages).toHaveBeenCalled();
+    expect(
+      useChatSessionStore.getState().confirmationToolCallMap.has("cr-1"),
+    ).toBe(false);
+  });
+
+  it("leaves a non-matching confirmation untouched", () => {
+    const ctx = makeCtx();
+    useInteractionStore.getState().showConfirmation({
+      requestId: "cr-1",
+      toolName: "acp_spawn",
+      riskLevel: "high",
+      input: {},
+    });
+
+    handleInteractionResolved(
+      {
+        type: "interaction_resolved",
+        requestId: "other-request",
+        conversationId: "conv-1",
+        kind: "confirmation",
+        state: "cancelled",
+      },
+      ctx,
+    );
+
+    expect(
+      useInteractionStore.getState().pendingConfirmation?.requestId,
+    ).toBe("cr-1");
+  });
+
+  it("ignores non-confirmation interaction kinds", () => {
+    const ctx = makeCtx();
+    useInteractionStore.getState().showConfirmation({
+      requestId: "cr-1",
+      toolName: "acp_spawn",
+      riskLevel: "high",
+      input: {},
+    });
+
+    handleInteractionResolved(
+      {
+        type: "interaction_resolved",
+        requestId: "cr-1",
+        conversationId: "conv-1",
+        kind: "host_bash",
+        state: "cancelled",
+      },
+      ctx,
+    );
+
+    // Host-proxy steps own their own lifecycle and must not clear the card.
+    expect(
+      useInteractionStore.getState().pendingConfirmation?.requestId,
+    ).toBe("cr-1");
+    expect(ctx.setMessages).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
@@ -1,10 +1,13 @@
 import { attachConfirmationToToolCall } from "@/domains/chat/utils/chat";
 import type { PendingConfirmationState } from "@/domains/chat/types";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { clearConfirmationByRequestId } from "@/domains/chat/utils/send-message-utils";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import type {
   ConfirmationRequestEvent,
   ContactRequestEvent,
+  InteractionResolvedEvent,
   QuestionRequestEvent,
   SecretRequestEvent,
 } from "@vellumai/assistant-api";
@@ -62,6 +65,47 @@ export function handleConfirmationRequest(
   } else {
     useInteractionStore.getState().setInlineConfirmationToolCallId(null);
   }
+}
+
+/**
+ * Retire an active confirmation prompt when the daemon reports its pending
+ * interaction has resolved (approved, rejected, cancelled, or superseded).
+ *
+ * `interaction_resolved` is conversation-scoped, so by the time it reaches a
+ * chat stream handler it is guaranteed to be for the active conversation.
+ * Attention tracking (`use-attention-tracking`) deliberately skips the active
+ * conversation and defers its confirmation card to this handler — so without
+ * it, a confirmation the daemon has already discarded (e.g. an `acp_spawn`
+ * that timed out) would linger on screen with no way to act on it, and tapping
+ * Allow/Deny would 404.
+ *
+ * Only confirmation kinds render a card here; other kinds (host-proxy steps,
+ * secrets, questions) own their own lifecycle. The requestId guards make a
+ * mismatched or already-cleared confirmation a no-op.
+ */
+export function handleInteractionResolved(
+  event: InteractionResolvedEvent,
+  ctx: StreamHandlerContext,
+): void {
+  if (event.kind !== "confirmation" && event.kind !== "acp_confirmation") {
+    return;
+  }
+  const { requestId } = event;
+  const session = useChatSessionStore.getState();
+  const interaction = useInteractionStore.getState();
+
+  interaction.dismissConfirmationIfMatches(requestId);
+
+  const mappedToolCallId = session.confirmationToolCallMap.get(requestId);
+  if (
+    mappedToolCallId &&
+    interaction.inlineConfirmationToolCallId === mappedToolCallId
+  ) {
+    interaction.setInlineConfirmationToolCallId(null);
+  }
+
+  ctx.setMessages((prev) => clearConfirmationByRequestId(prev, requestId));
+  session.deleteConfirmationToolCall(requestId);
 }
 
 export function handleContactRequest(


### PR DESCRIPTION
## Problem

A user reported (on iOS): *"Can't make it past this permission prompt and error message."* The confirmation card stays on screen showing **"No pending interaction found for this requestId"**, and tapping **Allow/Deny** just re-triggers the same error — the user is permanently stuck.

## Root cause (from the attached feedback bundle)

The session shows an `acp_spawn` ("Spawn Claude Opus") confirmation, `requestId 2a9f99f1…`, in conversation `43925d32…`. The diagnostics make the failure mode clear:

- The `acp_spawn` tool calls **timed out at "5m 0s"** (visible in the screenshot). When the daemon discards a pending interaction, `POST /v1/confirm` returns **404** (`NotFoundError("No pending interaction found for this requestId")`).
- The web client surfaced that raw 404 as a **blocking error banner and kept the card** (`handleConfirmationSubmit` set the error and returned *without* cleanup), so every subsequent tap re-hit the same 404.
- The daemon **does** emit an `interaction_resolved` SSE event that should retire the card — but the iOS app was bouncing between conversations and backgrounding repeatedly (many `app.hidden`/`app.resume` + SSE reconnects in the lifecycle log). The SSE stream is **live-only with no replay**, so that event was permanently missed. During the capture window the stream was even delivering events for *other* conversations (198 `sse_event_wrong_conversation_filtered`).
- Even when received live, the chat stream handler **no-op'd `interaction_resolved`** for the active conversation — while `use-attention-tracking` deliberately *skips* the active conversation and defers to the chat view. So nothing ever cleared the active card.

## Fix (both angles)

1. **Reactive safety net** (`confirmation-actions.ts`): a 404 on confirm submit is terminal and non-retryable — the server has moved on. Quietly retire the prompt (dismiss card, clear inline confirmation, drop attention) instead of showing a blocking, un-actionable error. Non-404 failures still surface so transient errors remain retryable. `handleAllowAndCreateRule` similarly suppresses the scary banner on 404.
2. **Proactive** (`use-stream-event-handler.ts` + `interaction-handlers.ts`): handle `interaction_resolved` in the chat stream handler to clear the active conversation's confirmation card by `requestId` (confirmation kinds only; requestId-guarded so mismatches are no-ops).

The reactive fix is the guaranteed unblock for the exact scenario here (missed SSE due to backgrounding); the proactive fix prevents the stale card in the common live case.

## Tests
- `confirmation-actions.test.ts` (new): 404 retires the prompt with no error banner; non-404 still surfaces an error and keeps the card.
- `interaction-handlers.test.ts`: `handleInteractionResolved` clears a matching active card, leaves non-matching ones, and ignores non-confirmation kinds.

`bunx tsc --noEmit` and `eslint` clean; affected suites green. (An unrelated `slack-channel-footer.test.tsx` happy-dom/bun segfault exists on the suite and is independent of these files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLFhLMSVD8HdLFZpkEJ26b)_