### PR TITLE
fix(gateway): contact-prompt non-guardian path writes gateway-first via upsertContact

### DIFF
--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -263,7 +263,7 @@ describe("handleContactPromptSubmit", () => {
     expect(typeof ipcCall.body.error).toBe("string");
   });
 
-  test("non-guardian prompt — creates new contact and channel", async () => {
+  test("non-guardian prompt — creates new contact and channel (gateway-first)", async () => {
     const res = await handleContactPromptSubmit(
       makeRequest({
         requestId: "req-4",
@@ -276,31 +276,102 @@ describe("handleContactPromptSubmit", () => {
 
     expect(res.status).toBe(200);
 
-    const contacts = testAssistantDb!
-      .prepare(`SELECT id, role FROM contacts WHERE display_name = 'Alice'`)
-      .all() as { id: string; role: string }[];
-    expect(contacts).toHaveLength(1);
-    expect(contacts[0].role).toBe("contact");
+    // Gateway DB is the source of truth: contact + channel rows must exist
+    // (unverified / allow / primary).
+    const gwContactRows = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.displayName, "Alice"))
+      .all();
+    expect(gwContactRows).toHaveLength(1);
+    expect(gwContactRows[0].role).toBe("contact");
 
-    const channels = testAssistantDb!
-      .prepare(`SELECT contact_id FROM contact_channels WHERE type = 'email' AND address = ?`)
-      .all("alice@example.com") as { contact_id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].contact_id).toBe(contacts[0].id);
+    const gwChannelRows = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "alice@example.com"))
+      .all();
+    expect(gwChannelRows).toHaveLength(1);
+    expect(gwChannelRows[0].contactId).toBe(gwContactRows[0].id);
+    expect(gwChannelRows[0].status).toBe("unverified");
+    expect(gwChannelRows[0].policy).toBe("allow");
+    expect(gwChannelRows[0].isPrimary).toBe(true);
+
+    // The channel id handed to resolve_contact_prompt matches the gateway row.
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    expect(ipcCall.body.channelId).toBe(gwChannelRows[0].id);
+    expect(ipcCall.body.contactId).toBe(gwContactRows[0].id);
   });
 
-  test("non-guardian prompt — reuses existing contact when channel already known", async () => {
+  test("non-guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
+    // Make the best-effort assistant-DB mirror fail. The gateway-first write
+    // must still succeed and the request still be accepted.
+    const realDb = testAssistantDb!;
+    testAssistantDb = {
+      prepare() {
+        throw new Error("assistant DB mirror unavailable");
+      },
+    } as unknown as Database;
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-mirror",
+          address: "bob@example.com",
+          channelType: "email",
+          role: "trusted-contact",
+          displayName: "Bob",
+        }),
+      );
+    } finally {
+      testAssistantDb = realDb;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Gateway DB rows are present despite the mirror failure.
+    const gwChannelRows = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "bob@example.com"))
+      .all();
+    expect(gwChannelRows).toHaveLength(1);
+
+    const gwContactRows = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.id, gwChannelRows[0].contactId))
+      .all();
+    expect(gwContactRows).toHaveLength(1);
+  });
+
+  test("non-guardian prompt — reuses existing gateway contact and preserves name when displayName omitted", async () => {
     const now = Date.now();
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('contact-1', 'Alice', 'contact', 'human', ?, ?)`,
-      [now, now],
-    );
-    testAssistantDb!.run(
-      `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-       VALUES ('chan-alice', 'contact-1', 'email', 'alice@example.com', 1, 'active', 'allow', 3, ?, ?)`,
-      [now, now],
-    );
+    // Seed an existing gateway contact + channel (gateway DB is the source of
+    // truth for the reuse-by-channel lookup).
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({ id: "contact-1", displayName: "Alice", role: "contact", createdAt: now, updatedAt: now })
+      .run();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-alice",
+        contactId: "contact-1",
+        type: "email",
+        address: "alice@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 3,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-5", address: "alice@example.com", channelType: "email" }),
@@ -308,14 +379,14 @@ describe("handleContactPromptSubmit", () => {
 
     expect(res.status).toBe(200);
 
-    // Should not have created a second contact.
-    const contacts = testAssistantDb!
-      .prepare(`SELECT id FROM contacts`)
-      .all() as { id: string }[];
-    expect(contacts).toHaveLength(1);
-    expect(contacts[0].id).toBe("contact-1");
+    // No duplicate contact row; the existing contact id is reused.
+    const gwContactRows = getGatewayDb().select().from(gwContacts).all();
+    expect(gwContactRows).toHaveLength(1);
+    expect(gwContactRows[0].id).toBe("contact-1");
+    // display_name not clobbered when displayName omitted from the body.
+    expect(gwContactRows[0].displayName).toBe("Alice");
 
-     
+
     const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
     expect(ipcCall.body.contactId).toBe("contact-1");
   });

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -6,7 +6,8 @@
  * Called by the client after the user fills in a contact address in response
  * to a `contact_request` broadcast from the daemon. This route:
  *   1. Validates the submitted contact info.
- *   2. Upserts the contact + channel via the assistant DB proxy (gateway owns writes).
+ *   2. Upserts the contact + channel gateway-first via ContactStore.upsertContact
+ *      (gateway DB is the source of truth; assistant DB is a best-effort mirror).
  *   3. Calls daemon IPC `resolve_contact_prompt` to unblock the waiting CLI.
  *   4. Returns { accepted: true } to the client.
  *
@@ -20,6 +21,7 @@ import {
   assistantDbRun,
 } from "../../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../../db/connection.js";
+import { ContactStore } from "../../db/contact-store.js";
 import {
   contactChannels as gwContactChannels,
   contacts as gwContacts,
@@ -29,6 +31,15 @@ import { getLogger } from "../../logger.js";
 import { canonicalizeInboundIdentity } from "../../verification/identity.js";
 
 const log = getLogger("contact-prompt");
+
+let store: ContactStore | null = null;
+
+function getStore(): ContactStore {
+  if (!store) {
+    store = new ContactStore();
+  }
+  return store;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -140,40 +151,43 @@ export async function handleContactPromptSubmit(
         }
       }
     } else {
-      // Reuse an existing contact if this channel address is already known.
-      const existingForChannel = await assistantDbQuery<{ contactId: string }>(
-        `SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1`,
-        [channelType, normalizedAddress],
-      );
-      if (existingForChannel.length > 0) {
-        contactId = existingForChannel[0].contactId;
-      } else {
-        contactId = crypto.randomUUID();
-        createdNewContact = true;
-        await assistantDbRun(
-          `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-           VALUES (?, ?, ?, 'human', ?, ?)`,
-          [contactId, effectiveDisplayName, effectiveRole, now, now],
+      // Non-guardian: resolve/create the contact + channel gateway-first via
+      // ContactStore.upsertContact. The gateway DB is the source of truth; the
+      // assistant DB receives a best-effort mirror.
+      const store = getStore();
+      const { contact } = await store.upsertContact({
+        // omit-to-preserve: pass the caller's optional displayName, NOT
+        // effectiveDisplayName. An existing contact keeps its name; a brand-new
+        // contact falls back to the canonical channel address inside upsertContact.
+        displayName,
+        channels: [
+          { type: channelType, address: normalizedAddress, isPrimary: true },
+        ],
+      });
+      contactId = contact.id;
+      const channel = store
+        .getChannelsForContact(contactId)
+        .find(
+          (ch) =>
+            ch.type === channelType &&
+            ch.address.toLowerCase() === normalizedAddress.toLowerCase(),
         );
-        try {
-          getGatewayDb()
-            .insert(gwContacts)
-            .values({
-              id: contactId,
-              displayName: effectiveDisplayName,
-              role: effectiveRole,
-              createdAt: now,
-              updatedAt: now,
-            })
-            .onConflictDoNothing()
-            .run();
-        } catch (gwErr) {
-          log.warn(
-            { err: gwErr },
-            "contact-prompt-submit: gateway DB contact INSERT dual-write failed",
-          );
-        }
-      }
+      channelId = channel?.id ?? "";
+
+      log.info(
+        { channelType, address: normalizedAddress, contactId, channelId },
+        "contact-prompt-submit: upserted contact + channel via ContactStore",
+      );
+
+      // Non-guardian is fully resolved by upsertContact; skip the guardian-only
+      // Phase 2 channel-creation block below and go straight to resolve.
+      return await resolveContactPrompt({
+        requestId,
+        contactId,
+        channelId,
+        channelType,
+        address: normalizedAddress,
+      });
     }
 
     // -----------------------------------------------------------------------
@@ -304,16 +318,31 @@ export async function handleContactPromptSubmit(
     );
   }
 
-  // Notify daemon to unblock the waiting contacts/prompt IPC call.
+  return await resolveContactPrompt({
+    requestId,
+    contactId,
+    channelId,
+    channelType,
+    address: normalizedAddress,
+  });
+}
+
+/**
+ * Notify the daemon to unblock the waiting contacts/prompt IPC call, then
+ * return { accepted: true }. IPC failures are best-effort — they only mean the
+ * CLI may time out, not that the write failed.
+ */
+async function resolveContactPrompt(args: {
+  requestId: string;
+  contactId: string;
+  channelId: string;
+  channelType: string;
+  address: string;
+}): Promise<Response> {
+  const { requestId, contactId, channelId, channelType, address } = args;
   try {
     const ipcResult = await ipcCallAssistant("resolve_contact_prompt", {
-      body: {
-        requestId,
-        contactId,
-        channelId,
-        channelType,
-        address: normalizedAddress,
-      },
+      body: { requestId, contactId, channelId, channelType, address },
     });
     if ((ipcResult as { resolved?: boolean }).resolved === false) {
       log.warn(


### PR DESCRIPTION
## Summary
- Non-guardian contact-prompt submit now resolves+creates the contact and channel via ContactStore.upsertContact (gateway DB source of truth, assistant DB best-effort mirror), replacing the assistant-first raw SQL flow.
- Guardian branch left unchanged (converted in PR 2).

Part of plan: contacts-prompt-gateway-first.md (PR 1 of 2)