### PR TITLE
fix(gateway): contact-prompt guardian path resolves + binds channel gateway-first

### DIFF
--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -161,14 +161,24 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("handleContactPromptSubmit", () => {
-  test("guardian prompt — creates channel bound to existing guardian contact", async () => {
+  // Seed a guardian contact into BOTH the gateway DB (source of truth) and the
+  // assistant DB mirror. The handler resolves the guardian from the gateway DB;
+  // the assistant row keeps the FK for the best-effort channel mirror.
+  function seedGuardian(id = "guardian-1", name = "Vargas"): void {
     const now = Date.now();
-    // Seed an existing guardian contact in the assistant DB.
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({ id, displayName: name, role: "guardian", createdAt: now, updatedAt: now })
+      .run();
     testAssistantDb!.run(
       `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('guardian-1', 'Vargas', 'guardian', 'human', ?, ?)`,
-      [now, now],
+       VALUES (?, ?, 'guardian', 'human', ?, ?)`,
+      [id, name, now, now],
     );
+  }
+
+  test("guardian prompt — binds channel to existing gateway guardian, role preserved", async () => {
+    seedGuardian();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-1", address: "+15551234567", channelType: "phone", role: "guardian" }),
@@ -178,32 +188,50 @@ describe("handleContactPromptSubmit", () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body.accepted).toBe(true);
 
-    // Channel should be created in assistant DB pointing to guardian.
-    const channels = testAssistantDb!
-      .prepare(`SELECT contact_id FROM contact_channels WHERE type = 'phone' AND address = ?`)
-      .all("+15551234567") as { contact_id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].contact_id).toBe("guardian-1");
+    // Gateway DB is the source of truth: channel row bound to the guardian.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15551234567"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].contactId).toBe("guardian-1");
 
-    // IPC should have been called with the guardian contactId.
+    // Guardian role must be preserved on the gateway contact row.
+    const gwGuardian = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.id, "guardian-1"))
+      .all();
+    expect(gwGuardian).toHaveLength(1);
+    expect(gwGuardian[0].role).toBe("guardian");
+
+    // IPC should have been called with the guardian contactId + gateway channel id.
     expect(ipcMock).toHaveBeenCalledTimes(1);
-     
+
     const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
     expect(ipcCall.body.contactId).toBe("guardian-1");
+    expect(ipcCall.body.channelId).toBe(gwChannels[0].id);
   });
 
   test("guardian prompt — reuses channel already bound to guardian", async () => {
     const now = Date.now();
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('guardian-1', 'Vargas', 'guardian', 'human', ?, ?)`,
-      [now, now],
-    );
-    testAssistantDb!.run(
-      `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-       VALUES ('chan-1', 'guardian-1', 'phone', '+15551234567', 1, 'active', 'allow', 5, ?, ?)`,
-      [now, now],
-    );
+    seedGuardian();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-1",
+        contactId: "guardian-1",
+        type: "phone",
+        address: "+15551234567",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 5,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-2", address: "+15551234567", channelType: "phone", role: "guardian" }),
@@ -213,33 +241,44 @@ describe("handleContactPromptSubmit", () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body.accepted).toBe(true);
 
-    // No new channel should have been inserted.
-    const channels = testAssistantDb!
-      .prepare(`SELECT id FROM contact_channels WHERE type = 'phone'`)
-      .all() as { id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].id).toBe("chan-1");
+    // No new channel should have been inserted in the gateway DB.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.type, "phone"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-1");
+
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    expect(ipcCall.body.channelId).toBe("chan-1");
   });
 
   test("guardian prompt — 409 when channel already belongs to another contact", async () => {
     const now = Date.now();
-    // Guardian contact.
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('guardian-1', 'Vargas', 'guardian', 'human', ?, ?)`,
-      [now, now],
-    );
-    // A different (orphaned or stale) contact that owns the channel.
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('other-1', 'Orphan', 'contact', 'human', ?, ?)`,
-      [now, now],
-    );
-    testAssistantDb!.run(
-      `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-       VALUES ('chan-other', 'other-1', 'phone', '+15551234567', 1, 'unverified', 'allow', 0, ?, ?)`,
-      [now, now],
-    );
+    seedGuardian();
+    // A different (orphaned or stale) contact that owns the channel in the
+    // gateway DB.
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({ id: "other-1", displayName: "Orphan", role: "contact", createdAt: now, updatedAt: now })
+      .run();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-other",
+        contactId: "other-1",
+        type: "phone",
+        address: "+15551234567",
+        isPrimary: true,
+        status: "unverified",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-3", address: "+15551234567", channelType: "phone", role: "guardian" }),
@@ -249,18 +288,96 @@ describe("handleContactPromptSubmit", () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body.accepted).toBe(false);
 
-    // The stale channel must not have been deleted.
-    const channels = testAssistantDb!
-      .prepare(`SELECT id FROM contact_channels WHERE type = 'phone'`)
-      .all() as { id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].id).toBe("chan-other");
+    // The stale gateway channel must not have been deleted or reassigned, and no
+    // new channel row created for the guardian.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.type, "phone"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-other");
+    expect(gwChannels[0].contactId).toBe("other-1");
+
+    // No assistant-DB channel write occurred for that address either.
+    const asChannels = testAssistantDb!
+      .prepare(`SELECT id FROM contact_channels WHERE address = ?`)
+      .all("+15551234567") as { id: string }[];
+    expect(asChannels).toHaveLength(0);
 
     // IPC should have been called with an error so the CLI doesn't hang.
     expect(ipcMock).toHaveBeenCalledTimes(1);
-     
+
     const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
     expect(typeof ipcCall.body.error).toBe("string");
+  });
+
+  test("guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
+    seedGuardian();
+
+    // Make the best-effort assistant-DB mirror fail. The gateway-first write
+    // must still succeed and the request still be accepted.
+    const realDb = testAssistantDb!;
+    testAssistantDb = {
+      prepare() {
+        throw new Error("assistant DB mirror unavailable");
+      },
+    } as unknown as Database;
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({ requestId: "req-mirror-g", address: "+15550009999", channelType: "phone", role: "guardian" }),
+      );
+    } finally {
+      testAssistantDb = realDb;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Gateway DB guardian channel row is present despite the mirror failure.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15550009999"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].contactId).toBe("guardian-1");
+  });
+
+  test("guardian prompt — creates guardian gateway-first when none exists (bootstrap sub-case)", async () => {
+    // No guardian seeded anywhere — handler must mint one gateway-first.
+    const res = await handleContactPromptSubmit(
+      makeRequest({ requestId: "req-boot", address: "+15557654321", channelType: "phone", role: "guardian", displayName: "Boot Guardian" }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Guardian created in the gateway DB with role=guardian.
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(1);
+    expect(gwGuardians[0].displayName).toBe("Boot Guardian");
+
+    // Channel bound to the newly minted guardian.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15557654321"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].contactId).toBe(gwGuardians[0].id);
+
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    expect(ipcCall.body.contactId).toBe(gwGuardians[0].id);
   });
 
   test("non-guardian prompt — creates new contact and channel (gateway-first)", async () => {

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -14,12 +14,9 @@
  * Auth: edge (same as all ingress contact routes).
  */
 
-import { eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 
-import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../../db/assistant-db-proxy.js";
+import { assistantDbRun } from "../../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../../db/connection.js";
 import { ContactStore } from "../../db/contact-store.js";
 import {
@@ -39,6 +36,25 @@ function getStore(): ContactStore {
     store = new ContactStore();
   }
   return store;
+}
+
+/**
+ * Resolve the id of the just-bound channel from the gateway DB (the source of
+ * truth `upsertContact` wrote to). Returns "" if not found.
+ */
+function resolveChannelId(
+  contactId: string,
+  channelType: string,
+  address: string,
+): string {
+  const channel = getStore()
+    .getChannelsForContact(contactId)
+    .find(
+      (ch) =>
+        ch.type === channelType &&
+        ch.address.toLowerCase() === address.toLowerCase(),
+    );
+  return channel?.id ?? "";
 }
 
 // ---------------------------------------------------------------------------
@@ -112,41 +128,49 @@ export async function handleContactPromptSubmit(
     let createdNewContact = false;
 
     if (effectiveRole === "guardian") {
-      const guardianRows = await assistantDbQuery<{ id: string }>(
-        `SELECT id FROM contacts WHERE role = 'guardian' ORDER BY created_at ASC LIMIT 1`,
-        [],
-      );
-      if (guardianRows.length > 0) {
-        contactId = guardianRows[0].id;
+      // Guardian lives in the gateway DB (source of truth) — bootstrap
+      // dual-writes it there. Resolve from there, not the assistant mirror.
+      const guardianRow = getGatewayDb()
+        .select({ id: gwContacts.id })
+        .from(gwContacts)
+        .where(eq(gwContacts.role, "guardian"))
+        .orderBy(asc(gwContacts.createdAt))
+        .get();
+      if (guardianRow) {
+        contactId = guardianRow.id;
       } else {
-        // Bootstrap hasn't run yet — create the guardian contact.
+        // Bootstrap hasn't run yet — create the guardian contact gateway-first.
+        // upsertContact can't be used here: its create path forces
+        // role="contact". Guardian role writes stay raw per the
+        // ContactStore.upsertContact SECURITY note, but hit the gateway DB
+        // (source of truth) first, then mirror to the assistant DB best-effort.
         log.warn(
           { channelType, address: normalizedAddress },
           "contact-prompt-submit: no guardian contact found, creating one",
         );
         contactId = crypto.randomUUID();
         createdNewContact = true;
-        await assistantDbRun(
-          `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-           VALUES (?, ?, 'guardian', 'human', ?, ?)`,
-          [contactId, effectiveDisplayName, now, now],
-        );
+        getGatewayDb()
+          .insert(gwContacts)
+          .values({
+            id: contactId,
+            displayName: effectiveDisplayName,
+            role: "guardian",
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoNothing()
+          .run();
         try {
-          getGatewayDb()
-            .insert(gwContacts)
-            .values({
-              id: contactId,
-              displayName: effectiveDisplayName,
-              role: "guardian",
-              createdAt: now,
-              updatedAt: now,
-            })
-            .onConflictDoNothing()
-            .run();
-        } catch (gwErr) {
+          await assistantDbRun(
+            `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
+             VALUES (?, ?, 'guardian', 'human', ?, ?)`,
+            [contactId, effectiveDisplayName, now, now],
+          );
+        } catch (mirrorErr) {
           log.warn(
-            { err: gwErr },
-            "contact-prompt-submit: gateway DB guardian contact INSERT dual-write failed",
+            { err: mirrorErr },
+            "contact-prompt-submit: assistant DB guardian contact mirror INSERT failed",
           );
         }
       }
@@ -165,14 +189,7 @@ export async function handleContactPromptSubmit(
         ],
       });
       contactId = contact.id;
-      const channel = store
-        .getChannelsForContact(contactId)
-        .find(
-          (ch) =>
-            ch.type === channelType &&
-            ch.address.toLowerCase() === normalizedAddress.toLowerCase(),
-        );
-      channelId = channel?.id ?? "";
+      channelId = resolveChannelId(contactId, channelType, normalizedAddress);
 
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
@@ -198,24 +215,27 @@ export async function handleContactPromptSubmit(
     // is a conflict the caller must resolve — return 409.  Otherwise create a
     // new channel bound to the resolved contact.
     // -----------------------------------------------------------------------
-    const existingChannel = await assistantDbQuery<{
-      id: string;
-      contactId: string;
-    }>(
-      `SELECT id, contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1`,
-      [channelType, normalizedAddress],
-    );
+    const existingChannel = getGatewayDb()
+      .select({
+        id: gwContactChannels.id,
+        contactId: gwContactChannels.contactId,
+      })
+      .from(gwContactChannels)
+      .where(
+        and(
+          eq(gwContactChannels.type, channelType),
+          sql`${gwContactChannels.address} = ${normalizedAddress} COLLATE NOCASE`,
+        ),
+      )
+      .get();
 
-    if (
-      existingChannel.length > 0 &&
-      existingChannel[0].contactId === contactId
-    ) {
-      channelId = existingChannel[0].id;
+    if (existingChannel && existingChannel.contactId === contactId) {
+      channelId = existingChannel.id;
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: channel already exists",
       );
-    } else if (existingChannel.length > 0) {
+    } else if (existingChannel) {
       // Channel exists but belongs to a different contact.  The caller must
       // clean up the stale binding before a guardian channel can be created.
       log.warn(
@@ -223,7 +243,7 @@ export async function handleContactPromptSubmit(
           channelType,
           address: normalizedAddress,
           contactId,
-          existingContactId: existingChannel[0].contactId,
+          existingContactId: existingChannel.contactId,
         },
         "contact-prompt-submit: channel already assigned to another contact",
       );
@@ -239,56 +259,39 @@ export async function handleContactPromptSubmit(
         { status: 409 },
       );
     } else {
-      channelId = crypto.randomUUID();
-
       try {
-        await assistantDbRun(
-          `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-           VALUES (?, ?, ?, ?, 1, 'unverified', 'allow', 0, ?, ?)`,
-          [channelId, contactId, channelType, normalizedAddress, now, now],
-        );
-        try {
-          getGatewayDb()
-            .insert(gwContactChannels)
-            .values({
-              id: channelId,
-              contactId,
-              type: channelType,
-              address: normalizedAddress,
-              isPrimary: true,
-              status: "unverified",
-              policy: "allow",
-              interactionCount: 0,
-              createdAt: now,
-              updatedAt: now,
-            })
-            .onConflictDoNothing()
-            .run();
-        } catch (gwErr) {
-          log.warn(
-            { err: gwErr },
-            "contact-prompt-submit: gateway DB channel INSERT dual-write failed",
-          );
-        }
+        // Bind gateway-first. Passing the guardian's id keys the update to the
+        // existing guardian and preserves role="guardian" (upsertContact's
+        // id-path role preservation); the gateway channel is the source of
+        // truth, the assistant mirror is dual-written best-effort.
+        await getStore().upsertContact({
+          id: contactId,
+          channels: [
+            { type: channelType, address: normalizedAddress, isPrimary: true },
+          ],
+        });
+        channelId = resolveChannelId(contactId, channelType, normalizedAddress);
       } catch (channelErr) {
         // Compensating delete — only remove the contact if we created it here.
+        // "Stale over lost": delete gateway-first, then mirror the delete to
+        // the assistant DB best-effort.
         log.error(
           { channelErr, contactId, channelType },
-          "contact-prompt-submit: channel INSERT failed, rolling back contact",
+          "contact-prompt-submit: channel bind failed, rolling back contact",
         );
         if (createdNewContact) {
-          await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
-            contactId,
-          ]);
+          getGatewayDb()
+            .delete(gwContacts)
+            .where(eq(gwContacts.id, contactId))
+            .run();
           try {
-            getGatewayDb()
-              .delete(gwContacts)
-              .where(eq(gwContacts.id, contactId))
-              .run();
-          } catch (gwErr) {
+            await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
+              contactId,
+            ]);
+          } catch (mirrorErr) {
             log.warn(
-              { err: gwErr },
-              "contact-prompt-submit: gateway DB contact rollback DELETE dual-write failed",
+              { err: mirrorErr },
+              "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
             );
           }
         }


### PR DESCRIPTION
## Summary
- Guardian contact-prompt submit now resolves the guardian from the gateway DB and binds the channel via ContactStore.upsertContact (gateway source of truth, assistant best-effort mirror), preserving role=guardian.
- Bootstrap sub-case creates the guardian gateway-first; compensating cleanup inverted to gateway-first.

Part of plan: contacts-prompt-gateway-first.md (PR 2 of 2)