### PR TITLE
fix(gateway): contact-prompt review follow-ups (empty channelId guard, mirror heal, cleanup)

### DIFF
--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -15,6 +15,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 import { Database } from "bun:sqlite";
@@ -67,6 +68,7 @@ const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
 );
 const { contactChannels: gwContactChannels, contacts: gwContacts } =
   await import("../db/schema.js");
+const { ContactStore } = await import("../db/contact-store.js");
 const { eq } = await import("drizzle-orm");
 
 // ---------------------------------------------------------------------------
@@ -533,5 +535,150 @@ describe("handleContactPromptSubmit", () => {
       .all();
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].contactId).toBe("guardian-1");
+  });
+
+  test("guardian prompt — reuse path heals the assistant-DB mirror channel", async () => {
+    const now = Date.now();
+    seedGuardian();
+    // Gateway channel already bound to the guardian (the reuse precondition),
+    // but the assistant-DB mirror has NO channel row — simulating a mirror that
+    // was unavailable when the channel was first bound.
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-reuse",
+        contactId: "guardian-1",
+        type: "phone",
+        address: "+15551112222",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // Precondition: assistant mirror has no channel for this address.
+    expect(
+      testAssistantDb!
+        .prepare(`SELECT id FROM contact_channels WHERE address = ?`)
+        .all("+15551112222"),
+    ).toHaveLength(0);
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-heal",
+        address: "+15551112222",
+        channelType: "phone",
+        role: "guardian",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // No new gateway channel — the existing one is reused.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15551112222"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-reuse");
+
+    // The reuse path called upsertContact, which healed the assistant-DB
+    // mirror: a channel row for the address now exists under the guardian.
+    const asChannels = testAssistantDb!
+      .prepare(
+        `SELECT contact_id FROM contact_channels WHERE address = ?`,
+      )
+      .all("+15551112222") as { contact_id: string }[];
+    expect(asChannels).toHaveLength(1);
+    expect(asChannels[0].contact_id).toBe("guardian-1");
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(ipcCall.body.channelId).toBe("chan-reuse");
+  });
+
+  test("non-guardian prompt — 500 + daemon error when channel can't be resolved (no empty channelId)", async () => {
+    // Force resolveChannelId to miss by making getChannelsForContact return [].
+    const spy = spyOn(
+      ContactStore.prototype,
+      "getChannelsForContact",
+    ).mockReturnValue([]);
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-noresolve",
+          address: "carol@example.com",
+          channelType: "email",
+          role: "trusted-contact",
+          displayName: "Carol",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(false);
+
+    // Daemon was notified with an error (not a success resolve with empty id).
+    expect(ipcMock).toHaveBeenCalledTimes(1);
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(typeof ipcCall.body.error).toBe("string");
+    expect(ipcCall.body.channelId).toBeUndefined();
+  });
+
+  test("guardian bind — rolls back freshly-created guardian + 500 when channel can't be resolved", async () => {
+    // No guardian seeded: the handler mints one gateway-first, then binds the
+    // channel. Force the post-bind resolve to miss so the empty-channelId guard
+    // fires and the just-created guardian is cleaned up.
+    const spy = spyOn(
+      ContactStore.prototype,
+      "getChannelsForContact",
+    ).mockReturnValue([]);
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-boot-noresolve",
+          address: "+15553334444",
+          channelType: "phone",
+          role: "guardian",
+          displayName: "Doomed Guardian",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(false);
+
+    // The freshly-created guardian was rolled back (compensating delete).
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(0);
+
+    // Daemon notified with an error.
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(typeof ipcCall.body.error).toBe("string");
   });
 });

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -110,8 +110,7 @@ export async function handleContactPromptSubmit(
   const normalizedAddress =
     canonicalizeInboundIdentity(channelType, address) ?? address.trim();
   const effectiveDisplayName = displayName ?? normalizedAddress;
-  // Map prompt roles to valid ContactRole values ("guardian" | "contact").
-  const effectiveRole: string = role === "guardian" ? "guardian" : "contact";
+  const isGuardian = role === "guardian";
   const now = Date.now();
 
   let contactId: string;
@@ -127,7 +126,7 @@ export async function handleContactPromptSubmit(
     // -----------------------------------------------------------------------
     let createdNewContact = false;
 
-    if (effectiveRole === "guardian") {
+    if (isGuardian) {
       // Guardian lives in the gateway DB (source of truth) — bootstrap
       // dual-writes it there. Resolve from there, not the assistant mirror.
       const guardianRow = getGatewayDb()
@@ -196,6 +195,14 @@ export async function handleContactPromptSubmit(
         "contact-prompt-submit: upserted contact + channel via ContactStore",
       );
 
+      if (!channelId) {
+        log.error(
+          { channelType, address: normalizedAddress, contactId },
+          "contact-prompt-submit: channel resolution failed after upsert",
+        );
+        return await channelResolutionError(requestId);
+      }
+
       // Non-guardian is fully resolved by upsertContact; skip the guardian-only
       // Phase 2 channel-creation block below and go straight to resolve.
       return await resolveContactPrompt({
@@ -230,11 +237,29 @@ export async function handleContactPromptSubmit(
       .get();
 
     if (existingChannel && existingChannel.contactId === contactId) {
-      channelId = existingChannel.id;
+      // Heal the best-effort assistant-DB mirror on retry (matching the
+      // non-guardian path's self-healing). Passing the guardian's id preserves
+      // role="guardian" via upsertContact's id-path role preservation; the
+      // gateway channel already exists, so this is a no-op there and only
+      // recovers a previously-unavailable assistant mirror.
+      await getStore().upsertContact({
+        id: contactId,
+        channels: [
+          { type: channelType, address: normalizedAddress, isPrimary: true },
+        ],
+      });
+      channelId = resolveChannelId(contactId, channelType, normalizedAddress);
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: channel already exists",
       );
+      if (!channelId) {
+        log.error(
+          { channelType, address: normalizedAddress, contactId },
+          "contact-prompt-submit: channel resolution failed on guardian reuse",
+        );
+        return await channelResolutionError(requestId);
+      }
     } else if (existingChannel) {
       // Channel exists but belongs to a different contact.  The caller must
       // clean up the stale binding before a guardian channel can be created.
@@ -259,6 +284,28 @@ export async function handleContactPromptSubmit(
         { status: 409 },
       );
     } else {
+      // Compensating delete — only remove the contact if we created it here.
+      // "Stale over lost": delete gateway-first, then mirror the delete to
+      // the assistant DB best-effort. Used by both the bind-failure path and
+      // the empty-channelId guard below.
+      const rollbackCreatedContact = async (): Promise<void> => {
+        if (!createdNewContact) return;
+        getGatewayDb()
+          .delete(gwContacts)
+          .where(eq(gwContacts.id, contactId))
+          .run();
+        try {
+          await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
+            contactId,
+          ]);
+        } catch (mirrorErr) {
+          log.warn(
+            { err: mirrorErr },
+            "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
+          );
+        }
+      };
+
       try {
         // Bind gateway-first. Passing the guardian's id keys the update to the
         // existing guardian and preserves role="guardian" (upsertContact's
@@ -272,29 +319,11 @@ export async function handleContactPromptSubmit(
         });
         channelId = resolveChannelId(contactId, channelType, normalizedAddress);
       } catch (channelErr) {
-        // Compensating delete — only remove the contact if we created it here.
-        // "Stale over lost": delete gateway-first, then mirror the delete to
-        // the assistant DB best-effort.
         log.error(
           { channelErr, contactId, channelType },
           "contact-prompt-submit: channel bind failed, rolling back contact",
         );
-        if (createdNewContact) {
-          getGatewayDb()
-            .delete(gwContacts)
-            .where(eq(gwContacts.id, contactId))
-            .run();
-          try {
-            await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
-              contactId,
-            ]);
-          } catch (mirrorErr) {
-            log.warn(
-              { err: mirrorErr },
-              "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
-            );
-          }
-        }
+        await rollbackCreatedContact();
 
         // Notify daemon of failure so the CLI doesn't hang.
         await notifyDaemonResolveError(
@@ -305,6 +334,15 @@ export async function handleContactPromptSubmit(
           { accepted: false, error: "Failed to create contact channel" },
           { status: 500 },
         );
+      }
+
+      if (!channelId) {
+        log.error(
+          { channelType, address: normalizedAddress, contactId },
+          "contact-prompt-submit: channel resolution failed after guardian bind, rolling back contact",
+        );
+        await rollbackCreatedContact();
+        return await channelResolutionError(requestId);
       }
 
       log.info(
@@ -328,6 +366,19 @@ export async function handleContactPromptSubmit(
     channelType,
     address: normalizedAddress,
   });
+}
+
+/**
+ * Notify the daemon of a failed channel resolution and return 500. Used when the
+ * gateway DB read can't find the just-bound channel — resolving the prompt with
+ * an empty channelId would falsely report success for a channel-less contact.
+ */
+async function channelResolutionError(requestId: string): Promise<Response> {
+  await notifyDaemonResolveError(requestId, "Channel resolution failed");
+  return Response.json(
+    { accepted: false, error: "Channel resolution failed" },
+    { status: 500 },
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
Addresses self-review gaps on the contacts-prompt gateway-first migration:
- Guard against resolving a prompt with an empty channelId (notify daemon + 500 instead).
- Guardian channel-reuse branch now heals the best-effort assistant-DB mirror via upsertContact.
- Replace dead effectiveRole scaffolding with an isGuardian boolean.

Part of plan: contacts-prompt-gateway-first.md (review fixes)