### PR TITLE
fix(browser): treat Chrome Web Store tab as a restricted (unscriptable) active tab

### DIFF
--- a/assistant/src/tools/browser/__tests__/browser-status.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-status.test.ts
@@ -296,4 +296,24 @@ describe("executeBrowserStatus", () => {
     expect(extension.available).toBe(true);
     expect(extension.details.transport).toBe("extension-ws");
   });
+
+  test("reports extension as connected when probe fails on the Chrome Web Store / extensions gallery", async () => {
+    mockSingletonProxy = { isAvailable: () => true, hasExtensionClient: () => true, request: () => {} };
+    probeOutcomes[BROWSER_STATUS_MODE.EXTENSION] = "fail";
+    probeErrors[BROWSER_STATUS_MODE.EXTENSION] = new CdpError(
+      "cdp_error",
+      "The extensions gallery cannot be scripted.",
+    );
+
+    const result = await executeBrowserStatus({}, makeContext());
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(true);
+    expect(extension.verified).toBe("active_probe");
+    expect(extension.details.restrictedActiveTab).toBe(true);
+  });
 });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -345,10 +345,17 @@ function collectRemediationHints(
 
 /**
  * Detect the common extension CDP failure where the active tab is a
- * restricted Chrome internal page (e.g. `chrome://newtab`).
+ * page Chrome forbids extensions from scripting — either a privileged
+ * `chrome://` internal page (e.g. `chrome://newtab`) or the Chrome Web
+ * Store / extensions gallery (which yields "The extensions gallery
+ * cannot be scripted."). The latter is especially common right after
+ * install, when the Web Store page is still the active tab.
  */
 function isRestrictedChromePageProbeError(error: CdpError): boolean {
-  return error.message.toLowerCase().includes("chrome://");
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("chrome://") || message.includes("cannot be scripted")
+  );
 }
 
 /**
@@ -2450,9 +2457,9 @@ async function checkExtensionModeStatus(
       verified: "active_probe",
       autoCandidate,
       summary:
-        "Extension mode transport is connected, but the active Chrome tab is a restricted chrome:// page. Switch to a regular website tab if browser actions fail.",
+        "Extension mode transport is connected, but the active Chrome tab is a page Chrome won't let extensions script (a chrome:// page or the Chrome Web Store / extensions gallery). Switch to a regular website tab if browser actions fail.",
       userActions: [
-        "Switch Chrome to a regular http(s) tab (not chrome://...) and retry.",
+        "Switch Chrome to a regular http(s) tab — not a chrome:// page or the Chrome Web Store / extensions gallery — and retry.",
       ],
       tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
       details: {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -350,6 +350,11 @@ function collectRemediationHints(
  * Store / extensions gallery (which yields "The extensions gallery
  * cannot be scripted."). The latter is especially common right after
  * install, when the Web Store page is still the active tab.
+ *
+ * Keep this restricted-error match in sync with the Page.navigate
+ * recovery in the chrome-extension dispatcher (host-browser-dispatcher.ts,
+ * separate package, duplicated by necessity): the status side reports the
+ * tab as recoverable, and the navigate side must actually recover it.
  */
 function isRestrictedChromePageProbeError(error: CdpError): boolean {
   const message = error.message.toLowerCase();

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -44,6 +44,13 @@ interface MockCdpProxyOptions {
   sendThrows?: Error;
   /** If set, `attach()` will reject with this error. */
   attachThrows?: Error;
+  /**
+   * If set, only the FIRST `attach()` call rejects with this error;
+   * subsequent calls succeed. Used to exercise the Page.navigate
+   * recovery path, where the initial attach fails on a restricted tab
+   * and the retry attaches to a freshly created blank tab.
+   */
+  attachThrowsOnce?: Error;
 }
 
 interface MockCdpProxy extends CdpProxy {
@@ -91,6 +98,9 @@ function createMockCdpProxy(options: MockCdpProxyOptions = {}): MockCdpProxy {
     async attach(target, requiredVersion) {
       attachCalls.push({ target, requiredVersion });
       if (options.attachThrows) throw options.attachThrows;
+      if (options.attachThrowsOnce && attachCalls.length === 1) {
+        throw options.attachThrowsOnce;
+      }
     },
     async detach(target) {
       detachCalls.push(target);
@@ -683,6 +693,74 @@ describe('createHostBrowserDispatcher', () => {
 
       // We still attempted to post the error envelope once.
       expect(postResultCalls).toBe(1);
+    });
+  });
+
+  describe('handle — Page.navigate restricted-tab recovery', () => {
+    const navigateRequest: HostBrowserRequestEnvelope = {
+      type: 'host_browser_request',
+      requestId: 'nav-1',
+      conversationId: 'conv-1',
+      cdpMethod: 'Page.navigate',
+      cdpParams: { url: 'https://example.com' },
+    };
+
+    test('recovers from a privileged chrome:// tab by creating a new tab and retargeting', async () => {
+      harness = createHarness({
+        attachThrowsOnce: new Error('Cannot access a chrome:// URL'),
+      });
+      harness.createTabImpl = async () => ({ tabId: 99 });
+
+      await harness.dispatcher.handle(navigateRequest);
+
+      // First attach on the active (restricted) tab failed; recovery
+      // created a new tab and the retry attached to it.
+      expect(harness.createTabCalls).toBe(1);
+      expect(harness.proxy.attachCalls.length).toBe(2);
+      expect(harness.proxy.attachCalls[1].target).toEqual({ tabId: 99 });
+      // The actual navigate was sent against the recovered tab.
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].target).toEqual({ tabId: 99 });
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('recovers from a Chrome Web Store / extensions gallery tab ("cannot be scripted")', async () => {
+      harness = createHarness({
+        attachThrowsOnce: new Error('The extensions gallery cannot be scripted.'),
+      });
+      harness.createTabImpl = async () => ({ tabId: 99 });
+
+      await harness.dispatcher.handle(navigateRequest);
+
+      expect(harness.createTabCalls).toBe(1);
+      expect(harness.proxy.attachCalls.length).toBe(2);
+      expect(harness.proxy.attachCalls[1].target).toEqual({ tabId: 99 });
+      expect(harness.proxy.sendCalls[0].target).toEqual({ tabId: 99 });
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('does NOT open a new tab for non-navigate methods on a restricted tab', async () => {
+      // Status-probe Runtime.evaluate against a Web Store tab must surface
+      // the error, not silently spawn a tab as a side effect.
+      harness = createHarness({
+        attachThrowsOnce: new Error('The extensions gallery cannot be scripted.'),
+      });
+      harness.createTabImpl = async () => ({ tabId: 99 });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpMethod: 'Runtime.evaluate',
+      });
+
+      expect(harness.createTabCalls).toBe(0);
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(true);
+      expect(harness.results[0].content).toBe(
+        'The extensions gallery cannot be scripted.',
+      );
     });
   });
 

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -651,15 +651,21 @@ export function createHostBrowserDispatcher(
           if (msg.includes('already attached')) {
             attachedTargets.add(key);
           } else {
-            // chrome.debugger cannot attach to privileged URLs (chrome://,
-            // edge://, devtools://, etc.). For Page.navigate specifically,
-            // recover by creating a new about:blank tab and retargeting.
-            // For other methods (e.g. Runtime.evaluate probes from status
-            // checks), let the error propagate — status checks should not
-            // have the side effect of opening new tabs.
+            // chrome.debugger cannot script restricted tabs: privileged URLs
+            // (chrome://, edge://, devtools://) reject with "cannot access",
+            // and the Chrome Web Store / extensions gallery rejects with "The
+            // extensions gallery cannot be scripted." For Page.navigate
+            // specifically, recover from either by creating a new about:blank
+            // tab and retargeting. For other methods (e.g. Runtime.evaluate
+            // probes from status checks), let the error propagate — status
+            // checks should not have the side effect of opening new tabs.
+            // Keep this restricted-error match in sync with
+            // isRestrictedChromePageProbeError in the assistant's
+            // browser-execution.ts (separate package, duplicated by necessity).
             if (
               envelope.cdpMethod === 'Page.navigate' &&
-              msg.includes('cannot access')
+              (msg.includes('cannot access') ||
+                msg.includes('cannot be scripted'))
             ) {
               const newTarget = await deps.createTab?.();
               if (newTarget) {


### PR DESCRIPTION
## Summary
- Extension-mode browser status probes a tab with CDP `Runtime.evaluate`; when the active tab is the Chrome Web Store / extensions gallery, Chrome returns `The extensions gallery cannot be scripted.`. That string lacks `chrome://`, so `isRestrictedChromePageProbeError` didn't recognize it and the graceful "switch to a regular tab" remediation never fired — the probe just reported a generic failure.
- This is the single most likely first-run failure: right after installing the extension, the Web Store page is still the active tab, so the assistant's first browser action silently fails.
- Broaden the detector to also match `cannot be scripted`, and update the user-facing summary/userActions copy to name the Web Store / extensions gallery alongside `chrome://` pages. Added a test covering the gallery error string.

## Original prompt
A user reported the Chrome extension "didn't work" in 0.10.0 despite showing CONNECTED. Their diagnostics showed a healthy SSE connection and exactly one logged operation: a CDP `Runtime.evaluate` of `document.readyState` that failed with "The extensions gallery cannot be scripted." — because their active tab was the Vellum Assistant Chrome Web Store page. The assistant did invoke the browser skill but was blocked at the first probe, and the existing restricted-tab remediation (which only matched `chrome://`) never surfaced. Fix the detection gap so this common post-install case is recognized and the user gets the "switch to a regular tab" guidance.