### PR TITLE
refactor(web): composer owns its store state — orchestrator reads zero composer slices

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -51,12 +51,6 @@ mock.module(
   }),
 );
 
-mock.module(
-  "@/domains/chat/components/chat-composer/chat-composer",
-  () => ({
-    ChatComposer: () => <div data-testid="composer">COMPOSER</div>,
-  }),
-);
 
 mock.module("@vellumai/design-library", () => ({
   Button: ({
@@ -112,7 +106,8 @@ function baseProps(
       transcriptRef: null,
       transcriptProps: { messages: [], onScrollToMessage: noop } as never,
     },
-    composerProps: {} as never,
+    composerSlot: <div data-testid="composer">COMPOSER</div>,
+    onStopGenerating: noop,
     dragHandlers: {
       onDragEnter: noopDrag,
       onDragOver: noopDrag,
@@ -232,7 +227,6 @@ describe("ChatBody — read-only cancellation", () => {
       <ChatBody
         {...baseProps({
           isChannelReadonly: true,
-          composerProps: { onStopGenerating: noop } as never,
         })}
       />,
     );
@@ -248,7 +242,6 @@ describe("ChatBody — read-only cancellation", () => {
         {...baseProps({
           isChannelReadonly: true,
           canStopGenerating: true,
-          composerProps: { onStopGenerating: noop } as never,
         })}
       />,
     );

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -2,7 +2,6 @@ import { type DragEventHandler, type ReactNode } from "react";
 
 import { Eye, Paperclip, Square } from "lucide-react";
 
-import { ChatComposer, type ChatComposerProps } from "@/domains/chat/components/chat-composer/chat-composer";
 import { QuestionPromptSlot } from "@/domains/chat/components/question-prompt-slot";
 import { ChatScrollArea, type ChatScrollAreaProps } from "@/domains/chat/components/chat-scroll-area";
 import { ScrollToLatestButton } from "@/domains/chat/components/scroll-to-latest-button";
@@ -60,8 +59,18 @@ export interface ChatBodyProps {
   /** Props forwarded to {@link ChatScrollArea}. */
   scrollAreaProps: ChatScrollAreaProps;
 
-  /** Props forwarded to {@link ChatComposer}. */
-  composerProps: ChatComposerProps;
+  /**
+   * The composer element to render below the scroll area. The orchestrator
+   * builds `<ChatComposer …/>` with explicit props and passes it as a node;
+   * `ChatBody` only positions it (and swaps it for the read-only banner).
+   */
+  composerSlot: ReactNode;
+  /**
+   * Stop-generation handler for the read-only banner's cancel control. In
+   * read-only conversations the composer is replaced by the banner, so this is
+   * passed alongside {@link composerSlot} rather than read off it.
+   */
+  onStopGenerating: () => void;
 
   /** Drag handlers attached to the outer container for attachment drag-and-drop. */
   dragHandlers: ChatBodyDragHandlers;
@@ -164,7 +173,8 @@ function ChatReadonlyBanner({
 export function ChatBody({
   variant,
   scrollAreaProps,
-  composerProps,
+  composerSlot,
+  onStopGenerating,
   dragHandlers,
   isAttachmentDragOver,
   showScrollToLatest,
@@ -263,7 +273,7 @@ export function ChatBody({
                   <Button
                     variant="primary"
                     iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
-                    onClick={composerProps.onStopGenerating}
+                    onClick={onStopGenerating}
                     aria-label="Stop generating"
                     title="Stop generation"
                   />
@@ -272,11 +282,11 @@ export function ChatBody({
             ) : (
               <ChatReadonlyBanner
                 canStopGenerating={canStopGenerating}
-                onStopGenerating={composerProps.onStopGenerating}
+                onStopGenerating={onStopGenerating}
               />
             )
           ) : (
-            <ChatComposer {...composerProps} />
+            composerSlot
           )}
           {startersSlot}
         </div>

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -402,18 +402,72 @@ describe("computeGhostSuffix", () => {
 afterEach(cleanup);
 beforeEach(() => {
   resetLiveVoiceMocks();
-  // The composer reads its draft from the store; clear it between tests so a
-  // seeded value can't leak across cases.
-  useComposerStore.setState({ input: "" });
+  // The composer self-sources its draft + attachments from the store; reset
+  // them between tests so seeded values can't leak across cases.
+  useComposerStore.setState({
+    input: "",
+    attachments: [],
+    attachmentLastError: null,
+    restoredDraftConversationId: null,
+  });
 });
 
+/**
+ * Build a composer-store `attachments` array from the test's intent. The
+ * composer derives uploading-count and can-send from the real list, so seeding
+ * the list exercises the real derivation rather than injecting the booleans.
+ */
+function seedAttachments(
+  uploadingCount = 0,
+  canSend = false,
+): ChatAttachment[] {
+  const list: ChatAttachment[] = [];
+  for (let i = 0; i < uploadingCount; i++) {
+    list.push({
+      kind: "uploading",
+      localId: `uploading-${i}`,
+      filename: "file",
+      mimeType: "text/plain",
+      sizeBytes: 1,
+    });
+  }
+  if (canSend) {
+    list.push({
+      kind: "uploaded",
+      localId: "uploaded-0",
+      id: "att-id-0",
+      filename: "file",
+      mimeType: "text/plain",
+      sizeBytes: 1,
+      previewUrl: null,
+    });
+  }
+  return list;
+}
+
 function renderComposer(
-  props: Partial<Parameters<typeof ChatComposer>[0]> & { input?: string } = {},
+  props: Partial<Parameters<typeof ChatComposer>[0]> & {
+    input?: string;
+    chatAttachments?: ChatAttachment[];
+    attachmentsUploadingCount?: number;
+    canSendAttachments?: boolean;
+  } = {},
 ) {
-  // The composer self-sources its draft from the store, so seed it there
-  // rather than passing it as a prop.
-  const { input = "", ...rest } = props;
-  useComposerStore.setState({ input });
+  // The composer self-sources its draft + attachments from the store, so seed
+  // them there rather than passing them as props.
+  const {
+    input = "",
+    chatAttachments,
+    attachmentsUploadingCount,
+    canSendAttachments,
+    ...rest
+  } = props;
+  useComposerStore.setState({
+    input,
+    attachments:
+      chatAttachments ??
+      seedAttachments(attachmentsUploadingCount, canSendAttachments),
+  });
   const { container } = render(
     <ChatComposer
       placeholder="Custom placeholder"
@@ -421,11 +475,7 @@ function renderComposer(
       inputRef={createRef<HTMLTextAreaElement>()}
       typingDisabled={false}
       sendDisabled={false}
-      attachmentsUploadingCount={0}
-      canSendAttachments={false}
-      chatAttachments={[]}
       onAddAttachmentFiles={() => {}}
-      onRemoveAttachment={() => {}}
       onStopGenerating={() => {}}
       canStopGenerating={false}
       assistantId="asst_test"
@@ -654,18 +704,14 @@ function renderVoiceComposer(
   props: Partial<Parameters<typeof ChatComposer>[0]> & { input?: string } = {},
 ) {
   const { input = "", ...rest } = props;
-  useComposerStore.setState({ input });
+  useComposerStore.setState({ input, attachments: [] });
   return render(
     <ChatComposer
       onSubmit={() => {}}
       inputRef={createRef<HTMLTextAreaElement>()}
       typingDisabled={false}
       sendDisabled={false}
-      attachmentsUploadingCount={0}
-      canSendAttachments={false}
-      chatAttachments={[]}
       onAddAttachmentFiles={() => {}}
-      onRemoveAttachment={() => {}}
       onStopGenerating={() => {}}
       canStopGenerating={false}
       assistantId="asst_test"

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import type { ChatAttachment } from "@/domains/chat/composer-store";
+import { type ChatAttachment, useComposerStore } from "@/domains/chat/composer-store";
 import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
 
@@ -400,13 +400,22 @@ describe("computeGhostSuffix", () => {
 // ---------------------------------------------------------------------------
 
 afterEach(cleanup);
-beforeEach(resetLiveVoiceMocks);
+beforeEach(() => {
+  resetLiveVoiceMocks();
+  // The composer reads its draft from the store; clear it between tests so a
+  // seeded value can't leak across cases.
+  useComposerStore.setState({ input: "" });
+});
 
-function renderComposer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
+function renderComposer(
+  props: Partial<Parameters<typeof ChatComposer>[0]> & { input?: string } = {},
+) {
+  // The composer self-sources its draft from the store, so seed it there
+  // rather than passing it as a prop.
+  const { input = "", ...rest } = props;
+  useComposerStore.setState({ input });
   const { container } = render(
     <ChatComposer
-      input=""
-      setInput={() => {}}
       placeholder="Custom placeholder"
       onSubmit={() => {}}
       inputRef={createRef<HTMLTextAreaElement>()}
@@ -420,7 +429,7 @@ function renderComposer(props: Partial<Parameters<typeof ChatComposer>[0]> = {})
       onStopGenerating={() => {}}
       canStopGenerating={false}
       assistantId="asst_test"
-      {...props}
+      {...rest}
     />,
   );
   return container.innerHTML;
@@ -642,12 +651,12 @@ describe("Slash popup — SSR rendering", () => {
 
 /** Render the composer with the dictation voice props supplied. */
 function renderVoiceComposer(
-  props: Partial<Parameters<typeof ChatComposer>[0]> = {},
+  props: Partial<Parameters<typeof ChatComposer>[0]> & { input?: string } = {},
 ) {
+  const { input = "", ...rest } = props;
+  useComposerStore.setState({ input });
   return render(
     <ChatComposer
-      input=""
-      setInput={() => {}}
       onSubmit={() => {}}
       inputRef={createRef<HTMLTextAreaElement>()}
       typingDisabled={false}
@@ -663,7 +672,7 @@ function renderVoiceComposer(
       conversationId="conv_test"
       voiceInputRef={createRef<VoiceInputButtonHandle>()}
       onVoiceTranscript={() => {}}
-      {...props}
+      {...rest}
     />,
   );
 }

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -1,10 +1,8 @@
 import { ArrowUp, Square } from "lucide-react";
 import {
-    type Dispatch,
     type FormEvent,
     type ReactNode,
     type RefObject,
-    type SetStateAction,
     useCallback,
     useEffect,
     useLayoutEffect,
@@ -18,7 +16,7 @@ import {
     AttachFileButton,
     ChatAttachmentsStrip,
 } from "@/domains/chat/components/chat-attachments/chat-attachments";
-import { type ChatAttachment } from "@/domains/chat/composer-store";
+import { type ChatAttachment, useComposerStore } from "@/domains/chat/composer-store";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import {
@@ -56,9 +54,14 @@ import { SlashCommandPopup } from "@/domains/chat/components/chat-composer/slash
 import { useTextPopup } from "@/domains/chat/components/chat-composer/use-text-popup";
 
 /**
- * Controlled composer used at the bottom of the chat (main variant) and inside
- * the app-editing split layout. The two call sites previously inlined the
- * composer JSX; this component is the consolidated version.
+ * Composer used at the bottom of the chat (main variant) and inside the
+ * app-editing split layout.
+ *
+ * The draft text is the only high-frequency state here, so the composer
+ * subscribes to it directly from `composer-store` via atomic selectors (per
+ * `docs/STATE_MANAGEMENT.md`) rather than receiving it as a prop. That keeps a
+ * keystroke from re-rendering the orchestrator and the transcript above it —
+ * only this component re-renders as you type.
  *
  * The optional slots/voice props exist because the app-editing variant does
  * NOT render a voice button, threshold picker, context-window indicator, or
@@ -66,15 +69,6 @@ import { useTextPopup } from "@/domains/chat/components/chat-composer/use-text-p
  * those as `undefined` keeps the app-editing layout byte-identical.
  */
 export interface ChatComposerProps {
-  // text + form
-  input: string;
-  /**
-   * Accepts both a plain setter (`setInput("foo")`) and the React-state
-   * updater form (`setInput((current) => …)`). The voice transcript handler
-   * relies on the updater form; the rest of the composer only writes plain
-   * strings.
-   */
-  setInput: Dispatch<SetStateAction<string>>;
   placeholder?: string;
   onSubmit: (event: FormEvent) => void;
   inputRef: RefObject<HTMLTextAreaElement | null>;
@@ -150,8 +144,6 @@ export interface ChatComposerProps {
 }
 
 export function ChatComposer({
-  input,
-  setInput,
   placeholder = "What would you like to do?",
   onSubmit,
   inputRef,
@@ -182,6 +174,12 @@ export function ChatComposer({
   onRecallLastMessage,
   onCancelEdit,
 }: ChatComposerProps) {
+  // Draft text is owned by the composer store; subscribing here (rather than
+  // receiving it as a prop) means a keystroke re-renders only this component,
+  // not the orchestrator or the transcript above it.
+  const input = useComposerStore.use.input();
+  const setInput = useComposerStore.use.setInput();
+
   const voicePhase = useVoiceRecordingStore.use.phase();
   const isVoiceActive = voicePhase === "recording" || voicePhase === "processing";
   // Holds the MediaStream opened by VoiceInputButton so we can reuse it for

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -16,7 +16,12 @@ import {
     AttachFileButton,
     ChatAttachmentsStrip,
 } from "@/domains/chat/components/chat-attachments/chat-attachments";
-import { type ChatAttachment, useComposerStore } from "@/domains/chat/composer-store";
+import {
+    selectUploadedIds,
+    selectUploadingCount,
+    useComposerStore,
+} from "@/domains/chat/composer-store";
+import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import {
@@ -74,13 +79,12 @@ export interface ChatComposerProps {
   inputRef: RefObject<HTMLTextAreaElement | null>;
   typingDisabled: boolean;
   sendDisabled: boolean;
-  attachmentsUploadingCount: number;
-  canSendAttachments: boolean;
 
-  // attachments
-  chatAttachments: ChatAttachment[];
+  // Adding files is orchestration-owned: it runs the vision-capability gate
+  // (which depends on the active model) before queueing the upload. The rest of
+  // the attachment lifecycle — the strip, the uploading/can-send derivation, and
+  // removal — is read straight from the composer store below.
   onAddAttachmentFiles: (files: FileList | File[]) => void;
-  onRemoveAttachment: (id: string) => void;
 
   // voice — optional; when `voiceInputRef` is omitted the voice button is
   // skipped entirely (matches the app-editing variant which has no voice).
@@ -149,11 +153,7 @@ export function ChatComposer({
   inputRef,
   typingDisabled,
   sendDisabled,
-  attachmentsUploadingCount,
-  canSendAttachments,
-  chatAttachments,
   onAddAttachmentFiles,
-  onRemoveAttachment,
   voiceInputRef,
   onVoiceTranscript,
   onVoiceInterimTranscript,
@@ -179,6 +179,13 @@ export function ChatComposer({
   // not the orchestrator or the transcript above it.
   const input = useComposerStore.use.input();
   const setInput = useComposerStore.use.setInput();
+  // Attachments are composer-owned too: read the list and derive send-gating
+  // here rather than threading four props down from the orchestrator.
+  const attachments = useComposerStore.use.attachments();
+  const removeAttachment = useComposerStore.use.removeAttachment();
+  const attachmentsUploadingCount = selectUploadingCount(attachments);
+  const canSendAttachments =
+    attachmentsUploadingCount === 0 && selectUploadedIds(attachments).length > 0;
 
   const voicePhase = useVoiceRecordingStore.use.phase();
   const isVoiceActive = voicePhase === "recording" || voicePhase === "processing";
@@ -314,13 +321,16 @@ export function ChatComposer({
         pointerCoarse,
         suggestion: suggestion ?? null,
         input,
-        hasAttachments: chatAttachments.length > 0,
+        hasAttachments: attachments.length > 0,
       }),
-    [pointerCoarse, suggestion, input, chatAttachments],
+    [pointerCoarse, suggestion, input, attachments],
   );
 
   return (
     <>
+      {/* Composer-owned draft/attachment notices (self-sourced), above the
+          orchestration banner stack. */}
+      <ComposerDraftNotices />
       {noticesAboveFormSlot}
       <Popover.Root open={emoji.show || slash.show}>
         <Popover.Anchor asChild>
@@ -331,8 +341,8 @@ export function ChatComposer({
             }`}
           >
             <ChatAttachmentsStrip
-              attachments={chatAttachments}
-              onRemove={onRemoveAttachment}
+              attachments={attachments}
+              onRemove={removeAttachment}
             />
             {/* CSS Grid hidden-mirror technique for auto-growing textarea.
             A hidden div mirrors the textarea content in the same grid cell.
@@ -369,6 +379,13 @@ export function ChatComposer({
                   const value = e.target.value;
                   cursorRef.current = e.target.selectionStart ?? value.length;
                   setInput(value);
+                  // The user has edited the text, so it's no longer a pristine
+                  // restored draft — retire the "draft restored" marker (and its
+                  // notice). Keeps `restoredDraftConversationId` an accurate
+                  // signal for "unedited restored draft" (see use-deep-link-consumer).
+                  if (useComposerStore.getState().restoredDraftConversationId !== null) {
+                    useComposerStore.getState().clearRestoredDraftNotice();
+                  }
                 }}
                 onPaste={(e) => {
                   const items = e.clipboardData?.items;

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -30,8 +30,9 @@ import { useChatBannerSlots } from "@/domains/chat/hooks/use-chat-banner-slots";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone";
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
-import { useComposerStore, selectUploadingCount, selectUploadedIds } from "@/domains/chat/composer-store";
+import { useComposerStore } from "@/domains/chat/composer-store";
 import { ChatBody } from "@/domains/chat/components/chat-body";
+import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
 import { ComposerNotices } from "@/domains/chat/components/composer-notices";
 import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
@@ -47,7 +48,7 @@ import { usePullRefresh } from "@/domains/chat/hooks/use-pull-refresh";
 import type { TranscriptHandle, TranscriptProps } from "@/domains/chat/transcript/transcript";
 import { useTranscriptScroll } from "@/domains/chat/transcript/use-transcript-scroll";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { Button, Notice } from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library";
 import { Link, useLocation, useNavigate } from "react-router";
 import { getChatBillingBannerDecision, shouldShowGenericChatErrorNotice } from "@/domains/chat/utils/error-classification";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
@@ -181,23 +182,12 @@ export function ChatMainPanel({
   const isChannelReadonly = isChannelConversation(activeConversation);
 
   // -------------------------------------------------------------------------
-  // Store reads — composer
-  // -------------------------------------------------------------------------
-  // Draft text is subscribed by `ChatComposer` itself (atomic selector) so a
-  // keystroke doesn't re-render this orchestrator or the transcript. The only
-  // thing this component needs from the draft is whether it's non-empty, which
-  // flips at most once per typing session — read it as its own narrow slice.
-  const composerHasText = useComposerStore((s) => s.input.trim().length > 0);
-  const restoredDraftConversationId = useComposerStore.use.restoredDraftConversationId();
-  const chatAttachments = useComposerStore.use.attachments();
-  const attachmentLastError = useComposerStore.use.attachmentLastError();
-  const removeChatAttachment = useComposerStore.use.removeAttachment();
-  const dismissChatAttachmentError = useComposerStore.use.dismissAttachmentError();
-  const attachmentsUploadingCount = useMemo(() => selectUploadingCount(chatAttachments), [chatAttachments]);
-  const attachmentUploadedIds = useMemo(() => selectUploadedIds(chatAttachments), [chatAttachments]);
-
-  // -------------------------------------------------------------------------
-  // Store reads — identity, lifecycle, feature flags
+  // Composer — `ChatComposer` and `ComposerDraftNotices` self-source every
+  // composer-store slice they render (draft text, attachments, draft notices),
+  // so this orchestrator subscribes to NONE of it: typing or attaching never
+  // re-renders the transcript. The only composer-store touch left here is the
+  // vision-gated *write* below (queueing dropped/attached files), which depends
+  // on the active model and so can't move into the composer.
   // -------------------------------------------------------------------------
   const addChatAttachmentFiles = useCallback(
     (files: FileList | File[]) => useComposerStore.getState().addFiles(files, assistantId),
@@ -477,9 +467,6 @@ export function ChatMainPanel({
       />
     ) : null;
 
-  const canSendAttachments =
-    attachmentsUploadingCount === 0 && attachmentUploadedIds.length > 0;
-
   // While a conversation's row hasn't loaded (a draft, or one opened by URL
   // mid-load), its profile lives in the composer stash, not on a server row —
   // feed it in so attachment/vision gating reflects the profile the first
@@ -496,14 +483,6 @@ export function ChatMainPanel({
   );
   const activeModelSupportsVision = activeProfileModel?.supportsVision ?? true;
   const visionGateActive = useVisionAttachmentGate();
-
-  const showUploadBlockedNotice =
-    attachmentsUploadingCount > 0 &&
-    (composerHasText || attachmentUploadedIds.length > 0);
-
-  const showRestoredDraftNotice =
-    restoredDraftConversationId !== null &&
-    restoredDraftConversationId === activeConversationId;
 
   const isInMaintenanceWithNoMessages =
     !isLoadingHistory &&
@@ -579,26 +558,6 @@ export function ChatMainPanel({
   const handleScrollToLatest = useCallback(() => {
     scrollCoordinator.scrollToLatest({ behavior: "smooth" });
   }, [scrollCoordinator]);
-
-  // -------------------------------------------------------------------------
-  // Draft notice auto-dismiss
-  // -------------------------------------------------------------------------
-  useEffect(() => {
-    if (!showRestoredDraftNotice) return;
-    const id = window.setTimeout(() => {
-      useComposerStore.getState().clearRestoredDraftNotice();
-    }, 5000);
-    return () => window.clearTimeout(id);
-  }, [showRestoredDraftNotice]);
-
-  useEffect(() => {
-    if (
-      restoredDraftConversationId !== null &&
-      restoredDraftConversationId !== activeConversationId
-    ) {
-      useComposerStore.getState().clearRestoredDraftNotice();
-    }
-  }, [activeConversationId, restoredDraftConversationId]);
 
   // -------------------------------------------------------------------------
   // Composer submit (extracted hook — fixes fake FormEvent pattern)
@@ -681,30 +640,6 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   // JSX construction
   // -------------------------------------------------------------------------
-  const textStateNoticesJsx = (
-    <>
-      {showUploadBlockedNotice && (
-        <div className="mb-2">
-          <Notice tone="info">
-            {attachmentsUploadingCount === 1
-              ? "Waiting for the attachment to finish uploading before sending."
-              : `Waiting for ${attachmentsUploadingCount} attachments to finish uploading before sending.`}
-          </Notice>
-        </div>
-      )}
-      {showRestoredDraftNotice && (
-        <div className="mb-2">
-          <Notice
-            tone="info"
-            onDismiss={() => useComposerStore.getState().clearRestoredDraftNotice()}
-          >
-            Draft restored from your previous session.
-          </Notice>
-        </div>
-      )}
-    </>
-  );
-
   const chatTranscriptProps: TranscriptProps = {
     items: transcriptItems,
     conversationId: activeConversationId,
@@ -734,90 +669,92 @@ export function ChatMainPanel({
     renderOnboardingChoice,
   };
 
-  const sharedComposerNoticeProps = {
-    billingBannerSlot: billingBannerDecision === "managed_credits"
-      ? <CreditsExhaustedBanner onAddFunds={() => setShowAddCreditsModal(true)} />
-      : billingBannerDecision === "provider_billing"
-      ? <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
-      : null,
-    diskPressureBanner: diskPressureBannerSlot,
-    showMissingApiKeyBanner:
-      error?.code === "PROVIDER_NOT_CONFIGURED" ||
-      error?.code === "MANAGED_KEY_INVALID",
-    onOpenAiSettings: pushToAiSettings,
-    onDismissApiKeyError: handleDismissApiKeyError,
-    compactionCircuitOpenUntil,
-    onCompactionCircuitExpired: handleCompactionCircuitExpired,
-    showMaintenanceBanner:
-      assistantState.kind === "active" &&
-      assistantState.maintenanceMode?.enabled === true,
-    showMaintenanceExitAction: !statusBannerVisible,
-    assistantId,
-    onMaintenanceExited: handleMaintenanceExited,
-  };
-
   const cmdEnterMode = cmdEnterToSend.useValue();
 
-  const chatBodyComposerProps = {
-    cmdEnterMode,
-    placeholder: isEmptyConversation
-      ? emptyStatePlaceholder
-      : "What would you like to do?",
-    onSubmit: handleFormSubmit,
-    inputRef,
-    typingDisabled,
-    sendDisabled,
-    attachmentsUploadingCount,
-    canSendAttachments,
-    chatAttachments,
-    onAddAttachmentFiles: handleDroppedFiles,
-    onRemoveAttachment: removeChatAttachment,
-    voiceInputRef,
-    voiceInterim: voiceInterim ?? undefined,
-    onVoiceTranscript: handleVoiceTranscript,
-    onVoiceInterimTranscript: setVoiceInterim,
-    onVoiceError: setVoiceError,
-    onVoiceBeforeStart: handleVoiceBeforeStart,
-    onStopGenerating: handleStopGenerating,
-    canStopGenerating,
-    assistantId,
-    conversationId: activeConversation?.conversationId,
-    onRecallLastMessage: isIdle ? handleRecallLastMessage : undefined,
-    onCancelEdit: isEditing ? handleCancelEdit : undefined,
-    textareaMaxHeightPx: isEmptyConversation ? 320 : undefined,
-    thresholdPickerSlot: assistantId ? (
-      <ComposerSettingsMenu
-        assistantId={assistantId}
-        conversationId={activeConversation?.conversationId}
-      />
-    ) : undefined,
-    contextWindowIndicatorSlot: (
-      <ContextWindowIndicator
-        usage={contextWindowUsage}
-        assistantName={assistantName}
-        onClearContext={
-          activeConversation?.conversationId && !sendDisabled
-            ? handleClearContext
-            : undefined
-        }
-      />
-    ),
-    noticesAboveFormSlot: (
-      <ComposerNotices
-        {...sharedComposerNoticeProps}
-        attachmentLastError={attachmentLastError}
-        onDismissAttachmentError={dismissChatAttachmentError}
-        voiceError={voiceError}
-        onClearVoiceError={clearVoiceError}
-        onRetryMicPermission={handleRetryMicPermission}
-        onOpenMicSettings={handleOpenMicSettings}
-        onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
-        textStateNoticesSlot={textStateNoticesJsx}
-      />
-    ),
-    suggestion,
-    hasBillingBanner: billingBannerDecision !== null,
-  };
+  // Explicit props (no spread bundle): the contract is visible here, and the
+  // composer self-sources its own store state, so nothing high-frequency is
+  // threaded through. `ChatBody` renders this node as-is.
+  const composerNode = (
+    <ChatComposer
+      cmdEnterMode={cmdEnterMode}
+      placeholder={
+        isEmptyConversation ? emptyStatePlaceholder : "What would you like to do?"
+      }
+      onSubmit={handleFormSubmit}
+      inputRef={inputRef}
+      typingDisabled={typingDisabled}
+      sendDisabled={sendDisabled}
+      onAddAttachmentFiles={handleDroppedFiles}
+      voiceInputRef={voiceInputRef}
+      voiceInterim={voiceInterim ?? undefined}
+      onVoiceTranscript={handleVoiceTranscript}
+      onVoiceInterimTranscript={setVoiceInterim}
+      onVoiceError={setVoiceError}
+      onVoiceBeforeStart={handleVoiceBeforeStart}
+      onStopGenerating={handleStopGenerating}
+      canStopGenerating={canStopGenerating}
+      assistantId={assistantId}
+      conversationId={activeConversation?.conversationId}
+      onRecallLastMessage={isIdle ? handleRecallLastMessage : undefined}
+      onCancelEdit={isEditing ? handleCancelEdit : undefined}
+      textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}
+      suggestion={suggestion}
+      hasBillingBanner={billingBannerDecision !== null}
+      thresholdPickerSlot={
+        assistantId ? (
+          <ComposerSettingsMenu
+            assistantId={assistantId}
+            conversationId={activeConversation?.conversationId}
+          />
+        ) : undefined
+      }
+      contextWindowIndicatorSlot={
+        <ContextWindowIndicator
+          usage={contextWindowUsage}
+          assistantName={assistantName}
+          onClearContext={
+            activeConversation?.conversationId && !sendDisabled
+              ? handleClearContext
+              : undefined
+          }
+        />
+      }
+      noticesAboveFormSlot={
+        <ComposerNotices
+          voiceError={voiceError}
+          onClearVoiceError={clearVoiceError}
+          onRetryMicPermission={handleRetryMicPermission}
+          onOpenMicSettings={handleOpenMicSettings}
+          onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
+          billingBannerSlot={
+            billingBannerDecision === "managed_credits" ? (
+              <CreditsExhaustedBanner
+                onAddFunds={() => setShowAddCreditsModal(true)}
+              />
+            ) : billingBannerDecision === "provider_billing" ? (
+              <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
+            ) : null
+          }
+          diskPressureBanner={diskPressureBannerSlot}
+          showMissingApiKeyBanner={
+            error?.code === "PROVIDER_NOT_CONFIGURED" ||
+            error?.code === "MANAGED_KEY_INVALID"
+          }
+          onOpenAiSettings={pushToAiSettings}
+          onDismissApiKeyError={handleDismissApiKeyError}
+          compactionCircuitOpenUntil={compactionCircuitOpenUntil}
+          onCompactionCircuitExpired={handleCompactionCircuitExpired}
+          showMaintenanceBanner={
+            assistantState.kind === "active" &&
+            assistantState.maintenanceMode?.enabled === true
+          }
+          showMaintenanceExitAction={!statusBannerVisible}
+          assistantId={assistantId}
+          onMaintenanceExited={handleMaintenanceExited}
+        />
+      }
+    />
+  );
 
   const chatBodyScrollAreaPropsBase = {
     isLoadingHistory,
@@ -843,7 +780,8 @@ export function ChatMainPanel({
           ...chatBodyScrollAreaPropsBase,
           showMaintenanceRecoveryCard: isSidePanel ? false : isInMaintenanceWithNoMessages,
         }}
-        composerProps={chatBodyComposerProps}
+        composerSlot={composerNode}
+        onStopGenerating={handleStopGenerating}
         dragHandlers={attachmentDropHandlers}
         isAttachmentDragOver={isAttachmentDragOver}
         showScrollToLatest={

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -183,8 +183,11 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   // Store reads — composer
   // -------------------------------------------------------------------------
-  const input = useComposerStore.use.input();
-  const setInput = useComposerStore.use.setInput();
+  // Draft text is subscribed by `ChatComposer` itself (atomic selector) so a
+  // keystroke doesn't re-render this orchestrator or the transcript. The only
+  // thing this component needs from the draft is whether it's non-empty, which
+  // flips at most once per typing session — read it as its own narrow slice.
+  const composerHasText = useComposerStore((s) => s.input.trim().length > 0);
   const restoredDraftConversationId = useComposerStore.use.restoredDraftConversationId();
   const chatAttachments = useComposerStore.use.attachments();
   const attachmentLastError = useComposerStore.use.attachmentLastError();
@@ -243,7 +246,7 @@ export function ChatMainPanel({
     handlePrimerCancel,
     handleRetryMicPermission,
     handleOpenMicSettings,
-  } = useVoiceInput({ assistantId, inputRef, setInput });
+  } = useVoiceInput({ assistantId, inputRef });
 
 
 
@@ -361,13 +364,13 @@ export function ChatMainPanel({
 
   const handleRecallLastMessage = useCallback(() => {
     const content = startEditing();
-    if (content !== null) setInput(content);
-  }, [startEditing, setInput]);
+    if (content !== null) useComposerStore.getState().setInput(content);
+  }, [startEditing]);
 
   const handleCancelEdit = useCallback(() => {
     cancelEditing();
-    setInput("");
-  }, [cancelEditing, setInput]);
+    useComposerStore.getState().setInput("");
+  }, [cancelEditing]);
 
   // -------------------------------------------------------------------------
   // Nudges + ghost text
@@ -456,7 +459,7 @@ export function ChatMainPanel({
         message={error.message}
         onClose={() => {
           if (typeof error.restoreContent === "string") {
-            setInput(error.restoreContent);
+            useComposerStore.getState().setInput(error.restoreContent);
           }
           useChatSessionStore.getState().setError(null);
         }}
@@ -496,7 +499,7 @@ export function ChatMainPanel({
 
   const showUploadBlockedNotice =
     attachmentsUploadingCount > 0 &&
-    (input.trim().length > 0 || attachmentUploadedIds.length > 0);
+    (composerHasText || attachmentUploadedIds.length > 0);
 
   const showRestoredDraftNotice =
     restoredDraftConversationId !== null &&
@@ -614,9 +617,9 @@ export function ChatMainPanel({
   });
 
   const handleSelectStarter = useCallback((starter: { prompt: string }) => {
-    setInput(starter.prompt);
+    useComposerStore.getState().setInput(starter.prompt);
     void submitMessage(starter.prompt);
-  }, [setInput, submitMessage]);
+  }, [submitMessage]);
 
   // -------------------------------------------------------------------------
   // Rule editor bridge (viewer-store seq → rule editor open)
@@ -756,8 +759,6 @@ export function ChatMainPanel({
   const cmdEnterMode = cmdEnterToSend.useValue();
 
   const chatBodyComposerProps = {
-    input,
-    setInput,
     cmdEnterMode,
     placeholder: isEmptyConversation
       ? emptyStatePlaceholder

--- a/clients/web/src/domains/chat/components/composer-draft-notices.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-draft-notices.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { useComposerStore } from "@/domains/chat/composer-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
+
+function reset() {
+  useComposerStore.setState({
+    input: "",
+    attachments: [],
+    attachmentLastError: null,
+    restoredDraftConversationId: null,
+  });
+  useConversationStore.setState({ activeConversationId: null });
+}
+
+beforeEach(reset);
+afterEach(() => {
+  cleanup();
+  reset();
+});
+
+function renderNotices(): string {
+  const { container } = render(<ComposerDraftNotices />);
+  return container.innerHTML;
+}
+
+describe("ComposerDraftNotices", () => {
+  test("shows the upload-blocked notice while an attachment uploads and there is text", () => {
+    useComposerStore.setState({
+      input: "hello",
+      attachments: [
+        {
+          kind: "uploading",
+          localId: "u1",
+          filename: "f",
+          mimeType: "text/plain",
+          sizeBytes: 1,
+        },
+      ],
+    });
+    expect(renderNotices()).toContain(
+      "Waiting for the attachment to finish uploading",
+    );
+  });
+
+  test("no upload-blocked notice when nothing is uploading", () => {
+    useComposerStore.setState({ input: "hello" });
+    expect(renderNotices()).not.toContain("Waiting for");
+  });
+
+  test("shows the restored-draft notice for the active conversation", () => {
+    useConversationStore.setState({ activeConversationId: "c1" });
+    useComposerStore.setState({ input: "draft", restoredDraftConversationId: "c1" });
+    expect(renderNotices()).toContain("Draft restored");
+  });
+
+  test("hides the restored-draft notice when it belongs to another conversation", () => {
+    useConversationStore.setState({ activeConversationId: "c2" });
+    useComposerStore.setState({ input: "draft", restoredDraftConversationId: "c1" });
+    expect(renderNotices()).not.toContain("Draft restored");
+  });
+
+  test("surfaces the attachment error", () => {
+    useComposerStore.setState({ attachmentLastError: "File is too large" });
+    expect(renderNotices()).toContain("File is too large");
+  });
+
+  test("clears a stale restored-draft marker from another conversation on mount", () => {
+    useConversationStore.setState({ activeConversationId: "c2" });
+    useComposerStore.setState({ restoredDraftConversationId: "c1" });
+    render(<ComposerDraftNotices />);
+    expect(useComposerStore.getState().restoredDraftConversationId).toBe(null);
+  });
+});

--- a/clients/web/src/domains/chat/components/composer-draft-notices.tsx
+++ b/clients/web/src/domains/chat/components/composer-draft-notices.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from "react";
+
+import { Notice } from "@vellumai/design-library";
+
+import {
+  selectUploadedIds,
+  selectUploadingCount,
+  useComposerStore,
+} from "@/domains/chat/composer-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+/**
+ * Composer-owned notice stack, rendered at the top of the composer above the
+ * orchestration banners. Self-sources everything it needs from `composer-store`
+ * (plus the active conversation id) so the chat orchestrator never subscribes to
+ * draft/attachment state — attaching a file or restoring a draft re-renders only
+ * this component, not the transcript.
+ *
+ * Owns the restored-draft notice lifecycle: it auto-dismisses after a few
+ * seconds and clears when the active conversation no longer matches the
+ * conversation whose draft was restored.
+ */
+export function ComposerDraftNotices() {
+  const hasText = useComposerStore((s) => s.input.trim().length > 0);
+  const attachments = useComposerStore.use.attachments();
+  const attachmentLastError = useComposerStore.use.attachmentLastError();
+  const restoredDraftConversationId =
+    useComposerStore.use.restoredDraftConversationId();
+  const activeConversationId = useConversationStore.use.activeConversationId();
+
+  const uploadingCount = selectUploadingCount(attachments);
+  const showUploadBlocked =
+    uploadingCount > 0 && (hasText || selectUploadedIds(attachments).length > 0);
+  const showRestoredDraft =
+    restoredDraftConversationId !== null &&
+    restoredDraftConversationId === activeConversationId;
+
+  // Auto-dismiss the restored-draft notice after a few seconds.
+  useEffect(() => {
+    if (!showRestoredDraft) return;
+    const id = window.setTimeout(
+      () => useComposerStore.getState().clearRestoredDraftNotice(),
+      5000,
+    );
+    return () => window.clearTimeout(id);
+  }, [showRestoredDraft]);
+
+  // Drop a stale restored-draft marker carried over from a previous conversation.
+  useEffect(() => {
+    if (
+      restoredDraftConversationId !== null &&
+      restoredDraftConversationId !== activeConversationId
+    ) {
+      useComposerStore.getState().clearRestoredDraftNotice();
+    }
+  }, [activeConversationId, restoredDraftConversationId]);
+
+  return (
+    <>
+      {showUploadBlocked && (
+        <div className="mb-2">
+          <Notice tone="info">
+            {uploadingCount === 1
+              ? "Waiting for the attachment to finish uploading before sending."
+              : `Waiting for ${uploadingCount} attachments to finish uploading before sending.`}
+          </Notice>
+        </div>
+      )}
+      {showRestoredDraft && (
+        <div className="mb-2">
+          <Notice
+            tone="info"
+            onDismiss={() =>
+              useComposerStore.getState().clearRestoredDraftNotice()
+            }
+          >
+            Draft restored from your previous session.
+          </Notice>
+        </div>
+      )}
+      {attachmentLastError && (
+        <div className="mb-2">
+          <Notice
+            tone="error"
+            onDismiss={() =>
+              useComposerStore.getState().dismissAttachmentError()
+            }
+          >
+            {attachmentLastError}
+          </Notice>
+        </div>
+      )}
+    </>
+  );
+}

--- a/clients/web/src/domains/chat/components/composer-notices.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.tsx
@@ -12,38 +12,19 @@ import {
 import { Button, Notice } from "@vellumai/design-library";
 
 /**
- * Banner/notice stack rendered immediately above the chat composer's form
- * (in `ChatComposer`'s `noticesAboveFormSlot`). Each notice is fully
- * controlled by the parent — this component only owns the composition and
- * ordering, not the visibility logic. Notices are ordered from most
- * action-specific (top) to most state-level (bottom) so urgent feedback
- * (e.g. attachment errors triggered by the user's last action) appears
- * closest to the composer.
- *
- * Stale-text affordances (the upload-blocked and restored-draft notices
- * from LUM-1516) are rendered first because they directly answer "why
- * didn't pressing Enter send my message?" — the rest of the stack is for
- * setup / billing / operational state.
+ * Orchestration banner stack rendered above the chat composer's form (in
+ * `ChatComposer`'s `noticesAboveFormSlot`, below the composer-owned
+ * {@link ComposerDraftNotices}). Each banner is fully controlled by the parent
+ * — this component only owns composition and ordering. Banners cover voice,
+ * disk pressure, billing, setup, and operational state; the composer-owned
+ * draft/attachment notices live in {@link ComposerDraftNotices}, which renders
+ * ahead of this stack.
  *
  * All props are optional or boolean flags so the component can be used by
  * both the main chat path (full feature set) and the app-editing side
- * panel (which has no voice input and no per-attachment error surface).
+ * panel (which has no voice input).
  */
 export interface ComposerNoticesProps {
-  /**
-   * Stale-text notice content rendered above all other notices. The parent
-   * page owns this JSX so it can wire dismiss handlers and per-notice
-   * tones without this component knowing about restored-draft / upload-
-   * blocked state. Optional — when omitted nothing is rendered at the
-   * top of the stack.
-   */
-  textStateNoticesSlot?: ReactNode;
-
-  /** Last attachment-upload error, or `null` when no error is active. */
-  attachmentLastError?: string | null;
-  /** Dismiss handler for {@link attachmentLastError}. Required when error is non-null. */
-  onDismissAttachmentError?: () => void;
-
   /** Live voice-input error code, or `null` when no error is active. */
   voiceError?: string | null;
   /** Dismiss handler for {@link voiceError}. Required when error is non-null. */
@@ -100,9 +81,6 @@ export interface ComposerNoticesProps {
 }
 
 export function ComposerNotices({
-  textStateNoticesSlot,
-  attachmentLastError,
-  onDismissAttachmentError,
   voiceError,
   onClearVoiceError,
   onRetryMicPermission,
@@ -122,14 +100,6 @@ export function ComposerNotices({
 }: ComposerNoticesProps) {
   return (
     <>
-      {textStateNoticesSlot}
-      {attachmentLastError && (
-        <div className="mb-2">
-          <Notice tone="error" onDismiss={onDismissAttachmentError}>
-            {attachmentLastError}
-          </Notice>
-        </div>
-      )}
       {voiceError && (
         <div className="mb-2">
           <Notice

--- a/clients/web/src/domains/chat/hooks/use-deep-link-consumer.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-deep-link-consumer.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
 import { useComposerStore } from "@/domains/chat/composer-store";
+import { useConversationStore } from "@/stores/conversation-store";
 import {
   __resetPendingDeepLinkForTesting,
   usePendingDeepLinkStore,
@@ -24,6 +25,9 @@ const renderConsumer = (composerInput: string) => {
 beforeEach(() => {
   __resetPendingDeepLinkForTesting();
   useComposerStore.getState().fullReset();
+  // fullReset only clears attachments — reset the draft fields this suite drives.
+  useComposerStore.setState({ input: "", restoredDraftConversationId: null });
+  useConversationStore.setState({ activeConversationId: null });
   sentryBreadcrumbMock.mockClear();
 });
 
@@ -69,6 +73,25 @@ describe("pending message consumption", () => {
     renderConsumer("   \n  ");
 
     expect(useComposerStore.getState().input).toBe("hello");
+  });
+
+  test("a deeplink overrides a cold-load restored draft, not live typing", () => {
+    // The draft-restore effect (registered ahead of this hook) can populate the
+    // composer with a *restored* draft before this effect runs. A restored
+    // draft is not live typing, so the explicit deeplink must still win.
+    useConversationStore.setState({ activeConversationId: "conv-1" });
+    useComposerStore.setState({
+      input: "restored draft text",
+      restoredDraftConversationId: "conv-1",
+    });
+    usePendingDeepLinkStore.getState().setPendingComposerMessage("from link");
+
+    renderHook(() => useDeepLinkConsumer());
+
+    expect(useComposerStore.getState().input).toBe("from link");
+    // The restored-draft notice is retired since the deeplink replaced it.
+    expect(useComposerStore.getState().restoredDraftConversationId).toBe(null);
+    expect(sentryBreadcrumbMock).not.toHaveBeenCalled();
   });
 
   test("no-op when no message is pending", () => {

--- a/clients/web/src/domains/chat/hooks/use-deep-link-consumer.ts
+++ b/clients/web/src/domains/chat/hooks/use-deep-link-consumer.ts
@@ -22,15 +22,15 @@ import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
  * - If non-empty, drop with a Sentry breadcrumb — refusing to
  *   overwrite the user's in-progress typing is the conservative
  *   call until we have telemetry to justify a "queue or prompt" UX.
- * - Runs on every render where `pendingComposerMessage` is non-null,
- *   so a deep link arriving WHILE `ChatPage` is already mounted is
- *   picked up on the next render. The Zustand selector re-renders
- *   the component when the slice changes.
+ * - Fires when `pendingComposerMessage` becomes non-null — the Zustand
+ *   atomic selector re-renders this hook's host when that slice changes, so a
+ *   deep link arriving WHILE `ChatPage` is already mounted is still picked up.
+ *   It deliberately does NOT subscribe to the composer draft (that would
+ *   re-render the host on every keystroke); the empty-check reads `getState()`.
  */
 
 export function useDeepLinkConsumer(): void {
   const pending = usePendingDeepLinkStore.use.pendingComposerMessage();
-  const input = useComposerStore.use.input();
 
   useEffect(() => {
     if (pending === null) return;
@@ -38,7 +38,10 @@ export function useDeepLinkConsumer(): void {
       .getState()
       .consumePendingComposerMessage();
     if (consumed === null) return;
-    if (input.trim().length > 0) {
+    // Read the draft imperatively — this is a one-shot decision when a link
+    // arrives, not something to re-run on every keystroke, so we must NOT
+    // subscribe to `input` (that would re-render this hook's host per keypress).
+    if (useComposerStore.getState().input.trim().length > 0) {
       Sentry.addBreadcrumb({
         category: "deeplink",
         level: "info",
@@ -48,5 +51,5 @@ export function useDeepLinkConsumer(): void {
       return;
     }
     useComposerStore.getState().setInput(consumed);
-  }, [pending, input]);
+  }, [pending]);
 }

--- a/clients/web/src/domains/chat/hooks/use-deep-link-consumer.ts
+++ b/clients/web/src/domains/chat/hooks/use-deep-link-consumer.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import * as Sentry from "@sentry/react";
 
 import { useComposerStore } from "@/domains/chat/composer-store";
+import { useConversationStore } from "@/stores/conversation-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 
 /**
@@ -17,16 +18,22 @@ import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
  *
  * Semantics:
  *
- * - If the composer is empty (`.trim().length === 0`), consume the
- *   pending message and `setComposerInput(message)`.
- * - If non-empty, drop with a Sentry breadcrumb — refusing to
- *   overwrite the user's in-progress typing is the conservative
- *   call until we have telemetry to justify a "queue or prompt" UX.
+ * - If the composer is empty, or holds a draft that was just *restored* on
+ *   cold load (not typed), consume the pending message and set it. A deeplink
+ *   is an explicit user action, so it wins over a restored draft — otherwise an
+ *   incoming link would silently no-op behind leftover draft text.
+ * - If the composer holds genuine in-progress typing, drop with a Sentry
+ *   breadcrumb — refusing to overwrite is the conservative call until we have
+ *   telemetry to justify a "queue or prompt" UX.
  * - Fires when `pendingComposerMessage` becomes non-null — the Zustand
  *   atomic selector re-renders this hook's host when that slice changes, so a
  *   deep link arriving WHILE `ChatPage` is already mounted is still picked up.
  *   It deliberately does NOT subscribe to the composer draft (that would
- *   re-render the host on every keystroke); the empty-check reads `getState()`.
+ *   re-render the host on every keystroke); the checks read `getState()`.
+ *
+ * The restored-draft carve-out matters because `useDraftPersistence`'s cold-load
+ * restore is registered ahead of this hook in `ActiveChatView`, so the draft can
+ * already be in the store by the time this effect runs.
  */
 
 export function useDeepLinkConsumer(): void {
@@ -38,10 +45,18 @@ export function useDeepLinkConsumer(): void {
       .getState()
       .consumePendingComposerMessage();
     if (consumed === null) return;
-    // Read the draft imperatively — this is a one-shot decision when a link
-    // arrives, not something to re-run on every keystroke, so we must NOT
-    // subscribe to `input` (that would re-render this hook's host per keypress).
-    if (useComposerStore.getState().input.trim().length > 0) {
+    // Read imperatively — a one-shot decision when a link arrives, not something
+    // to re-run per keystroke, so this hook must not subscribe to the draft.
+    const { input, restoredDraftConversationId, setInput, clearRestoredDraftNotice } =
+      useComposerStore.getState();
+    const activeConversationId =
+      useConversationStore.getState().activeConversationId;
+    // A just-restored draft (cold load) is not live typing, so a deeplink may
+    // replace it; only genuine typed text blocks the prefill.
+    const inputIsRestoredDraft =
+      restoredDraftConversationId !== null &&
+      restoredDraftConversationId === activeConversationId;
+    if (input.trim().length > 0 && !inputIsRestoredDraft) {
       Sentry.addBreadcrumb({
         category: "deeplink",
         level: "info",
@@ -50,6 +65,8 @@ export function useDeepLinkConsumer(): void {
       });
       return;
     }
-    useComposerStore.getState().setInput(consumed);
+    setInput(consumed);
+    // The deeplink supersedes the restored draft, so retire its notice too.
+    if (inputIsRestoredDraft) clearRestoredDraftNotice();
   }, [pending]);
 }

--- a/clients/web/src/domains/chat/hooks/use-voice-input.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-voice-input.test.tsx
@@ -1,6 +1,8 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import type { Dispatch, RefObject, SetStateAction } from "react";
+import type { RefObject } from "react";
+
+import { useComposerStore } from "@/domains/chat/composer-store";
 
 type TextInsertionStatus =
   | "inserted"
@@ -61,11 +63,10 @@ mock.module("@/runtime/system-permissions", () => ({
 const { useVoiceInput } = await import("./use-voice-input");
 
 const renderVoiceInput = (assistantId: string | null = null) => {
-  let input = "";
+  // The hook writes transcripts straight to the composer store; start clean so
+  // each case asserts only what this render produced.
+  useComposerStore.setState({ input: "" });
   let focusCount = 0;
-  const setInput: Dispatch<SetStateAction<string>> = (value) => {
-    input = typeof value === "function" ? value(input) : value;
-  };
   const inputRef = {
     current: {
       selectionStart: null,
@@ -75,19 +76,18 @@ const renderVoiceInput = (assistantId: string | null = null) => {
     } as unknown as HTMLTextAreaElement,
   } satisfies RefObject<HTMLTextAreaElement | null>;
 
-  const hook = renderHook(() =>
-    useVoiceInput({ assistantId, inputRef, setInput }),
-  );
+  const hook = renderHook(() => useVoiceInput({ assistantId, inputRef }));
 
   return {
     hook,
-    getInput: () => input,
+    getInput: () => useComposerStore.getState().input,
     getFocusCount: () => focusCount,
   };
 };
 
 afterEach(() => {
   cleanup();
+  useComposerStore.setState({ input: "" });
   nextTextInsertionStatus = "unavailable";
   nextDictationResult = null;
   insertedTexts.length = 0;

--- a/clients/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/clients/web/src/domains/chat/hooks/use-voice-input.ts
@@ -1,6 +1,7 @@
 
-import { type Dispatch, type RefObject, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { useComposerStore } from "@/domains/chat/composer-store";
 import {
   type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
@@ -30,8 +31,6 @@ export interface UseVoiceInputOptions {
   assistantId: string | null;
   /** Ref to the composer textarea for cursor-position reads and resize. */
   inputRef: RefObject<HTMLTextAreaElement | null>;
-  /** State setter for the composer input value (React useState dispatch). */
-  setInput: Dispatch<SetStateAction<string>>;
 }
 
 export interface UseVoiceInputReturn {
@@ -102,7 +101,6 @@ export interface UseVoiceInputReturn {
 export function useVoiceInput({
   assistantId,
   inputRef,
-  setInput,
 }: UseVoiceInputOptions): UseVoiceInputReturn {
   const [voiceInterim, setVoiceInterim] = useState("");
   const [voiceError, setVoiceError] = useState<string | null>(null);
@@ -179,7 +177,10 @@ export function useVoiceInput({
           .flagDictationInsertionError("dictation-paste-blocked");
       }
 
-      setInput((current: string) => {
+      // Imperative write — voice transcripts can land while the composer is
+      // unfocused (front-app dictation), so we go through the store rather than
+      // a subscribed setter (per docs/STATE_MANAGEMENT.md: getState in callbacks).
+      useComposerStore.getState().setInput((current: string) => {
         const insertAt = capturedPos ?? current.length;
         const pos = Math.min(insertAt, current.length);
         const before = current.slice(0, pos);
@@ -191,7 +192,7 @@ export function useVoiceInput({
 
       inputRef.current?.focus();
     },
-    [assistantId, inputRef, setInput],
+    [assistantId, inputRef],
   );
 
   const isRecording = useVoiceRecordingStore.use.phase() === "recording";


### PR DESCRIPTION
**Linear:** [LUM-2527](https://linear.app/vellum/issue/LUM-2527/internalize-composer-draft-chatcomposer-reads-composer-store-directly) (child of [LUM-2255](https://linear.app/vellum/issue/LUM-2255))

## Problem

Typing/pasting in chat felt laggy and the caret was delayed — worst on long conversations and in Electron (Chromium = same web layer). Root cause: the composer's draft text lived in `composer-store` but was *subscribed by the orchestrator* (`ChatMainPanel`) and threaded back down as props, so every keystroke re-rendered the orchestrator and reconciled the entire non-virtualized transcript. This violated the codebase's own docs (`STATE_MANAGEMENT.md`: atomic selectors, no prop drilling; `CONVENTIONS.md`: no god components).

## What this does

Moves **all** composer-owned state to the leaf that renders it, so the orchestrator subscribes to **zero** composer-store slices — typing, attaching a file, or a draft notice never re-renders `ChatMainPanel` or the transcript.

- **`ChatComposer`** self-sources `input`/`setInput` **and** `attachments`, deriving uploading-count / can-send locally instead of taking four props.
- **`ComposerDraftNotices`** (new) self-sources the composer-owned notices (upload-blocked, restored-draft, attachment-error) and owns the restored-draft lifecycle effects (5s auto-dismiss, clear-on-conversation-change). `ComposerNotices` is now just the orchestration banner stack (voice/disk/billing/maintenance).
- **`ChatMainPanel`**'s only remaining composer-store touch is the vision-gated *write* (queueing dropped/attached files), which depends on the active model and can't move into the composer. Verified: **0 reactive composer subscriptions** in the orchestrator.
- **`ChatBody`** takes the composer as an explicit `composerSlot` node instead of a `{...composerProps}` spread; `ComposerNotices` is wired with explicit props too — both prop-bundle spreads are gone and the contract is visible at the construction site.
- The **"draft restored" marker clears on the user's first edit**, keeping `restoredDraftConversationId` an accurate "unedited restored draft" signal for the deeplink consumer (and dismissing the notice on edit). This also fixes a review-found cold-load race where a deeplink could be dropped behind a restored draft.

## Tests

Composer/voice tests now seed the **real store** (exercising the real send-gating + notice derivation instead of injected booleans — fixes tests that pinned a bypassed contract). New `composer-draft-notices` suite covers the extracted seam. All affected suites pass in isolation; typecheck + lint clean (one pre-existing `exhaustive-deps` warning on the slash popup, unrelated).

## Deliberately deferred (stated, not hidden)

- **Streaming re-renders** — `messages` is still woven through ~10 `ChatMainPanel` derivations; that's the transcript half of LUM-2255 and its prop-spreads (`<Transcript {...}/>`) go with it.
- **`draftsMap` module-global** (should be store state) and the **deep-link two-store hand-off** are separate subsystems — flagged, not patched.
- **React Compiler** (React 19, off) — app-level infra decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh1GBRgSSWtkxgCnMw9sR5