### PR TITLE
fix(gateway): contact-prompt re-review follow-ups (non-fatal heal, guardian role preserved)

### DIFF
--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -604,6 +604,157 @@ describe("handleContactPromptSubmit", () => {
     expect(ipcCall.body.channelId).toBe("chan-reuse");
   });
 
+  test("guardian reuse — mirror-heal upsert throwing is non-fatal (still accepted, reuses channel)", async () => {
+    const now = Date.now();
+    seedGuardian();
+    // Gateway channel already bound to the guardian — reuse precondition.
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-reuse-fail",
+        contactId: "guardian-1",
+        type: "phone",
+        address: "+15558887777",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // The reuse-branch mirror-heal upsertContact throws (e.g. transient
+    // gateway SQLITE_BUSY). The reuse path must stay success-guaranteed.
+    const spy = spyOn(
+      ContactStore.prototype,
+      "upsertContact",
+    ).mockImplementation(async () => {
+      throw new Error("SQLITE_BUSY: database is locked");
+    });
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-reuse-fail",
+          address: "+15558887777",
+          channelType: "phone",
+          role: "guardian",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Existing gateway channel reused — no new row, no reassignment.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15558887777"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-reuse-fail");
+    expect(gwChannels[0].contactId).toBe("guardian-1");
+
+    // Daemon resolved with the existing channel id (success, not error).
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(ipcCall.body.channelId).toBe("chan-reuse-fail");
+    expect(ipcCall.body.error).toBeUndefined();
+  });
+
+  test("guardian bootstrap-create — assistant mirror keeps role='guardian' even if create-mirror INSERT fails", async () => {
+    // No guardian seeded: handler mints one gateway-first. Make the
+    // bootstrap-create assistant mirror INSERT (role='guardian') fail, so the
+    // assistant DB has no guardian row when Phase-2 upsertContact runs. Without
+    // the role re-assert, that upsert would INSERT the id with role='contact',
+    // downgrading the guardian in the mirror.
+    const realDb = testAssistantDb!;
+    let failNextGuardianInsert = true;
+    testAssistantDb = {
+      prepare(sql: string) {
+        if (
+          failNextGuardianInsert &&
+          /INSERT INTO contacts/i.test(sql) &&
+          /'guardian'/.test(sql)
+        ) {
+          failNextGuardianInsert = false;
+          throw new Error("assistant DB guardian INSERT unavailable");
+        }
+        return realDb.prepare(sql);
+      },
+    } as unknown as Database;
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-boot-downgrade",
+          address: "+15552223333",
+          channelType: "phone",
+          role: "guardian",
+          displayName: "Mirror Guardian",
+        }),
+      );
+    } finally {
+      testAssistantDb = realDb;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Gateway DB: guardian minted with role=guardian (authoritative).
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(1);
+
+    // Assistant mirror: the role re-assert healed any Phase-2 downgrade — the
+    // row exists and is role='guardian', NOT 'contact'.
+    const asContacts = testAssistantDb!
+      .prepare(`SELECT role FROM contacts WHERE id = ?`)
+      .all(gwGuardians[0].id) as { role: string }[];
+    expect(asContacts).toHaveLength(1);
+    expect(asContacts[0].role).toBe("guardian");
+  });
+
+  test("guardian bootstrap-create — assistant mirror row is role='guardian'", async () => {
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-boot-role",
+        address: "+15554445555",
+        channelType: "phone",
+        role: "guardian",
+        displayName: "Role Guardian",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Record<string, unknown>).accepted).toBe(true);
+
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(1);
+
+    const asContacts = testAssistantDb!
+      .prepare(`SELECT role FROM contacts WHERE id = ?`)
+      .all(gwGuardians[0].id) as { role: string }[];
+    expect(asContacts).toHaveLength(1);
+    expect(asContacts[0].role).toBe("guardian");
+  });
+
   test("non-guardian prompt — 500 + daemon error when channel can't be resolved (no empty channelId)", async () => {
     // Force resolveChannelId to miss by making getChannelsForContact return [].
     const spy = spyOn(

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -237,29 +237,30 @@ export async function handleContactPromptSubmit(
       .get();
 
     if (existingChannel && existingChannel.contactId === contactId) {
-      // Heal the best-effort assistant-DB mirror on retry (matching the
-      // non-guardian path's self-healing). Passing the guardian's id preserves
-      // role="guardian" via upsertContact's id-path role preservation; the
-      // gateway channel already exists, so this is a no-op there and only
-      // recovers a previously-unavailable assistant mirror.
-      await getStore().upsertContact({
-        id: contactId,
-        channels: [
-          { type: channelType, address: normalizedAddress, isPrimary: true },
-        ],
-      });
-      channelId = resolveChannelId(contactId, channelType, normalizedAddress);
+      // Reuse is success-guaranteed: the gateway channel already belongs to
+      // this guardian. Best-effort heal the assistant-DB mirror (passing the
+      // guardian's id preserves role="guardian" via upsertContact's id-path
+      // role preservation). The gateway-side syncChannels UPDATE here is
+      // incidental — the real purpose is recovering a stale mirror — so a
+      // transient gateway error must never fail the request.
+      try {
+        await getStore().upsertContact({
+          id: contactId,
+          channels: [
+            { type: channelType, address: normalizedAddress, isPrimary: true },
+          ],
+        });
+      } catch (healErr) {
+        log.warn(
+          { err: healErr, contactId, channelType, address: normalizedAddress },
+          "contact-prompt-submit: guardian reuse mirror-heal failed (best-effort), continuing with existing channel",
+        );
+      }
+      channelId = existingChannel.id;
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: channel already exists",
       );
-      if (!channelId) {
-        log.error(
-          { channelType, address: normalizedAddress, contactId },
-          "contact-prompt-submit: channel resolution failed on guardian reuse",
-        );
-        return await channelResolutionError(requestId);
-      }
     } else if (existingChannel) {
       // Channel exists but belongs to a different contact.  The caller must
       // clean up the stale binding before a guardian channel can be created.
@@ -349,6 +350,25 @@ export async function handleContactPromptSubmit(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: created new channel",
       );
+    }
+
+    // Re-assert role="guardian" in the best-effort assistant mirror: if the
+    // bootstrap-create mirror INSERT failed, the Phase-2 upsertContact INSERTs
+    // this id with a hardcoded role="contact", downgrading the guardian in the
+    // mirror (gateway stays authoritative, so ACL is unaffected). Heal only
+    // when this request minted the guardian; never fails the request.
+    if (createdNewContact) {
+      try {
+        await assistantDbRun(
+          "UPDATE contacts SET role = 'guardian', updated_at = ? WHERE id = ?",
+          [now, contactId],
+        );
+      } catch (roleErr) {
+        log.warn(
+          { err: roleErr, contactId },
+          "contact-prompt-submit: assistant DB guardian role re-assert failed (best-effort)",
+        );
+      }
     }
   } catch (err) {
     log.error({ err, requestId }, "contact-prompt-submit: DB error");


### PR DESCRIPTION
## Summary
Addresses re-review gaps on the contacts-prompt gateway-first migration:
- Guardian channel-reuse mirror-heal is now best-effort (its own try/catch); a transient gateway write no longer 500s an otherwise-guaranteed reuse.
- After a freshly-created guardian binds its channel, re-assert role='guardian' in the best-effort assistant mirror so a failed bootstrap mirror INSERT followed by a Phase-2 upsert can't downgrade the guardian to role='contact'.

Part of plan: contacts-prompt-gateway-first.md (re-review fixes)