### PR TITLE
fix(web): gate Settings restart on local-host availability

### DIFF
--- a/clients/web/src/domains/settings/components/restart-assistant.tsx
+++ b/clients/web/src/domains/settings/components/restart-assistant.tsx
@@ -2,8 +2,9 @@ import { Loader2, RotateCcw } from "lucide-react";
 import { useState } from "react";
 
 import { restartAssistant } from "@/assistant/api";
-import { getLockfile, isLocalAssistant, isLocalMode } from "@/lib/local-mode";
+import { isCliWakeableAssistant } from "@/lib/local-mode";
 import {
+  isLocalModeHostAvailable,
   sleepLocalAssistantHost,
   wakeLocalAssistantHost,
 } from "@/runtime/local-mode-host";
@@ -33,10 +34,11 @@ export function RestartAssistant({ assistantId }: { assistantId: string }) {
     setConfirmOpen(false);
     setRestarting(true);
     try {
-      const lockfileEntry = isLocalMode()
-        ? getLockfile().assistants.find((a) => a.assistantId === assistantId)
-        : undefined;
-      const isCli = !!lockfileEntry && isLocalAssistant(lockfileEntry);
+      // CLI restart (sleep + wake) only when a local host is present to run it
+      // and the assistant is one wake operates on; otherwise the platform API.
+      // Mirrors the wake-affordance gating in status-banner / connect-recovery.
+      const isCli =
+        isLocalModeHostAvailable() && isCliWakeableAssistant(assistantId);
 
       if (isCli) {
         const result = await restartLocalAssistant(assistantId);


### PR DESCRIPTION
## Problem

`clients/web/src/domains/settings/components/restart-assistant.tsx` chose between CLI restart (`sleep`+`wake` via the host) and the platform restart API with:

```ts
const lockfileEntry = isLocalMode()
  ? getLockfile().assistants.find((a) => a.assistantId === assistantId)
  : undefined;
const isCli = !!lockfileEntry && isLocalAssistant(lockfileEntry);
```

- **No host-availability check** — it gates on `isLocalMode()` (a build-time flag) rather than `isLocalModeHostAvailable()` (whether a local host is actually present to run `wake`). On a hostless build that is somehow in local mode (a misconfigured deployment, or a stale `localStorage` lockfile), it routes a local assistant to CLI `sleep`/`wake`, which no-op `{ ok: false }` off-host → a confusing "Failed to restart" toast.
- **Identity predicate for an operational decision** — it uses `isLocalAssistant` (identity) and re-implements the lockfile lookup `isCliWakeableAssistant` already does.

The wake affordances elsewhere — `status-banner.tsx` and the connect-recovery dialog (`select-assistant-screen.tsx`, hardened in #35378) — correctly gate on `isLocalModeHostAvailable()`. This one didn't.

## Fix

```ts
const isCli =
  isLocalModeHostAvailable() && isCliWakeableAssistant(assistantId);
```

Mirrors the established wake-affordance gating, uses the operational predicate, and drops the duplicate lockfile find (and the now-unused `getLockfile`/`isLocalAssistant`/`isLocalMode` imports).

## Behaviour

Behaviour-preserving in real configs: on local hosts (`isLocalModeHostAvailable()` true) the set is unchanged (`isCliWakeableAssistant` resolves the same `{local, null}` entries); on managed-web both gates are false → platform API restart, as before. The only change is the hostless-local-mode misconfig edge, which now routes to the API path (which fails gracefully) instead of a doomed CLI restart.

## Context

Surfaced by the first-principles audit of #35378 (the local-assistant identity/connectivity split). Pre-existing — not introduced by that PR. Low severity (worst case today is a harmless error toast).

## Testing

`tsc` clean, ESLint clean, full web suite **399/399**. (No existing `restart-assistant` unit test; the change is covered by the predicates' own tests — `isCliWakeableAssistant` in `local-mode.test.ts`, `isLocalModeHostAvailable` in `local-mode-host.test.ts`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeN6mWBq3CBbG9N72Y7Kk

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLeN6mWBq3CBbG9N72Y7Kk)_