### PR TITLE
refactor(chat): export phase-group helpers for reuse by the subagent timeline

### DIFF
--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
@@ -11,7 +11,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, render } from "@testing-library/react";
 
-import { PhaseGroupedStepList } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import {
+  PhaseGroupedStepList,
+  phaseHeaderStatus,
+  sumDurationLabels,
+} from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 
 afterEach(() => {
@@ -371,5 +375,43 @@ describe("PhaseGroupedStepList — phase header total duration", () => {
     // THEN the duration renders without the tooltip hover trigger
     expect(header.textContent).toContain("3s");
     expect(header.querySelector(".cursor-default")).toBeNull();
+  });
+});
+
+describe("phaseHeaderStatus", () => {
+  test("returns 'running' when any step is running (precedence over failure)", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("rm -rf /nope", "error", "1s", "tc-a"),
+      bash("sleep 5", "running", "", "tc-b"),
+    ];
+    expect(phaseHeaderStatus(steps)).toBe("running");
+  });
+
+  test("returns 'failed' when a step errored or was denied with none running", () => {
+    expect(
+      phaseHeaderStatus([bash("rm -rf /nope", "error", "1s", "tc-a")]),
+    ).toBe("failed");
+    expect(
+      phaseHeaderStatus([bash("sudo rm -rf /", "denied", "", "tc-b")]),
+    ).toBe("failed");
+  });
+
+  test("returns 'completed' otherwise", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "2s", "tc-b"),
+    ];
+    expect(phaseHeaderStatus(steps)).toBe("completed");
+  });
+});
+
+describe("sumDurationLabels", () => {
+  test("sums non-empty labels and re-formats the total", () => {
+    expect(sumDurationLabels(["3s", "2s"])).toBe("5s");
+  });
+
+  test("returns an empty string for an empty or all-empty input", () => {
+    expect(sumDurationLabels([])).toBe("");
+    expect(sumDurationLabels(["", ""])).toBe("");
   });
 });

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -169,7 +169,7 @@ function PhaseDurationLabel({
 }
 
 /** Total of `formatMs`-style labels, re-formatted via `formatMs`. */
-function sumDurationLabels(labels: string[]): string {
+export function sumDurationLabels(labels: string[]): string {
   let total = 0;
   let anyPresent = false;
   for (const label of labels) {
@@ -186,7 +186,7 @@ function sumDurationLabels(labels: string[]): string {
  * an in-flight retry inside a phase that has already produced a failure
  * still reads as in-progress.
  */
-type PhaseHeaderStatus = "completed" | "failed" | "running";
+export type PhaseHeaderStatus = "completed" | "failed" | "running";
 
 /**
  * Classify a phase's overall status for header icon rendering.
@@ -200,7 +200,9 @@ type PhaseHeaderStatus = "completed" | "failed" | "running";
  * "Searched the web"), so we treat any `web_search` step with that title
  * as in-flight. `thinking` is always neutral (no in-flight signal carried).
  */
-function phaseHeaderStatus(steps: ToolCallCardStep[]): PhaseHeaderStatus {
+export function phaseHeaderStatus(
+  steps: ToolCallCardStep[],
+): PhaseHeaderStatus {
   if (steps.length === 0) return "running";
   let failed = false;
   for (const step of steps) {
@@ -224,7 +226,7 @@ function phaseHeaderStatus(steps: ToolCallCardStep[]): PhaseHeaderStatus {
 }
 
 /** Phase-grouped section as consumed by the renderer. */
-interface PhaseSection {
+export interface PhaseSection {
   label: string;
   steps: ToolCallCardStep[];
 }
@@ -446,7 +448,7 @@ function TimelinePhaseSection({
  * below / end above each node (with a small gap), so the icon never needs to
  * mask the line passing behind it.
  */
-function TimelineNode({
+export function TimelineNode({
   status,
   isThinking,
 }: {


### PR DESCRIPTION
## Summary
- Export phaseHeaderStatus, sumDurationLabels, TimelineNode, PhaseHeaderStatus, PhaseSection from phase-grouped-step-list.tsx (purely additive)
- Add unit coverage for the exported helpers

Part of plan: subagent-detail-panel-figma.md (PR 1 of 5)