### PR TITLE
Contacts Prompt — Gateway-First Source-of-Truth Write

### DIFF
--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -263,7 +263,7 @@ describe("handleContactPromptSubmit", () => {
     expect(typeof ipcCall.body.error).toBe("string");
   });
 
-  test("non-guardian prompt — creates new contact and channel", async () => {
+  test("non-guardian prompt — creates new contact and channel (gateway-first)", async () => {
     const res = await handleContactPromptSubmit(
       makeRequest({
         requestId: "req-4",
@@ -276,31 +276,102 @@ describe("handleContactPromptSubmit", () => {
 
     expect(res.status).toBe(200);
 
-    const contacts = testAssistantDb!
-      .prepare(`SELECT id, role FROM contacts WHERE display_name = 'Alice'`)
-      .all() as { id: string; role: string }[];
-    expect(contacts).toHaveLength(1);
-    expect(contacts[0].role).toBe("contact");
+    // Gateway DB is the source of truth: contact + channel rows must exist
+    // (unverified / allow / primary).
+    const gwContactRows = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.displayName, "Alice"))
+      .all();
+    expect(gwContactRows).toHaveLength(1);
+    expect(gwContactRows[0].role).toBe("contact");
 
-    const channels = testAssistantDb!
-      .prepare(`SELECT contact_id FROM contact_channels WHERE type = 'email' AND address = ?`)
-      .all("alice@example.com") as { contact_id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].contact_id).toBe(contacts[0].id);
+    const gwChannelRows = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "alice@example.com"))
+      .all();
+    expect(gwChannelRows).toHaveLength(1);
+    expect(gwChannelRows[0].contactId).toBe(gwContactRows[0].id);
+    expect(gwChannelRows[0].status).toBe("unverified");
+    expect(gwChannelRows[0].policy).toBe("allow");
+    expect(gwChannelRows[0].isPrimary).toBe(true);
+
+    // The channel id handed to resolve_contact_prompt matches the gateway row.
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    expect(ipcCall.body.channelId).toBe(gwChannelRows[0].id);
+    expect(ipcCall.body.contactId).toBe(gwContactRows[0].id);
   });
 
-  test("non-guardian prompt — reuses existing contact when channel already known", async () => {
+  test("non-guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
+    // Make the best-effort assistant-DB mirror fail. The gateway-first write
+    // must still succeed and the request still be accepted.
+    const realDb = testAssistantDb!;
+    testAssistantDb = {
+      prepare() {
+        throw new Error("assistant DB mirror unavailable");
+      },
+    } as unknown as Database;
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-mirror",
+          address: "bob@example.com",
+          channelType: "email",
+          role: "trusted-contact",
+          displayName: "Bob",
+        }),
+      );
+    } finally {
+      testAssistantDb = realDb;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Gateway DB rows are present despite the mirror failure.
+    const gwChannelRows = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "bob@example.com"))
+      .all();
+    expect(gwChannelRows).toHaveLength(1);
+
+    const gwContactRows = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.id, gwChannelRows[0].contactId))
+      .all();
+    expect(gwContactRows).toHaveLength(1);
+  });
+
+  test("non-guardian prompt — reuses existing gateway contact and preserves name when displayName omitted", async () => {
     const now = Date.now();
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('contact-1', 'Alice', 'contact', 'human', ?, ?)`,
-      [now, now],
-    );
-    testAssistantDb!.run(
-      `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-       VALUES ('chan-alice', 'contact-1', 'email', 'alice@example.com', 1, 'active', 'allow', 3, ?, ?)`,
-      [now, now],
-    );
+    // Seed an existing gateway contact + channel (gateway DB is the source of
+    // truth for the reuse-by-channel lookup).
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({ id: "contact-1", displayName: "Alice", role: "contact", createdAt: now, updatedAt: now })
+      .run();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-alice",
+        contactId: "contact-1",
+        type: "email",
+        address: "alice@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 3,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-5", address: "alice@example.com", channelType: "email" }),
@@ -308,14 +379,14 @@ describe("handleContactPromptSubmit", () => {
 
     expect(res.status).toBe(200);
 
-    // Should not have created a second contact.
-    const contacts = testAssistantDb!
-      .prepare(`SELECT id FROM contacts`)
-      .all() as { id: string }[];
-    expect(contacts).toHaveLength(1);
-    expect(contacts[0].id).toBe("contact-1");
+    // No duplicate contact row; the existing contact id is reused.
+    const gwContactRows = getGatewayDb().select().from(gwContacts).all();
+    expect(gwContactRows).toHaveLength(1);
+    expect(gwContactRows[0].id).toBe("contact-1");
+    // display_name not clobbered when displayName omitted from the body.
+    expect(gwContactRows[0].displayName).toBe("Alice");
 
-     
+
     const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
     expect(ipcCall.body.contactId).toBe("contact-1");
   });

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -161,14 +161,24 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("handleContactPromptSubmit", () => {
-  test("guardian prompt — creates channel bound to existing guardian contact", async () => {
+  // Seed a guardian contact into BOTH the gateway DB (source of truth) and the
+  // assistant DB mirror. The handler resolves the guardian from the gateway DB;
+  // the assistant row keeps the FK for the best-effort channel mirror.
+  function seedGuardian(id = "guardian-1", name = "Vargas"): void {
     const now = Date.now();
-    // Seed an existing guardian contact in the assistant DB.
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({ id, displayName: name, role: "guardian", createdAt: now, updatedAt: now })
+      .run();
     testAssistantDb!.run(
       `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('guardian-1', 'Vargas', 'guardian', 'human', ?, ?)`,
-      [now, now],
+       VALUES (?, ?, 'guardian', 'human', ?, ?)`,
+      [id, name, now, now],
     );
+  }
+
+  test("guardian prompt — binds channel to existing gateway guardian, role preserved", async () => {
+    seedGuardian();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-1", address: "+15551234567", channelType: "phone", role: "guardian" }),
@@ -178,32 +188,50 @@ describe("handleContactPromptSubmit", () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body.accepted).toBe(true);
 
-    // Channel should be created in assistant DB pointing to guardian.
-    const channels = testAssistantDb!
-      .prepare(`SELECT contact_id FROM contact_channels WHERE type = 'phone' AND address = ?`)
-      .all("+15551234567") as { contact_id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].contact_id).toBe("guardian-1");
+    // Gateway DB is the source of truth: channel row bound to the guardian.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15551234567"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].contactId).toBe("guardian-1");
 
-    // IPC should have been called with the guardian contactId.
+    // Guardian role must be preserved on the gateway contact row.
+    const gwGuardian = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.id, "guardian-1"))
+      .all();
+    expect(gwGuardian).toHaveLength(1);
+    expect(gwGuardian[0].role).toBe("guardian");
+
+    // IPC should have been called with the guardian contactId + gateway channel id.
     expect(ipcMock).toHaveBeenCalledTimes(1);
-     
+
     const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
     expect(ipcCall.body.contactId).toBe("guardian-1");
+    expect(ipcCall.body.channelId).toBe(gwChannels[0].id);
   });
 
   test("guardian prompt — reuses channel already bound to guardian", async () => {
     const now = Date.now();
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('guardian-1', 'Vargas', 'guardian', 'human', ?, ?)`,
-      [now, now],
-    );
-    testAssistantDb!.run(
-      `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-       VALUES ('chan-1', 'guardian-1', 'phone', '+15551234567', 1, 'active', 'allow', 5, ?, ?)`,
-      [now, now],
-    );
+    seedGuardian();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-1",
+        contactId: "guardian-1",
+        type: "phone",
+        address: "+15551234567",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 5,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-2", address: "+15551234567", channelType: "phone", role: "guardian" }),
@@ -213,33 +241,44 @@ describe("handleContactPromptSubmit", () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body.accepted).toBe(true);
 
-    // No new channel should have been inserted.
-    const channels = testAssistantDb!
-      .prepare(`SELECT id FROM contact_channels WHERE type = 'phone'`)
-      .all() as { id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].id).toBe("chan-1");
+    // No new channel should have been inserted in the gateway DB.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.type, "phone"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-1");
+
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    expect(ipcCall.body.channelId).toBe("chan-1");
   });
 
   test("guardian prompt — 409 when channel already belongs to another contact", async () => {
     const now = Date.now();
-    // Guardian contact.
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('guardian-1', 'Vargas', 'guardian', 'human', ?, ?)`,
-      [now, now],
-    );
-    // A different (orphaned or stale) contact that owns the channel.
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('other-1', 'Orphan', 'contact', 'human', ?, ?)`,
-      [now, now],
-    );
-    testAssistantDb!.run(
-      `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-       VALUES ('chan-other', 'other-1', 'phone', '+15551234567', 1, 'unverified', 'allow', 0, ?, ?)`,
-      [now, now],
-    );
+    seedGuardian();
+    // A different (orphaned or stale) contact that owns the channel in the
+    // gateway DB.
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({ id: "other-1", displayName: "Orphan", role: "contact", createdAt: now, updatedAt: now })
+      .run();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-other",
+        contactId: "other-1",
+        type: "phone",
+        address: "+15551234567",
+        isPrimary: true,
+        status: "unverified",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
 
     const res = await handleContactPromptSubmit(
       makeRequest({ requestId: "req-3", address: "+15551234567", channelType: "phone", role: "guardian" }),
@@ -249,18 +288,96 @@ describe("handleContactPromptSubmit", () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body.accepted).toBe(false);
 
-    // The stale channel must not have been deleted.
-    const channels = testAssistantDb!
-      .prepare(`SELECT id FROM contact_channels WHERE type = 'phone'`)
-      .all() as { id: string }[];
-    expect(channels).toHaveLength(1);
-    expect(channels[0].id).toBe("chan-other");
+    // The stale gateway channel must not have been deleted or reassigned, and no
+    // new channel row created for the guardian.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.type, "phone"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-other");
+    expect(gwChannels[0].contactId).toBe("other-1");
+
+    // No assistant-DB channel write occurred for that address either.
+    const asChannels = testAssistantDb!
+      .prepare(`SELECT id FROM contact_channels WHERE address = ?`)
+      .all("+15551234567") as { id: string }[];
+    expect(asChannels).toHaveLength(0);
 
     // IPC should have been called with an error so the CLI doesn't hang.
     expect(ipcMock).toHaveBeenCalledTimes(1);
-     
+
     const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
     expect(typeof ipcCall.body.error).toBe("string");
+  });
+
+  test("guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
+    seedGuardian();
+
+    // Make the best-effort assistant-DB mirror fail. The gateway-first write
+    // must still succeed and the request still be accepted.
+    const realDb = testAssistantDb!;
+    testAssistantDb = {
+      prepare() {
+        throw new Error("assistant DB mirror unavailable");
+      },
+    } as unknown as Database;
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({ requestId: "req-mirror-g", address: "+15550009999", channelType: "phone", role: "guardian" }),
+      );
+    } finally {
+      testAssistantDb = realDb;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Gateway DB guardian channel row is present despite the mirror failure.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15550009999"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].contactId).toBe("guardian-1");
+  });
+
+  test("guardian prompt — creates guardian gateway-first when none exists (bootstrap sub-case)", async () => {
+    // No guardian seeded anywhere — handler must mint one gateway-first.
+    const res = await handleContactPromptSubmit(
+      makeRequest({ requestId: "req-boot", address: "+15557654321", channelType: "phone", role: "guardian", displayName: "Boot Guardian" }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Guardian created in the gateway DB with role=guardian.
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(1);
+    expect(gwGuardians[0].displayName).toBe("Boot Guardian");
+
+    // Channel bound to the newly minted guardian.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15557654321"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].contactId).toBe(gwGuardians[0].id);
+
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    expect(ipcCall.body.contactId).toBe(gwGuardians[0].id);
   });
 
   test("non-guardian prompt — creates new contact and channel (gateway-first)", async () => {

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -604,6 +604,157 @@ describe("handleContactPromptSubmit", () => {
     expect(ipcCall.body.channelId).toBe("chan-reuse");
   });
 
+  test("guardian reuse — mirror-heal upsert throwing is non-fatal (still accepted, reuses channel)", async () => {
+    const now = Date.now();
+    seedGuardian();
+    // Gateway channel already bound to the guardian — reuse precondition.
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-reuse-fail",
+        contactId: "guardian-1",
+        type: "phone",
+        address: "+15558887777",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // The reuse-branch mirror-heal upsertContact throws (e.g. transient
+    // gateway SQLITE_BUSY). The reuse path must stay success-guaranteed.
+    const spy = spyOn(
+      ContactStore.prototype,
+      "upsertContact",
+    ).mockImplementation(async () => {
+      throw new Error("SQLITE_BUSY: database is locked");
+    });
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-reuse-fail",
+          address: "+15558887777",
+          channelType: "phone",
+          role: "guardian",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Existing gateway channel reused — no new row, no reassignment.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15558887777"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-reuse-fail");
+    expect(gwChannels[0].contactId).toBe("guardian-1");
+
+    // Daemon resolved with the existing channel id (success, not error).
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(ipcCall.body.channelId).toBe("chan-reuse-fail");
+    expect(ipcCall.body.error).toBeUndefined();
+  });
+
+  test("guardian bootstrap-create — assistant mirror keeps role='guardian' even if create-mirror INSERT fails", async () => {
+    // No guardian seeded: handler mints one gateway-first. Make the
+    // bootstrap-create assistant mirror INSERT (role='guardian') fail, so the
+    // assistant DB has no guardian row when Phase-2 upsertContact runs. Without
+    // the role re-assert, that upsert would INSERT the id with role='contact',
+    // downgrading the guardian in the mirror.
+    const realDb = testAssistantDb!;
+    let failNextGuardianInsert = true;
+    testAssistantDb = {
+      prepare(sql: string) {
+        if (
+          failNextGuardianInsert &&
+          /INSERT INTO contacts/i.test(sql) &&
+          /'guardian'/.test(sql)
+        ) {
+          failNextGuardianInsert = false;
+          throw new Error("assistant DB guardian INSERT unavailable");
+        }
+        return realDb.prepare(sql);
+      },
+    } as unknown as Database;
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-boot-downgrade",
+          address: "+15552223333",
+          channelType: "phone",
+          role: "guardian",
+          displayName: "Mirror Guardian",
+        }),
+      );
+    } finally {
+      testAssistantDb = realDb;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Gateway DB: guardian minted with role=guardian (authoritative).
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(1);
+
+    // Assistant mirror: the role re-assert healed any Phase-2 downgrade — the
+    // row exists and is role='guardian', NOT 'contact'.
+    const asContacts = testAssistantDb!
+      .prepare(`SELECT role FROM contacts WHERE id = ?`)
+      .all(gwGuardians[0].id) as { role: string }[];
+    expect(asContacts).toHaveLength(1);
+    expect(asContacts[0].role).toBe("guardian");
+  });
+
+  test("guardian bootstrap-create — assistant mirror row is role='guardian'", async () => {
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-boot-role",
+        address: "+15554445555",
+        channelType: "phone",
+        role: "guardian",
+        displayName: "Role Guardian",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Record<string, unknown>).accepted).toBe(true);
+
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(1);
+
+    const asContacts = testAssistantDb!
+      .prepare(`SELECT role FROM contacts WHERE id = ?`)
+      .all(gwGuardians[0].id) as { role: string }[];
+    expect(asContacts).toHaveLength(1);
+    expect(asContacts[0].role).toBe("guardian");
+  });
+
   test("non-guardian prompt — 500 + daemon error when channel can't be resolved (no empty channelId)", async () => {
     // Force resolveChannelId to miss by making getChannelsForContact return [].
     const spy = spyOn(

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -15,6 +15,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 import { Database } from "bun:sqlite";
@@ -67,6 +68,7 @@ const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
 );
 const { contactChannels: gwContactChannels, contacts: gwContacts } =
   await import("../db/schema.js");
+const { ContactStore } = await import("../db/contact-store.js");
 const { eq } = await import("drizzle-orm");
 
 // ---------------------------------------------------------------------------
@@ -533,5 +535,150 @@ describe("handleContactPromptSubmit", () => {
       .all();
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].contactId).toBe("guardian-1");
+  });
+
+  test("guardian prompt — reuse path heals the assistant-DB mirror channel", async () => {
+    const now = Date.now();
+    seedGuardian();
+    // Gateway channel already bound to the guardian (the reuse precondition),
+    // but the assistant-DB mirror has NO channel row — simulating a mirror that
+    // was unavailable when the channel was first bound.
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-reuse",
+        contactId: "guardian-1",
+        type: "phone",
+        address: "+15551112222",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // Precondition: assistant mirror has no channel for this address.
+    expect(
+      testAssistantDb!
+        .prepare(`SELECT id FROM contact_channels WHERE address = ?`)
+        .all("+15551112222"),
+    ).toHaveLength(0);
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-heal",
+        address: "+15551112222",
+        channelType: "phone",
+        role: "guardian",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // No new gateway channel — the existing one is reused.
+    const gwChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "+15551112222"))
+      .all();
+    expect(gwChannels).toHaveLength(1);
+    expect(gwChannels[0].id).toBe("chan-reuse");
+
+    // The reuse path called upsertContact, which healed the assistant-DB
+    // mirror: a channel row for the address now exists under the guardian.
+    const asChannels = testAssistantDb!
+      .prepare(
+        `SELECT contact_id FROM contact_channels WHERE address = ?`,
+      )
+      .all("+15551112222") as { contact_id: string }[];
+    expect(asChannels).toHaveLength(1);
+    expect(asChannels[0].contact_id).toBe("guardian-1");
+
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(ipcCall.body.channelId).toBe("chan-reuse");
+  });
+
+  test("non-guardian prompt — 500 + daemon error when channel can't be resolved (no empty channelId)", async () => {
+    // Force resolveChannelId to miss by making getChannelsForContact return [].
+    const spy = spyOn(
+      ContactStore.prototype,
+      "getChannelsForContact",
+    ).mockReturnValue([]);
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-noresolve",
+          address: "carol@example.com",
+          channelType: "email",
+          role: "trusted-contact",
+          displayName: "Carol",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(false);
+
+    // Daemon was notified with an error (not a success resolve with empty id).
+    expect(ipcMock).toHaveBeenCalledTimes(1);
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(typeof ipcCall.body.error).toBe("string");
+    expect(ipcCall.body.channelId).toBeUndefined();
+  });
+
+  test("guardian bind — rolls back freshly-created guardian + 500 when channel can't be resolved", async () => {
+    // No guardian seeded: the handler mints one gateway-first, then binds the
+    // channel. Force the post-bind resolve to miss so the empty-channelId guard
+    // fires and the just-created guardian is cleaned up.
+    const spy = spyOn(
+      ContactStore.prototype,
+      "getChannelsForContact",
+    ).mockReturnValue([]);
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-boot-noresolve",
+          address: "+15553334444",
+          channelType: "phone",
+          role: "guardian",
+          displayName: "Doomed Guardian",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(false);
+
+    // The freshly-created guardian was rolled back (compensating delete).
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(0);
+
+    // Daemon notified with an error.
+    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(typeof ipcCall.body.error).toBe("string");
   });
 });

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -510,6 +510,41 @@ describe("handleContactPromptSubmit", () => {
     expect(ipcCall.body.contactId).toBe("contact-1");
   });
 
+  test("non-guardian prompt — explicit null displayName is treated as omitted (preserves name, no 500)", async () => {
+    const now = Date.now();
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({ id: "contact-1", displayName: "Alice", role: "contact", createdAt: now, updatedAt: now })
+      .run();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id: "chan-alice",
+        contactId: "contact-1",
+        type: "email",
+        address: "alice@example.com",
+        isPrimary: true,
+        status: "active",
+        policy: "allow",
+        interactionCount: 3,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // displayName: null must NOT be written through to the NOT NULL column.
+    const res = await handleContactPromptSubmit(
+      makeRequest({ requestId: "req-null", address: "alice@example.com", channelType: "email", displayName: null }),
+    );
+
+    expect(res.status).toBe(200);
+
+    const gwContactRows = getGatewayDb().select().from(gwContacts).all();
+    expect(gwContactRows).toHaveLength(1);
+    expect(gwContactRows[0].id).toBe("contact-1");
+    expect(gwContactRows[0].displayName).toBe("Alice");
+  });
+
   test("gateway DB receives dual-write for new contact and channel", async () => {
     const now = Date.now();
     testAssistantDb!.run(

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -86,7 +86,12 @@ export async function handleContactPromptSubmit(
     );
   }
 
-  const { requestId, address, channelType, role, displayName } = body;
+  const { requestId, address, channelType, role } = body;
+  // Treat a non-string displayName (incl. an explicit null) as omitted, so
+  // upsertContact preserves an existing contact's name instead of writing the
+  // value through to the NOT NULL display_name column (which would 500).
+  const displayName =
+    typeof body.displayName === "string" ? body.displayName : undefined;
 
   if (!requestId || typeof requestId !== "string") {
     return Response.json(

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -237,29 +237,30 @@ export async function handleContactPromptSubmit(
       .get();
 
     if (existingChannel && existingChannel.contactId === contactId) {
-      // Heal the best-effort assistant-DB mirror on retry (matching the
-      // non-guardian path's self-healing). Passing the guardian's id preserves
-      // role="guardian" via upsertContact's id-path role preservation; the
-      // gateway channel already exists, so this is a no-op there and only
-      // recovers a previously-unavailable assistant mirror.
-      await getStore().upsertContact({
-        id: contactId,
-        channels: [
-          { type: channelType, address: normalizedAddress, isPrimary: true },
-        ],
-      });
-      channelId = resolveChannelId(contactId, channelType, normalizedAddress);
+      // Reuse is success-guaranteed: the gateway channel already belongs to
+      // this guardian. Best-effort heal the assistant-DB mirror (passing the
+      // guardian's id preserves role="guardian" via upsertContact's id-path
+      // role preservation). The gateway-side syncChannels UPDATE here is
+      // incidental — the real purpose is recovering a stale mirror — so a
+      // transient gateway error must never fail the request.
+      try {
+        await getStore().upsertContact({
+          id: contactId,
+          channels: [
+            { type: channelType, address: normalizedAddress, isPrimary: true },
+          ],
+        });
+      } catch (healErr) {
+        log.warn(
+          { err: healErr, contactId, channelType, address: normalizedAddress },
+          "contact-prompt-submit: guardian reuse mirror-heal failed (best-effort), continuing with existing channel",
+        );
+      }
+      channelId = existingChannel.id;
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: channel already exists",
       );
-      if (!channelId) {
-        log.error(
-          { channelType, address: normalizedAddress, contactId },
-          "contact-prompt-submit: channel resolution failed on guardian reuse",
-        );
-        return await channelResolutionError(requestId);
-      }
     } else if (existingChannel) {
       // Channel exists but belongs to a different contact.  The caller must
       // clean up the stale binding before a guardian channel can be created.
@@ -349,6 +350,25 @@ export async function handleContactPromptSubmit(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: created new channel",
       );
+    }
+
+    // Re-assert role="guardian" in the best-effort assistant mirror: if the
+    // bootstrap-create mirror INSERT failed, the Phase-2 upsertContact INSERTs
+    // this id with a hardcoded role="contact", downgrading the guardian in the
+    // mirror (gateway stays authoritative, so ACL is unaffected). Heal only
+    // when this request minted the guardian; never fails the request.
+    if (createdNewContact) {
+      try {
+        await assistantDbRun(
+          "UPDATE contacts SET role = 'guardian', updated_at = ? WHERE id = ?",
+          [now, contactId],
+        );
+      } catch (roleErr) {
+        log.warn(
+          { err: roleErr, contactId },
+          "contact-prompt-submit: assistant DB guardian role re-assert failed (best-effort)",
+        );
+      }
     }
   } catch (err) {
     log.error({ err, requestId }, "contact-prompt-submit: DB error");

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -14,12 +14,9 @@
  * Auth: edge (same as all ingress contact routes).
  */
 
-import { eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 
-import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../../db/assistant-db-proxy.js";
+import { assistantDbRun } from "../../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../../db/connection.js";
 import { ContactStore } from "../../db/contact-store.js";
 import {
@@ -39,6 +36,25 @@ function getStore(): ContactStore {
     store = new ContactStore();
   }
   return store;
+}
+
+/**
+ * Resolve the id of the just-bound channel from the gateway DB (the source of
+ * truth `upsertContact` wrote to). Returns "" if not found.
+ */
+function resolveChannelId(
+  contactId: string,
+  channelType: string,
+  address: string,
+): string {
+  const channel = getStore()
+    .getChannelsForContact(contactId)
+    .find(
+      (ch) =>
+        ch.type === channelType &&
+        ch.address.toLowerCase() === address.toLowerCase(),
+    );
+  return channel?.id ?? "";
 }
 
 // ---------------------------------------------------------------------------
@@ -112,41 +128,49 @@ export async function handleContactPromptSubmit(
     let createdNewContact = false;
 
     if (effectiveRole === "guardian") {
-      const guardianRows = await assistantDbQuery<{ id: string }>(
-        `SELECT id FROM contacts WHERE role = 'guardian' ORDER BY created_at ASC LIMIT 1`,
-        [],
-      );
-      if (guardianRows.length > 0) {
-        contactId = guardianRows[0].id;
+      // Guardian lives in the gateway DB (source of truth) — bootstrap
+      // dual-writes it there. Resolve from there, not the assistant mirror.
+      const guardianRow = getGatewayDb()
+        .select({ id: gwContacts.id })
+        .from(gwContacts)
+        .where(eq(gwContacts.role, "guardian"))
+        .orderBy(asc(gwContacts.createdAt))
+        .get();
+      if (guardianRow) {
+        contactId = guardianRow.id;
       } else {
-        // Bootstrap hasn't run yet — create the guardian contact.
+        // Bootstrap hasn't run yet — create the guardian contact gateway-first.
+        // upsertContact can't be used here: its create path forces
+        // role="contact". Guardian role writes stay raw per the
+        // ContactStore.upsertContact SECURITY note, but hit the gateway DB
+        // (source of truth) first, then mirror to the assistant DB best-effort.
         log.warn(
           { channelType, address: normalizedAddress },
           "contact-prompt-submit: no guardian contact found, creating one",
         );
         contactId = crypto.randomUUID();
         createdNewContact = true;
-        await assistantDbRun(
-          `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-           VALUES (?, ?, 'guardian', 'human', ?, ?)`,
-          [contactId, effectiveDisplayName, now, now],
-        );
+        getGatewayDb()
+          .insert(gwContacts)
+          .values({
+            id: contactId,
+            displayName: effectiveDisplayName,
+            role: "guardian",
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoNothing()
+          .run();
         try {
-          getGatewayDb()
-            .insert(gwContacts)
-            .values({
-              id: contactId,
-              displayName: effectiveDisplayName,
-              role: "guardian",
-              createdAt: now,
-              updatedAt: now,
-            })
-            .onConflictDoNothing()
-            .run();
-        } catch (gwErr) {
+          await assistantDbRun(
+            `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
+             VALUES (?, ?, 'guardian', 'human', ?, ?)`,
+            [contactId, effectiveDisplayName, now, now],
+          );
+        } catch (mirrorErr) {
           log.warn(
-            { err: gwErr },
-            "contact-prompt-submit: gateway DB guardian contact INSERT dual-write failed",
+            { err: mirrorErr },
+            "contact-prompt-submit: assistant DB guardian contact mirror INSERT failed",
           );
         }
       }
@@ -165,14 +189,7 @@ export async function handleContactPromptSubmit(
         ],
       });
       contactId = contact.id;
-      const channel = store
-        .getChannelsForContact(contactId)
-        .find(
-          (ch) =>
-            ch.type === channelType &&
-            ch.address.toLowerCase() === normalizedAddress.toLowerCase(),
-        );
-      channelId = channel?.id ?? "";
+      channelId = resolveChannelId(contactId, channelType, normalizedAddress);
 
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
@@ -198,24 +215,27 @@ export async function handleContactPromptSubmit(
     // is a conflict the caller must resolve — return 409.  Otherwise create a
     // new channel bound to the resolved contact.
     // -----------------------------------------------------------------------
-    const existingChannel = await assistantDbQuery<{
-      id: string;
-      contactId: string;
-    }>(
-      `SELECT id, contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1`,
-      [channelType, normalizedAddress],
-    );
+    const existingChannel = getGatewayDb()
+      .select({
+        id: gwContactChannels.id,
+        contactId: gwContactChannels.contactId,
+      })
+      .from(gwContactChannels)
+      .where(
+        and(
+          eq(gwContactChannels.type, channelType),
+          sql`${gwContactChannels.address} = ${normalizedAddress} COLLATE NOCASE`,
+        ),
+      )
+      .get();
 
-    if (
-      existingChannel.length > 0 &&
-      existingChannel[0].contactId === contactId
-    ) {
-      channelId = existingChannel[0].id;
+    if (existingChannel && existingChannel.contactId === contactId) {
+      channelId = existingChannel.id;
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: channel already exists",
       );
-    } else if (existingChannel.length > 0) {
+    } else if (existingChannel) {
       // Channel exists but belongs to a different contact.  The caller must
       // clean up the stale binding before a guardian channel can be created.
       log.warn(
@@ -223,7 +243,7 @@ export async function handleContactPromptSubmit(
           channelType,
           address: normalizedAddress,
           contactId,
-          existingContactId: existingChannel[0].contactId,
+          existingContactId: existingChannel.contactId,
         },
         "contact-prompt-submit: channel already assigned to another contact",
       );
@@ -239,56 +259,39 @@ export async function handleContactPromptSubmit(
         { status: 409 },
       );
     } else {
-      channelId = crypto.randomUUID();
-
       try {
-        await assistantDbRun(
-          `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, status, policy, interaction_count, created_at, updated_at)
-           VALUES (?, ?, ?, ?, 1, 'unverified', 'allow', 0, ?, ?)`,
-          [channelId, contactId, channelType, normalizedAddress, now, now],
-        );
-        try {
-          getGatewayDb()
-            .insert(gwContactChannels)
-            .values({
-              id: channelId,
-              contactId,
-              type: channelType,
-              address: normalizedAddress,
-              isPrimary: true,
-              status: "unverified",
-              policy: "allow",
-              interactionCount: 0,
-              createdAt: now,
-              updatedAt: now,
-            })
-            .onConflictDoNothing()
-            .run();
-        } catch (gwErr) {
-          log.warn(
-            { err: gwErr },
-            "contact-prompt-submit: gateway DB channel INSERT dual-write failed",
-          );
-        }
+        // Bind gateway-first. Passing the guardian's id keys the update to the
+        // existing guardian and preserves role="guardian" (upsertContact's
+        // id-path role preservation); the gateway channel is the source of
+        // truth, the assistant mirror is dual-written best-effort.
+        await getStore().upsertContact({
+          id: contactId,
+          channels: [
+            { type: channelType, address: normalizedAddress, isPrimary: true },
+          ],
+        });
+        channelId = resolveChannelId(contactId, channelType, normalizedAddress);
       } catch (channelErr) {
         // Compensating delete — only remove the contact if we created it here.
+        // "Stale over lost": delete gateway-first, then mirror the delete to
+        // the assistant DB best-effort.
         log.error(
           { channelErr, contactId, channelType },
-          "contact-prompt-submit: channel INSERT failed, rolling back contact",
+          "contact-prompt-submit: channel bind failed, rolling back contact",
         );
         if (createdNewContact) {
-          await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
-            contactId,
-          ]);
+          getGatewayDb()
+            .delete(gwContacts)
+            .where(eq(gwContacts.id, contactId))
+            .run();
           try {
-            getGatewayDb()
-              .delete(gwContacts)
-              .where(eq(gwContacts.id, contactId))
-              .run();
-          } catch (gwErr) {
+            await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
+              contactId,
+            ]);
+          } catch (mirrorErr) {
             log.warn(
-              { err: gwErr },
-              "contact-prompt-submit: gateway DB contact rollback DELETE dual-write failed",
+              { err: mirrorErr },
+              "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
             );
           }
         }

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -6,7 +6,8 @@
  * Called by the client after the user fills in a contact address in response
  * to a `contact_request` broadcast from the daemon. This route:
  *   1. Validates the submitted contact info.
- *   2. Upserts the contact + channel via the assistant DB proxy (gateway owns writes).
+ *   2. Upserts the contact + channel gateway-first via ContactStore.upsertContact
+ *      (gateway DB is the source of truth; assistant DB is a best-effort mirror).
  *   3. Calls daemon IPC `resolve_contact_prompt` to unblock the waiting CLI.
  *   4. Returns { accepted: true } to the client.
  *
@@ -20,6 +21,7 @@ import {
   assistantDbRun,
 } from "../../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../../db/connection.js";
+import { ContactStore } from "../../db/contact-store.js";
 import {
   contactChannels as gwContactChannels,
   contacts as gwContacts,
@@ -29,6 +31,15 @@ import { getLogger } from "../../logger.js";
 import { canonicalizeInboundIdentity } from "../../verification/identity.js";
 
 const log = getLogger("contact-prompt");
+
+let store: ContactStore | null = null;
+
+function getStore(): ContactStore {
+  if (!store) {
+    store = new ContactStore();
+  }
+  return store;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -140,40 +151,43 @@ export async function handleContactPromptSubmit(
         }
       }
     } else {
-      // Reuse an existing contact if this channel address is already known.
-      const existingForChannel = await assistantDbQuery<{ contactId: string }>(
-        `SELECT contact_id AS contactId FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1`,
-        [channelType, normalizedAddress],
-      );
-      if (existingForChannel.length > 0) {
-        contactId = existingForChannel[0].contactId;
-      } else {
-        contactId = crypto.randomUUID();
-        createdNewContact = true;
-        await assistantDbRun(
-          `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-           VALUES (?, ?, ?, 'human', ?, ?)`,
-          [contactId, effectiveDisplayName, effectiveRole, now, now],
+      // Non-guardian: resolve/create the contact + channel gateway-first via
+      // ContactStore.upsertContact. The gateway DB is the source of truth; the
+      // assistant DB receives a best-effort mirror.
+      const store = getStore();
+      const { contact } = await store.upsertContact({
+        // omit-to-preserve: pass the caller's optional displayName, NOT
+        // effectiveDisplayName. An existing contact keeps its name; a brand-new
+        // contact falls back to the canonical channel address inside upsertContact.
+        displayName,
+        channels: [
+          { type: channelType, address: normalizedAddress, isPrimary: true },
+        ],
+      });
+      contactId = contact.id;
+      const channel = store
+        .getChannelsForContact(contactId)
+        .find(
+          (ch) =>
+            ch.type === channelType &&
+            ch.address.toLowerCase() === normalizedAddress.toLowerCase(),
         );
-        try {
-          getGatewayDb()
-            .insert(gwContacts)
-            .values({
-              id: contactId,
-              displayName: effectiveDisplayName,
-              role: effectiveRole,
-              createdAt: now,
-              updatedAt: now,
-            })
-            .onConflictDoNothing()
-            .run();
-        } catch (gwErr) {
-          log.warn(
-            { err: gwErr },
-            "contact-prompt-submit: gateway DB contact INSERT dual-write failed",
-          );
-        }
-      }
+      channelId = channel?.id ?? "";
+
+      log.info(
+        { channelType, address: normalizedAddress, contactId, channelId },
+        "contact-prompt-submit: upserted contact + channel via ContactStore",
+      );
+
+      // Non-guardian is fully resolved by upsertContact; skip the guardian-only
+      // Phase 2 channel-creation block below and go straight to resolve.
+      return await resolveContactPrompt({
+        requestId,
+        contactId,
+        channelId,
+        channelType,
+        address: normalizedAddress,
+      });
     }
 
     // -----------------------------------------------------------------------
@@ -304,16 +318,31 @@ export async function handleContactPromptSubmit(
     );
   }
 
-  // Notify daemon to unblock the waiting contacts/prompt IPC call.
+  return await resolveContactPrompt({
+    requestId,
+    contactId,
+    channelId,
+    channelType,
+    address: normalizedAddress,
+  });
+}
+
+/**
+ * Notify the daemon to unblock the waiting contacts/prompt IPC call, then
+ * return { accepted: true }. IPC failures are best-effort — they only mean the
+ * CLI may time out, not that the write failed.
+ */
+async function resolveContactPrompt(args: {
+  requestId: string;
+  contactId: string;
+  channelId: string;
+  channelType: string;
+  address: string;
+}): Promise<Response> {
+  const { requestId, contactId, channelId, channelType, address } = args;
   try {
     const ipcResult = await ipcCallAssistant("resolve_contact_prompt", {
-      body: {
-        requestId,
-        contactId,
-        channelId,
-        channelType,
-        address: normalizedAddress,
-      },
+      body: { requestId, contactId, channelId, channelType, address },
     });
     if ((ipcResult as { resolved?: boolean }).resolved === false) {
       log.warn(

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -110,8 +110,7 @@ export async function handleContactPromptSubmit(
   const normalizedAddress =
     canonicalizeInboundIdentity(channelType, address) ?? address.trim();
   const effectiveDisplayName = displayName ?? normalizedAddress;
-  // Map prompt roles to valid ContactRole values ("guardian" | "contact").
-  const effectiveRole: string = role === "guardian" ? "guardian" : "contact";
+  const isGuardian = role === "guardian";
   const now = Date.now();
 
   let contactId: string;
@@ -127,7 +126,7 @@ export async function handleContactPromptSubmit(
     // -----------------------------------------------------------------------
     let createdNewContact = false;
 
-    if (effectiveRole === "guardian") {
+    if (isGuardian) {
       // Guardian lives in the gateway DB (source of truth) — bootstrap
       // dual-writes it there. Resolve from there, not the assistant mirror.
       const guardianRow = getGatewayDb()
@@ -196,6 +195,14 @@ export async function handleContactPromptSubmit(
         "contact-prompt-submit: upserted contact + channel via ContactStore",
       );
 
+      if (!channelId) {
+        log.error(
+          { channelType, address: normalizedAddress, contactId },
+          "contact-prompt-submit: channel resolution failed after upsert",
+        );
+        return await channelResolutionError(requestId);
+      }
+
       // Non-guardian is fully resolved by upsertContact; skip the guardian-only
       // Phase 2 channel-creation block below and go straight to resolve.
       return await resolveContactPrompt({
@@ -230,11 +237,29 @@ export async function handleContactPromptSubmit(
       .get();
 
     if (existingChannel && existingChannel.contactId === contactId) {
-      channelId = existingChannel.id;
+      // Heal the best-effort assistant-DB mirror on retry (matching the
+      // non-guardian path's self-healing). Passing the guardian's id preserves
+      // role="guardian" via upsertContact's id-path role preservation; the
+      // gateway channel already exists, so this is a no-op there and only
+      // recovers a previously-unavailable assistant mirror.
+      await getStore().upsertContact({
+        id: contactId,
+        channels: [
+          { type: channelType, address: normalizedAddress, isPrimary: true },
+        ],
+      });
+      channelId = resolveChannelId(contactId, channelType, normalizedAddress);
       log.info(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: channel already exists",
       );
+      if (!channelId) {
+        log.error(
+          { channelType, address: normalizedAddress, contactId },
+          "contact-prompt-submit: channel resolution failed on guardian reuse",
+        );
+        return await channelResolutionError(requestId);
+      }
     } else if (existingChannel) {
       // Channel exists but belongs to a different contact.  The caller must
       // clean up the stale binding before a guardian channel can be created.
@@ -259,6 +284,28 @@ export async function handleContactPromptSubmit(
         { status: 409 },
       );
     } else {
+      // Compensating delete — only remove the contact if we created it here.
+      // "Stale over lost": delete gateway-first, then mirror the delete to
+      // the assistant DB best-effort. Used by both the bind-failure path and
+      // the empty-channelId guard below.
+      const rollbackCreatedContact = async (): Promise<void> => {
+        if (!createdNewContact) return;
+        getGatewayDb()
+          .delete(gwContacts)
+          .where(eq(gwContacts.id, contactId))
+          .run();
+        try {
+          await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
+            contactId,
+          ]);
+        } catch (mirrorErr) {
+          log.warn(
+            { err: mirrorErr },
+            "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
+          );
+        }
+      };
+
       try {
         // Bind gateway-first. Passing the guardian's id keys the update to the
         // existing guardian and preserves role="guardian" (upsertContact's
@@ -272,29 +319,11 @@ export async function handleContactPromptSubmit(
         });
         channelId = resolveChannelId(contactId, channelType, normalizedAddress);
       } catch (channelErr) {
-        // Compensating delete — only remove the contact if we created it here.
-        // "Stale over lost": delete gateway-first, then mirror the delete to
-        // the assistant DB best-effort.
         log.error(
           { channelErr, contactId, channelType },
           "contact-prompt-submit: channel bind failed, rolling back contact",
         );
-        if (createdNewContact) {
-          getGatewayDb()
-            .delete(gwContacts)
-            .where(eq(gwContacts.id, contactId))
-            .run();
-          try {
-            await assistantDbRun("DELETE FROM contacts WHERE id = ?", [
-              contactId,
-            ]);
-          } catch (mirrorErr) {
-            log.warn(
-              { err: mirrorErr },
-              "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
-            );
-          }
-        }
+        await rollbackCreatedContact();
 
         // Notify daemon of failure so the CLI doesn't hang.
         await notifyDaemonResolveError(
@@ -305,6 +334,15 @@ export async function handleContactPromptSubmit(
           { accepted: false, error: "Failed to create contact channel" },
           { status: 500 },
         );
+      }
+
+      if (!channelId) {
+        log.error(
+          { channelType, address: normalizedAddress, contactId },
+          "contact-prompt-submit: channel resolution failed after guardian bind, rolling back contact",
+        );
+        await rollbackCreatedContact();
+        return await channelResolutionError(requestId);
       }
 
       log.info(
@@ -328,6 +366,19 @@ export async function handleContactPromptSubmit(
     channelType,
     address: normalizedAddress,
   });
+}
+
+/**
+ * Notify the daemon of a failed channel resolution and return 500. Used when the
+ * gateway DB read can't find the just-bound channel — resolving the prompt with
+ * an empty channelId would falsely report success for a channel-less contact.
+ */
+async function channelResolutionError(requestId: string): Promise<Response> {
+  await notifyDaemonResolveError(requestId, "Channel resolution failed");
+  return Response.json(
+    { accepted: false, error: "Channel resolution failed" },
+    { status: 500 },
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
Converts the `POST /v1/contacts/prompt/submit` handler (`gateway/src/http/routes/contact-prompt.ts`) from assistant-DB-first raw-SQL writes to **gateway-first** writes, so the gateway DB (which drives every ACL decision) is the source of truth and the assistant DB is a best-effort mirror — matching the ordering the contacts migration established everywhere else (same bug class as Combo 3 / #35585, but for this HTTP path). Both sub-flows are converted: non-guardian (via `ContactStore.upsertContact`) and guardian (resolve from the gateway DB, bind via `upsertContact({ id })` preserving `role="guardian"`, gateway-first bootstrap + compensating cleanup).

## Self-review result
PASS — 3 review rounds. 2 gaps fixed in round 1 (empty-channelId guard; guardian-reuse mirror heal; `effectiveRole`→`isGuardian` cleanup), 2 in round 2 (non-fatal reuse heal so a transient gateway write can't 500 a guaranteed-success reuse; re-assert `role="guardian"` in the assistant mirror so a failed bootstrap mirror INSERT + Phase-2 upsert can't downgrade the guardian). Round 3: all passes PASS. One non-blocking note: a redundant-but-correct happy-path test could be dropped.

## PRs merged into feature branch
- #35618: contact-prompt non-guardian path writes gateway-first via upsertContact
- #35619: contact-prompt guardian path resolves + binds channel gateway-first
- #35620: review follow-ups (empty channelId guard, mirror heal, cleanup)
- #35625: re-review follow-ups (non-fatal heal, guardian role preserved)

Part of plan: contacts-prompt-gateway-first.md