### PR TITLE
feat(chat): add compact, expandable phase-grouped subagent timeline

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -39,6 +39,10 @@ function bash(
   };
 }
 
+function thinking(text: string, duration = "1s"): ToolCallCardStep {
+  return { kind: "thinking", durationLabel: duration, text };
+}
+
 describe("SubagentPhaseTimeline — empty input", () => {
   test("renders nothing when there are no steps (panel owns the empty state)", () => {
     const { container } = render(<SubagentPhaseTimeline steps={[]} />);
@@ -137,5 +141,52 @@ describe("SubagentPhaseTimeline — phase grouping", () => {
     const sections = getAllByTestId("subagent-phase-section");
     expect(sections.length).toBe(1);
     expect(sections[0]!.getAttribute("data-phase-label")).toBe("Working");
+  });
+
+  // Regression: historical/older subagent events can carry an empty
+  // `toolCallId` (`use-subagent-card-data.ts` maps `event.toolUseId ?? ""`).
+  // Two same-label "Working" phases whose first steps both have empty
+  // `toolCallId` must still get distinct section keys, so expanding one does
+  // not expand the other.
+  test("same-label phases with empty toolCallId expand/collapse independently", () => {
+    const steps: ToolCallCardStep[] = [
+      // First "Working" group — empty toolCallId on every step.
+      bash("ls", "completed", "1s", ""),
+      bash("pwd", "completed", "1s", ""),
+      // Thinking step splits the timeline into two "Working" sections.
+      thinking("Considering options"),
+      // Second "Working" group — also empty toolCallId.
+      bash("cat x", "completed", "1s", ""),
+      bash("cat y", "completed", "1s", ""),
+    ];
+    const { getAllByTestId, queryAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    // Two distinct "Working" rows (plus the "Thinking" row between them).
+    const sections = getAllByTestId("subagent-phase-section");
+    const working = sections.filter(
+      (s) => s.getAttribute("data-phase-label") === "Working",
+    );
+    expect(working.length).toBe(2);
+
+    const headerOf = (section: Element) =>
+      section.querySelector('[data-testid="subagent-phase-header"]')!;
+
+    // Collapsed by default.
+    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+
+    // Expanding the first "Working" row reveals only its 2 pills.
+    fireEvent.click(headerOf(working[0]!));
+    expect(queryAllByTestId("phase-step-pill").length).toBe(2);
+
+    // Expanding the second "Working" row reveals its own 2 pills (4 total) —
+    // the two same-label phases are keyed independently.
+    fireEvent.click(headerOf(working[1]!));
+    expect(queryAllByTestId("phase-step-pill").length).toBe(4);
+
+    // Collapsing the first leaves the second's pills visible.
+    fireEvent.click(headerOf(working[0]!));
+    expect(queryAllByTestId("phase-step-pill").length).toBe(2);
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for `SubagentPhaseTimeline`.
+ *
+ * The timeline is pure presentational. Assertions cover: a completed row's
+ * label + "Worked for <dur>" summary with its step pills hidden until clicked
+ * (and re-hidden on toggle back); a running row's `ThreeDotIndicator` node plus
+ * the Brain + live-activity sub-label sourced from the running tool step's
+ * `activity`; the conditional "N steps" pill (present for >= 2 steps, absent
+ * for 1); and contiguous same-phase collapsing into a single row.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
+import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
+
+afterEach(() => {
+  cleanup();
+});
+
+function bash(
+  command: string,
+  status: "running" | "completed" | "error" | "denied" = "completed",
+  duration = "",
+  toolCallId = `tc-${command}`,
+  activity = "",
+): ToolCallCardStep {
+  return {
+    kind: "tool",
+    title: "Working",
+    info: command,
+    activity,
+    iconName: "code",
+    durationLabel: duration,
+    toolCallId,
+    status,
+  };
+}
+
+describe("SubagentPhaseTimeline — empty input", () => {
+  test("renders nothing when there are no steps (panel owns the empty state)", () => {
+    const { container } = render(<SubagentPhaseTimeline steps={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("SubagentPhaseTimeline — completed row", () => {
+  test("shows label + 'Worked for <dur>', hides pills by default, toggles on click", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "2s", "tc-b"),
+    ];
+    const { getAllByTestId, getByTestId, queryAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    // One row for the single "Working" phase.
+    const sections = getAllByTestId("subagent-phase-section");
+    expect(sections.length).toBe(1);
+
+    const header = getByTestId("subagent-phase-header");
+    expect(header.textContent).toContain("Working");
+    // 1s + 2s summed and re-formatted.
+    expect(header.textContent).toContain("Worked for 3s");
+
+    // Collapsed by default — no step pills.
+    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+
+    // Click reveals the pills.
+    fireEvent.click(header);
+    expect(queryAllByTestId("phase-step-pill").length).toBe(2);
+
+    // Toggling back hides them.
+    fireEvent.click(header);
+    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+  });
+});
+
+describe("SubagentPhaseTimeline — running row", () => {
+  test("renders the ThreeDotIndicator node and a Brain + live activity sub-label", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("sleep 5", "running", "", "tc-a", "Compiling the project"),
+    ];
+    const { getByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+
+    // The running node is the three-dot indicator: it stamps no `data-status`
+    // and exposes 3 dot children (the `ThreeDotIndicator` contract).
+    const node = getByTestId("phase-header-status-icon");
+    expect(node.getAttribute("data-status")).toBeNull();
+    expect(node.children.length).toBe(3);
+
+    // The sub-label is sourced from the running tool step's `activity`.
+    const header = getByTestId("subagent-phase-header");
+    expect(header.textContent).toContain("Compiling the project");
+  });
+
+  test("falls back to the running step's info when activity is empty", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("npm run build", "running", "", "tc-a", ""),
+    ];
+    const { getByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    const header = getByTestId("subagent-phase-header");
+    expect(header.textContent).toContain("npm run build");
+  });
+});
+
+describe("SubagentPhaseTimeline — step-count pill", () => {
+  test("renders the 'N steps' pill for a 3-step phase", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("a", "completed", "1s", "tc-a"),
+      bash("b", "completed", "1s", "tc-b"),
+      bash("c", "completed", "1s", "tc-c"),
+    ];
+    const { getByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    expect(getByTestId("subagent-phase-step-count").textContent).toBe(
+      "3 steps",
+    );
+  });
+
+  test("omits the step-count pill for a 1-step phase", () => {
+    const steps: ToolCallCardStep[] = [bash("a", "completed", "1s", "tc-a")];
+    const { queryByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    expect(queryByTestId("subagent-phase-step-count")).toBeNull();
+  });
+});
+
+describe("SubagentPhaseTimeline — phase grouping", () => {
+  test("contiguous same-phase steps collapse into one row", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "1s", "tc-b"),
+      bash("cat x", "completed", "1s", "tc-c"),
+    ];
+    const { getAllByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    const sections = getAllByTestId("subagent-phase-section");
+    expect(sections.length).toBe(1);
+    expect(sections[0]!.getAttribute("data-phase-label")).toBe("Working");
+  });
+});

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -1,0 +1,234 @@
+/**
+ * Compact, expandable phase-grouped timeline for the subagent detail panel.
+ *
+ * Renders one collapsed row per phase (status node + label + a duration / live
+ * activity sub-label + an optional "N steps" pill). Clicking a row with an
+ * expandable body toggles its step pills open/closed. Reuses the main-chat
+ * timeline's connector/node geometry (see `TimelinePhaseSection` in
+ * `phase-grouped-step-list.tsx`) so the panel reads as the same timeline.
+ *
+ * Pure / presentational: takes only `steps`. The owning panel renders the
+ * empty state, so this returns `null` for an empty input.
+ */
+
+import { Brain, ChevronDown, ChevronRight } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import {
+  DefaultStepPill,
+  groupStepsByPhase,
+  phaseHeaderStatus,
+  sumDurationLabels,
+  TimelineNode,
+  type PhaseSection,
+} from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
+import { cn } from "@/utils/misc";
+
+/**
+ * Stable per-step key — `toolCallId` for a tool step, else `${kind}-${index}`.
+ * Shared by the section key and the expanded body's pill list.
+ */
+function stepKey(step: ToolCallCardStep, index: number): string {
+  return step.kind === "tool" ? step.toolCallId : `${step.kind}-${index}`;
+}
+
+/**
+ * Stable key for a phase section — its label plus the first step's identity, so
+ * two same-labelled sections (e.g. two non-contiguous "Working" phases) get
+ * distinct expand keys.
+ */
+function sectionKey(section: PhaseSection, index: number): string {
+  const first = section.steps[0];
+  return `${section.label}-${first ? stepKey(first, index) : index}`;
+}
+
+/**
+ * Live activity sub-label for a running phase: the `activity` of the last
+ * still-running tool step, falling back to that step's `info`, then to the
+ * phase label so the row never reads blank.
+ */
+function runningActivity(section: PhaseSection): string {
+  for (let i = section.steps.length - 1; i >= 0; i--) {
+    const step = section.steps[i]!;
+    if (step.kind === "tool" && step.status === "running") {
+      return step.activity || step.info || section.label;
+    }
+  }
+  return section.label;
+}
+
+export function SubagentPhaseTimeline({
+  steps,
+}: {
+  steps: ToolCallCardStep[];
+}) {
+  // Expanded section keys. Default collapsed; the toggler is memoized so
+  // already-rendered rows stay referentially stable across toggles.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  if (steps.length === 0) return null;
+  const sections = groupStepsByPhase(steps);
+
+  return (
+    <div className="flex w-full flex-col">
+      {sections.map((section, index) => {
+        const key = sectionKey(section, index);
+        return (
+          <SubagentPhaseRow
+            key={key}
+            section={section}
+            isLast={index === sections.length - 1}
+            expanded={expanded.has(key)}
+            sectionKeyValue={key}
+            onToggle={toggle}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function SubagentPhaseRow({
+  section,
+  isLast,
+  expanded,
+  sectionKeyValue,
+  onToggle,
+}: {
+  section: PhaseSection;
+  isLast: boolean;
+  expanded: boolean;
+  sectionKeyValue: string;
+  onToggle: (key: string) => void;
+}) {
+  const status = phaseHeaderStatus(section.steps);
+  const isThinking = section.steps[0]?.kind === "thinking";
+  const stepCount = section.steps.length;
+
+  // A row is interactive only when it has step pills worth revealing. Rows with
+  // a single step carry no separate body, so they render no chevron / toggle.
+  const isExpandable = stepCount >= 2;
+
+  const totalDuration =
+    status === "running"
+      ? ""
+      : sumDurationLabels(
+          section.steps.map((s) =>
+            "durationLabel" in s ? s.durationLabel : "",
+          ),
+        );
+  const activity = status === "running" ? runningActivity(section) : "";
+  // Whether a trailing detail (activity or duration) follows the label — the
+  // faint `|` separator only renders when one does.
+  const hasTrailingDetail = status === "running" || Boolean(totalDuration);
+  const stepCountLabel = `${stepCount} step${stepCount === 1 ? "" : "s"}`;
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div
+      data-testid="subagent-phase-section"
+      data-phase-label={section.label}
+      className="relative flex flex-col gap-2"
+    >
+      {/* Connector line mirroring the main-chat timeline: starts below this
+          node and runs to the section bottom, omitted on the last row. */}
+      {!isLast && (
+        <div
+          aria-hidden
+          className="absolute bottom-0 left-[6.5px] top-6 w-px bg-[var(--border-element)]"
+        />
+      )}
+
+      <button
+        type="button"
+        data-testid="subagent-phase-header"
+        disabled={!isExpandable}
+        onClick={isExpandable ? () => onToggle(sectionKeyValue) : undefined}
+        className={cn(
+          "flex w-full items-center gap-2 py-[2px] text-left",
+          isExpandable && "cursor-pointer",
+        )}
+      >
+        <TimelineNode status={status} isThinking={isThinking} />
+        <Typography
+          variant="body-medium-default"
+          className="text-[var(--content-default)]"
+        >
+          {section.label}
+        </Typography>
+
+        {hasTrailingDetail && (
+          <span
+            aria-hidden
+            className="text-[var(--content-tertiary)] opacity-10"
+          >
+            |
+          </span>
+        )}
+
+        {status === "running" ? (
+          <span className="flex min-w-0 items-center gap-1">
+            <Brain
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]"
+            />
+            <Typography
+              variant="body-small-default"
+              className="min-w-0 truncate text-[var(--content-tertiary)]"
+            >
+              {activity}
+            </Typography>
+          </span>
+        ) : totalDuration ? (
+          <Typography
+            variant="body-small-default"
+            className="truncate text-[var(--content-tertiary)]"
+          >
+            {`Worked for ${totalDuration}`}
+          </Typography>
+        ) : null}
+
+        {isExpandable && (
+          <span className="ml-auto flex items-center gap-1">
+            <Chevron
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]"
+            />
+            <span
+              data-testid="subagent-phase-step-count"
+              className="rounded-[100px] bg-[var(--surface-base)] px-1.5 py-1"
+            >
+              <Typography
+                variant="body-small-default"
+                className="text-[var(--content-secondary)]"
+              >
+                {stepCountLabel}
+              </Typography>
+            </span>
+          </span>
+        )}
+      </button>
+
+      {/* Expanded body: the section's steps as default pills, indented to align
+          under the phase title (icon 14px + the row's 8px gap → 22px). */}
+      {isExpandable && expanded && (
+        <div className="flex flex-col items-start gap-1 pb-3 pl-[22px]">
+          {section.steps.map((step, stepIdx) => (
+            <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -28,21 +28,26 @@ import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils
 import { cn } from "@/utils/misc";
 
 /**
- * Stable per-step key — `toolCallId` for a tool step, else `${kind}-${index}`.
+ * Stable per-step key — a tool step's non-empty `toolCallId`, else the
+ * positional `${kind}-${index}` fallback. Historical/older subagent events can
+ * carry an empty `toolCallId` (see `use-subagent-card-data.ts`), so guarding on
+ * a non-empty string keeps keys unique instead of collapsing onto `""`.
  * Shared by the section key and the expanded body's pill list.
  */
 function stepKey(step: ToolCallCardStep, index: number): string {
-  return step.kind === "tool" ? step.toolCallId : `${step.kind}-${index}`;
+  if (step.kind === "tool" && step.toolCallId) return step.toolCallId;
+  return `${step.kind}-${index}`;
 }
 
 /**
- * Stable key for a phase section — its label plus the first step's identity, so
- * two same-labelled sections (e.g. two non-contiguous "Working" phases) get
- * distinct expand keys.
+ * Stable key for a phase section — its positional index plus its label and the
+ * first step's identity. The index keeps two same-labelled sections (e.g. two
+ * non-contiguous "Working" phases) distinct even when their first steps share a
+ * key (both empty `toolCallId`).
  */
 function sectionKey(section: PhaseSection, index: number): string {
   const first = section.steps[0];
-  return `${section.label}-${first ? stepKey(first, index) : index}`;
+  return `${index}-${section.label}-${first ? stepKey(first, index) : ""}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- New SubagentPhaseTimeline: one compact, expandable row per phase (status node + label + 'Worked for Xs' or live activity + 'N steps' pill), reusing PhaseGroupedStepList helpers
- Click a row to reveal/hide its step pills
- Unit tests for completed/running rows, step-count pill, and phase collapsing

Part of plan: subagent-detail-panel-figma.md (PR 2 of 5)