### PR TITLE
Keep macOS dictation overlay above chat window

### DIFF
--- a/clients/macos/src/main/dictation-overlay-window.test.ts
+++ b/clients/macos/src/main/dictation-overlay-window.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import {
+  DICTATION_OVERLAY_ALWAYS_ON_TOP_LEVEL,
   DONE_HIDE_MS,
   ERROR_HIDE_MS,
   createDictationOverlayController,
@@ -177,5 +178,11 @@ describe("positionDictationOverlayInWorkArea", () => {
       x: 580,
       y: 50,
     });
+  });
+});
+
+describe("dictation overlay window level", () => {
+  test("uses the screen-saver level so it stays above focused app windows", () => {
+    expect(DICTATION_OVERLAY_ALWAYS_ON_TOP_LEVEL).toBe("screen-saver");
   });
 });

--- a/clients/macos/src/main/dictation-overlay-window.ts
+++ b/clients/macos/src/main/dictation-overlay-window.ts
@@ -31,6 +31,13 @@ import { handle, on } from "./ipc";
 const OVERLAY_KIND = "dictation-overlay";
 const OVERLAY_PATH = "/floating/dictation-overlay";
 
+type AlwaysOnTopLevel = NonNullable<
+  Parameters<BrowserWindow["setAlwaysOnTop"]>[1]
+>;
+
+export const DICTATION_OVERLAY_ALWAYS_ON_TOP_LEVEL =
+  "screen-saver" satisfies AlwaysOnTopLevel;
+
 // The window is a fixed-size transparent canvas larger than the visible
 // pill: the page renders the pill top-centered and sized to content, with
 // padding so its CSS shadow has room to paint (the window itself draws no
@@ -168,6 +175,7 @@ const ensureOverlayWindow = (): BrowserWindow => {
     width: OVERLAY_WIDTH,
     height: OVERLAY_HEIGHT,
     focusOnShow: false,
+    alwaysOnTopLevel: DICTATION_OVERLAY_ALWAYS_ON_TOP_LEVEL,
     ignoreMouseEvents: true,
     position: overlayPosition,
     browserWindow: {


### PR DESCRIPTION
## Summary
- Raise the macOS dictation overlay to Electron's screen-saver always-on-top level so the voice HUD remains outside and above focused app windows.
- Add focused coverage for the overlay window level to prevent regressions.

## Original prompt
The macOS Electron voice bar should always appear outside the Vellum window at the top of the screen. This should hold even when the user is currently in the chat window, so the dictation HUD behaves like a system overlay rather than an in-window element.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->