### PR TITLE
fix(workflows): tool leaf fails loud instead of returning empty output

### DIFF
--- a/assistant/src/workflows/leaf-runner.test.ts
+++ b/assistant/src/workflows/leaf-runner.test.ts
@@ -511,6 +511,45 @@ describe("runLeaf — tool path", () => {
   });
 });
 
+describe("runLeaf — tool path fails loud on empty output", () => {
+  test("rethrows a swallowed provider rejection instead of returning empty", async () => {
+    // The agent loop does not throw out of run() on a provider rejection — it
+    // emits an `error` event and returns with no assistant text. An empty
+    // responseQueue makes the mocked provider reject on the first call, which
+    // the real AgentLoop swallows. Before the fix runToolLeaf returned
+    // `{ output: "" }` (a phantom success the engine scored as completed); now
+    // the leaf rethrows the captured error so the engine journals it failed.
+    responseQueue = [];
+
+    await expect(
+      runLeaf({ prompt: "do work", tools: [], trustContext }),
+    ).rejects.toThrow(/responseQueue exhausted/);
+  });
+
+  test("throws when the model produces no output text", async () => {
+    // A clean end_turn with empty text is still a failure for a leaf whose
+    // contract is to return a result — surfacing it lets `map`/`parallel`
+    // yield null rather than a silent empty success.
+    responseQueue = [
+      {
+        content: [{ type: "text", text: "   " }],
+        model: "test",
+        usage: { inputTokens: 4, outputTokens: 0 },
+        stopReason: "end_turn",
+      },
+    ];
+
+    await expect(
+      runLeaf({
+        prompt: "do work",
+        tools: [],
+        label: "empty-leaf",
+        trustContext,
+      }),
+    ).rejects.toThrow(/produced no output text/);
+  });
+});
+
 describe("runLeaf — no persistence", () => {
   test("creates no conversation rows and no workspace files", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "leaf-runner-test-"));

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -449,12 +449,22 @@ async function runToolLeaf(
   let inputTokens = 0;
   let outputTokens = 0;
   let toolCallCount = 0;
+  // The agent loop is shared with the main-agent path: on a terminal provider
+  // rejection it does NOT throw out of `run()` — it emits an `error` event and
+  // returns with no assistant text, leaving the main loop's event consumer to
+  // surface it. A leaf has no such consumer, so capture the terminal error here
+  // and rethrow it below; otherwise a swallowed rejection becomes an empty
+  // `output` the engine scores as success — a whole fan-out "completes" having
+  // produced nothing (`clustersAuthored: 0` with an empty failure list).
+  let loopError: Error | undefined;
   const onEvent = (event: AgentEvent): void => {
     if (event.type === "usage") {
       inputTokens += event.inputTokens;
       outputTokens += event.outputTokens;
     } else if (event.type === "tool_use") {
       toolCallCount += 1;
+    } else if (event.type === "error") {
+      loopError = event.error;
     }
   };
 
@@ -467,8 +477,23 @@ async function runToolLeaf(
     ...(overrideProfile !== undefined ? { overrideProfile } : {}),
   });
 
+  const output = finalAssistantText(result.history);
+  // Fail loud on a leaf that produced nothing. A captured terminal error is
+  // rethrown verbatim (the real failure); empty output with no error means the
+  // model emitted no text — still a failure for a leaf whose contract is to
+  // return a result. Either way the leaf rejects, so the engine journals it
+  // `failed` and `map`/`parallel` yield `null` instead of a phantom success.
+  if (output.length === 0) {
+    throw (
+      loopError ??
+      new Error(
+        `Workflow tool leaf "${opts.label ?? "tool"}" produced no output text.`,
+      )
+    );
+  }
+
   return {
-    output: finalAssistantText(result.history),
+    output,
     inputTokens,
     outputTokens,
     toolCallCount,


### PR DESCRIPTION
## Problem

A workflow **tool leaf** silently swallowed terminal provider errors. The `AgentLoop` is shared with the main-agent path: on a provider rejection it emits an `error` event and **returns with no assistant text** (it does not throw — the main loop's event consumer is expected to surface the error). `runToolLeaf` consumed only `usage` and `tool_use` events, so the error was lost and `finalAssistantText()` returned `""`. The engine only maps a *thrown* leaf to `null`; a returned `""` is scored as a **completed** leaf.

Net effect: a whole fan-out could "complete" having produced nothing — the field signature was `clustersAuthored: 0` with an **empty** failure list (a `.filter(Boolean)`-style check drops the empty string without it ever landing in `failures`).

## Fix

In `runToolLeaf`:
- Capture the loop's terminal `error` event into `loopError`.
- After `loop.run()`, if the leaf produced no output text, **rethrow** the captured error (or throw a clear "produced no output" error when the model simply emitted nothing).

The leaf now rejects, so the engine journals it `failed` and `map`/`parallel` yield `null` — a real failure instead of a phantom success. No other behavior changes; non-empty leaves are unaffected.

## Tests

Two regression tests in `leaf-runner.test.ts`:
- a swallowed provider rejection is rethrown (was: returned `""`);
- a clean `end_turn` with empty text throws "produced no output text".

All 19 leaf-runner tests pass; `tsc --noEmit` clean.

## Scope note

This PR is the minimal fail-loud fix. A separate, orthogonal config-fidelity issue exists (the tool path builds its `AgentLoop` without a `callSite`, so `max_tokens`/`thinking`/`effort` resolve from `DEFAULT_CONFIG` rather than the resolved `workflowLeaf` profile config). Left for a follow-up to keep this change focused — it was not the cause of the silent-failure bug.

Part of #35635

🤖 Generated with [Claude Code](https://claude.com/claude-code)