### PR TITLE
fix(notifications): de-dupe the in-app guardian approval card

### DIFF
--- a/assistant/src/__tests__/access-request-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/access-request-seed-content-blocks.test.ts
@@ -22,6 +22,8 @@ describe("buildAccessRequestSeedContentBlocks", () => {
     expect(blocks).toHaveLength(2);
     expect((blocks[0] as Record<string, unknown>).type).toBe("ui_surface");
     expect((blocks[1] as Record<string, unknown>).type).toBe("text");
+    // The fallback block is flagged so surface-capable clients skip it.
+    expect((blocks[1] as Record<string, unknown>)._surfaceFallback).toBe(true);
   });
 
   test("card surface has correct surfaceType and surfaceId", () => {

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -751,6 +751,45 @@ describe("renderHistoryContent", () => {
     expect(output.textSegments).toEqual([]);
     expect(output.contentOrder).toEqual([]);
   });
+
+  test("keeps a flagged surface-fallback text block in .text but out of blocks/segments", () => {
+    // The approval-card builder emits [ui_surface, text(_surfaceFallback)]. The
+    // surface renders the card for rich clients; the flagged fallback must stay
+    // in the flat `.text` body (CLI/search) but NOT appear as a text segment or
+    // content block, or the card would render twice.
+    const output = renderHistoryContent([
+      {
+        type: "ui_surface",
+        surfaceId: "tool-approval-1",
+        surfaceType: "card",
+        title: "Tool Approval",
+        data: { title: "Bob" },
+      },
+      { type: "text", text: "Bob wants to use bash", _surfaceFallback: true },
+    ]);
+
+    expect(output.text).toBe("Bob wants to use bash");
+    expect(output.textSegments).toEqual([]);
+    expect(output.surfaces).toHaveLength(1);
+    expect(output.contentOrder).toEqual(["surface:0"]);
+    expect(output.contentBlocks.map((b) => b.type)).toEqual(["surface"]);
+  });
+
+  test("renders an unflagged text block after a surface (legacy [ui_surface, text])", () => {
+    // Pre-flag rows carry no `_surfaceFallback`, so the sibling text still
+    // renders as its own block — legacy cards keep their duplicate text until
+    // re-seeded. New rows carry the flag and de-dupe.
+    const output = renderHistoryContent([
+      { type: "ui_surface", surfaceId: "s1", surfaceType: "card", data: {} },
+      { type: "text", text: "legacy fallback" },
+    ]);
+
+    expect(output.contentBlocks.map((b) => b.type)).toEqual([
+      "surface",
+      "text",
+    ]);
+    expect(output.text).toBe("legacy fallback");
+  });
 });
 
 describe("renderHistoryContent contentBlocks", () => {

--- a/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
@@ -70,6 +70,8 @@ describe("buildToolApprovalSeedContentBlocks", () => {
     expect(blocks).toHaveLength(2);
     expect((blocks[0] as Record<string, unknown>).type).toBe("ui_surface");
     expect((blocks[1] as Record<string, unknown>).type).toBe("text");
+    // The fallback block is flagged so surface-capable clients skip it.
+    expect((blocks[1] as Record<string, unknown>)._surfaceFallback).toBe(true);
   });
 
   test("produces a ui_surface block and a text fallback block for tool_grant_request", () => {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -453,6 +453,13 @@ export function renderHistoryContent(
       // time filter in cleanAssistantContent and migration 222.
       if (isPlaceholderSentinelText(displayText)) continue;
       textParts.push(displayText);
+      // A ui_surface card's plain-text fallback (flagged `_surfaceFallback` by
+      // the approval-card builder) is represented by the adjacent surface for
+      // surface-capable clients. Keep it in the flat `.text` body above (CLI,
+      // search, channel replies, non-surface clients) but don't emit it as a
+      // text segment or content block, or those clients would render the card
+      // AND its fallback text.
+      if (block._surfaceFallback === true) continue;
       ensureSegment();
       currentSegmentParts.push(displayText);
       seenText = true;

--- a/assistant/src/notifications/approval-card-builder.ts
+++ b/assistant/src/notifications/approval-card-builder.ts
@@ -40,8 +40,14 @@ export interface ApprovalCardParams {
  * Build a `[ui_surface, text]` block pair for a guardian approval notification.
  *
  * The `ui_surface` block renders as a card with Approve/Reject buttons in
- * clients that support Surface rendering. The `text` block provides a
- * plain-text fallback for older clients, search indexing, and CLI display.
+ * clients that support Surface rendering. The `text` block is the card's
+ * plain-text fallback — it feeds the model, search indexing, CLI display, and
+ * channel replies, which read it as ordinary text.
+ *
+ * The fallback block is flagged `_surfaceFallback` so the display projector
+ * (`renderHistoryContent`) keeps it in the flat `.text` body but omits it from
+ * `contentBlocks`/`textSegments`. Without that, a surface-capable client would
+ * render the card AND its fallback text — the duplicate this flag prevents.
  */
 export function buildApprovalCardBlocks(params: ApprovalCardParams): unknown[] {
   const {
@@ -87,6 +93,11 @@ export function buildApprovalCardBlocks(params: ApprovalCardParams): unknown[] {
   const textBlock = {
     type: "text" as const,
     text: fallbackText,
+    // Display-only hint: surface-capable clients render the card from
+    // `surfaceBlock` and must skip this block (see `renderHistoryContent`), or
+    // they show the card and a duplicate text line. Non-display consumers
+    // (model, search, CLI `.text`) read it as ordinary text.
+    _surfaceFallback: true,
   };
 
   return [surfaceBlock, textBlock];


### PR DESCRIPTION
## What

The in-app guardian **approval card renders twice** — the interactive `ui_surface` card plus a duplicate plain-text block under it. This fixes that. (LUM-2528)

## Root cause

The card is seeded as a `[ui_surface, text]` pair: the `ui_surface` for surface-capable clients, and the sibling `text` block as the plain-text fallback that every **non-display** consumer (the model, search/RAG, CLI `.text`, channel replies) already reads. The bug is purely in the **display projection** — `renderHistoryContent` emits *both* blocks into `contentBlocks`, so surface-capable clients (web/macOS) render the card **and** its fallback text.

## The fix

Fix it at the layer the bug lives in, with no change to the stored shape:

- The builder flags the fallback block **`_surfaceFallback: true`** — the same `_`-prefixed block-hint idiom `renderHistoryContent` already uses for tool/thinking metadata (`_startedAt`, `_confirmationDecision`, `_riskLevel`, …).
- `renderHistoryContent` keeps a flagged block in the flat **`.text`** body (CLI, search, channel replies, non-surface clients) but **omits it from `contentBlocks`/`textSegments`** — so surface-capable clients render the card exactly once.

That's the whole change: **2 production files** (`approval-card-builder`, `renderHistoryContent`).

## What does *not* change

- **The stored shape stays `[ui_surface, text]`** — no data-format change, no migration needed.
- **No change for any non-display consumer** (model, search, Slack transcript, on-disk view, token counting): they read the stored `text` block directly, exactly as before. No provider wrapper, no projection, no per-consumer edits.
- **No public API / schema / `openapi.yaml` change.**

## Caveat

Legacy rows already in the DB (no `_surfaceFallback` flag) keep rendering their sibling text — they still double-render until re-seeded. A one-line backfill migration could flag them if we want old cards fixed too; not included here since new cards are correct and backward-compat is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YR1eM2jvwurYnnpqV2NetY