### PR TITLE
refactor(web): trim MCP server config UI and reuse SkillRow for tool list

### DIFF
--- a/clients/web/src/domains/settings/mcp/mcp-page.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-page.tsx
@@ -136,8 +136,6 @@ function McpPageInner() {
       name: string;
       defaultRiskLevel?: string;
       maxTools?: number;
-      allowedTools?: string[] | null;
-      blockedTools?: string[] | null;
     }) => {
       setIsSaving(true);
       try {

--- a/clients/web/src/domains/settings/mcp/mcp-server-card.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-server-card.tsx
@@ -13,6 +13,7 @@ import { useCallback, useState } from "react";
 import type { McpServerEntry, McpToolsSummaryServer } from "./mcp-api";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
+import { SkillRow } from "@vellumai/design-library/components/skill-row";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 const STATUS_CONFIG: Record<string, { icon: typeof CheckCircle2; label: string; className: string }> = {
@@ -142,20 +143,18 @@ export function McpServerCard({
             {toolsExpanded ? (
               <div className="mt-2 max-h-60 space-y-1 overflow-y-auto">
                 {toolsSummary.tools.map((tool) => (
-                  <div
+                  <SkillRow
                     key={tool.name}
-                    className="flex items-center justify-between rounded px-2 py-1 text-body-small-default hover:bg-[var(--ghost-hover)]"
-                  >
-                    <div className="min-w-0 flex-1">
+                    title={
                       <span className="font-medium text-[var(--content-default)]">{tool.name}</span>
-                      {tool.description ? (
-                        <p className="truncate text-[var(--content-tertiary)]">{tool.description}</p>
-                      ) : null}
-                    </div>
-                    <span className="shrink-0 text-[var(--content-tertiary)]">
-                      ~{tool.estimatedTokens.toLocaleString()} tok
-                    </span>
-                  </div>
+                    }
+                    subtitle={tool.description || undefined}
+                    action={
+                      <span className="whitespace-nowrap text-body-small-default text-[var(--content-tertiary)]">
+                        ~{tool.estimatedTokens.toLocaleString()} tok
+                      </span>
+                    }
+                  />
                 ))}
               </div>
             ) : null}

--- a/clients/web/src/domains/settings/mcp/mcp-server-detail-modal.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-server-detail-modal.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useState } from "react";
 
 import type { McpServerEntry, McpToolsSummaryServer } from "./mcp-api";
 import { Button } from "@vellumai/design-library/components/button";
-import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 const RISK_LEVELS = ["low", "medium", "high"] as const;
@@ -16,8 +15,6 @@ interface McpServerDetailModalProps {
     name: string;
     defaultRiskLevel?: string;
     maxTools?: number;
-    allowedTools?: string[] | null;
-    blockedTools?: string[] | null;
   }) => void;
   isPending: boolean;
 }
@@ -30,14 +27,10 @@ export function McpServerDetailModal({
   isPending,
 }: McpServerDetailModalProps) {
   const [riskLevel, setRiskLevel] = useState("medium");
-  const [allowedToolsText, setAllowedToolsText] = useState("");
-  const [blockedToolsText, setBlockedToolsText] = useState("");
 
   useEffect(() => {
     if (server) {
       setRiskLevel(server.defaultRiskLevel);
-      setAllowedToolsText(server.allowedTools?.join(", ") ?? "");
-      setBlockedToolsText(server.blockedTools?.join(", ") ?? "");
     }
   }, [server]);
 
@@ -46,16 +39,11 @@ export function McpServerDetailModal({
       return;
     }
 
-    const allowed = allowedToolsText.trim();
-    const blocked = blockedToolsText.trim();
-
     onSave(server.id, {
       name: server.id,
       defaultRiskLevel: riskLevel,
-      allowedTools: allowed ? allowed.split(",").map((s) => s.trim()).filter(Boolean) : null,
-      blockedTools: blocked ? blocked.split(",").map((s) => s.trim()).filter(Boolean) : null,
     });
-  }, [server, riskLevel, allowedToolsText, blockedToolsText, onSave]);
+  }, [server, riskLevel, onSave]);
 
   const handleClose = useCallback(() => {
     if (!isPending) {
@@ -95,34 +83,6 @@ export function McpServerDetailModal({
                   </option>
                 ))}
               </select>
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="text-body-small-default text-[var(--content-secondary)]" htmlFor="mcp-allowed">
-                Allowed tools (comma-separated, leave empty for all)
-              </label>
-              <Input
-                id="mcp-allowed"
-                type="text"
-                value={allowedToolsText}
-                onChange={(e) => setAllowedToolsText(e.target.value)}
-                placeholder="tool_a, tool_b"
-                fullWidth
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="text-body-small-default text-[var(--content-secondary)]" htmlFor="mcp-blocked">
-                Blocked tools (comma-separated)
-              </label>
-              <Input
-                id="mcp-blocked"
-                type="text"
-                value={blockedToolsText}
-                onChange={(e) => setBlockedToolsText(e.target.value)}
-                placeholder="dangerous_tool"
-                fullWidth
-              />
             </div>
 
             {toolsSummary && toolsSummary.tools.length > 0 ? (


### PR DESCRIPTION
## Summary

Polish pass on the MCP settings UI (`settings → mcp`).

### Remove Allowed/Blocked tools fields
The configure-server modal exposed **Allowed tools** and **Blocked tools** comma-separated free-text inputs. This PR removes those fields and all associated client logic (state, `useEffect` hydration, comma-split parsing, and the `allowedTools`/`blockedTools` write params through `mcp-page.tsx` → `mcp-api.ts`).

The allowlist/blocklist **filtering logic itself is kept** — it predates this UI by ~4 months (shipped in the original MCP support PR #10467, 2026-02-27; this UI landed in #35305, 2026-06-18). It still lives in the assistant config schema (`assistant/src/config/schemas/mcp.ts`) and `filterTools()` (`assistant/src/mcp/manager.ts`), and the update route still accepts the fields, so any existing config with `allowedTools`/`blockedTools` continues to be honored. Only the editing UI is gone — no migration needed.

### Polish the registered-tools list
The server card hand-rolled its expanded tool rows, which left tool names and descriptions cramped together. Replaced with the shared **`SkillRow`** design-library component (`title` / `subtitle` / `action`), which gives consistent spacing between name and description and aligns the token count as the trailing value.

## Testing
- `bunx tsc --noEmit` (clients/web) — passes
- `eslint src/domains/settings/mcp/` — clean

## Review focus
Low risk, UI-only. Confirm the backend filtering should remain editable only via config file (no longer via UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->