### PR TITLE
fix(workflows): surface that schema leaves have no read tools

### DIFF
--- a/assistant/docs/workflows.md
+++ b/assistant/docs/workflows.md
@@ -150,12 +150,12 @@ only as fast as the slowest leaf in each stage.
 
 ### Leaf options (`opts` for `agent` / `leaf`)
 
-| Option    | Type                       | Effect                                                                                  |
-| --------- | -------------------------- | --------------------------------------------------------------------------------------- |
-| `schema`  | JSON Schema object literal | Forces structured output via a tool. A schema leaf runs with **no tools**.              |
-| `label`   | string                     | Short display/diagnostic label for the leaf.                                            |
-| `profile` | string                     | Overrides the model profile. Must exist in `llm.profiles` or the leaf throws.           |
-| `persona` | boolean                    | `true` makes the leaf speak as the assistant (identity + memory). Default is anonymous. |
+| Option    | Type                       | Effect                                                                                                           |
+| --------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `schema`  | JSON Schema object literal | Forces structured output via a tool. A schema leaf runs with **no tools** — no read/recall; pass content inline. |
+| `label`   | string                     | Short display/diagnostic label for the leaf.                                                                     |
+| `profile` | string                     | Overrides the model profile. Must exist in `llm.profiles` or the leaf throws.                                    |
+| `persona` | boolean                    | `true` makes the leaf speak as the assistant (identity + memory). Default is anonymous.                          |
 
 #### `schema` is a JSON Schema literal, not Zod
 
@@ -163,7 +163,12 @@ A script runs in the sandbox and cannot hold a host-side Zod object, so a leaf's
 `schema` is a plain **JSON Schema object literal**. The engine builds a forced
 `tool_choice` call whose synthetic tool input is that schema, validates the
 model's output against it, and returns the structured object. A leaf with a
-`schema` is a pure judge/extractor — it gets **no tools**:
+`schema` is a pure judge/extractor — it gets **no tools**, so it has no
+`file_read`/`file_list`/`recall`/`web_search` and **cannot read files or recall
+memory**. Anything it must judge has to be passed **inline** in the prompt; a
+schema leaf told to "read these files" will confabulate against the schema. (To
+read first and then emit structured output, use a tool leaf that returns JSON in
+its text and parse it yourself.)
 
 ```js
 leaf(`Score this option 0-10 for fit: ${opt}`, {

--- a/assistant/src/config/bundled-skills/workflows/SKILL.md
+++ b/assistant/src/config/bundled-skills/workflows/SKILL.md
@@ -105,7 +105,7 @@ Use `agent` for a single sequential leaf (throws on failure). Use `parallel`/`ma
 
 | Option    | Type                       | Effect                                                                                  |
 | --------- | -------------------------- | --------------------------------------------------------------------------------------- |
-| `schema`  | JSON Schema object literal | Forces structured output via a tool. A schema leaf runs with **no tools** (pure judge/extractor). Use a plain JSON Schema literal, not Zod. |
+| `schema`  | JSON Schema object literal | Forces structured output via a tool. A schema leaf runs with **no tools** — no `file_read`/`file_list`/`recall`/`web_search`, so it **cannot read files or recall memory** (pure judge/extractor). Pass anything it must judge **inline** in the prompt; a schema leaf told to "read these files" answers from the model's prior, not real data. Use a plain JSON Schema literal, not Zod. |
 | `label`   | string                     | Short display/diagnostic label for the leaf.                                            |
 | `profile` | string                     | Overrides the model profile. Must exist in `llm.profiles` or the leaf throws. See [Listing profiles](#listing-available-profiles). |
 | `persona` | boolean                    | `true` makes the leaf speak AS the assistant (identity + memory) — use for output meant to be in the assistant's voice. Default is anonymous — use for impartial judging/extraction. |
@@ -128,8 +128,9 @@ workflow**.
 }
 ```
 
-- **Read-only baseline** (always available, no declaration, no launch prompt):
-  `file_read`, `file_list`, `recall`, `web_search`.
+- **Read-only baseline** (available to **tool** leaves, no declaration, no launch prompt):
+  `file_read`, `file_list`, `recall`, `web_search`. **A schema leaf gets none of these**
+  (it runs as a single forced-tool-choice call) — pass it inline content, never tell it to read.
 - **`web_fetch` is NOT in the baseline** — an outbound fetch is side-effecting (its
   URL can exfiltrate read data), so a leaf that must fetch a URL has to declare
   `"web_fetch"` in `capabilities.tools`.

--- a/assistant/src/workflows/engine.ts
+++ b/assistant/src/workflows/engine.ts
@@ -638,6 +638,11 @@ export async function executeWorkflow(
   let inputTokens = existing ? existing.inputTokens : 0;
   let outputTokens = existing ? existing.outputTokens : 0;
   let capExceeded = false;
+  // Warn ONCE per run (not per leaf) the first time a schema leaf is launched:
+  // schema leaves run with no tools, so a judge panel that correctly passes its
+  // content inline shouldn't get a wall of warnings, but the author still gets a
+  // visible signal that these leaves cannot read.
+  let warnedSchemaLeafNoTools = false;
 
   /** Persist live counters so `getRun` reports them mid-flight. */
   const flushCounters = (): void => {
@@ -697,6 +702,23 @@ export async function executeWorkflow(
       // resolved capabilities always include a non-empty read-only baseline, so
       // forward `tools` only on the tool-leaf path; a schema leaf runs with none.
       const isSchemaLeaf = leafOpts.schema !== undefined;
+      if (isSchemaLeaf && !warnedSchemaLeafNoTools) {
+        warnedSchemaLeafNoTools = true;
+        // The forced-tool-choice structured-output path forwards NO tools, so a
+        // schema leaf has no file_read/file_list/recall/web_search — it cannot
+        // read files or look anything up. A schema leaf told to "read these
+        // files and compare" will answer from the model's prior, not real data
+        // (the source of confabulated output). Anything it must judge has to be
+        // passed inline in its prompt. Surfaced once per run as a backstop; the
+        // primary guidance lives in the workflows skill the author reads first.
+        log.warn(
+          { runId },
+          "Schema leaves run with NO tools (no file_read/file_list/recall/" +
+            "web_search) — they cannot read files or recall memory. Pass any " +
+            "content a schema leaf must judge INLINE in its prompt; a schema " +
+            "leaf asked to read or look something up will confabulate.",
+        );
+      }
       const result = await leafRunner({
         prompt,
         ...(leafOpts.label !== undefined ? { label: leafOpts.label } : {}),


### PR DESCRIPTION
## Problem

A workflow `leaf({ schema })` is dispatched as a single forced-tool-choice structured-output call with **no tools** (`engine.ts`: `isSchemaLeaf ? {} : { tools: capabilities.tools }`). It therefore has no `file_read`/`file_list`/`recall`/`web_search` — it **cannot read files or recall memory**. A schema leaf whose prompt says "read these files and compare" reads nothing and confabulates output that merely conforms to the schema.

This was silent: no warning at launch, and the docs (the bundled `workflows` SKILL.md the model reads before authoring, plus `docs/workflows.md`) presented "no tools" as a neutral fact. In the field it produced a fan-out of hundreds of hallucinated findings.

## Fix

- **Engine warns once per run** the first time a schema leaf is launched — *not* once per schema leaf, so a judge panel that correctly passes content inline doesn't get a wall of warnings, but an author still gets a visible signal that schema leaves can't read.
- **Doc corrections** in the bundled `workflows` SKILL.md and `docs/workflows.md`: state that "no tools" means no read/recall, that content must be passed **inline**, and document the read-first alternative (a tool leaf that returns JSON in its text, parsed by the caller).

## Why no unit test on the log line

bun hoists static imports above `mock.module`, so `engine.js` binds the real logger at module-init *before* a test's logger mock runs — the documented `mock-logger` preload-hoisting limitation (the existing "Silence the logger" mock doesn't intercept the engine's logger either). Async pino makes stdout capture flaky. The once-per-run logic is trivial and was verified via the emitted log during a test run; the existing `engine.test.ts` "a schema leaf is called with NO tools" test pins the underlying tool-forwarding behavior. `tsc --noEmit` and the workflows test suite pass.

## Follow-up (separate PR)

The migration skill's own loss-audit template ships the buggy shape (passes `schema` *and* tells the leaf to "read each source page"); rewriting it is part of the skill-docs PR in #35635.

Part of #35635

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->