### PR TITLE
fix(calls): mock contact-store in relay-setup-router test to unbreak main CI

### DIFF
--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -20,10 +20,7 @@ import {
   type AdmissionPolicy,
 } from "@vellumai/gateway-client";
 
-import type {
-  ChannelPolicy,
-  ChannelStatus,
-} from "../../contacts/types.js";
+import type { ChannelPolicy, ChannelStatus } from "../../contacts/types.js";
 import type {
   ActorTrustContext,
   TrustClass,
@@ -55,6 +52,7 @@ mock.module("../../runtime/channel-verification-service.js", () => ({
 
 // Controllable active voice invites.
 let activeInvites: Array<{
+  contactId: string;
   friendName: string | null;
   guardianName: string | null;
   expiresAt?: number;
@@ -63,38 +61,41 @@ mock.module("../../memory/invite-store.js", () => ({
   findActiveVoiceInvites: () => activeInvites,
 }));
 
+// Controllable bound contact for invite-redemption name resolution.
+let boundContact: { displayName?: string | null } | null = null;
+mock.module("../../contacts/contact-store.js", () => ({
+  getContact: () => boundContact,
+}));
+
 // Real floor semantics, exemption bypassed (see file header).
-mock.module(
-  "../../runtime/routes/inbound-stages/admission-policy.js",
-  () => ({
-    enforceAdmissionPolicy: (input: {
-      trustClass: TrustClass;
-      memberStatus: ChannelStatus | undefined;
-      policy: AdmissionPolicy;
-    }) => {
-      if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
-        return {
-          admitted: false,
-          reason:
-            input.memberStatus === "blocked"
-              ? "member_blocked"
-              : "member_revoked",
-          shouldChallenge: false,
-          effectivePolicy: input.policy,
-        };
-      }
-      const rank = TRUST_CLASS_RANK[input.trustClass];
-      const floor = ADMISSION_FLOOR[input.policy];
-      if (rank >= floor) return { admitted: true };
+mock.module("../../runtime/routes/inbound-stages/admission-policy.js", () => ({
+  enforceAdmissionPolicy: (input: {
+    trustClass: TrustClass;
+    memberStatus: ChannelStatus | undefined;
+    policy: AdmissionPolicy;
+  }) => {
+    if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
       return {
         admitted: false,
-        reason: `admission_policy_${input.policy}`,
+        reason:
+          input.memberStatus === "blocked"
+            ? "member_blocked"
+            : "member_revoked",
         shouldChallenge: false,
         effectivePolicy: input.policy,
       };
-    },
-  }),
-);
+    }
+    const rank = TRUST_CLASS_RANK[input.trustClass];
+    const floor = ADMISSION_FLOOR[input.policy];
+    if (rank >= floor) return { admitted: true };
+    return {
+      admitted: false,
+      reason: `admission_policy_${input.policy}`,
+      shouldChallenge: false,
+      effectivePolicy: input.policy,
+    };
+  },
+}));
 
 const { routeSetup } = await import("../relay-setup-router.js");
 
@@ -149,6 +150,7 @@ function route(admissionPolicy?: AdmissionPolicy | null) {
 beforeEach(() => {
   pendingChallenge = null;
   activeInvites = [];
+  boundContact = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -334,9 +336,19 @@ describe("routeSetup — permissive floor admits to normal_call", () => {
 describe("routeSetup — floor bypasses", () => {
   test("active voice invite bypasses the floor (no_one policy)", () => {
     nextTrust = makeTrust("unknown");
-    activeInvites = [{ friendName: "Friend", guardianName: "Guardian" }];
+    activeInvites = [
+      {
+        contactId: "contact-123",
+        friendName: "Friend",
+        guardianName: "Guardian",
+      },
+    ];
+    boundContact = { displayName: "Friend Name" };
     const { outcome } = route("no_one");
     expect(outcome.action).toBe("invite_redemption");
+    if (outcome.action === "invite_redemption") {
+      expect(outcome.inviteeName).toBe("Friend Name");
+    }
   });
 
   test("pending verification challenge bypasses the floor (no_one policy)", () => {


### PR DESCRIPTION
## Summary
- `relay-setup-router.test.ts` mocks every DB-backed dependency except `contact-store`. PR #35581 added a `getContact(matchedInvite.contactId)` call to the invite-redemption path, so the one test that sets an active voice invite hit the real `getContact`, which queries a `contacts` table absent from the test's bare in-memory DB → `SQLiteError: no such table: contacts`. This broke the Test job on main CI.
- Add a controllable `getContact` mock (matching the four existing controllable-mock patterns in the file) so the router's name resolution runs without touching the DB, and reset it in `beforeEach`.
- Give the invite fixture a `contactId` and a bound contact so the test now exercises PR #35581's name-resolution path and asserts the resolved `inviteeName`. (Committing also applied a mechanical Prettier normalization to a pre-existing import and mock block in the same file.)

## Original prompt
Fix the specific CI failure in the Test job of the Main Assistant Checks run (27970942900), scoped to that one failing job only. The job failed because `relay-setup-router.test.ts` threw `SQLiteError: no such table: contacts` from a newly added `getContact` call in the invite-redemption path that the test never mocked.