### PR TITLE
fix(web): match sidebar top-nav row spacing to the conversation list

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -433,56 +433,59 @@ export function AssistantSideMenu({
             <div className="flex items-center gap-2">{headerActions}</div>
           </div>
         ) : null}
-        <SideMenu.Item
-          icon={Brain}
-          label={assistantName || "Your Assistant"}
-          showCollapsedTooltip
-          active={isIntelligenceActive}
-          onSelect={onOpenIntelligence ? () => { onOpenIntelligence(); onClose?.(); } : undefined}
-        />
-        {onOpenLibrary ? (
+        {/* 2px row gap to match the conversation list. */}
+        <div className="flex flex-col gap-[2px]">
           <SideMenu.Item
-            icon={LayoutGrid}
-            label="Library"
+            icon={Brain}
+            label={assistantName || "Your Assistant"}
             showCollapsedTooltip
-            active={isLibraryActive}
-            onSelect={onOpenLibrary ? () => { onOpenLibrary(); onClose?.(); } : undefined}
+            active={isIntelligenceActive}
+            onSelect={onOpenIntelligence ? () => { onOpenIntelligence(); onClose?.(); } : undefined}
           />
-        ) : null}
-        {onOpenHome ? (
-          <SideMenu.Item
-            icon={Calendar}
-            label="Activity"
-            showCollapsedTooltip
-            active={isHomeActive}
-            badge={
-              hasUnreadHome && !isHomeActive ? (
-                <span
-                  className="h-2 w-2 rounded-full bg-[var(--system-negative-strong)]"
-                  aria-hidden="true"
-                />
-              ) : undefined
-            }
-            onSelect={onOpenHome ? () => { onOpenHome(); onClose?.(); } : undefined}
-          />
-        ) : null}
-        {pinnedApps.map((app) => (
-          <SideMenu.Item
-            key={app.appId}
-            // Apps source their icon as an emoji string on the manifest
-            // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
-            // apps still get a leading icon in the rail.
-            icon={app.icon ?? Rocket}
-            label={app.name}
-            showCollapsedTooltip
-            active={activeAppId === app.appId}
-            onSelect={onOpenApp ? () => { onOpenApp(app.appId); onClose?.(); } : undefined}
-          />
-        ))}
+          {onOpenLibrary ? (
+            <SideMenu.Item
+              icon={LayoutGrid}
+              label="Library"
+              showCollapsedTooltip
+              active={isLibraryActive}
+              onSelect={onOpenLibrary ? () => { onOpenLibrary(); onClose?.(); } : undefined}
+            />
+          ) : null}
+          {onOpenHome ? (
+            <SideMenu.Item
+              icon={Calendar}
+              label="Activity"
+              showCollapsedTooltip
+              active={isHomeActive}
+              badge={
+                hasUnreadHome && !isHomeActive ? (
+                  <span
+                    className="h-2 w-2 rounded-full bg-[var(--system-negative-strong)]"
+                    aria-hidden="true"
+                  />
+                ) : undefined
+              }
+              onSelect={onOpenHome ? () => { onOpenHome(); onClose?.(); } : undefined}
+            />
+          ) : null}
+          {pinnedApps.map((app) => (
+            <SideMenu.Item
+              key={app.appId}
+              // Apps source their icon as an emoji string on the manifest
+              // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
+              // apps still get a leading icon in the rail.
+              icon={app.icon ?? Rocket}
+              label={app.name}
+              showCollapsedTooltip
+              active={activeAppId === app.appId}
+              onSelect={onOpenApp ? () => { onOpenApp(app.appId); onClose?.(); } : undefined}
+            />
+          ))}
+        </div>
         <SideMenu.Separator />
       </SideMenu.Header>
 
-      <SideMenu.Body className="gap-[2px] pt-3 max-md:pt-4">
+      <SideMenu.Body className="gap-1 pt-3 max-md:pt-4">
         {collapsed && variant === "rail" ? (
           <div className="flex flex-col items-center gap-1">
             {headerActions}


### PR DESCRIPTION
## What this fixes

The top nav rows in the assistant sidebar — **Vex** (assistant), **Library**, **Activity**, and the pinned-app rows (**Vex Ops**, **Slack Permissions Map**) — sit much further apart than the conversation list below them. The top rows are `gap-2` (**8px**) apart; the conversation rows are `gap-[2px]` (**2px**) apart. The screenshots from the issue show the difference clearly (e.g. the gap between a selected and a hovered top row vs. the near-flush conversation rows).

## Why the earlier change didn't take effect

This was *supposed* to be fixed by **#35316** ("fix(sidebar): consistent section spacing + stable pinned order", merged 6/18). That PR is genuinely in `main` — but it edited the wrong element:

- The top rows live in **`SideMenu.Header`**, whose spacing is the design-library default `flex flex-col gap-2` (8px) — and `SideMenu.Header` was never touched.
- #35316 instead changed **`SideMenu.Body`** from `gap-1` → `gap-[2px]`, which only controls the gap *between the Pinned and Conversations section blocks* — not the top rows.

So the merged change shipped, but the items in the screenshot never moved.

## The fix

1. **Wrap the header nav rows in a `gap-[2px]` column** so they match the 2px conversation rhythm. The `Header`'s own `gap-2` still separates this cluster from the overlay (mobile) controls above and the trailing `Separator` below, so the section divider keeps its breathing room.
2. **Revert the misdirected `SideMenu.Body` change** (`gap-[2px]` → `gap-1`), restoring the deliberate 4px section-to-section rhythm established in #33022. This was the part of #35316 that was aimed at the wrong place.

The unrelated, correct half of #35316 (stable pinned ordering by `createdAt`) is left untouched.

## Testing

- `bun test src/domains/chat/components/assistant-side-menu.test.tsx` — **14 pass**
- `bunx tsc --noEmit` — **0 errors**
- `eslint` on the changed file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gg4rS5gtFUbdSbm9H9dk1k)_