### PR TITLE
Add stop button to macOS dictation overlay

### DIFF
--- a/clients/macos/src/main/dictation-overlay-window.ts
+++ b/clients/macos/src/main/dictation-overlay-window.ts
@@ -218,6 +218,7 @@ const hideOverlay = (): void => {
   latestState = null;
   const win = getFloatingWindow(OVERLAY_KIND);
   if (win) {
+    setOverlayInteractive(false);
     win.hide();
   }
 };

--- a/clients/macos/src/main/dictation-overlay-window.ts
+++ b/clients/macos/src/main/dictation-overlay-window.ts
@@ -10,7 +10,7 @@ import { createFloatingWindow, getFloatingWindow } from "./floating-window";
 import { handle, on } from "./ipc";
 
 /**
- * System-wide dictation overlay — a floating, click-through panel pinned
+ * System-wide dictation overlay — a floating panel pinned
  * top-center of the active display that shows the user's words live while
  * they dictate via push-to-talk into another app. Matches the native Swift
  * client's `DictationOverlayWindow`: a small pill that expands with partial
@@ -24,8 +24,8 @@ import { handle, on } from "./ipc";
  * `clients/web/`, same standalone pattern as Quick Input).
  *
  * `type: "panel"` + `focusable: false` keep the overlay from ever stealing
- * focus from the app being dictated into, and the window is fully
- * click-through — it's a display surface only.
+ * focus from the app being dictated into. The transparent canvas is
+ * click-through except while the pointer is over the Stop control.
  */
 
 const OVERLAY_KIND = "dictation-overlay";
@@ -152,6 +152,24 @@ const sendState = (state: DictationOverlayState): void => {
   }
 };
 
+const broadcastStopRequested = (): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+      win.webContents.send("vellum:dictationOverlay:stopRequested");
+    }
+  }
+};
+
+const setOverlayInteractive = (interactive: boolean): void => {
+  const win = getFloatingWindow(OVERLAY_KIND);
+  if (!win || win.isDestroyed()) return;
+  if (interactive) {
+    win.setIgnoreMouseEvents(false);
+  } else {
+    win.setIgnoreMouseEvents(true, { forward: true });
+  }
+};
+
 export const positionDictationOverlayInWorkArea = (workArea: {
   x: number;
   y: number;
@@ -176,7 +194,7 @@ const ensureOverlayWindow = (): BrowserWindow => {
     height: OVERLAY_HEIGHT,
     focusOnShow: false,
     alwaysOnTopLevel: DICTATION_OVERLAY_ALWAYS_ON_TOP_LEVEL,
-    ignoreMouseEvents: true,
+    ignoreMouseEvents: { forward: true },
     position: overlayPosition,
     browserWindow: {
       movable: false,
@@ -237,6 +255,18 @@ export const installDictationOverlay = (
     ([message]) => {
       options.onRecordingLifecycle?.(message.kind === "recording");
       controller.handleMessage(message);
+    },
+  );
+
+  on("vellum:dictationOverlay:requestStop", z.tuple([]), () => {
+    broadcastStopRequested();
+  });
+
+  on(
+    "vellum:dictationOverlay:setInteractive",
+    z.tuple([z.boolean()]),
+    ([interactive]) => {
+      setOverlayInteractive(interactive);
     },
   );
 

--- a/clients/macos/src/main/floating-window.test.ts
+++ b/clients/macos/src/main/floating-window.test.ts
@@ -291,6 +291,31 @@ describe("createFloatingWindow", () => {
     ]);
   });
 
+  test("reapplies click-through behavior when reusing an existing window", () => {
+    const singletonKind = kind("click-through-reuse");
+
+    const win = createFloatingWindow({
+      kind: singletonKind,
+      route: "/overlay",
+      width: 100,
+      height: 100,
+      ignoreMouseEvents: { forward: true },
+    }) as unknown as StubWindow;
+    win.setIgnoreMouseEvents.mockClear();
+
+    createFloatingWindow({
+      kind: singletonKind,
+      route: "/overlay",
+      width: 100,
+      height: 100,
+      ignoreMouseEvents: { forward: true },
+    });
+
+    expect(win.setIgnoreMouseEvents.mock.calls).toEqual([
+      [true, { forward: true }],
+    ]);
+  });
+
   test("drops the singleton reference when the window closes", () => {
     const cleanupKind = kind("closed");
     const first = createFloatingWindow({

--- a/clients/macos/src/main/floating-window.test.ts
+++ b/clients/macos/src/main/floating-window.test.ts
@@ -67,9 +67,11 @@ const makeWindow = (): StubWindow => {
     },
     setPosition: mock((_x: number, _y: number) => undefined),
     setAlwaysOnTop: mock((_flag: boolean, _level: string) => undefined),
-    setIgnoreMouseEvents: mock((_ignore: boolean) => {
-      calls.push("setIgnoreMouseEvents");
-    }),
+    setIgnoreMouseEvents: mock(
+      (_ignore: boolean, _options?: { forward?: boolean }) => {
+        calls.push("setIgnoreMouseEvents");
+      },
+    ),
     setVisibleOnAllWorkspaces: mock(
       (_visible: boolean, _opts: Record<string, boolean>) => undefined,
     ),
@@ -273,6 +275,20 @@ describe("createFloatingWindow", () => {
 
     expect(win.setIgnoreMouseEvents.mock.calls).toEqual([[true]]);
     expect(win.__calls).toEqual(["setIgnoreMouseEvents", "showInactive"]);
+  });
+
+  test("can forward mouse movement while click-through", () => {
+    const win = createFloatingWindow({
+      kind: kind("click-through-forward"),
+      route: "/overlay",
+      width: 100,
+      height: 100,
+      ignoreMouseEvents: { forward: true },
+    }) as unknown as StubWindow;
+
+    expect(win.setIgnoreMouseEvents.mock.calls).toEqual([
+      [true, { forward: true }],
+    ]);
   });
 
   test("drops the singleton reference when the window closes", () => {

--- a/clients/macos/src/main/floating-window.ts
+++ b/clients/macos/src/main/floating-window.ts
@@ -10,6 +10,9 @@ import { createWindow } from "./windows";
 type AlwaysOnTopLevel = NonNullable<
   Parameters<BrowserWindow["setAlwaysOnTop"]>[1]
 >;
+type IgnoreMouseEventsOptions = NonNullable<
+  Parameters<BrowserWindow["setIgnoreMouseEvents"]>[1]
+>;
 
 export type FloatingWindowPosition =
   | { x: number; y: number }
@@ -23,7 +26,7 @@ export interface CreateFloatingWindowOptions {
   focusOnShow?: boolean;
   alwaysOnTopLevel?: AlwaysOnTopLevel;
   visibleOnAllWorkspaces?: boolean;
-  ignoreMouseEvents?: boolean;
+  ignoreMouseEvents?: boolean | IgnoreMouseEventsOptions;
   browserWindow?: Omit<
     BrowserWindowConstructorOptions,
     | "webPreferences"
@@ -117,7 +120,11 @@ export const createFloatingWindow = ({
 
   win.setAlwaysOnTop(true, alwaysOnTopLevel);
   if (ignoreMouseEvents) {
-    win.setIgnoreMouseEvents(true);
+    if (typeof ignoreMouseEvents === "boolean") {
+      win.setIgnoreMouseEvents(true);
+    } else {
+      win.setIgnoreMouseEvents(true, ignoreMouseEvents);
+    }
   }
   if (visibleOnAllWorkspaces) {
     win.setVisibleOnAllWorkspaces(true, {

--- a/clients/macos/src/main/floating-window.ts
+++ b/clients/macos/src/main/floating-window.ts
@@ -83,6 +83,17 @@ const showFloatingWindow = (
   win.showInactive();
 };
 
+const applyIgnoreMouseEvents = (
+  win: BrowserWindow,
+  ignoreMouseEvents: boolean | IgnoreMouseEventsOptions,
+): void => {
+  if (typeof ignoreMouseEvents === "boolean") {
+    win.setIgnoreMouseEvents(true);
+  } else {
+    win.setIgnoreMouseEvents(true, ignoreMouseEvents);
+  }
+};
+
 export const createFloatingWindow = ({
   kind,
   route,
@@ -98,6 +109,9 @@ export const createFloatingWindow = ({
   const existing = getFloatingWindow(kind);
   if (existing) {
     applyPosition(existing, position);
+    if (ignoreMouseEvents) {
+      applyIgnoreMouseEvents(existing, ignoreMouseEvents);
+    }
     showFloatingWindow(existing, focusOnShow);
     return existing;
   }
@@ -120,11 +134,7 @@ export const createFloatingWindow = ({
 
   win.setAlwaysOnTop(true, alwaysOnTopLevel);
   if (ignoreMouseEvents) {
-    if (typeof ignoreMouseEvents === "boolean") {
-      win.setIgnoreMouseEvents(true);
-    } else {
-      win.setIgnoreMouseEvents(true, ignoreMouseEvents);
-    }
+    applyIgnoreMouseEvents(win, ignoreMouseEvents);
   }
   if (visibleOnAllWorkspaces) {
     win.setVisibleOnAllWorkspaces(true, {

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -494,6 +494,21 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(
         "vellum:dictationOverlay:getState",
       ) as Promise<DictationOverlayState | null>,
+    requestStop: (): void => {
+      ipcRenderer.send("vellum:dictationOverlay:requestStop");
+    },
+    onStopRequested: (callback) => {
+      const handler = () => {
+        callback();
+      };
+      ipcRenderer.on("vellum:dictationOverlay:stopRequested", handler);
+      return () => {
+        ipcRenderer.off("vellum:dictationOverlay:stopRequested", handler);
+      };
+    },
+    setInteractive: (interactive: boolean): void => {
+      ipcRenderer.send("vellum:dictationOverlay:setInteractive", interactive);
+    },
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/clients/web/src/components/dictation-overlay-page.test.tsx
+++ b/clients/web/src/components/dictation-overlay-page.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { DictationOverlayState } from "@/runtime/is-electron";
+
+let currentState: DictationOverlayState | null = null;
+const requestStopMock = mock(() => undefined);
+const setInteractiveMock = mock((_interactive: boolean) => undefined);
+
+mock.module("@/runtime/dictation-overlay", () => ({
+  getDictationOverlayState: async () => currentState,
+  subscribeToDictationOverlayState: () => () => undefined,
+  requestDictationOverlayStop: requestStopMock,
+  setDictationOverlayInteractive: setInteractiveMock,
+}));
+
+const { DictationOverlayPage } = await import("./dictation-overlay-page");
+
+afterEach(() => {
+  cleanup();
+  currentState = null;
+  requestStopMock.mockClear();
+  setInteractiveMock.mockClear();
+});
+
+describe("DictationOverlayPage", () => {
+  test("renders a far-right stop control during recording", async () => {
+    currentState = {
+      kind: "recording",
+      transcription: "hello",
+      audioLevel: 0.5,
+    };
+
+    const { getByLabelText } = render(<DictationOverlayPage />);
+    const stopButton = await waitFor(() => getByLabelText("Stop recording"));
+
+    fireEvent.mouseEnter(stopButton);
+    fireEvent.click(stopButton);
+
+    expect(setInteractiveMock.mock.calls).toContainEqual([true]);
+    expect(requestStopMock).toHaveBeenCalledTimes(1);
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+  });
+
+  test("does not render the stop control after recording ends", async () => {
+    currentState = { kind: "processing" };
+
+    const { queryByLabelText } = render(<DictationOverlayPage />);
+
+    await waitFor(() => {
+      expect(queryByLabelText("Stop recording")).toBeNull();
+    });
+  });
+});

--- a/clients/web/src/components/dictation-overlay-page.test.tsx
+++ b/clients/web/src/components/dictation-overlay-page.test.tsx
@@ -31,14 +31,63 @@ describe("DictationOverlayPage", () => {
       audioLevel: 0.5,
     };
 
-    const { getByLabelText } = render(<DictationOverlayPage />);
+    const { container, getByLabelText } = render(<DictationOverlayPage />);
     const stopButton = await waitFor(() => getByLabelText("Stop recording"));
+    const overlay = container.firstElementChild;
+    if (!overlay) {
+      throw new Error("Expected overlay root to render");
+    }
+    stopButton.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        right: 30,
+        top: 10,
+        bottom: 30,
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
 
-    fireEvent.mouseEnter(stopButton);
+    fireEvent.mouseMove(overlay, { clientX: 20, clientY: 20 });
     fireEvent.click(stopButton);
 
     expect(setInteractiveMock.mock.calls).toContainEqual([true]);
     expect(requestStopMock).toHaveBeenCalledTimes(1);
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+  });
+
+  test("returns to click-through when forwarded mouse movement leaves the stop control", async () => {
+    currentState = {
+      kind: "recording",
+      transcription: "",
+      audioLevel: 0.5,
+    };
+
+    const { container, getByLabelText } = render(<DictationOverlayPage />);
+    const stopButton = await waitFor(() => getByLabelText("Stop recording"));
+    const overlay = container.firstElementChild;
+    if (!overlay) {
+      throw new Error("Expected overlay root to render");
+    }
+    stopButton.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        right: 30,
+        top: 10,
+        bottom: 30,
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    fireEvent.mouseMove(overlay, { clientX: 20, clientY: 20 });
+    fireEvent.mouseMove(overlay, { clientX: 100, clientY: 100 });
+
+    expect(setInteractiveMock.mock.calls).toContainEqual([true]);
     expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
   });
 

--- a/clients/web/src/components/dictation-overlay-page.tsx
+++ b/clients/web/src/components/dictation-overlay-page.tsx
@@ -1,17 +1,19 @@
-import { Check, Loader2, TriangleAlert } from "lucide-react";
+import { Check, Loader2, Square, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import {
   getDictationOverlayState,
+  requestDictationOverlayStop,
+  setDictationOverlayInteractive,
   subscribeToDictationOverlayState,
 } from "@/runtime/dictation-overlay";
 import type { DictationOverlayState } from "@/runtime/is-electron";
 
 /**
  * Live dictation pill rendered inside the Electron dictation overlay
- * BrowserWindow — a click-through, non-activating panel pinned top-center
- * of the active display while the user dictates via push-to-talk into
- * another app. The Electron port of the native Swift client's
+ * BrowserWindow — a non-activating panel pinned top-center of the active
+ * display while the user dictates via push-to-talk into another app. The
+ * Electron port of the native Swift client's
  * `DictationOverlayWindow`: a status row (state icon + label), compact
  * audio meter, and optional two-line live transcription.
  *
@@ -54,9 +56,7 @@ export function DictationOverlayPage() {
           <span className="truncate text-[11px] font-medium text-[var(--content-secondary)]">
             {stateLabel(state)}
           </span>
-          {state.kind === "recording" && (
-            <AudioMeter level={audioLevel} />
-          )}
+          {state.kind === "recording" && <RecordingActions level={audioLevel} />}
         </div>
         {transcription && (
           // Bottom-anchored two-line text: the transcript grows as words
@@ -73,12 +73,50 @@ export function DictationOverlayPage() {
   );
 }
 
+function RecordingActions({ level }: { level: number }) {
+  useEffect(() => {
+    return () => {
+      setDictationOverlayInteractive(false);
+    };
+  }, []);
+
+  const enableInteraction = () => {
+    setDictationOverlayInteractive(true);
+  };
+  const disableInteraction = () => {
+    setDictationOverlayInteractive(false);
+  };
+  const stopRecording = () => {
+    requestDictationOverlayStop();
+    setDictationOverlayInteractive(false);
+  };
+
+  return (
+    <div className="ml-auto flex shrink-0 items-center gap-2">
+      <AudioMeter level={level} />
+      <button
+        type="button"
+        className="flex size-5 items-center justify-center rounded-full text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-overlay)] hover:text-[var(--system-negative-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--system-negative-strong)]"
+        aria-label="Stop recording"
+        title="Stop recording"
+        onMouseEnter={enableInteraction}
+        onMouseLeave={disableInteraction}
+        onFocus={enableInteraction}
+        onBlur={disableInteraction}
+        onClick={stopRecording}
+      >
+        <Square className="size-2.5 fill-current" strokeWidth={2} aria-hidden />
+      </button>
+    </div>
+  );
+}
+
 function AudioMeter({ level }: { level: number }) {
   const clamped = Math.max(0, Math.min(1, level));
 
   return (
     <div
-      className="ml-auto flex h-4 w-16 shrink-0 items-end gap-0.5"
+      className="flex h-4 w-16 shrink-0 items-end gap-0.5"
       aria-hidden
     >
       {[0.16, 0.32, 0.48, 0.64, 0.8, 0.96].map((threshold, index) => (

--- a/clients/web/src/components/dictation-overlay-page.tsx
+++ b/clients/web/src/components/dictation-overlay-page.tsx
@@ -1,4 +1,4 @@
-import { Check, Loader2, Square, TriangleAlert } from "lucide-react";
+import { Check, Loader2, StopCircle, TriangleAlert } from "lucide-react";
 import {
   useEffect,
   useRef,
@@ -159,7 +159,7 @@ function RecordingActions({
         onBlur={() => onInteractiveChange(false)}
         onClick={onStop}
       >
-        <Square className="size-2.5 fill-current" strokeWidth={2} aria-hidden />
+        <StopCircle className="size-4" strokeWidth={2} aria-hidden />
       </button>
     </div>
   );

--- a/clients/web/src/components/dictation-overlay-page.tsx
+++ b/clients/web/src/components/dictation-overlay-page.tsx
@@ -1,5 +1,11 @@
 import { Check, Loader2, Square, TriangleAlert } from "lucide-react";
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type RefObject,
+} from "react";
 
 import {
   getDictationOverlayState,
@@ -25,6 +31,8 @@ import type { DictationOverlayState } from "@/runtime/is-electron";
  */
 export function DictationOverlayPage() {
   const [state, setState] = useState<DictationOverlayState | null>(null);
+  const stopButtonRef = useRef<HTMLButtonElement | null>(null);
+  const interactiveRef = useRef(false);
 
   useEffect(() => {
     const unsubscribe = subscribeToDictationOverlayState(setState);
@@ -40,6 +48,18 @@ export function DictationOverlayPage() {
     return unsubscribe;
   }, []);
 
+  useEffect(() => {
+    return () => {
+      setDictationOverlayInteractive(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (state?.kind === "recording" || !interactiveRef.current) return;
+    interactiveRef.current = false;
+    setDictationOverlayInteractive(false);
+  }, [state?.kind]);
+
   if (!state) {
     return null;
   }
@@ -47,16 +67,56 @@ export function DictationOverlayPage() {
   const transcription =
     state.kind === "recording" ? state.transcription.trim() : "";
   const audioLevel = state.kind === "recording" ? (state.audioLevel ?? 0) : 0;
+  const setInteractive = (interactive: boolean) => {
+    if (interactiveRef.current === interactive) return;
+    interactiveRef.current = interactive;
+    setDictationOverlayInteractive(interactive);
+  };
+  const updateInteractionFromPointer = (
+    event: MouseEvent<HTMLDivElement>,
+  ) => {
+    if (state.kind !== "recording") {
+      setInteractive(false);
+      return;
+    }
+    const button = stopButtonRef.current;
+    if (!button) {
+      setInteractive(false);
+      return;
+    }
+    const rect = button.getBoundingClientRect();
+    setInteractive(
+      event.clientX >= rect.left &&
+        event.clientX <= rect.right &&
+        event.clientY >= rect.top &&
+        event.clientY <= rect.bottom,
+    );
+  };
+  const stopRecording = () => {
+    requestDictationOverlayStop();
+    setInteractive(false);
+  };
 
   return (
-    <div className="flex h-screen w-screen items-start justify-center bg-transparent p-4">
+    <div
+      className="flex h-screen w-screen items-start justify-center bg-transparent p-4"
+      onMouseMove={updateInteractionFromPointer}
+      onMouseLeave={() => setInteractive(false)}
+    >
       <div className="flex w-[min(28rem,calc(100vw-2rem))] flex-col gap-1 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] px-4 py-2.5 shadow-lg">
         <div className="flex min-w-0 items-center gap-2">
           <StateIcon state={state} />
           <span className="truncate text-[11px] font-medium text-[var(--content-secondary)]">
             {stateLabel(state)}
           </span>
-          {state.kind === "recording" && <RecordingActions level={audioLevel} />}
+          {state.kind === "recording" && (
+            <RecordingActions
+              level={audioLevel}
+              stopButtonRef={stopButtonRef}
+              onInteractiveChange={setInteractive}
+              onStop={stopRecording}
+            />
+          )}
         </div>
         {transcription && (
           // Bottom-anchored two-line text: the transcript grows as words
@@ -73,37 +133,31 @@ export function DictationOverlayPage() {
   );
 }
 
-function RecordingActions({ level }: { level: number }) {
-  useEffect(() => {
-    return () => {
-      setDictationOverlayInteractive(false);
-    };
-  }, []);
-
-  const enableInteraction = () => {
-    setDictationOverlayInteractive(true);
-  };
-  const disableInteraction = () => {
-    setDictationOverlayInteractive(false);
-  };
-  const stopRecording = () => {
-    requestDictationOverlayStop();
-    setDictationOverlayInteractive(false);
-  };
-
+function RecordingActions({
+  level,
+  stopButtonRef,
+  onInteractiveChange,
+  onStop,
+}: {
+  level: number;
+  stopButtonRef: RefObject<HTMLButtonElement | null>;
+  onInteractiveChange: (interactive: boolean) => void;
+  onStop: () => void;
+}) {
   return (
     <div className="ml-auto flex shrink-0 items-center gap-2">
       <AudioMeter level={level} />
       <button
+        ref={stopButtonRef}
         type="button"
         className="flex size-5 items-center justify-center rounded-full text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-overlay)] hover:text-[var(--system-negative-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--system-negative-strong)]"
         aria-label="Stop recording"
         title="Stop recording"
-        onMouseEnter={enableInteraction}
-        onMouseLeave={disableInteraction}
-        onFocus={enableInteraction}
-        onBlur={disableInteraction}
-        onClick={stopRecording}
+        onMouseEnter={() => onInteractiveChange(true)}
+        onMouseLeave={() => onInteractiveChange(false)}
+        onFocus={() => onInteractiveChange(true)}
+        onBlur={() => onInteractiveChange(false)}
+        onClick={onStop}
       >
         <Square className="size-2.5 fill-current" strokeWidth={2} aria-hidden />
       </button>

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { forwardRef } from "react";
+import { forwardRef, useImperativeHandle } from "react";
 
 type TextInsertionStatus =
   | "inserted"
@@ -22,20 +22,37 @@ let latestVoiceInputProps: VoiceInputButtonProps | null = null;
 let nextTextInsertionStatus: TextInsertionStatus = "unavailable";
 const insertedTexts: string[] = [];
 let nextDictationResult: { mode: "dictation"; text: string } | null = null;
+let overlayStopCallback: (() => void) | null = null;
+const voiceStopMock = mock(() => undefined);
 type ToastErrorOptions = { id?: string };
 const toastErrorMock = mock(
   (_message: string, _options?: ToastErrorOptions) => undefined,
 );
 
 mock.module("@/domains/chat/components/voice-input-button", () => ({
-  VoiceInputButton: forwardRef<unknown, VoiceInputButtonProps>((props, _ref) => {
+  VoiceInputButton: forwardRef<unknown, VoiceInputButtonProps>((props, ref) => {
     latestVoiceInputProps = props;
+    useImperativeHandle(ref, () => ({
+      start: () => undefined,
+      stop: voiceStopMock,
+    }));
     return null;
   }),
 }));
 
 mock.module("@/domains/chat/hooks/use-dictation-overlay-sync", () => ({
   useDictationOverlaySync: () => undefined,
+}));
+
+mock.module("@/runtime/dictation-overlay", () => ({
+  subscribeToDictationOverlayStop: (callback: () => void) => {
+    overlayStopCallback = callback;
+    return () => {
+      if (overlayStopCallback === callback) {
+        overlayStopCallback = null;
+      }
+    };
+  },
 }));
 
 mock.module(
@@ -76,6 +93,9 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 const { GlobalPushToTalkBridge } = await import("./global-push-to-talk-bridge");
 const { formatVoiceError } = await import("@/domains/chat/utils/chat");
 const { useComposerStore } = await import("@/domains/chat/composer-store");
+const { useVoiceRecordingStore } = await import(
+  "@/domains/chat/voice/voice-recording-store"
+);
 const { useConversationStore } = await import("@/stores/conversation-store");
 const { useViewerStore } = await import("@/stores/viewer-store");
 
@@ -90,10 +110,13 @@ const renderBridge = (assistantId: string | null = "assistant-1") => {
 afterEach(() => {
   cleanup();
   latestVoiceInputProps = null;
+  overlayStopCallback = null;
+  voiceStopMock.mockClear();
   nextTextInsertionStatus = "unavailable";
   nextDictationResult = null;
   insertedTexts.length = 0;
   toastErrorMock.mockClear();
+  useVoiceRecordingStore.getState().reset();
   useComposerStore.getState().setInput("");
   useComposerStore.getState().fullReset();
   useConversationStore.getState().reset();
@@ -150,5 +173,28 @@ describe("GlobalPushToTalkBridge", () => {
         { id: "voice-error:stt-not-configured" },
       ],
     ]);
+  });
+
+  test("stops the active voice input when the overlay requests stop during recording", () => {
+    renderBridge();
+
+    act(() => {
+      useVoiceRecordingStore.getState().startRecording();
+    });
+    act(() => {
+      overlayStopCallback?.();
+    });
+
+    expect(voiceStopMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores overlay stop requests outside a recording session", () => {
+    renderBridge();
+
+    act(() => {
+      overlayStopCallback?.();
+    });
+
+    expect(voiceStopMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -15,6 +15,7 @@ import { useNativePushToTalkRegistration } from "@/domains/chat/voice/use-native
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { usePushToTalk } from "@/domains/chat/voice/use-push-to-talk";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
+import { subscribeToDictationOverlayStop } from "@/runtime/dictation-overlay";
 import { insertTextIntoFrontApp } from "@/runtime/text-insertion";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -77,6 +78,13 @@ export function GlobalPushToTalkBridge({
       (assistantId ? fallbackVoiceInputRef.current : null),
     [assistantId],
   );
+
+  useEffect(() => {
+    return subscribeToDictationOverlayStop(() => {
+      if (useVoiceRecordingStore.getState().phase !== "recording") return;
+      resolveTarget()?.stop();
+    });
+  }, [resolveTarget]);
 
   usePushToTalk(resolveTarget, { enabled: shouldEnablePushToTalk() });
 

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -136,9 +136,9 @@ export const routeTree = [
     { path: "/assistant/floating/command-palette", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/command-palette/command-palette-window-page").then((m) => m.CommandPaletteWindowPage) } },
 
     // Dictation overlay — live transcription pill rendered inside the
-    // Electron dictation overlay BrowserWindow (a click-through floating
-    // panel pinned top-center of the screen while push-to-talk dictation
-    // is active). Same pattern as Quick Input: sibling of `/assistant`,
+    // Electron dictation overlay BrowserWindow (a floating panel pinned
+    // top-center of the screen while push-to-talk dictation is active).
+    // Same pattern as Quick Input: sibling of `/assistant`,
     // outside auth middleware and RootLayout for fast load.
     { path: "/assistant/floating/dictation-overlay", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/dictation-overlay-page").then((m) => m.DictationOverlayPage) } },
     // Legacy direct path retained so old dev windows do not blank during

--- a/clients/web/src/runtime/dictation-overlay.ts
+++ b/clients/web/src/runtime/dictation-overlay.ts
@@ -1,7 +1,7 @@
 /**
  * Runtime wrapper for the dictation overlay bridge surface.
  *
- * The Electron main process owns a system-wide, click-through panel pinned
+ * The Electron main process owns a system-wide panel pinned
  * top-center of the active display that shows the user's words live while
  * they dictate via push-to-talk into another app (the Electron port of the
  * native Swift client's `DictationOverlayWindow`).
@@ -53,4 +53,23 @@ export async function getDictationOverlayState(): Promise<DictationOverlayState 
     return null;
   }
   return window.vellum.dictationOverlay.getState();
+}
+
+export function requestDictationOverlayStop(): void {
+  if (!isElectron()) return;
+  window.vellum?.dictationOverlay?.requestStop?.();
+}
+
+export function subscribeToDictationOverlayStop(
+  callback: () => void,
+): () => void {
+  if (!isElectron() || !window.vellum?.dictationOverlay?.onStopRequested) {
+    return () => undefined;
+  }
+  return window.vellum.dictationOverlay.onStopRequested(callback);
+}
+
+export function setDictationOverlayInteractive(interactive: boolean): void {
+  if (!isElectron()) return;
+  window.vellum?.dictationOverlay?.setInteractive?.(interactive);
 }

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -263,6 +263,9 @@ declare global {
           callback: (state: DictationOverlayState) => void,
         ): () => void;
         getState(): Promise<DictationOverlayState | null>;
+        requestStop(): void;
+        onStopRequested(callback: () => void): () => void;
+        setInteractive(interactive: boolean): void;
       };
       notifications?: {
         show(

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -229,6 +229,9 @@ export interface VellumBridge {
     setState(state: DictationOverlayMessage): void;
     onState(callback: (state: DictationOverlayState) => void): () => void;
     getState(): Promise<DictationOverlayState | null>;
+    requestStop(): void;
+    onStopRequested(callback: () => void): () => void;
+    setInteractive(interactive: boolean): void;
   };
   popout: {
     open(conversationId: string): Promise<void>;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -121,6 +121,12 @@ export const COMMAND_PALETTE_SELECT = "vellum:commandPalette:select";
 export const DICTATION_OVERLAY_SET_STATE = "vellum:dictationOverlay:setState";
 export const DICTATION_OVERLAY_STATE_EVENT = "vellum:dictationOverlay:state";
 export const DICTATION_OVERLAY_GET_STATE = "vellum:dictationOverlay:getState";
+export const DICTATION_OVERLAY_REQUEST_STOP =
+  "vellum:dictationOverlay:requestStop";
+export const DICTATION_OVERLAY_STOP_REQUESTED =
+  "vellum:dictationOverlay:stopRequested";
+export const DICTATION_OVERLAY_SET_INTERACTIVE =
+  "vellum:dictationOverlay:setInteractive";
 
 // Popout
 export const POPOUT_OPEN = "vellum:popout:open";


### PR DESCRIPTION
## Summary
- Add a far-right Stop control to the macOS dictation overlay while recording.
- Route overlay stop clicks through the Electron bridge to the active voice input target.
- Keep the transparent overlay click-through outside the Stop control by toggling mouse interactivity on hover/focus.

## Original prompt
The macOS Electron dictation overlay should include a Stop button on the far right of the voice bar. The button should be functional, stopping the current dictation session from the overlay itself while preserving the overlay behavior established for the top-of-screen voice bar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->