### PR TITLE
fix(chat): expandable single-step phases; consolidate stepKey + connector

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -43,6 +43,10 @@ function thinking(text: string, duration = "1s"): ToolCallCardStep {
   return { kind: "thinking", durationLabel: duration, text };
 }
 
+function toolError(message: string): ToolCallCardStep {
+  return { kind: "tool_error", message };
+}
+
 describe("SubagentPhaseTimeline — empty input", () => {
   test("renders nothing when there are no steps (panel owns the empty state)", () => {
     const { container } = render(<SubagentPhaseTimeline steps={[]} />);
@@ -127,6 +131,50 @@ describe("SubagentPhaseTimeline — step-count pill", () => {
     const steps: ToolCallCardStep[] = [bash("a", "completed", "1s", "tc-a")];
     const { queryByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
     expect(queryByTestId("subagent-phase-step-count")).toBeNull();
+  });
+});
+
+describe("SubagentPhaseTimeline — single-step expandability", () => {
+  // Regression (Gap 1): a single `tool_error` phase carries its message only in
+  // the step pill. The row must be expandable (chevron shown) even though there
+  // is no "N steps" pill, so the error text stays reachable.
+  test("a single tool_error phase is expandable and reveals its error on click", () => {
+    const steps: ToolCallCardStep[] = [toolError("context window exceeded")];
+    const { getByTestId, queryByTestId, queryAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    const header = getByTestId("subagent-phase-header");
+    // No "N steps" pill for a lone step, but the row is still interactive.
+    expect(queryByTestId("subagent-phase-step-count")).toBeNull();
+    expect(header.hasAttribute("disabled")).toBe(false);
+
+    // Collapsed by default — the error message is hidden.
+    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+
+    // Clicking reveals the lone error pill carrying the message.
+    fireEvent.click(header);
+    const pills = queryAllByTestId("phase-step-pill");
+    expect(pills.length).toBe(1);
+    expect(pills[0]!.textContent).toContain("context window exceeded");
+  });
+
+  // Regression (Gap 1): a lone successful tool step with no `info` renders a
+  // null `DefaultStepPill` (nothing to reveal), so the row stays non-expandable
+  // — no chevron, no toggle, disabled header.
+  test("a single info-less successful tool step is NOT expandable", () => {
+    const steps: ToolCallCardStep[] = [bash("", "completed", "1s", "tc-a")];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    const header = getByTestId("subagent-phase-header");
+    expect(header.hasAttribute("disabled")).toBe(true);
+    expect(queryByTestId("subagent-phase-step-count")).toBeNull();
+
+    // Clicking a disabled header does nothing — no pill ever appears.
+    fireEvent.click(header);
+    expect(queryByTestId("phase-step-pill")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -20,7 +20,9 @@ import {
   DefaultStepPill,
   groupStepsByPhase,
   phaseHeaderStatus,
+  stepKey,
   sumDurationLabels,
+  TimelineConnector,
   TimelineNode,
   type PhaseSection,
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
@@ -28,15 +30,29 @@ import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils
 import { cn } from "@/utils/misc";
 
 /**
- * Stable per-step key — a tool step's non-empty `toolCallId`, else the
- * positional `${kind}-${index}` fallback. Historical/older subagent events can
- * carry an empty `toolCallId` (see `use-subagent-card-data.ts`), so guarding on
- * a non-empty string keeps keys unique instead of collapsing onto `""`.
- * Shared by the section key and the expanded body's pill list.
+ * Whether a step renders a non-null body in `DefaultStepPill` — i.e. whether it
+ * carries detail worth revealing. Mirrors `DefaultStepPill`'s per-kind logic:
+ * `tool_error` / `web_search_error` always render a message; `thinking` renders
+ * only when its text is non-empty; a `tool` step renders only when it has
+ * non-empty `info` OR a failing (`error`/`denied`) status; `web_search` renders
+ * its title. A single-step phase is expandable only when its lone step has
+ * detail — otherwise expanding it would reveal nothing.
  */
-function stepKey(step: ToolCallCardStep, index: number): string {
-  if (step.kind === "tool" && step.toolCallId) return step.toolCallId;
-  return `${step.kind}-${index}`;
+function stepHasDetail(step: ToolCallCardStep): boolean {
+  switch (step.kind) {
+    case "tool_error":
+    case "web_search_error":
+    case "web_search":
+      return true;
+    case "thinking":
+      return step.text.length > 0;
+    case "tool":
+      return (
+        step.info.length > 0 ||
+        step.status === "error" ||
+        step.status === "denied"
+      );
+  }
 }
 
 /**
@@ -121,9 +137,14 @@ function SubagentPhaseRow({
   const isThinking = section.steps[0]?.kind === "thinking";
   const stepCount = section.steps.length;
 
-  // A row is interactive only when it has step pills worth revealing. Rows with
-  // a single step carry no separate body, so they render no chevron / toggle.
-  const isExpandable = stepCount >= 2;
+  // The "N steps" pill only makes sense for a multi-step phase.
+  const showStepCount = stepCount >= 2;
+  // A row is interactive (chevron + toggle) when it has a body worth revealing:
+  // any multi-step phase, OR a single-step phase whose lone step carries detail
+  // (an error message, tool input, response text, …). A lone info-less success
+  // step renders a null `DefaultStepPill`, so it stays non-expandable.
+  const isExpandable =
+    stepCount >= 2 || (stepCount === 1 && stepHasDetail(section.steps[0]!));
 
   const totalDuration =
     status === "running"
@@ -146,14 +167,8 @@ function SubagentPhaseRow({
       data-phase-label={section.label}
       className="relative flex flex-col gap-2"
     >
-      {/* Connector line mirroring the main-chat timeline: starts below this
-          node and runs to the section bottom, omitted on the last row. */}
-      {!isLast && (
-        <div
-          aria-hidden
-          className="absolute bottom-0 left-[6.5px] top-6 w-px bg-[var(--border-element)]"
-        />
-      )}
+      {/* No connector trails below the final row. */}
+      {!isLast && <TimelineConnector />}
 
       <button
         type="button"
@@ -210,17 +225,19 @@ function SubagentPhaseRow({
               aria-hidden="true"
               className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]"
             />
-            <span
-              data-testid="subagent-phase-step-count"
-              className="rounded-[100px] bg-[var(--surface-base)] px-1.5 py-1"
-            >
-              <Typography
-                variant="body-small-default"
-                className="text-[var(--content-secondary)]"
+            {showStepCount && (
+              <span
+                data-testid="subagent-phase-step-count"
+                className="rounded-[100px] bg-[var(--surface-base)] px-1.5 py-1"
               >
-                {stepCountLabel}
-              </Typography>
-            </span>
+                <Typography
+                  variant="body-small-default"
+                  className="text-[var(--content-secondary)]"
+                >
+                  {stepCountLabel}
+                </Typography>
+              </span>
+            )}
           </span>
         )}
       </button>

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -37,7 +37,10 @@ import { Tooltip, Typography } from "@vellumai/design-library";
 
 import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
-import { formatMs, type ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
+import {
+  formatMs,
+  type ToolCallCardStep,
+} from "@/domains/chat/utils/tool-call-card-utils";
 import { cn } from "@/utils/misc";
 
 /** Concrete lucide icon for each `IconName` produced by `deriveStepLabel`. */
@@ -391,18 +394,7 @@ function TimelinePhaseSection({
       data-phase-label={section.label}
       className="relative flex flex-col gap-2"
     >
-      {/* Connector line at the node's center x. It starts BELOW this node
-          (`top-6`) and runs to the section bottom (`bottom-0`), which lands a
-          small, consistent gap before the next node — the timeline reads as
-          evenly-spaced segments rather than one line touching every circle.
-          The last section renders none (nothing trails below the final
-          circle). */}
-      {!isLast && (
-        <div
-          aria-hidden
-          className="absolute bottom-0 left-[6.5px] top-6 w-px bg-[var(--border-element)]"
-        />
-      )}
+      {!isLast && <TimelineConnector />}
       {/* Header row: circular node + label share ONE items-center row so the
           icon is vertically centered with the title regardless of line-height;
           the duration is pushed to the right edge. */}
@@ -440,6 +432,25 @@ function TimelinePhaseSection({
         {renderSectionSteps(section, baseIndex)}
       </div>
     </div>
+  );
+}
+
+/**
+ * The vertical connector line joining one timeline node down to the next. Sits
+ * at the node's center x (`left-[6.5px]`: the 14px icon at the section's left →
+ * center ≈ 7px). It starts BELOW this node (`top-6`) and runs to the section
+ * bottom (`bottom-0`), landing a small, consistent gap before the next node —
+ * the timeline reads as evenly-spaced segments rather than one line touching
+ * every circle. Render only for non-last sections (nothing trails below the
+ * final circle). Shared by the main-chat timeline and the subagent timeline so
+ * the geometry stays in one place.
+ */
+export function TimelineConnector() {
+  return (
+    <div
+      aria-hidden
+      className="absolute bottom-0 left-[6.5px] top-6 w-px bg-[var(--border-element)]"
+    />
   );
 }
 
@@ -506,9 +517,15 @@ function TimelineNodeIcon({
   return <ThreeDotIndicator data-testid={testId} className="shrink-0" />;
 }
 
-/** Stable key for a step descriptor — mirrors the dispatcher card helper. */
-function stepKey(step: ToolCallCardStep, idx: number): string {
-  if (step.kind === "tool") return step.toolCallId;
+/**
+ * Stable per-step key — a tool step's non-empty `toolCallId`, else the
+ * positional `${kind}-${idx}` fallback. Historical/older subagent events can
+ * carry an empty `toolCallId` (see `use-subagent-card-data.ts`), so guarding on
+ * a non-empty string keeps keys unique instead of collapsing every empty-id
+ * tool step onto the same `""` key. Shared with the subagent phase timeline.
+ */
+export function stepKey(step: ToolCallCardStep, idx: number): string {
+  if (step.kind === "tool" && step.toolCallId) return step.toolCallId;
   return `${step.kind}-${idx}`;
 }
 


### PR DESCRIPTION
## Summary
Fixes self-review gaps for plan subagent-detail-panel-figma.md:
- Single-step phases are now expandable when the lone step carries detail (error/tool input/response), so content is no longer unreachable
- Consolidate stepKey into phase-grouped-step-list.tsx (empty-toolCallId guard now benefits the main-chat timeline too); remove the duplicated local copy
- Extract a shared TimelineConnector to de-duplicate the connector geometry