### PR TITLE
fix(chat): reset objective expand state when switching subagents

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -279,4 +279,46 @@ describe("SubagentDetailPanel — objective", () => {
       restore();
     }
   });
+
+  test("switching to a different subagent resets the expanded objective state", () => {
+    // The desktop parent reuses this component instance across subagent
+    // switches (no React `key`). Expand the first subagent's long objective,
+    // then re-render the SAME instance with a different subagent whose
+    // objective is short. The expand state must reset and re-measure: the new
+    // objective renders collapsed with no toggle.
+    const longObjective = "x ".repeat(400).trim();
+    const restore = installOverflow(longObjective);
+    try {
+      const { rerender } = render(
+        <SubagentDetailPanel
+          entry={makeEntry({ subagentId: "sub-1", objective: longObjective })}
+          onClose={noop}
+        />,
+      );
+
+      // Expand the first subagent's objective.
+      fireEvent.click(screen.getByText("Show more"));
+      expect(screen.getByText("Show less")).toBeDefined();
+      expect(screen.getByText(longObjective).className).not.toContain(
+        "line-clamp-3",
+      );
+
+      // Switch to a different subagent with a short objective. Same instance,
+      // different `entry.subagentId`.
+      rerender(
+        <SubagentDetailPanel
+          entry={makeEntry({ subagentId: "sub-2", objective: "Short" })}
+          onClose={noop}
+        />,
+      );
+
+      // State reset + re-measured: collapsed, no stale "Show less"/toggle.
+      const shortBody = screen.getByText("Short");
+      expect(shortBody.className).toContain("line-clamp-3");
+      expect(screen.queryByText("Show less")).toBeNull();
+      expect(screen.queryByText("Show more")).toBeNull();
+    } finally {
+      restore();
+    }
+  });
 });

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -72,6 +72,21 @@ export function SubagentDetailPanel({
   const [objectiveOverflows, setObjectiveOverflows] = useState(false);
   const objectiveBodyRef = useRef<HTMLParagraphElement>(null);
 
+  // Reset objective collapse state when the subagent changes. The desktop
+  // parent reuses this instance across subagent switches (no `key`), so without
+  // this an objective expanded for one subagent leaks onto the next — and since
+  // the measurement effect below early-returns while `objectiveExpanded` is
+  // true, the new (possibly short) objective would render stale-expanded with a
+  // spurious "Show less" and never re-measure. Resetting during render (React's
+  // "store previous prop" pattern) clears both flags before paint (no flash);
+  // clearing `objectiveOverflows` lets the effect re-measure from a clean state.
+  const [prevSubagentId, setPrevSubagentId] = useState(entry.subagentId);
+  if (prevSubagentId !== entry.subagentId) {
+    setPrevSubagentId(entry.subagentId);
+    setObjectiveExpanded(false);
+    setObjectiveOverflows(false);
+  }
+
   // Measure overflow against the collapsed clamp. While collapsed the clamp is
   // the source of truth, so `scrollHeight` exceeds `clientHeight` only when the
   // body is taller than the visible 3 lines. Skip measuring while expanded


### PR DESCRIPTION
## Summary
Fixes a self-review gap for plan subagent-detail-panel-figma.md: the Objective Show more/less state now resets and re-measures when entry.subagentId changes, so a newly-selected subagent no longer inherits a stale-expanded objective + spurious 'Show less'.