### PR TITLE
docs(memory-v3-migration): harden the eval gate + fix the schema-leaf audit trap

### DIFF
--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -164,7 +164,7 @@ Resolve cross-references. Walk every staged article's `links:` and inline `[[wik
 This is what makes loss-proof real. Two passes (see `references/loss-proofing.md`):
 
 1. **Mechanical quote-screen** — extract quoted strings, dates, and numbers from each snapshot source; confirm each appears in the staged article that claims it (frontmatter stripped). A stdlib helper does this; flag misses.
-2. **Semantic reader panel** — fan out one reader per cluster (anonymous **schema** leaves — cheap, impartial, no persona) that reads source-vs-staged in full and lists substance present in the source but absent/weakened in the draft, tagged `[load-bearing]` / `[secondary]` / `[incidental]`. Adapt the loss-audit template in `references/workflows.md` (§2).
+2. **Semantic reader panel** — pre-assemble each cluster's source-vs-staged text into a bundle, then fan out one **non-schema** reader leaf per bundle that lists substance present in the source but absent/weakened in the draft, tagged `[load-bearing]` / `[secondary]` / `[incidental]`. A schema leaf has **no `file_read`** and would hallucinate findings against files it never read — use the bundle-reading template in `references/workflows.md` (§2).
 
 **Patch every `[load-bearing]` drop back verbatim** into the right section. Also confirm the drop-check: every snapshot path appears as a source in some staged article's provenance (or in `unrouted`). Then **review and approve** each cluster (`status: draft → final`) — you are reading content that is already verified whole.
 
@@ -176,13 +176,24 @@ cd "$VELLUM_WORKSPACE_DIR" && git add -A && git commit -m "memory-v3-migration: 
 
 ### Step 8 — Eval gate (prove it before cutover)
 
-Prove the staged wiki retrieves at least as well as today's corpus before cutting over. The `assistant memory v3 eval` command does the mechanical half — it mines recent real turns, retrieves the top pages from BOTH the snapshot and the staged wiki per turn (needle + dense, in memory, nothing live touched), and writes blinded A/B packets:
+Prove the staged wiki retrieves at least as well as today's corpus before cutting over. `assistant memory v3 eval` does the mechanical half — it mines recent real turns, retrieves the top pages from BOTH the snapshot and the staged wiki per turn (needle + dense, in memory, nothing live touched), and writes blinded A/B packets. Mine the turns **once**, excluding this migration's own conversation, then **pin that turn set on every re-judge** so iteration is reproducible (an unpinned re-run re-mines a different turn set, which reads as judge noise):
 
 ```
-assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval
+# first run — mines fresh turns; --exclude-conversation is the conversation you are in
+assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval --exclude-conversation <this-conversation-id>
+# every later run — pin the same turns so only the staged corpus varies
+assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval --turns-file .mv3/eval/key.json
 ```
 
-That writes `.mv3/eval/packets.json` (blinded A/B memory sets per turn) and `.mv3/eval/key.json` (the unblinding map). Then launch the **blind-judge workflow** (adapt `references/workflows.md` §3, pass `packets.json` as `args.packets`) to score each turn on coverage, map the verdicts back through `key.json`, and tally. The gate: the wiki must **win or tie**. If it loses, the losing turns name the clusters that under-retrieve (thin lead, over-merged article, missing link) — repair, re-run `eval`, re-judge. Do **not** cut over on a losing or unrun eval. See `references/eval-gate.md` for the methodology. (Embedding both corpora can take a while on a large corpus; `--no-dense` gives a fast lexical-only pass for iteration.)
+That writes `packets.json` (blinded A/B sets per turn), `key.json` (the per-turn unblinding map), and `eval-meta.json` (seed/k/dense, turn ids, and the **embedding identity** — confirm it's stable across runs; dense embedding drift makes runs incomparable). Then launch the **blind-judge workflow as a panel** (adapt `references/workflows.md` §3, pass `packets.json` as `args.packets`), write its verdicts to `.mv3/eval/verdicts.json`, and **decide with the deterministic tally** — never a hand count (A/B is shuffled per turn, so a global A-vs-B tally is wrong):
+
+```
+assistant memory v3 eval-tally --verdicts .mv3/eval/verdicts.json --key .mv3/eval/key.json
+```
+
+The gate is `eval-tally`'s `gate` field: **`pass`** if the wiki wins or ties (a within-noise difference is a tie, not a loss), **`fail`** only on a statistically significant loss. On `fail`, the losing turns name the clusters that under-retrieve (thin lead, over-merged article, missing link) — repair, re-run `eval` with the same `--turns-file`, re-judge, re-tally. Heed the `confident` flag — re-judge with a bigger panel if it's low. Do **not** cut over on a `fail`, a low-confidence, or an unrun gate. See `references/eval-gate.md`.
+
+**Judge model:** judging is the most quality-sensitive step — pin a strong, **known-working** leaf profile for it, and confirm the judge run's verdict count matches packets × panel size. (A profile can pass config validation yet no-op as a workflow leaf; the engine now fails such a leaf loudly rather than returning empty, but verify the count.)
 
 ### Step 9 — Cutover (deploy + go live)
 
@@ -219,7 +230,7 @@ Close the inference session if you opened one (`assistant inference session clos
 - **Loss-proof is verified, not intended.** The mechanical drop-check + load-bearing patch (Step 7) is mandatory. Patch drops **verbatim**.
 - **Editorial judgment is the assistant's.** Taxonomy (Step 3) and final review (Step 7) are the assistant's calls; fan-out leaves draft, they never mark an article final.
 - **Cluster-grain authoring.** One agent per topic cluster, not per page — keeps the run under the engine's 500-agent cap and keeps topical judgment coherent.
-- **No eval, no cutover.** The wiki ships only after the blind judge says it retrieves ≥ the v2 corpus.
+- **No eval, no cutover.** The wiki ships only after `assistant memory v3 eval-tally` returns `gate: pass` (wiki wins or ties) on a pinned, reproducible turn set — never on a hand tally. A `fail`, a low-confidence verdict, or an unrun gate blocks cutover.
 - **Freeze consolidation, then go live by config.** Before the snapshot (Step 1) disable both consolidation triggers (`consolidation_max_buffer_lines: null`, `consolidation_interval_hours` huge) and wait out any in-flight run via `memory/.v2-state/consolidation.lock` — consolidation is the only live-corpus writer. At cutover (Step 9) set `memory.v3.live true` _then_ restore the triggers; the order keeps the next consolidation in v3 shape.
 - **Lowercase, dash-separated flat slugs.** `the-cutover.md`, not `Arcs/The-Cutover.md`. v3 slugs are flat; hubs organize via `main:`/`links:`, not folders.
 - **Three sentinel commits**, all prefixed `memory-v3-migration:` — start / staged+audited / complete.
@@ -228,5 +239,5 @@ Close the inference session if you opened one (`assistant inference session clos
 
 - `references/v3-wiki-principles.md` — the v3 article skeleton and the principles every article obeys. Read first.
 - `references/loss-proofing.md` — the snapshot/staging/provenance/verify contract.
-- `references/eval-gate.md` — the blind-judge methodology and the ship gate.
-- `references/workflows.md` — the three fan-out templates the assistant adapts and launches via `run_workflow`: §1 author-clusters (write staged articles + provenance), §2 loss-audit (schema-leaf reader panel), §3 blind-judge (A/B content judge over mined turns).
+- `references/eval-gate.md` — the reproducible-eval + `eval-tally` ship gate methodology.
+- `references/workflows.md` — the three fan-out templates the assistant adapts and launches via `run_workflow`: §1 author-clusters (write staged articles + provenance), §2 loss-audit (bundle-reading reader panel, no schema), §3 blind-judge (A/B content judge panel over mined turns, tallied by `eval-tally`).

--- a/skills/vellum-memory-v3-migration/references/eval-gate.md
+++ b/skills/vellum-memory-v3-migration/references/eval-gate.md
@@ -20,17 +20,33 @@ It writes `.mv3/eval/packets.json` (per turn: `{turn, context, userMessage, repl
 - **Retrieves both sides identically** — a BM25F section needle unioned with dense cosine over freshly-embedded section vectors (the same section grain the live engine uses), top-`k` pages per corpus, rendered as the model sees them (card + matched section). Everything is in memory; the live lanes and Qdrant are untouched.
 - **No time-gating is needed.** The staged wiki is a pure reorganization of the snapshot — both corpora hold the _same knowledge_, so a page encoding post-turn information is reachable in both and can't bias either side. The eval cleanly measures retrieval **shape**, which is exactly the question.
 
-Use `--no-dense` for a fast lexical-only pass while iterating; the full run embeds every section of both corpora and can take a while on a large corpus. Re-run after fixing staged articles.
+Use `--no-dense` for a fast lexical-only pass while iterating; the full run embeds every section of both corpora and can take a while on a large corpus.
 
-## The gate
+## Iterate reproducibly — this is what makes the gate converge
 
-Run the blind-judge workflow over the packets, map A/B back to v2/wiki via the key, and tally. **Ship only if the wiki wins or ties** across the set. If it loses:
+The non-convergence to avoid is **comparing different things across runs and reading it as judge noise.** Three controls prevent it:
 
-- The losing turns name the clusters that under-retrieve. Read those packets — usually a thin lead (the card doesn't carry), an over-merged article (the matched section is buried), or a missing cross-link.
-- Fix the staged articles, re-embed the changed ones, re-judge. Iterate until the gate is green.
+- **Pin the turn set.** The first run mines fresh recent turns and writes `eval-meta.json` (seed, k, dense, the resolved turn ids, and the embedding identity). On every later run pass `--turns-file .mv3/eval/key.json` so the re-judge measures the _same_ turns while only the staged corpus changes. Without pinning, each run re-mines by recency — a different turn set.
+- **Exclude the migration's own conversation** with `--exclude-conversation <id>` (the conversation you're running in), or the eval judges turns from the very chat driving the migration.
+- **Hold the retrieval mode and embedding fixed.** Don't compare a `--no-dense` run against a dense one (different lanes), and check `eval-meta.json`'s `embedding` is identical across runs — dense retrieval re-embeds both corpora with the live-configured provider, so a mid-migration model/dimension change makes runs incomparable.
+
+## The gate — decide with `eval-tally`, never by hand
+
+Run the blind-judge workflow (`workflows.md` §3) as a **panel** (default 3 judges/turn), write its verdicts to `.mv3/eval/verdicts.json`, and decide with:
+
+```
+assistant memory v3 eval-tally --verdicts .mv3/eval/verdicts.json --key .mv3/eval/key.json
+```
+
+`eval-tally` maps each verdict through `key.json` (A/B is shuffled **per turn** — a global A-vs-B count is wrong and flipped the result in the field), aggregates the panel by majority, and applies a two-sided sign test. Its `gate` field is the ship decision:
+
+- **`pass`** — the wiki **wins or ties**. A within-noise difference (most turns decided by a single point of a 0–10 score) is a tie, not a loss. A tie means the reform didn't regress retrieval; proceeding is then a judgment call about whether the v3 _shape_ is worth it, not a retrieval win.
+- **`fail`** — the snapshot beats the wiki by a **statistically significant** margin. Don't cut over. The losing turns name the clusters that under-retrieve — usually a thin lead (the card doesn't carry), an over-merged article (the matched section is buried), or a missing cross-link. Fix the staged articles, re-run `eval` **with the same `--turns-file`**, re-judge, and re-tally until `gate: pass`.
+
+Heed the `confident` flag and `notes`: a single-vote panel or too few decided turns means re-judge with a larger panel before trusting the verdict. **Never hand-tally A-vs-B** — that is exactly what produced the divergent, non-converging numbers this gate is designed to prevent.
 
 ## Honesty caveats
 
-- **The judge has variance.** Run a small panel per turn, or repeat the set with different `--seed` values; don't ship on a one-vote margin.
+- **The judge has variance** — which is why §3 runs a panel and `eval-tally` applies a sign test rather than trusting a raw win count. Don't ship on a one-vote margin or an unpinned re-run; the `confident` flag flags both.
 - **This eval tests on-disk corpus shape, not the whole live engine.** It exercises the needle + dense lanes over the two corpora; it does not replicate every live lane (learned-edges, carry-forward accumulation, capability rows). It answers the reform's actual risk — _"does the reshaped corpus retrieve its own content at least as well?"_ — not _"is the live system byte-identical post-cutover."_
 - **No eval, no cutover** is a hard rule (SKILL.md). An unrun gate is a failed gate.

--- a/skills/vellum-memory-v3-migration/references/workflows.md
+++ b/skills/vellum-memory-v3-migration/references/workflows.md
@@ -8,7 +8,7 @@ The heavy stages — authoring, loss-audit, blind-judge — fan out through the 
 - `meta` must be a **pure literal with only `name` + `description`** — no variables, calls, template strings, or nested objects/arrays. The extractor captures up to the **first `}`**, so any nested brace (e.g. a `phases:` array) truncates the literal and the run fails to launch before any leaf runs. Show progress with `phase(...)` calls in the body, not in `meta`.
 - The body must **`return`** its result (it runs as a function body; a bare trailing expression is discarded).
 - No `Date.now()` / `Math.random()` / argless `new Date()` — they throw in the sandbox. Pass timestamps/seeds via `args`.
-- Leaves get `file_read` / `file_list` / `recall` as baseline. `file_write` is granted only if you declare it in `capabilities.tools`, and resolves relative to the workspace dir.
+- Leaves get `file_read` / `file_list` / `recall` as baseline. `file_write` is granted only if you declare it in `capabilities.tools`, and resolves relative to the workspace dir. **A `schema` leaf gets NONE of these** — it runs as a single forced-tool-choice call with no tools, so it cannot read or recall. Give a schema leaf its inputs INLINE (it returns structured output); to read first, use a non-schema tool leaf that emits a JSON block you parse (see §2). Mixing `schema` with a "read these files" prompt silently confabulates.
 - A failed leaf inside `map`/`parallel` comes back as `null` (the batch survives); an `agent()` call throws and fails the whole run. Use `map` + `.filter(Boolean)` so one bad cluster doesn't sink the run.
 - Caps: 500 leaves/run, 6 concurrent, 3 runs concurrent (config, no flag). Cluster-grain keeps you well under. Shard across runs only if clusters exceed a few hundred; resume replays completed leaves after an interruption.
 
@@ -17,6 +17,8 @@ The heavy stages — authoring, loss-audit, blind-judge — fan out through the 
 ## 1. Author clusters (write staged articles)
 
 Launch with `capabilities: { tools: ["file_write"] }`. One leaf per cluster — each reads its cluster's source pages and writes that cluster's whole article set into `.mv3/staging/`. (If the assistant has an established writing style worth preserving, add `persona: true` to the leaf opts and the run capabilities — but most migrations don't need it, and it is the more expensive path.)
+
+> ⚠️ If you pin a leaf `profile`, verify it actually produces output: some profiles pass config validation yet no-op as a workflow leaf. The engine now **fails** such a leaf loudly (it lands in the run's failures), but always sanity-check `clustersAuthored` against the cluster count and spot-check `.mv3/staging/` on disk — a run that authored nothing is the first thing to rule out.
 
 ```ts
 export const meta = {
@@ -65,46 +67,19 @@ return {
 
 ---
 
-## 2. Loss audit (schema leaves, read-only)
+## 2. Loss audit (read a bundle, NO schema)
 
-Read-only — no `file_write`. A cheap, impartial reader panel; launch with no side-effecting capabilities. One leaf per cluster reads source-vs-staged and reports drops; you patch `[load-bearing]` drops verbatim afterward.
+Read-only — no `file_write`. One leaf per cluster lists substance present in the v2 sources but missing/weakened in the staged wiki; you patch `[load-bearing]` drops verbatim afterward.
+
+> ⚠️ **Do not give an audit leaf a `schema`.** A schema leaf runs with **no tools** — no `file_read` — so a leaf told to "read the sources and compare" reads _nothing_ and **confabulates** drops that merely fit the schema. In the field this produced hundreds of phantom findings citing files that don't exist. Use a plain (non-schema) tool leaf that reads a pre-assembled **bundle** and returns a JSON block you parse yourself, so it can only report what is literally in front of it.
+
+Pre-assemble the bundles **host-side before launching**: for each cluster write `.mv3/audit/bundle-<cluster>.txt` containing every source page (under an `OLD SOURCE` heading, clearly delimited) followed by every staged article (under a `NEW STAGED` heading). Then launch with no side-effecting capabilities:
 
 ```ts
 export const meta = {
   name: "memory-v3-loss-audit",
   description:
-    "Per-cluster reader panel: list substance present in the v2 sources but missing/weakened in the staged wiki.",
-};
-
-const DROP_SCHEMA = {
-  type: "object",
-  properties: {
-    cluster: { type: "string" },
-    drops: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          fact: {
-            type: "string",
-            description:
-              "the specific quote/date/number/detail that is missing or weakened",
-          },
-          severity: {
-            type: "string",
-            enum: ["load-bearing", "secondary", "incidental"],
-          },
-          sourcePath: { type: "string" },
-          shouldLiveOn: {
-            type: "string",
-            description: "staged slug + section where it belongs",
-          },
-        },
-        required: ["fact", "severity", "sourcePath", "shouldLiveOn"],
-      },
-    },
-  },
-  required: ["cluster", "drops"],
+    "Per-cluster reader: list substance in the v2 sources missing/weakened in the staged wiki.",
 };
 
 phase("audit");
@@ -112,33 +87,40 @@ phase("audit");
 const audited = map(args.clusters, (cluster) =>
   leaf(
     [
-      `Audit cluster "${cluster.id}" for information loss. Read each SOURCE page and each STAGED article`,
-      "in full. List every substantive fact, quote, date, number, or detail that is present in a source",
-      "but absent or materially weakened in the staged articles. Be strict; err toward listing.",
+      `Audit cluster "${cluster.id}" for information loss. Read the bundle file`,
+      `${args.auditDir}/bundle-${cluster.id}.txt with file_read. It has an OLD`,
+      "SOURCE half and a NEW STAGED half. List every substantive fact, quote,",
+      "date, number, or detail present in the OLD half but absent or materially",
+      "weakened in the NEW half. Report ONLY facts literally present in the OLD",
+      "half — never infer or invent. Be strict; err toward listing.",
       "",
-      "Sources:",
-      ...cluster.sourcePaths.map((p) => `  - ${p}`),
-      "Staged:",
-      ...cluster.stagedPaths.map((p) => `  - ${p}`),
+      "Return ONLY a fenced json block (no prose) shaped:",
+      '  { "cluster": "<id>", "drops": [',
+      '    { "fact": "<quote/date/number/detail>",',
+      '      "severity": "load-bearing" | "secondary" | "incidental",',
+      '      "sourcePath": "<snapshot path>",',
+      '      "shouldLiveOn": "<staged slug + section>" } ] }',
     ].join("\n"),
-    { label: `audit:${cluster.id}`, schema: DROP_SCHEMA },
+    { label: `audit:${cluster.id}` }, // NO schema — keeps file_read
   ),
 );
 
-const reports = audited.filter(Boolean);
-return {
-  loadBearingDrops: reports.flatMap((r) =>
-    r.drops.filter((d) => d.severity === "load-bearing"),
-  ),
-  allReports: reports,
-};
+// Each leaf returns text containing a fenced json block; parse it host-side
+// (strip the fences, JSON.parse). A leaf that returned no parseable block is a
+// failure to re-run, not an empty audit.
+return { reports: audited.filter(Boolean) };
 ```
 
 ---
 
-## 3. Blind judge (schema leaves, the ship gate)
+## 3. Blind judge (inline packets, the ship gate)
 
-Decides whether the wiki retrieves ≥ the v2 corpus. The two memory sets per turn are built **outside** the workflow (the retrieval/eval step — see `eval-gate.md`), then passed in as blinded packets. Each leaf judges one turn without knowing which side is which.
+Decides whether the wiki retrieves ≥ the v2 corpus. The two memory sets per turn are built **outside** the workflow (`assistant memory v3 eval` — see `eval-gate.md`) and passed in as blinded packets. Each leaf judges one turn without knowing which side is which.
+
+Two rules make this gate trustworthy:
+
+- **Each leaf gets its one packet INLINE** (`p.context`, `p.reply`, `p.setA`, `p.setB`). Because nothing is read from disk, a `schema` is safe here. **Never** "improve" this by having a leaf `file_read` a packet file _with a schema set_ — a schema leaf has no `file_read` and will confabulate verdicts (the §2 trap).
+- **Run a panel** of `args.panel` judges per packet (default 3). A single vote per turn is noisy; the gate's confidence comes from the panel. Do **not** tally in the workflow — write the verdicts to `verdicts.json` and run `assistant memory v3 eval-tally`, which maps A/B → snapshot/staging via `key.json` (A/B is shuffled **per turn**, so a global A-vs-B count is wrong) and applies a noise-aware sign test.
 
 ```ts
 export const meta = {
@@ -154,39 +136,44 @@ const VERDICT_SCHEMA = {
     winner: { type: "string", enum: ["A", "B", "tie"] },
     scoreA: { type: "number" },
     scoreB: { type: "number" },
-    why: { type: "string" },
   },
-  required: ["turn", "winner", "scoreA", "scoreB", "why"],
+  required: ["turn", "winner", "scoreA", "scoreB"],
 };
 
 phase("judge");
 
-// args.packets: [{ turn, context, userMessage, reply, setA, setB }]
-// A/B are pre-shuffled per turn outside the workflow; the unblinding key is kept separately.
-const verdicts = map(args.packets, (p) =>
-  leaf(
-    [
-      "You are a blind judge. Score each memory set 0-10 on ONE question: does this content cover what",
-      "the reply actually needed? Credit the specific facts, named concepts, verbatim quotes, dates, and",
-      "details the reply used or echoed. Coverage dominates; never prefer a smaller set that",
-      "is missing needed content over a larger one that has it. Tie-break on noise. Ignore formatting and",
-      "page-vs-section shape. You do not know which system produced which set.",
-      "",
-      `### turn ${p.turn}`,
-      `Recent context:\n${p.context}`,
-      `User:\n${p.userMessage}`,
-      `Reply (ground truth for what memory was needed):\n${p.reply}`,
-      `\n--- Memory set A ---\n${p.setA}`,
-      `\n--- Memory set B ---\n${p.setB}`,
-    ].join("\n"),
-    { label: `judge:${p.turn}`, schema: VERDICT_SCHEMA },
-  ),
+const PANEL = args.panel ?? 3;
+const prompt = (p) =>
+  [
+    "You are a blind judge. Score each memory set 0-10 on ONE question: does this",
+    "content cover what the reply actually needed? Credit the specific facts, named",
+    "concepts, verbatim quotes, dates, and details the reply used or echoed. Coverage",
+    "dominates; never prefer a smaller set missing needed content over a larger one",
+    "that has it. Tie-break on noise. Ignore formatting and page-vs-section shape.",
+    "You do not know which system produced which set.",
+    "",
+    `### turn ${p.turn}`,
+    `Recent context:\n${p.context}`,
+    `User:\n${p.userMessage}`,
+    `Reply (ground truth for what memory was needed):\n${p.reply}`,
+    `\n--- Memory set A ---\n${p.setA}`,
+    `\n--- Memory set B ---\n${p.setB}`,
+  ].join("\n");
+
+// Flatten packets × panel into one flat fan-out (PANEL verdicts per turn).
+// args.packets: [{ turn, context, userMessage, reply, setA, setB }] — A/B
+// pre-shuffled per turn; the unblinding key (key.json) is kept separately.
+const jobs = args.packets.flatMap((p) =>
+  Array.from({ length: PANEL }, (_unused, i) => ({ p, i })),
+);
+const verdicts = map(jobs, (job) =>
+  leaf(prompt(job.p), {
+    label: `judge:${job.p.turn}:${job.i}`,
+    schema: VERDICT_SCHEMA,
+  }),
 );
 
-const v = verdicts.filter(Boolean);
-return {
-  judged: v.length,
-  // Caller maps A/B back to v2/wiki via the unblinding key, then tallies wins.
-  verdicts: v,
-};
+// Write `verdicts` to .mv3/eval/verdicts.json, then decide with:
+//   assistant memory v3 eval-tally --verdicts .mv3/eval/verdicts.json --key .mv3/eval/key.json
+return { verdicts: verdicts.filter(Boolean) };
 ```


### PR DESCRIPTION
## Summary

Brings the `vellum-memory-v3-migration` skill in line with the eval-tooling fixes (#35647, #35652) and removes the two footgun patterns it shipped that the field report tripped over.

## Changes

- **Step 8 / `eval-gate.md` — reproducible gate.** Mine turns **once**, then pin with `--turns-file` on every re-judge; `--exclude-conversation` for the migration's own chat; hold retrieval mode + embedding identity fixed across runs (check `eval-meta.json`). Decide with **`assistant memory v3 eval-tally`** (deterministic per-turn unblind + sign test) — never a hand A-vs-B count. The gate is `pass` on win-or-tie, `fail` only on a significant loss.
- **`workflows.md` §2 (loss audit) — fix the confabulation trap.** It shipped a `schema` leaf told to "read each source page", but a schema leaf has **no `file_read`**, so it invented findings (the field's hundreds of phantom drops). Rewritten to read a pre-assembled **bundle** with a **non-schema** leaf that returns JSON-in-text.
- **`workflows.md` §3 (blind judge).** Keep packets **inline** (schema is safe only because nothing is read), run a **panel**, and hand verdicts to `eval-tally`; explicit warning never to convert it to `schema` + `file_read`.
- **`workflows.md` engine contract + §1.** State that a schema leaf gets no tools, and that a pinned leaf `profile` must be verified to actually produce output (some profiles pass validation yet no-op as a leaf — now fails loud after #35637).

Docs-only; code-fence balance verified, prettier clean. No behavior change beyond the guidance the assistant reads when running the migration.

Part of #35635

🤖 Generated with [Claude Code](https://claude.com/claude-code)