### PR TITLE
fix(chat): re-measure objective overflow on subagent switch

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -321,4 +321,43 @@ describe("SubagentDetailPanel — objective", () => {
       restore();
     }
   });
+
+  test("re-measures overflow when switching to a different subagent with identical objective text", () => {
+    // The render-phase reset forces `objectiveOverflows` to `false` on every
+    // subagent switch. If the measurement effect only depended on the
+    // objective text + expanded flag, switching from subagent A to a DIFFERENT
+    // subagent B with byte-identical (still overflowing) objective text would
+    // change neither dep, the effect would skip, and the toggle would vanish.
+    // Depending on `entry.subagentId` forces a re-measure so "Show more"
+    // survives the switch.
+    const longObjective = "x ".repeat(400).trim();
+    const restore = installOverflow(longObjective);
+    try {
+      const { rerender } = render(
+        <SubagentDetailPanel
+          entry={makeEntry({ subagentId: "sub-1", objective: longObjective })}
+          onClose={noop}
+        />,
+      );
+
+      // Subagent A: overflowing objective offers the toggle.
+      expect(screen.getByText("Show more")).toBeDefined();
+
+      // Switch to a DIFFERENT subagent with an IDENTICAL objective string.
+      rerender(
+        <SubagentDetailPanel
+          entry={makeEntry({ subagentId: "sub-2", objective: longObjective })}
+          onClose={noop}
+        />,
+      );
+
+      // Re-measured despite identical text: the toggle is still present.
+      expect(screen.getByText("Show more")).toBeDefined();
+      expect(screen.getByText(longObjective).className).toContain(
+        "line-clamp-3",
+      );
+    } finally {
+      restore();
+    }
+  });
 });

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -92,6 +92,13 @@ export function SubagentDetailPanel({
   // body is taller than the visible 3 lines. Skip measuring while expanded
   // (the clamp is removed, which would otherwise report no overflow) so the
   // "Show less" affordance stays visible.
+  //
+  // Depend on `entry.subagentId` too: the render-phase reset above forces
+  // `objectiveOverflows` to `false` on a subagent switch, so the effect must
+  // re-run to recompute it. Without the id in the deps a switch between two
+  // subagents whose objective text is byte-identical changes neither
+  // `entry.objective` nor `objectiveExpanded`, the effect skips, and the
+  // toggle would stay incorrectly hidden for an overflowing objective.
   useLayoutEffect(() => {
     if (objectiveExpanded) {
       return;
@@ -101,7 +108,7 @@ export function SubagentDetailPanel({
       return;
     }
     setObjectiveOverflows(node.scrollHeight > node.clientHeight);
-  }, [entry.objective, objectiveExpanded]);
+  }, [entry.subagentId, entry.objective, objectiveExpanded]);
 
   useEffect(() => {
     if (onRequestDetail && entry.conversationId && entry.events.length === 0) {


### PR DESCRIPTION
## Summary
- Add entry.subagentId to the objective overflow-measurement effect deps so the Show more/less toggle is correctly recomputed even when two subagents share identical objective text