### PR TITLE
fix(chat): single-source step-render predicate (no empty expansions)

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -135,9 +135,9 @@ describe("SubagentPhaseTimeline — step-count pill", () => {
 });
 
 describe("SubagentPhaseTimeline — single-step expandability", () => {
-  // Regression (Gap 1): a single `tool_error` phase carries its message only in
-  // the step pill. The row must be expandable (chevron shown) even though there
-  // is no "N steps" pill, so the error text stays reachable.
+  // A single `tool_error` phase carries its message only in the step pill, so
+  // the row is expandable (chevron shown) even without an "N steps" pill and
+  // the error text stays reachable.
   test("a single tool_error phase is expandable and reveals its error on click", () => {
     const steps: ToolCallCardStep[] = [toolError("context window exceeded")];
     const { getByTestId, queryByTestId, queryAllByTestId } = render(
@@ -159,9 +159,9 @@ describe("SubagentPhaseTimeline — single-step expandability", () => {
     expect(pills[0]!.textContent).toContain("context window exceeded");
   });
 
-  // Regression (Gap 1): a lone successful tool step with no `info` renders a
-  // null `DefaultStepPill` (nothing to reveal), so the row stays non-expandable
-  // — no chevron, no toggle, disabled header.
+  // A lone successful tool step with no `info` renders a null `DefaultStepPill`
+  // (nothing to reveal), so the row stays non-expandable — no chevron, no
+  // toggle, disabled header.
   test("a single info-less successful tool step is NOT expandable", () => {
     const steps: ToolCallCardStep[] = [bash("", "completed", "1s", "tc-a")];
     const { getByTestId, queryByTestId } = render(
@@ -173,6 +173,24 @@ describe("SubagentPhaseTimeline — single-step expandability", () => {
     expect(queryByTestId("subagent-phase-step-count")).toBeNull();
 
     // Clicking a disabled header does nothing — no pill ever appears.
+    fireEvent.click(header);
+    expect(queryByTestId("phase-step-pill")).toBeNull();
+  });
+
+  // A lone failing tool step with no `info` also renders a null
+  // `DefaultStepPill` — `DefaultStepPill` ignores status when `info` is empty —
+  // so the row stays non-expandable rather than expanding to an empty body.
+  test("a single info-less error tool step is NOT expandable", () => {
+    const steps: ToolCallCardStep[] = [bash("", "error", "1s", "tc-a")];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    const header = getByTestId("subagent-phase-header");
+    expect(header.hasAttribute("disabled")).toBe(true);
+    expect(queryByTestId("subagent-phase-step-count")).toBeNull();
+
+    // Clicking the disabled header reveals nothing — no empty body.
     fireEvent.click(header);
     expect(queryByTestId("phase-step-pill")).toBeNull();
   });

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -21,6 +21,7 @@ import {
   groupStepsByPhase,
   phaseHeaderStatus,
   stepKey,
+  stepRendersPill,
   sumDurationLabels,
   TimelineConnector,
   TimelineNode,
@@ -28,32 +29,6 @@ import {
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 import { cn } from "@/utils/misc";
-
-/**
- * Whether a step renders a non-null body in `DefaultStepPill` — i.e. whether it
- * carries detail worth revealing. Mirrors `DefaultStepPill`'s per-kind logic:
- * `tool_error` / `web_search_error` always render a message; `thinking` renders
- * only when its text is non-empty; a `tool` step renders only when it has
- * non-empty `info` OR a failing (`error`/`denied`) status; `web_search` renders
- * its title. A single-step phase is expandable only when its lone step has
- * detail — otherwise expanding it would reveal nothing.
- */
-function stepHasDetail(step: ToolCallCardStep): boolean {
-  switch (step.kind) {
-    case "tool_error":
-    case "web_search_error":
-    case "web_search":
-      return true;
-    case "thinking":
-      return step.text.length > 0;
-    case "tool":
-      return (
-        step.info.length > 0 ||
-        step.status === "error" ||
-        step.status === "denied"
-      );
-  }
-}
 
 /**
  * Stable key for a phase section — its positional index plus its label and the
@@ -139,12 +114,11 @@ function SubagentPhaseRow({
 
   // The "N steps" pill only makes sense for a multi-step phase.
   const showStepCount = stepCount >= 2;
-  // A row is interactive (chevron + toggle) when it has a body worth revealing:
-  // any multi-step phase, OR a single-step phase whose lone step carries detail
-  // (an error message, tool input, response text, …). A lone info-less success
-  // step renders a null `DefaultStepPill`, so it stays non-expandable.
-  const isExpandable =
-    stepCount >= 2 || (stepCount === 1 && stepHasDetail(section.steps[0]!));
+  // A row is interactive (chevron + toggle) when at least one step actually
+  // renders a pill — `stepRendersPill` is `DefaultStepPill`'s own predicate, so
+  // the chevron can never expand to an empty body. A lone info-less tool step
+  // (whether successful or failed) renders no pill, so it stays non-expandable.
+  const isExpandable = section.steps.some(stepRendersPill);
 
   const totalDuration =
     status === "running"

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -590,6 +590,31 @@ function PhaseHeaderRow({
 }
 
 /**
+ * Whether {@link DefaultStepPill} renders a non-null body for a step — the
+ * single source of truth for "does this step produce a pill". Consumers that
+ * gate UI on whether a step is worth revealing (e.g. row expandability in the
+ * subagent timeline) call this so they can never drift from the rendering:
+ *
+ *  - `thinking` → always renders a pill.
+ *  - `tool` → renders only when `info` is non-empty (status is ignored: a
+ *    failing tool step with no `info` still has nothing to show).
+ *  - `tool_error` / `web_search_error` → always render a message.
+ *  - `web_search` → always renders its title.
+ */
+export function stepRendersPill(step: ToolCallCardStep): boolean {
+  switch (step.kind) {
+    case "thinking":
+      return true;
+    case "tool":
+      return step.info.length > 0;
+    case "tool_error":
+    case "web_search_error":
+    case "web_search":
+      return true;
+  }
+}
+
+/**
  * Default per-step pill rendering — a single bordered pill containing the
  * step's icon (when available) and its primary text. Matches Figma
  * `5010-103135` — 100px radius, 10px/6px padding, `--surface-base` border.
@@ -614,7 +639,7 @@ export function DefaultStepPill({ step }: { step: ToolCallCardStep }) {
     // pill entirely rather than duplicating the phase header's title — e.g.
     // a skill call with no skill name shouldn't render a literal "Using a
     // skill" pill underneath a "Using a skill" phase header.
-    if (!step.info) return null;
+    if (!stepRendersPill(step)) return null;
     return (
       <StepPill>
         <Glyph


### PR DESCRIPTION
## Summary
- Export stepRendersPill from phase-grouped-step-list.tsx and use it in both DefaultStepPill and SubagentPhaseTimeline's expandability check, so a chevron can never expand to an empty body (error/denied tool steps with empty info are no longer falsely expandable)
- Rephrase two test comments to present-tense per AGENTS.md