### PR TITLE
fix(memory): add eval-tally to expected v3 subcommands test

### DIFF
--- a/assistant/src/cli/commands/memory/__tests__/memory-v3.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-v3.test.ts
@@ -145,7 +145,12 @@ describe("subcommand registration", () => {
     const v3 = memory!.commands.find((c) => c.name() === "v3");
     expect(v3).toBeDefined();
     const subcommandNames = v3!.commands.map((c) => c.name()).sort();
-    expect(subcommandNames).toEqual(["backfill-sections", "eval", "rebuild-index"]);
+    expect(subcommandNames).toEqual([
+      "backfill-sections",
+      "eval",
+      "eval-tally",
+      "rebuild-index",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- The `memory v3 eval-tally` subcommand was registered in #35652 but the subcommand-registration assertion in `memory-v3.test.ts` still expected only three subcommands, breaking the Test job on main.
- Add `eval-tally` to the expected list so it matches the four subcommands the source actually registers (`rebuild-index`, `backfill-sections`, `eval`, `eval-tally`).

## Original prompt

Fix the specific failing CI job (Test, run 27973026324) on main. The `memory-v3.test.ts` subcommand-registration test asserted a hardcoded list of v3 subcommands that drifted behind the source after `eval-tally` was added, producing a one-element mismatch. Scope is limited to making that single failing assertion pass without touching unrelated code.