### PR TITLE
chore(chat): drop unused export on PhaseHeaderStatus type

### DIFF
--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -189,7 +189,7 @@ export function sumDurationLabels(labels: string[]): string {
  * an in-flight retry inside a phase that has already produced a failure
  * still reads as in-progress.
  */
-export type PhaseHeaderStatus = "completed" | "failed" | "running";
+type PhaseHeaderStatus = "completed" | "failed" | "running";
 
 /**
  * Classify a phase's overall status for header icon rendering.


### PR DESCRIPTION
## Summary
- Narrow PhaseHeaderStatus back to a module-private type (nothing imports it externally; callers of the exported phaseHeaderStatus function get the union via inference)

Part of plan: subagent-detail-panel-figma.md (self-review cleanup)