### PR TITLE
refactor(calls): use real enforceAdmissionPolicy in relay tests; colocate TRUST_CLASS_RANK

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -26,10 +26,6 @@ import {
   test,
 } from "bun:test";
 
-import { ADMISSION_FLOOR } from "@vellumai/gateway-client";
-
-import { TRUST_CLASS_RANK } from "../runtime/actor-trust-resolver.js";
-
 // ── Platform + logger mocks (must come before any source imports) ────
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -164,42 +160,6 @@ mock.module("../calls/channel-admission-reader.js", () => ({
     }
     if (mockAdmissionGate) await mockAdmissionGate;
     return mockAdmissionPolicy;
-  },
-}));
-
-// Real floor semantics, mirroring relay-setup-router.test.ts. The
-// enforceAdmissionPolicy mock omits the exempt-channel short-circuit so the
-// deny path can be exercised end-to-end regardless of channel.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const realAdmissionPolicyModule = require("../runtime/routes/inbound-stages/admission-policy.js");
-mock.module("../runtime/routes/inbound-stages/admission-policy.js", () => ({
-  ...realAdmissionPolicyModule,
-  enforceAdmissionPolicy: (input: {
-    trustClass: string;
-    memberStatus: string | undefined;
-    policy: import("@vellumai/gateway-client").AdmissionPolicy;
-  }) => {
-    if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
-      return {
-        admitted: false,
-        reason:
-          input.memberStatus === "blocked"
-            ? "member_blocked"
-            : "member_revoked",
-        shouldChallenge: false,
-        effectivePolicy: input.policy,
-      };
-    }
-    const rank =
-      (TRUST_CLASS_RANK as Record<string, number>)[input.trustClass] ?? 0;
-    const floor = ADMISSION_FLOOR[input.policy];
-    if (rank >= floor) return { admitted: true };
-    return {
-      admitted: false,
-      reason: `admission_policy_${input.policy}`,
-      shouldChallenge: false,
-      effectivePolicy: input.policy,
-    };
   },
 }));
 

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -1,31 +1,33 @@
 /**
  * Tests for the inbound admission-floor enforcement in `routeSetup`.
  *
- * `routeSetup` is pure routing logic but reads several module-level singletons
- * (config, trust resolver, pending verification session, invite store). These
- * are mocked so the table below can drive trust class, member status, pending
- * challenge, and active invites independently of any DB.
+ * `routeSetup` reads several module-level singletons (config, trust resolver,
+ * pending verification session, invite store, contact store). Those I/O
+ * collaborators are mocked so the tables below can drive trust class, member
+ * status, pending challenge, active invites, and the bound invite contact
+ * directly — no database is touched.
  *
- * The floor verdict is exercised through the REAL `enforceAdmissionPolicy`
- * floor tables (`TRUST_CLASS_RANK` × `ADMISSION_FLOOR`), with the exempt-channel
- * short-circuit bypassed in the mock so the tests assert the true floor
- * semantics independent of any channel's exempt status (`phone` is now
- * enforced).
+ * The admission floor is exercised through the REAL, pure `enforceAdmissionPolicy`:
+ * `phone` is an enforced (non-exempt) channel, so the real function applies the
+ * true `rank >= floor` semantics. We deliberately do not reimplement the floor
+ * here — a test-local copy of production logic would silently drift from it.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
-  ADMISSION_FLOOR,
-  type AdmissionPolicy,
-} from "@vellumai/gateway-client";
+import type { AdmissionPolicy } from "@vellumai/gateway-client";
 
-import type { ChannelPolicy, ChannelStatus } from "../../contacts/types.js";
+import type {
+  ChannelPolicy,
+  ChannelStatus,
+  ContactChannel,
+  ContactRole,
+  ContactWithChannels,
+} from "../../contacts/types.js";
 import type {
   ActorTrustContext,
   TrustClass,
 } from "../../runtime/actor-trust-resolver.js";
-import { TRUST_CLASS_RANK } from "../../runtime/actor-trust-resolver.js";
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
@@ -40,8 +42,6 @@ mock.module("../../config/loader.js", () => ({
 let nextTrust: ActorTrustContext;
 mock.module("../../runtime/actor-trust-resolver.js", () => ({
   resolveActorTrust: () => nextTrust,
-  // Re-export the real rank table; the floor mock below consumes it.
-  TRUST_CLASS_RANK,
 }));
 
 // Controllable pending verification challenge.
@@ -67,66 +67,80 @@ mock.module("../../contacts/contact-store.js", () => ({
   getContact: () => boundContact,
 }));
 
-// Real floor semantics, exemption bypassed (see file header).
-mock.module("../../runtime/routes/inbound-stages/admission-policy.js", () => ({
-  enforceAdmissionPolicy: (input: {
-    trustClass: TrustClass;
-    memberStatus: ChannelStatus | undefined;
-    policy: AdmissionPolicy;
-  }) => {
-    if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
-      return {
-        admitted: false,
-        reason:
-          input.memberStatus === "blocked"
-            ? "member_blocked"
-            : "member_revoked",
-        shouldChallenge: false,
-        effectivePolicy: input.policy,
-      };
-    }
-    const rank = TRUST_CLASS_RANK[input.trustClass];
-    const floor = ADMISSION_FLOOR[input.policy];
-    if (rank >= floor) return { admitted: true };
-    return {
-      admitted: false,
-      reason: `admission_policy_${input.policy}`,
-      shouldChallenge: false,
-      effectivePolicy: input.policy,
-    };
-  },
-}));
-
 const { routeSetup } = await import("../relay-setup-router.js");
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
+function makeChannel(overrides: Partial<ContactChannel> = {}): ContactChannel {
+  return {
+    id: "ch_1",
+    contactId: "ct_1",
+    type: "phone",
+    address: "+12025550142",
+    isPrimary: true,
+    externalChatId: null,
+    status: "active",
+    policy: "allow",
+    verifiedAt: null,
+    verifiedVia: null,
+    inviteId: null,
+    revokedReason: null,
+    blockedReason: null,
+    lastSeenAt: null,
+    interactionCount: 0,
+    lastInteraction: null,
+    updatedAt: null,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+function makeContact(
+  overrides: Partial<ContactWithChannels> = {},
+): ContactWithChannels {
+  return {
+    id: "ct_1",
+    displayName: "Test Caller",
+    notes: null,
+    lastInteraction: null,
+    interactionCount: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    role: "contact",
+    contactType: "human",
+    principalId: null,
+    userFile: null,
+    channels: [],
+    ...overrides,
+  };
+}
+
 function makeTrust(
   trustClass: TrustClass,
-  channel?: { status: ChannelStatus; policy?: ChannelPolicy; role?: string },
+  channel?: {
+    status: ChannelStatus;
+    policy?: ChannelPolicy;
+    role?: ContactRole;
+  },
 ): ActorTrustContext {
   const memberRecord = channel
     ? {
-        contact: {
-          displayName: "Test Caller",
-          role: channel.role ?? "trusted_contact",
-        } as never,
-        channel: {
-          id: "ch_1",
+        contact: makeContact({ role: channel.role ?? "contact" }),
+        channel: makeChannel({
           status: channel.status,
           policy: channel.policy ?? "allow",
-        } as never,
+        }),
       }
     : null;
   return {
-    canonicalSenderId: "+15551234567",
+    canonicalSenderId: "+12025550142",
     guardianBindingMatch: null,
     memberRecord,
     trustClass,
     actorMetadata: {
-      identifier: "+15551234567",
+      identifier: "+12025550142",
       displayName: undefined,
       senderDisplayName: undefined,
       memberDisplayName: undefined,
@@ -134,15 +148,15 @@ function makeTrust(
       channel: "phone",
       trustStatus: trustClass,
     },
-  } as ActorTrustContext;
+  };
 }
 
 function route(admissionPolicy?: AdmissionPolicy | null) {
   return routeSetup({
     callSessionId: "cs_1",
     session: null, // inbound
-    from: "+15551234567",
-    to: "+15559999999",
+    from: "+12025550142",
+    to: "+12025550199",
     admissionPolicy,
   });
 }

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -58,22 +58,6 @@ export type TrustClass =
   | "unknown";
 
 /**
- * Trust-class ordinal used by the per-channel admission policy floor check.
- * Higher rank = more trusted. Blocked/revoked never reach classification —
- * their effective rank is 0 and is enforced by the inbound ACL stage's
- * member-status short-circuit, not via this table.
- *
- * See `wave-b-plan.md` §2.4. Paired with `ADMISSION_FLOOR` from
- * `@vellumai/gateway-client` — both tables move together.
- */
-export const TRUST_CLASS_RANK: Record<TrustClass, number> = {
-  guardian: 4,
-  trusted_contact: 3,
-  unverified_contact: 2,
-  unknown: 1,
-};
-
-/**
  * Fully resolved trust context from the actor trust resolver.
  *
  * This is the intermediate representation between raw inbound identity

--- a/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
+++ b/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
@@ -30,10 +30,7 @@ import {
 
 import type { ChannelId } from "../../../channels/types.js";
 import type { ChannelStatus } from "../../../contacts/types.js";
-import {
-  TRUST_CLASS_RANK,
-  type TrustClass,
-} from "../../actor-trust-resolver.js";
+import type { TrustClass } from "../../actor-trust-resolver.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -76,6 +73,23 @@ export type AdmissionPolicyResult =
 // ---------------------------------------------------------------------------
 
 /**
+ * Trust-class ordinal compared against {@link ADMISSION_FLOOR} to make the
+ * admission decision (`rank >= floor`). Higher rank = more trusted.
+ * Blocked/revoked never reach this comparison — they short-circuit to deny on
+ * member status above — so they carry no rank here.
+ *
+ * The two halves of the floor check: this table is keyed by `TrustClass`,
+ * `ADMISSION_FLOOR` (from `@vellumai/gateway-client`) by `AdmissionPolicy`.
+ * They are only ever read together, here, so they live next to their use.
+ */
+const TRUST_CLASS_RANK: Record<TrustClass, number> = {
+  guardian: 4,
+  trusted_contact: 3,
+  unverified_contact: 2,
+  unknown: 1,
+};
+
+/**
  * Policies under which completing verification could lift the sender past
  * the floor. Used to decide whether to fire the upgrade UX on deny.
  * `unverified_contact` (rank 2) reaches `any_contact` (floor 2) and
@@ -116,7 +130,8 @@ export function enforceAdmissionPolicy(
   if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
     return {
       admitted: false,
-      reason: input.memberStatus === "blocked" ? "member_blocked" : "member_revoked",
+      reason:
+        input.memberStatus === "blocked" ? "member_blocked" : "member_revoked",
       shouldChallenge: false,
       effectivePolicy: input.policy,
     };


### PR DESCRIPTION
## What

`relay-setup-router.test.ts` and `relay-server.test.ts` each hand-reimplemented `enforceAdmissionPolicy` — a test-local copy of production floor logic (`blocked/revoked → deny`, `rank >= floor`) that can silently drift from the real function. This replaces both copies with the **real, pure** `enforceAdmissionPolicy`.

The reimplementation only existed to bypass the exempt-channel short-circuit, but `phone` is an enforced (non-exempt) channel, so the real function already yields identical verdicts for these tests.

## Changes

- **`admission-policy.ts`**: `TRUST_CLASS_RANK` now lives here — its sole production consumer, directly beside the `rank >= floor` comparison and the `ADMISSION_FLOOR` table it is paired with. Now a private const; nothing else imported it. Moving it out of the (frequently-mocked) `actor-trust-resolver` module is what lets the tests reach the real `enforceAdmissionPolicy` without re-exporting the rank table through a mock.
- **`actor-trust-resolver.ts`**: drop the relocated `TRUST_CLASS_RANK` export.
- **`relay-setup-router.test.ts` / `relay-server.test.ts`**: delete the reimplemented `enforceAdmissionPolicy` mocks; exercise the real function.
- **`relay-setup-router.test.ts`**: replace the `as never` trust fixtures with typed `ContactChannel` / `ContactWithChannels` factories — this surfaced and fixes a fabricated `role: "trusted_contact"`, which is not a valid `ContactRole`. Phone fixtures now use the reserved `555-01XX` range.

## Why it's safe

`enforceAdmissionPolicy` is unchanged and the constant move is a pure relocation — every admit/deny verdict is identical, and all tests pass unchanged.

## Tests

`relay-setup-router.test.ts` (35), `relay-server.test.ts` (91), `admission-policy.test.ts` (12), `media-stream-server-integration.test.ts` (36), `twilio-routes.test.ts` (44) pass. `tsc --noEmit`, eslint, and knip are clean.

## Note

`relay-server.test.ts` carries pre-existing prettier non-compliance and non-reserved phone fixtures unrelated to this change. This PR keeps its edit surgical (deletions only) rather than bundling that file-wide cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP)_