### PR TITLE
refactor(lockfile): one Zod schema as the single source of truth

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -398,7 +398,7 @@
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "@vellumai/local-mode/@vellumai/environments": ["@vellumai/environments@file:../packages/environments", {}],
+    "@vellumai/local-mode/@vellumai/environments": ["@vellumai/environments@file:../packages/environments", { "devDependencies": { "@types/bun": "1.3.11", "typescript": "5.9.3" } }],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/cli/src/commands/exec.ts
+++ b/cli/src/commands/exec.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process";
 
-import { resolveAssistant, resolveCloud } from "../lib/assistant-config";
+import { resolveAssistant } from "../lib/assistant-config";
 import { dockerResourceNames } from "../lib/docker";
 import type { ServiceName } from "../lib/docker";
 import { execAppleContainer } from "../lib/exec-apple-container";
@@ -153,7 +153,7 @@ export async function exec(): Promise<void> {
     process.exit(1);
   }
 
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
 
   if (cloud === "local") {
     const child = spawn(command[0], command.slice(1), { stdio: "inherit" });

--- a/cli/src/commands/logs.ts
+++ b/cli/src/commands/logs.ts
@@ -7,7 +7,6 @@ import { join } from "path";
 import {
   extractHostFromUrl,
   resolveAssistant,
-  resolveCloud,
   type AssistantEntry,
 } from "../lib/assistant-config";
 import { dockerResourceNames } from "../lib/docker";
@@ -589,7 +588,7 @@ export async function logs(): Promise<void> {
     process.exit(1);
   }
 
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
 
   switch (cloud) {
     case "local":

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -10,7 +10,6 @@ import {
   getDaemonPidPath,
   loadAllAssistants,
   lookupAssistantByIdentifier,
-  resolveCloud,
   type AssistantEntry,
 } from "../lib/assistant-config";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
@@ -381,7 +380,7 @@ async function getDockerProcesses(entry: AssistantEntry): Promise<TableRow[]> {
 }
 
 async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
 
   console.log(`Processes for ${formatAssistantReference(entry)} (${cloud}):\n`);
 

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -9,7 +9,6 @@ import {
   loadAllAssistants,
   lookupAssistantByIdentifier,
   removeAssistantEntry,
-  resolveCloud,
   type AssistantEntry,
 } from "../lib/assistant-config.js";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
@@ -249,7 +248,7 @@ async function retireInner(): Promise<void> {
   const entry = lookup.entry;
   const assistantId = entry.assistantId;
   const source = parsed.source;
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
 
   if (cloud === "paired") {
     // A remote assistant paired from another machine. Retiring tears the

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -2,7 +2,6 @@ import {
   findAssistantByName,
   getActiveAssistant,
   loadAllAssistants,
-  resolveCloud,
   saveAssistantEntry,
   type AssistantEntry,
 } from "../lib/assistant-config";
@@ -208,7 +207,7 @@ async function rollbackPlatformViaEndpoint(
 export async function rollback(): Promise<void> {
   const { name, version } = parseArgs();
   const entry = resolveTargetAssistant(name);
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
 
   if (cloud === "apple-container") {
     console.error(

--- a/cli/src/commands/ssh.ts
+++ b/cli/src/commands/ssh.ts
@@ -3,7 +3,6 @@ import { spawn } from "child_process";
 import {
   extractHostFromUrl,
   resolveAssistant,
-  resolveCloud,
 } from "../lib/assistant-config";
 import { dockerResourceNames } from "../lib/docker";
 import { getPlatformUrl, readPlatformToken } from "../lib/platform-client";
@@ -47,7 +46,7 @@ export async function ssh(): Promise<void> {
     process.exit(1);
   }
 
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
 
   if (cloud === "local") {
     console.error(

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -3,7 +3,6 @@ import {
   loadAllAssistants,
   getDaemonPidPath,
   removeAssistantEntry,
-  resolveCloud,
   saveAssistantEntry,
   setActiveAssistant,
   type AssistantEntry,
@@ -841,7 +840,7 @@ export async function resolveOrHatchTarget(
     const existing = findAssistantByName(targetName);
     if (existing) {
       // Validate the existing assistant's cloud matches the requested env
-      const existingCloud = resolveCloud(existing);
+      const existingCloud = existing.cloud;
       const normalizedExisting =
         existingCloud === "vellum" ? "platform" : existingCloud;
       if (normalizedExisting !== targetEnv) {
@@ -1190,7 +1189,7 @@ export async function teleport(): Promise<void> {
     process.exit(1);
   }
 
-  const fromCloud = resolveCloud(fromEntry);
+  const fromCloud = fromEntry.cloud;
 
   if (fromCloud === "apple-container") {
     console.error(
@@ -1216,7 +1215,7 @@ export async function teleport(): Promise<void> {
 
     if (existingTarget) {
       // Target exists — validate cloud matches the flag, then run preflight
-      const toCloud = resolveCloud(existingTarget);
+      const toCloud = existingTarget.cloud;
       const normalizedTargetEnv = toCloud === "vellum" ? "platform" : toCloud;
       if (normalizedTargetEnv !== targetEnv) {
         console.error(
@@ -1320,7 +1319,7 @@ export async function teleport(): Promise<void> {
     // exporting — so we don't waste work on an invalid command.
     const existingTarget = targetName ? findAssistantByName(targetName) : null;
     if (existingTarget) {
-      const existingCloud = resolveCloud(existingTarget);
+      const existingCloud = existingTarget.cloud;
       if (existingCloud !== "vellum") {
         console.error(
           `Error: Assistant '${targetName}' is a ${existingCloud} assistant, not platform. ` +
@@ -1376,7 +1375,7 @@ export async function teleport(): Promise<void> {
 
     // Hatch (export succeeded — safe to create the target)
     const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
-    const toCloud = resolveCloud(toEntry);
+    const toCloud = toEntry.cloud;
 
     // Import from GCS
     console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
@@ -1463,7 +1462,7 @@ export async function teleport(): Promise<void> {
 
   // Resolve or hatch target (after source is stopped to avoid port conflicts)
   const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
-  const toCloud = resolveCloud(toEntry);
+  const toCloud = toEntry.cloud;
 
   // Post-hatch same-environment safety net — uses resolved clouds in case
   // the resolved target cloud differs from the CLI flag (e.g., --docker

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -6,7 +6,6 @@ import {
   findAssistantByName,
   getActiveAssistant,
   loadAllAssistants,
-  resolveCloud,
   saveAssistantEntry,
   type AssistantEntry,
 } from "../lib/assistant-config";
@@ -1211,7 +1210,7 @@ export async function upgrade(): Promise<void> {
     effectiveVersion = latestTag;
   }
 
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
 
   try {
     if (cloud === "docker") {

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -11,6 +11,11 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 
 import { SEEDS, type EnvironmentDefinition } from "@vellumai/environments";
+import {
+  resolveCloud,
+  type LocalAssistantResources,
+  type LockfileAssistant,
+} from "@vellumai/local-mode/contract";
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./constants.js";
 import {
@@ -23,11 +28,17 @@ import { getCurrentEnvironment } from "./environments/resolve.js";
 import { probePort } from "./port-probe.js";
 
 /**
- * Per-instance resource paths and ports. Each local assistant instance gets
- * its own directory tree, ports, and socket so multiple instances can run
- * side-by-side without conflicts.
+ * Per-instance resource paths and ports. Each local assistant instance gets its
+ * own directory tree, ports, and socket so multiple instances can run
+ * side-by-side without conflicts. Extends the renderer-safe resources contract
+ * (`instanceDir`, `gatewayPort`, `daemonPort`) with the host-only ports and the
+ * signing key. Host-only and same-process, so it is a plain type — the
+ * renderer-facing shape is the one with a Zod contract.
  */
-export interface LocalInstanceResources {
+export type LocalInstanceResources = Omit<
+  LocalAssistantResources,
+  "instanceDir"
+> & {
   /**
    * Instance-specific data root. New local assistants are placed under
    * `$XDG_DATA_HOME/vellum{-env}/assistants/<name>/`. Legacy entries
@@ -36,10 +47,6 @@ export interface LocalInstanceResources {
    * lives inside it.
    */
   instanceDir: string;
-  /** HTTP port for the daemon runtime server */
-  daemonPort: number;
-  /** HTTP port for the gateway */
-  gatewayPort: number;
   /** HTTP port for the Qdrant vector store */
   qdrantPort: number;
   /** HTTP port for the CES (Claude Extension Server) */
@@ -48,7 +55,7 @@ export interface LocalInstanceResources {
    *  client actor tokens remain valid across `wake` cycles. */
   signingKey?: string;
   [key: string]: unknown;
-}
+};
 
 /** Docker image metadata for the service group. Enables rollback to known-good digests. */
 export interface ContainerInfo {
@@ -65,26 +72,32 @@ export interface ContainerInfo {
   networkName?: string;
 }
 
-export interface AssistantEntry {
-  assistantId: string;
-  /** Platform-provided display name, when available. */
-  name?: string;
+/**
+ * The CLI's full view of an assistant entry: the renderer-safe base
+ * (`LockfileAssistant`, the one canonical Zod contract) plus the host-only and
+ * sensitive fields the CLI reads and writes. Those extra fields never cross a
+ * validation boundary — the same toolchain writes and reads them — so they are
+ * modeled as plain types here rather than re-validated.
+ *
+ * `runtimeUrl` is required (`readAssistants` only returns entries that have one)
+ * and `resources` is the richer host shape. `cloud` is inherited from
+ * `LockfileAssistant` (always present; normalized at the read seam — see
+ * `readAssistants`). The index signature preserves unknown on-disk fields so a
+ * read→write round-trip never drops a newer writer's data.
+ */
+export type AssistantEntry = Omit<
+  LockfileAssistant,
+  "runtimeUrl" | "resources"
+> & {
+  runtimeUrl: string;
+  /** Per-instance resource config. Present for local entries in multi-instance setups. */
+  resources?: LocalInstanceResources;
   /** Older lockfile key for the display name, if present. */
   assistantName?: string;
-  runtimeUrl: string;
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
   localUrl?: string;
   bearerToken?: string;
-  /** Deployment topology / how the assistant is reached. Known values:
-   *  `"local"` (on-machine daemon), `"docker"` (local container),
-   *  `"apple-container"` (macOS-app-managed container), `"vellum"`
-   *  (platform-managed, uses the X-Session-Token auth path), `"gcp"` / `"aws"`
-   *  / `"custom"` (remote, SSH-managed), and `"paired"` (a remote assistant
-   *  paired from another machine — reached via a bearer guardian token at
-   *  `runtimeUrl`; has no local process, container, or `resources`).
-   *  Kept as a free `string` (not a union) for forward-compatibility. */
-  cloud: string;
   /** True when this entry was registered via `vellum connect import` (a remote
    *  pairing). Set alongside `cloud: "paired"`; also backs the re-import /
    *  overwrite guard in connect import. */
@@ -93,12 +106,8 @@ export interface AssistantEntry {
   namespace?: string;
   project?: string;
   region?: string;
-  species?: string;
   sshUser?: string;
   zone?: string;
-  hatchedAt?: string;
-  /** Per-instance resource config. Present for local entries in multi-instance setups. */
-  resources?: LocalInstanceResources;
   /** PID of the file watcher process for docker instances hatched with --watch. */
   watcherPid?: number;
   /** Local bootstrap secret used to lease guardian tokens for Docker assistants after detached hatch. */
@@ -119,7 +128,7 @@ export interface AssistantEntry {
   /** Pre-upgrade workspace migration ID — used by rollback to know how far back to revert. */
   previousWorkspaceMigrationId?: string;
   [key: string]: unknown;
-}
+};
 
 export type AssistantLookupResult =
   | { status: "found"; entry: AssistantEntry }
@@ -300,10 +309,20 @@ function readAssistants(): AssistantEntry[] {
     writeLockfile(data);
   }
 
-  return entries.filter(
-    (e): e is AssistantEntry =>
-      typeof e.assistantId === "string" && typeof e.runtimeUrl === "string",
-  );
+  const result: AssistantEntry[] = [];
+  for (const entry of entries) {
+    if (
+      typeof entry.assistantId !== "string" ||
+      typeof entry.runtimeUrl !== "string"
+    ) {
+      continue;
+    }
+    // Normalize `cloud` once, at the read seam every reader shares, so
+    // downstream code reads `entry.cloud` instead of re-deriving the topology.
+    entry.cloud = resolveCloud(entry);
+    result.push(entry as AssistantEntry);
+  }
+  return result;
 }
 
 function writeAssistants(entries: AssistantEntry[]): void {
@@ -471,6 +490,7 @@ export function loadAllAssistantsAcrossEnvs(
       ) {
         continue;
       }
+      entry.cloud = resolveCloud(entry);
       all.push(entry);
     }
   }
@@ -553,22 +573,6 @@ export function resolveTargetAssistant(nameArg?: string): AssistantEntry {
     }
   }
   process.exit(1);
-}
-
-/**
- * Determine which cloud topology an assistant entry is running on.
- */
-export function resolveCloud(entry: AssistantEntry): string {
-  if (entry.cloud) {
-    return entry.cloud;
-  }
-  if (entry.project) {
-    return "gcp";
-  }
-  if (entry.sshUser) {
-    return "custom";
-  }
-  return "local";
 }
 
 /**

--- a/cli/src/lib/terminal-session.ts
+++ b/cli/src/lib/terminal-session.ts
@@ -6,7 +6,7 @@
  * resolver without cross-importing commands (per cli/CONTRIBUTING.md).
  */
 
-import { resolveAssistant, resolveCloud } from "./assistant-config.js";
+import { resolveAssistant } from "./assistant-config.js";
 import { getPlatformUrl, readPlatformToken } from "./platform-client.js";
 import {
   closeTerminalSession,
@@ -49,7 +49,7 @@ export function resolveManagedAssistant(
     process.exit(1);
   }
 
-  const cloud = resolveCloud(entry);
+  const cloud = entry.cloud;
   if (cloud !== "vellum") {
     if (cloud === "local") {
       console.error(

--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -127,6 +127,7 @@ describe("host-proxy-router", () => {
         assistants: [
           {
             assistantId: "a1",
+            cloud: "local",
             resources: { gatewayPort: 9001, daemonPort: 9002 },
           },
         ],
@@ -148,7 +149,7 @@ describe("host-proxy-router", () => {
       // Appear
       lockfileListener?.({
         assistants: [
-          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
         ],
         activeAssistant: "a1",
       });
@@ -165,7 +166,7 @@ describe("host-proxy-router", () => {
       installHostProxyBridge(fakeCliResolver);
 
       lockfileListener?.({
-        assistants: [{ assistantId: "no-resources" }],
+        assistants: [{ assistantId: "no-resources", cloud: "local" }],
         activeAssistant: null,
       });
       await flush();
@@ -178,7 +179,7 @@ describe("host-proxy-router", () => {
 
       const lockfile: Lockfile = {
         assistants: [
-          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
         ],
         activeAssistant: "a1",
       };
@@ -198,7 +199,7 @@ describe("host-proxy-router", () => {
 
       lockfileListener?.({
         assistants: [
-          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
         ],
         activeAssistant: "a1",
       });
@@ -218,7 +219,7 @@ describe("host-proxy-router", () => {
 
       lockfileListener?.({
         assistants: [
-          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
         ],
         activeAssistant: "a1",
       });
@@ -355,7 +356,7 @@ describe("host-proxy-router", () => {
 
       lockfileListener?.({
         assistants: [
-          { assistantId: "local-1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+          { assistantId: "local-1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
           { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://platform.vellum.ai" },
         ],
         activeAssistant: "local-1",

--- a/clients/macos/src/main/lockfile-watcher.test.ts
+++ b/clients/macos/src/main/lockfile-watcher.test.ts
@@ -11,7 +11,8 @@ mock.module("@vellumai/local-mode", () => ({
   resolveLockfilePaths: () => mockPaths,
 }));
 
-// Stub @vellumai/local-mode/contract — passthrough the real parseLockfile.
+// Passthrough the real parseLockfile — stubbing the @vellumai/local-mode
+// entry above doesn't touch the /contract subpath it lives in.
 const { parseLockfile } = await import("@vellumai/local-mode/contract");
 mock.module("@vellumai/local-mode/contract", () => ({
   parseLockfile,
@@ -26,8 +27,8 @@ const {
 
 const SAMPLE_LOCKFILE: Lockfile = {
   assistants: [
-    { assistantId: "ast-1", name: "Alpha" },
-    { assistantId: "ast-2", name: "Beta" },
+    { assistantId: "ast-1", name: "Alpha", cloud: "local" },
+    { assistantId: "ast-2", name: "Beta", cloud: "local" },
   ],
   activeAssistant: "ast-1",
 };
@@ -141,7 +142,7 @@ describe("lockfile-watcher", () => {
       // filesystem registers a different mtime than the initial read).
       await new Promise((resolve) => setTimeout(resolve, 50));
       const updated: Lockfile = {
-        assistants: [{ assistantId: "ast-3", name: "Gamma" }],
+        assistants: [{ assistantId: "ast-3", name: "Gamma", cloud: "local" }],
         activeAssistant: "ast-3",
       };
       writeLockfile(updated);
@@ -250,7 +251,7 @@ describe("lockfile-watcher", () => {
       // WHEN a write creates the canonical file (simulating a CLI write)
       await new Promise((resolve) => setTimeout(resolve, 50));
       const updated: Lockfile = {
-        assistants: [{ assistantId: "ast-new", name: "NewAssistant" }],
+        assistants: [{ assistantId: "ast-new", name: "NewAssistant", cloud: "local" }],
         activeAssistant: "ast-new",
       };
       writeLockfile(updated, CANONICAL_PATH);

--- a/clients/web/src/assistant/retire-service.test.ts
+++ b/clients/web/src/assistant/retire-service.test.ts
@@ -31,8 +31,7 @@ const syncPlatformAssistantsToLockfileMock = mock(
 );
 mock.module("@/lib/local-mode", () => ({
   getLockfile: () => ({ assistants: lockfileAssistants, activeAssistant: null }),
-  isLocalAssistant: (a: { cloud?: string }) =>
-    a.cloud == null || a.cloud === "local",
+  isLocalAssistant: (a: { cloud?: string }) => a.cloud === "local",
   isLocalMode: () => isLocalModeValue,
   retireLocalAssistant: retireLocalAssistantMock,
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+import { parseLockfile } from "@vellumai/local-mode/contract";
+
 import * as localModeHost from "@/runtime/local-mode-host";
 
 const replacePlatformAssistantsHost = mock(
@@ -224,9 +226,15 @@ describe("assistant classification", () => {
     expect(isLocalAssistant(appleContainer)).toBe(false);
   });
 
-  test("a legacy entry with no cloud is treated as local", () => {
-    const legacy = { assistantId: "old" } as LockfileAssistant;
-    expect(isLocalAssistant(legacy)).toBe(true);
+  test("a legacy entry with no cloud normalizes to local at the parse seam", () => {
+    // Entries that predate the `cloud` field are normalized to "local" by
+    // parseLockfile (see @vellumai/local-mode/contract), so by the time one
+    // reaches isLocalAssistant its cloud is already set.
+    const { assistants } = parseLockfile({
+      assistants: [{ assistantId: "old" }],
+      activeAssistant: null,
+    });
+    expect(isLocalAssistant(assistants[0]!)).toBe(true);
   });
 
   test("remote self-hosted clouds are neither local nor platform", () => {
@@ -290,11 +298,13 @@ describe("isCliWakeableAssistant", () => {
     expect(isCliWakeableAssistant("legacy")).toBe(true);
   });
 
-  test("a cloud:null (legacy) entry is wakeable", () => {
-    setLockfile({
-      assistants: [{ assistantId: "old" } as LockfileAssistant],
-      activeAssistant: "old",
-    });
+  test("a legacy (cloud-less) entry is wakeable once normalized at parse", () => {
+    setLockfile(
+      parseLockfile({
+        assistants: [{ assistantId: "old" }],
+        activeAssistant: "old",
+      }),
+    );
     expect(isCliWakeableAssistant("old")).toBe(true);
   });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -322,18 +322,19 @@ export function hasAssistants(): boolean {
 /**
  * A local-kind assistant, by origin: a plain on-machine assistant the web client
  * drives through its local flows (gateway connect, wake, local retire) — cloud
- * `"local"`, or a legacy entry with no `cloud`. Identity only — whether it
- * currently has a reachable gateway is a separate, connect-time question (see
- * `getLocalGatewayUrl`).
+ * `"local"`. (Legacy entries that predate the `cloud` field are normalized to
+ * `"local"` at the parse seam, so `cloud` is always set by the time it reaches
+ * here.) Identity only — whether it currently has a reachable gateway is a
+ * separate, connect-time question (see `getLocalGatewayUrl`).
  *
  * Deliberately excludes the externally-managed container runtimes (`docker`,
  * `apple-container`) and remote self-hosted clouds (`paired`/`gcp`/`aws`/
  * `custom`, reached at their own `runtimeUrl`), along with platform (`vellum`):
- * the web client manages none of those through its local flows. See the `cloud`
- * taxonomy in `cli/src/lib/assistant-config.ts`.
+ * the web client manages none of those through its local flows. See the
+ * `KNOWN_CLOUDS` taxonomy in `@vellumai/local-mode/contract`.
  */
 export function isLocalAssistant(a: LockfileAssistant): boolean {
-  return a.cloud == null || a.cloud === "local";
+  return a.cloud === "local";
 }
 
 export function isPlatformAssistant(a: LockfileAssistant): boolean {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -166,8 +166,7 @@ mock.module("@/lib/auth/remote-gateway-session", () => ({
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => mockIsLocalMode,
   isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
-  isLocalAssistant: (a: { cloud?: string }) =>
-    a.cloud == null || a.cloud === "local",
+  isLocalAssistant: (a: { cloud?: string }) => a.cloud === "local",
   isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
   getPlatformAssistants: () => mockPlatformAssistants,
   getLocalAssistants: () => [],

--- a/packages/local-mode/bun.lock
+++ b/packages/local-mode/bun.lock
@@ -6,6 +6,7 @@
       "name": "@vellumai/local-mode",
       "dependencies": {
         "@vellumai/environments": "file:../environments",
+        "zod": "4.3.6",
       },
       "devDependencies": {
         "@types/bun": "1.3.11",
@@ -25,5 +26,7 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
   }
 }

--- a/packages/local-mode/package.json
+++ b/packages/local-mode/package.json
@@ -13,7 +13,8 @@
     "test": "bun test src/"
   },
   "dependencies": {
-    "@vellumai/environments": "file:../environments"
+    "@vellumai/environments": "file:../environments",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@types/bun": "1.3.11",

--- a/packages/local-mode/src/__tests__/package-boundary.test.ts
+++ b/packages/local-mode/src/__tests__/package-boundary.test.ts
@@ -6,10 +6,9 @@
  * uses node builtins for filesystem, child-process, and network work.
  *
  * Enforces that the package:
- * 1. Imports only node builtins, its own relative modules, and
- *    `@vellumai/environments` — no other `@vellumai/*` packages and no
- *    third-party runtime imports (so any bundler host can inline it).
- * 2. Declares exactly one runtime dependency: `@vellumai/environments`.
+ * 1. Imports only node builtins, its own relative modules, `@vellumai/environments`,
+ *    and `zod` (the lockfile contract's schema library) — nothing else.
+ * 2. Declares exactly those two runtime dependencies.
  * 3. Is marked `private`.
  */
 
@@ -20,7 +19,7 @@ import { join, resolve } from "node:path";
 const PACKAGE_ROOT = resolve(import.meta.dirname, "../..");
 const SRC_DIR = join(PACKAGE_ROOT, "src");
 
-const ALLOWED_PACKAGES = new Set(["@vellumai/environments"]);
+const ALLOWED_PACKAGES = new Set(["@vellumai/environments", "zod"]);
 
 function collectSourceFiles(dir: string): string[] {
   const files: string[] = [];
@@ -92,13 +91,14 @@ describe("package boundary", () => {
     }
   });
 
-  test("package.json declares it as private with only the @vellumai/environments dependency", () => {
+  test("package.json declares it as private with only its environments and zod dependencies", () => {
     const pkg = JSON.parse(
       readFileSync(join(PACKAGE_ROOT, "package.json"), "utf-8"),
     );
     expect(pkg.private).toBe(true);
     expect(pkg.dependencies ?? {}).toEqual({
       "@vellumai/environments": "file:../environments",
+      zod: "4.3.6",
     });
   });
 });

--- a/packages/local-mode/src/lockfile-contract.test.ts
+++ b/packages/local-mode/src/lockfile-contract.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseLockfile, type Lockfile } from "./lockfile-contract";
+import {
+  KNOWN_CLOUDS,
+  parseLockfile,
+  resolveCloud,
+  SENSITIVE_KEYS,
+  type Lockfile,
+} from "./lockfile-contract";
 
 describe("parseLockfile", () => {
   test("passes through a fully-populated lockfile", () => {
@@ -42,24 +48,28 @@ describe("parseLockfile", () => {
 
   test("salvages a legacy entry that has only an assistantId", () => {
     // The oldest persisted entries carry just the identity; the CLI fills the
-    // rest in lazily. assistantId is the only required field, so the entry
-    // must survive intact rather than being discarded.
+    // rest in lazily. assistantId is the only required field, so the entry must
+    // survive — normalized to the default `local` cloud.
     const parsed = parseLockfile({
       activeAssistant: "asst_1",
       assistants: [{ assistantId: "asst_1" }],
     });
-    expect(parsed.assistants).toEqual([{ assistantId: "asst_1" }]);
+    expect(parsed.assistants).toEqual([
+      { assistantId: "asst_1", cloud: "local" },
+    ]);
   });
 
   test("salvages an entry whose cloud and runtimeUrl are absent", () => {
     // Older CLI builds predate the `cloud` field and persisted the runtime URL
     // under a different key (`localUrl`), so a real on-disk entry can lack both
-    // modeled fields. It must still be returned (the macOS↔CLI skew window).
+    // modeled fields. It must still be returned, normalized to `local`.
     const parsed = parseLockfile({
       activeAssistant: null,
       assistants: [{ assistantId: "asst_1", localUrl: "http://127.0.0.1:7777" }],
     });
-    expect(parsed.assistants).toEqual([{ assistantId: "asst_1" }]);
+    expect(parsed.assistants).toEqual([
+      { assistantId: "asst_1", cloud: "local" },
+    ]);
   });
 
   test("drops malformed entries but salvages valid siblings", () => {
@@ -111,7 +121,9 @@ describe("parseLockfile", () => {
   });
 
   test("coerces a non-string activeAssistant to null", () => {
-    expect(parseLockfile({ assistants: [], activeAssistant: 7 }).activeAssistant).toBeNull();
+    expect(
+      parseLockfile({ assistants: [], activeAssistant: 7 }).activeAssistant,
+    ).toBeNull();
     expect(parseLockfile({ assistants: [] }).activeAssistant).toBeNull();
   });
 
@@ -124,9 +136,9 @@ describe("parseLockfile", () => {
   });
 
   test("drops a mistyped optional field but keeps the entry", () => {
-    // assistantId is the only required field. A mistyped optional field (here
-    // cloud / runtimeUrl) is dropped from the result, but the entry survives on
-    // the strength of its identity rather than being discarded wholesale.
+    // assistantId is the only required field. A mistyped optional field is
+    // dropped from the result, but the entry survives on the strength of its
+    // identity. (A mistyped `cloud` is dropped, then re-normalized to `local`.)
     const raw = {
       assistants: [
         { assistantId: "asst_1", cloud: 7, runtimeUrl: "http://a" }, // cloud not a string
@@ -135,7 +147,7 @@ describe("parseLockfile", () => {
       activeAssistant: null,
     };
     expect(parseLockfile(raw).assistants).toEqual([
-      { assistantId: "asst_1", runtimeUrl: "http://a" },
+      { assistantId: "asst_1", cloud: "local", runtimeUrl: "http://a" },
       { assistantId: "asst_2", cloud: "local" },
     ]);
   });
@@ -190,11 +202,38 @@ describe("parseLockfile", () => {
     expect(assistant?.resources).toBeUndefined();
   });
 
+  test("strips sensitive and host-only fields from resources", () => {
+    // The renderer-facing resources shape is ports + instanceDir only; the
+    // signing key and other ports are host-only and never cross the boundary.
+    const raw = {
+      assistants: [
+        {
+          assistantId: "asst_1",
+          cloud: "local",
+          resources: {
+            instanceDir: "/data",
+            gatewayPort: 7777,
+            daemonPort: 7778,
+            qdrantPort: 7779,
+            cesPort: 7780,
+            signingKey: "hunter2",
+          },
+        },
+      ],
+      activeAssistant: null,
+    };
+    expect(parseLockfile(raw).assistants[0]?.resources).toEqual({
+      instanceDir: "/data",
+      gatewayPort: 7777,
+      daemonPort: 7778,
+    });
+  });
+
   test("resolves cloud from legacy remote markers when the field is absent", () => {
     // Pre-`cloud` remote entries encode topology in `project` (gcp) / `sshUser`
     // (custom). The parser resolves these so a cloudless remote entry is never
-    // mistaken for a local one downstream; a cloudless entry with no markers
-    // stays cloudless (local). The raw markers are not carried through.
+    // mistaken for a local one; a cloudless entry with no markers normalizes to
+    // `local`. The raw markers are not carried through.
     const raw = {
       assistants: [
         { assistantId: "gcp_1", project: "my-proj", runtimeUrl: "https://a" },
@@ -206,17 +245,55 @@ describe("parseLockfile", () => {
     expect(parseLockfile(raw).assistants).toEqual([
       { assistantId: "gcp_1", cloud: "gcp", runtimeUrl: "https://a" },
       { assistantId: "ssh_1", cloud: "custom", runtimeUrl: "https://b" },
-      { assistantId: "local_1", runtimeUrl: "http://localhost:7830" },
+      { assistantId: "local_1", cloud: "local", runtimeUrl: "http://localhost:7830" },
     ]);
   });
 
   test("prefers an explicit cloud over legacy remote markers", () => {
     const raw = {
-      assistants: [{ assistantId: "a", cloud: "local", project: "stale-proj" }],
+      assistants: [{ assistantId: "a", cloud: "vellum", project: "stale-proj" }],
       activeAssistant: null,
     };
     expect(parseLockfile(raw).assistants).toEqual([
-      { assistantId: "a", cloud: "local" },
+      { assistantId: "a", cloud: "vellum" },
+    ]);
+  });
+});
+
+describe("resolveCloud", () => {
+  test("prefers an explicit cloud", () => {
+    expect(resolveCloud({ cloud: "vellum", project: "p", sshUser: "u" })).toBe(
+      "vellum",
+    );
+  });
+
+  test("falls back to legacy markers, then local", () => {
+    expect(resolveCloud({ project: "p" })).toBe("gcp");
+    expect(resolveCloud({ sshUser: "u" })).toBe("custom");
+    expect(resolveCloud({})).toBe("local");
+    expect(resolveCloud({ cloud: "" })).toBe("local");
+  });
+});
+
+describe("taxonomy", () => {
+  test("KNOWN_CLOUDS covers the documented topologies", () => {
+    expect(KNOWN_CLOUDS).toEqual([
+      "local",
+      "docker",
+      "apple-container",
+      "vellum",
+      "gcp",
+      "aws",
+      "custom",
+      "paired",
+    ]);
+  });
+
+  test("SENSITIVE_KEYS lists the redacted secrets", () => {
+    expect(SENSITIVE_KEYS).toEqual([
+      "signingKey",
+      "bearerToken",
+      "guardianBootstrapSecret",
     ]);
   });
 });

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -1,52 +1,124 @@
 /**
- * The lockfile wire contract — the types and the parser that validates them —
- * kept in its own module so consumers can import the contract without pulling
- * in the host I/O graph (`node:fs`, the CLI resolver, the environments
- * package). The renderer relies on that separation: it imports these types
- * type-only and must not transitively reference Node built-ins.
+ * The lockfile wire contract — one Zod schema that is the single source of truth
+ * for an assistant entry's shape, its validation, the `cloud` taxonomy, the
+ * normalization, and the redaction policy.
  *
- * Validation is hand-written rather than schema-library-based on purpose: this
- * package is inlined from source by three different bundler hosts (the CLI, the
- * Electron main process, and the web dev server) and deliberately carries no
- * third-party runtime dependencies (enforced by `__tests__/package-boundary`).
- * The contract is small enough that a typed parser is clearer than a dependency.
+ * Kept in its own module, exported from the package as `./contract`, so
+ * consumers import the contract without pulling in the host I/O graph
+ * (`node:fs`, the CLI resolver). The CLI, the host I/O layer, the Electron and
+ * dev-server bridges, and the renderer all depend on this one definition. It
+ * references no node built-ins — the renderer bundles it directly — and `zod`
+ * is its only third-party import.
  *
  * The lockfile is written by the Vellum CLI and read across the macOS↔CLI
- * boundary, which do not release in lockstep. The parser is therefore
- * permissive about unknown fields: it reads only the modeled fields below and
- * ignores everything else, so a newer writer's extra fields never fail an
- * older reader. Unknown fields are preserved on disk by the write path (see
- * `lockfile.ts`); the validated value returned to callers carries only the
- * modeled shape.
- *
- * `assistantId` is the only required field — it is the entry's identity (the
- * key every reader and the write path look entries up by) and the one field
- * the CLI always writes. Everything else is optional on disk: older entries
- * predate the `cloud` field, the runtime URL has historically been persisted
- * under a different key (`localUrl`), and resource ports are only present for
- * multi-instance local setups. The parser therefore salvages any entry that
- * has a string `assistantId` and copies the remaining modeled fields only when
- * they are present and well-typed, rather than discarding an otherwise-usable
- * assistant because an optional field is missing or malformed.
+ * boundary, which do not release in lockstep, so the parser is permissive: it
+ * validates the modeled fields, salvages an entry on the strength of its
+ * `assistantId` alone (dropping individual malformed optional fields rather
+ * than the whole entry), and ignores unknown fields so a newer writer never
+ * breaks an older reader. Unknown fields are preserved on disk by the write
+ * path (see `lockfile.ts`); the validated value carries only the modeled,
+ * renderer-safe shape.
  */
+import { z } from "zod";
 
-export interface LocalAssistantResources {
-  instanceDir?: string;
-  gatewayPort: number;
-  daemonPort: number;
+/**
+ * Known deployment topologies. `cloud` is stored as a free string on disk for
+ * forward-compatibility — an older reader must tolerate a newer writer's value
+ * — but the known set is enumerated here so callers switch on it exhaustively
+ * instead of matching string literals scattered across the codebase:
+ *  - `local` — on-machine daemon
+ *  - `docker` — local container
+ *  - `apple-container` — macOS-app-managed container
+ *  - `vellum` — platform-managed (uses the X-Session-Token auth path)
+ *  - `gcp` / `aws` / `custom` — remote, SSH-managed
+ *  - `paired` — a remote assistant paired from another machine
+ */
+export const KNOWN_CLOUDS = [
+  "local",
+  "docker",
+  "apple-container",
+  "vellum",
+  "gcp",
+  "aws",
+  "custom",
+  "paired",
+] as const;
+export type KnownCloud = (typeof KNOWN_CLOUDS)[number];
+export type Cloud = KnownCloud | (string & {});
+
+/**
+ * Keys that must never cross the host→renderer boundary. Stripped from raw
+ * lockfile JSON before it leaves a host (see `stripSensitiveFields`) and absent
+ * from the renderer-facing schema below; the CLI's extended type is the only
+ * place they are modeled.
+ */
+export const SENSITIVE_KEYS = [
+  "signingKey",
+  "bearerToken",
+  "guardianBootstrapSecret",
+] as const;
+
+/**
+ * Resolve an entry's deployment topology from its raw on-disk fields. Prefers
+ * an explicit `cloud`, then the legacy markers that predate the field
+ * (`project` ⇒ gcp, `sshUser` ⇒ custom), and defaults to "local". This is the
+ * one definition every reader shares, so a cloudless entry is classified
+ * identically by the CLI, the host I/O layer, and the renderer.
+ */
+export function resolveCloud(raw: {
+  cloud?: unknown;
+  project?: unknown;
+  sshUser?: unknown;
+}): Cloud {
+  if (typeof raw.cloud === "string" && raw.cloud) return raw.cloud;
+  if (typeof raw.project === "string" && raw.project) return "gcp";
+  if (typeof raw.sshUser === "string" && raw.sshUser) return "custom";
+  return "local";
 }
 
-export interface LockfileAssistant {
-  assistantId: string;
-  name?: string;
-  cloud?: string;
-  runtimeUrl?: string;
-  species?: string;
-  hatchedAt?: string;
+/**
+ * Per-instance resources for a local assistant: the renderer-facing subset of
+ * ports plus the instance directory. Richer host-only fields (other ports, the
+ * signing key) live on the CLI's type and are stripped from this shape.
+ */
+export const LocalAssistantResourcesSchema = z.object({
+  instanceDir: z.string().optional(),
+  gatewayPort: z.number(),
+  daemonPort: z.number(),
+});
+export type LocalAssistantResources = z.infer<
+  typeof LocalAssistantResourcesSchema
+>;
+
+/**
+ * The renderer-safe shape of one assistant entry. `assistantId` is the only
+ * required field — the identity every reader looks entries up by — and every
+ * other field is salvaged by {@link parseLockfile}. The CLI extends this with
+ * its host-only and sensitive fields; this base carries only what is safe to
+ * surface in the renderer.
+ */
+export const LockfileAssistantSchema = z.object({
+  assistantId: z.string(),
+  name: z.string().optional(),
+  cloud: z.string().optional(),
+  runtimeUrl: z.string().optional(),
+  species: z.string().optional(),
+  hatchedAt: z.string().optional(),
   /** Owning org for platform assistants; absent for local ones. */
-  organizationId?: string;
-  resources?: LocalAssistantResources;
-}
+  organizationId: z.string().optional(),
+  resources: LocalAssistantResourcesSchema.optional(),
+});
+
+/**
+ * A validated, normalized assistant entry. Identical to the schema's inferred
+ * shape except `cloud` is always present — {@link parseLockfile} resolves it for
+ * every entry (defaulting to "local"), so readers never special-case its
+ * absence.
+ */
+export type LockfileAssistant = Omit<
+  z.infer<typeof LockfileAssistantSchema>,
+  "cloud"
+> & { cloud: Cloud };
 
 export interface Lockfile {
   assistants: LockfileAssistant[];
@@ -55,8 +127,8 @@ export interface Lockfile {
 
 /**
  * Renderer-facing result of a lockfile write, returned across the host bridge.
- * Carries no HTTP-style `status` — the hosts map that away because the
- * renderer surfaces failures by message alone.
+ * Carries no HTTP-style status — hosts map that away because the renderer
+ * surfaces failures by message alone.
  */
 export type LockfileWriteResult =
   | { ok: true; lockfile: Lockfile }
@@ -66,60 +138,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseResources(value: unknown): LocalAssistantResources | undefined {
-  if (!isRecord(value)) return undefined;
-  if (typeof value.gatewayPort !== "number") return undefined;
-  if (typeof value.daemonPort !== "number") return undefined;
-  return {
-    ...(typeof value.instanceDir === "string"
-      ? { instanceDir: value.instanceDir }
-      : {}),
-    gatewayPort: value.gatewayPort,
-    daemonPort: value.daemonPort,
-  };
-}
-
 /**
- * Validate a single assistant entry. Returns `null` only when the entry lacks a
- * string `assistantId` (its identity); any other entry is salvaged. Each
- * optional field is copied only when present and well-typed — a missing or
- * mistyped optional field is dropped from the result without discarding the
- * entry — and unknown fields are ignored.
+ * Validate and normalize a single entry. Returns null only when `assistantId`
+ * is missing or not a string; any other entry is salvaged — each modeled field
+ * is copied only when present and well-typed (a malformed optional field is
+ * dropped without discarding the entry), unknown fields are ignored, and
+ * `cloud` is resolved from the raw markers so a cloudless remote entry is never
+ * mistaken for a local one and a markerless entry defaults to "local".
  */
-function parseAssistant(value: unknown): LockfileAssistant | null {
-  if (!isRecord(value)) return null;
-  if (typeof value.assistantId !== "string") return null;
-
-  const assistant: LockfileAssistant = { assistantId: value.assistantId };
-  if (typeof value.name === "string") assistant.name = value.name;
-  // Normalize `cloud`. A pre-`cloud` remote entry encodes its topology in legacy
-  // markers (`project` => "gcp", `sshUser` => "custom") that aren't modeled
-  // fields; resolve them here — mirroring the CLI's `resolveCloud` — so a
-  // cloudless remote entry isn't indistinguishable from a local one downstream.
-  // A cloudless entry with no markers stays cloudless (i.e. local).
-  if (typeof value.cloud === "string") {
-    assistant.cloud = value.cloud;
-  } else if (typeof value.project === "string" && value.project) {
-    assistant.cloud = "gcp";
-  } else if (typeof value.sshUser === "string" && value.sshUser) {
-    assistant.cloud = "custom";
+function parseAssistant(raw: unknown): LockfileAssistant | null {
+  if (!isRecord(raw) || typeof raw.assistantId !== "string") return null;
+  const out: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(LockfileAssistantSchema.shape)) {
+    const result = (field as z.ZodType).safeParse(raw[key]);
+    if (result.success && result.data !== undefined) out[key] = result.data;
   }
-  if (typeof value.runtimeUrl === "string") assistant.runtimeUrl = value.runtimeUrl;
-  if (typeof value.species === "string") assistant.species = value.species;
-  if (typeof value.hatchedAt === "string") assistant.hatchedAt = value.hatchedAt;
-  if (typeof value.organizationId === "string") assistant.organizationId = value.organizationId;
-  const resources = parseResources(value.resources);
-  if (resources) assistant.resources = resources;
-  return assistant;
+  out.cloud = resolveCloud(raw);
+  return out as LockfileAssistant;
 }
 
 /**
- * Coerce parsed JSON into a validated `Lockfile`. Total and non-throwing:
- * individual assistant entries that fail validation are dropped (so one
- * malformed entry can't discard the whole file), a missing/non-array
- * `assistants` becomes `[]`, and a non-string `activeAssistant` becomes
- * `null`. Callers pass the result through unchanged; the only failure modes a
- * host surfaces are I/O and JSON-parse errors, handled by `getLockfileData`.
+ * Coerce parsed JSON into a validated {@link Lockfile}. Total and non-throwing:
+ * entries that fail validation are dropped (one malformed entry can't discard
+ * the file), a missing or non-array `assistants` becomes `[]`, and a non-string
+ * `activeAssistant` becomes null.
  */
 export function parseLockfile(raw: unknown): Lockfile {
   const root = isRecord(raw) ? raw : {};

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -74,7 +74,9 @@ describe("getLockfileData", () => {
     const result = getLockfileData([lockfilePath]);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.data.assistants).toEqual([{ assistantId: "asst_legacy" }]);
+      expect(result.data.assistants).toEqual([
+        { assistantId: "asst_legacy", cloud: "local" },
+      ]);
       expect(result.data.activeAssistant).toBe("asst_legacy");
     }
   });

--- a/packages/local-mode/src/util.ts
+++ b/packages/local-mode/src/util.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
+import { SENSITIVE_KEYS } from "./lockfile-contract";
+
 const CLI_PACKAGE_NAME = "@vellumai/cli";
 
 /**
@@ -17,24 +19,18 @@ export interface CliInvocation {
   baseArgs: string[];
 }
 
-const SENSITIVE_FIELDS = [
-  "signingKey",
-  "bearerToken",
-  "guardianBootstrapSecret",
-] as const;
-
 export function stripSensitiveFields(data: Record<string, unknown>): void {
   const assistants = data.assistants;
   if (!Array.isArray(assistants)) return;
   for (const assistant of assistants) {
     if (assistant && typeof assistant === "object") {
       const entry = assistant as Record<string, unknown>;
-      for (const field of SENSITIVE_FIELDS) {
+      for (const field of SENSITIVE_KEYS) {
         delete entry[field];
       }
       const resources = entry.resources;
       if (resources && typeof resources === "object") {
-        for (const field of SENSITIVE_FIELDS) {
+        for (const field of SENSITIVE_KEYS) {
           delete (resources as Record<string, unknown>)[field];
         }
       }


### PR DESCRIPTION
## Why

The lockfile assistant-entry shape was described in several places — the CLI's `AssistantEntry` interface, the contract's `LockfileAssistant` interface and its hand-written parser, and the `cloud` taxonomy living only in a doc-comment — with `resolveCloud` implemented **twice**. Those copies drift, and that drift is the root of the portless-local / cloud-classification bug class we've been patching one symptom at a time.

## What

Make the existing **`@vellumai/local-mode/contract`** the single source of truth: one **Zod** schema for the renderer-safe entry shape (type via `z.infer`), its validation, the `cloud` taxonomy (`KNOWN_CLOUDS`), the normalization (one `resolveCloud`), and the redaction policy (`SENSITIVE_KEYS`).

It already *is* the lockfile contract — every host and the renderer import it — so this needs **no new package and no CI wiring**. `zod` is its one new dependency (the package-boundary test allows it; the `install-shared-packages` guard only polices `packages/*` `file:` deps, so workflows are untouched).

- **`cloud` is normalized at the parse seam** (markerless entries default to `"local"`). The CLI deletes its duplicate `resolveCloud`, reads `entry.cloud` at its 12 call sites, and normalizes once in `readAssistants` — which also fixes a **latent bug** where `allocateLocalResources` skipped port reservation for legacy markerless-local entries. The renderer's `isLocalAssistant` drops its now-dead `cloud == null` branch.
- The CLI's `AssistantEntry` is the contract's `LockfileAssistant` type **plus** its host-only and sensitive fields, modeled as plain types — they never cross a validation boundary, so Zod stays scoped to the validated wire contract and the shared shape has one owner.
- `util.ts` strips the contract's `SENSITIVE_KEYS` instead of its own copy.

Host I/O (lockfile read/write, atomic rename) and env-dependent migration stay where they belong; only the shape, validation, taxonomy, and redaction move to the one schema.

## Approach note

An earlier revision of this PR extracted the contract into a *new* `@vellumai/lockfile-contract` package. That was over-engineered for this repo's no-workspaces / `file:`-dep model: it cost ~24 `install-shared-packages` edits across 12 workflow files plus path triggers, all to eliminate one small duplicated type in `ipc-contract`. The in-place version drops all of that. `ipc-contract` keeps its small hand-written bridge-type copy (it can't depend on `local-mode` due to a transitive `file:` chain) — unchanged from `main`.

## Verification

Typecheck clean across all five affected packages (local-mode, ipc-contract, cli, web, macos). Suites green: local-mode (84), cli (748), and every touched web/macOS suite (local-mode, local-mode-host, retire-service, auth-store, lockfile-watcher, host-proxy-router, dock). `bun install --frozen-lockfile` verified in each package (the CI install gate). Tests that pinned the old "cloud-less = local" behavior were updated to exercise the real parse-seam normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeN6mWBq3CBbG9N72Y7Kk