### PR TITLE
Fix Queue drawer staying open after a queued send is processed directly

### DIFF
--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -403,10 +403,20 @@ function findOptimisticUserEchoIdx(
  *  2. An optimistic user row is correlated by `clientMessageId` (or, absent
  *     the nonce, the most recent optimistic row) — the originating client
  *     whose POST hasn't resolved yet (the echo beat the 202). Swap its id to
- *     the server `messageId` and clear `isOptimistic`, mirroring the
- *     POST-resolve path so a later reconcile can't double it. With no
- *     `messageId` (synthetic echo) there is nothing to upgrade to, so the
- *     optimistic row is left as-is.
+ *     the server `messageId`, clear `isOptimistic`, and clear any optimistic
+ *     `queueStatus`/`queuePosition`, mirroring the POST-resolve path so a
+ *     later reconcile can't double it. Clearing the queue status here is
+ *     load-bearing: the echo is only emitted once the daemon has begun
+ *     *processing* the message (a direct send, or a queued send right after
+ *     it is dequeued), so the row is no longer waiting in the queue. When the
+ *     client optimistically marked the row `queued` (it believed a turn was
+ *     in flight) but the daemon processed it directly — no `message_queued` /
+ *     `message_dequeued` pair is ever sent — the echo is the only signal that
+ *     clears the stale queue badge. Because the echo swaps the row id, the
+ *     POST-resolve path's `clearQueueStatus(userMessage.id)` (keyed on the
+ *     original optimistic id) can no longer find the row, so the clear must
+ *     happen here. With no `messageId` (synthetic echo) there is nothing to
+ *     upgrade to, so the optimistic row is left as-is.
  *  3. Otherwise append a new user row — passive client or synthetic
  *     prompt. Keyed by `messageId` when present so reconcile/refetch merges
  *     by id; otherwise optimistic.
@@ -438,6 +448,8 @@ export function applyUserMessageEcho(
       ...next[optimisticIdx]!,
       id: serverId,
       isOptimistic: false,
+      queueStatus: undefined,
+      queuePosition: undefined,
     };
     return next;
   }

--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -403,19 +403,11 @@ function findOptimisticUserEchoIdx(
  *  2. An optimistic user row is correlated by `clientMessageId` (or, absent
  *     the nonce, the most recent optimistic row) — the originating client
  *     whose POST hasn't resolved yet (the echo beat the 202). Swap its id to
- *     the server `messageId`, clear `isOptimistic`, and clear any optimistic
- *     `queueStatus`/`queuePosition`, mirroring the POST-resolve path so a
- *     later reconcile can't double it. Clearing the queue status here is
- *     load-bearing: the echo is only emitted once the daemon has begun
- *     *processing* the message (a direct send, or a queued send right after
- *     it is dequeued), so the row is no longer waiting in the queue. When the
- *     client optimistically marked the row `queued` (it believed a turn was
- *     in flight) but the daemon processed it directly — no `message_queued` /
- *     `message_dequeued` pair is ever sent — the echo is the only signal that
- *     clears the stale queue badge. Because the echo swaps the row id, the
- *     POST-resolve path's `clearQueueStatus(userMessage.id)` (keyed on the
- *     original optimistic id) can no longer find the row, so the clear must
- *     happen here. With no `messageId` (synthetic echo) there is nothing to
+ *     the server `messageId`, clear `isOptimistic`, and clear any
+ *     `queueStatus`/`queuePosition`: the echo is emitted only once the daemon
+ *     is processing the message (a direct send, or a queued send right after
+ *     it is dequeued), so a persisted echo means the row is no longer waiting
+ *     in the queue. With no `messageId` (synthetic echo) there is nothing to
  *     upgrade to, so the optimistic row is left as-is.
  *  3. Otherwise append a new user row — passive client or synthetic
  *     prompt. Keyed by `messageId` when present so reconcile/refetch merges

--- a/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -1140,6 +1140,46 @@ describe("applyUserMessageEcho", () => {
     expect(result[0]!.isOptimistic).toBe(false);
   });
 
+  it("clears optimistic queue status when upgrading the originating row", () => {
+    /**
+     * Regression: the client optimistically marks a send `queued` when it
+     * believes a turn is in flight, but the daemon had just gone idle and
+     * processes the message directly — emitting only `user_message_echo`,
+     * never the `message_queued` / `message_dequeued` pair that would clear
+     * the badge. Because the echo swaps the row id, the POST-resolve path's
+     * `clearQueueStatus(originalId)` can no longer find the row, so the echo
+     * must clear the stale queue status itself or the Queue drawer never
+     * closes.
+     */
+    // GIVEN an optimistic row the client marked queued
+    const prev: DisplayMessage[] = [
+      {
+        id: "client-uuid",
+        clientMessageId: "client-uuid",
+        role: "user",
+        ...seg("queue me"),
+        isOptimistic: true,
+        queueStatus: "queued",
+        queuePosition: 0,
+        timestamp: 1,
+      },
+    ];
+
+    // WHEN the echo for that send arrives (daemon processed it directly)
+    const result = applyUserMessageEcho(prev, {
+      text: "queue me",
+      messageId: "msg-server-q",
+      clientMessageId: "client-uuid",
+    });
+
+    // THEN the row is upgraded and no longer reads as queued
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("msg-server-q");
+    expect(result[0]!.isOptimistic).toBe(false);
+    expect(result[0]!.queueStatus).toBeUndefined();
+    expect(result[0]!.queuePosition).toBeUndefined();
+  });
+
   it("is a no-op when a row already carries the server id", () => {
     /**
      * A redelivered echo (reconnect/resume) or an already-resolved POST


### PR DESCRIPTION
## What

Fixes a user report: **"Queue message modal doesn't close down"** — the `Queue · 1` drawer stays open even after the assistant has already replied to the queued message.

## Root cause

Reproduced from the attached feedback logs (conversation `f472e35b…`):

1. The user sent a message while the client believed a turn was in flight, so `useSendMessage` optimistically marked the row `queueStatus: "queued"` (`willQueue` path).
2. The daemon had actually **just gone idle** (`assistant_activity_state: idle` at `19:03:10.448`), so it processed the message **directly** — emitting only a single `user_message_echo` (`19:03:10.466`, with `messageId` + `requestId`) and **never** the `message_queued` / `message_dequeued` pair. The diagnostics confirm zero queue SSE events, and `queuedCount` stayed at `1` from `19:03:10` to the end of the capture.
3. `applyUserMessageEcho` swapped the optimistic row's id to the server id and cleared `isOptimistic`, **but left `queueStatus`/`queuePosition` intact**.
4. That id swap also defeated the POST-resolve fallback in `useSendMessage`, which keys `clearQueueStatus(userMessage.id)` on the *original optimistic id* the echo had already replaced — so it found nothing to clear.

Net result: the row was stuck at `queueStatus: "queued"` (verified in the captured client state: `id: a228e638…, queueStatus: "queued", isOptimistic: false`, with an assistant reply already after it), and `QueuedMessagesDrawer` renders whenever any row is still `queued`.

## Fix

Clear `queueStatus`/`queuePosition` when `applyUserMessageEcho` upgrades the optimistic row to the server id. The echo is only ever emitted once the daemon is *processing* a message (a direct send, or a queued send right after it is dequeued), so the row is never still waiting at that point — making the clear correct and idempotent with the normal dequeue path (where `message_dequeued` already cleared it just before the echo lands).

## Testing

- Added a regression test in `stream-updaters.test.ts` covering the exact scenario (optimistic `queued` row + direct-send echo).
- `bun test stream-updaters.test.ts` → 69 pass.
- Touched files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xch8LavkAnPHSY1SWhasUc)_