### PR TITLE
test(attachments): validate upload response against its schema, not an `as` cast

### DIFF
--- a/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
+++ b/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
@@ -26,7 +26,10 @@ mock.module("../config/env.js", () => ({
 }));
 
 import { initializeDb } from "../memory/db-init.js";
-import { ROUTES } from "../runtime/routes/attachment-routes.js";
+import {
+  attachmentMetadataSchema,
+  ROUTES,
+} from "../runtime/routes/attachment-routes.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 
@@ -62,7 +65,7 @@ describe("attachment upload — trustedSource flag", () => {
   });
 
   test("svc_gateway + trustedSource:true accepts a non-allowlisted MIME type", async () => {
-    const result = (await uploadRoute.handler(
+    const raw = await uploadRoute.handler(
       makeUploadArgs(
         {
           filename: "clip.mkv",
@@ -72,14 +75,15 @@ describe("attachment upload — trustedSource flag", () => {
         },
         "svc_gateway",
       ),
-    )) as { id: string; mimeType: string };
+    );
+    const result = attachmentMetadataSchema.parse(raw);
 
     expect(result.id).toBeDefined();
     expect(result.mimeType).toBe("video/x-matroska");
   });
 
   test("svc_gateway + trustedSource:true accepts a dangerous extension", async () => {
-    const result = (await uploadRoute.handler(
+    const raw = await uploadRoute.handler(
       makeUploadArgs(
         {
           filename: "installer.dmg",
@@ -89,7 +93,8 @@ describe("attachment upload — trustedSource flag", () => {
         },
         "svc_gateway",
       ),
-    )) as { id: string };
+    );
+    const result = attachmentMetadataSchema.parse(raw);
 
     expect(result.id).toBeDefined();
   });

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -122,7 +122,7 @@ const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
  * response schemas so the generated client type is a single source of truth
  * (camelCase, matching the rest of the daemon API and the get-by-id response).
  */
-const attachmentMetadataSchema = z.object({
+export const attachmentMetadataSchema = z.object({
   id: z.string(),
   filename: z.string(),
   mimeType: z.string(),


### PR DESCRIPTION
The trusted-source test cast the upload handler result to a hand-written `{ id; mimeType }` shape. An `as` cast tells the type checker to trust that shape blindly — which is exactly what hid the snake_case `mime_type` drift behind a passing type check.

Export the route's `attachmentMetadataSchema` and parse the result against it instead: a renamed or missing field now throws in the test rather than silently reading `undefined`.

Two files, no new abstractions.

Closes LUM-2533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh1GBRgSSWtkxgCnMw9sR5