### PR TITLE
fix(contacts): surface contact mutation failures as toasts, not crashes

### DIFF
--- a/clients/web/src/domains/contacts/components/contact-detail-view.tsx
+++ b/clients/web/src/domains/contacts/components/contact-detail-view.tsx
@@ -18,8 +18,8 @@ interface ContactDetailViewProps {
   canMerge?: boolean;
   availableChannels?: ChannelInfo[];
   a2aEnabled?: boolean;
-  onSave: (patch: { displayName: string; notes: string }) => Promise<void>;
-  onDelete: () => Promise<void>;
+  onSave: (patch: { displayName: string; notes: string }) => void;
+  onDelete: () => void;
   onMerge?: () => void;
   onSetupChannel?: (type: string) => void;
   onVerifyChannel?: (type: string) => void;
@@ -70,7 +70,7 @@ function ContactDetailViewInner({
 
   const requestDelete = () => {
     if (isEmptyDraft) {
-      void onDelete();
+      onDelete();
     } else {
       setConfirmOpen(true);
     }
@@ -176,9 +176,9 @@ function ContactDetailViewInner({
         message="This will permanently delete this contact and all their channels. This action cannot be undone."
         confirmLabel="Delete"
         destructive
-        onConfirm={async () => {
+        onConfirm={() => {
           setConfirmOpen(false);
-          await onDelete();
+          onDelete();
         }}
         onCancel={() => setConfirmOpen(false)}
       />

--- a/clients/web/src/domains/contacts/components/guardian-detail-view.tsx
+++ b/clients/web/src/domains/contacts/components/guardian-detail-view.tsx
@@ -17,7 +17,7 @@ interface GuardianDetailViewProps {
   canMerge?: boolean;
   availableChannels?: ChannelInfo[];
   a2aEnabled?: boolean;
-  onSave: (patch: { displayName: string; notes: string }) => Promise<void>;
+  onSave: (patch: { displayName: string; notes: string }) => void;
   onMerge?: () => void;
   onSetupChannel?: (type: string) => void;
   onVerifyChannel?: (type: string) => void;

--- a/clients/web/src/domains/contacts/contacts-page.test.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.test.tsx
@@ -1,17 +1,10 @@
 /**
- * Regression test for VELLUM-ASSISTANT-MACOS-1QV.
+ * A failing contact mutation (e.g. a gateway 404) must surface as a toast
+ * and must not escalate to an unhandled promise rejection.
  *
- * A failing contact mutation — e.g. a 404 from the gateway when a contact
- * row is missing — must surface as a toast and must NOT escalate to an
- * unhandled promise rejection. Before the fix the detail-view Save/Delete
- * buttons fired `updateMutation.mutateAsync(...)` /
- * `deleteMutation.mutateAsync(...)` fire-and-forget with no `onError`, so
- * the rejection bubbled to `window.onunhandledrejection` and Sentry logged
- * it as a crash.
- *
- * The test drives the real `ContactsPage` (real `@tanstack/react-query`)
- * so it exercises the actual mutation wiring; only the gateway, the
- * generated query layer, and `toast` are mocked. The mocking style mirrors
+ * Drives the real `ContactsPage` (real `@tanstack/react-query`) so the
+ * actual mutation wiring is exercised; only the gateway, the generated
+ * query layer, and `toast` are mocked. Mirrors the mocking style in
  * `domains/settings/ai/provider-create-form.test.tsx`.
  */
 
@@ -37,7 +30,7 @@ const unhandledRejections: unknown[] = [];
 const GUARDIAN = {
   id: "c-guardian",
   role: "guardian",
-  displayName: "Ada Lovelace",
+  displayName: "Example User",
   notes: "",
   channels: [],
   interactionCount: 0,
@@ -178,7 +171,7 @@ describe("ContactsPage mutation error handling", () => {
     const nameInput = await waitFor(() => getInputByPlaceholder("Your name"));
 
     // Dirty the form so Save enables, then submit.
-    fireEvent.change(nameInput, { target: { value: "Ada L." } });
+    fireEvent.change(nameInput, { target: { value: "Example Guardian" } });
     fireEvent.click(getButton("Save"));
 
     // The gateway 404 is surfaced to the user as a toast carrying the
@@ -187,8 +180,8 @@ describe("ContactsPage mutation error handling", () => {
       expect(toastErrorCalls).toEqual(["Not found"]);
     });
 
-    // ...and the rejection never escaped to window.onunhandledrejection
-    // (the Sentry crash symptom). `.mutate()` keeps it internal.
+    // ...and the rejection never escaped to window.onunhandledrejection.
+    // `.mutate()` keeps it internal to React Query.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(unhandledRejections).toEqual([]);
   });

--- a/clients/web/src/domains/contacts/contacts-page.test.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Regression test for VELLUM-ASSISTANT-MACOS-1QV.
+ *
+ * A failing contact mutation — e.g. a 404 from the gateway when a contact
+ * row is missing — must surface as a toast and must NOT escalate to an
+ * unhandled promise rejection. Before the fix the detail-view Save/Delete
+ * buttons fired `updateMutation.mutateAsync(...)` /
+ * `deleteMutation.mutateAsync(...)` fire-and-forget with no `onError`, so
+ * the rejection bubbled to `window.onunhandledrejection` and Sentry logged
+ * it as a crash.
+ *
+ * The test drives the real `ContactsPage` (real `@tanstack/react-query`)
+ * so it exercises the actual mutation wiring; only the gateway, the
+ * generated query layer, and `toast` are mocked. The mocking style mirrors
+ * `domains/settings/ai/provider-create-form.test.tsx`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import { ApiError } from "@/utils/api-errors";
+import type { ContactPayload } from "@/domains/contacts/types";
+import * as rqGen from "@/generated/daemon/@tanstack/react-query.gen";
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+// ---------------------------------------------------------------------------
+// Module-level holders
+// ---------------------------------------------------------------------------
+
+let toastErrorCalls: string[] = [];
+let upsertShouldReject = false;
+const unhandledRejections: unknown[] = [];
+
+const GUARDIAN = {
+  id: "c-guardian",
+  role: "guardian",
+  displayName: "Ada Lovelace",
+  notes: "",
+  channels: [],
+  interactionCount: 0,
+  contactType: null,
+} as unknown as ContactPayload;
+
+const CONTACTS_KEY = ["contactsGet", "test"] as const;
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    success: () => {},
+    error: (message: string) => {
+      toastErrorCalls.push(message);
+    },
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+mock.module("@/domains/contacts/contacts-gateway", () => ({
+  upsertContact: async () => {
+    if (upsertShouldReject) {
+      throw new ApiError(404, "Not found");
+    }
+    return GUARDIAN;
+  },
+  deleteContact: async () => {},
+  verifyContactChannel: async () => {},
+  redeemA2AInvite: async () => ({ success: true }),
+}));
+
+// Resolve every query the page renders synchronously to a fixture so the
+// guardian auto-selects and no real network is attempted. Real mutation
+// hooks (merge / channel-patch) are kept — they aren't fired here.
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  ...rqGen,
+  contactsGetOptions: () => ({
+    queryKey: CONTACTS_KEY,
+    queryFn: async () => ({ contacts: [GUARDIAN] }),
+  }),
+  contactsGetQueryKey: () => CONTACTS_KEY,
+  contactsGetSetQueryData: () => {},
+  channelsReadinessGetOptions: () => ({
+    queryKey: ["channelsReadiness", "test"],
+    queryFn: async () => ({ snapshots: [] }),
+  }),
+  channelsReadinessGetQueryKey: () => ["channelsReadiness", "test"],
+  channelsAvailableGetOptions: () => ({
+    queryKey: ["channelsAvailable", "test"],
+  }),
+  integrationsSlackChannelConfigGetOptions: () => ({
+    queryKey: ["slackConfig", "test"],
+    queryFn: async () => ({ threadMode: "single" }),
+  }),
+  integrationsSlackChannelConfigGetQueryKey: () => ["slackConfig", "test"],
+}));
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  channelsAvailableGet: async () => ({
+    data: undefined,
+    error: undefined,
+    response: { ok: false, status: 404 },
+  }),
+}));
+
+const { ContactsPage } = await import("@/domains/contacts/contacts-page");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function getInputByPlaceholder(placeholder: string): HTMLInputElement {
+  const input = Array.from(
+    document.querySelectorAll<HTMLInputElement>("input"),
+  ).find((el) => el.placeholder === placeholder);
+  if (!input) {
+    throw new Error(`expected an input with placeholder "${placeholder}"`);
+  }
+  return input;
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.trim() === label);
+  if (!match) {
+    throw new Error(`expected a "${label}" button`);
+  }
+  return match;
+}
+
+function onUnhandled(reason: unknown) {
+  unhandledRejections.push(reason);
+}
+
+beforeEach(() => {
+  toastErrorCalls = [];
+  upsertShouldReject = false;
+  unhandledRejections.length = 0;
+  process.on("unhandledRejection", onUnhandled);
+});
+
+afterEach(() => {
+  process.off("unhandledRejection", onUnhandled);
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ContactsPage mutation error handling", () => {
+  test("a failed contact save surfaces a toast and does not reject", async () => {
+    upsertShouldReject = true;
+
+    render(
+      <Wrapper>
+        <ContactsPage assistantId="asst-1" />
+      </Wrapper>,
+    );
+
+    // The guardian auto-selects, rendering its editable Name field.
+    const nameInput = await waitFor(() => getInputByPlaceholder("Your name"));
+
+    // Dirty the form so Save enables, then submit.
+    fireEvent.change(nameInput, { target: { value: "Ada L." } });
+    fireEvent.click(getButton("Save"));
+
+    // The gateway 404 is surfaced to the user as a toast carrying the
+    // server message...
+    await waitFor(() => {
+      expect(toastErrorCalls).toEqual(["Not found"]);
+    });
+
+    // ...and the rejection never escaped to window.onunhandledrejection
+    // (the Sentry crash symptom). `.mutate()` keeps it internal.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(unhandledRejections).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -115,6 +115,23 @@ const READINESS_REFETCH_MS = 15000;
 
 const EMPTY_CHANNELS: ChannelInfo[] = [];
 
+/**
+ * Build a React Query `onError` handler that surfaces a failed contact
+ * mutation as a toast, preferring the server-provided message (carried on
+ * `ApiError.message`) and falling back to an action label.
+ *
+ * Pairing this with `.mutate()` — rather than awaiting `.mutateAsync()` at
+ * the call site — is what keeps a failed gateway call (e.g. a 404 from
+ * `upsertContact`/`deleteContact`) from escalating to an unhandled promise
+ * rejection: `.mutate()` never returns a rejecting promise, and the error is
+ * reported here instead.
+ */
+function toastContactError(fallback: string) {
+  return (err: unknown) => {
+    toast.error(err instanceof Error ? err.message : fallback);
+  };
+}
+
 export interface ContactsPageProps {
   assistantId: string;
   onStartSetupConversation?: (prompt: string) => void;
@@ -270,6 +287,7 @@ export function ContactsPage({
       );
       setSelection({ kind: "contact", contactId: contact.id });
     },
+    onError: toastContactError("Failed to create contact"),
     onSettled: () => invalidateContacts(),
   });
 
@@ -287,6 +305,7 @@ export function ContactsPage({
       );
       setSelection({ kind: "assistant" });
     },
+    onError: toastContactError("Failed to delete contact"),
     onSettled: () => invalidateContacts(),
   });
 
@@ -315,6 +334,7 @@ export function ContactsPage({
           : undefined,
       );
     },
+    onError: toastContactError("Failed to save contact"),
     onSettled: () => invalidateContacts(),
   });
 
@@ -528,11 +548,7 @@ export function ContactsPage({
     mutationFn: (args: { channelId: string }) =>
       verifyContactChannel(assistantId, args.channelId),
     onSuccess: () => invalidateContacts(),
-    onError: (err) => {
-      const message =
-        err instanceof Error ? err.message : "Failed to verify channel";
-      toast.error(message);
-    },
+    onError: toastContactError("Failed to verify channel"),
   });
 
   const handleVerifyChannel = useCallback(
@@ -651,8 +667,8 @@ export function ContactsPage({
               canMerge={canMerge}
               availableChannels={availableChannels}
               a2aEnabled={a2aChannel}
-              onSave={async (patch) => {
-                await updateMutation.mutateAsync({
+              onSave={(patch) => {
+                updateMutation.mutate({
                   contactId: optimisticContact.id,
                   patch,
                 });
@@ -675,14 +691,14 @@ export function ContactsPage({
               canMerge={canMerge}
               availableChannels={availableChannels}
               a2aEnabled={a2aChannel}
-              onSave={async (patch) => {
-                await updateMutation.mutateAsync({
+              onSave={(patch) => {
+                updateMutation.mutate({
                   contactId: optimisticContact.id,
                   patch,
                 });
               }}
-              onDelete={async () => {
-                await deleteMutation.mutateAsync(optimisticContact.id);
+              onDelete={() => {
+                deleteMutation.mutate(optimisticContact.id);
               }}
               onMerge={handleOpenMerge}
               onSetupChannel={


### PR DESCRIPTION
## Summary

Fixes the Sentry crash **`VELLUM-ASSISTANT-MACOS-1QV`** — `ApiError: Not found`, reported via `onunhandledrejection` (`handled: no`) on `app://vellum.ai/assistant/contacts`.

### Root cause
The culprit frame `contacts-gateway-…js` de-minifies to `clients/web/src/domains/contacts/contacts-gateway.ts`, which throws `ApiError` on any non-OK response. In `contacts-page.tsx` the **contact create/update/delete mutations had no `onError` handler**, and update/delete were invoked with **`mutateAsync` fired-and-forgotten** from the detail-view Save/Delete buttons:

- `ContactDetailView`: `onClick={() => onSave(...)}`, `void onDelete()`, and `ConfirmDialog.onConfirm` (`onConfirm` is `() => void`, so the returned promise is dropped).
- `GuardianDetailView`: `onClick={() => onSave(...)}`.

`mutateAsync` returns a promise that **rejects** on failure. With no catch at the call site *and* no `onError`, a 404 from `upsertContact` (update-with-`id`) or `deleteContact` became an **unhandled promise rejection** → `window.onunhandledrejection` → Sentry crash. It also meant these failures were swallowed silently. (`verifyChannelMutation` in the same file already did this correctly — `.mutate()` + an `onError` toast.)

The 404 itself is a legitimate response: PR #35565 made the **gateway DB the source of truth** for contacts (assistant DB is a best-effort mirror), so a row present in the mirror but absent from the gateway returns `Not found`. The client should degrade gracefully regardless — this PR makes it do so.

### Change
- Add `onError` toasts to `createMutation` / `updateMutation` / `deleteMutation`, and route all four contact mutations (incl. the existing `verifyChannelMutation`) through one small `toastContactError(fallback)` helper (prefers the server message, falls back to an action label).
- Switch the fire-and-forget call sites from `mutateAsync`/`await` to **`.mutate()`** — which never returns a rejecting promise — eliminating the unhandled rejection at the root and surfacing failures to the user.
- Drop the now-inaccurate `Promise<void>` shape on the detail-view `onSave`/`onDelete` props for `() => void` (they were already invoked fire-and-forget). Both components are imported only by `contacts-page.tsx`, so the type change has no other consumers.

### Test
`contacts-page.test.tsx` drives the **real** `ContactsPage` (real `@tanstack/react-query`) so a gateway 404 exercises the actual mutation wiring, asserting the failure (a) surfaces as a toast and (b) never escapes as an unhandled rejection. Verified it **fails on the pre-fix code** (the uncaught `mutateAsync` rejection at `contacts-page.tsx:655`) and passes after. `tsc --noEmit` and `eslint` are clean.

### Related work (no conflict)
- **#35565** (merged) — introduced the contacts gateway module + gateway-as-source-of-truth model that produces these 404s.
- **#35630** (open) — *server-side only* (`gateway/src/http/routes/contact-prompt.ts`); doesn't touch the web client. This client fix is complementary: it tolerates exactly the transient drift that work eliminates.

### Risk
Low. Happy path is unchanged; on failure the only change is "silent failure / crash" → "error toast." No new consumers of the changed prop types. We deliberately do **not** also `captureError()` these (like `verifyChannelMutation` and the channel-credential forms, they're expected, user-actionable, retryable) — server-side visibility is better served by the gateway-first work above.

### Alternatives considered
- *Keep `mutateAsync` + `try/catch` at each call site* — correct but leaves the footgun; `.mutate()` + `onError` is the idiomatic TanStack pattern and removes it.
- *Global `unhandledrejection` swallow / Sentry `ignoreErrors`* — rejected; hides real regressions (`sentry-init.ts` explicitly forbids filters matching `src/`).
- *Make `deleteContact` treat 404 as success (idempotent DELETE)* — out of scope; would mask the server-side drift under active repair.
- *Fix the same bug class in `notifications-page.tsx`* — real, but a separate surface; better as a follow-up.

Fixes VELLUM-ASSISTANT-MACOS-1QV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjKGwJVMiZ53G5nyg5gUdF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjKGwJVMiZ53G5nyg5gUdF)_