### PR TITLE
Add Together AI as a managed provider hosting MiniMax M3

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13293,8 +13293,8 @@ paths:
           schema:
             type: string
           description:
-            "Filter by provider. One of: anthropic, openai, gemini, ollama, fireworks, openrouter, openai-compatible,
-            minimax, atlascloud"
+            "Filter by provider. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
+            openai-compatible, minimax, atlascloud"
       responses:
         "200":
           description: Successful response
@@ -29012,6 +29012,7 @@ components:
         - openai-compatible
         - minimax
         - atlascloud
+        - together
     ProfilePatchEntry:
       type: object
       properties:
@@ -29388,6 +29389,7 @@ components:
         - gemini
         - ollama
         - fireworks
+        - together
         - openrouter
         - openai-compatible
         - minimax

--- a/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
@@ -212,6 +212,7 @@ const MANAGED_FALLBACK_PROVIDERS: string[] = [
   "gemini",
   "openai",
   "fireworks",
+  "together",
 ];
 
 function enableManagedProxy() {
@@ -335,18 +336,25 @@ describe("managed proxy integration — credential precedence", () => {
       },
     );
 
-    test("managed bootstrap registers anthropic, openai, gemini, and fireworks", async () => {
+    test("managed bootstrap registers anthropic, openai, gemini, fireworks, and together", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
       await initializeProviders(makeProvidersConfig("anthropic", "test-model"));
       expect(listProviders()).toEqual(
-        expect.arrayContaining(["anthropic", "openai", "gemini", "fireworks"]),
+        expect.arrayContaining([
+          "anthropic",
+          "openai",
+          "gemini",
+          "fireworks",
+          "together",
+        ]),
       );
-      expect(listProviders()).toHaveLength(4);
+      expect(listProviders()).toHaveLength(5);
       expect(getProviderRoutingSource("anthropic")).toBe("managed-proxy");
       expect(getProviderRoutingSource("openai")).toBe("managed-proxy");
       expect(getProviderRoutingSource("gemini")).toBe("managed-proxy");
       expect(getProviderRoutingSource("fireworks")).toBe("managed-proxy");
+      expect(getProviderRoutingSource("together")).toBe("managed-proxy");
       expect(getProviderRoutingSource("openrouter")).toBeUndefined();
     });
 
@@ -681,8 +689,14 @@ describe("config mode flip → provider reinit", () => {
 });
 
 describe("managed proxy integration — constants integrity", () => {
-  test("anthropic, openai, gemini, and fireworks have metadata with managed=true and a proxyPath", () => {
-    for (const provider of ["anthropic", "openai", "gemini", "fireworks"]) {
+  test("anthropic, openai, gemini, fireworks, and together have metadata with managed=true and a proxyPath", () => {
+    for (const provider of [
+      "anthropic",
+      "openai",
+      "gemini",
+      "fireworks",
+      "together",
+    ]) {
       const meta = PLATFORM_PROVIDER_META[provider];
       expect(meta).toBeDefined();
       expect(meta.managed).toBe(true);
@@ -712,6 +726,12 @@ describe("managed proxy integration — constants integrity", () => {
   test("fireworks routes through fireworks proxy path", () => {
     expect(PLATFORM_PROVIDER_META.fireworks.proxyPath).toBe(
       "/v1/runtime-proxy/fireworks",
+    );
+  });
+
+  test("together routes through together proxy path", () => {
+    expect(PLATFORM_PROVIDER_META.together.proxyPath).toBe(
+      "/v1/runtime-proxy/together",
     );
   });
 

--- a/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
@@ -17,6 +17,7 @@ const MANAGED_PROVIDERS = [
   "openai",
   "gemini",
   "fireworks",
+  "together",
 ] as const;
 
 let platformBaseUrlOverride: string | undefined;

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -24,6 +24,7 @@ export const LLMProvider = z
     "openai-compatible",
     "minimax",
     "atlascloud",
+    "together",
   ])
   .meta({ id: "LLMProvider" });
 type LLMProvider = z.infer<typeof LLMProvider>;

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -29,6 +29,7 @@ import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provid
 import { OpenAIResponsesProvider } from "../openai/responses-provider.js";
 import { OpenRouterProvider } from "../openrouter/client.js";
 import { RetryProvider } from "../retry.js";
+import { TogetherProvider } from "../together/client.js";
 import type { Provider } from "../types.js";
 import { UsageTrackingProvider } from "../usage-tracking.js";
 import type { ResolvedAuth } from "./auth.js";
@@ -117,6 +118,11 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
     new MinimaxProvider(apiKey, model, { streamTimeoutMs }),
   atlascloud: ({ apiKey, model, streamTimeoutMs }) =>
     new AtlasCloudProvider(apiKey, model, { streamTimeoutMs }),
+  together: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
+    new TogetherProvider(apiKey, model, {
+      streamTimeoutMs,
+      ...(baseURL ? { baseURL } : {}),
+    }),
 };
 
 /**

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -346,6 +346,12 @@ const CANONICAL_CONNECTIONS: Array<{
     auth: { type: "platform" },
     label: "Fireworks",
   },
+  {
+    name: "together-managed",
+    provider: "together",
+    auth: { type: "platform" },
+    label: "Together AI",
+  },
 ];
 
 /**
@@ -415,4 +421,3 @@ export function seedCanonicalConnections(db: DrizzleDb): void {
       .run();
   }
 }
-

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -766,6 +766,43 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     apiKeyPlaceholder: "fw_...",
   },
   {
+    id: "together",
+    displayName: "Together AI",
+    subtitle: "Open models served by Together AI. Requires a Together API key.",
+    setupMode: "api-key",
+    setupHint: "Enter your Together API key to enable Together models.",
+    envVar: "TOGETHER_API_KEY",
+    credentialsGuide: {
+      description: "Sign in to the Together dashboard and create an API key.",
+      url: "https://api.together.ai/settings/api-keys",
+      linkLabel: "Open Together Dashboard",
+    },
+    models: [
+      {
+        id: "MiniMaxAI/MiniMax-M3",
+        displayName: "MiniMax M3",
+        // Together serves MiniMax M3 — the managed route that replaces the
+        // Fireworks copy (which mishandles forced tool_choice + object-typed
+        // tool args). ponytail: window/pricing mirror the Fireworks-served
+        // values; set to Together's actual served window + price once known.
+        contextWindowTokens: 524288,
+        maxOutputTokens: 512000,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: true,
+        supportsToolUse: true,
+        maxEffort: "high",
+        pricing: {
+          inputPer1mTokens: 0.3,
+          outputPer1mTokens: 1.2,
+        },
+      },
+    ],
+    defaultModel: "MiniMaxAI/MiniMax-M3",
+    apiKeyUrl: "https://api.together.ai/settings/api-keys",
+    apiKeyPlaceholder: "...",
+  },
+  {
     id: "openrouter",
     displayName: "OpenRouter",
     subtitle: "Route to many LLM providers via a single OpenRouter API key.",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -783,18 +783,18 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         displayName: "MiniMax M3",
         // Together serves MiniMax M3 — the managed route that replaces the
         // Fireworks copy (which mishandles forced tool_choice + object-typed
-        // tool args). ponytail: window/pricing mirror the Fireworks-served
-        // values; set to Together's actual served window + price once known.
+        // tool args). Window + pricing from Together's published rate card.
         contextWindowTokens: 524288,
         maxOutputTokens: 512000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
         maxEffort: "high",
         pricing: {
           inputPer1mTokens: 0.3,
           outputPer1mTokens: 1.2,
+          cacheReadPer1mTokens: 0.06,
         },
       },
     ],

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -781,9 +781,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       {
         id: "MiniMaxAI/MiniMax-M3",
         displayName: "MiniMax M3",
-        // Together serves MiniMax M3 — the managed route that replaces the
-        // Fireworks copy (which mishandles forced tool_choice + object-typed
-        // tool args). Window + pricing from Together's published rate card.
+        // Managed route for MiniMax M3. Together honors forced tool_choice
+        // and serializes object-typed tool args correctly. Window and pricing
+        // are from Together's published rate card.
         contextWindowTokens: 524288,
         maxOutputTokens: 512000,
         supportsThinking: true,

--- a/assistant/src/providers/platform-proxy/constants.ts
+++ b/assistant/src/providers/platform-proxy/constants.ts
@@ -46,6 +46,11 @@ export const PLATFORM_PROVIDER_META: Record<string, ManagedProviderMeta> = {
     managed: true,
     proxyPath: "/v1/runtime-proxy/fireworks",
   },
+  together: {
+    name: "together",
+    managed: true,
+    proxyPath: "/v1/runtime-proxy/together",
+  },
   openrouter: {
     name: "openrouter",
     managed: false,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -44,6 +44,7 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
   "openai",
   "openrouter",
   "fireworks",
+  "together",
 ]);
 
 /**

--- a/assistant/src/providers/together/client.ts
+++ b/assistant/src/providers/together/client.ts
@@ -1,0 +1,38 @@
+import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
+
+export interface TogetherProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+  streamTimeoutMs?: number;
+}
+
+const DEFAULT_TOGETHER_BASE_URL = "https://api.together.ai/v1";
+
+/**
+ * Together AI exposes an OpenAI-compatible endpoint. Used as the managed route
+ * for MiniMax M3, replacing the Fireworks copy whose function-call
+ * serialization collapses object-typed tool args to `{}` and mishandles forced
+ * tool_choice. Together serializes object args correctly, so — unlike
+ * {@link FireworksProvider} — no `coerceObjectArgsToJsonString` workaround is
+ * needed.
+ */
+export class TogetherProvider extends OpenAIChatCompletionsProvider {
+  constructor(
+    apiKey: string,
+    model: string,
+    options: TogetherProviderOptions = {},
+  ) {
+    super(apiKey, model, {
+      baseURL: options.baseURL?.trim() || DEFAULT_TOGETHER_BASE_URL,
+      providerName: "together",
+      providerLabel: "Together AI",
+      streamTimeoutMs: options.streamTimeoutMs,
+      // MiniMax M3 is a reasoning model; Together emits chain-of-thought via
+      // `reasoning_content`, which the base provider parses into thinking
+      // blocks and replays on multi-turn requests. Mirrors the Fireworks route
+      // this replaces.
+      assistantReasoningField: "reasoning_content",
+      maxReasoningEffort: "high",
+    });
+  }
+}

--- a/assistant/src/providers/together/client.ts
+++ b/assistant/src/providers/together/client.ts
@@ -10,11 +10,9 @@ const DEFAULT_TOGETHER_BASE_URL = "https://api.together.ai/v1";
 
 /**
  * Together AI exposes an OpenAI-compatible endpoint. Used as the managed route
- * for MiniMax M3, replacing the Fireworks copy whose function-call
- * serialization collapses object-typed tool args to `{}` and mishandles forced
- * tool_choice. Together serializes object args correctly, so — unlike
- * {@link FireworksProvider} — no `coerceObjectArgsToJsonString` workaround is
- * needed.
+ * for MiniMax M3. Together serializes object-typed tool args correctly, so —
+ * unlike {@link FireworksProvider} — no `coerceObjectArgsToJsonString`
+ * workaround is needed.
  */
 export class TogetherProvider extends OpenAIChatCompletionsProvider {
   constructor(
@@ -29,8 +27,7 @@ export class TogetherProvider extends OpenAIChatCompletionsProvider {
       streamTimeoutMs: options.streamTimeoutMs,
       // MiniMax M3 is a reasoning model; Together emits chain-of-thought via
       // `reasoning_content`, which the base provider parses into thinking
-      // blocks and replays on multi-turn requests. Mirrors the Fireworks route
-      // this replaces.
+      // blocks and replays on multi-turn requests.
       assistantReasoningField: "reasoning_content",
       maxReasoningEffort: "high",
     });

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -28,6 +28,7 @@ export const LLM_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   openrouter: "OPENROUTER_API_KEY",
   minimax: "MINIMAX_API_KEY",
   atlascloud: "ATLASCLOUD_API_KEY",
+  together: "TOGETHER_API_KEY",
 };
 
 /** Search-provider env var names. Mirrors `SEARCH_PROVIDER_CATALOG` BYOK entries. */

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -277,6 +277,16 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
+  together: [
+    {
+      id: "MiniMaxAI/MiniMax-M3",
+      displayName: "MiniMax M3",
+      contextWindowTokens: 524_288,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 512_000,
+      supportsThinking: true,
+    },
+  ],
   openrouter: [
     {
       id: "anthropic/claude-fable-5",
@@ -615,6 +625,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   openai: "gpt-5.5",
   gemini: "gemini-2.5-flash",
   fireworks: "accounts/fireworks/models/kimi-k2p5",
+  together: "MiniMaxAI/MiniMax-M3",
   openrouter: "x-ai/grok-4.20-beta",
   minimax: "MiniMax-M2.7",
   atlascloud: "deepseek-ai/deepseek-v4-pro",
@@ -633,6 +644,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   gemini: "Google Gemini",
   ollama: "Ollama",
   fireworks: "Fireworks",
+  together: "Together AI",
   openrouter: "OpenRouter",
   "openai-compatible": "OpenAI-compatible",
   minimax: "MiniMax",
@@ -652,6 +664,7 @@ export const PROVIDER_SUPPORTS_PLATFORM_AUTH: Record<string, boolean> = {
   gemini: true,
   ollama: false,
   fireworks: true,
+  together: true,
   openrouter: false,
   "openai-compatible": false,
   minimax: false,

--- a/clients/web/src/domains/settings/ai/constants.ts
+++ b/clients/web/src/domains/settings/ai/constants.ts
@@ -11,6 +11,7 @@ export const INFERENCE_PROVIDERS = [
   "anthropic",
   "openai",
   "fireworks",
+  "together",
   "openrouter",
   "gemini",
   "minimax",

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -23,6 +23,7 @@ export const CONNECTION_PROVIDERS: ConnectionProvider[] = [
   "gemini",
   "ollama",
   "fireworks",
+  "together",
   "openrouter",
   "minimax",
   "atlascloud",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -686,6 +686,40 @@
       ]
     },
     {
+      "id": "together",
+      "displayName": "Together AI",
+      "subtitle": "Open models served by Together AI. Requires a Together API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your Together API key to enable Together models.",
+      "envVar": "TOGETHER_API_KEY",
+      "apiKeyPlaceholder": "...",
+      "credentialsGuide": {
+        "description": "Sign in to the Together dashboard and create an API key.",
+        "url": "https://api.together.ai/settings/api-keys",
+        "linkLabel": "Open Together Dashboard"
+      },
+      "supportsPlatformAuth": true,
+      "defaultModel": "MiniMaxAI/MiniMax-M3",
+      "models": [
+        {
+          "id": "MiniMaxAI/MiniMax-M3",
+          "displayName": "MiniMax M3",
+          "contextWindowTokens": 524288,
+          "maxOutputTokens": 512000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 1.2
+          }
+        }
+      ]
+    },
+    {
       "id": "openrouter",
       "displayName": "OpenRouter",
       "subtitle": "Route to many LLM providers via a single OpenRouter API key.",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -709,12 +709,13 @@
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 0.3,
-            "outputPer1mTokens": 1.2
+            "outputPer1mTokens": 1.2,
+            "cacheReadPer1mTokens": 0.06
           }
         }
       ]


### PR DESCRIPTION
## What

Adds **Together AI** as a managed, OpenAI-compatible provider in the LLM catalog, hosting **MiniMax M3** (`MiniMaxAI/MiniMax-M3`). Routes through the platform proxy at `/v1/runtime-proxy/together`.

| File | Change |
|------|--------|
| `assistant/src/providers/model-catalog.ts` | `together` provider + `MiniMaxAI/MiniMax-M3` model |
| `assistant/src/providers/together/client.ts` | **new** — `OpenAIChatCompletionsProvider` subclass (`reasoning_content`; no `coerceObjectArgsToJsonString`, since Together serializes object args correctly) |
| `assistant/src/providers/inference/adapter-factory.ts` | register the `together` factory |
| `assistant/src/providers/platform-proxy/constants.ts` | managed meta + `proxyPath` |
| `cli/src/shared/provider-env-vars.ts` | `TOGETHER_API_KEY` (env-var parity) |
| `meta/llm-provider-catalog.json` | regenerated (`bun run sync:llm-catalog`) |
| `provider-platform-proxy-integration.test.ts` | managed bootstrap now registers 5 providers |

## Why

Fireworks' MiniMax M3 mishandles forced `tool_choice` + free-form object-typed tool args. Together serves the same model correctly (verified with the exact failing payload).

## Scope — additive only

This makes MiniMax M3 **available** via managed Together. It deliberately does **not** flip the default managed **Balanced** profile (currently Fireworks `accounts/fireworks/models/minimax-m3` → `fireworks-managed`) onto Together. That flip is a separate change because it carries a **workspace migration** to repoint existing installs' seeded profiles, plus `config-loader-backfill` / managed-profile test updates. Fireworks MiniMax M3 stays in the catalog for BYO-key users and as rollback.

## Cross-repo

Pairs with `vellum-assistant-platform`:
- TOGETHER_API_KEY secret (Terraform PR #8595)
- runtime-proxy `together` provider + rate card (PR #8596)
- the vendored web catalog (`web/src/lib/generated/`) is refreshed separately from this JSON.

## Checks

- `bunx tsc --noEmit` ✅ · lint ✅ · format ✅ (pre-push hook green)
- `provider-platform-proxy-integration.test.ts` + `llm-catalog-parity.test.ts` ✅ (57)
- CLI `llm-provider-env-var-parity.test.ts` ✅
- `bun test src/providers`: 460 pass / 24 fail — **all 24 fail identically on clean `main`** (local DB-harness, unrelated); this PR adds zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->