### PR TITLE
feat(plugins): add admin-copilot to the plugin marketplace catalog

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -76,6 +76,18 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/advisor",
       "license": "MIT"
+    },
+    {
+      "name": "admin-copilot",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/admin-copilot",
+        "ref": "287276f2dd36608f660851858cea14c85e1785d1"
+      },
+      "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
+      "category": "productivity",
+      "homepage": "https://github.com/vellum-ai/admin-copilot",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
Registers the new **Admin Copilot** plugin in `plugins/marketplace.json` so it surfaces in the assistant plugin overview and installs via `assistant plugins install admin-copilot`.

Following the same pattern as `marketing-expert` / `advisor` / `model-router`, the plugin source lives in its own standalone repo, **[vellum-ai/admin-copilot](https://github.com/vellum-ai/admin-copilot)**, and this PR adds only the SHA-pinned catalog entry. (Earlier revisions of this branch vendored the source under `assistant/examples/plugins/` — that's been removed in favor of the standalone repo.)

## The plugin

A proactive **chief-of-staff** for routine admin work:
- **Morning digest** — calendar + meeting prep, inbox triage summary, competitor deltas, follow-ups.
- **Inbox triage (propose-then-confirm)** — pre-sorts noise and proposes actions; never auto-sends. Delegates to the `inbox-management` trust ladder.
- **Calendar prep** — surfaced in the digest.
- **Weekly competitor brief** — tracks a saved competitor list, reports only what materially changed (content-hash pre-filter + model-judged materiality + week-over-week diff).

It's an orchestration layer over the assistant's existing email/calendar/digest/scheduling capabilities; proactivity is delivered entirely by cron schedules (no per-turn hooks, no watchers, no boot-time LLM work).

## Catalog entry

```json
{
  "name": "admin-copilot",
  "source": { "source": "github", "repo": "vellum-ai/admin-copilot", "ref": "3ea856f99cbfc913cd37a9ddb8882a556393700a" },
  "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
  "category": "productivity",
  "homepage": "https://github.com/vellum-ai/admin-copilot",
  "license": "MIT"
}
```

## Verification

- `plugins/marketplace.json` validates as JSON; `admin-copilot` present.
- Standalone repo builds/type-checks clean (verified before publish); ref pins `main` HEAD.
- **Not yet run:** live `assistant plugins install admin-copilot` against an instance — can smoke-test via the `cli-testing` skill on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)