### PR TITLE
fix(web): stop Radix DismissableLayer ref loop on React 19 (Maximum update depth)

### DIFF
--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -100,7 +100,11 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@radix-ui/react-dismissable-layer@1.1.13": "patches/@radix-ui%2Freact-dismissable-layer@1.1.13.patch",
+  },
   "overrides": {
+    "@radix-ui/react-dismissable-layer": "1.1.13",
     "es-toolkit": "1.46.1",
   },
   "packages": {
@@ -448,7 +452,7 @@
 
     "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="],
 
-    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-escape-keydown": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg=="],
 
     "@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.16", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw=="],
 
@@ -488,7 +492,7 @@
 
     "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
 
-    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.2", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
@@ -1792,6 +1796,14 @@
 
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@radix-ui/react-dismissable-layer/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw=="],
+
     "@radix-ui/react-menu/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
@@ -1800,13 +1812,13 @@
 
     "@radix-ui/react-tooltip/@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
 
-    "@radix-ui/react-tooltip/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ=="],
-
     "@radix-ui/react-tooltip/@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-use-escape-keydown/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -1925,6 +1937,8 @@
     "@hey-api/shared/open/define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "@hey-api/shared/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.30.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -122,6 +122,10 @@
     "vite": "8.0.11"
   },
   "overrides": {
-    "es-toolkit": "1.46.1"
+    "es-toolkit": "1.46.1",
+    "@radix-ui/react-dismissable-layer": "1.1.13"
+  },
+  "patchedDependencies": {
+    "@radix-ui/react-dismissable-layer@1.1.13": "patches/@radix-ui%2Freact-dismissable-layer@1.1.13.patch"
   }
 }

--- a/clients/web/patches/@radix-ui%2Freact-dismissable-layer@1.1.13.patch
+++ b/clients/web/patches/@radix-ui%2Freact-dismissable-layer@1.1.13.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.js b/dist/index.js
+index 2611540cc52bf7c234f485e9f15dfe946264589e..2725720cd4d7bc76b72df9daaa64ace580bd893a 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -79,7 +79,7 @@ var DismissableLayer = React.forwardRef(
+     const [node, setNode] = React.useState(null);
+     const ownerDocument = node?.ownerDocument ?? globalThis?.document;
+     const [, force] = React.useState({});
+-    const composedRefs = (0, import_react_compose_refs.useComposedRefs)(forwardedRef, (node2) => setNode(node2));
++    const composedRefs = (0, import_react_compose_refs.useComposedRefs)(forwardedRef, setNode);
+     const layers = Array.from(context.layers);
+     const [highestLayerWithOutsidePointerEventsDisabled] = [...context.layersWithOutsidePointerEventsDisabled].slice(-1);
+     const highestLayerWithOutsidePointerEventsDisabledIndex = layers.indexOf(highestLayerWithOutsidePointerEventsDisabled);
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 9d19cc7984803f74cbc01de8edd80622d21a5314..e94d661d129e47de73274edfa4d83233496b43cf 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -40,7 +40,7 @@ var DismissableLayer = React.forwardRef(
+     const [node, setNode] = React.useState(null);
+     const ownerDocument = node?.ownerDocument ?? globalThis?.document;
+     const [, force] = React.useState({});
+-    const composedRefs = useComposedRefs(forwardedRef, (node2) => setNode(node2));
++    const composedRefs = useComposedRefs(forwardedRef, setNode);
+     const layers = Array.from(context.layers);
+     const [highestLayerWithOutsidePointerEventsDisabled] = [...context.layersWithOutsidePointerEventsDisabled].slice(-1);
+     const highestLayerWithOutsidePointerEventsDisabledIndex = layers.indexOf(highestLayerWithOutsidePointerEventsDisabled);

--- a/clients/web/src/__tests__/radix-dismissable-ref-loop.test.tsx
+++ b/clients/web/src/__tests__/radix-dismissable-ref-loop.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Guard for the Radix x React 19 "Maximum update depth exceeded" fix
+ * (VELLUM-ASSISTANT-WEB-5C / -MACOS-1QW).
+ *
+ * Radix `DismissableLayer` (mounted by open Tooltip/Popover/Dropdown/Dialog
+ * content) passed an unstable inline ref `(node) => setNode(node)` to
+ * `useComposedRefs`. Under React 19's ref-cleanup semantics the ever-changing
+ * ref identity makes React detach (ref(null) -> setNode(null)) and re-attach
+ * (ref(node) -> setNode(node)) on every commit; while the subtree re-renders
+ * rapidly (SSE streaming) that thrash blows past React's 50-update limit.
+ *
+ * Fix: `patches/@radix-ui%2Freact-dismissable-layer@1.1.13.patch` passes the
+ * stable `setNode` setter directly so the composed ref identity is stable.
+ *
+ * The runtime loop is commit-phase/timing-sensitive and does NOT reproduce
+ * under happy-dom (it needs a real browser; this repo otherwise tests Radix via
+ * static markup). So rather than a flaky/non-discriminating runtime test, this
+ * guard asserts the shipped dependency source actually carries the fix — it
+ * fails loudly if a Radix version bump or a dropped `overrides`/patch entry
+ * silently reverts us to the looping inline ref. Remove this guard (and the
+ * patch) once upstream ships the fix in `@radix-ui/react-dismissable-layer`
+ * (track: https://github.com/radix-ui/primitives/issues/3799).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// The package `exports` map doesn't expose explicit `/dist/*` subpaths, so
+// resolve the package root (allowed) and derive the dist dir from it.
+const distDir = dirname(
+  Bun.resolveSync("@radix-ui/react-dismissable-layer", import.meta.dir),
+);
+
+function readDismissableLayer(entry: "index.mjs" | "index.js"): string {
+  return readFileSync(join(distDir, entry), "utf8");
+}
+
+describe("Radix DismissableLayer ref stabilization (React 19 fix)", () => {
+  for (const entry of ["index.mjs", "index.js"] as const) {
+    test(`${entry}: composed ref uses the stable setNode setter, not a per-render arrow`, () => {
+      const src = readDismissableLayer(entry);
+      // The looping pattern must be gone...
+      expect(src).not.toContain("(node2) => setNode(node2)");
+      // ...and replaced by the stable setter passed directly (the call is
+      // formatted differently in the ESM vs CJS builds, so match the args).
+      expect(src).toContain("(forwardedRef, setNode)");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the production **"Maximum update depth exceeded"** crash on the conversation route, reported on two channels of the same frontend:
- [`VELLUM-ASSISTANT-WEB-5C`](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-WEB-5C) (web)
- [`VELLUM-ASSISTANT-MACOS-1QW`](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-MACOS-1QW) (macOS Electron, which embeds the web build)

Same root cause — the web issue's non-minified stack resolves the macOS issue's minified `cn`/`Array.map` frames.

Tracking the eventual removal of this stopgap: **LUM-2541**.

## Root cause

Radix `DismissableLayer` (the layer behind Tooltip/Popover/Dropdown/Dialog/Menu content) passes an **unstable inline callback ref** to `useComposedRefs`:

```js
const [node, setNode] = React.useState(null);
const composedRefs = useComposedRefs(forwardedRef, (node) => setNode(node)); // new identity every render
```

The inline arrow is a new function each render, so the composed ref's identity changes every render. Under **React 19's ref-cleanup semantics**, a callback ref whose identity changes is detached (called with `null` → `setNode(null)`) and re-attached (`setNode(node)`) on **every commit**. While the chat transcript re-renders rapidly during **SSE streaming**, that `setNode` thrash exceeds React's 50-nested-update limit → #185, caught at the `RouterProvider` error boundary (the user sees the route's "Something went wrong / Reload" screen mid-stream).

The crash trace lands squarely in Radix internals:

```
commitLayoutEffectOnFiber → safelyAttachRef → ref(instanceToUse)
  → @radix-ui/react-compose-refs  refs.map(ref => …)
  → @radix-ui/react-tooltip/.../react-dismissable-layer:36
        useComposedRefs(forwardedRef, (node2) => setNode(node2))
  → dispatchSetStateInternal → Error(185)
```

Known upstream as [radix-ui/primitives#3963](https://github.com/radix-ui/primitives/issues/3963) / [#3799](https://github.com/radix-ui/primitives/issues/3799).

## Why not just upgrade Radix or React?

Both verified **not** to fix it:
- **Latest Radix** `@radix-ui/react-dismissable-layer@1.1.13` (and unified `radix-ui@1.6.0`, which just depends on it) still ship the inline ref.
- **`react`/`react-dom@19.2.7`** (latest) is **byte-identical** to our `19.2.6` except version strings.

## Upstream is fixed — but unreleased

The fix is already merged upstream in [radix-ui/primitives#3967](https://github.com/radix-ui/primitives/pull/3967) (closes #3963, merged 2026-06-15), using exactly the approach here (pass the setter directly). **But it merged without a changeset** ("will not cause a version bump"), so it is **not published to npm** and there's no fixed version to bump to, with no firm ETA. So we apply that same one-line fix **early, as a bridge**, and remove it when Radix publishes (tracked in **LUM-2541**).

## The change (4 files)

- `overrides` dedupes `@radix-ui/react-dismissable-layer` → a single `1.1.13`, so **one** patch covers every overlay.
- `bun patch` applies the one-line fix to both the ESM and CJS builds (`patches/@radix-ui%2Freact-dismissable-layer@1.1.13.patch`):

```diff
-    const composedRefs = useComposedRefs(forwardedRef, (node2) => setNode(node2));
+    const composedRefs = useComposedRefs(forwardedRef, setNode);
```

`setNode` (a `useState` setter) is referentially stable → stable composed-ref identity → React stops re-attaching every render. Runtime behavior is identical (`setNode(node)` on attach, `setNode(null)` on real unmount).
- Guard test (`src/__tests__/radix-dismissable-ref-loop.test.tsx`) asserts the shipped dependency source carries the fix, so it **fails loudly** if a version bump or a dropped `overrides`/patch entry silently reverts us.

## Verification

- ✅ Patch applies on a clean install (`rm -rf` + `bun install` → both builds show `setNode`).
- ✅ Guard test verified **red → green** (fails when the patch is reverted, passes when applied).
- ⚠️ The runtime loop is commit-phase/timing-sensitive and does **not** reproduce under happy-dom (this repo otherwise tests Radix via static markup, which has no commit phase). Final live confirmation = hover a Radix tooltip during a streaming turn on a preview build — not runnable in CI here.

## Removing this later (LUM-2541)

When upstream publishes a fixed `@radix-ui/react-dismissable-layer` (> 1.1.13 with the stabilized ref): bump the dep, drop the `overrides` + `patchedDependencies` + patch file, and delete the guard test. The guard test flags if the patch silently stops applying before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uEzEXPeXov63EGyqg5mgH