### PR TITLE
fix(gateway): guardian-channel-create finds the guardian in the gateway DB

### DIFF
--- a/gateway/src/__tests__/guardian-channel-create.test.ts
+++ b/gateway/src/__tests__/guardian-channel-create.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for findGuardian — the guardian lookup behind
+ * POST /v1/contacts/guardian/channel. The lookup now resolves from the
+ * gateway DB (source of truth for ACL identity), so these seed the gateway
+ * contacts table directly rather than mocking the assistant DB proxy.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "./test-preload.js";
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+import { findGuardian } from "../http/routes/guardian-channel-create.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedContact(opts: {
+  id: string;
+  role: string;
+  principalId: string | null;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: `name-${opts.id}`,
+      role: opts.role,
+      principalId: opts.principalId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+describe("findGuardian", () => {
+  test("returns the guardian seeded in the gateway DB", async () => {
+    seedContact({ id: "g-1", role: "guardian", principalId: "prin-owner" });
+
+    const guardian = await findGuardian();
+    expect(guardian).not.toBeNull();
+    expect(guardian?.id).toBe("g-1");
+    expect(guardian?.principal_id).toBe("prin-owner");
+  });
+
+  test("returns null when no guardian exists", async () => {
+    seedContact({ id: "c-1", role: "contact", principalId: "prin-c" });
+
+    expect(await findGuardian()).toBeNull();
+  });
+
+  test("returns null when the guardian has no principal_id", async () => {
+    seedContact({ id: "g-1", role: "guardian", principalId: null });
+
+    expect(await findGuardian()).toBeNull();
+  });
+});

--- a/gateway/src/http/routes/guardian-channel-create.test.ts
+++ b/gateway/src/http/routes/guardian-channel-create.test.ts
@@ -1,4 +1,14 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "../../__tests__/test-preload.js";
 
 // --- Mocks ----------------------------------------------------------------
 
@@ -30,6 +40,10 @@ mock.module("../../auth/guardian-bootstrap.js", () => ({
 const { createGuardianChannelHandler } = await import(
   "./guardian-channel-create.js"
 );
+const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
+  "../../db/connection.js"
+);
+const { contacts, contactChannels } = await import("../../db/schema.js");
 
 // --- Helpers ---------------------------------------------------------------
 
@@ -41,17 +55,40 @@ function postRequest(body: unknown): Request {
   });
 }
 
+// Seed a guardian contact in the gateway DB so findGuardian() resolves it.
+function seedGuardian(principalId: string | null): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: "guardian-1",
+      displayName: "guardian",
+      role: "guardian",
+      principalId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
 // --- Tests -----------------------------------------------------------------
 
 describe("POST /v1/contacts/guardian/channel", () => {
+  beforeAll(async () => {
+    await initGatewayDb();
+  });
+
+  afterAll(() => {
+    resetGatewayDb();
+  });
+
   beforeEach(() => {
+    const db = getGatewayDb();
+    db.delete(contactChannels).run();
+    db.delete(contacts).run();
+
     assistantDbQueryMock.mockReset();
     createGuardianBindingMock.mockReset();
-
-    // Default: guardian exists
-    assistantDbQueryMock.mockResolvedValue([
-      { id: "guardian-1", principal_id: "principal-1" },
-    ]);
 
     createGuardianBindingMock.mockResolvedValue({
       contactId: "contact-1",
@@ -62,6 +99,8 @@ describe("POST /v1/contacts/guardian/channel", () => {
   });
 
   it("creates a guardian channel binding and returns 200", async () => {
+    seedGuardian("principal-1");
+
     const handler = createGuardianChannelHandler();
     const res = await handler(
       postRequest({
@@ -93,7 +132,7 @@ describe("POST /v1/contacts/guardian/channel", () => {
   });
 
   it("returns 404 when no guardian contact exists", async () => {
-    assistantDbQueryMock.mockResolvedValue([]);
+    // Empty gateway DB — no guardian row seeded.
 
     const handler = createGuardianChannelHandler();
     const res = await handler(
@@ -112,9 +151,7 @@ describe("POST /v1/contacts/guardian/channel", () => {
   });
 
   it("returns 404 when guardian has no principal_id", async () => {
-    assistantDbQueryMock.mockResolvedValue([
-      { id: "guardian-1", principal_id: null },
-    ]);
+    seedGuardian(null);
 
     const handler = createGuardianChannelHandler();
     const res = await handler(
@@ -177,9 +214,8 @@ describe("POST /v1/contacts/guardian/channel", () => {
   });
 
   it("returns 500 when createGuardianBinding throws", async () => {
-    createGuardianBindingMock.mockRejectedValue(
-      new Error("DB write failed"),
-    );
+    seedGuardian("principal-1");
+    createGuardianBindingMock.mockRejectedValue(new Error("DB write failed"));
 
     const handler = createGuardianChannelHandler();
     const res = await handler(

--- a/gateway/src/http/routes/guardian-channel-create.ts
+++ b/gateway/src/http/routes/guardian-channel-create.ts
@@ -11,7 +11,7 @@
  * proxy-signed request before the handler runs.
  */
 
-import { eq } from "drizzle-orm";
+import { and, asc, eq, isNotNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
@@ -54,7 +54,12 @@ export async function findGuardian(): Promise<
     getGatewayDb()
       .select({ id: gwContacts.id, principalId: gwContacts.principalId })
       .from(gwContacts)
-      .where(eq(gwContacts.role, "guardian"))
+      // Skip principal-less guardian stubs (e.g. created by the gateway-first
+      // contact-prompt path before bootstrap); pick the oldest real guardian.
+      .where(
+        and(eq(gwContacts.role, "guardian"), isNotNull(gwContacts.principalId)),
+      )
+      .orderBy(asc(gwContacts.createdAt))
       .limit(1)
       .get() ?? null;
 

--- a/gateway/src/http/routes/guardian-channel-create.ts
+++ b/gateway/src/http/routes/guardian-channel-create.ts
@@ -11,10 +11,12 @@
  * proxy-signed request before the handler runs.
  */
 
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
-import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
+import { getGatewayDb } from "../../db/connection.js";
+import { contacts as gwContacts } from "../../db/schema.js";
 import { getLogger } from "../../logger.js";
 import { canonicalizeInboundIdentity } from "../../verification/identity.js";
 
@@ -41,19 +43,23 @@ interface GuardianRow {
 }
 
 /**
- * Find the existing guardian contact (any channel). Returns null if no
- * guardian has been verified yet or if the guardian has no principal_id.
+ * Find the existing guardian contact (any channel) in the gateway DB. Returns
+ * null if no guardian has been verified yet or if the guardian has no
+ * principal_id.
  */
-async function findGuardian(): Promise<
+export async function findGuardian(): Promise<
   (GuardianRow & { principal_id: string }) | null
 > {
-  const rows = await assistantDbQuery<GuardianRow>(
-    `SELECT id, principal_id FROM contacts WHERE role = 'guardian' LIMIT 1`,
-  );
+  const row =
+    getGatewayDb()
+      .select({ id: gwContacts.id, principalId: gwContacts.principalId })
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .limit(1)
+      .get() ?? null;
 
-  const row = rows[0] ?? null;
-  if (!row?.principal_id) return null;
-  return row as GuardianRow & { principal_id: string };
+  if (!row?.principalId) return null;
+  return { id: row.id, principal_id: row.principalId };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Repoint guardian-channel-create findGuardian from the assistant DB to the gateway DB.

Part of plan: gateway-reads-own-acl.md (PR 3 of 5)