### PR TITLE
fix(gateway): inbound-register finds the guardian in the gateway DB

### DIFF
--- a/gateway/src/__tests__/inbound-register.test.ts
+++ b/gateway/src/__tests__/inbound-register.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for inbound-register's guardian lookup, which now reads from the
+ * gateway DB (source of truth for ACL identity) rather than the assistant DB.
+ * The gateway DB is a real (file-backed) DB seeded per test; mirrors the
+ * pattern in contact-rich-read.test.ts.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "./test-preload.js";
+
+import { findGuardian } from "../http/routes/inbound-register.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts } from "../db/schema.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  getGatewayDb().delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedContact(opts: {
+  id: string;
+  role: string;
+  principalId: string | null;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: `name-${opts.id}`,
+      role: opts.role,
+      principalId: opts.principalId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+describe("findGuardian", () => {
+  test("finds a guardian seeded in the gateway DB", async () => {
+    seedContact({ id: "g-1", role: "guardian", principalId: "principal-1" });
+
+    const guardian = await findGuardian();
+    expect(guardian).toEqual({ id: "g-1", principal_id: "principal-1" });
+  });
+
+  test("returns null when no guardian exists", async () => {
+    seedContact({ id: "c-1", role: "contact", principalId: "principal-1" });
+
+    expect(await findGuardian()).toBeNull();
+  });
+
+  test("returns null when the guardian has no principal_id", async () => {
+    seedContact({ id: "g-1", role: "guardian", principalId: null });
+
+    expect(await findGuardian()).toBeNull();
+  });
+});

--- a/gateway/src/http/routes/inbound-register.ts
+++ b/gateway/src/http/routes/inbound-register.ts
@@ -13,7 +13,7 @@
  * the assistant and gateway databases (dual-write).
  */
 
-import { eq } from "drizzle-orm";
+import { and, asc, eq, isNotNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
@@ -83,7 +83,12 @@ export async function findGuardian(): Promise<
     getGatewayDb()
       .select({ id: gwContacts.id, principalId: gwContacts.principalId })
       .from(gwContacts)
-      .where(eq(gwContacts.role, "guardian"))
+      // Skip principal-less guardian stubs (e.g. created by the gateway-first
+      // contact-prompt path before bootstrap); pick the oldest real guardian.
+      .where(
+        and(eq(gwContacts.role, "guardian"), isNotNull(gwContacts.principalId)),
+      )
+      .orderBy(asc(gwContacts.createdAt))
       .limit(1)
       .get() ?? null;
 

--- a/gateway/src/http/routes/inbound-register.ts
+++ b/gateway/src/http/routes/inbound-register.ts
@@ -13,10 +13,12 @@
  * the assistant and gateway databases (dual-write).
  */
 
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
-import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
+import { getGatewayDb } from "../../db/connection.js";
+import { contacts as gwContacts } from "../../db/schema.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
@@ -70,17 +72,23 @@ interface GuardianRow {
 }
 
 /**
- * Find the existing guardian contact (any channel). Returns null if no
- * guardian has been verified yet or if the guardian has no principal_id.
+ * Find the existing guardian contact (any channel) from the gateway DB.
+ * Returns null if no guardian has been verified yet or if the guardian has
+ * no principal_id.
  */
-async function findGuardian(): Promise<(GuardianRow & { principal_id: string }) | null> {
-  const rows = await assistantDbQuery<GuardianRow>(
-    `SELECT id, principal_id FROM contacts WHERE role = 'guardian' LIMIT 1`,
-  );
+export async function findGuardian(): Promise<
+  (GuardianRow & { principal_id: string }) | null
+> {
+  const row =
+    getGatewayDb()
+      .select({ id: gwContacts.id, principalId: gwContacts.principalId })
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .limit(1)
+      .get() ?? null;
 
-  const row = rows[0] ?? null;
-  if (!row?.principal_id) return null;
-  return row as GuardianRow & { principal_id: string };
+  if (!row?.principalId) return null;
+  return { id: row.id, principal_id: row.principalId };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Repoint inbound-register findGuardian from the assistant DB to the gateway DB.

Part of plan: gateway-reads-own-acl.md (PR 4 of 5)