### PR TITLE
refactor(notifications): use try/catch for handleAck, not a promise chain

### DIFF
--- a/clients/web/src/domains/settings/pages/notifications-page.tsx
+++ b/clients/web/src/domains/settings/pages/notifications-page.tsx
@@ -44,6 +44,7 @@ import { Menu } from "@vellumai/design-library/components/menu";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Popover } from "@vellumai/design-library/components/popover";
+import { toast } from "@vellumai/design-library/components/toast";
 
 interface SnoozeMenuProps {
   notificationId: string;
@@ -531,24 +532,25 @@ export function NotificationsPage() {
     [queryClient],
   );
 
-  const handleAck = (id: string, acknowledged: boolean) => {
+  const handleAck = async (id: string, acknowledged: boolean) => {
     setAckingIds((prev) => new Set(prev).add(id));
-    // `ackMutation` is a single observer shared by every row, and TanStack
-    // only runs per-`mutate` callbacks for the latest call — so overlapping
-    // acks would leave earlier ids stuck in `ackingIds`. Drive each ack with
-    // its own promise chain instead; the `.catch` keeps a failed request from
-    // escaping as an unhandled rejection.
-    void ackMutation
-      .mutateAsync({ path: { id }, body: { acknowledged } })
-      .then(() => invalidateLists())
-      .catch(toastOnError("Failed to update notification"))
-      .finally(() => {
-        setAckingIds((prev) => {
-          const next = new Set(prev);
-          next.delete(id);
-          return next;
-        });
+    // `ackMutation` is one observer shared by every row, so await this call's
+    // own promise (rather than `.mutate` callbacks, which only fire for the
+    // latest call) to keep overlapping acks from leaving a row stuck.
+    try {
+      await ackMutation.mutateAsync({ path: { id }, body: { acknowledged } });
+      invalidateLists();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update notification",
+      );
+    } finally {
+      setAckingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
       });
+    }
   };
 
   const handleMarkAllRead = async () => {
@@ -766,7 +768,7 @@ export function NotificationsPage() {
             <NotificationCard
               key={notification.id}
               notification={notification}
-              onAck={(id, ack) => handleAck(id, ack)}
+              onAck={(id, ack) => void handleAck(id, ack)}
               isAcking={ackingIds.has(notification.id)}
             />
           ))}


### PR DESCRIPTION
## Summary

Small readability follow-up to #35673. `handleAck` guarded its acknowledge mutation with a `void mutateAsync().then().catch().finally()` chain. This swaps it for the standard `async` `try/catch/finally` — the guarded-`mutateAsync` idiom used everywhere else in the client (the channel-credential forms, the settings cards, etc.).

**Behavior is unchanged.** `ackMutation` is a single observer shared by every row, so the fix still awaits *this call's own promise* (not `.mutate()` callbacks, which only fire for the latest call) — overlapping "Mark as read" clicks each clean up their own `ackingIds` entry, and a failed request surfaces as a toast instead of escaping as an unhandled rejection. The promise chain and the `try/catch` are equivalent here; this is just the conventional, readable form.

Scoped deliberately to this one handler — no per-card refactor, no global error boundary. The existing per-call error-handling convention is already applied consistently everywhere else.

## Tests

The notifications regression tests (merged in #35673) are unchanged and still pass: a failed acknowledge toasts and produces no unhandled rejection, and two overlapping acks each clear their loading state (the latter fails if `handleAck` regresses to per-call `.mutate()` callbacks). `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjKGwJVMiZ53G5nyg5gUdF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjKGwJVMiZ53G5nyg5gUdF)_