### PR TITLE
fix(gateway): pair resolves the local guardian principal from the gateway DB

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -14,8 +14,8 @@ import { initSigningKey } from "../auth/token-service.js";
 
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
-// The assistant DB proxy is no longer on the pair guardian-lookup path, but it
-// is still mocked so any incidental assistant access stays inert in tests.
+// The pair guardian-lookup reads the gateway DB; the assistant DB proxy is
+// mocked so any incidental assistant access stays inert in tests.
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbQuery: mock(),
   assistantDbRun: mock(),

--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -14,18 +14,17 @@ import { initSigningKey } from "../auth/token-service.js";
 
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
-// resolveLocalGuardianPrincipalId() queries the assistant DB; mock it to a
-// stable principal. Device records live in the (real) gateway DB below.
-const mockQuery = mock();
+// The assistant DB proxy is no longer on the pair guardian-lookup path, but it
+// is still mocked so any incidental assistant access stays inert in tests.
 mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: mockQuery,
+  assistantDbQuery: mock(),
   assistantDbRun: mock(),
   assistantDbExec: mock(),
 }));
 
 const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
-const { actorTokenRecords, actorRefreshTokenRecords } =
+const { actorTokenRecords, actorRefreshTokenRecords, contacts, contactChannels } =
   await import("../db/schema.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
 const { handleListDevices, handleRevokeDevice } =
@@ -129,12 +128,41 @@ function activeRefreshCount(device: string): number {
 }
 
 beforeEach(async () => {
-  mockQuery.mockResolvedValue([{ principalId: GUARDIAN_ID }]);
   testRoot = mkdtempSync(join(tmpdir(), "devices-test-"));
   const securityDir = join(testRoot, "protected");
   mkdirSync(securityDir, { recursive: true });
   process.env.GATEWAY_SECURITY_DIR = securityDir;
   await initGatewayDb();
+
+  // resolveLocalGuardianPrincipalId() reads the gateway DB for the vellum
+  // active guardian principal; seed one so device endpoints scope to it.
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: GUARDIAN_ID,
+      displayName: "Guardian",
+      role: "guardian",
+      principalId: GUARDIAN_ID,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: `ch-${GUARDIAN_ID}`,
+      contactId: GUARDIAN_ID,
+      type: "vellum",
+      address: "guardian-vellum",
+      isPrimary: false,
+      status: "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
 });
 
 afterEach(() => {

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -14,19 +14,17 @@ import { initSigningKey } from "../auth/token-service.js";
 // Must init signing key before importing modules that mint tokens.
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
-// pair.ts → resolveLocalGuardianPrincipalId() queries the assistant DB; mock it
-// to return a stable principal. The device-bound token records live in the
-// (real) gateway DB initialized below.
-const mockQuery = mock();
+// The assistant DB proxy is no longer on the pair guardian-lookup path, but it
+// is still mocked so any incidental assistant access stays inert in tests.
 mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: mockQuery,
+  assistantDbQuery: mock(),
   assistantDbRun: mock(),
   assistantDbExec: mock(),
 }));
 
 const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
-const { actorTokenRecords, actorRefreshTokenRecords } =
+const { actorTokenRecords, actorRefreshTokenRecords, contacts, contactChannels } =
   await import("../db/schema.js");
 const { handlePair, resetPairRateLimiterForTests } =
   await import("../http/routes/pair.js");
@@ -62,12 +60,41 @@ function activeTokens() {
 
 beforeEach(async () => {
   resetPairRateLimiterForTests();
-  mockQuery.mockResolvedValue([{ principalId: GUARDIAN_ID }]);
   testRoot = mkdtempSync(join(tmpdir(), "pair-device-test-"));
   const securityDir = join(testRoot, "protected");
   mkdirSync(securityDir, { recursive: true });
   process.env.GATEWAY_SECURITY_DIR = securityDir;
   await initGatewayDb();
+
+  // pair.ts → resolveLocalGuardianPrincipalId() reads the gateway DB for the
+  // vellum active guardian principal; seed one so device-bound mints carry it.
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: GUARDIAN_ID,
+      displayName: "Guardian",
+      role: "guardian",
+      principalId: GUARDIAN_ID,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: `ch-${GUARDIAN_ID}`,
+      contactId: GUARDIAN_ID,
+      type: "vellum",
+      address: "guardian-vellum",
+      isPrimary: false,
+      status: "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
 });
 
 afterEach(() => {

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -14,8 +14,8 @@ import { initSigningKey } from "../auth/token-service.js";
 // Must init signing key before importing modules that mint tokens.
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
-// The assistant DB proxy is no longer on the pair guardian-lookup path, but it
-// is still mocked so any incidental assistant access stays inert in tests.
+// The pair guardian-lookup reads the gateway DB; the assistant DB proxy is
+// mocked so any incidental assistant access stays inert in tests.
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbQuery: mock(),
   assistantDbRun: mock(),

--- a/gateway/src/__tests__/pair.test.ts
+++ b/gateway/src/__tests__/pair.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for resolveLocalGuardianPrincipalId — the pair endpoint's local
+ * guardian principal lookup. The lookup reads the gateway DB directly:
+ * a seeded vellum active guardian resolves its principal; an empty DB (or a
+ * read failure) falls back to "local".
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "./test-preload.js";
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+import { resolveLocalGuardianPrincipalId } from "../http/routes/pair.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedGuardian(opts: {
+  contactId: string;
+  principalId: string | null;
+  channelType?: string;
+  channelStatus?: string;
+  role?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: opts.contactId,
+      displayName: `name-${opts.contactId}`,
+      role: opts.role ?? "guardian",
+      principalId: opts.principalId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: `ch-${opts.contactId}`,
+      contactId: opts.contactId,
+      type: opts.channelType ?? "vellum",
+      address: `addr-${opts.contactId}`,
+      isPrimary: false,
+      status: opts.channelStatus ?? "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+describe("resolveLocalGuardianPrincipalId", () => {
+  test("returns the principal of a vellum active guardian seeded in the gateway DB", async () => {
+    seedGuardian({ contactId: "guardian-1", principalId: "principal-owner" });
+    expect(await resolveLocalGuardianPrincipalId()).toBe("principal-owner");
+  });
+
+  test("falls back to 'local' on an empty gateway DB", async () => {
+    expect(await resolveLocalGuardianPrincipalId()).toBe("local");
+  });
+
+  test("falls back to 'local' when the vellum guardian channel is not active", async () => {
+    seedGuardian({
+      contactId: "guardian-2",
+      principalId: "principal-owner",
+      channelStatus: "unverified",
+    });
+    expect(await resolveLocalGuardianPrincipalId()).toBe("local");
+  });
+
+  test("falls back to 'local' when the active guardian channel is non-vellum", async () => {
+    seedGuardian({
+      contactId: "guardian-3",
+      principalId: "principal-owner",
+      channelType: "slack",
+    });
+    expect(await resolveLocalGuardianPrincipalId()).toBe("local");
+  });
+});

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -27,11 +27,17 @@
  * renew via `/v1/guardian/refresh` instead of re-pairing.
  */
 
+import { and, eq } from "drizzle-orm";
+
 import { mintAndRecordDeviceBoundTokenPair } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken } from "../../auth/token-service.js";
 import { KNOWN_EXTENSION_ORIGINS } from "../../chrome-extension-origins.js";
-import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
+import { getGatewayDb } from "../../db/connection.js";
+import {
+  contacts as gwContacts,
+  contactChannels as gwContactChannels,
+} from "../../db/schema.js";
 import { getLogger } from "../../logger.js";
 import { enforceLoopbackOnly, errorResponse } from "../loopback-guard.js";
 
@@ -102,22 +108,26 @@ export function resetPairRateLimiterForTests(): void {
 // Guardian resolution
 // ---------------------------------------------------------------------------
 
-interface GuardianPrincipalRow {
-  principalId: string | null;
-}
-
 export async function resolveLocalGuardianPrincipalId(): Promise<string> {
   try {
-    const rows = await assistantDbQuery<GuardianPrincipalRow>(
-      `SELECT c.principal_id AS principalId
-       FROM contacts c
-       JOIN contact_channels cc ON cc.contact_id = c.id
-       WHERE c.role = 'guardian' AND cc.type = 'vellum' AND cc.status = 'active'
-       LIMIT 1`,
-      [],
-    );
-    if (rows.length > 0 && rows[0].principalId) {
-      return rows[0].principalId;
+    const row = getGatewayDb()
+      .select({ principalId: gwContacts.principalId })
+      .from(gwContacts)
+      .innerJoin(
+        gwContactChannels,
+        eq(gwContactChannels.contactId, gwContacts.id),
+      )
+      .where(
+        and(
+          eq(gwContacts.role, "guardian"),
+          eq(gwContactChannels.type, "vellum"),
+          eq(gwContactChannels.status, "active"),
+        ),
+      )
+      .limit(1)
+      .get();
+    if (row?.principalId) {
+      return row.principalId;
     }
   } catch (err) {
     log.warn(


### PR DESCRIPTION
## Summary
- Repoint pair.ts resolveLocalGuardianPrincipalId from the assistant DB to the gateway DB; fallback to 'local' preserved.

Part of plan: gateway-reads-own-acl.md (PR 5 of 5)