### PR TITLE
fix(gateway): binding-helpers reads guardian bindings from the gateway DB

### DIFF
--- a/gateway/src/__tests__/binding-helpers.test.ts
+++ b/gateway/src/__tests__/binding-helpers.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the guardian binding-helper lookups, which read the gateway DB
+ * (source of truth for ACL). The gateway DB is a real (file-backed) DB seeded
+ * per test; the assistant DB proxy is mocked and throws on read so the tests
+ * prove the lookups never touch the assistant mirror. revokeExistingChannel
+ * Guardian still writes both the assistant UPDATE and the gateway dual-write.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+
+import "./test-preload.js";
+
+// Assistant DB proxy: reads throw (lookups must not touch it); the revoke
+// UPDATE is captured so we can assert the assistant mirror write still fires.
+const assistantRunCalls: { sql: string; bind?: unknown[] }[] = [];
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(async () => {
+    throw new Error("assistant DB read not expected in binding lookups");
+  }),
+  assistantDbRun: mock(async (sql: string, bind?: unknown[]) => {
+    assistantRunCalls.push({ sql, bind });
+    return { changes: 1, lastInsertRowid: 0 };
+  }),
+  assistantDbExec: mock(async () => undefined),
+}));
+
+import {
+  getExistingGuardianBinding,
+  getMostRecentChannelGuardianTimestamp,
+  resolveCanonicalPrincipal,
+  revokeExistingChannelGuardian,
+} from "../verification/binding-helpers.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  assistantRunCalls.length = 0;
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+let seq = 0;
+
+function seedContact(opts: {
+  id: string;
+  role?: string;
+  principalId?: string | null;
+}): void {
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: `name-${opts.id}`,
+      role: opts.role ?? "contact",
+      principalId: opts.principalId ?? null,
+      createdAt: 100,
+      updatedAt: 100,
+    })
+    .run();
+}
+
+function seedChannel(opts: {
+  id?: string;
+  contactId: string;
+  type: string;
+  address?: string;
+  status: string;
+  createdAt?: number;
+  updatedAt?: number | null;
+}): string {
+  const id = opts.id ?? `ch-${seq++}`;
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id,
+      contactId: opts.contactId,
+      type: opts.type,
+      address: opts.address ?? `addr-${id}`,
+      isPrimary: false,
+      externalChatId: null,
+      status: opts.status,
+      policy: "allow",
+      verifiedAt: null,
+      verifiedVia: null,
+      inviteId: null,
+      revokedReason: null,
+      blockedReason: null,
+      lastSeenAt: null,
+      interactionCount: 0,
+      lastInteraction: null,
+      createdAt: opts.createdAt ?? 100,
+      updatedAt: opts.updatedAt ?? null,
+    })
+    .run();
+  return id;
+}
+
+describe("getExistingGuardianBinding", () => {
+  test("returns the active guardian channel address from the gateway DB", async () => {
+    seedContact({ id: "g1", role: "guardian" });
+    seedChannel({
+      contactId: "g1",
+      type: "slack",
+      address: "U_OWNER",
+      status: "active",
+    });
+
+    expect(await getExistingGuardianBinding("slack")).toEqual({
+      address: "U_OWNER",
+    });
+  });
+
+  test("returns null when no active guardian binding exists", async () => {
+    seedContact({ id: "g1", role: "guardian" });
+    seedChannel({ contactId: "g1", type: "slack", status: "revoked" });
+    // Non-guardian active channel of the same type must not match.
+    seedContact({ id: "c1", role: "contact" });
+    seedChannel({ contactId: "c1", type: "slack", status: "active" });
+
+    expect(await getExistingGuardianBinding("slack")).toBeNull();
+  });
+});
+
+describe("getMostRecentChannelGuardianTimestamp", () => {
+  test("returns the max of active + revoked, excluding unverified", async () => {
+    seedContact({ id: "g1", role: "guardian" });
+    seedChannel({
+      contactId: "g1",
+      type: "phone",
+      status: "active",
+      updatedAt: 1000,
+    });
+    seedChannel({
+      contactId: "g1",
+      type: "phone",
+      status: "revoked",
+      updatedAt: 2000,
+    });
+    // Newer unverified row must be ignored.
+    seedChannel({
+      contactId: "g1",
+      type: "phone",
+      status: "unverified",
+      updatedAt: 9000,
+    });
+
+    expect(await getMostRecentChannelGuardianTimestamp("phone")).toBe(2000);
+  });
+
+  test("falls back to created_at when updated_at is null", async () => {
+    seedContact({ id: "g1", role: "guardian" });
+    seedChannel({
+      contactId: "g1",
+      type: "phone",
+      status: "active",
+      createdAt: 1500,
+      updatedAt: null,
+    });
+
+    expect(await getMostRecentChannelGuardianTimestamp("phone")).toBe(1500);
+  });
+
+  test("returns null when no guardian binding has ever existed", async () => {
+    expect(await getMostRecentChannelGuardianTimestamp("phone")).toBeNull();
+  });
+});
+
+describe("resolveCanonicalPrincipal", () => {
+  test("returns the guardian's principal from the active vellum channel", async () => {
+    seedContact({ id: "g1", role: "guardian", principalId: "principal-owner" });
+    seedChannel({ contactId: "g1", type: "vellum", status: "active" });
+
+    expect(await resolveCanonicalPrincipal("fallback")).toBe("principal-owner");
+  });
+
+  test("falls back when no active vellum guardian exists", async () => {
+    seedContact({ id: "g1", role: "guardian", principalId: "principal-owner" });
+    // Active guardian channel of a different type does not satisfy the lookup.
+    seedChannel({ contactId: "g1", type: "slack", status: "active" });
+
+    expect(await resolveCanonicalPrincipal("fallback")).toBe("fallback");
+  });
+});
+
+describe("revokeExistingChannelGuardian", () => {
+  test("revokes the gateway channel and mirrors the write to the assistant DB", async () => {
+    seedContact({ id: "g1", role: "guardian" });
+    const chId = seedChannel({
+      contactId: "g1",
+      type: "slack",
+      status: "active",
+    });
+
+    await revokeExistingChannelGuardian("slack");
+
+    // Gateway DB status flipped to revoked.
+    const after = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .all()
+      .find((r) => r.id === chId);
+    expect(after?.status).toBe("revoked");
+    expect(after?.policy).toBe("deny");
+
+    // Assistant mirror UPDATE fired with the fetched id.
+    expect(assistantRunCalls.length).toBe(1);
+    expect(assistantRunCalls[0]!.sql).toContain("UPDATE contact_channels");
+    expect(assistantRunCalls[0]!.bind).toContain(chId);
+  });
+
+  test("no-ops (no writes) when no active guardian binding exists", async () => {
+    seedContact({ id: "g1", role: "guardian" });
+    seedChannel({ contactId: "g1", type: "slack", status: "revoked" });
+
+    await revokeExistingChannelGuardian("slack");
+
+    expect(assistantRunCalls.length).toBe(0);
+  });
+});

--- a/gateway/src/verification/binding-helpers.ts
+++ b/gateway/src/verification/binding-helpers.ts
@@ -5,14 +5,18 @@
  * Binding creation uses the existing createGuardianBinding from
  * gateway/src/auth/guardian-bootstrap.ts which already dual-writes.
  *
- * All assistant DB access is via raw SQL (assistantDbQuery/assistantDbRun).
+ * Guardian lookups read the gateway DB (source of truth for ACL). Only the
+ * revoke path's status write mirrors into the assistant DB (best-effort).
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
-import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
+import { assistantDbRun } from "../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../db/connection.js";
-import { contactChannels as gwContactChannels } from "../db/schema.js";
+import {
+  contacts as gwContacts,
+  contactChannels as gwContactChannels,
+} from "../db/schema.js";
 import { getLogger } from "../logger.js";
 
 const log = getLogger("verification-bindings");
@@ -27,15 +31,23 @@ const log = getLogger("verification-bindings");
 export async function getExistingGuardianBinding(
   channel: string,
 ): Promise<{ address: string } | null> {
-  const rows = await assistantDbQuery<{ address: string }>(
-    `SELECT cc.address
-     FROM contacts c
-     JOIN contact_channels cc ON cc.contact_id = c.id
-     WHERE c.role = 'guardian' AND cc.type = ? AND cc.status = 'active'
-     LIMIT 1`,
-    [channel],
-  );
-  return rows[0] ?? null;
+  const row = getGatewayDb()
+    .select({ address: gwContactChannels.address })
+    .from(gwContacts)
+    .innerJoin(
+      gwContactChannels,
+      eq(gwContactChannels.contactId, gwContacts.id),
+    )
+    .where(
+      and(
+        eq(gwContacts.role, "guardian"),
+        eq(gwContactChannels.type, channel),
+        eq(gwContactChannels.status, "active"),
+      ),
+    )
+    .limit(1)
+    .get();
+  return row ? { address: row.address } : null;
 }
 
 /**
@@ -57,16 +69,24 @@ export async function getExistingGuardianBinding(
 export async function getMostRecentChannelGuardianTimestamp(
   channel: string,
 ): Promise<number | null> {
-  const rows = await assistantDbQuery<{ maxUpdatedAt: number | null }>(
-    `SELECT MAX(COALESCE(cc.updated_at, cc.created_at)) AS maxUpdatedAt
-     FROM contacts c
-     JOIN contact_channels cc ON cc.contact_id = c.id
-     WHERE c.role = 'guardian'
-       AND cc.type = ?
-       AND cc.status IN ('active', 'revoked')`,
-    [channel],
-  );
-  return rows[0]?.maxUpdatedAt ?? null;
+  const row = getGatewayDb()
+    .select({
+      maxUpdatedAt: sql<number | null>`MAX(COALESCE(${gwContactChannels.updatedAt}, ${gwContactChannels.createdAt}))`,
+    })
+    .from(gwContacts)
+    .innerJoin(
+      gwContactChannels,
+      eq(gwContactChannels.contactId, gwContacts.id),
+    )
+    .where(
+      and(
+        eq(gwContacts.role, "guardian"),
+        eq(gwContactChannels.type, channel),
+        inArray(gwContactChannels.status, ["active", "revoked"]),
+      ),
+    )
+    .get();
+  return row?.maxUpdatedAt ?? null;
 }
 
 /**
@@ -76,15 +96,23 @@ export async function getMostRecentChannelGuardianTimestamp(
 export async function resolveCanonicalPrincipal(
   fallback: string,
 ): Promise<string> {
-  const rows = await assistantDbQuery<{ principalId: string | null }>(
-    `SELECT c.principal_id AS principalId
-     FROM contacts c
-     JOIN contact_channels cc ON cc.contact_id = c.id
-     WHERE c.role = 'guardian' AND cc.type = 'vellum' AND cc.status = 'active'
-     LIMIT 1`,
-    [],
-  );
-  return rows[0]?.principalId ?? fallback;
+  const row = getGatewayDb()
+    .select({ principalId: gwContacts.principalId })
+    .from(gwContacts)
+    .innerJoin(
+      gwContactChannels,
+      eq(gwContactChannels.contactId, gwContacts.id),
+    )
+    .where(
+      and(
+        eq(gwContacts.role, "guardian"),
+        eq(gwContactChannels.type, "vellum"),
+        eq(gwContactChannels.status, "active"),
+      ),
+    )
+    .limit(1)
+    .get();
+  return row?.principalId ?? fallback;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,13 +128,21 @@ export async function revokeExistingChannelGuardian(
 ): Promise<void> {
   const now = Date.now();
 
-  const revokedRows = await assistantDbQuery<{ id: string }>(
-    `SELECT cc.id
-     FROM contacts c
-     JOIN contact_channels cc ON cc.contact_id = c.id
-     WHERE c.role = 'guardian' AND cc.type = ? AND cc.status = 'active'`,
-    [channel],
-  );
+  const revokedRows = getGatewayDb()
+    .select({ id: gwContactChannels.id })
+    .from(gwContacts)
+    .innerJoin(
+      gwContactChannels,
+      eq(gwContactChannels.contactId, gwContacts.id),
+    )
+    .where(
+      and(
+        eq(gwContacts.role, "guardian"),
+        eq(gwContactChannels.type, channel),
+        eq(gwContactChannels.status, "active"),
+      ),
+    )
+    .all();
 
   if (revokedRows.length === 0) return;
 

--- a/gateway/src/verification/outbound-voice-verification-sync.test.ts
+++ b/gateway/src/verification/outbound-voice-verification-sync.test.ts
@@ -5,7 +5,12 @@ import { join } from "node:path";
 import { Database } from "bun:sqlite";
 
 import { initSigningKey } from "../auth/token-service.js";
-import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
@@ -115,6 +120,8 @@ async function setupTestDirs(): Promise<void> {
   await initGatewayDb();
 }
 
+// Seeds both DBs: the assistant mirror (for activeBindingFor reads) and the
+// gateway DB (now the source of truth for guardian-binding lookups).
 function insertGuardianContact(id: string, principalId: string, now: number) {
   testAssistantDb!
     .prepare(
@@ -122,6 +129,18 @@ function insertGuardianContact(id: string, principalId: string, now: number) {
        VALUES (?, ?, 'guardian', ?, ?, ?)`,
     )
     .run(id, `Guardian ${id}`, principalId, now, now);
+
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: `Guardian ${id}`,
+      role: "guardian",
+      principalId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
 }
 
 function insertChannel(opts: {
@@ -150,6 +169,22 @@ function insertChannel(opts: {
       opts.createdAt,
       opts.updatedAt,
     );
+
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: opts.id,
+      contactId: opts.contactId,
+      type: opts.type,
+      address: opts.externalUserId,
+      externalChatId: opts.externalUserId,
+      isPrimary: true,
+      status: opts.status,
+      policy: "allow",
+      createdAt: opts.createdAt,
+      updatedAt: opts.updatedAt,
+    })
+    .run();
 }
 
 function activeBindingFor(phone: string): {


### PR DESCRIPTION
## Summary
- Repoint binding-helpers guardian lookups (existing binding, most-recent timestamp, canonical principal, revoke select) from the assistant DB to the gateway DB.
- Writes unchanged; assistantDbQuery in this file is now info-free.

Part of plan: gateway-reads-own-acl.md (PR 1 of 5)