### PR TITLE
refactor(chat): extract ToolDetailBody from ToolDetailPanel for reuse

### DIFF
--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -200,6 +200,75 @@ function ThinkingDetailBody({
   );
 }
 
+/**
+ * Tool-variant detail sections — the risk-reason note, "Technical details"
+ * (input `CodeBlock`), and "Output" (result or running-state fallback) — with
+ * no surrounding shell, header, or close button. Composed by `ToolDetailPanel`
+ * inside its own `DetailShell`, and reused by `SubagentDetailPanel` to show a
+ * nested tool call under the subagent's own header.
+ */
+export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
+  const hasResult = detail.result !== undefined && detail.result !== "";
+  const isRunning = detail.status === "running";
+  const inputJson = JSON.stringify(detail.input, null, 2);
+
+  return (
+    <>
+      {detail.riskReason && (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="mb-4 text-[var(--content-tertiary)]"
+        >
+          {detail.riskReason}
+        </Typography>
+      )}
+
+      {/* Technical details section */}
+      <div>
+        <SectionLabel>Technical details</SectionLabel>
+        <Typography
+          variant="body-medium-default"
+          as="div"
+          className="text-[var(--content-default)]"
+        >
+          {titleCaseToolName(detail.toolName)}
+        </Typography>
+        {detail.activity && (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="mt-0.5 text-[var(--content-secondary)]"
+          >
+            {detail.activity}
+          </Typography>
+        )}
+        <div className="mt-2">
+          <CodeBlock text={inputJson} />
+        </div>
+      </div>
+
+      {/* Output section — omitted entirely when there's no result */}
+      {(hasResult || isRunning) && (
+        <div className="mt-5">
+          <SectionLabel>Output</SectionLabel>
+          {hasResult ? (
+            <CodeBlock text={detail.result as string} />
+          ) : (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              Running…
+            </Typography>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
 export function ToolDetailPanel({
   detail,
   onClose,
@@ -219,9 +288,6 @@ export function ToolDetailPanel({
   const Glyph = ICON_MAP[iconName] ?? Bolt;
 
   const title = detail.activity || detail.title;
-  const hasResult = detail.result !== undefined && detail.result !== "";
-  const isRunning = detail.status === "running";
-  const inputJson = JSON.stringify(detail.input, null, 2);
 
   return (
     <DetailShell
@@ -232,59 +298,7 @@ export function ToolDetailPanel({
         <RiskBadge level={detail.riskLevel} onClick={onRiskBadgeClick} />
       }
     >
-      <>
-        {detail.riskReason && (
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="mb-4 text-[var(--content-tertiary)]"
-          >
-            {detail.riskReason}
-          </Typography>
-        )}
-
-        {/* Technical details section */}
-        <div>
-          <SectionLabel>Technical details</SectionLabel>
-          <Typography
-            variant="body-medium-default"
-            as="div"
-            className="text-[var(--content-default)]"
-          >
-            {titleCaseToolName(detail.toolName)}
-          </Typography>
-          {detail.activity && (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="mt-0.5 text-[var(--content-secondary)]"
-            >
-              {detail.activity}
-            </Typography>
-          )}
-          <div className="mt-2">
-            <CodeBlock text={inputJson} />
-          </div>
-        </div>
-
-        {/* Output section — omitted entirely when there's no result */}
-        {(hasResult || isRunning) && (
-          <div className="mt-5">
-            <SectionLabel>Output</SectionLabel>
-            {hasResult ? (
-              <CodeBlock text={detail.result as string} />
-            ) : (
-              <Typography
-                variant="body-small-default"
-                as="p"
-                className="text-[var(--content-tertiary)]"
-              >
-                Running…
-              </Typography>
-            )}
-          </div>
-        )}
-      </>
+      <ToolDetailBody detail={detail} />
     </DetailShell>
   );
 }


### PR DESCRIPTION
## Summary
- Extract the tool-detail sections (Technical details + Input + Output) into an exported ToolDetailBody
- ToolDetailPanel now composes DetailShell + ToolDetailBody; rendered output unchanged

Part of plan: subagent-tool-detail-pills.md (PR 3 of 5)