### PR TITLE
fix(chat): preserve raw tool input/result on subagent timeline events

### DIFF
--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -656,6 +656,33 @@ describe("receiveEvent", () => {
     expect(ev.input).toBeUndefined();
   });
 
+  it("preserves result on an errored tool_result (mapped to type error)", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: {
+        type: "tool_result",
+        toolName: "bash",
+        result: "Error: command not found: foo",
+        isError: true,
+      },
+      timestamp: NOW + 400,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    // mapInnerEventType routes isError to "error", but the raw result must
+    // still be retained for the detail view.
+    expect(ev.type).toBe("error");
+    expect(ev.isError).toBe(true);
+    expect(ev.result).toBe("Error: command not found: foo");
+  });
+
   it("falls back to content for tool_result result when result is absent", () => {
     getState().spawnSubagent({
       subagentId: "sa-1",

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -609,6 +609,90 @@ describe("receiveEvent", () => {
     expect(getState().byId).toEqual(before.byId);
     expect(getState().orderedIds).toEqual(before.orderedIds);
   });
+
+  it("preserves raw input on tool_use_start alongside the content summary", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: {
+        type: "tool_use_start",
+        toolName: "bash",
+        input: { command: "ls -la" },
+      },
+      timestamp: NOW + 100,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.type).toBe("tool_call");
+    expect(ev.input?.command).toBe("ls -la");
+    // The summary that drives labels is still derived from the input.
+    expect(ev.content).toBe("ls -la");
+    expect(ev.result).toBeUndefined();
+  });
+
+  it("preserves raw result on tool_result", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "tool_result", result: "total 0\nfile.txt" },
+      timestamp: NOW + 200,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.type).toBe("tool_result");
+    expect(ev.result).toBe("total 0\nfile.txt");
+    expect(ev.input).toBeUndefined();
+  });
+
+  it("falls back to content for tool_result result when result is absent", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "tool_result", content: "File contents here" },
+      timestamp: NOW + 300,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.type).toBe("tool_result");
+    expect(ev.result).toBe("File contents here");
+  });
+
+  it("leaves input/result unset for text events", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "assistant_text_delta", content: "Hello" },
+      timestamp: NOW + 100,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.input).toBeUndefined();
+    expect(ev.result).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -479,8 +479,12 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       // disturbing the `content` summary computed above.
       input:
         params.event.type === "tool_use_start" ? params.event.input : undefined,
+      // Key off the RAW event type, not the mapped timeline type: a failed
+      // tool emits `tool_result` with `isError: true`, which `mapInnerEventType`
+      // routes to `"error"`. Using `eventType` here would drop the error output
+      // the detail view needs, so capture both success and error results.
       result:
-        eventType === "tool_result"
+        params.event.type === "tool_result"
           ? params.event.result ?? params.event.content ?? params.event.text
           : undefined,
     };

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -39,6 +39,12 @@ export interface SubagentTimelineEvent {
    * tool (which `toolName` alone cannot disambiguate).
    */
   toolUseId?: string;
+  /**
+   * `content` remains the ≤120-char summary that drives labels; `input`/
+   * `result` are the raw payloads used only by the nested tool-detail view.
+   */
+  input?: Record<string, unknown>;
+  result?: string;
 }
 
 export interface SubagentEntry {
@@ -469,6 +475,14 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       isError: params.event.isError,
       timestamp: params.timestamp,
       toolUseId: params.event.toolUseId,
+      // Preserve raw payloads for the nested tool-detail view without
+      // disturbing the `content` summary computed above.
+      input:
+        params.event.type === "tool_use_start" ? params.event.input : undefined,
+      result:
+        eventType === "tool_result"
+          ? params.event.result ?? params.event.content ?? params.event.text
+          : undefined,
     };
 
     set({


### PR DESCRIPTION
## Summary
- Add optional input/result to SubagentTimelineEvent
- Preserve raw input on tool_use_start and result on tool_result in receiveEvent
- Keep the existing content summary that drives labels

Part of plan: subagent-tool-detail-pills.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)