### PR TITLE
feat(chat): make subagent timeline tool pills clickable

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -9,7 +9,7 @@
  * for 1); and contiguous same-phase collapsing into a single row.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
@@ -193,6 +193,81 @@ describe("SubagentPhaseTimeline — single-step expandability", () => {
     // Clicking the disabled header reveals nothing — no empty body.
     fireEvent.click(header);
     expect(queryByTestId("phase-step-pill")).toBeNull();
+  });
+});
+
+describe("SubagentPhaseTimeline — clickable tool steps", () => {
+  test("tool steps render as clickable buttons and call back with toolCallId", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "2s", "tc-b"),
+    ];
+    const { getByTestId, getAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+
+    const pills = getAllByTestId("tool-step-pill");
+    expect(pills.length).toBe(2);
+    pills.forEach((pill) => expect(pill.tagName).toBe("BUTTON"));
+
+    fireEvent.click(pills[0]!);
+    expect(onToolStepClick).toHaveBeenCalledTimes(1);
+    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-a");
+
+    fireEvent.click(pills[1]!);
+    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-b");
+  });
+
+  test("a thinking step does NOT render as a clickable tool pill", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [thinking("Considering options")];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
+  test("a tool_error step does NOT render as a clickable tool pill", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [toolError("context window exceeded")];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
+  test("tool steps with an empty toolCallId stay non-clickable", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", ""),
+      bash("pwd", "completed", "2s", ""),
+    ];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
+  test("without the callback, tool steps remain non-clickable", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "2s", "tc-b"),
+    ];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -29,6 +29,7 @@ import {
   TimelineNode,
   type PhaseSection,
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 import { cn } from "@/utils/misc";
 
@@ -60,8 +61,15 @@ function runningActivity(section: PhaseSection): string {
 
 export function SubagentPhaseTimeline({
   steps,
+  onToolStepClick,
 }: {
   steps: ToolCallCardStep[];
+  /**
+   * When supplied, expanded tool steps render as clickable `ToolStepPill`
+   * buttons; clicking one calls back with the step's `toolCallId`. Optional so
+   * this component is deploy-safe without a consumer wired up.
+   */
+  onToolStepClick?: (toolCallId: string) => void;
 }) {
   // Expanded section keys. Default collapsed; the toggler is memoized so
   // already-rendered rows stay referentially stable across toggles.
@@ -90,6 +98,7 @@ export function SubagentPhaseTimeline({
             expanded={expanded.has(key)}
             sectionKeyValue={key}
             onToggle={toggle}
+            onToolStepClick={onToolStepClick}
           />
         );
       })}
@@ -103,12 +112,14 @@ function SubagentPhaseRow({
   expanded,
   sectionKeyValue,
   onToggle,
+  onToolStepClick,
 }: {
   section: PhaseSection;
   isLast: boolean;
   expanded: boolean;
   sectionKeyValue: string;
   onToggle: (key: string) => void;
+  onToolStepClick?: (toolCallId: string) => void;
 }) {
   const status = phaseHeaderStatus(section.steps);
   const isThinking = section.steps[0]?.kind === "thinking";
@@ -250,9 +261,30 @@ function SubagentPhaseRow({
           from the next group rather than 12px (pb-3) + 16px. */}
       {isExpandable && expanded && (
         <div className="flex flex-col items-start gap-1 pl-[22px]">
-          {section.steps.map((step, stepIdx) => (
-            <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />
-          ))}
+          {section.steps.map((step, stepIdx) => {
+            // Clickable only for tool steps with a real `toolCallId` AND a
+            // consumer wired up; everything else keeps the non-interactive
+            // `DefaultStepPill` (thinking detail is intentionally out of scope).
+            if (step.kind === "tool" && step.toolCallId && onToolStepClick) {
+              return (
+                <ToolStepPill
+                  key={stepKey(step, stepIdx)}
+                  variant="tool"
+                  iconName={step.iconName}
+                  label={step.activity || step.info || step.title}
+                  riskLevel={step.riskLevel}
+                  tone={
+                    step.status === "error" || step.status === "denied"
+                      ? "error"
+                      : "default"
+                  }
+                  ariaLabel="View tool details"
+                  onClick={() => onToolStepClick(step.toolCallId)}
+                />
+              );
+            }
+            return <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />;
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add optional onToolStepClick prop to SubagentPhaseTimeline
- Render expanded tool steps via clickable ToolStepPill when the callback is provided
- Non-tool steps and the no-callback case keep DefaultStepPill; geometry untouched

Part of plan: subagent-tool-detail-pills.md (PR 4 of 5)