### PR TITLE
feat(chat): derive ToolDetailPayloads for subagent tool calls

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildSubagentToolDetails,
   computeSubagentCardData,
   mapToolEventToStep,
 } from "@/domains/chat/hooks/use-subagent-card-data";
@@ -655,5 +656,234 @@ describe("computeSubagentCardData — error event toolUseId correlation", () => 
     if (err.kind === "tool_error") {
       expect(err.message).toBe("boom");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSubagentToolDetails — nested tool-detail payload map
+// ---------------------------------------------------------------------------
+
+describe("buildSubagentToolDetails", () => {
+  test("tool_call + tool_result → one completed payload with raw input/result + duration", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              content: "ls -la",
+              input: { command: "ls -la" },
+              timestamp: NOW,
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              result: "total 0",
+              timestamp: NOW + 2500,
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(details.size).toBe(1);
+    const payload = details.get("tu-1")!;
+    expect(payload.toolCallId).toBe("tu-1");
+    expect(payload.toolName).toBe("bash");
+    // Raw input is preserved verbatim (not the reconstructed summary bag).
+    expect(payload.input).toEqual({ command: "ls -la" });
+    expect(payload.result).toBe("total 0");
+    expect(payload.status).toBe("completed");
+    expect(payload.durationLabel).toBe("3s");
+    expect(payload.kind).toBe("tool");
+  });
+
+  test("falls back to event.content for result when result is absent", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "bash", toolUseId: "tu-1" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              content: "fallback output",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(details.get("tu-1")!.result).toBe("fallback output");
+  });
+
+  test("in-flight tool_call with no result → running payload, result undefined", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              input: { command: "sleep 5" },
+            },
+            0,
+          ),
+        ],
+      }),
+    );
+    expect(details.size).toBe(1);
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("running");
+    expect(payload.result).toBeUndefined();
+    expect(payload.durationLabel).toBe("");
+    expect(payload.input).toEqual({ command: "sleep 5" });
+  });
+
+  test("tool_call with empty toolUseId is skipped (can't be keyed/clicked)", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [makeEvent({ type: "tool_call", toolName: "bash" })],
+      }),
+    );
+    expect(details.size).toBe(0);
+  });
+
+  test("parallel calls to the same tool with distinct ids → two payloads matched by id", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-A",
+              input: { command: "first" },
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-B",
+              input: { command: "second" },
+            },
+            1,
+          ),
+          // The SECOND call's result lands first; must close tu-B, not tu-A.
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-B",
+              result: "second done",
+            },
+            2,
+          ),
+        ],
+      }),
+    );
+    expect(details.size).toBe(2);
+    const a = details.get("tu-A")!;
+    const b = details.get("tu-B")!;
+    expect(a.status).toBe("running");
+    expect(a.result).toBeUndefined();
+    expect(a.input).toEqual({ command: "first" });
+    expect(b.status).toBe("completed");
+    expect(b.result).toBe("second done");
+    expect(b.input).toEqual({ command: "second" });
+  });
+
+  test("isError result → error status with the result preserved", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "bash", toolUseId: "tu-1" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              isError: true,
+              result: "command failed",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("error");
+    expect(payload.result).toBe("command failed");
+  });
+
+  test("a FAILED tool result mapped to a raw error event is still matched", () => {
+    // When a tool fails, the store maps the inner event to type `"error"`
+    // (not `"tool_result"`) but preserves `result` + `isError`. The matcher
+    // must catch it regardless of the mapped type.
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "bash", toolUseId: "tu-1" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "error",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              isError: true,
+              result: "boom",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("error");
+    expect(payload.result).toBe("boom");
+  });
+
+  test("equal timestamps (synthetic history) yield no durationLabel", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "bash",
+            toolUseId: "tu-1",
+            timestamp: NOW,
+          }),
+          makeEvent({
+            type: "tool_result",
+            toolName: "bash",
+            toolUseId: "tu-1",
+            result: "ok",
+            timestamp: NOW,
+          }),
+        ],
+      }),
+    );
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("completed");
+    expect(payload.durationLabel).toBe("");
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -44,6 +44,7 @@ import {
   type ToolCallCardData,
   type ToolCallCardStep,
 } from "@/domains/chat/utils/tool-call-card-utils";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 export type { ToolCallCardData, ToolCallCardStep };
 
@@ -142,12 +143,41 @@ export function mapToolEventToStep(
 }
 
 /**
- * Find the index of the most recent in-flight tool step that matches a
- * follow-up event (`tool_result` or `error`). Match precedence:
+ * Core in-flight matching predicate, shared by `findMatchingInFlightToolIndex`
+ * (which drives `computeSubagentCardData`) and `buildSubagentToolDetails` so
+ * the two projections can't drift. Walks `candidates` newest-first and returns
+ * the index of the first still-`running` tool that matches the follow-up
+ * `event`. Match precedence:
  *   1. Exact `toolUseId` match — required when the event carries one (so
  *      parallel calls to the same tool don't bleed into each other).
  *   2. `toolName` match against the originating `tool_call`'s name.
  *   3. "Latest in-flight" — when neither identifier is present.
+ *
+ * Returns -1 when no in-flight candidate matches.
+ */
+function matchInFlightTool(
+  candidates: Array<{ toolCallId: string; toolName: string; running: boolean }>,
+  event: { toolUseId?: string; toolName?: string },
+): number {
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const candidate = candidates[i]!;
+    if (!candidate.running) continue;
+    if (event.toolUseId) {
+      if (candidate.toolCallId === event.toolUseId) return i;
+      // Exact-match-only when the event carries a toolUseId — do NOT fall
+      // through to toolName matching for a different ID.
+      continue;
+    }
+    if (!event.toolName || candidate.toolName === event.toolName) return i;
+  }
+  return -1;
+}
+
+/**
+ * Find the index of the most recent in-flight tool step that matches a
+ * follow-up event (`tool_result` or `error`). Thin adapter over
+ * `matchInFlightTool` projecting the `(steps, toolMeta)` parallel arrays into
+ * the shared candidate shape.
  *
  * Returns -1 when no in-flight step matches.
  */
@@ -156,19 +186,14 @@ function findMatchingInFlightToolIndex(
   toolMeta: Array<{ startTs: number; toolName: string } | undefined>,
   event: { toolUseId?: string; toolName?: string },
 ): number {
-  for (let i = steps.length - 1; i >= 0; i--) {
-    const step = steps[i]!;
-    if (step.kind !== "tool" || step.status !== "running") continue;
-    if (event.toolUseId) {
-      if (step.toolCallId === event.toolUseId) return i;
-      // Exact-match-only when the event carries a toolUseId — do NOT fall
-      // through to toolName matching for a different ID.
-      continue;
-    }
-    const stepToolName = toolMeta[i]?.toolName ?? "";
-    if (!event.toolName || stepToolName === event.toolName) return i;
-  }
-  return -1;
+  return matchInFlightTool(
+    steps.map((step, i) => ({
+      toolCallId: step.kind === "tool" ? step.toolCallId : "",
+      toolName: toolMeta[i]?.toolName ?? "",
+      running: step.kind === "tool" && step.status === "running",
+    })),
+    event,
+  );
 }
 
 /**
@@ -407,4 +432,85 @@ export function useSubagentCardData(
     if (!entry) return null;
     return computeSubagentCardData(entry);
   }, [entry]);
+}
+
+/**
+ * Pure projection of (entry) → a `toolCallId`-keyed map of nested tool-detail
+ * payloads. Separate from `computeSubagentCardData` (whose `ToolCallCardStep`s
+ * carry only label/duration, not the raw `input`/`result`) so the clickable
+ * timeline pills can open the full tool-detail drawer (`ToolDetailBody`) for
+ * the tool whose id they emit.
+ *
+ * Walks `entry.events` in order, tracking in-flight payloads and resolving
+ * `tool_result` / `error` follow-ups against them with `matchInFlightTool` —
+ * the same precedence `computeSubagentCardData` uses, so the two stay aligned.
+ *
+ * Keyed by `toolUseId`; `tool_call` events with an empty id are skipped (they
+ * can't be keyed or clicked). Risk fields (`riskLevel`/`riskReason`) are
+ * omitted — subagent timeline events don't carry them.
+ */
+export function buildSubagentToolDetails(
+  entry: SubagentEntry,
+): Map<string, ToolDetailPayload> {
+  const payloads: ToolDetailPayload[] = [];
+  // Parallel array: start timestamp + running flag per payload, used for
+  // matching follow-ups and duration calc. Indexed by `payloads` position.
+  const meta: Array<{ startTs: number; running: boolean }> = [];
+
+  for (const event of entry.events) {
+    if (event.type === "tool_call") {
+      const toolCallId = event.toolUseId ?? "";
+      // Skip calls without an id — they can't be keyed or clicked.
+      if (!toolCallId) continue;
+      const toolName = event.toolName ?? "";
+      const labelInput =
+        event.input ?? reconstructInputBag(toolName, event.content ?? "");
+      const label = deriveStepLabelFromName(toolName, labelInput);
+      payloads.push({
+        toolCallId,
+        toolName,
+        title: label.title,
+        activity: label.activity,
+        input: event.input ?? {},
+        status: "running",
+        durationLabel: "",
+        kind: "tool",
+      });
+      meta.push({ startTs: event.timestamp, running: true });
+      continue;
+    }
+
+    // A follow-up carrying a result. A FAILED tool result is mapped to a raw
+    // `error`-typed event (see `mapInnerEventType`) yet still carries its
+    // `result` + `isError`, so we resolve both `tool_result` and `error`
+    // against the in-flight list regardless of the mapped type.
+    if (event.type === "tool_result" || event.type === "error") {
+      const matchIndex = matchInFlightTool(
+        payloads.map((payload, i) => ({
+          toolCallId: payload.toolCallId,
+          toolName: payload.toolName,
+          running: meta[i]!.running,
+        })),
+        event,
+      );
+      if (matchIndex === -1) continue;
+      const target = payloads[matchIndex]!;
+      const start = meta[matchIndex]!.startTs;
+      // Same non-positive-delta suppression as `computeSubagentCardData`:
+      // synthetic equal-timestamp history events → "".
+      const delta =
+        Number.isFinite(start) && event.timestamp > start
+          ? event.timestamp - start
+          : 0;
+      payloads[matchIndex] = {
+        ...target,
+        result: event.result ?? event.content,
+        status: event.isError ? "error" : "completed",
+        durationLabel: delta > 0 ? formatMs(delta) : "",
+      };
+      meta[matchIndex]!.running = false;
+    }
+  }
+
+  return new Map(payloads.map((payload) => [payload.toolCallId, payload]));
 }


### PR DESCRIPTION
## Summary
- Add buildSubagentToolDetails(entry): Map<toolCallId, ToolDetailPayload>
- Reuse the tool_call/tool_result matching + duration rules; omit risk fields
- Leave computeSubagentCardData and shared types untouched

Part of plan: subagent-tool-detail-pills.md (PR 2 of 5)