### PR TITLE
feat(skills): make start-the-day the general layer below admin-copilot

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -787,17 +787,27 @@
     {
       "id": "start-the-day",
       "name": "start-the-day",
-      "description": "Get a personalized daily briefing with weather, news, and actionable insights",
+      "description": "An on-demand personal daily briefing — weather, headlines, the shape of your day, and one thing worth your attention — in a sharp executive-assistant voice. The general-purpose morning brief; richer work or admin digests compose it as their general layer.",
       "metadata": {
         "icon": "assets/icon.svg",
         "emoji": "🌅",
         "vellum": {
           "category": "productivity",
-          "display-name": "Start the Day"
+          "display-name": "Start the Day",
+          "user-invocable": "true",
+          "activation-hints": [
+            "User asks to start their day, for a morning briefing, or a daily briefing/recap",
+            "User asks what's going on today or what they should know this morning",
+            "User wants weather, headlines, and a quick personal rundown"
+          ],
+          "avoid-when": [
+            "User wants a detailed work/admin digest — deep inbox triage, follow-up tracking, or meeting-by-meeting prep — rather than a general briefing",
+            "User wants to set up recurring or automated briefings rather than one right now"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-06-22T21:39:19.000Z"
     },
     {
       "id": "stripe-app-setup",
@@ -978,7 +988,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-20T16:20:53.000Z"
+      "updatedAt": "2026-06-21T15:06:32.000Z"
     },
     {
       "id": "vellum-memory-v2-migration",
@@ -1024,7 +1034,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-18T03:26:43.000Z"
+      "updatedAt": "2026-06-22T18:02:37.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/start-the-day/SKILL.md
+++ b/skills/start-the-day/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-the-day
-description: Get a personalized daily briefing with weather, news, and actionable insights
+description: "An on-demand personal daily briefing — weather, headlines, the shape of your day, and one thing worth your attention — in a sharp executive-assistant voice. The general-purpose morning brief; richer work or admin digests compose it as their general layer."
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   icon: assets/icon.svg
@@ -8,75 +8,80 @@ metadata:
   vellum:
     category: "productivity"
     display-name: "Start the Day"
+    user-invocable: true
+    activation-hints:
+      - "User asks to start their day, for a morning briefing, or a daily briefing/recap"
+      - "User asks what's going on today or what they should know this morning"
+      - "User wants weather, headlines, and a quick personal rundown"
+    avoid-when:
+      - "User wants a detailed work/admin digest — deep inbox triage, follow-up tracking, or meeting-by-meeting prep — rather than a general briefing"
+      - "User wants to set up recurring or automated briefings rather than one right now"
 ---
 
-You are a personal daily briefing assistant. When the user invokes this skill, generate a concise, actionable briefing tailored to the current moment.
+You are a personal daily briefing assistant. When the user invokes this skill,
+produce a concise, scannable briefing tailored to the current moment. Use what
+you know about the user to decide which sections are worth including — skip the
+rest.
 
-## Briefing Structure
+## Scope & composition
 
-Build the briefing in sections. Use what you know about the user and their context to decide which sections are relevant. Don't include sections you have nothing useful to say about.
+This skill owns the **general** briefing: weather, headlines, an at-a-glance read
+of the day, and one interesting thing — in a sharp, human, executive-assistant
+voice. Keep it that way.
 
-### 1. Weather & Conditions
+When a richer digest includes this skill as its general layer, own **only** that
+general material and let the parent own the detail: meeting-by-meeting prep, inbox
+triage, follow-up tracking, work priorities, and delivery. Don't repeat those
+here. When invoked on your own, give the lightweight at-a-glance versions below so
+the briefing still stands alone.
 
-Check the user's location (from system context or ask once) and provide:
+## Capability awareness
 
-- Current conditions and temperature
-- High/low for the day
-- Notable weather (rain, extreme temps, wind) - only if it affects plans
+Build only the sections you can actually fill. Check what you have first —
+location and web access for weather and news, a connected calendar or inbox for
+the at-a-glance read — and silently skip anything you can't source. Never emit "I
+don't have access to X" filler. Two real sections beat six empty ones.
 
-### 2. Top Headlines
+## Briefing sections
 
-Summarize 3-5 notable news items. Prioritize:
+### Weather & conditions
 
-- Stories relevant to the user's interests or industry
-- Major world events
-- Tech/product launches if relevant
-- Keep each to one sentence
+Current conditions and temperature, plus the day's high/low. Call out notable
+weather (rain, extreme temps, wind) only when it affects plans.
 
-### 3. Calendar & Meetings
+### Top headlines
 
-If you have access to calendar context:
+3–5 notable items, one sentence each. Prioritize the user's interests and
+industry, then major world events and relevant product/tech launches.
 
-- List today's meetings with times
-- Flag any prep needed (documents to review, talking points)
-- Note gaps that could be used for focused work
+### At a glance
 
-### 4. Email & Messages
+A lightweight read of the day's shape — not a triage or prep pipeline:
 
-If you have access to communication context:
+- Today's commitments: how many, first and last, any obvious gap for focused work.
+- Anything clearly urgent or time-sensitive in mail or messages.
+- The one thing worth tackling first.
 
-- Summarize unread messages that need responses
-- Draft quick replies for straightforward ones - present them for review
-- Flag anything urgent or time-sensitive
+Keep this short. If a richer digest is composing this skill, leave the detail to
+it and lean on its sections instead.
 
-### 5. Tasks & Priorities
+### Something interesting
 
-If you have context on the user's work:
-
-- Surface top 3 priorities for the day
-- Note any deadlines approaching
-- Suggest one thing to tackle first
-
-### 6. Something Interesting
-
-End with one of:
-
-- An interesting fact or quote
-- A relevant article worth reading later
-- A tip related to something the user is working on
+End with one: an interesting fact or quote, an article worth reading later, or a
+tip related to something the user is working on.
 
 ## Tone
 
-- Concise and scannable - use bullet points, not paragraphs
-- Conversational but efficient - like a sharp executive assistant
-- Don't pad with filler - if you only have 2 useful sections, give 2 sections
-- Time-aware: morning briefings differ from afternoon check-ins
+- Concise and scannable — bullets, not paragraphs.
+- Conversational but efficient, like a sharp executive assistant.
+- No filler — if you have two useful sections, give two.
+- Time-aware: a morning briefing reads differently from an afternoon check-in, in
+  the user's own timezone.
 
-## Adaptation Over Time
+## Adaptation over time
 
-As you learn more about the user:
-
-- Weight news toward their interests and industry
-- Remember their schedule patterns (e.g. "you usually have standup at 10")
-- Track recurring tasks and deadlines
-- Get more specific and less generic with each use
+Lean on what you already know and remember about the user, and get more specific
+with each briefing — weight news toward their interests, recall their usual
+schedule shape, track recurring priorities. Don't fabricate details to fill a
+section, and don't assume any preference store exists; work from what you
+genuinely know.


### PR DESCRIPTION
## What & why

`start-the-day` is `includes:`-ed by `admin-copilot`'s `admin-digest` and `admin-copilot-setup` skills. The skill loader **concatenates an included skill's full body** into the parent, so start-the-day's Calendar / Email / Tasks-&-Priorities sections were injected right next to admin-digest's own calendar/inbox/follow-ups/priorities — duplicated and conflicting instructions. `admin-digest` already treats start-the-day as its *general/lifestyle layer* ("weather/news/something-interesting tone; this skill adds the admin spine on top").

This reframes start-the-day as the **foundational, plugin-agnostic general briefing** that sits *below* admin-copilot.

## Changes

- **Body**: collapse the three admin sections into one lightweight **At a glance** that explicitly defers to the parent when composed. Add a **Scope & composition** block (own only the general layer when included; let the parent own detail + delivery) and a concrete **Capability awareness** block (check-then-skip, no "I don't have access" filler). Rewrite **Adaptation over time** to be honestly memory-mediated (no assumed preference store).
- **Frontmatter**: sharpen `description`; add `user-invocable: true`, `activation-hints`, and `avoid-when` (routes detailed work/admin digests away — phrased generically, no plugin named).
- Regenerate `skills/catalog.json`.

**Layering invariant:** zero upward references (`admin-copilot`, `admin_copilot_prefs`, `competitor-brief`, `schedule_create`). The dependency arrow points down only; start-the-day stays a pure instruction skill (admin-copilot owns the schedules, prefs tool, and delivery above it).

## Notes for review
- The catalog regen also picked up **pre-existing `updatedAt` drift** on two unrelated entries (`vellum-memory-v2-migration`, `vellum-oauth-integrations`) — skills edited on main without a regen. These must stay, since `check-catalog.mjs` compares against a full fresh regen.
- `description` is a single-line string on purpose: the catalog generator's minimal YAML parser doesn't understand `>-` folded block scalars.

## Verification
- `bun run scripts/skills/check-catalog.mjs` → up to date
- `bun run scripts/skills/lint-skill-spec.mjs` → 68/68 conform

🤖 Generated with [Claude Code](https://claude.com/claude-code)