### PR TITLE
inference: flip the managed Balanced profile to Together AI (MiniMax M3)

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -485,11 +485,9 @@ describe("loadConfig startup behavior", () => {
       "anthropic-personal",
     );
     // Managed profiles exist as well.
-    expect(config.llm.profiles.balanced?.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(config.llm.profiles.balanced?.model).toBe("MiniMaxAI/MiniMax-M3");
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
@@ -498,9 +496,7 @@ describe("loadConfig startup behavior", () => {
       model: "claude-opus-4-7",
     });
     expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
   });
 
   test("on-platform hatch seeds only managed profiles", () => {
@@ -528,11 +524,9 @@ describe("loadConfig startup behavior", () => {
     const config = loadConfig();
 
     expect(config.llm.activeProfile).toBe("balanced");
-    expect(config.llm.profiles.balanced?.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(config.llm.profiles.balanced?.model).toBe("MiniMaxAI/MiniMax-M3");
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
     // No user profiles created on platform.
     expect(config.llm.profiles["custom-balanced"]).toBeUndefined();
@@ -574,10 +568,10 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
       "anthropic-personal",
     );
-    // Managed balanced profile is seeded for fireworks-managed (MiniMax M3).
-    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
+    // Managed balanced profile is seeded for together-managed (MiniMax M3).
+    expect(raw.llm.profiles.balanced.provider).toBe("together");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
   });
 
@@ -611,9 +605,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     // On-platform: no user profiles created, active resets to managed balanced.
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
+    expect(raw.llm.profiles.balanced.provider).toBe("together");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
     // The old custom-balanced is preserved on disk but no longer active.
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("openai");
@@ -665,10 +659,10 @@ describe("loadConfig startup behavior", () => {
       "gpt-5.4-nano",
     );
 
-    // Managed profiles are also seeded (balanced uses Fireworks/MiniMax M3).
-    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
+    // Managed profiles are also seeded (balanced uses Together/MiniMax M3).
+    expect(raw.llm.profiles.balanced.provider).toBe("together");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
     expect(raw.llm.profiles.balanced.source).toBe("managed");
     // Quality is now GLM 5.2 on Fireworks; Frontier carries the Anthropic Opus
@@ -703,11 +697,9 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
   });
@@ -812,13 +804,11 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
     expect(raw.llm.profiles.balanced.maxTokens).toBe(32000);
     expect(raw.llm.profiles.balanced.topP).toBe(0.95);
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
   });
@@ -848,9 +838,7 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     // Content refreshes from the template...
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
     // ...but the user's label and status overrides are preserved.
     expect(raw.llm.profiles.balanced.label).toBe("My Default");
     expect(raw.llm.profiles.balanced.status).toBe("disabled");
@@ -878,9 +866,7 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     // Model still gets the new template value (provider-controlled).
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
     // But the user's label override is preserved across the reseed.
     expect(raw.llm.profiles.balanced.label).toBe("My Default");
   });
@@ -908,9 +894,7 @@ describe("loadConfig startup behavior", () => {
 
     expect(raw.llm.profiles.balanced.status).toBe("disabled");
     // Model still refreshes — only label/status are user-owned.
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
   });
 
   test("reseed preserves user-edited topP on managed profiles", () => {
@@ -939,9 +923,7 @@ describe("loadConfig startup behavior", () => {
     // the template default of 0.95).
     expect(raw.llm.profiles.balanced.topP).toBe(0.5);
     // Model still refreshes — topP is user-owned, the rest is template-owned.
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
   });
 
   test("reseed seeds the template topP on a fresh managed balanced profile", () => {
@@ -993,9 +975,7 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.profiles.balanced.label).toBe("Balanced (Managed)");
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
     // Status is unset by default — must not appear as `undefined`.
     expect("status" in raw.llm.profiles.balanced).toBe(false);
   });
@@ -1081,18 +1061,18 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
     expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
 
-    // Next boot, no overlay: content reconciles to the fireworks-managed code
+    // Next boot, no overlay: content reconciles to the together-managed code
     // template; only the overlay-set label is carried across.
     mergeDefaultConfigAndSeedInferenceProfiles();
 
     const afterRestart = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(afterRestart.llm.activeProfile).toBe("balanced");
-    expect(afterRestart.llm.profiles.balanced.provider).toBe("fireworks");
+    expect(afterRestart.llm.profiles.balanced.provider).toBe("together");
     expect(afterRestart.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
     expect(afterRestart.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
+      "MiniMaxAI/MiniMax-M3",
     );
     expect(afterRestart.llm.profiles.balanced.maxTokens).toBe(32000);
     expect(afterRestart.llm.profiles.balanced.thinking).toEqual({
@@ -1139,9 +1119,7 @@ describe("loadConfig startup behavior", () => {
     // Off-platform hatch: user profiles are active.
     expect(raw.llm.activeProfile).toBe("custom-balanced");
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/minimax-m3",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
   });
 
   test("still quarantines corrupt JSON", () => {
@@ -1290,7 +1268,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 
     expect(raw.llm.activeProfile).toBe("balanced");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "together-managed",
     );
     expect("status" in raw.llm.profiles.balanced).toBe(false);
     // Connections exist (status is no longer a connection-level concept).

--- a/assistant/src/__tests__/workspace-migration-110-flip-balanced-profile-to-together.test.ts
+++ b/assistant/src/__tests__/workspace-migration-110-flip-balanced-profile-to-together.test.ts
@@ -1,0 +1,167 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { flipBalancedProfileToTogetherMigration } from "../workspace/migrations/110-flip-balanced-profile-to-together.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  return (readConfig().llm as Record<string, unknown>).profiles as Record<
+    string,
+    Record<string, unknown>
+  >;
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-110-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("110-flip-balanced-profile-to-together migration", () => {
+  test("no-op when config.json does not exist", () => {
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no llm.profiles", () => {
+    const original = { llm: { default: { provider: "anthropic" } } };
+    writeConfig(original);
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("flips the managed balanced profile from Fireworks to Together", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/minimax-m3",
+            label: "Balanced",
+          },
+        },
+      },
+    });
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    const profile = readProfiles().balanced!;
+    expect(profile.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(profile.provider).toBe("together");
+    expect(profile.provider_connection).toBe("together-managed");
+    expect(profile.label).toBe("Balanced");
+  });
+
+  test("flips a source-less legacy managed balanced profile", () => {
+    // Migration 052 seeded canonical profiles without a `source`; absent source
+    // on this reserved name means legacy managed, so it must still be flipped.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/minimax-m3",
+          },
+        },
+      },
+    });
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    const profile = readProfiles().balanced!;
+    expect(profile.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(profile.provider).toBe("together");
+    expect(profile.provider_connection).toBe("together-managed");
+  });
+
+  test("leaves a user-owned balanced profile untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "user",
+            provider: "fireworks",
+            model: "accounts/fireworks/models/minimax-m3",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("leaves a user-retargeted managed model untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("idempotency: no-op on already-flipped config (no writes)", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+          },
+        },
+      },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+    flipBalancedProfileToTogetherMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -42,12 +42,12 @@ type ManagedProfileTemplate = Omit<
  * (`preserveProfileNames`) take precedence when present.
  */
 const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
-  // Served by MiniMax M3 on Fireworks via managed platform inference: a strong
+  // Served by MiniMax M3 on Together AI via managed platform inference: a strong
   // open model at a lower price point than the managed Anthropic route.
   balanced: {
     intent: "balanced",
-    provider: "fireworks",
-    connectionName: "fireworks-managed",
+    provider: "together",
+    connectionName: "together-managed",
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",

--- a/assistant/src/workspace/migrations/110-flip-balanced-profile-to-together.ts
+++ b/assistant/src/workspace/migrations/110-flip-balanced-profile-to-together.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Move the managed `balanced` profile from Fireworks MiniMax M3 to Together AI.
+//
+// Together serves MiniMax M3 with correct forced-`tool_choice` and object-typed
+// tool-arg handling; the Fireworks copy collapses object args to `{}`. The boot
+// seeder reconciles managed-profile content from the templates, but only when
+// it reseeds a profile: off-platform installs reseed every boot, while a
+// platform workspace keeps the profile it was hatched with (the seeder skips
+// overlay-supplied profiles, and the overlay is consumed once). A platform
+// workspace whose `balanced` profile still resolves to Fireworks MiniMax M3
+// therefore relies on this migration to move it to Together.
+//
+// Scope: only the managed `balanced` profile still on the Fireworks MiniMax M3
+// default is rewritten. A user-owned `balanced` (`source: "user"`) or one whose
+// model the user changed is left alone. Migration 052 seeds `balanced`
+// source-less, so absent `source` means legacy managed — treat it as ours. The
+// profile key stays `balanced`, so persisted `inference_profile` pins on
+// conversations/schedules keep resolving and need no rewrite.
+
+const OLD_MODEL = "accounts/fireworks/models/minimax-m3";
+const NEW_MODEL = "MiniMaxAI/MiniMax-M3";
+
+export const flipBalancedProfileToTogetherMigration: WorkspaceMigration = {
+  id: "110-flip-balanced-profile-to-together",
+  description:
+    "Move the managed balanced profile from Fireworks to Together AI (MiniMax M3)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    if (profiles === null) return;
+
+    const profile = readObject(profiles["balanced"]);
+    // Only the managed profile still on the Fireworks MiniMax M3 default is
+    // ours to migrate. `balanced` is seeded source-less by migration 052, so
+    // absent `source` means legacy managed; only an explicit `source: "user"`
+    // is left untouched. Matching on the old model id leaves a user-retargeted
+    // profile alone and makes the migration idempotent.
+    if (
+      profile === null ||
+      profile.source === "user" ||
+      profile.model !== OLD_MODEL
+    ) {
+      return;
+    }
+
+    profile.model = NEW_MODEL;
+    profile.provider = "together";
+    profile.provider_connection = "together-managed";
+    profiles["balanced"] = profile;
+    llm.profiles = profiles;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -107,6 +107,7 @@ import { dropCollectUsageDataMigration } from "./106-drop-collect-usage-data.js"
 import { dropSendDiagnosticsMigration } from "./107-drop-send-diagnostics.js";
 import { dropBalancedEconomyProfileMigration } from "./108-drop-balanced-economy-profile.js";
 import { swapQualityProfileToGlm52Migration } from "./109-swap-quality-profile-to-glm-5p2.js";
+import { flipBalancedProfileToTogetherMigration } from "./110-flip-balanced-profile-to-together.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -225,4 +226,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropSendDiagnosticsMigration,
   dropBalancedEconomyProfileMigration,
   swapQualityProfileToGlm52Migration,
+  flipBalancedProfileToTogetherMigration,
 ];


### PR DESCRIPTION
## What

Switches the default managed **Balanced** profile from Fireworks MiniMax M3 to **Together AI** MiniMax M3.

| File | Change |
|------|--------|
| `config/seed-inference-profiles.ts` | `balanced` template → `provider: together`, `connectionName: together-managed` (model resolves via the `balanced` intent to Together's catalog default `MiniMaxAI/MiniMax-M3`) |
| `workspace/migrations/110-flip-balanced-profile-to-together.ts` | **new** — repoints existing managed installs' persisted `balanced` profile |
| `workspace/migrations/registry.ts` | register migration 110 |
| `__tests__/workspace-migration-110-*.test.ts` | **new** — migration coverage (8 cases) |
| `__tests__/config-loader-backfill.test.ts` | seeded balanced now asserts Together / `MiniMaxAI/MiniMax-M3` |

## Why

Fireworks' MiniMax M3 collapses object-typed tool args to `{}` and mishandles forced `tool_choice`. Together serves the same model correctly. This is the change that moves **default** users (not just opt-in selectors) off the buggy route.

## Why a migration is needed

The boot seeder reconciles managed profiles from the template **only when it reseeds them**: off-platform installs reseed every boot (so the template change alone suffices), but on-platform workspaces keep the profile they were hatched with. Migration 110 rewrites those persisted profiles — `provider` + `provider_connection` + `model` — **only when still on the Fireworks MiniMax M3 default**. User-owned (`source: "user"`) or user-retargeted profiles are left untouched; it's idempotent and forward-only. Mirrors migrations 101 / 109. The profile **key stays `balanced`**, so `inference_profile` pins on conversations/schedules need no rewrite.

## Dependencies & rollout

- Depends on the `together-managed` canonical connection (merged with the daemon Together provider). The platform-side runtime-proxy provider, rate card, and `TOGETHER_API_KEY` secret are already merged/set.
- Fireworks MiniMax M3 stays in the catalog for BYO-key users and as instant rollback (revert this PR).
- Takes effect per managed pod when it upgrades to a daemon build containing this change (migration runs on boot).

## Checks

- `bunx tsc --noEmit` ✅ · lint ✅ · format ✅ (pre-push hook green)
- `workspace-migration-110-*.test.ts` ✅ (8) · `config-loader-backfill.test.ts` ✅ (56)
- Broader managed-profile/seed suites: zero new failures — the DB-harness failures present are **identical on clean `main`** (136 pass / 14 fail both ways).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->