### PR TITLE
feat(web): clickable subagent timeline tool pills → nested tool detail

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25660,6 +25660,13 @@ paths:
                           type: boolean
                         messageId:
                           type: string
+                        toolUseId:
+                          type: string
+                        input:
+                          type: object
+                          propertyNames:
+                            type: string
+                          additionalProperties: {}
                       required:
                         - type
                         - content

--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -130,6 +130,33 @@ describe("parseSubagentMessages", () => {
     expect(result.objective).toBe("Research vampire lore");
   });
 
+  test("emits toolUseId and raw input on tool_use, toolUseId on tool_result", () => {
+    const messages = [
+      msg("user", [{ type: "text", text: "Do something" }]),
+      msg("assistant", [
+        {
+          type: "tool_use",
+          id: "t-abc",
+          name: "bash",
+          input: { command: "ls -la" },
+        },
+      ]),
+      msg("user", [
+        { type: "tool_result", tool_use_id: "t-abc", content: "total 0" },
+      ]),
+    ];
+
+    const result = parseSubagentMessages("sub-1", messages);
+    const toolUse = result.events.find((e) => e.type === "tool_use");
+    expect(toolUse).toBeDefined();
+    expect(toolUse!.toolUseId).toBe("t-abc");
+    expect(toolUse!.input).toEqual({ command: "ls -la" });
+
+    const toolResult = result.events.find((e) => e.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.toolUseId).toBe("t-abc");
+  });
+
   test("includes messageId on text events from assistant messages", () => {
     const messages = [
       msg("user", [{ type: "text", text: "Do something" }]),

--- a/assistant/src/api/responses/subagent-detail.ts
+++ b/assistant/src/api/responses/subagent-detail.ts
@@ -31,6 +31,23 @@ export const SubagentDetailEventSchema = z.object({
   toolName: z.string().optional(),
   isError: z.boolean().optional(),
   messageId: z.string().optional(),
+  /**
+   * Tool-call id — the `tool_use.id` on a tool-call event and the referencing
+   * `tool_use_id` on its tool-result event, in the daemon's canonical
+   * content-block format. That format is provider-agnostic: every provider
+   * (Anthropic, OpenAI, Gemini, …) normalizes its native tool calls into these
+   * `tool_use`/`tool_result` blocks (see `providers/types.ts`), so this id is
+   * present regardless of which model produced the call. Lets the web client
+   * pair a result with its call and key the nested tool-detail view, so tool
+   * pills on reloaded/history subagents are clickable (not just live ones).
+   */
+  toolUseId: z.string().optional(),
+  /**
+   * Raw tool input object on tool-call events. (`content` also carries a
+   * JSON-stringified copy for back-compat / label derivation.) Surfaced in the
+   * tool-detail view's input section.
+   */
+  input: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type SubagentDetailEvent = z.infer<typeof SubagentDetailEventSchema>;

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -20,10 +20,7 @@ import {
   type AdmissionPolicy,
 } from "@vellumai/gateway-client";
 
-import type {
-  ChannelPolicy,
-  ChannelStatus,
-} from "../../contacts/types.js";
+import type { ChannelPolicy, ChannelStatus } from "../../contacts/types.js";
 import type {
   ActorTrustContext,
   TrustClass,
@@ -64,37 +61,43 @@ mock.module("../../memory/invite-store.js", () => ({
 }));
 
 // Real floor semantics, exemption bypassed (see file header).
-mock.module(
-  "../../runtime/routes/inbound-stages/admission-policy.js",
-  () => ({
-    enforceAdmissionPolicy: (input: {
-      trustClass: TrustClass;
-      memberStatus: ChannelStatus | undefined;
-      policy: AdmissionPolicy;
-    }) => {
-      if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
-        return {
-          admitted: false,
-          reason:
-            input.memberStatus === "blocked"
-              ? "member_blocked"
-              : "member_revoked",
-          shouldChallenge: false,
-          effectivePolicy: input.policy,
-        };
-      }
-      const rank = TRUST_CLASS_RANK[input.trustClass];
-      const floor = ADMISSION_FLOOR[input.policy];
-      if (rank >= floor) return { admitted: true };
+mock.module("../../runtime/routes/inbound-stages/admission-policy.js", () => ({
+  enforceAdmissionPolicy: (input: {
+    trustClass: TrustClass;
+    memberStatus: ChannelStatus | undefined;
+    policy: AdmissionPolicy;
+  }) => {
+    if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
       return {
         admitted: false,
-        reason: `admission_policy_${input.policy}`,
+        reason:
+          input.memberStatus === "blocked"
+            ? "member_blocked"
+            : "member_revoked",
         shouldChallenge: false,
         effectivePolicy: input.policy,
       };
-    },
-  }),
-);
+    }
+    const rank = TRUST_CLASS_RANK[input.trustClass];
+    const floor = ADMISSION_FLOOR[input.policy];
+    if (rank >= floor) return { admitted: true };
+    return {
+      admitted: false,
+      reason: `admission_policy_${input.policy}`,
+      shouldChallenge: false,
+      effectivePolicy: input.policy,
+    };
+  },
+}));
+
+// `routeSetup` resolves the invitee's display name from the bound contact for
+// the post-redemption greeting. Stub the contact store so the router never
+// touches a real DB. This keeps the test self-contained regardless of
+// `bun test` file-load order — without it the test relies on a sibling file's
+// leaked `mock.module`, which breaks whenever the suite's file set changes.
+mock.module("../../contacts/contact-store.js", () => ({
+  getContact: () => null,
+}));
 
 const { routeSetup } = await import("../relay-setup-router.js");
 

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -39,6 +39,8 @@ export interface SubagentDetailResult {
     toolName?: string;
     isError?: boolean;
     messageId?: string;
+    toolUseId?: string;
+    input?: Record<string, unknown>;
   }>;
 }
 
@@ -112,6 +114,8 @@ export function parseSubagentMessages(
           type: "tool_use",
           content: JSON.stringify(input),
           toolName: name,
+          toolUseId: id || undefined,
+          input,
         });
         if (id) pendingTools.set(id, name);
       } else if (
@@ -147,6 +151,7 @@ export function parseSubagentMessages(
           content: resultContent,
           toolName: toolName ?? "unknown",
           isError,
+          toolUseId: toolUseId || undefined,
         });
       }
     }

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -423,12 +423,14 @@ describe("SubagentDetailPanel — nested tool detail", () => {
 
     // Timeline view first.
     expect(screen.getByTestId("timeline")).toBeDefined();
-    expect(screen.queryByText("Technical details")).toBeNull();
+    expect(screen.queryByText("Back to timeline")).toBeNull();
 
     fireEvent.click(screen.getByTestId("timeline-pill"));
 
-    // Detail body is shown: Technical details + Input + Output sections.
-    expect(screen.getByText("Technical details")).toBeDefined();
+    // Detail body is shown (tool input + Output sections). The nested view
+    // omits the "Technical details" label — redundant under the subagent
+    // header + "Back to timeline" affordance — so it must NOT appear.
+    expect(screen.queryByText("Technical details")).toBeNull();
     expect(screen.getByText("Output")).toBeDefined();
     expect(screen.getByText("file-listing-output")).toBeDefined();
     // Timeline is no longer rendered (body swapped, not stacked).
@@ -442,18 +444,18 @@ describe("SubagentDetailPanel — nested tool detail", () => {
     render(<SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />);
 
     fireEvent.click(screen.getByTestId("timeline-pill"));
-    expect(screen.getByText("Technical details")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
 
     fireEvent.click(screen.getByText("Back to timeline"));
     expect(screen.getByTestId("timeline")).toBeDefined();
-    expect(screen.queryByText("Technical details")).toBeNull();
+    expect(screen.queryByText("Back to timeline")).toBeNull();
   });
 
   test("selecting a still-running tool shows the 'Running…' output state", () => {
     render(<SubagentDetailPanel entry={entryWithTool(false)} onClose={noop} />);
 
     fireEvent.click(screen.getByTestId("timeline-pill"));
-    expect(screen.getByText("Technical details")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
     expect(screen.getByText("Running…")).toBeDefined();
   });
 
@@ -466,7 +468,7 @@ describe("SubagentDetailPanel — nested tool detail", () => {
     );
 
     fireEvent.click(screen.getByTestId("timeline-pill"));
-    expect(screen.getByText("Technical details")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
 
     rerender(
       <SubagentDetailPanel
@@ -477,6 +479,6 @@ describe("SubagentDetailPanel — nested tool detail", () => {
 
     // Reset to the timeline for the new subagent.
     expect(screen.getByTestId("timeline")).toBeDefined();
-    expect(screen.queryByText("Technical details")).toBeNull();
+    expect(screen.queryByText("Back to timeline")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -29,10 +29,25 @@ mock.module("@/domains/chat/components/subagent-status-badge", () => ({
 mock.module("@/domains/chat/components/subagent-phase-timeline", () => ({
   SubagentPhaseTimeline: ({
     onToolStepClick,
+    expandedKeys,
+    onExpandedKeysChange,
   }: {
     onToolStepClick?: (toolCallId: string) => void;
+    expandedKeys?: Set<string>;
+    onExpandedKeysChange?: (next: Set<string>) => void;
   }) => (
     <div data-testid="timeline">
+      {/* Surfaces the controlled expand state so a test can assert the panel
+          preserves it across the tool-detail view swap. */}
+      <button
+        type="button"
+        data-testid="timeline-expand"
+        onClick={() =>
+          onExpandedKeysChange?.(new Set(expandedKeys).add("grp-1"))
+        }
+      >
+        {expandedKeys?.has("grp-1") ? "group-open" : "group-closed"}
+      </button>
       <button
         type="button"
         data-testid="timeline-pill"
@@ -423,13 +438,13 @@ describe("SubagentDetailPanel — nested tool detail", () => {
 
     // Timeline view first.
     expect(screen.getByTestId("timeline")).toBeDefined();
-    expect(screen.queryByText("Back to timeline")).toBeNull();
+    expect(screen.queryByText("Back")).toBeNull();
 
     fireEvent.click(screen.getByTestId("timeline-pill"));
 
     // Detail body is shown (tool input + Output sections). The nested view
     // omits the "Technical details" label — redundant under the subagent
-    // header + "Back to timeline" affordance — so it must NOT appear.
+    // header + "Back" affordance — so it must NOT appear.
     expect(screen.queryByText("Technical details")).toBeNull();
     expect(screen.getByText("Output")).toBeDefined();
     expect(screen.getByText("file-listing-output")).toBeDefined();
@@ -440,15 +455,15 @@ describe("SubagentDetailPanel — nested tool detail", () => {
     expect(screen.getByLabelText("Close subagent detail")).toBeDefined();
   });
 
-  test("'Back to timeline' restores the timeline view", () => {
+  test("'Back' restores the timeline view", () => {
     render(<SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />);
 
     fireEvent.click(screen.getByTestId("timeline-pill"));
     expect(screen.getByText("Output")).toBeDefined();
 
-    fireEvent.click(screen.getByText("Back to timeline"));
+    fireEvent.click(screen.getByText("Back"));
     expect(screen.getByTestId("timeline")).toBeDefined();
-    expect(screen.queryByText("Back to timeline")).toBeNull();
+    expect(screen.queryByText("Back")).toBeNull();
   });
 
   test("selecting a still-running tool shows the 'Running…' output state", () => {
@@ -459,14 +474,39 @@ describe("SubagentDetailPanel — nested tool detail", () => {
     expect(screen.getByText("Running…")).toBeDefined();
   });
 
-  test("switching to a different subagent resets the nested view to the timeline", () => {
+  test("returning via 'Back' preserves the expanded timeline group", () => {
+    render(<SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />);
+
+    // Expand a group.
+    expect(screen.getByTestId("timeline-expand").textContent).toBe(
+      "group-closed",
+    );
+    fireEvent.click(screen.getByTestId("timeline-expand"));
+    expect(screen.getByTestId("timeline-expand").textContent).toBe(
+      "group-open",
+    );
+
+    // Open a tool's detail (the timeline unmounts) then return via "Back".
+    fireEvent.click(screen.getByTestId("timeline-pill"));
+    expect(screen.getByText("Output")).toBeDefined();
+    fireEvent.click(screen.getByText("Back"));
+
+    // The group the user had open is still expanded — the lifted expand state
+    // survived the timeline unmounting.
+    expect(screen.getByTestId("timeline-expand").textContent).toBe(
+      "group-open",
+    );
+  });
+
+  test("switching to a different subagent resets the nested view and expanded groups", () => {
     // The desktop parent reuses this instance across subagent switches (no
-    // React `key`), so an open nested detail must not leak onto the next
-    // subagent.
+    // React `key`), so neither an open nested detail nor an expanded group may
+    // leak onto the next subagent.
     const { rerender } = render(
       <SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />,
     );
 
+    fireEvent.click(screen.getByTestId("timeline-expand"));
     fireEvent.click(screen.getByTestId("timeline-pill"));
     expect(screen.getByText("Output")).toBeDefined();
 
@@ -477,8 +517,12 @@ describe("SubagentDetailPanel — nested tool detail", () => {
       />,
     );
 
-    // Reset to the timeline for the new subagent.
+    // Reset to the timeline for the new subagent, with no leaked detail or
+    // expansion.
     expect(screen.getByTestId("timeline")).toBeDefined();
-    expect(screen.queryByText("Back to timeline")).toBeNull();
+    expect(screen.queryByText("Back")).toBeNull();
+    expect(screen.getByTestId("timeline-expand").textContent).toBe(
+      "group-closed",
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -457,38 +457,6 @@ function entryWithThinking(): SubagentEntry {
   });
 }
 
-describe("SubagentDetailPanel — header step carousel", () => {
-  test("shows the live current-step line, and hides it (no duplicate) in a detail", () => {
-    render(<SubagentDetailPanel entry={entryWithThinking()} onClose={noop} />);
-
-    // Timeline view: the header reuses HeaderStepCarousel, surfacing the
-    // current step's text. The stubbed timeline body doesn't render it, so the
-    // single match is the header line.
-    expect(
-      screen.getAllByText("Full reasoning the pill preview truncates.").length,
-    ).toBe(1);
-
-    // Opening a step detail hides the live header line so the reasoning isn't
-    // duplicated across the header and the body — it renders once, in the body.
-    fireEvent.click(screen.getByTestId("timeline-thinking-pill"));
-    expect(
-      screen.getAllByText("Full reasoning the pill preview truncates.").length,
-    ).toBe(1);
-  });
-
-  test("renders no header line before any step exists", () => {
-    render(
-      <SubagentDetailPanel
-        entry={makeEntry({ status: "running", events: [] })}
-        onClose={noop}
-      />,
-    );
-    // No steps yet → the carousel is suppressed so it doesn't just echo the
-    // label; "Working" (the no-step title) never paints.
-    expect(screen.queryByText("Working")).toBeNull();
-  });
-});
-
 describe("SubagentDetailPanel — nested tool detail", () => {
   test("clicking a timeline tool pill swaps the body to the tool detail while keeping the header", () => {
     render(<SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />);

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -23,22 +23,22 @@ mock.module("@/domains/chat/components/subagent-status-badge", () => ({
 
 // The real timeline is exercised in its own test; here we stub it so the panel
 // tests stay focused on the panel's own behavior. The stub renders a button
-// that forwards a fixed tool-call id to the panel's `onToolStepClick`, letting
+// that forwards a fixed tool-call id to the panel's `onStepDetailClick`, letting
 // us drive the nested tool-detail swap without depending on the timeline's
 // expand/pill internals.
 mock.module("@/domains/chat/components/subagent-phase-timeline", () => ({
   SubagentPhaseTimeline: ({
-    onToolStepClick,
+    onStepDetailClick,
     expandedKeys,
     onExpandedKeysChange,
   }: {
-    onToolStepClick?: (toolCallId: string) => void;
+    onStepDetailClick?: (detailKey: string) => void;
     expandedKeys?: Set<string>;
     onExpandedKeysChange?: (next: Set<string>) => void;
   }) => (
     <div data-testid="timeline">
       {/* Surfaces the controlled expand state so a test can assert the panel
-          preserves it across the tool-detail view swap. */}
+          preserves it across the detail view swap. */}
       <button
         type="button"
         data-testid="timeline-expand"
@@ -51,9 +51,16 @@ mock.module("@/domains/chat/components/subagent-phase-timeline", () => ({
       <button
         type="button"
         data-testid="timeline-pill"
-        onClick={() => onToolStepClick?.("tool-1")}
+        onClick={() => onStepDetailClick?.("tool-1")}
       >
         pill
+      </button>
+      <button
+        type="button"
+        data-testid="timeline-thinking-pill"
+        onClick={() => onStepDetailClick?.("think-1")}
+      >
+        thinking
       </button>
     </div>
   ),
@@ -398,7 +405,7 @@ describe("SubagentDetailPanel — objective", () => {
 
 /**
  * A `tool_call`/`tool_result` pair whose `toolUseId` matches the id the stubbed
- * timeline forwards (`tool-1`), so `buildSubagentToolDetails(entry)` produces a
+ * timeline forwards (`tool-1`), so `buildSubagentStepDetails(entry)` produces a
  * payload the panel can swap into. `completed` overrides whether the call has a
  * result (closed) or is still in flight (running output state).
  */
@@ -428,6 +435,24 @@ function entryWithTool(completed: boolean): SubagentEntry {
             },
           ]
         : []),
+    ],
+  });
+}
+
+/**
+ * A single `text` event whose id matches the key the stubbed thinking pill
+ * forwards (`think-1`), so `buildSubagentStepDetails(entry)` produces a
+ * `kind: "thinking"` payload carrying the full reasoning markdown.
+ */
+function entryWithThinking(): SubagentEntry {
+  return makeEntry({
+    events: [
+      {
+        id: "think-1",
+        type: "text",
+        content: "Full reasoning the pill preview truncates.",
+        timestamp: Date.now(),
+      },
     ],
   });
 }
@@ -524,5 +549,24 @@ describe("SubagentDetailPanel — nested tool detail", () => {
     expect(screen.getByTestId("timeline-expand").textContent).toBe(
       "group-closed",
     );
+  });
+
+  test("clicking a thinking pill shows its full reasoning, no tool sections", () => {
+    render(<SubagentDetailPanel entry={entryWithThinking()} onClose={noop} />);
+
+    fireEvent.click(screen.getByTestId("timeline-thinking-pill"));
+
+    // The full (un-truncated) reasoning is rendered as markdown, with none of
+    // the tool-detail sections.
+    expect(
+      screen.getByText("Full reasoning the pill preview truncates."),
+    ).toBeDefined();
+    expect(screen.queryByText("Technical details")).toBeNull();
+    expect(screen.queryByText("Output")).toBeNull();
+
+    // Back returns to the timeline.
+    fireEvent.click(screen.getByText("Back"));
+    expect(screen.getByTestId("timeline")).toBeDefined();
+    expect(screen.queryByText("Back")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -457,6 +457,38 @@ function entryWithThinking(): SubagentEntry {
   });
 }
 
+describe("SubagentDetailPanel — header step carousel", () => {
+  test("shows the live current-step line, and hides it (no duplicate) in a detail", () => {
+    render(<SubagentDetailPanel entry={entryWithThinking()} onClose={noop} />);
+
+    // Timeline view: the header reuses HeaderStepCarousel, surfacing the
+    // current step's text. The stubbed timeline body doesn't render it, so the
+    // single match is the header line.
+    expect(
+      screen.getAllByText("Full reasoning the pill preview truncates.").length,
+    ).toBe(1);
+
+    // Opening a step detail hides the live header line so the reasoning isn't
+    // duplicated across the header and the body — it renders once, in the body.
+    fireEvent.click(screen.getByTestId("timeline-thinking-pill"));
+    expect(
+      screen.getAllByText("Full reasoning the pill preview truncates.").length,
+    ).toBe(1);
+  });
+
+  test("renders no header line before any step exists", () => {
+    render(
+      <SubagentDetailPanel
+        entry={makeEntry({ status: "running", events: [] })}
+        onClose={noop}
+      />,
+    );
+    // No steps yet → the carousel is suppressed so it doesn't just echo the
+    // label; "Working" (the no-step title) never paints.
+    expect(screen.queryByText("Working")).toBeNull();
+  });
+});
+
 describe("SubagentDetailPanel — nested tool detail", () => {
   test("clicking a timeline tool pill swaps the body to the tool detail while keeping the header", () => {
     render(<SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />);

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -287,14 +287,14 @@ describe("SubagentDetailPanel — objective", () => {
 
       const body = screen.getByText(longObjective);
       // Collapsed by default: clamped and offering "Show more".
-      expect(body.className).toContain("line-clamp-3");
+      expect(body.className).toContain("line-clamp-5");
       const toggle = screen.getByText("Show more");
 
       fireEvent.click(toggle);
       // Expanded: clamp removed and the affordance flips to "Show less".
       expect(screen.getByText("Show less")).toBeDefined();
       expect(screen.getByText(longObjective).className).not.toContain(
-        "line-clamp-3",
+        "line-clamp-5",
       );
 
       fireEvent.click(screen.getByText("Show less"));
@@ -341,7 +341,7 @@ describe("SubagentDetailPanel — objective", () => {
       fireEvent.click(screen.getByText("Show more"));
       expect(screen.getByText("Show less")).toBeDefined();
       expect(screen.getByText(longObjective).className).not.toContain(
-        "line-clamp-3",
+        "line-clamp-5",
       );
 
       // Switch to a different subagent with a short objective. Same instance,
@@ -355,7 +355,7 @@ describe("SubagentDetailPanel — objective", () => {
 
       // State reset + re-measured: collapsed, no stale "Show less"/toggle.
       const shortBody = screen.getByText("Short");
-      expect(shortBody.className).toContain("line-clamp-3");
+      expect(shortBody.className).toContain("line-clamp-5");
       expect(screen.queryByText("Show less")).toBeNull();
       expect(screen.queryByText("Show more")).toBeNull();
     } finally {
@@ -395,7 +395,7 @@ describe("SubagentDetailPanel — objective", () => {
       // Re-measured despite identical text: the toggle is still present.
       expect(screen.getByText("Show more")).toBeDefined();
       expect(screen.getByText(longObjective).className).toContain(
-        "line-clamp-3",
+        "line-clamp-5",
       );
     } finally {
       restore();

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -21,8 +21,27 @@ mock.module("@/domains/chat/components/subagent-status-badge", () => ({
   ),
 }));
 
+// The real timeline is exercised in its own test; here we stub it so the panel
+// tests stay focused on the panel's own behavior. The stub renders a button
+// that forwards a fixed tool-call id to the panel's `onToolStepClick`, letting
+// us drive the nested tool-detail swap without depending on the timeline's
+// expand/pill internals.
 mock.module("@/domains/chat/components/subagent-phase-timeline", () => ({
-  SubagentPhaseTimeline: () => <div data-testid="timeline" />,
+  SubagentPhaseTimeline: ({
+    onToolStepClick,
+  }: {
+    onToolStepClick?: (toolCallId: string) => void;
+  }) => (
+    <div data-testid="timeline">
+      <button
+        type="button"
+        data-testid="timeline-pill"
+        onClick={() => onToolStepClick?.("tool-1")}
+      >
+        pill
+      </button>
+    </div>
+  ),
 }));
 
 import { SubagentDetailPanel } from "@/domains/chat/components/subagent-detail-panel";
@@ -359,5 +378,105 @@ describe("SubagentDetailPanel — objective", () => {
     } finally {
       restore();
     }
+  });
+});
+
+/**
+ * A `tool_call`/`tool_result` pair whose `toolUseId` matches the id the stubbed
+ * timeline forwards (`tool-1`), so `buildSubagentToolDetails(entry)` produces a
+ * payload the panel can swap into. `completed` overrides whether the call has a
+ * result (closed) or is still in flight (running output state).
+ */
+function entryWithTool(completed: boolean): SubagentEntry {
+  const now = Date.now();
+  return makeEntry({
+    events: [
+      {
+        id: "te-call",
+        type: "tool_call",
+        content: "ls -la",
+        toolName: "bash",
+        toolUseId: "tool-1",
+        input: { command: "ls -la" },
+        timestamp: now,
+      },
+      ...(completed
+        ? [
+            {
+              id: "te-result",
+              type: "tool_result" as const,
+              content: "file-listing-output",
+              result: "file-listing-output",
+              toolName: "bash",
+              toolUseId: "tool-1",
+              timestamp: now + 1000,
+            },
+          ]
+        : []),
+    ],
+  });
+}
+
+describe("SubagentDetailPanel — nested tool detail", () => {
+  test("clicking a timeline tool pill swaps the body to the tool detail while keeping the header", () => {
+    render(<SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />);
+
+    // Timeline view first.
+    expect(screen.getByTestId("timeline")).toBeDefined();
+    expect(screen.queryByText("Technical details")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("timeline-pill"));
+
+    // Detail body is shown: Technical details + Input + Output sections.
+    expect(screen.getByText("Technical details")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
+    expect(screen.getByText("file-listing-output")).toBeDefined();
+    // Timeline is no longer rendered (body swapped, not stacked).
+    expect(screen.queryByTestId("timeline")).toBeNull();
+    // The subagent header stays mounted in the detail view.
+    expect(screen.getByText("Research agent")).toBeDefined();
+    expect(screen.getByLabelText("Close subagent detail")).toBeDefined();
+  });
+
+  test("'Back to timeline' restores the timeline view", () => {
+    render(<SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />);
+
+    fireEvent.click(screen.getByTestId("timeline-pill"));
+    expect(screen.getByText("Technical details")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Back to timeline"));
+    expect(screen.getByTestId("timeline")).toBeDefined();
+    expect(screen.queryByText("Technical details")).toBeNull();
+  });
+
+  test("selecting a still-running tool shows the 'Running…' output state", () => {
+    render(<SubagentDetailPanel entry={entryWithTool(false)} onClose={noop} />);
+
+    fireEvent.click(screen.getByTestId("timeline-pill"));
+    expect(screen.getByText("Technical details")).toBeDefined();
+    expect(screen.getByText("Running…")).toBeDefined();
+  });
+
+  test("switching to a different subagent resets the nested view to the timeline", () => {
+    // The desktop parent reuses this instance across subagent switches (no
+    // React `key`), so an open nested detail must not leak onto the next
+    // subagent.
+    const { rerender } = render(
+      <SubagentDetailPanel entry={entryWithTool(true)} onClose={noop} />,
+    );
+
+    fireEvent.click(screen.getByTestId("timeline-pill"));
+    expect(screen.getByText("Technical details")).toBeDefined();
+
+    rerender(
+      <SubagentDetailPanel
+        entry={{ ...entryWithTool(true), subagentId: "sub-2" }}
+        onClose={noop}
+      />,
+    );
+
+    // Reset to the timeline for the new subagent.
+    expect(screen.getByTestId("timeline")).toBeDefined();
+    expect(screen.queryByText("Technical details")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -128,7 +128,7 @@ export function SubagentDetailPanel({
 
   // Measure overflow against the collapsed clamp. While collapsed the clamp is
   // the source of truth, so `scrollHeight` exceeds `clientHeight` only when the
-  // body is taller than the visible 3 lines. Skip measuring while expanded
+  // body is taller than the visible 5 lines. Skip measuring while expanded
   // (the clamp is removed, which would otherwise report no overflow) so the
   // "Show less" affordance stays visible.
   //
@@ -273,7 +273,7 @@ export function SubagentDetailPanel({
                   variant="body-medium-lighter"
                   as="p"
                   className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
-                    objectiveExpanded ? "" : "line-clamp-3"
+                    objectiveExpanded ? "" : "line-clamp-5"
                   }`}
                 >
                   {entry.objective}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -24,7 +24,6 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
 import { Button, Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
-import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
@@ -178,30 +177,15 @@ export function SubagentDetailPanel({
         ) : (
           <div style={{ width: 32, height: 32, flexShrink: 0 }} aria-hidden />
         )}
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <div className="flex min-w-0 items-center gap-2">
-            <Typography
-              variant="title-medium"
-              title={entry.label}
-              className="min-w-0 shrink truncate text-[var(--content-default)]"
-            >
-              {entry.label}
-            </Typography>
-            <StatusBadge status={entry.status} />
-          </div>
-          {/* Live "what the subagent is doing now" line — reuses the main-chat
-              header carousel, fed by the same derived (title, info) the inline
-              card uses. Hidden until there's at least one step (so an event-less
-              spawn doesn't just echo the label) and while a nested step detail
-              is open (the body is focused on one step, not the live latest). */}
-          {cardData.steps.length > 0 && !activeDetail && (
-            <HeaderStepCarousel
-              currentStepTitle={cardData.currentStepTitle}
-              currentStepInfo={cardData.currentStepInfo}
-              bypassDwell={cardData.state !== "loading"}
-            />
-          )}
-        </div>
+        <Typography
+          variant="title-medium"
+          title={entry.label}
+          className="min-w-0 shrink truncate text-[var(--content-default)]"
+        >
+          {entry.label}
+        </Typography>
+        <StatusBadge status={entry.status} />
+        <span className="flex-1" />
         {isRunning && onStop && (
           <button
             type="button"
@@ -355,6 +339,9 @@ export function SubagentDetailPanel({
                   onStepDetailClick={(key) => {
                     if (stepDetails.has(key)) setSelectedDetailKey(key);
                   }}
+                  // Keeps the last phase's node pulsing while the subagent is
+                  // still active but its last phase has settled.
+                  isRunning={isRunning}
                 />
               ) : (
                 <Typography

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -24,8 +24,10 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
 import { Button, Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
+import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
 import {
     buildSubagentStepDetails,
     computeSubagentCardData,
@@ -176,15 +178,30 @@ export function SubagentDetailPanel({
         ) : (
           <div style={{ width: 32, height: 32, flexShrink: 0 }} aria-hidden />
         )}
-        <Typography
-          variant="title-medium"
-          title={entry.label}
-          className="min-w-0 shrink truncate text-[var(--content-default)]"
-        >
-          {entry.label}
-        </Typography>
-        <StatusBadge status={entry.status} />
-        <span className="flex-1" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex min-w-0 items-center gap-2">
+            <Typography
+              variant="title-medium"
+              title={entry.label}
+              className="min-w-0 shrink truncate text-[var(--content-default)]"
+            >
+              {entry.label}
+            </Typography>
+            <StatusBadge status={entry.status} />
+          </div>
+          {/* Live "what the subagent is doing now" line — reuses the main-chat
+              header carousel, fed by the same derived (title, info) the inline
+              card uses. Hidden until there's at least one step (so an event-less
+              spawn doesn't just echo the label) and while a nested step detail
+              is open (the body is focused on one step, not the live latest). */}
+          {cardData.steps.length > 0 && !activeDetail && (
+            <HeaderStepCarousel
+              currentStepTitle={cardData.currentStepTitle}
+              currentStepInfo={cardData.currentStepInfo}
+              bypassDwell={cardData.state !== "loading"}
+            />
+          )}
+        </div>
         {isRunning && onStop && (
           <button
             type="button"
@@ -220,13 +237,16 @@ export function SubagentDetailPanel({
               <Typography variant="label-medium-default">Back</Typography>
             </button>
             {/* Thinking steps render their full reasoning markdown statically
-                (subagent detail isn't a live chat-session source); tool steps
-                use the shared technical-details/output body. */}
+                (subagent detail isn't a live chat-session source); web_search
+                steps render their query + source links; tool steps use the
+                shared technical-details/output body. */}
             {activeDetail.kind === "thinking" ? (
               <ChatMarkdownMessage
                 content={activeDetail.thinkingText ?? ""}
                 hardLineBreaks
               />
+            ) : activeDetail.kind === "web_search" ? (
+              <WebSearchDetailView detail={activeDetail} />
             ) : (
               <ToolDetailBody
                 detail={activeDetail}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -23,10 +23,11 @@ import { isActiveStatus } from "@/utils/subagent-status";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button, Typography } from "@vellumai/design-library";
 
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
 import {
-    buildSubagentToolDetails,
+    buildSubagentStepDetails,
     computeSubagentCardData,
 } from "@/domains/chat/hooks/use-subagent-card-data";
 
@@ -75,18 +76,20 @@ export function SubagentDetailPanel({
   // panel body to a tool's input/output when its timeline pill is clicked —
   // without ever touching the global viewer-store / main view.
   //
-  // A tool step is clickable only when its event carries a `toolUseId` (the
-  // key) — true for both live streaming events and reloaded/history subagents
-  // hydrated via `onRequestDetail` from `GET /subagents/:id` (the route emits
-  // the tool id + raw input, and `mapDetailEvents` carries them through). Steps
-  // without a `toolUseId` simply have no entry here and render as non-clickable
-  // pills — a graceful fallback, not an error.
-  const toolDetails = useMemo(() => buildSubagentToolDetails(entry), [entry]);
+  // Detail payloads for clickable timeline steps, keyed by the id a pill emits.
+  // Tool steps key on their `toolUseId` (present for both live streaming events
+  // and reloaded/history subagents hydrated via `onRequestDetail` from
+  // `GET /subagents/:id`, which emits the tool id + raw input that
+  // `mapDetailEvents` carries through); thinking/text steps key on the source
+  // event id and carry the full, un-truncated reasoning. Steps with no entry
+  // here render as non-clickable pills — a graceful fallback, not an error.
+  const stepDetails = useMemo(() => buildSubagentStepDetails(entry), [entry]);
 
-  // Which tool call's detail (if any) is shown nested inside this panel. `null`
-  // shows the timeline. Reset on subagent switch via the render-phase block
-  // below so a detail opened for one subagent doesn't leak onto the next.
-  const [selectedToolCallId, setSelectedToolCallId] = useState<string | null>(
+  // Which step's detail (if any) is shown nested inside this panel — the key
+  // into `stepDetails` (a tool call or a thinking segment), or `null` to show
+  // the timeline. Reset on subagent switch via the render-phase block below so
+  // a detail opened for one subagent doesn't leak onto the next.
+  const [selectedDetailKey, setSelectedDetailKey] = useState<string | null>(
     null,
   );
 
@@ -119,7 +122,7 @@ export function SubagentDetailPanel({
     setObjectiveOverflows(false);
     // Switching subagents returns the panel to the timeline view and clears
     // the previous subagent's expanded groups.
-    setSelectedToolCallId(null);
+    setSelectedDetailKey(null);
     setExpandedSectionKeys(new Set());
   }
 
@@ -154,8 +157,8 @@ export function SubagentDetailPanel({
 
   // The selected tool's nested payload, or `undefined` when nothing is selected
   // or the id has no payload (defensive — fall back to the timeline view).
-  const activeDetail = selectedToolCallId
-    ? toolDetails.get(selectedToolCallId)
+  const activeDetail = selectedDetailKey
+    ? stepDetails.get(selectedDetailKey)
     : undefined;
 
   return (
@@ -203,23 +206,33 @@ export function SubagentDetailPanel({
         />
       </div>
 
-      {/* Scrollable body — swaps to a tool's nested detail when one is selected,
+      {/* Scrollable body — swaps to a step's nested detail when one is selected,
           keeping the header above mounted in both views. */}
       <div className="flex-1 overflow-y-auto px-5 py-5">
         {activeDetail ? (
           <>
             <button
               type="button"
-              onClick={() => setSelectedToolCallId(null)}
+              onClick={() => setSelectedDetailKey(null)}
               className="mb-4 flex cursor-pointer items-center gap-1.5 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
             >
               <ChevronLeft className="h-4 w-4" aria-hidden />
               <Typography variant="label-medium-default">Back</Typography>
             </button>
-            <ToolDetailBody
-              detail={activeDetail}
-              showTechnicalDetailsLabel={false}
-            />
+            {/* Thinking steps render their full reasoning markdown statically
+                (subagent detail isn't a live chat-session source); tool steps
+                use the shared technical-details/output body. */}
+            {activeDetail.kind === "thinking" ? (
+              <ChatMarkdownMessage
+                content={activeDetail.thinkingText ?? ""}
+                hardLineBreaks
+              />
+            ) : (
+              <ToolDetailBody
+                detail={activeDetail}
+                showTechnicalDetailsLabel={false}
+              />
+            )}
           </>
         ) : (
           <>
@@ -319,8 +332,8 @@ export function SubagentDetailPanel({
                   steps={cardData.steps}
                   expandedKeys={expandedSectionKeys}
                   onExpandedKeysChange={setExpandedSectionKeys}
-                  onToolStepClick={(id) => {
-                    if (toolDetails.has(id)) setSelectedToolCallId(id);
+                  onStepDetailClick={(key) => {
+                    if (stepDetails.has(key)) setSelectedDetailKey(key);
                   }}
                 />
               ) : (

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -3,6 +3,7 @@ import {
     ArrowDownToLine,
     ArrowUpFromLine,
     ChevronDown,
+    ChevronLeft,
     DollarSign,
     Square,
     X,
@@ -23,7 +24,11 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
 import { Button, Typography } from "@vellumai/design-library";
 
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
-import { computeSubagentCardData } from "@/domains/chat/hooks/use-subagent-card-data";
+import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
+import {
+    buildSubagentToolDetails,
+    computeSubagentCardData,
+} from "@/domains/chat/hooks/use-subagent-card-data";
 
 /** Format a cost value (e.g. 0.68 -> "0.68"). */
 function formatCost(cost: number): string {
@@ -66,6 +71,28 @@ export function SubagentDetailPanel({
   // chat-content-layout.tsx, so memoizing on `entry` keeps the steps fresh.
   const cardData = useMemo(() => computeSubagentCardData(entry), [entry]);
 
+  // `toolCallId`-keyed map of nested tool-detail payloads, used to swap the
+  // panel body to a tool's input/output when its timeline pill is clicked —
+  // without ever touching the global viewer-store / main view.
+  //
+  // Availability is live-only by design: streaming subagent events carry a
+  // `toolUseId` plus raw `input`/`result`, so `buildSubagentToolDetails`
+  // produces a payload and the pill becomes clickable. Reloaded/history
+  // subagents are hydrated via `onRequestDetail` from the daemon's
+  // `GET /subagents/:id` route, which currently omits the tool id / raw
+  // input / result (see assistant `subagents-routes.ts` + `mapDetailEvents`),
+  // so those tool steps have no entry here and render as non-clickable pills —
+  // a graceful fallback, not an error. Surfacing detail for history subagents
+  // requires the daemon route to carry those fields (tracked as a follow-up).
+  const toolDetails = useMemo(() => buildSubagentToolDetails(entry), [entry]);
+
+  // Which tool call's detail (if any) is shown nested inside this panel. `null`
+  // shows the timeline. Reset on subagent switch via the render-phase block
+  // below so a detail opened for one subagent doesn't leak onto the next.
+  const [selectedToolCallId, setSelectedToolCallId] = useState<string | null>(
+    null,
+  );
+
   // Objective collapse/expand. The toggle only appears when the clamped body
   // actually overflows, so short objectives show no affordance.
   const [objectiveExpanded, setObjectiveExpanded] = useState(false);
@@ -85,6 +112,8 @@ export function SubagentDetailPanel({
     setPrevSubagentId(entry.subagentId);
     setObjectiveExpanded(false);
     setObjectiveOverflows(false);
+    // Switching subagents returns the panel to the timeline view.
+    setSelectedToolCallId(null);
   }
 
   // Measure overflow against the collapsed clamp. While collapsed the clamp is
@@ -115,6 +144,12 @@ export function SubagentDetailPanel({
       onRequestDetail(entry.subagentId);
     }
   }, [entry.subagentId, entry.conversationId, entry.events.length, onRequestDetail]);
+
+  // The selected tool's nested payload, or `undefined` when nothing is selected
+  // or the id has no payload (defensive — fall back to the timeline view).
+  const activeDetail = selectedToolCallId
+    ? toolDetails.get(selectedToolCallId)
+    : undefined;
 
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
@@ -161,112 +196,134 @@ export function SubagentDetailPanel({
         />
       </div>
 
-      {/* Scrollable body */}
+      {/* Scrollable body — swaps to a tool's nested detail when one is selected,
+          keeping the header above mounted in both views. */}
       <div className="flex-1 overflow-y-auto px-5 py-5">
-        {/* Metrics row */}
-        <div className="mb-5 grid grid-cols-3 gap-3">
-          <AnimatedMetricCard
-            icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-            target={entry.inputTokens}
-            format={(n) => formatNumber(Math.round(n))}
-            label="Input"
-          />
-          <AnimatedMetricCard
-            icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-            target={entry.outputTokens}
-            format={(n) => formatNumber(Math.round(n))}
-            label="Output"
-          />
-          <AnimatedMetricCard
-            icon={<DollarSign className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-            target={entry.totalCost}
-            format={formatCost}
-            label="Cost"
-          />
-        </div>
+        {activeDetail ? (
+          <>
+            <button
+              type="button"
+              onClick={() => setSelectedToolCallId(null)}
+              className="mb-4 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" aria-hidden />
+              <Typography variant="label-small-default">
+                Back to timeline
+              </Typography>
+            </button>
+            <ToolDetailBody detail={activeDetail} />
+          </>
+        ) : (
+          <>
+            {/* Metrics row */}
+            <div className="mb-5 grid grid-cols-3 gap-3">
+              <AnimatedMetricCard
+                icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+                target={entry.inputTokens}
+                format={(n) => formatNumber(Math.round(n))}
+                label="Input"
+              />
+              <AnimatedMetricCard
+                icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+                target={entry.outputTokens}
+                format={(n) => formatNumber(Math.round(n))}
+                label="Output"
+              />
+              <AnimatedMetricCard
+                icon={<DollarSign className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+                target={entry.totalCost}
+                format={formatCost}
+                label="Cost"
+              />
+            </div>
 
-        {/* Objective section */}
-        {entry.objective && (
-          <div className="mb-5">
-            <Typography
-              variant="body-medium-default"
-              as="h3"
-              className="mb-2 text-[var(--content-emphasised)]"
-            >
-              Objective
-            </Typography>
-            <Typography
-              ref={objectiveBodyRef}
-              variant="body-medium-lighter"
-              as="p"
-              className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
-                objectiveExpanded ? "" : "line-clamp-3"
-              }`}
-            >
-              {entry.objective}
-            </Typography>
-            {objectiveOverflows && (
-              <button
-                type="button"
-                onClick={() => setObjectiveExpanded((prev) => !prev)}
-                className="mt-1.5 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
-              >
-                <Typography variant="label-small-default">
-                  {objectiveExpanded ? "Show less" : "Show more"}
+            {/* Objective section */}
+            {entry.objective && (
+              <div className="mb-5">
+                <Typography
+                  variant="body-medium-default"
+                  as="h3"
+                  className="mb-2 text-[var(--content-emphasised)]"
+                >
+                  Objective
                 </Typography>
-                <ChevronDown
-                  className={`h-3.5 w-3.5 transition-transform ${
-                    objectiveExpanded ? "rotate-180" : ""
+                <Typography
+                  ref={objectiveBodyRef}
+                  variant="body-medium-lighter"
+                  as="p"
+                  className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
+                    objectiveExpanded ? "" : "line-clamp-3"
                   }`}
-                  aria-hidden
-                />
-              </button>
+                >
+                  {entry.objective}
+                </Typography>
+                {objectiveOverflows && (
+                  <button
+                    type="button"
+                    onClick={() => setObjectiveExpanded((prev) => !prev)}
+                    className="mt-1.5 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+                  >
+                    <Typography variant="label-small-default">
+                      {objectiveExpanded ? "Show less" : "Show more"}
+                    </Typography>
+                    <ChevronDown
+                      className={`h-3.5 w-3.5 transition-transform ${
+                        objectiveExpanded ? "rotate-180" : ""
+                      }`}
+                      aria-hidden
+                    />
+                  </button>
+                )}
+                <div className="mt-5 h-px w-full bg-[var(--border-hover)]" />
+              </div>
             )}
-            <div className="mt-5 h-px w-full bg-[var(--border-hover)]" />
-          </div>
-        )}
 
-        {/* Timeline section */}
-        <div>
-          <Typography
-            variant="title-medium"
-            as="h3"
-            className="mb-4 text-[var(--content-emphasised)]"
-          >
-            Timeline
-          </Typography>
-          {/*
-           * Key by subagent id so the timeline remounts on subagent switch,
-           * resetting the expand/collapse state it holds. The drawer keeps this
-           * component mounted across switches, so without a per-subagent reset
-           * an expanded phase would leak its expanded state onto the next
-           * subagent's same-positioned phase.
-           */}
-          {/*
-           * Gate the empty state on the RAW `entry.events`, not on
-           * `cardData.steps`. `computeSubagentCardData` can intentionally
-           * DROP events (e.g. a `tool_result` with no preceding in-flight
-           * `tool_call`), so `entry.events` can be non-empty while
-           * `cardData.steps` is empty. Gating on steps would show a false
-           * "No events yet" AND — because `entry.events.length !== 0` — the
-           * detail-refetch effect above wouldn't fire to recover. When the
-           * store has events we render the timeline (which returns null for
-           * zero steps, an acceptable no-op).
-           */}
-          {entry.events.length > 0 ? (
-            <SubagentPhaseTimeline
-              key={entry.subagentId}
-              steps={cardData.steps}
-            />
-          ) : (
-            <Typography
-              variant="body-small-default"
-              className="py-4 text-center text-[var(--content-tertiary)]"
-            >
-              No events yet
-            </Typography>
-          )}
-        </div>
+            {/* Timeline section */}
+            <div>
+              <Typography
+                variant="title-medium"
+                as="h3"
+                className="mb-4 text-[var(--content-emphasised)]"
+              >
+                Timeline
+              </Typography>
+              {/*
+               * Key by subagent id so the timeline remounts on subagent switch,
+               * resetting the expand/collapse state it holds. The drawer keeps this
+               * component mounted across switches, so without a per-subagent reset
+               * an expanded phase would leak its expanded state onto the next
+               * subagent's same-positioned phase.
+               */}
+              {/*
+               * Gate the empty state on the RAW `entry.events`, not on
+               * `cardData.steps`. `computeSubagentCardData` can intentionally
+               * DROP events (e.g. a `tool_result` with no preceding in-flight
+               * `tool_call`), so `entry.events` can be non-empty while
+               * `cardData.steps` is empty. Gating on steps would show a false
+               * "No events yet" AND — because `entry.events.length !== 0` — the
+               * detail-refetch effect above wouldn't fire to recover. When the
+               * store has events we render the timeline (which returns null for
+               * zero steps, an acceptable no-op).
+               */}
+              {entry.events.length > 0 ? (
+                <SubagentPhaseTimeline
+                  key={entry.subagentId}
+                  steps={cardData.steps}
+                  onToolStepClick={(id) => {
+                    if (toolDetails.has(id)) setSelectedToolCallId(id);
+                  }}
+                />
+              ) : (
+                <Typography
+                  variant="body-small-default"
+                  className="py-4 text-center text-[var(--content-tertiary)]"
+                >
+                  No events yet
+                </Typography>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -201,14 +201,17 @@ export function SubagentDetailPanel({
             <button
               type="button"
               onClick={() => setSelectedToolCallId(null)}
-              className="mb-4 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+              className="mb-4 flex cursor-pointer items-center gap-1.5 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
             >
-              <ChevronLeft className="h-3.5 w-3.5" aria-hidden />
-              <Typography variant="label-small-default">
+              <ChevronLeft className="h-4 w-4" aria-hidden />
+              <Typography variant="label-medium-default">
                 Back to timeline
               </Typography>
             </button>
-            <ToolDetailBody detail={activeDetail} />
+            <ToolDetailBody
+              detail={activeDetail}
+              showTechnicalDetailsLabel={false}
+            />
           </>
         ) : (
           <>

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -75,15 +75,12 @@ export function SubagentDetailPanel({
   // panel body to a tool's input/output when its timeline pill is clicked —
   // without ever touching the global viewer-store / main view.
   //
-  // Availability is live-only by design: streaming subagent events carry a
-  // `toolUseId` plus raw `input`/`result`, so `buildSubagentToolDetails`
-  // produces a payload and the pill becomes clickable. Reloaded/history
-  // subagents are hydrated via `onRequestDetail` from the daemon's
-  // `GET /subagents/:id` route, which currently omits the tool id / raw
-  // input / result (see assistant `subagents-routes.ts` + `mapDetailEvents`),
-  // so those tool steps have no entry here and render as non-clickable pills —
-  // a graceful fallback, not an error. Surfacing detail for history subagents
-  // requires the daemon route to carry those fields (tracked as a follow-up).
+  // A tool step is clickable only when its event carries a `toolUseId` (the
+  // key) — true for both live streaming events and reloaded/history subagents
+  // hydrated via `onRequestDetail` from `GET /subagents/:id` (the route emits
+  // the tool id + raw input, and `mapDetailEvents` carries them through). Steps
+  // without a `toolUseId` simply have no entry here and render as non-clickable
+  // pills — a graceful fallback, not an error.
   const toolDetails = useMemo(() => buildSubagentToolDetails(entry), [entry]);
 
   // Which tool call's detail (if any) is shown nested inside this panel. `null`

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -90,6 +90,14 @@ export function SubagentDetailPanel({
     null,
   );
 
+  // Which timeline groups are expanded. Lifted out of `SubagentPhaseTimeline`
+  // so the expansion survives the timeline unmounting while a nested tool
+  // detail is shown — returning via "Back" restores the same open group. Reset
+  // on subagent switch via the render-phase block below.
+  const [expandedSectionKeys, setExpandedSectionKeys] = useState<Set<string>>(
+    new Set(),
+  );
+
   // Objective collapse/expand. The toggle only appears when the clamped body
   // actually overflows, so short objectives show no affordance.
   const [objectiveExpanded, setObjectiveExpanded] = useState(false);
@@ -109,8 +117,10 @@ export function SubagentDetailPanel({
     setPrevSubagentId(entry.subagentId);
     setObjectiveExpanded(false);
     setObjectiveOverflows(false);
-    // Switching subagents returns the panel to the timeline view.
+    // Switching subagents returns the panel to the timeline view and clears
+    // the previous subagent's expanded groups.
     setSelectedToolCallId(null);
+    setExpandedSectionKeys(new Set());
   }
 
   // Measure overflow against the collapsed clamp. While collapsed the clamp is
@@ -204,9 +214,7 @@ export function SubagentDetailPanel({
               className="mb-4 flex cursor-pointer items-center gap-1.5 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
             >
               <ChevronLeft className="h-4 w-4" aria-hidden />
-              <Typography variant="label-medium-default">
-                Back to timeline
-              </Typography>
+              <Typography variant="label-medium-default">Back</Typography>
             </button>
             <ToolDetailBody
               detail={activeDetail}
@@ -309,6 +317,8 @@ export function SubagentDetailPanel({
                 <SubagentPhaseTimeline
                   key={entry.subagentId}
                   steps={cardData.steps}
+                  expandedKeys={expandedSectionKeys}
+                  onExpandedKeysChange={setExpandedSectionKeys}
                   onToolStepClick={(id) => {
                     if (toolDetails.has(id)) setSelectedToolCallId(id);
                   }}

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
@@ -47,7 +47,7 @@ describe("SubagentInlineProgressCard — spawn race", () => {
 });
 
 describe("SubagentInlineProgressCard — fixture timeline", () => {
-  test("shows Thinking title with text preview while a text event is the latest", () => {
+  test("titles the card with the subagent task name, with the live text preview as subtitle", () => {
     spawn("sa-1");
     useSubagentStore.getState().receiveEvent({
       subagentId: "sa-1",
@@ -59,7 +59,9 @@ describe("SubagentInlineProgressCard — fixture timeline", () => {
       <SubagentInlineProgressCard subagentId="sa-1" />,
     );
 
-    expect(getByText("Thinking")).toBeTruthy();
+    // Title is the subagent's task name (not the derived "Thinking" status);
+    // the live reasoning preview moves to the subtitle.
+    expect(getByText("Research Agent")).toBeTruthy();
     expect(getByText("Checking the docs")).toBeTruthy();
     // Single-step cards suppress the count pill — it only shows for 2+.
     expect(queryByText("1 step")).toBeNull();
@@ -87,7 +89,8 @@ describe("SubagentInlineProgressCard — fixture timeline", () => {
     const { getByText } = render(
       <SubagentInlineProgressCard subagentId="sa-2" />,
     );
-    expect(getByText("Working")).toBeTruthy();
+    // Title stays the task name; the running tool's detail is the subtitle.
+    expect(getByText("Research Agent")).toBeTruthy();
     expect(getByText("ls -la")).toBeTruthy();
     expect(getByText("2 steps")).toBeTruthy();
   });
@@ -118,7 +121,9 @@ describe("SubagentInlineProgressCard — fixture timeline", () => {
     const { getByText, queryByText } = render(
       <SubagentInlineProgressCard subagentId="sa-3" />,
     );
-    expect(getByText("Used File Read")).toBeTruthy();
+    // Title is the task name even for a completed subagent (the derived
+    // "Used File Read" status is no longer the title).
+    expect(getByText("Research Agent")).toBeTruthy();
     // Single-step cards suppress the count pill.
     expect(queryByText("1 step")).toBeNull();
   });

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
@@ -28,6 +28,7 @@ import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
 import { PhaseGroupedStepList } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
 import { useSubagentCardData } from "@/domains/chat/hooks/use-subagent-card-data";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
 
 export interface SubagentInlineProgressCardProps {
   subagentId: string;
@@ -49,6 +50,10 @@ export function SubagentInlineProgressCard({
   onStopSubagent,
 }: SubagentInlineProgressCardProps) {
   const data = useSubagentCardData(subagentId);
+  // The subagent's task name (e.g. "research-car-brands") titles the card so it
+  // reads as "which subagent"; the derived live status/detail moves to the
+  // subtitle (below).
+  const label = useSubagentStore((s) => s.byId[subagentId]?.label);
   // The shell's `loading` state subsumes running / pending / awaiting_input
   // (see `deriveCardState` in use-subagent-card-data) — exactly the window
   // where stopping the subagent is a meaningful action.
@@ -72,6 +77,18 @@ export function SubagentInlineProgressCard({
   if (!data) return null;
 
   const leadingIcon = <SubagentAvatarChip subagentId={subagentId} size={20} />;
+
+  // Title = the subagent's task name. The previously-derived status ("Working",
+  // "Searching the web") + detail collapse into the subtitle: prefer the
+  // specific detail, falling back to the status word when a step carries none
+  // (e.g. a web_search, whose detail is empty) or when the only "detail" is the
+  // label itself (no steps yet) — so the subtitle never reads blank or echoes
+  // the title.
+  const headerTitle = label ?? data.currentStepTitle;
+  const headerInfo =
+    data.currentStepInfo && data.currentStepInfo !== label
+      ? data.currentStepInfo
+      : data.currentStepTitle;
 
   // Stop button only — the open affordance is gone; the whole header row
   // now fires `onSubagentClick` via the shell's `onHeaderClick` override.
@@ -97,8 +114,8 @@ export function SubagentInlineProgressCard({
         statusIndicatorTestId="subagent-inline-card-status-indicator"
         state={data.state}
         leadingIcon={leadingIcon}
-        currentStepTitle={data.currentStepTitle}
-        currentStepInfo={data.currentStepInfo}
+        currentStepTitle={headerTitle}
+        currentStepInfo={headerInfo}
         stepCount={data.stepCount}
         // The shell's expanded body is unused — there is no inline timeline
         // to reveal. Disabling expand keeps the shell from tracking state

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -39,8 +39,12 @@ function bash(
   };
 }
 
-function thinking(text: string, duration = "1s"): ToolCallCardStep {
-  return { kind: "thinking", durationLabel: duration, text };
+function thinking(
+  text: string,
+  duration = "1s",
+  detailKey?: string,
+): ToolCallCardStep {
+  return { kind: "thinking", durationLabel: duration, text, detailKey };
 }
 
 function toolError(message: string): ToolCallCardStep {
@@ -198,13 +202,13 @@ describe("SubagentPhaseTimeline — single-step expandability", () => {
 
 describe("SubagentPhaseTimeline — clickable tool steps", () => {
   test("tool steps render as clickable buttons and call back with toolCallId", () => {
-    const onToolStepClick = mock((_id: string) => {});
+    const onStepDetailClick = mock((_id: string) => {});
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", "tc-a"),
       bash("pwd", "completed", "2s", "tc-b"),
     ];
     const { getByTestId, getAllByTestId } = render(
-      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
     );
 
     fireEvent.click(getByTestId("subagent-phase-header"));
@@ -214,11 +218,11 @@ describe("SubagentPhaseTimeline — clickable tool steps", () => {
     pills.forEach((pill) => expect(pill.tagName).toBe("BUTTON"));
 
     fireEvent.click(pills[0]!);
-    expect(onToolStepClick).toHaveBeenCalledTimes(1);
-    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-a");
+    expect(onStepDetailClick).toHaveBeenCalledTimes(1);
+    expect(onStepDetailClick).toHaveBeenLastCalledWith("tc-a");
 
     fireEvent.click(pills[1]!);
-    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-b");
+    expect(onStepDetailClick).toHaveBeenLastCalledWith("tc-b");
   });
 
   // A clickable tool step whose labeler produced no `info` still renders a
@@ -228,10 +232,10 @@ describe("SubagentPhaseTimeline — clickable tool steps", () => {
   // step — and thus disabling the row even though the clickable arm would have
   // rendered a real pill.
   test("a single info-less tool step is expandable + clickable when a handler is wired", () => {
-    const onToolStepClick = mock((_id: string) => {});
+    const onStepDetailClick = mock((_id: string) => {});
     const steps: ToolCallCardStep[] = [bash("", "completed", "1s", "tc-a")];
     const { getByTestId } = render(
-      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
     );
 
     const header = getByTestId("subagent-phase-header");
@@ -242,26 +246,44 @@ describe("SubagentPhaseTimeline — clickable tool steps", () => {
     expect(pill.tagName).toBe("BUTTON");
 
     fireEvent.click(pill);
-    expect(onToolStepClick).toHaveBeenCalledTimes(1);
-    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-a");
+    expect(onStepDetailClick).toHaveBeenCalledTimes(1);
+    expect(onStepDetailClick).toHaveBeenLastCalledWith("tc-a");
   });
 
-  test("a thinking step does NOT render as a clickable tool pill", () => {
-    const onToolStepClick = mock((_id: string) => {});
+  test("a thinking step WITHOUT a detail key is not clickable", () => {
+    const onStepDetailClick = mock((_id: string) => {});
     const steps: ToolCallCardStep[] = [thinking("Considering options")];
     const { getByTestId, queryByTestId } = render(
-      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
     );
 
     fireEvent.click(getByTestId("subagent-phase-header"));
     expect(queryByTestId("tool-step-pill")).toBeNull();
   });
 
+  test("a thinking step WITH a detail key renders a clickable pill and calls back", () => {
+    const onStepDetailClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [
+      thinking("Considering options", "1s", "think-1"),
+    ];
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    const pill = getByTestId("tool-step-pill");
+    expect(pill.tagName).toBe("BUTTON");
+
+    fireEvent.click(pill);
+    expect(onStepDetailClick).toHaveBeenCalledTimes(1);
+    expect(onStepDetailClick).toHaveBeenLastCalledWith("think-1");
+  });
+
   test("a tool_error step does NOT render as a clickable tool pill", () => {
-    const onToolStepClick = mock((_id: string) => {});
+    const onStepDetailClick = mock((_id: string) => {});
     const steps: ToolCallCardStep[] = [toolError("context window exceeded")];
     const { getByTestId, queryByTestId } = render(
-      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
     );
 
     fireEvent.click(getByTestId("subagent-phase-header"));
@@ -269,13 +291,13 @@ describe("SubagentPhaseTimeline — clickable tool steps", () => {
   });
 
   test("tool steps with an empty toolCallId stay non-clickable", () => {
-    const onToolStepClick = mock((_id: string) => {});
+    const onStepDetailClick = mock((_id: string) => {});
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", ""),
       bash("pwd", "completed", "2s", ""),
     ];
     const { getByTestId, queryByTestId } = render(
-      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
     );
 
     fireEvent.click(getByTestId("subagent-phase-header"));

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -356,3 +356,45 @@ describe("SubagentPhaseTimeline — phase grouping", () => {
     expect(queryAllByTestId("phase-step-pill").length).toBe(2);
   });
 });
+
+describe("SubagentPhaseTimeline — controlled expand state", () => {
+  // When `expandedKeys`/`onExpandedKeysChange` are supplied the parent owns the
+  // expansion (so it can outlive an unmount): the component renders from the
+  // prop and reports toggles instead of self-managing, and does not expand
+  // until the parent feeds the new set back.
+  test("renders expansion from `expandedKeys` and reports toggles to the parent", () => {
+    const onExpandedKeysChange = mock((_next: Set<string>) => {});
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "2s", "tc-b"),
+    ];
+
+    const { rerender, getByTestId, queryAllByTestId } = render(
+      <SubagentPhaseTimeline
+        steps={steps}
+        expandedKeys={new Set()}
+        onExpandedKeysChange={onExpandedKeysChange}
+      />,
+    );
+
+    // Controlled + collapsed: no pills yet.
+    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+
+    // Clicking the header reports the next set but does NOT self-expand.
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(onExpandedKeysChange).toHaveBeenCalledTimes(1);
+    const nextKeys = onExpandedKeysChange.mock.calls[0]![0];
+    expect(nextKeys.size).toBe(1);
+    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+
+    // Feeding the reported set back expands the section.
+    rerender(
+      <SubagentPhaseTimeline
+        steps={steps}
+        expandedKeys={nextKeys}
+        onExpandedKeysChange={onExpandedKeysChange}
+      />,
+    );
+    expect(queryAllByTestId("phase-step-pill").length).toBe(2);
+  });
+});

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -221,6 +221,31 @@ describe("SubagentPhaseTimeline — clickable tool steps", () => {
     expect(onToolStepClick).toHaveBeenLastCalledWith("tc-b");
   });
 
+  // A clickable tool step whose labeler produced no `info` still renders a
+  // `ToolStepPill` (its label falls back to `step.title`), so the row must be
+  // expandable and the nested detail reachable. Regression for `isExpandable`
+  // consulting only `stepRendersPill` — which is false for an info-less tool
+  // step — and thus disabling the row even though the clickable arm would have
+  // rendered a real pill.
+  test("a single info-less tool step is expandable + clickable when a handler is wired", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [bash("", "completed", "1s", "tc-a")];
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    const header = getByTestId("subagent-phase-header");
+    expect(header.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.click(header);
+    const pill = getByTestId("tool-step-pill");
+    expect(pill.tagName).toBe("BUTTON");
+
+    fireEvent.click(pill);
+    expect(onToolStepClick).toHaveBeenCalledTimes(1);
+    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-a");
+  });
+
   test("a thinking step does NOT render as a clickable tool pill", () => {
     const onToolStepClick = mock((_id: string) => {});
     const steps: ToolCallCardStep[] = [thinking("Considering options")];

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -9,7 +9,7 @@
  * for 1); and contiguous same-phase collapsing into a single row.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
@@ -193,6 +193,81 @@ describe("SubagentPhaseTimeline — single-step expandability", () => {
     // Clicking the disabled header reveals nothing — no empty body.
     fireEvent.click(header);
     expect(queryByTestId("phase-step-pill")).toBeNull();
+  });
+});
+
+describe("SubagentPhaseTimeline — clickable tool steps", () => {
+  test("tool steps render as clickable buttons and call back with toolCallId", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "2s", "tc-b"),
+    ];
+    const { getByTestId, getAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+
+    const pills = getAllByTestId("tool-step-pill");
+    expect(pills.length).toBe(2);
+    pills.forEach((pill) => expect(pill.tagName).toBe("BUTTON"));
+
+    fireEvent.click(pills[0]!);
+    expect(onToolStepClick).toHaveBeenCalledTimes(1);
+    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-a");
+
+    fireEvent.click(pills[1]!);
+    expect(onToolStepClick).toHaveBeenLastCalledWith("tc-b");
+  });
+
+  test("a thinking step does NOT render as a clickable tool pill", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [thinking("Considering options")];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
+  test("a tool_error step does NOT render as a clickable tool pill", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [toolError("context window exceeded")];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
+  test("tool steps with an empty toolCallId stay non-clickable", () => {
+    const onToolStepClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", ""),
+      bash("pwd", "completed", "2s", ""),
+    ];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onToolStepClick={onToolStepClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
+  test("without the callback, tool steps remain non-clickable", () => {
+    const steps: ToolCallCardStep[] = [
+      bash("ls", "completed", "1s", "tc-a"),
+      bash("pwd", "completed", "2s", "tc-b"),
+    ];
+    const { getByTestId, queryByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    expect(queryByTestId("tool-step-pill")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -51,6 +51,23 @@ function toolError(message: string): ToolCallCardStep {
   return { kind: "tool_error", message };
 }
 
+function webSearch(
+  results: Array<{ title: string; url: string; domain: string }>,
+  title = "Searched the web",
+  query?: string,
+  detailKey?: string,
+): ToolCallCardStep {
+  return {
+    kind: "web_search",
+    title,
+    query,
+    durationLabel: "",
+    linkCount: results.length,
+    results: results.map((r, i) => ({ rank: i + 1, ...r })),
+    detailKey,
+  };
+}
+
 describe("SubagentPhaseTimeline — empty input", () => {
   test("renders nothing when there are no steps (panel owns the empty state)", () => {
     const { container } = render(<SubagentPhaseTimeline steps={[]} />);
@@ -315,6 +332,147 @@ describe("SubagentPhaseTimeline — clickable tool steps", () => {
 
     fireEvent.click(getByTestId("subagent-phase-header"));
     expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
+  test("a web_search step WITH a detail key renders a clickable query pill and calls back", () => {
+    const onStepDetailClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [
+      webSearch(
+        [{ title: "R1", url: "https://a.com", domain: "a.com" }],
+        "Searched the web",
+        "best vector databases",
+        "ws-1",
+      ),
+    ];
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    // The query renders as a single clickable tool pill (a button) that opens
+    // the nested detail — NOT the inline web-source anchors.
+    const pill = getByTestId("tool-step-pill");
+    expect(pill.tagName).toBe("BUTTON");
+    expect(pill.textContent).toContain("best vector databases");
+
+    fireEvent.click(pill);
+    expect(onStepDetailClick).toHaveBeenCalledTimes(1);
+    expect(onStepDetailClick).toHaveBeenLastCalledWith("ws-1");
+  });
+
+  test("a web_search step WITHOUT a detail key falls back to inline source chips", () => {
+    const onStepDetailClick = mock((_id: string) => {});
+    const steps: ToolCallCardStep[] = [
+      webSearch([
+        { title: "R1", url: "https://a.com", domain: "a.com" },
+        { title: "R2", url: "https://b.com", domain: "b.com" },
+      ]),
+    ];
+    const { getByTestId, getAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} onStepDetailClick={onStepDetailClick} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    // No detailKey → the deploy-safe inline web chips (anchors), not a button,
+    // and nothing to open.
+    const chips = getAllByTestId("tool-step-pill");
+    expect(chips.length).toBe(2);
+    chips.forEach((chip) => expect(chip.tagName).toBe("A"));
+    expect(onStepDetailClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("SubagentPhaseTimeline — web_search ticker", () => {
+  test("an in-flight web_search phase renders the rotating result ticker", () => {
+    const steps: ToolCallCardStep[] = [
+      webSearch(
+        [
+          { title: "First Source", url: "https://a.com", domain: "a.com" },
+          { title: "Second Source", url: "https://b.com", domain: "b.com" },
+        ],
+        "Searched the web",
+      ),
+      // The latest search is still in flight → the phase reads as running.
+      webSearch([], "Searching the web"),
+    ];
+    const { getByText } = render(<SubagentPhaseTimeline steps={steps} />);
+    // The ticker (WebsiteCarousel) sits under the group header and starts on
+    // the first accumulated source — no expansion needed.
+    expect(getByText("First Source")).toBeDefined();
+  });
+
+  test("a completed web_search phase does NOT render the ticker", () => {
+    const steps: ToolCallCardStep[] = [
+      webSearch(
+        [{ title: "First Source", url: "https://a.com", domain: "a.com" }],
+        "Searched the web",
+      ),
+    ];
+    const { queryByText } = render(<SubagentPhaseTimeline steps={steps} />);
+    // Completed + collapsed → no rotating ticker; the sources live in the
+    // expandable detail instead.
+    expect(queryByText("First Source")).toBeNull();
+  });
+});
+
+describe("SubagentPhaseTimeline — web_search chips", () => {
+  test("a web_search step renders its results as favicon link chips when expanded", () => {
+    const steps: ToolCallCardStep[] = [
+      webSearch([
+        { title: "First Result", url: "https://example.com/a", domain: "example.com" },
+        { title: "Second Result", url: "https://foo.org/b", domain: "foo.org" },
+      ]),
+      // A second search so the group is multi-step (has the "N steps" pill).
+      webSearch([
+        { title: "Third Result", url: "https://bar.net/c", domain: "bar.net" },
+      ]),
+    ];
+    const { getByTestId, getAllByTestId, queryAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    // Both searches collapse into one "Searching the web" group.
+    const section = getByTestId("subagent-phase-section");
+    expect(section.getAttribute("data-phase-label")).toBe("Searching the web");
+
+    // Collapsed by default — no chips.
+    expect(queryAllByTestId("tool-step-pill").length).toBe(0);
+
+    // Expanding reveals every result chip inline (no clamp): 2 + 1 = 3.
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    const chips = getAllByTestId("tool-step-pill");
+    expect(chips.length).toBe(3);
+    chips.forEach((chip) => {
+      // Web chips render as external-link anchors, not buttons.
+      expect(chip.tagName).toBe("A");
+      expect(chip.getAttribute("data-variant")).toBe("web");
+    });
+    expect(chips[0]!.getAttribute("href")).toBe("https://example.com/a");
+    expect(chips[0]!.textContent).toContain("First Result");
+    expect(chips[2]!.getAttribute("href")).toBe("https://bar.net/c");
+  });
+
+  test("labels each search with its query so multiple searches stay distinct", () => {
+    const steps: ToolCallCardStep[] = [
+      webSearch(
+        [{ title: "R1", url: "https://a.com", domain: "a.com" }],
+        "Searched the web",
+        "most popular AI assistants 2026",
+      ),
+      webSearch(
+        [{ title: "R2", url: "https://b.com", domain: "b.com" }],
+        "Searched the web",
+        "ChatGPT users market share 2026",
+      ),
+    ];
+    const { getByTestId, container } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-phase-header"));
+    // Both queries render as labels above their chip clusters.
+    expect(container.textContent).toContain("most popular AI assistants 2026");
+    expect(container.textContent).toContain("ChatGPT users market share 2026");
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -112,7 +112,11 @@ describe("SubagentPhaseTimeline — running row", () => {
     const steps: ToolCallCardStep[] = [
       bash("sleep 5", "running", "", "tc-a", "Compiling the project"),
     ];
-    const { getByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    // A running phase implies a running subagent (the panel always passes this);
+    // only then is the last phase the pulsing active tail.
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} isRunning />,
+    );
 
     // The running node is the three-dot indicator: it stamps no `data-status`
     // and exposes 3 dot children (the `ThreeDotIndicator` contract).
@@ -129,9 +133,96 @@ describe("SubagentPhaseTimeline — running row", () => {
     const steps: ToolCallCardStep[] = [
       bash("npm run build", "running", "", "tc-a", ""),
     ];
-    const { getByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} isRunning />,
+    );
     const header = getByTestId("subagent-phase-header");
     expect(header.textContent).toContain("npm run build");
+  });
+
+  test("an in-flight web_search surfaces its query as the live sub-label", () => {
+    // Title "Searching the web" → the phase reads as running; the running row's
+    // sub-label is the search query, not the generic phase label.
+    const steps: ToolCallCardStep[] = [
+      webSearch([], "Searching the web", "best thermos 2025"),
+    ];
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} isRunning />,
+    );
+    const header = getByTestId("subagent-phase-header");
+    expect(header.textContent).toContain("best thermos 2025");
+  });
+});
+
+describe("SubagentPhaseTimeline — running tail", () => {
+  test("the last phase's node keeps pulsing when the subagent is running but its steps have settled", () => {
+    // Settled bash phase + the subagent is still running → the node is the
+    // pulsing ThreeDotIndicator (no `data-status`, 3 dot children), NOT a green
+    // check — so the timeline shows ongoing work without a separate row.
+    const steps: ToolCallCardStep[] = [bash("ls", "completed", "1s", "tc-a")];
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} isRunning />,
+    );
+    const node = getByTestId("phase-header-status-icon");
+    expect(node.getAttribute("data-status")).toBeNull();
+    expect(node.children.length).toBe(3);
+  });
+
+  test("the last node shows its settled status when the subagent is NOT running", () => {
+    const steps: ToolCallCardStep[] = [bash("ls", "completed", "1s", "tc-a")];
+    const { getByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    const node = getByTestId("phase-header-status-icon");
+    expect(node.getAttribute("data-status")).toBe("completed");
+  });
+
+  test("a non-last phase whose web_search never resolved does NOT pulse (coerced to settled)", () => {
+    // The web_search keeps the present-tense title because its `tool_result`
+    // never arrived, so phaseHeaderStatus reads it as "running". With a later
+    // phase after it, it must read as settled — only the tail may pulse.
+    const steps: ToolCallCardStep[] = [
+      webSearch([], "Searching the web", "orphaned query"),
+      bash("ls", "completed", "1s", "tc-a"),
+    ];
+    const { getAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} isRunning />,
+    );
+    const nodes = getAllByTestId("phase-header-status-icon");
+    // The stuck search node is coerced to a completed check, not the pulse.
+    expect(nodes[0]!.getAttribute("data-status")).toBe("completed");
+    // The genuine tail (bash) pulses.
+    const last = nodes[nodes.length - 1]!;
+    expect(last.getAttribute("data-status")).toBeNull();
+    expect(last.children.length).toBe(3);
+  });
+
+  test("an orphaned web_search does not pulse once the subagent is terminal", () => {
+    // Same stuck search, but as the LAST phase with the subagent no longer
+    // running — it must not pulse (the subagent is done).
+    const steps: ToolCallCardStep[] = [
+      webSearch([], "Searching the web", "orphaned query"),
+    ];
+    const { getByTestId } = render(<SubagentPhaseTimeline steps={steps} />);
+    expect(
+      getByTestId("phase-header-status-icon").getAttribute("data-status"),
+    ).toBe("completed");
+  });
+
+  test("only the last phase pulses — earlier settled phases keep their status", () => {
+    // Working → Thinking → Working. While running, only the final Working phase
+    // pulses; the first Working stays a completed check.
+    const steps: ToolCallCardStep[] = [
+      bash("a", "completed", "1s", "tc-a"),
+      thinking("t1"),
+      bash("b", "completed", "1s", "tc-b"),
+    ];
+    const { getAllByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} isRunning />,
+    );
+    const nodes = getAllByTestId("phase-header-status-icon");
+    expect(nodes[0]!.getAttribute("data-status")).toBe("completed");
+    const last = nodes[nodes.length - 1]!;
+    expect(last.getAttribute("data-status")).toBeNull();
+    expect(last.children.length).toBe(3);
   });
 });
 
@@ -382,35 +473,43 @@ describe("SubagentPhaseTimeline — clickable tool steps", () => {
   });
 });
 
-describe("SubagentPhaseTimeline — web_search ticker", () => {
-  test("an in-flight web_search phase renders the rotating result ticker", () => {
-    const steps: ToolCallCardStep[] = [
-      webSearch(
-        [
-          { title: "First Source", url: "https://a.com", domain: "a.com" },
-          { title: "Second Source", url: "https://b.com", domain: "b.com" },
-        ],
-        "Searched the web",
-      ),
-      // The latest search is still in flight → the phase reads as running.
-      webSearch([], "Searching the web"),
-    ];
-    const { getByText } = render(<SubagentPhaseTimeline steps={steps} />);
-    // The ticker (WebsiteCarousel) sits under the group header and starts on
-    // the first accumulated source — no expansion needed.
-    expect(getByText("First Source")).toBeDefined();
-  });
-
-  test("a completed web_search phase does NOT render the ticker", () => {
+describe("SubagentPhaseTimeline — web_search trailing query", () => {
+  test("an in-flight search shows the most recent query to the right of the divider", () => {
     const steps: ToolCallCardStep[] = [
       webSearch(
         [{ title: "First Source", url: "https://a.com", domain: "a.com" }],
         "Searched the web",
+        "thermos history",
+      ),
+      // The latest search is still in flight (no resolved query yet) → the phase
+      // reads as running and falls back to the previous, known query.
+      webSearch([], "Searching the web"),
+    ];
+    const { getByTestId } = render(
+      <SubagentPhaseTimeline steps={steps} isRunning />,
+    );
+    expect(getByTestId("subagent-phase-header").textContent).toContain(
+      "thermos history",
+    );
+  });
+
+  test("a completed search shows its query in the trailing slot (not under the row)", () => {
+    const steps: ToolCallCardStep[] = [
+      webSearch(
+        [{ title: "First Source", url: "https://a.com", domain: "a.com" }],
+        "Searched the web",
+        "best vacuum flask 2025",
       ),
     ];
-    const { queryByText } = render(<SubagentPhaseTimeline steps={steps} />);
-    // Completed + collapsed → no rotating ticker; the sources live in the
-    // expandable detail instead.
+    const { getByTestId, queryByText } = render(
+      <SubagentPhaseTimeline steps={steps} />,
+    );
+    // Query sits inline on the header row...
+    expect(getByTestId("subagent-phase-header").textContent).toContain(
+      "best vacuum flask 2025",
+    );
+    // ...and the result source is NOT rendered under the row (no ticker); it
+    // only appears in the expandable detail.
     expect(queryByText("First Source")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -128,11 +128,22 @@ function SubagentPhaseRow({
   // The "N steps" pill only makes sense for a multi-step phase.
   const showStepCount = stepCount >= 2;
   // A row is interactive (the whole row is a pointer-cursor toggle) when at
-  // least one step actually renders a pill — `stepRendersPill` is
-  // `DefaultStepPill`'s own predicate, so expanding can never reveal an empty
-  // body. A lone info-less tool step (successful or failed) renders no pill, so
-  // it stays non-expandable.
-  const isExpandable = section.steps.some(stepRendersPill);
+  // least one step actually renders a pill in the expanded body, so expanding
+  // can never reveal an empty body. That happens two ways: the step renders a
+  // `DefaultStepPill` (`stepRendersPill`, `DefaultStepPill`'s own predicate),
+  // OR it renders a clickable `ToolStepPill`. A clickable tool step renders
+  // even when its labeler left `info` empty (the pill falls back to
+  // `step.title`), so it counts toward expandability too — otherwise a
+  // tool-only phase whose tool produced no `info` would be wrongly
+  // non-expandable and its nested tool detail unreachable. The clickable arm
+  // mirrors the expanded body's render condition below.
+  const isExpandable = section.steps.some(
+    (step) =>
+      stepRendersPill(step) ||
+      (step.kind === "tool" &&
+        Boolean(step.toolCallId) &&
+        Boolean(onToolStepClick)),
+  );
 
   const totalDuration =
     status === "running"

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -29,6 +29,7 @@ import {
   TimelineNode,
   type PhaseSection,
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 import { cn } from "@/utils/misc";
 
@@ -60,8 +61,15 @@ function runningActivity(section: PhaseSection): string {
 
 export function SubagentPhaseTimeline({
   steps,
+  onToolStepClick,
 }: {
   steps: ToolCallCardStep[];
+  /**
+   * When supplied, expanded tool steps render as clickable `ToolStepPill`
+   * buttons; clicking one calls back with the step's `toolCallId`. Optional so
+   * this component is deploy-safe without a consumer wired up.
+   */
+  onToolStepClick?: (toolCallId: string) => void;
 }) {
   // Expanded section keys. Default collapsed; the toggler is memoized so
   // already-rendered rows stay referentially stable across toggles.
@@ -90,6 +98,7 @@ export function SubagentPhaseTimeline({
             expanded={expanded.has(key)}
             sectionKeyValue={key}
             onToggle={toggle}
+            onToolStepClick={onToolStepClick}
           />
         );
       })}
@@ -103,12 +112,14 @@ function SubagentPhaseRow({
   expanded,
   sectionKeyValue,
   onToggle,
+  onToolStepClick,
 }: {
   section: PhaseSection;
   isLast: boolean;
   expanded: boolean;
   sectionKeyValue: string;
   onToggle: (key: string) => void;
+  onToolStepClick?: (toolCallId: string) => void;
 }) {
   const status = phaseHeaderStatus(section.steps);
   const isThinking = section.steps[0]?.kind === "thinking";
@@ -250,9 +261,30 @@ function SubagentPhaseRow({
           from the next group rather than 12px (pb-3) + 16px. */}
       {isExpandable && expanded && (
         <div className="flex flex-col items-start gap-1 pl-[22px]">
-          {section.steps.map((step, stepIdx) => (
-            <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />
-          ))}
+          {section.steps.map((step, stepIdx) => {
+            // Clickable only for tool steps with a real `toolCallId` AND a
+            // consumer wired up; everything else keeps the non-interactive
+            // `DefaultStepPill` (thinking detail is intentionally out of scope).
+            if (step.kind === "tool" && step.toolCallId && onToolStepClick) {
+              return (
+                <ToolStepPill
+                  key={stepKey(step, stepIdx)}
+                  variant="tool"
+                  iconName={step.iconName}
+                  label={step.activity || step.info || step.title}
+                  riskLevel={step.riskLevel}
+                  tone={
+                    step.status === "error" || step.status === "denied"
+                      ? "error"
+                      : "default"
+                  }
+                  ariaLabel="View tool details"
+                  onClick={() => onToolStepClick(step.toolCallId)}
+                />
+              );
+            }
+            return <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />;
+          })}
         </div>
       )}
     </div>

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -288,11 +288,11 @@ function SubagentPhaseRow({
         {isExpandable && showStepCount && (
           <span
             data-testid="subagent-phase-step-count"
-            // `inline-flex` (not the default inline span, which ignores
-            // height) + `max-h-full` caps the pill at the row's height
-            // (`h-[22px]`), and `items-center` keeps the label centered within
-            // that cap so it can never grow the grouped row.
-            className="ml-auto inline-flex max-h-full shrink-0 items-center whitespace-nowrap rounded-full bg-[var(--surface-base)] px-2 py-0.5"
+            // `inline-flex` + `self-stretch` makes the pill fill the grouped
+            // row's full height (`h-[22px]`) — `self-stretch` overrides the
+            // header's `items-center` for this item — and `items-center` keeps
+            // the label vertically centered within it.
+            className="ml-auto inline-flex shrink-0 items-center self-stretch whitespace-nowrap rounded-full bg-[var(--surface-base)] px-2"
           >
             <Typography
               variant="body-small-default"

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -62,6 +62,8 @@ function runningActivity(section: PhaseSection): string {
 export function SubagentPhaseTimeline({
   steps,
   onToolStepClick,
+  expandedKeys,
+  onExpandedKeysChange,
 }: {
   steps: ToolCallCardStep[];
   /**
@@ -70,18 +72,41 @@ export function SubagentPhaseTimeline({
    * this component is deploy-safe without a consumer wired up.
    */
   onToolStepClick?: (toolCallId: string) => void;
+  /**
+   * Controlled expand/collapse state — the set of currently-expanded section
+   * keys. When supplied (with `onExpandedKeysChange`), the parent owns this
+   * state so it survives the timeline being unmounted (e.g. while a nested tool
+   * detail is shown) and is restored on return. When omitted, the component
+   * manages the state internally.
+   */
+  expandedKeys?: Set<string>;
+  onExpandedKeysChange?: (next: Set<string>) => void;
 }) {
-  // Expanded section keys. Default collapsed; the toggler is memoized so
-  // already-rendered rows stay referentially stable across toggles.
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const toggle = useCallback((key: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
+  // Expanded section keys. Controlled by the parent when `expandedKeys` is
+  // supplied (so the state outlives an unmount); otherwise managed internally.
+  // Default collapsed.
+  const [internalExpanded, setInternalExpanded] = useState<Set<string>>(
+    new Set(),
+  );
+  const expanded = expandedKeys ?? internalExpanded;
+  const toggle = useCallback(
+    (key: string) => {
+      if (onExpandedKeysChange) {
+        const next = new Set(expanded);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        onExpandedKeysChange(next);
+        return;
+      }
+      setInternalExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        return next;
+      });
+    },
+    [expanded, onExpandedKeysChange],
+  );
 
   if (steps.length === 0) return null;
   const sections = groupStepsByPhase(steps);

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -30,6 +30,11 @@ import {
   type PhaseSection,
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
+import {
+  WebSearchErrorRow,
+  WebSearchStepRow,
+} from "@/domains/chat/components/web-search/web-search-step-row";
+import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 import { cn } from "@/utils/misc";
 
@@ -68,6 +73,7 @@ function runningActivity(section: PhaseSection): string {
 function stepDetailKey(step: ToolCallCardStep): string | undefined {
   if (step.kind === "tool") return step.toolCallId || undefined;
   if (step.kind === "thinking") return step.detailKey;
+  if (step.kind === "web_search") return step.detailKey;
   return undefined;
 }
 
@@ -162,6 +168,12 @@ function SubagentPhaseRow({
   const status = phaseHeaderStatus(section.steps);
   const isThinking = section.steps[0]?.kind === "thinking";
   const stepCount = section.steps.length;
+
+  // Accumulated web-search result sources for this phase, in order. Drives the
+  // rotating thumbnail ticker shown while the phase is still in flight.
+  const webResults = section.steps.flatMap((step) =>
+    step.kind === "web_search" ? step.results : [],
+  );
 
   // The "N steps" pill only makes sense for a multi-step phase.
   const showStepCount = stepCount >= 2;
@@ -304,6 +316,17 @@ function SubagentPhaseRow({
         )}
       </button>
 
+      {status === "running" && webResults.length > 0 && (
+        // Rotating "sites searched" ticker for an in-flight web-search phase —
+        // the same `WebsiteCarousel` main chat shows in its collapsed header,
+        // placed as its own row here (the timeline header is pinned to 22px, so
+        // the 28px ticker can't sit inline). Disappears once the phase
+        // completes; the expanded query pills + source detail cover the results.
+        <div className="pl-[22px]">
+          <WebsiteCarousel items={webResults} />
+        </div>
+      )}
+
       {/* Expanded body: the section's steps as default pills, indented to clear
           the bullet rail and align under the status icon (bullet 14px + the
           row's 8px gap → 22px). No own bottom padding — the container's `pb-4`
@@ -349,6 +372,53 @@ function SubagentPhaseRow({
                   />
                 );
               }
+              if (step.kind === "web_search") {
+                // The search's query becomes a clickable pill; its result
+                // sources move into the nested detail (query + links), mirroring
+                // the thinking-pill → reasoning-detail pattern. Falls back to the
+                // inline query label + chips below when no detail handler is
+                // wired (deploy-safe).
+                return (
+                  <ToolStepPill
+                    key={stepKey(step, stepIdx)}
+                    variant="tool"
+                    iconName="globe"
+                    label={step.query || step.title}
+                    ariaLabel="View search details"
+                    onClick={() => onStepDetailClick(detailKey)}
+                  />
+                );
+              }
+            }
+            // Web steps render as their own chip clusters (favicon chips /
+            // error chip) rather than the title-only `DefaultStepPill`, matching
+            // main chat. `web_search` results are parsed from the tool result by
+            // `computeSubagentCardData`.
+            if (step.kind === "web_search") {
+              // Label each search with its query so multiple (unclamped)
+              // searches in one "Searching the web" group stay visually
+              // distinct — the "N steps" count then maps to N labelled clusters.
+              return (
+                <div
+                  key={stepKey(step, stepIdx)}
+                  className="flex w-full flex-col gap-1"
+                >
+                  {step.query ? (
+                    <Typography
+                      variant="body-small-default"
+                      className="text-[var(--content-secondary)]"
+                    >
+                      {`"${step.query}"`}
+                    </Typography>
+                  ) : null}
+                  <WebSearchStepRow step={step} />
+                </div>
+              );
+            }
+            if (step.kind === "web_search_error") {
+              return (
+                <WebSearchErrorRow key={stepKey(step, stepIdx)} step={step} />
+              );
             }
             return <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />;
           })}

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -13,7 +13,7 @@
  * empty state, so this returns `null` for an empty input.
  */
 
-import { Brain } from "lucide-react";
+import { Brain, Globe } from "lucide-react";
 import { useCallback, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
@@ -29,12 +29,12 @@ import {
   TimelineNode,
   type PhaseSection,
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
 import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
 import {
   WebSearchErrorRow,
   WebSearchStepRow,
 } from "@/domains/chat/components/web-search/web-search-step-row";
-import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 import { cn } from "@/utils/misc";
 
@@ -50,18 +50,50 @@ function sectionKey(section: PhaseSection, index: number): string {
 }
 
 /**
- * Live activity sub-label for a running phase: the `activity` of the last
- * still-running tool step, falling back to that step's `info`, then to the
- * phase label so the row never reads blank.
+ * The last still-running step of a phase — a running tool, or an in-flight
+ * web_search (whose title is still the present-tense placeholder). Drives the
+ * running row's live activity text + leading icon. `undefined` when the phase
+ * has no running step.
  */
-function runningActivity(section: PhaseSection): string {
+function runningStep(section: PhaseSection): ToolCallCardStep | undefined {
   for (let i = section.steps.length - 1; i >= 0; i--) {
     const step = section.steps[i]!;
-    if (step.kind === "tool" && step.status === "running") {
-      return step.activity || step.info || section.label;
+    if (step.kind === "tool" && step.status === "running") return step;
+    if (step.kind === "web_search" && step.title === "Searching the web") {
+      return step;
     }
   }
-  return section.label;
+  return undefined;
+}
+
+/**
+ * Live activity sub-label for a running tool phase: the running tool's
+ * `activity`/`info`, falling back to the phase label. Search phases derive their
+ * trailing label from {@link mostRecentSearchQuery} instead (the query lands
+ * with the result, not at call time), so they don't route through here.
+ */
+function runningActivity(
+  step: ToolCallCardStep | undefined,
+  fallback: string,
+): string {
+  if (!step) return fallback;
+  if (step.kind === "tool") return step.activity || step.info || fallback;
+  return fallback;
+}
+
+/**
+ * The query of the most recent web_search step in a phase that has one — walked
+ * newest-first so an in-flight search (whose query hasn't resolved yet) shows
+ * the previous, known query rather than nothing. `undefined` when no search in
+ * the phase carries a query. Drives the trailing query shown to the right of the
+ * divider for a "Searching the web" phase.
+ */
+function mostRecentSearchQuery(section: PhaseSection): string | undefined {
+  for (let i = section.steps.length - 1; i >= 0; i--) {
+    const step = section.steps[i]!;
+    if (step.kind === "web_search" && step.query) return step.query;
+  }
+  return undefined;
 }
 
 /**
@@ -82,6 +114,7 @@ export function SubagentPhaseTimeline({
   onStepDetailClick,
   expandedKeys,
   onExpandedKeysChange,
+  isRunning = false,
 }: {
   steps: ToolCallCardStep[];
   /**
@@ -100,6 +133,17 @@ export function SubagentPhaseTimeline({
    */
   expandedKeys?: Set<string>;
   onExpandedKeysChange?: (next: Set<string>) => void;
+  /**
+   * Whether the owning subagent is still active. When `true`, the LAST phase's
+   * node keeps pulsing (a `ThreeDotIndicator`) even after its own steps settle,
+   * so the timeline reflects ongoing work during the between-steps window —
+   * without inventing a separate "Working" row. A separate row would flicker in
+   * and out: a same-type next step (e.g. another search) merges back into the
+   * last phase, so the interim bullet would appear then vanish. Defaults to
+   * `false`. A genuinely different next step opens a new phase row, which then
+   * becomes the pulsing tail.
+   */
+  isRunning?: boolean;
 }) {
   // Expanded section keys. Controlled by the parent when `expandedKeys` is
   // supplied (so the state outlives an unmount); otherwise managed internally.
@@ -134,11 +178,15 @@ export function SubagentPhaseTimeline({
     <div className="flex w-full flex-col">
       {sections.map((section, index) => {
         const key = sectionKey(section, index);
+        const isLast = index === sections.length - 1;
         return (
           <SubagentPhaseRow
             key={key}
             section={section}
-            isLast={index === sections.length - 1}
+            isLast={isLast}
+            // Only the last row keeps pulsing while the subagent runs — so the
+            // timeline shows ongoing work without a separate, flicker-prone row.
+            isActiveTail={isLast && isRunning}
             expanded={expanded.has(key)}
             sectionKeyValue={key}
             onToggle={toggle}
@@ -153,6 +201,7 @@ export function SubagentPhaseTimeline({
 function SubagentPhaseRow({
   section,
   isLast,
+  isActiveTail,
   expanded,
   sectionKeyValue,
   onToggle,
@@ -160,20 +209,40 @@ function SubagentPhaseRow({
 }: {
   section: PhaseSection;
   isLast: boolean;
+  /**
+   * The last row while the subagent is still running. Keeps the node pulsing
+   * after this phase's own steps settle, so the next same-type step merges back
+   * in (this row stays the tail) instead of a transient "Working" row flashing.
+   */
+  isActiveTail: boolean;
   expanded: boolean;
   sectionKeyValue: string;
   onToggle: (key: string) => void;
   onStepDetailClick?: (detailKey: string) => void;
 }) {
-  const status = phaseHeaderStatus(section.steps);
+  const rawStatus = phaseHeaderStatus(section.steps);
+  // Only the active tail — the last phase while the subagent is still running —
+  // may read as in-flight. Steps are sequential, so any OTHER phase computing
+  // "running" is stale: a web_search whose `tool_result` never arrives keeps its
+  // present-tense title ("Searching the web") forever, and `phaseHeaderStatus`
+  // reports that as running. Left alone it pulses mid-timeline with already
+  // settled phases after it (and a terminal subagent would pulse too). Coerce
+  // those orphaned "running" phases to "completed" so only the tail can pulse.
+  const status =
+    rawStatus === "running" && !isActiveTail ? "completed" : rawStatus;
+  // The node pulses for the active tail (equivalently, a genuinely running last
+  // phase — `status` stays "running" only there after the coercion above). The
+  // trailing slot still reflects `status` (query / "Worked for <dur>").
+  const nodePulses = status === "running" || isActiveTail;
   const isThinking = section.steps[0]?.kind === "thinking";
   const stepCount = section.steps.length;
 
-  // Accumulated web-search result sources for this phase, in order. Drives the
-  // rotating thumbnail ticker shown while the phase is still in flight.
-  const webResults = section.steps.flatMap((step) =>
-    step.kind === "web_search" ? step.results : [],
-  );
+  // A "Searching the web" phase surfaces its query to the right of the divider
+  // (running or done) instead of a duration / generic activity — that's the
+  // most useful thing to show for a search. `searchQuery` is the most recent
+  // resolved query in the phase (see the helper); `undefined` until one lands.
+  const isSearch = section.label === "Searching the web";
+  const searchQuery = isSearch ? mostRecentSearchQuery(section) : undefined;
 
   // The "N steps" pill only makes sense for a multi-step phase.
   const showStepCount = stepCount >= 2;
@@ -200,10 +269,27 @@ function SubagentPhaseRow({
             "durationLabel" in s ? s.durationLabel : "",
           ),
         );
-  const activity = status === "running" ? runningActivity(section) : "";
-  // Whether a trailing detail (activity or duration) follows the label — the
-  // faint `|` separator only renders when one does.
-  const hasTrailingDetail = status === "running" || Boolean(totalDuration);
+  const running = status === "running" ? runningStep(section) : undefined;
+  // Non-search running phases show the running tool's activity in the trailing
+  // slot; search phases use `searchTrailing` (their query) instead — see below.
+  const activity =
+    status === "running" && !isSearch
+      ? runningActivity(running, section.label)
+      : "";
+  // A search phase shows its query in the trailing slot whenever it's running
+  // OR has a resolved query — running or done, so the SAME animated carousel
+  // renders in both states. That keeps the animation alive as a multi-search
+  // phase flips between in-flight and settled: newer queries slide in instead of
+  // a component swap (carousel ↔ static text) silently dropping the transition.
+  // Falls back to the phase label during the brief window before the first
+  // query resolves.
+  const showSearchTrailing =
+    isSearch && (status === "running" || Boolean(searchQuery));
+  const searchTrailing = searchQuery ?? section.label;
+  // Whether a trailing detail (activity, search query, or duration) follows the
+  // label — the faint `|` separator only renders when one does.
+  const hasTrailingDetail =
+    status === "running" || showSearchTrailing || Boolean(totalDuration);
   const stepCountLabel = `${stepCount} step${stepCount === 1 ? "" : "s"}`;
 
   return (
@@ -255,7 +341,10 @@ function SubagentPhaseRow({
           <span className="h-[5px] w-[5px] rounded-full bg-[var(--content-disabled)]" />
         </span>
 
-        <TimelineNode status={status} isThinking={isThinking} />
+        <TimelineNode
+          status={nodePulses ? "running" : status}
+          isThinking={isThinking}
+        />
         <Typography
           variant="body-medium-default"
           className="shrink-0 text-[var(--content-default)]"
@@ -275,18 +364,33 @@ function SubagentPhaseRow({
           </span>
         )}
 
-        {status === "running" ? (
-          <span className="flex min-w-0 items-center gap-1">
+        {showSearchTrailing ? (
+          // Search phase (running or done): the query in the trailing slot with
+          // a globe, animated via the header carousel so newer queries slide in.
+          // Replaces "Worked for <dur>" once settled — the query is the useful
+          // thing to surface for a search, and matches what the row read as live.
+          <span className="flex min-w-0 flex-1 items-center gap-1">
+            <Globe
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]"
+            />
+            <HeaderStepCarousel
+              currentStepTitle=""
+              currentStepInfo={searchTrailing}
+            />
+          </span>
+        ) : status === "running" ? (
+          <span className="flex min-w-0 flex-1 items-center gap-1">
             <Brain
               aria-hidden="true"
               className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]"
             />
-            <Typography
-              variant="body-small-default"
-              className="min-w-0 truncate text-[var(--content-tertiary)]"
-            >
-              {activity}
-            </Typography>
+            {/* Live running activity, animated + throttled via the main-chat
+                header carousel so the current task slides/updates in place
+                instead of hard-cutting. Empty title — the phase label already
+                sits before the separator, so the carousel carries just the
+                running tool's activity. */}
+            <HeaderStepCarousel currentStepTitle="" currentStepInfo={activity} />
           </span>
         ) : totalDuration ? (
           <Typography
@@ -315,17 +419,6 @@ function SubagentPhaseRow({
           </span>
         )}
       </button>
-
-      {status === "running" && webResults.length > 0 && (
-        // Rotating "sites searched" ticker for an in-flight web-search phase —
-        // the same `WebsiteCarousel` main chat shows in its collapsed header,
-        // placed as its own row here (the timeline header is pinned to 22px, so
-        // the 28px ticker can't sit inline). Disappears once the phase
-        // completes; the expanded query pills + source detail cover the results.
-        <div className="pl-[22px]">
-          <WebsiteCarousel items={webResults} />
-        </div>
-      )}
 
       {/* Expanded body: the section's steps as default pills, indented to clear
           the bullet rail and align under the status icon (bullet 14px + the

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -288,7 +288,11 @@ function SubagentPhaseRow({
         {isExpandable && showStepCount && (
           <span
             data-testid="subagent-phase-step-count"
-            className="ml-auto shrink-0 whitespace-nowrap rounded-full bg-[var(--surface-base)] px-2 py-0.5"
+            // `inline-flex` (not the default inline span, which ignores
+            // height) + `max-h-full` caps the pill at the row's height
+            // (`h-[22px]`), and `items-center` keeps the label centered within
+            // that cap so it can never grow the grouped row.
+            className="ml-auto inline-flex max-h-full shrink-0 items-center whitespace-nowrap rounded-full bg-[var(--surface-base)] px-2 py-0.5"
           >
             <Typography
               variant="body-small-default"

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -59,19 +59,32 @@ function runningActivity(section: PhaseSection): string {
   return section.label;
 }
 
+/**
+ * Detail-map key for a step that can open a nested detail view: a tool step's
+ * `toolCallId`, or a thinking step's `detailKey` (stamped by the subagent
+ * projection). `undefined` for steps with no detail / no key, which stay
+ * non-interactive. Mirrors the keys `buildSubagentStepDetails` emits.
+ */
+function stepDetailKey(step: ToolCallCardStep): string | undefined {
+  if (step.kind === "tool") return step.toolCallId || undefined;
+  if (step.kind === "thinking") return step.detailKey;
+  return undefined;
+}
+
 export function SubagentPhaseTimeline({
   steps,
-  onToolStepClick,
+  onStepDetailClick,
   expandedKeys,
   onExpandedKeysChange,
 }: {
   steps: ToolCallCardStep[];
   /**
-   * When supplied, expanded tool steps render as clickable `ToolStepPill`
-   * buttons; clicking one calls back with the step's `toolCallId`. Optional so
-   * this component is deploy-safe without a consumer wired up.
+   * When supplied, expanded steps that have a detail (tool calls and thinking
+   * segments) render as clickable `ToolStepPill` buttons; clicking one calls
+   * back with that step's detail key (see `stepDetailKey`). Optional so this
+   * component is deploy-safe without a consumer wired up.
    */
-  onToolStepClick?: (toolCallId: string) => void;
+  onStepDetailClick?: (detailKey: string) => void;
   /**
    * Controlled expand/collapse state — the set of currently-expanded section
    * keys. When supplied (with `onExpandedKeysChange`), the parent owns this
@@ -123,7 +136,7 @@ export function SubagentPhaseTimeline({
             expanded={expanded.has(key)}
             sectionKeyValue={key}
             onToggle={toggle}
-            onToolStepClick={onToolStepClick}
+            onStepDetailClick={onStepDetailClick}
           />
         );
       })}
@@ -137,14 +150,14 @@ function SubagentPhaseRow({
   expanded,
   sectionKeyValue,
   onToggle,
-  onToolStepClick,
+  onStepDetailClick,
 }: {
   section: PhaseSection;
   isLast: boolean;
   expanded: boolean;
   sectionKeyValue: string;
   onToggle: (key: string) => void;
-  onToolStepClick?: (toolCallId: string) => void;
+  onStepDetailClick?: (detailKey: string) => void;
 }) {
   const status = phaseHeaderStatus(section.steps);
   const isThinking = section.steps[0]?.kind === "thinking";
@@ -153,21 +166,18 @@ function SubagentPhaseRow({
   // The "N steps" pill only makes sense for a multi-step phase.
   const showStepCount = stepCount >= 2;
   // A row is interactive (the whole row is a pointer-cursor toggle) when at
-  // least one step actually renders a pill in the expanded body, so expanding
-  // can never reveal an empty body. That happens two ways: the step renders a
-  // `DefaultStepPill` (`stepRendersPill`, `DefaultStepPill`'s own predicate),
-  // OR it renders a clickable `ToolStepPill`. A clickable tool step renders
-  // even when its labeler left `info` empty (the pill falls back to
-  // `step.title`), so it counts toward expandability too — otherwise a
-  // tool-only phase whose tool produced no `info` would be wrongly
-  // non-expandable and its nested tool detail unreachable. The clickable arm
-  // mirrors the expanded body's render condition below.
+  // least one step renders a pill in the expanded body, so expanding can never
+  // reveal an empty body. That happens two ways: the step renders a
+  // `DefaultStepPill` (`stepRendersPill`, its own predicate), OR it renders a
+  // clickable `ToolStepPill`. A step with a detail key (a tool call or a
+  // thinking segment, with a handler wired) renders a clickable pill even when
+  // `stepRendersPill` is false for it — e.g. an info-less tool call, whose pill
+  // falls back to `step.title` — so it counts toward expandability too. The
+  // clickable arm mirrors the expanded body's render condition below.
   const isExpandable = section.steps.some(
     (step) =>
       stepRendersPill(step) ||
-      (step.kind === "tool" &&
-        Boolean(step.toolCallId) &&
-        Boolean(onToolStepClick)),
+      (Boolean(onStepDetailClick) && Boolean(stepDetailKey(step))),
   );
 
   const totalDuration =
@@ -298,26 +308,43 @@ function SubagentPhaseRow({
       {isExpandable && expanded && (
         <div className="flex flex-col items-start gap-1 pl-[22px]">
           {section.steps.map((step, stepIdx) => {
-            // Clickable only for tool steps with a real `toolCallId` AND a
-            // consumer wired up; everything else keeps the non-interactive
-            // `DefaultStepPill` (thinking detail is intentionally out of scope).
-            if (step.kind === "tool" && step.toolCallId && onToolStepClick) {
-              return (
-                <ToolStepPill
-                  key={stepKey(step, stepIdx)}
-                  variant="tool"
-                  iconName={step.iconName}
-                  label={step.activity || step.info || step.title}
-                  riskLevel={step.riskLevel}
-                  tone={
-                    step.status === "error" || step.status === "denied"
-                      ? "error"
-                      : "default"
-                  }
-                  ariaLabel="View tool details"
-                  onClick={() => onToolStepClick(step.toolCallId)}
-                />
-              );
+            // A step with a detail key + a wired handler renders a clickable
+            // `ToolStepPill` that opens its nested detail; everything else keeps
+            // the non-interactive `DefaultStepPill`.
+            const detailKey = onStepDetailClick
+              ? stepDetailKey(step)
+              : undefined;
+            if (detailKey && onStepDetailClick) {
+              if (step.kind === "tool") {
+                return (
+                  <ToolStepPill
+                    key={stepKey(step, stepIdx)}
+                    variant="tool"
+                    iconName={step.iconName}
+                    label={step.activity || step.info || step.title}
+                    riskLevel={step.riskLevel}
+                    tone={
+                      step.status === "error" || step.status === "denied"
+                        ? "error"
+                        : "default"
+                    }
+                    ariaLabel="View tool details"
+                    onClick={() => onStepDetailClick(detailKey)}
+                  />
+                );
+              }
+              if (step.kind === "thinking") {
+                return (
+                  <ToolStepPill
+                    key={stepKey(step, stepIdx)}
+                    variant="tool"
+                    iconName="brain"
+                    label={step.text}
+                    ariaLabel="View reasoning"
+                    onClick={() => onStepDetailClick(detailKey)}
+                  />
+                );
+              }
             }
             return <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />;
           })}

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -17,6 +17,7 @@ import {
   Code,
   Copy,
   FileText,
+  Globe,
   Monitor,
   Pen,
   Plug,
@@ -47,6 +48,7 @@ import type { ToolDetailPayload } from "@/stores/viewer-store";
 const ICON_MAP: Record<IconName, LucideIcon> = {
   code: Code,
   file: FileText,
+  globe: Globe,
   pen: Pen,
   monitor: Monitor,
   plug: Plug,

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -200,6 +200,75 @@ function ThinkingDetailBody({
   );
 }
 
+/**
+ * Tool-variant detail sections — the risk-reason note, "Technical details"
+ * (input `CodeBlock`), and "Output" (result or running-state fallback) — with
+ * no surrounding shell, header, or close button. Composed by `ToolDetailPanel`
+ * inside its own `DetailShell`, and reused by `SubagentDetailPanel` to show a
+ * nested tool call under the subagent's own header.
+ */
+export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
+  const hasResult = detail.result !== undefined && detail.result !== "";
+  const isRunning = detail.status === "running";
+  const inputJson = JSON.stringify(detail.input, null, 2);
+
+  return (
+    <>
+      {detail.riskReason && (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="mb-4 text-[var(--content-tertiary)]"
+        >
+          {detail.riskReason}
+        </Typography>
+      )}
+
+      {/* Technical details section */}
+      <div>
+        <SectionLabel>Technical details</SectionLabel>
+        <Typography
+          variant="body-medium-default"
+          as="div"
+          className="text-[var(--content-default)]"
+        >
+          {titleCaseToolName(detail.toolName)}
+        </Typography>
+        {detail.activity && (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="mt-0.5 text-[var(--content-secondary)]"
+          >
+            {detail.activity}
+          </Typography>
+        )}
+        <div className="mt-2">
+          <CodeBlock text={inputJson} />
+        </div>
+      </div>
+
+      {/* Output section — omitted entirely when there's no result */}
+      {(hasResult || isRunning) && (
+        <div className="mt-5">
+          <SectionLabel>Output</SectionLabel>
+          {hasResult ? (
+            <CodeBlock text={detail.result as string} />
+          ) : (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              Running…
+            </Typography>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
 export function ToolDetailPanel({
   detail,
   onClose,
@@ -219,9 +288,6 @@ export function ToolDetailPanel({
   const Glyph = ICON_MAP[iconName] ?? Bolt;
 
   const title = detail.activity || detail.title;
-  const hasResult = detail.result !== undefined && detail.result !== "";
-  const isRunning = detail.status === "running";
-  const inputJson = JSON.stringify(detail.input, null, 2);
 
   return (
     <DetailShell
@@ -232,59 +298,7 @@ export function ToolDetailPanel({
         <RiskBadge level={detail.riskLevel} onClick={onRiskBadgeClick} />
       }
     >
-      <>
-        {detail.riskReason && (
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="mb-4 text-[var(--content-tertiary)]"
-          >
-            {detail.riskReason}
-          </Typography>
-        )}
-
-        {/* Technical details section */}
-        <div>
-          <SectionLabel>Technical details</SectionLabel>
-          <Typography
-            variant="body-medium-default"
-            as="div"
-            className="text-[var(--content-default)]"
-          >
-            {titleCaseToolName(detail.toolName)}
-          </Typography>
-          {detail.activity && (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="mt-0.5 text-[var(--content-secondary)]"
-            >
-              {detail.activity}
-            </Typography>
-          )}
-          <div className="mt-2">
-            <CodeBlock text={inputJson} />
-          </div>
-        </div>
-
-        {/* Output section — omitted entirely when there's no result */}
-        {(hasResult || isRunning) && (
-          <div className="mt-5">
-            <SectionLabel>Output</SectionLabel>
-            {hasResult ? (
-              <CodeBlock text={detail.result as string} />
-            ) : (
-              <Typography
-                variant="body-small-default"
-                as="p"
-                className="text-[var(--content-tertiary)]"
-              >
-                Running…
-              </Typography>
-            )}
-          </div>
-        )}
-      </>
+      <ToolDetailBody detail={detail} />
     </DetailShell>
   );
 }

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -207,7 +207,19 @@ function ThinkingDetailBody({
  * inside its own `DetailShell`, and reused by `SubagentDetailPanel` to show a
  * nested tool call under the subagent's own header.
  */
-export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
+export function ToolDetailBody({
+  detail,
+  showTechnicalDetailsLabel = true,
+}: {
+  detail: ToolDetailPayload;
+  /**
+   * Render the "Technical details" section label above the tool name + input.
+   * Defaults to true (main-chat `ToolDetailPanel`). `SubagentDetailPanel` passes
+   * false — its nested view already sits under the subagent header and a "Back
+   * to timeline" affordance, so the extra label reads as redundant there.
+   */
+  showTechnicalDetailsLabel?: boolean;
+}) {
   const hasResult = detail.result !== undefined && detail.result !== "";
   const isRunning = detail.status === "running";
   const inputJson = JSON.stringify(detail.input, null, 2);
@@ -226,7 +238,9 @@ export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
 
       {/* Technical details section */}
       <div>
-        <SectionLabel>Technical details</SectionLabel>
+        {showTechnicalDetailsLabel && (
+          <SectionLabel>Technical details</SectionLabel>
+        )}
         <Typography
           variant="body-medium-default"
           as="div"

--- a/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -32,7 +32,8 @@ export type IconName =
   | "sparkle"
   | "user-plus"
   | "bolt"
-  | "brain";
+  | "brain"
+  | "globe";
 
 /** Result of mapping a tool call to its carousel-header label. */
 export interface StepLabel {

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -24,6 +24,7 @@ import {
   CheckCircle2,
   Code,
   FileText,
+  Globe,
   Monitor,
   Pen,
   Plug,
@@ -47,6 +48,7 @@ import { cn } from "@/utils/misc";
 export const ICON_MAP: Record<IconName, LucideIcon> = {
   code: Code,
   file: FileText,
+  globe: Globe,
   pen: Pen,
   monitor: Monitor,
   plug: Plug,

--- a/clients/web/src/domains/chat/components/web-search/web-search-detail-view.test.tsx
+++ b/clients/web/src/domains/chat/components/web-search/web-search-detail-view.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for `WebSearchDetailView` — the nested detail shown when a subagent
+ * "Searching the web" query pill is clicked. Covers the query line + the
+ * source chips, and the empty-results fallback.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+afterEach(() => {
+  cleanup();
+});
+
+function payload(overrides: Partial<ToolDetailPayload>): ToolDetailPayload {
+  return {
+    toolCallId: "tu-ws",
+    toolName: "web_search",
+    title: "Searched the web",
+    activity: "",
+    input: {},
+    status: "completed",
+    kind: "web_search",
+    ...overrides,
+  };
+}
+
+describe("WebSearchDetailView", () => {
+  test("renders the query verbatim and one source chip per result", () => {
+    const { getByText, getAllByTestId } = render(
+      <WebSearchDetailView
+        detail={payload({
+          searchQuery: "best vector databases",
+          searchResults: [
+            { rank: 1, title: "First", url: "https://a.com/x", domain: "a.com" },
+            { rank: 2, title: "Second", url: "https://b.org/y", domain: "b.org" },
+          ],
+        })}
+      />,
+    );
+
+    // Query rendered verbatim (in quotes) above the source list.
+    expect(getByText('"best vector databases"')).toBeTruthy();
+    expect(getByText("Sources (2)")).toBeTruthy();
+
+    // Each source renders as the same external-link favicon chip the timeline
+    // uses (an anchor, variant "web").
+    const chips = getAllByTestId("tool-step-pill");
+    expect(chips.length).toBe(2);
+    chips.forEach((chip) => expect(chip.tagName).toBe("A"));
+    expect(chips[0]!.getAttribute("href")).toBe("https://a.com/x");
+    expect(chips[0]!.textContent).toContain("First");
+  });
+
+  test("shows an empty-state message when the search returned no sources", () => {
+    const { getByText, queryByTestId } = render(
+      <WebSearchDetailView
+        detail={payload({ searchQuery: "obscure query", searchResults: [] })}
+      />,
+    );
+
+    expect(getByText("Sources")).toBeTruthy();
+    expect(getByText("No sources found.")).toBeTruthy();
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/web-search/web-search-detail-view.tsx
+++ b/clients/web/src/domains/chat/components/web-search/web-search-detail-view.tsx
@@ -1,0 +1,74 @@
+/**
+ * Nested detail view for a subagent "Searching the web" query pill: the search
+ * query rendered verbatim, then the sources it returned as the same favicon
+ * source chips the timeline uses. Opened in-place by `SubagentDetailPanel` when
+ * a query pill is clicked — the search analogue of the thinking pill's reasoning
+ * view.
+ *
+ * Static / presentational: reads only the `searchQuery` + `searchResults` the
+ * panel already built into the `ToolDetailPayload` (see
+ * `buildSubagentStepDetails`), so it never re-parses or fetches.
+ */
+
+import { Typography } from "@vellumai/design-library";
+
+import { WebSearchStepRow } from "@/domains/chat/components/web-search/web-search-step-row";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+export function WebSearchDetailView({ detail }: { detail: ToolDetailPayload }) {
+  const query = detail.searchQuery ?? "";
+  const results = detail.searchResults ?? [];
+
+  return (
+    <div className="flex flex-col gap-5">
+      {query ? (
+        <div className="flex flex-col gap-2">
+          <Typography
+            variant="body-medium-default"
+            as="h3"
+            className="text-[var(--content-emphasised)]"
+          >
+            Query
+          </Typography>
+          <Typography
+            variant="body-medium-lighter"
+            as="p"
+            className="break-words leading-relaxed text-[var(--content-default)]"
+          >
+            {`"${query}"`}
+          </Typography>
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        <Typography
+          variant="body-medium-default"
+          as="h3"
+          className="text-[var(--content-emphasised)]"
+        >
+          {results.length > 0 ? `Sources (${results.length})` : "Sources"}
+        </Typography>
+        {results.length > 0 ? (
+          // Reuse the timeline's source-chip cluster so the detail and the
+          // timeline present identical visuals for the same sources.
+          <WebSearchStepRow
+            step={{
+              kind: "web_search",
+              title: "Searched the web",
+              durationLabel: "",
+              linkCount: results.length,
+              results,
+            }}
+          />
+        ) : (
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+          >
+            No sources found.
+          </Typography>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  buildSubagentToolDetails,
+  buildSubagentStepDetails,
   computeSubagentCardData,
   mapToolEventToStep,
 } from "@/domains/chat/hooks/use-subagent-card-data";
@@ -660,12 +660,12 @@ describe("computeSubagentCardData — error event toolUseId correlation", () => 
 });
 
 // ---------------------------------------------------------------------------
-// buildSubagentToolDetails — nested tool-detail payload map
+// buildSubagentStepDetails — nested tool-detail payload map
 // ---------------------------------------------------------------------------
 
-describe("buildSubagentToolDetails", () => {
+describe("buildSubagentStepDetails", () => {
   test("tool_call + tool_result → one completed payload with raw input/result + duration", () => {
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         events: [
           makeEvent(
@@ -704,8 +704,32 @@ describe("buildSubagentToolDetails", () => {
     expect(payload.kind).toBe("tool");
   });
 
+  test("text event → thinking payload with the full, un-truncated content", () => {
+    const content = "Line one.\n\nLine two with   many   spaces preserved.";
+    const details = buildSubagentStepDetails(
+      makeEntry({
+        events: [makeEvent({ type: "text", content }, 0)],
+      }),
+    );
+    expect(details.size).toBe(1);
+    const payload = details.get("te-0")!;
+    expect(payload.kind).toBe("thinking");
+    expect(payload.status).toBe("completed");
+    // Full content verbatim — NOT the collapsed/truncated timeline preview.
+    expect(payload.thinkingText).toBe(content);
+  });
+
+  test("whitespace-only text event produces no thinking payload", () => {
+    const details = buildSubagentStepDetails(
+      makeEntry({
+        events: [makeEvent({ type: "text", content: "   \n  " }, 0)],
+      }),
+    );
+    expect(details.size).toBe(0);
+  });
+
   test("falls back to event.content for result when result is absent", () => {
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         events: [
           makeEvent(
@@ -728,7 +752,7 @@ describe("buildSubagentToolDetails", () => {
   });
 
   test("in-flight tool_call with no result → running payload, result undefined", () => {
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         events: [
           makeEvent(
@@ -752,7 +776,7 @@ describe("buildSubagentToolDetails", () => {
   });
 
   test("tool_call with empty toolUseId is skipped (can't be keyed/clicked)", () => {
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         events: [makeEvent({ type: "tool_call", toolName: "bash" })],
       }),
@@ -761,7 +785,7 @@ describe("buildSubagentToolDetails", () => {
   });
 
   test("parallel calls to the same tool with distinct ids → two payloads matched by id", () => {
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         events: [
           makeEvent(
@@ -807,7 +831,7 @@ describe("buildSubagentToolDetails", () => {
   });
 
   test("isError result → error status with the result preserved", () => {
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         events: [
           makeEvent(
@@ -836,7 +860,7 @@ describe("buildSubagentToolDetails", () => {
     // When a tool fails, the store maps the inner event to type `"error"`
     // (not `"tool_result"`) but preserves `result` + `isError`. The matcher
     // must catch it regardless of the mapped type.
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         events: [
           makeEvent(
@@ -862,7 +886,7 @@ describe("buildSubagentToolDetails", () => {
   });
 
   test("equal timestamps (synthetic history) yield no durationLabel", () => {
-    const details = buildSubagentToolDetails(
+    const details = buildSubagentStepDetails(
       makeEntry({
         status: "completed",
         events: [

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -12,6 +12,10 @@ import {
   computeSubagentCardData,
   mapToolEventToStep,
 } from "@/domains/chat/hooks/use-subagent-card-data";
+import {
+  groupStepsByPhase,
+  phaseFromStep,
+} from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import type {
   SubagentEntry,
   SubagentTimelineEvent,
@@ -393,6 +397,379 @@ describe("computeSubagentCardData — step mapping", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Web-tool group-label alignment with main chat
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentCardData — web tools match main-chat group labels", () => {
+  test("web_search tool_call → web_search step grouped under 'Searching the web'", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_search",
+            toolUseId: "tu-ws",
+            content: "thermos history",
+          }),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("web_search");
+    if (step.kind === "web_search") {
+      expect(step.title).toBe("Searching the web");
+    }
+    // The whole point of the change: the phase label matches main chat
+    // ("Searching the web"), NOT the generic "Working" bucket.
+    expect(phaseFromStep(step)).toBe("Searching the web");
+  });
+
+  test("web_search step carries detailKey = toolUseId so the timeline can open its detail", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_search",
+            toolUseId: "tu-ws",
+            content: "thermos history",
+          }),
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("web_search");
+    if (step.kind === "web_search") {
+      expect(step.detailKey).toBe("tu-ws");
+    }
+  });
+
+  test("web_search tool_call → tool_result flips the title to past tense", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              content: "thermos history",
+              timestamp: NOW,
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              result: "results...",
+              timestamp: NOW + 2500,
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("web_search");
+    if (step.kind === "web_search") {
+      expect(step.title).toBe("Searched the web");
+      expect(step.durationLabel).toBe("3s");
+    }
+    // Both tenses still group under the same label.
+    expect(phaseFromStep(step)).toBe("Searching the web");
+  });
+
+  test("web_search result text is parsed into link chips (no clamp)", () => {
+    // The subagent timeline carries the raw result text (Title\nURL pairs), not
+    // structured metadata — parse it into chips like main chat does on reload.
+    const resultText = [
+      "First Result Title",
+      "https://example.com/a",
+      "Second Result Title",
+      "https://www.foo.org/b",
+      "Third Result Title",
+      "https://bar.net/c",
+    ].join("\n");
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              content: "q",
+              timestamp: NOW,
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              result: resultText,
+              timestamp: NOW + 1000,
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("web_search");
+    if (step.kind === "web_search") {
+      expect(step.title).toBe("Searched the web");
+      // All three results kept inline — no 5-cap, no overflow bucket.
+      expect(step.linkCount).toBe(3);
+      expect(step.results.map((r) => r.url)).toEqual([
+        "https://example.com/a",
+        "https://www.foo.org/b",
+        "https://bar.net/c",
+      ]);
+      expect(step.results[0]!.title).toBe("First Result Title");
+      // `www.` stripped by the shared domain extractor.
+      expect(step.results[1]!.domain).toBe("foo.org");
+      expect(step.overflowResults ?? []).toHaveLength(0);
+    }
+  });
+
+  test("web_search step carries its query (raw input preferred, content fallback) and it survives completion", () => {
+    // From raw input.
+    const fromInput = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_search",
+            toolUseId: "tu-a",
+            content: "summary",
+            input: { query: "best laptops 2026" },
+          }),
+        ],
+      }),
+    ).steps[0]!;
+    expect(fromInput.kind).toBe("web_search");
+    if (fromInput.kind === "web_search") {
+      expect(fromInput.query).toBe("best laptops 2026");
+    }
+
+    // Fallback to the content summary (which is the query for web_search).
+    const fromContent = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_search",
+            toolUseId: "tu-b",
+            content: "fallback query",
+          }),
+        ],
+      }),
+    ).steps[0]!;
+    if (fromContent.kind === "web_search") {
+      expect(fromContent.query).toBe("fallback query");
+    }
+
+    // Query survives the tool_result completion (title flip + results fill).
+    const completed = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "web_search",
+              toolUseId: "tu-c",
+              content: "persisted query",
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-c",
+              result: "Result\nhttps://x.com",
+            },
+            1,
+          ),
+        ],
+      }),
+    ).steps[0]!;
+    if (completed.kind === "web_search") {
+      expect(completed.title).toBe("Searched the web");
+      expect(completed.query).toBe("persisted query");
+    }
+  });
+
+  test("web_search chips parse from event.content when result is absent", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "web_search", toolUseId: "tu-ws" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              content: "Only Result\nhttps://solo.com/x",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    if (step.kind === "web_search") {
+      expect(step.linkCount).toBe(1);
+      expect(step.results[0]!.url).toBe("https://solo.com/x");
+    }
+  });
+
+  test("web_search failure (isError result) → web_search_error step", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "web_search", toolUseId: "tu-ws" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              isError: true,
+              result: "rate limited",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("web_search_error");
+    if (step.kind === "web_search_error") {
+      expect(step.title).toBe("Web search failed");
+      expect(step.errorMessage).toBe("rate limited");
+    }
+    // web_search_error still groups under "Searching the web".
+    expect(phaseFromStep(step)).toBe("Searching the web");
+  });
+
+  test("web_search closed by a raw error event → web_search_error + tool_error row", () => {
+    // Failed tool results arrive as type `"error"` (with isError/result) in the
+    // subagent timeline; the in-flight web_search must convert to
+    // web_search_error, mirroring how the tool path closes failed tools.
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "failed",
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "web_search", toolUseId: "tu-ws" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "error",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              content: "boom",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    // web_search_error step + the appended tool_error row.
+    expect(data.steps).toHaveLength(2);
+    expect(data.steps[0]!.kind).toBe("web_search_error");
+    expect(data.steps[1]!.kind).toBe("tool_error");
+  });
+
+  test("web_fetch tool_call → 'Reading <domain>' thinking step grouped under 'Thinking'", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_fetch",
+            toolUseId: "tu-wf",
+            content: "https://www.example.com/article",
+          }),
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(1);
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("thinking");
+    if (step.kind === "thinking") {
+      // Scheme + leading www. stripped, matching main chat's web_fetch label.
+      expect(step.text).toBe("Reading example.com");
+    }
+    // web_fetch maps to the "Thinking" group, exactly as main chat does.
+    expect(phaseFromStep(step)).toBe("Thinking");
+  });
+
+  test("web_fetch prefers the raw input url over the content summary", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_fetch",
+            toolUseId: "tu-wf",
+            content: "truncated summ…",
+            input: { url: "https://docs.vellum.ai/guide" },
+          }),
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    if (step.kind === "thinking") {
+      expect(step.text).toBe("Reading docs.vellum.ai");
+    }
+  });
+
+  test("a web_search run reads as one 'Searching the web' group, not 'Working'", () => {
+    // End-to-end label check: group the projected steps the same way the
+    // timeline does and assert the section label.
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_search",
+            toolUseId: "tu-ws",
+            content: "q",
+          }),
+        ],
+      }),
+    );
+    const sections = groupStepsByPhase(data.steps);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.label).toBe("Searching the web");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Header carousel content
 // ---------------------------------------------------------------------------
 
@@ -502,6 +879,23 @@ describe("computeSubagentCardData — current step title/info", () => {
     expect(data.currentStepTitle).toBe("Used File Read");
   });
 
+  test("latest step is a running web_search → 'Searching the web'", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "web_search",
+            toolUseId: "tu-ws",
+            content: "q",
+          }),
+        ],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Searching the web");
+  });
+
   test("latest step is an error → Errored + message", () => {
     const data = computeSubagentCardData(
       makeEntry({
@@ -594,6 +988,71 @@ describe("mapToolEventToStep", () => {
     });
     expect(step.title).toBe("Running tool");
     expect(step.toolCallId).toBe("");
+  });
+
+  test("derives the skill name from raw event.input, not the lossy summary", () => {
+    // `skill` isn't a `summarizeToolInput` priority key, so `content` is empty
+    // and the old reconstructInputBag path produced an info-less "Using a
+    // skill". The raw input carries the name.
+    const step = mapToolEventToStep({
+      id: "te-skill",
+      type: "tool_call",
+      content: "",
+      toolName: "skill",
+      toolUseId: "tu-skill",
+      input: { skill: "competitor-research" },
+      timestamp: 0,
+    });
+    expect(step.title).toBe("Using a skill");
+    expect(step.iconName).toBe("sparkle");
+    expect(step.info).toBe("competitor-research");
+  });
+
+  test("surfaces the rich `activity` sentence from raw input", () => {
+    // `reconstructInputBag` never carried `activity`, so the pill could never
+    // show the rich sentence — only the raw command. The raw input does.
+    const step = mapToolEventToStep({
+      id: "te-act",
+      type: "tool_call",
+      content: "rg -n TODO src/",
+      toolName: "bash",
+      toolUseId: "tu-act",
+      input: {
+        command: "rg -n TODO src/",
+        activity: "Searching the codebase for TODOs",
+      },
+      timestamp: 0,
+    });
+    expect(step.title).toBe("Working");
+    expect(step.activity).toBe("Searching the codebase for TODOs");
+  });
+
+  test("computer action comes from raw input (not a summary key)", () => {
+    const step = mapToolEventToStep({
+      id: "te-cu",
+      type: "tool_call",
+      content: "",
+      toolName: "computer",
+      toolUseId: "tu-cu",
+      input: { action: "screenshot" },
+      timestamp: 0,
+    });
+    expect(step.title).toBe("Using computer");
+    expect(step.info).toBe("screenshot");
+  });
+
+  test("falls back to reconstructInputBag when raw input is absent", () => {
+    // Older events without `input` still get a sensible label from the summary.
+    const step = mapToolEventToStep({
+      id: "te-fallback",
+      type: "tool_call",
+      content: "ls -la",
+      toolName: "bash",
+      toolUseId: "tu-fallback",
+      timestamp: 0,
+    });
+    expect(step.title).toBe("Working");
+    expect(step.info).toBe("ls -la");
   });
 });
 
@@ -717,6 +1176,52 @@ describe("buildSubagentStepDetails", () => {
     expect(payload.status).toBe("completed");
     // Full content verbatim — NOT the collapsed/truncated timeline preview.
     expect(payload.thinkingText).toBe(content);
+  });
+
+  test("web_search tool_call + tool_result → web_search payload with query + parsed sources", () => {
+    const resultText = [
+      "First Result Title",
+      "https://example.com/a",
+      "Second Result Title",
+      "https://foo.org/b",
+    ].join("\n");
+    const details = buildSubagentStepDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              input: { query: "best vector databases" },
+              timestamp: NOW,
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              result: resultText,
+              timestamp: NOW + 1500,
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(details.size).toBe(1);
+    const payload = details.get("tu-ws")!;
+    // A dedicated web_search payload (NOT the generic "tool" body) carrying the
+    // query + the parsed source list for the nested detail view.
+    expect(payload.kind).toBe("web_search");
+    expect(payload.searchQuery).toBe("best vector databases");
+    expect(payload.status).toBe("completed");
+    expect(payload.searchResults?.map((r) => r.url)).toEqual([
+      "https://example.com/a",
+      "https://foo.org/b",
+    ]);
   });
 
   test("whitespace-only text event produces no thinking payload", () => {

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildSubagentToolDetails,
   computeSubagentCardData,
   mapToolEventToStep,
 } from "@/domains/chat/hooks/use-subagent-card-data";
@@ -655,5 +656,234 @@ describe("computeSubagentCardData — error event toolUseId correlation", () => 
     if (err.kind === "tool_error") {
       expect(err.message).toBe("boom");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSubagentToolDetails — nested tool-detail payload map
+// ---------------------------------------------------------------------------
+
+describe("buildSubagentToolDetails", () => {
+  test("tool_call + tool_result → one completed payload with raw input/result + duration", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              content: "ls -la",
+              input: { command: "ls -la" },
+              timestamp: NOW,
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              result: "total 0",
+              timestamp: NOW + 2500,
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(details.size).toBe(1);
+    const payload = details.get("tu-1")!;
+    expect(payload.toolCallId).toBe("tu-1");
+    expect(payload.toolName).toBe("bash");
+    // Raw input is preserved verbatim (not the reconstructed summary bag).
+    expect(payload.input).toEqual({ command: "ls -la" });
+    expect(payload.result).toBe("total 0");
+    expect(payload.status).toBe("completed");
+    expect(payload.durationLabel).toBe("3s");
+    expect(payload.kind).toBe("tool");
+  });
+
+  test("falls back to event.content for result when result is absent", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "bash", toolUseId: "tu-1" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              content: "fallback output",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    expect(details.get("tu-1")!.result).toBe("fallback output");
+  });
+
+  test("in-flight tool_call with no result → running payload, result undefined", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              input: { command: "sleep 5" },
+            },
+            0,
+          ),
+        ],
+      }),
+    );
+    expect(details.size).toBe(1);
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("running");
+    expect(payload.result).toBeUndefined();
+    expect(payload.durationLabel).toBe("");
+    expect(payload.input).toEqual({ command: "sleep 5" });
+  });
+
+  test("tool_call with empty toolUseId is skipped (can't be keyed/clicked)", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [makeEvent({ type: "tool_call", toolName: "bash" })],
+      }),
+    );
+    expect(details.size).toBe(0);
+  });
+
+  test("parallel calls to the same tool with distinct ids → two payloads matched by id", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-A",
+              input: { command: "first" },
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "bash",
+              toolUseId: "tu-B",
+              input: { command: "second" },
+            },
+            1,
+          ),
+          // The SECOND call's result lands first; must close tu-B, not tu-A.
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-B",
+              result: "second done",
+            },
+            2,
+          ),
+        ],
+      }),
+    );
+    expect(details.size).toBe(2);
+    const a = details.get("tu-A")!;
+    const b = details.get("tu-B")!;
+    expect(a.status).toBe("running");
+    expect(a.result).toBeUndefined();
+    expect(a.input).toEqual({ command: "first" });
+    expect(b.status).toBe("completed");
+    expect(b.result).toBe("second done");
+    expect(b.input).toEqual({ command: "second" });
+  });
+
+  test("isError result → error status with the result preserved", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "bash", toolUseId: "tu-1" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              isError: true,
+              result: "command failed",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("error");
+    expect(payload.result).toBe("command failed");
+  });
+
+  test("a FAILED tool result mapped to a raw error event is still matched", () => {
+    // When a tool fails, the store maps the inner event to type `"error"`
+    // (not `"tool_result"`) but preserves `result` + `isError`. The matcher
+    // must catch it regardless of the mapped type.
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "bash", toolUseId: "tu-1" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "error",
+              toolName: "bash",
+              toolUseId: "tu-1",
+              isError: true,
+              result: "boom",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("error");
+    expect(payload.result).toBe("boom");
+  });
+
+  test("equal timestamps (synthetic history) yield no durationLabel", () => {
+    const details = buildSubagentToolDetails(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent({
+            type: "tool_call",
+            toolName: "bash",
+            toolUseId: "tu-1",
+            timestamp: NOW,
+          }),
+          makeEvent({
+            type: "tool_result",
+            toolName: "bash",
+            toolUseId: "tu-1",
+            result: "ok",
+            timestamp: NOW,
+          }),
+        ],
+      }),
+    );
+    const payload = details.get("tu-1")!;
+    expect(payload.status).toBe("completed");
+    expect(payload.durationLabel).toBe("");
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -486,6 +486,73 @@ describe("computeSubagentCardData — web tools match main-chat group labels", (
     expect(phaseFromStep(step)).toBe("Searching the web");
   });
 
+  test("web_search query backfills from the result's searchQuery when the call carried none (live)", () => {
+    // Live path: Anthropic resolves the web_search query only at completion, so
+    // the `tool_call` arrives with no query and the matching `tool_result`
+    // carries it (captured by the store from `activityMetadata`).
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "web_search", toolUseId: "tu-ws" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              result: "results...",
+              searchQuery: "best thermos 2025",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("web_search");
+    if (step.kind === "web_search") {
+      expect(step.query).toBe("best thermos 2025");
+    }
+  });
+
+  test("web_search keeps the call-time query over the result's searchQuery (history)", () => {
+    // History/detail path: the query is already on the call (rebuilt from the
+    // persisted resolved input), so it wins over any result-borne value.
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        events: [
+          makeEvent(
+            {
+              type: "tool_call",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              input: { query: "call-time query" },
+            },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              result: "results...",
+              searchQuery: "result query",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    if (step.kind === "web_search") {
+      expect(step.query).toBe("call-time query");
+    }
+  });
+
   test("web_search result text is parsed into link chips (no clamp)", () => {
     // The subagent timeline carries the raw result text (Title\nURL pairs), not
     // structured metadata — parse it into chips like main chat does on reload.
@@ -1222,6 +1289,32 @@ describe("buildSubagentStepDetails", () => {
       "https://example.com/a",
       "https://foo.org/b",
     ]);
+  });
+
+  test("web_search payload backfills searchQuery from the result when the call carried none (live)", () => {
+    const details = buildSubagentStepDetails(
+      makeEntry({
+        events: [
+          makeEvent(
+            { type: "tool_call", toolName: "web_search", toolUseId: "tu-ws" },
+            0,
+          ),
+          makeEvent(
+            {
+              type: "tool_result",
+              toolName: "web_search",
+              toolUseId: "tu-ws",
+              result: "results...",
+              searchQuery: "best thermos 2025",
+            },
+            1,
+          ),
+        ],
+      }),
+    );
+    const payload = details.get("tu-ws")!;
+    expect(payload.kind).toBe("web_search");
+    expect(payload.searchQuery).toBe("best thermos 2025");
   });
 
   test("whitespace-only text event produces no thinking payload", () => {

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -244,7 +244,10 @@ export function computeSubagentCardData(
       const text = trimTextPreview(event.content);
       // Skip empty text events — they'd render as a blank thinking step.
       if (text.length === 0) continue;
-      steps.push({ kind: "thinking", durationLabel: "", text });
+      // `detailKey` (the source event id) lets the timeline pill open the full,
+      // un-truncated reasoning via `buildSubagentStepDetails` — the pill itself
+      // only carries the collapsed `text` preview.
+      steps.push({ kind: "thinking", durationLabel: "", text, detailKey: event.id });
       toolMeta.push(undefined);
       continue;
     }
@@ -435,21 +438,24 @@ export function useSubagentCardData(
 }
 
 /**
- * Pure projection of (entry) → a `toolCallId`-keyed map of nested tool-detail
- * payloads. Separate from `computeSubagentCardData` (whose `ToolCallCardStep`s
- * carry only label/duration, not the raw `input`/`result`) so the clickable
- * timeline pills can open the full tool-detail drawer (`ToolDetailBody`) for
- * the tool whose id they emit.
+ * Pure projection of (entry) → a map of nested detail payloads, keyed by the
+ * id a clickable timeline pill emits. Separate from `computeSubagentCardData`
+ * (whose `ToolCallCardStep`s carry only label/duration + a truncated text
+ * preview, not the raw `input`/`result` or full reasoning) so the pills can
+ * open the full detail view:
+ *  - tool steps → `ToolDetailBody` (technical details + output), keyed by
+ *    `toolUseId`; `tool_call` events with an empty id are skipped.
+ *  - text/thinking steps → a `kind: "thinking"` payload carrying the FULL,
+ *    un-truncated reasoning markdown, keyed by the text event's id (matching
+ *    the `detailKey` `computeSubagentCardData` stamps on the thinking step).
  *
- * Walks `entry.events` in order, tracking in-flight payloads and resolving
+ * Walks `entry.events` in order, tracking in-flight tool payloads and resolving
  * `tool_result` / `error` follow-ups against them with `matchInFlightTool` —
  * the same precedence `computeSubagentCardData` uses, so the two stay aligned.
- *
- * Keyed by `toolUseId`; `tool_call` events with an empty id are skipped (they
- * can't be keyed or clicked). Risk fields (`riskLevel`/`riskReason`) are
- * omitted — subagent timeline events don't carry them.
+ * Risk fields (`riskLevel`/`riskReason`) are omitted — subagent timeline events
+ * don't carry them.
  */
-export function buildSubagentToolDetails(
+export function buildSubagentStepDetails(
   entry: SubagentEntry,
 ): Map<string, ToolDetailPayload> {
   const payloads: ToolDetailPayload[] = [];
@@ -458,6 +464,27 @@ export function buildSubagentToolDetails(
   const meta: Array<{ startTs: number; running: boolean }> = [];
 
   for (const event of entry.events) {
+    // Text events become clickable "thinking" pills. Carry the FULL content
+    // (the timeline pill shows only a collapsed preview) and key by the event
+    // id to match the step's `detailKey`. Skip whitespace-only text exactly as
+    // `computeSubagentCardData` does so steps and payloads stay aligned.
+    if (event.type === "text") {
+      if ((event.content ?? "").trim().length === 0) continue;
+      payloads.push({
+        toolCallId: event.id,
+        toolName: "",
+        title: "Thought",
+        activity: "",
+        input: {},
+        status: "completed",
+        durationLabel: "",
+        kind: "thinking",
+        thinkingText: event.content,
+      });
+      meta.push({ startTs: event.timestamp, running: false });
+      continue;
+    }
+
     if (event.type === "tool_call") {
       const toolCallId = event.toolUseId ?? "";
       // Skip calls without an id — they can't be keyed or clicked.

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -44,6 +44,7 @@ import {
   type ToolCallCardData,
   type ToolCallCardStep,
 } from "@/domains/chat/utils/tool-call-card-utils";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 export type { ToolCallCardData, ToolCallCardStep };
 
@@ -142,12 +143,41 @@ export function mapToolEventToStep(
 }
 
 /**
- * Find the index of the most recent in-flight tool step that matches a
- * follow-up event (`tool_result` or `error`). Match precedence:
+ * Core in-flight matching predicate, shared by `findMatchingInFlightToolIndex`
+ * (which drives `computeSubagentCardData`) and `buildSubagentToolDetails` so
+ * the two projections can't drift. Walks `candidates` newest-first and returns
+ * the index of the first still-`running` tool that matches the follow-up
+ * `event`. Match precedence:
  *   1. Exact `toolUseId` match — required when the event carries one (so
  *      parallel calls to the same tool don't bleed into each other).
  *   2. `toolName` match against the originating `tool_call`'s name.
  *   3. "Latest in-flight" — when neither identifier is present.
+ *
+ * Returns -1 when no in-flight candidate matches.
+ */
+function matchInFlightTool(
+  candidates: Array<{ toolCallId: string; toolName: string; running: boolean }>,
+  event: { toolUseId?: string; toolName?: string },
+): number {
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const candidate = candidates[i]!;
+    if (!candidate.running) continue;
+    if (event.toolUseId) {
+      if (candidate.toolCallId === event.toolUseId) return i;
+      // Exact-match-only when the event carries a toolUseId — do NOT fall
+      // through to toolName matching for a different ID.
+      continue;
+    }
+    if (!event.toolName || candidate.toolName === event.toolName) return i;
+  }
+  return -1;
+}
+
+/**
+ * Find the index of the most recent in-flight tool step that matches a
+ * follow-up event (`tool_result` or `error`). Thin adapter over
+ * `matchInFlightTool` projecting the `(steps, toolMeta)` parallel arrays into
+ * the shared candidate shape.
  *
  * Returns -1 when no in-flight step matches.
  */
@@ -156,19 +186,14 @@ function findMatchingInFlightToolIndex(
   toolMeta: Array<{ startTs: number; toolName: string } | undefined>,
   event: { toolUseId?: string; toolName?: string },
 ): number {
-  for (let i = steps.length - 1; i >= 0; i--) {
-    const step = steps[i]!;
-    if (step.kind !== "tool" || step.status !== "running") continue;
-    if (event.toolUseId) {
-      if (step.toolCallId === event.toolUseId) return i;
-      // Exact-match-only when the event carries a toolUseId — do NOT fall
-      // through to toolName matching for a different ID.
-      continue;
-    }
-    const stepToolName = toolMeta[i]?.toolName ?? "";
-    if (!event.toolName || stepToolName === event.toolName) return i;
-  }
-  return -1;
+  return matchInFlightTool(
+    steps.map((step, i) => ({
+      toolCallId: step.kind === "tool" ? step.toolCallId : "",
+      toolName: toolMeta[i]?.toolName ?? "",
+      running: step.kind === "tool" && step.status === "running",
+    })),
+    event,
+  );
 }
 
 /**
@@ -407,4 +432,85 @@ export function useSubagentCardData(
     if (!entry) return null;
     return computeSubagentCardData(entry);
   }, [entry]);
+}
+
+/**
+ * Pure projection of (entry) → a `toolCallId`-keyed map of nested tool-detail
+ * payloads. Separate from `computeSubagentCardData` (whose `ToolCallCardStep`s
+ * carry only label/duration, not the raw `input`/`result`) so the clickable
+ * timeline pills can open the full tool-detail drawer (`ToolDetailBody`) for
+ * the tool whose id they emit.
+ *
+ * Walks `entry.events` in order, tracking in-flight payloads and resolving
+ * `tool_result` / `error` follow-ups against them with `matchInFlightTool` —
+ * the same precedence `computeSubagentCardData` uses, so the two stay aligned.
+ *
+ * Keyed by `toolUseId`; `tool_call` events with an empty id are skipped (they
+ * can't be keyed or clicked). Risk fields (`riskLevel`/`riskReason`) are
+ * omitted — subagent timeline events don't carry them.
+ */
+export function buildSubagentToolDetails(
+  entry: SubagentEntry,
+): Map<string, ToolDetailPayload> {
+  const payloads: ToolDetailPayload[] = [];
+  // Parallel array: start timestamp + running flag per payload, used for
+  // matching follow-ups and duration calc. Indexed by `payloads` position.
+  const meta: Array<{ startTs: number; running: boolean }> = [];
+
+  for (const event of entry.events) {
+    if (event.type === "tool_call") {
+      const toolCallId = event.toolUseId ?? "";
+      // Skip calls without an id — they can't be keyed or clicked.
+      if (!toolCallId) continue;
+      const toolName = event.toolName ?? "";
+      const labelInput =
+        event.input ?? reconstructInputBag(toolName, event.content ?? "");
+      const label = deriveStepLabelFromName(toolName, labelInput);
+      payloads.push({
+        toolCallId,
+        toolName,
+        title: label.title,
+        activity: label.activity,
+        input: event.input ?? {},
+        status: "running",
+        durationLabel: "",
+        kind: "tool",
+      });
+      meta.push({ startTs: event.timestamp, running: true });
+      continue;
+    }
+
+    // A follow-up carrying a result. A FAILED tool result is mapped to a raw
+    // `error`-typed event (see `mapInnerEventType`) yet still carries its
+    // `result` + `isError`, so we resolve both `tool_result` and `error`
+    // against the in-flight list regardless of the mapped type.
+    if (event.type === "tool_result" || event.type === "error") {
+      const matchIndex = matchInFlightTool(
+        payloads.map((payload, i) => ({
+          toolCallId: payload.toolCallId,
+          toolName: payload.toolName,
+          running: meta[i]!.running,
+        })),
+        event,
+      );
+      if (matchIndex === -1) continue;
+      const target = payloads[matchIndex]!;
+      const start = meta[matchIndex]!.startTs;
+      // Same non-positive-delta suppression as `computeSubagentCardData`:
+      // synthetic equal-timestamp history events → "".
+      const delta =
+        Number.isFinite(start) && event.timestamp > start
+          ? event.timestamp - start
+          : 0;
+      payloads[matchIndex] = {
+        ...target,
+        result: event.result ?? event.content,
+        status: event.isError ? "error" : "completed",
+        durationLabel: delta > 0 ? formatMs(delta) : "",
+      };
+      meta[matchIndex]!.running = false;
+    }
+  }
+
+  return new Map(payloads.map((payload) => [payload.toolCallId, payload]));
 }

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -40,7 +40,12 @@ import { deriveStepLabelFromName } from "@/domains/chat/components/tool-progress
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
 import { truncate } from "@/domains/chat/utils/truncate";
 import {
+  extractDomain,
+  parseWebSearchResultText,
+} from "@/domains/chat/utils/web-search-result-text";
+import {
   formatMs,
+  WEB_TOOL_NAMES,
   type ToolCallCardData,
   type ToolCallCardStep,
 } from "@/domains/chat/utils/tool-call-card-utils";
@@ -58,10 +63,77 @@ const TEXT_PREVIEW_MAX = 160;
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-step metadata tracked in parallel with `steps` (indexed by step
+ * position): the start timestamp (for duration calc), the originating
+ * `toolName` (so the resting "Used <Tool>" header can re-humanise it), and the
+ * `toolUseId` — needed to match follow-up `tool_result`/`error` events back to
+ * `web_search` steps, whose step shape carries no id field. `undefined` for
+ * steps with no follow-up (thinking, tool_error).
+ */
+type ToolMeta = { startTs: number; toolName: string; toolUseId?: string };
+
 /** Trim newlines + collapse whitespace, then clamp to TEXT_PREVIEW_MAX. */
 function trimTextPreview(input: string): string {
   const collapsed = input.replace(/\s+/g, " ").trim();
   return truncate(collapsed, TEXT_PREVIEW_MAX);
+}
+
+/**
+ * "Reading <domain>" text for a `web_fetch` step (rendered as a `thinking`
+ * step, exactly as main chat does — see `buildWebFetchStep`). Prefers the raw
+ * `url` from the preserved input, else the event `content` summary (which is
+ * the URL for `web_fetch` — `url` is a `TOOL_INPUT_PRIORITY_KEYS` member).
+ * Delegates hostname extraction (+ `www.` stripping) to the shared
+ * `extractDomain`. Falls back to "Reading…" when nothing usable is present,
+ * mirroring the main-chat placeholder.
+ */
+function webFetchReadingText(event: SubagentTimelineEvent): string {
+  const fromInput =
+    event.input && typeof event.input.url === "string" ? event.input.url : "";
+  const raw = (fromInput || event.content || "").trim();
+  const domain = raw ? extractDomain(raw) : "";
+  return domain ? `Reading ${domain}` : "Reading…";
+}
+
+/**
+ * Duration label for a tool / web step from its start + end timestamps.
+ * Returns "" for an unknown or non-positive delta: `mapDetailEvents` stamps
+ * every fetched-history event with the same `Date.now()`, so a matched
+ * `tool_call`→`tool_result` delta is exactly 0 and `formatMs(0)` would render a
+ * misleading "<1s" for every historical run. Real streaming events carry
+ * distinct receive-time values (delta > 0), so genuine sub-second tools still
+ * show "<1s" — only the synthetic equal-timestamp case is dropped.
+ */
+function durationLabelBetween(
+  startTs: number | undefined,
+  endTs: number,
+): string {
+  const delta =
+    typeof startTs === "number" && Number.isFinite(startTs)
+      ? endTs - startTs
+      : 0;
+  return delta > 0 ? formatMs(delta) : "";
+}
+
+/**
+ * Build a `web_search_error` step from a failed web-search follow-up. Shared by
+ * the `tool_result` and `error` branches (a failed web search can arrive as
+ * either type). Distinct from the exported `buildWebSearchErrorStep` in
+ * `tool-call-card-utils`, which builds from the rich `ToolActivityMetadata` the
+ * subagent timeline doesn't carry.
+ */
+function webSearchErrorStep(
+  durationLabel: string,
+  event: SubagentTimelineEvent,
+): Extract<ToolCallCardStep, { kind: "web_search_error" }> {
+  return {
+    kind: "web_search_error",
+    title: "Web search failed",
+    durationLabel,
+    errorMessage:
+      trimTextPreview(event.result ?? event.content) || "Web search failed",
+  };
 }
 
 /**
@@ -89,10 +161,10 @@ function reconstructInputBag(
       return { command: content };
     case "str_replace_editor":
     case "text_editor":
-      // We lack the editor sub-command in the timeline summary, so route
-      // through "Editing" by default — safer than mis-classifying writes
-      // as reads. Callers who need the precise variant can wire raw input
-      // through when the subagent store starts preserving it.
+      // Fallback only: the summary lacks the editor sub-command, so route
+      // through "Editing" by default (safer than mis-classifying a write as a
+      // read). Callers prefer the raw `event.input` (which carries `command`)
+      // and only reach this when it's absent.
       return { path: content };
     case "computer":
       return { action: content };
@@ -114,11 +186,10 @@ function reconstructInputBag(
  *
  * Routes through the shared `deriveStepLabelFromName` helper so the inline
  * card's step pills inherit tool-specific titles + icons (`code` for bash,
- * `file` for str_replace_editor view, etc.) rather than always rendering
- * `bolt` / generic "Using <Tool>" labels. The subagent timeline carries
- * only a `content` summary string (no raw input object), so we
- * best-effort-reconstruct an input bag via `reconstructInputBag` before
- * dispatching.
+ * `sparkle` for skills, etc.) rather than always rendering `bolt` / generic
+ * "Using <Tool>" labels. Derives from the raw `event.input` when present,
+ * falling back to `reconstructInputBag(content)` only for older events that
+ * lack it.
  *
  * `toolCallId` mirrors `toolUseId` so the renderer key + result matcher
  * have a stable identifier.
@@ -128,7 +199,13 @@ export function mapToolEventToStep(
 ): Extract<ToolCallCardStep, { kind: "tool" }> {
   const toolName = event.toolName ?? "";
   const content = event.content ?? "";
-  const input = reconstructInputBag(toolName, content);
+  // Prefer the raw `input` (now preserved on the event) over the lossy
+  // `reconstructInputBag(content)` fallback — the summary `content` keeps only a
+  // single `TOOL_INPUT_PRIORITY_KEYS` field and never the `activity` sentence,
+  // so deriving from it drops skill names, computer actions, and the rich
+  // activity label. Mirrors `buildSubagentStepDetails` so the timeline pill and
+  // the nested detail view agree.
+  const input = event.input ?? reconstructInputBag(toolName, content);
   const label = deriveStepLabelFromName(toolName, input);
   return {
     kind: "tool",
@@ -183,15 +260,32 @@ function matchInFlightTool(
  */
 function findMatchingInFlightToolIndex(
   steps: ToolCallCardStep[],
-  toolMeta: Array<{ startTs: number; toolName: string } | undefined>,
+  toolMeta: Array<ToolMeta | undefined>,
   event: { toolUseId?: string; toolName?: string },
 ): number {
   return matchInFlightTool(
-    steps.map((step, i) => ({
-      toolCallId: step.kind === "tool" ? step.toolCallId : "",
-      toolName: toolMeta[i]?.toolName ?? "",
-      running: step.kind === "tool" && step.status === "running",
-    })),
+    steps.map((step, i) => {
+      const meta = toolMeta[i];
+      if (step.kind === "tool") {
+        return {
+          toolCallId: step.toolCallId,
+          toolName: meta?.toolName ?? "",
+          running: step.status === "running",
+        };
+      }
+      // A `web_search` step carries no id on its shape, so its `toolUseId` is
+      // tracked in `toolMeta`. It's in-flight while its title is still the
+      // present-tense placeholder; the `tool_result`/`error` follow-up flips it
+      // to past tense (or a `web_search_error`).
+      if (step.kind === "web_search") {
+        return {
+          toolCallId: meta?.toolUseId ?? "",
+          toolName: meta?.toolName ?? "",
+          running: step.title === "Searching the web",
+        };
+      }
+      return { toolCallId: "", toolName: meta?.toolName ?? "", running: false };
+    }),
     event,
   );
 }
@@ -230,14 +324,10 @@ export function computeSubagentCardData(
   entry: SubagentEntry,
 ): ToolCallCardData {
   const steps: ToolCallCardStep[] = [];
-  // Parallel array tracking per-tool metadata not carried on the shared
-  // `tool` step shape: the start timestamp (for duration calc) and the
-  // originating `toolName` (so the resting "Used <Tool>" header can
-  // re-humanise the name without re-parsing the title string). Indexed
-  // by `steps` position; `undefined` for non-tool entries.
-  const toolMeta: Array<
-    { startTs: number; toolName: string } | undefined
-  > = [];
+  // Parallel array tracking per-step metadata not carried on the shared step
+  // shapes (see `ToolMeta`). Indexed by `steps` position; `undefined` for
+  // entries with no follow-up (thinking, tool_error, web_fetch).
+  const toolMeta: Array<ToolMeta | undefined> = [];
 
   for (const event of entry.events) {
     if (event.type === "text") {
@@ -253,11 +343,56 @@ export function computeSubagentCardData(
     }
 
     if (event.type === "tool_call") {
+      const toolName = event.toolName ?? "";
+      // Route web tools to the dedicated step kinds so their phase labels match
+      // main chat ("Searching the web" / "Thinking") instead of the generic
+      // "Working" bucket the tool path produces. Mirrors the main-chat split in
+      // `tool-call-card-utils` (`buildWebSearchStep` / `buildWebFetchStep`).
+      if (WEB_TOOL_NAMES.has(toolName)) {
+        if (toolName === "web_fetch") {
+          // `web_fetch` renders as a "Reading <domain>" thinking step — no
+          // follow-up tracking needed (the domain is known at call time, and a
+          // thinking step is neutral for phase status).
+          steps.push({
+            kind: "thinking",
+            durationLabel: "",
+            text: webFetchReadingText(event),
+          });
+          toolMeta.push(undefined);
+        } else {
+          // `web_search` — placeholder until its result lands; the matched
+          // `tool_result` flips the title tense + fills in results (see below).
+          // `query` (raw input, else the `content` summary which is the query
+          // for web_search) labels the step so unclamped multi-search groups
+          // stay distinct in the timeline; it survives the `...target` spread on
+          // completion.
+          const query =
+            event.input && typeof event.input.query === "string"
+              ? event.input.query
+              : event.content || undefined;
+          steps.push({
+            kind: "web_search",
+            query,
+            title: "Searching the web",
+            durationLabel: "",
+            linkCount: 0,
+            results: [],
+            // The originating tool id keys this search's nested detail so the
+            // timeline can render it as a clickable pill (query + sources) —
+            // matches the key `buildSubagentStepDetails` emits. Survives the
+            // `...target` spread on completion alongside `query`.
+            detailKey: event.toolUseId,
+          });
+          toolMeta.push({
+            startTs: event.timestamp,
+            toolName,
+            toolUseId: event.toolUseId,
+          });
+        }
+        continue;
+      }
       steps.push(mapToolEventToStep(event));
-      toolMeta.push({
-        startTs: event.timestamp,
-        toolName: event.toolName ?? "",
-      });
+      toolMeta.push({ startTs: event.timestamp, toolName });
       continue;
     }
 
@@ -265,21 +400,32 @@ export function computeSubagentCardData(
       const matchIndex = findMatchingInFlightToolIndex(steps, toolMeta, event);
       if (matchIndex === -1) continue;
       const target = steps[matchIndex]!;
-      if (target.kind !== "tool") continue;
       const start = toolMeta[matchIndex]?.startTs;
-      // Suppress synthetic durations for fetched-history events. Detail
-      // events from `mapDetailEvents` stamp every event `timestamp:
-      // Date.now()`, so a matched `tool_call`→`tool_result` delta is
-      // exactly 0 and `formatMs(0)` would render a misleading "<1s" for
-      // every historical tool run. Omit the label (`""`) when the delta is
-      // non-positive. Real streaming events carry distinct receive-time
-      // `Date.now()` values (delta > 0), so genuine sub-second tools still
-      // show "<1s" — only the synthetic equal-timestamp case is dropped.
-      const delta =
-        typeof start === "number" && Number.isFinite(start)
-          ? event.timestamp - start
-          : 0;
-      const durationLabel = delta > 0 ? formatMs(delta) : "";
+      const durationLabel = durationLabelBetween(start, event.timestamp);
+      // `web_search` signals completion via title tense (not a `status` field):
+      // success flips "Searching" → "Searched"; an error becomes a
+      // `web_search_error` step (both still group under "Searching the web").
+      if (target.kind === "web_search") {
+        if (event.isError) {
+          steps[matchIndex] = webSearchErrorStep(durationLabel, event);
+          continue;
+        }
+        // Parse the result text (Title\nURL pairs) into link chips — the same
+        // fallback main chat uses on reload, since the subagent timeline carries
+        // the raw result text but not the structured `activityMetadata`. No
+        // clamp: the detail panel has room to show every source inline, so all
+        // results go in `results` and `overflowResults` stays empty.
+        const results = parseWebSearchResultText(event.result ?? event.content);
+        steps[matchIndex] = {
+          ...target,
+          title: "Searched the web",
+          durationLabel,
+          linkCount: results.length,
+          results,
+        };
+        continue;
+      }
+      if (target.kind !== "tool") continue;
       steps[matchIndex] = {
         ...target,
         status: event.isError ? "error" : "completed",
@@ -298,6 +444,11 @@ export function computeSubagentCardData(
         const target = steps[matchIndex]!;
         if (target.kind === "tool") {
           steps[matchIndex] = { ...target, status: "error" };
+        } else if (target.kind === "web_search") {
+          steps[matchIndex] = webSearchErrorStep(
+            durationLabelBetween(toolMeta[matchIndex]?.startTs, event.timestamp),
+            event,
+          );
         }
       }
       const message = trimTextPreview(event.content) || "Subagent error";
@@ -348,7 +499,7 @@ export function computeSubagentCardData(
 function deriveCurrentStep(
   entry: SubagentEntry,
   steps: ToolCallCardStep[],
-  toolMeta: Array<{ startTs: number; toolName: string } | undefined>,
+  toolMeta: Array<ToolMeta | undefined>,
 ): { currentStepTitle: string; currentStepInfo: string } {
   const isTerminal =
     entry.status === "completed" ||
@@ -417,8 +568,21 @@ function deriveCurrentStep(
     };
   }
 
-  // `web_search` / `web_search_error` aren't produced by this hook today,
-  // but the union includes them — fall through to a neutral header.
+  if (latest.kind === "web_search") {
+    // Title already carries the tense ("Searching the web" / "Searched the
+    // web"), set at call time and flipped on the matched result.
+    return { currentStepTitle: latest.title, currentStepInfo: "" };
+  }
+
+  if (latest.kind === "web_search_error") {
+    return {
+      currentStepTitle: latest.title,
+      currentStepInfo: latest.errorMessage,
+    };
+  }
+
+  // Every step kind is handled above; this neutral return only satisfies the
+  // exhaustive-union check.
   return { currentStepTitle: "", currentStepInfo: "" };
 }
 
@@ -448,6 +612,9 @@ export function useSubagentCardData(
  *  - text/thinking steps → a `kind: "thinking"` payload carrying the FULL,
  *    un-truncated reasoning markdown, keyed by the text event's id (matching
  *    the `detailKey` `computeSubagentCardData` stamps on the thinking step).
+ *  - web_search steps → a `kind: "web_search"` payload carrying the query +
+ *    the parsed result sources, keyed by `toolUseId` (matching the `detailKey`
+ *    `computeSubagentCardData` stamps on the search step).
  *
  * Walks `entry.events` in order, tracking in-flight tool payloads and resolving
  * `tool_result` / `error` follow-ups against them with `matchInFlightTool` —
@@ -490,6 +657,30 @@ export function buildSubagentStepDetails(
       // Skip calls without an id — they can't be keyed or clicked.
       if (!toolCallId) continue;
       const toolName = event.toolName ?? "";
+      // Web search → a dedicated detail payload carrying the query and (once the
+      // result lands) the parsed source list, rendered as favicon chips rather
+      // than the raw technical-details body. Mirrors the `web_search` step the
+      // timeline projection builds, keyed by the same `toolUseId`.
+      if (toolName === "web_search") {
+        const query =
+          event.input && typeof event.input.query === "string"
+            ? event.input.query
+            : event.content || undefined;
+        payloads.push({
+          toolCallId,
+          toolName,
+          title: "Searched the web",
+          activity: "",
+          input: event.input ?? {},
+          status: "running",
+          durationLabel: "",
+          kind: "web_search",
+          searchQuery: query,
+          searchResults: [],
+        });
+        meta.push({ startTs: event.timestamp, running: true });
+        continue;
+      }
       const labelInput =
         event.input ?? reconstructInputBag(toolName, event.content ?? "");
       const label = deriveStepLabelFromName(toolName, labelInput);
@@ -529,12 +720,26 @@ export function buildSubagentStepDetails(
         Number.isFinite(start) && event.timestamp > start
           ? event.timestamp - start
           : 0;
-      payloads[matchIndex] = {
-        ...target,
-        result: event.result ?? event.content,
-        status: event.isError ? "error" : "completed",
-        durationLabel: delta > 0 ? formatMs(delta) : "",
-      };
+      const durationLabel = delta > 0 ? formatMs(delta) : "";
+      // Web search → parse the raw result text into the same source chips the
+      // timeline renders; everything else keeps the raw `result` for the
+      // technical-details body.
+      payloads[matchIndex] =
+        target.kind === "web_search"
+          ? {
+              ...target,
+              status: event.isError ? "error" : "completed",
+              durationLabel,
+              searchResults: event.isError
+                ? []
+                : parseWebSearchResultText(event.result ?? event.content),
+            }
+          : {
+              ...target,
+              result: event.result ?? event.content,
+              status: event.isError ? "error" : "completed",
+              durationLabel,
+            };
       meta[matchIndex]!.running = false;
     }
   }

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -419,6 +419,12 @@ export function computeSubagentCardData(
         steps[matchIndex] = {
           ...target,
           title: "Searched the web",
+          // Backfill the query from the result's metadata. The originating
+          // `tool_call` carried empty input live (Anthropic resolves web_search
+          // input only at completion), so `target.query` is usually undefined
+          // until this result lands `searchQuery`. The history/detail path
+          // already has it on the call, hence the `target.query ||` precedence.
+          query: target.query || event.searchQuery,
           durationLabel,
           linkCount: results.length,
           results,
@@ -730,6 +736,10 @@ export function buildSubagentStepDetails(
               ...target,
               status: event.isError ? "error" : "completed",
               durationLabel,
+              // Backfill the query from the result metadata for the nested
+              // detail view — the call-time `searchQuery` is empty live (see
+              // the timeline projection's matching backfill).
+              searchQuery: target.searchQuery || event.searchQuery,
               searchResults: event.isError
                 ? []
                 : parseWebSearchResultText(event.result ?? event.content),

--- a/clients/web/src/domains/chat/map-detail-events.test.ts
+++ b/clients/web/src/domains/chat/map-detail-events.test.ts
@@ -81,6 +81,33 @@ describe("mapDetailEvents", () => {
     expect(mapDetailEvents([])).toEqual([]);
   });
 
+  it("carries toolUseId and raw input through to timeline events", () => {
+    const raw: SubagentDetailEvent[] = [
+      {
+        type: "tool_use",
+        content: '{"command":"ls -la"}',
+        toolName: "bash",
+        toolUseId: "toolu_1",
+        input: { command: "ls -la" },
+      },
+      {
+        type: "tool_result",
+        content: "total 0",
+        toolName: "bash",
+        toolUseId: "toolu_1",
+      },
+    ];
+    const events = mapDetailEvents(raw);
+
+    expect(events[0]!.type).toBe("tool_call");
+    expect(events[0]!.toolUseId).toBe("toolu_1");
+    expect(events[0]!.input).toEqual({ command: "ls -la" });
+    expect(events[1]!.type).toBe("tool_result");
+    expect(events[1]!.toolUseId).toBe("toolu_1");
+    // result rides in content; buildSubagentToolDetails falls back to it.
+    expect(events[1]!.content).toBe("total 0");
+  });
+
   it("generates sequential detail-N ids", () => {
     const raw: SubagentDetailEvent[] = [
       { type: "tool_use", content: "a", toolName: "t" },

--- a/clients/web/src/domains/chat/map-detail-events.test.ts
+++ b/clients/web/src/domains/chat/map-detail-events.test.ts
@@ -104,7 +104,7 @@ describe("mapDetailEvents", () => {
     expect(events[0]!.input).toEqual({ command: "ls -la" });
     expect(events[1]!.type).toBe("tool_result");
     expect(events[1]!.toolUseId).toBe("toolu_1");
-    // result rides in content; buildSubagentToolDetails falls back to it.
+    // result rides in content; buildSubagentStepDetails falls back to it.
     expect(events[1]!.content).toBe("total 0");
   });
 

--- a/clients/web/src/domains/chat/map-detail-events.ts
+++ b/clients/web/src/domains/chat/map-detail-events.ts
@@ -53,6 +53,12 @@ export function mapDetailEvents(
       content,
       toolName: evt.toolName,
       isError: evt.isError,
+      // Carry the tool id + raw input through so history/reloaded subagents'
+      // tool pills are clickable and the nested detail shows real input.
+      // `result` rides in `content`, which `buildSubagentToolDetails` already
+      // falls back to.
+      toolUseId: evt.toolUseId,
+      input: evt.input,
       timestamp: Date.now(),
     });
   }

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
+import type { SubagentInnerEvent } from "@vellumai/assistant-api";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 
 // ---------------------------------------------------------------------------
@@ -328,6 +329,43 @@ describe("receiveEvent", () => {
 
     expect(getState().byId["sa-1"]!.events).toHaveLength(1);
     expect(getState().byId["sa-1"]!.events[0]!.type).toBe("tool_result");
+  });
+
+  it("captures the web_search query from a tool_result's activityMetadata", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      // `activityMetadata` rides through on the subagent wire as a passthrough
+      // field (not on the inferred `SubagentInnerEvent` type), so cast to attach
+      // it — this is the only live source of the web_search query, since the
+      // originating `tool_use_start` carries empty input.
+      event: {
+        type: "tool_result",
+        toolName: "web_search",
+        toolUseId: "tu-ws",
+        result: "Title\nhttps://example.com",
+        activityMetadata: {
+          webSearch: {
+            query: "best thermos 2025",
+            provider: "anthropic-native",
+            resultCount: 1,
+            durationMs: 120,
+            results: [],
+          },
+        },
+      } as SubagentInnerEvent,
+      timestamp: NOW + 700,
+    });
+
+    expect(getState().byId["sa-1"]!.events[0]!.searchQuery).toBe(
+      "best thermos 2025",
+    );
   });
 
   it("maps to error type when isError is true", () => {

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -609,6 +609,117 @@ describe("receiveEvent", () => {
     expect(getState().byId).toEqual(before.byId);
     expect(getState().orderedIds).toEqual(before.orderedIds);
   });
+
+  it("preserves raw input on tool_use_start alongside the content summary", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: {
+        type: "tool_use_start",
+        toolName: "bash",
+        input: { command: "ls -la" },
+      },
+      timestamp: NOW + 100,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.type).toBe("tool_call");
+    expect(ev.input?.command).toBe("ls -la");
+    // The summary that drives labels is still derived from the input.
+    expect(ev.content).toBe("ls -la");
+    expect(ev.result).toBeUndefined();
+  });
+
+  it("preserves raw result on tool_result", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "tool_result", result: "total 0\nfile.txt" },
+      timestamp: NOW + 200,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.type).toBe("tool_result");
+    expect(ev.result).toBe("total 0\nfile.txt");
+    expect(ev.input).toBeUndefined();
+  });
+
+  it("preserves result on an errored tool_result (mapped to type error)", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: {
+        type: "tool_result",
+        toolName: "bash",
+        result: "Error: command not found: foo",
+        isError: true,
+      },
+      timestamp: NOW + 400,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    // mapInnerEventType routes isError to "error", but the raw result must
+    // still be retained for the detail view.
+    expect(ev.type).toBe("error");
+    expect(ev.isError).toBe(true);
+    expect(ev.result).toBe("Error: command not found: foo");
+  });
+
+  it("falls back to content for tool_result result when result is absent", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "tool_result", content: "File contents here" },
+      timestamp: NOW + 300,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.type).toBe("tool_result");
+    expect(ev.result).toBe("File contents here");
+  });
+
+  it("leaves input/result unset for text events", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "assistant_text_delta", content: "Hello" },
+      timestamp: NOW + 100,
+    });
+
+    const ev = getState().byId["sa-1"]!.events[0]!;
+    expect(ev.input).toBeUndefined();
+    expect(ev.result).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -17,6 +17,7 @@ import { subagentsByIdAbortPost } from "@/generated/daemon/sdk.gen";
 import { useConversationStore } from "@/stores/conversation-store";
 import { createSelectors } from "@/utils/create-selectors";
 import type { SubagentStatus, SubagentInnerEvent } from "@vellumai/assistant-api";
+import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
 import { isActiveStatus } from "@/utils/subagent-status";
 import { fetchSubagentDetail } from "./fetch-subagent-detail";
 import { mapDetailEvents } from "./map-detail-events";
@@ -45,6 +46,16 @@ export interface SubagentTimelineEvent {
    */
   input?: Record<string, unknown>;
   result?: string;
+  /**
+   * Resolved web-search query, captured from a `tool_result` event's
+   * `activityMetadata.webSearch.query`. Anthropic web_search resolves its
+   * `{query}` input only at content_block_stop, so the originating
+   * `tool_use_start` arrives with empty `input` and the query is otherwise
+   * absent live — it rides through on the matching result's metadata. The
+   * history/detail path rebuilds the query from the persisted resolved input
+   * instead, so this is only the live source.
+   */
+  searchQuery?: string;
 }
 
 export interface SubagentEntry {
@@ -340,6 +351,22 @@ function summarizeToolInput(input: Record<string, unknown>): string {
   return "";
 }
 
+/**
+ * Pull the resolved web-search query off a subagent inner event's
+ * `activityMetadata`. The query rides through on the matching `tool_result`'s
+ * metadata (passthrough on the subagent wire — see `SubagentInnerEventSchema`),
+ * which is the only place it appears live: the `tool_use_start` carries empty
+ * `input` for Anthropic web_search. `activityMetadata` isn't on the inferred
+ * `SubagentInnerEvent` type (it's a passthrough field), so read it via a narrow
+ * cast. Returns `undefined` for non-search events or an empty query.
+ */
+function extractSearchQuery(event: SubagentInnerEvent): string | undefined {
+  const meta = (event as { activityMetadata?: ToolActivityMetadata })
+    .activityMetadata;
+  const query = meta?.webSearch?.query;
+  return typeof query === "string" && query.length > 0 ? query : undefined;
+}
+
 let timelineEventCounter = 0;
 
 /** Generate a unique ID for timeline events. */
@@ -487,6 +514,9 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
         params.event.type === "tool_result"
           ? params.event.result ?? params.event.content ?? params.event.text
           : undefined,
+      // The resolved web-search query — only present (and only needed) on a
+      // web_search `tool_result`; `undefined` everywhere else.
+      searchQuery: extractSearchQuery(params.event),
     };
 
     set({

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -39,6 +39,12 @@ export interface SubagentTimelineEvent {
    * tool (which `toolName` alone cannot disambiguate).
    */
   toolUseId?: string;
+  /**
+   * `content` remains the ≤120-char summary that drives labels; `input`/
+   * `result` are the raw payloads used only by the nested tool-detail view.
+   */
+  input?: Record<string, unknown>;
+  result?: string;
 }
 
 export interface SubagentEntry {
@@ -469,6 +475,18 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       isError: params.event.isError,
       timestamp: params.timestamp,
       toolUseId: params.event.toolUseId,
+      // Preserve raw payloads for the nested tool-detail view without
+      // disturbing the `content` summary computed above.
+      input:
+        params.event.type === "tool_use_start" ? params.event.input : undefined,
+      // Key off the RAW event type, not the mapped timeline type: a failed
+      // tool emits `tool_result` with `isError: true`, which `mapInnerEventType`
+      // routes to `"error"`. Using `eventType` here would drop the error output
+      // the detail view needs, so capture both success and error results.
+      result:
+        params.event.type === "tool_result"
+          ? params.event.result ?? params.event.content ?? params.event.text
+          : undefined,
     };
 
     set({

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -70,6 +70,13 @@ export type ToolCallCardStep =
        * have no backing reasoning item and keep the snapshot path.
        */
       thinkingItemIndex?: number;
+      /**
+       * Opaque key into a parent-built detail-payload map, letting a clickable
+       * thinking pill open its full reasoning in a detail view. Set by the
+       * subagent timeline (the source text event's id); unset elsewhere, where
+       * thinking pills stay non-interactive.
+       */
+      detailKey?: string;
     }
   | {
       kind: "web_search";

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -81,6 +81,12 @@ export type ToolCallCardStep =
   | {
       kind: "web_search";
       title: string;
+      /**
+       * The search query, when known. Surfaced by the subagent timeline as a
+       * per-step label so multiple unclamped searches in one "Searching the web"
+       * group stay visually distinct; main-chat builders leave it unset.
+       */
+      query?: string;
       durationLabel: string;
       linkCount: number;
       /** Results shown inline as favicon chips (clamped to `MAX_VISIBLE_RESULTS`). */
@@ -91,6 +97,14 @@ export type ToolCallCardStep =
        * omitted when every result fits inline.
        */
       overflowResults?: WebSearchResultItem[];
+      /**
+       * Stable key (the originating `tool_call`'s `toolUseId`) that lets the
+       * subagent timeline render this search as a clickable pill opening its
+       * nested query + sources detail — matching the key
+       * `buildSubagentStepDetails` emits. Unset for main-chat builders, whose
+       * searches aren't clickable.
+       */
+      detailKey?: string;
     }
   | {
       kind: "web_search_error";

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -26,6 +26,8 @@ import { create } from "zustand";
 
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
+
+import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 import { createSelectors } from "@/utils/create-selectors";
 
 /** Views that overlay the main content and track a "back" destination. */
@@ -147,13 +149,26 @@ export interface ToolDetailPayload {
    * Variant discriminator. Absent or `"tool"` → the standard tool-call detail
    * view (technical details + output). `"thinking"` → the reasoning view that
    * renders `thinkingText` as markdown with no input/output sections.
+   * `"web_search"` → the search view that renders `searchQuery` + the
+   * `searchResults` source list with no technical input/output sections.
    */
-  kind?: "tool" | "thinking";
+  kind?: "tool" | "thinking" | "web_search";
   /**
    * Reasoning markdown captured when the drawer was opened. Used as the
    * fallback when the live source (below) can't be resolved.
    */
   thinkingText?: string;
+  /**
+   * The search query for a `"web_search"` detail, rendered verbatim above the
+   * source list. Unset for other kinds.
+   */
+  searchQuery?: string;
+  /**
+   * The parsed result sources for a `"web_search"` detail, rendered as the same
+   * favicon source chips the timeline uses. Empty while the search is still in
+   * flight. Unset for other kinds.
+   */
+  searchResults?: WebSearchResultItem[];
   /**
    * Stable identity of the reasoning run this drawer mirrors. When present, the
    * panel re-derives live text from the chat-session store (via


### PR DESCRIPTION
## Summary
Make the subagent detail panel's timeline tool-call pills clickable to open that tool call's input/output in a tool-detail view **nested inside the panel** (local master→detail with a "← Back to timeline" affordance) — no changes to the global viewer-store / mainView. Achieved via "Path B": preserve raw tool `input`/`result` through the subagent store, then reuse the existing `ToolDetailPanel` rendering.

## Self-review result
PASS — external/faithfulness/integration passes clean; slop pass raised only non-blocking nits (triaged, no fix needed). 0 gaps remediated.

## PRs merged into this branch
- #35683: refactor — extract reusable `ToolDetailBody` from `ToolDetailPanel`
- #35684: fix — preserve raw tool `input`/`result` on subagent timeline events (incl. errored results)
- #35685: feat — clickable tool pills in the subagent timeline (optional callback)
- #35689: feat — `buildSubagentToolDetails` → `Map<toolCallId, ToolDetailPayload>`
- #35692: feat — nested tool-detail view in `SubagentDetailPanel`

## Known limitation / follow-up
Nested detail is **live-only**: streaming subagents carry `toolUseId` + raw `input`/`result`. Reloaded/history subagents (hydrated from the daemon `GET /subagents/:id` route) omit those fields, so their tool pills render non-clickable (graceful fallback). Surfacing detail for history subagents requires a **daemon-side** change to carry tool id/input/result — tracked as a follow-up (assistant repo).

Targets the `Jasonnnz/subagent-detail-panel-figma` feature branch (not main).

Part of plan: subagent-tool-detail-pills.md