### PR TITLE
feat(notifications): reframe tool-approval guardian card to assistant-as-actor (LUM-2529)

### DIFF
--- a/assistant/src/__tests__/slack-notification-approval-card.test.ts
+++ b/assistant/src/__tests__/slack-notification-approval-card.test.ts
@@ -174,3 +174,114 @@ describe("Slack access-request card blocks", () => {
     ).toBe(true);
   });
 });
+
+/**
+ * Pins the Slack tool-approval card: the assistant-as-actor subtitle, the
+ * preview + command body, the action callback ids, and the source/permalink
+ * context block — all driven by the shared view model from `contextPayload`.
+ */
+const TOOL_CTX: Record<string, unknown> = {
+  requestId: "req-123",
+  requestCode: "ABC123",
+  requestKind: "tool_grant_request",
+  toolName: "web_fetch",
+  questionText: "ignored — the card recomposes from structured facts",
+  sourceChannel: "slack",
+  requesterIdentifier: "Noa Flaherty",
+  conversationExternalId: "C01ABC",
+  channelName: "general",
+  messageTs: "1700000000.000100",
+  messagePreview: "can you pull this?",
+  commandPreview: "GET https://example.com",
+};
+
+function buildToolPayload(
+  contextPayload: Record<string, unknown>,
+  approval: ApprovalUIMetadata = APPROVAL,
+): ChannelDeliveryPayload {
+  return {
+    sourceEventName: "guardian.question",
+    copy: { title: "Tool approval", body: "msg" },
+    urgency: "high",
+    approvalContext: approval,
+    contextPayload,
+  };
+}
+
+describe("Slack tool-approval card blocks", () => {
+  test("card title is generic; subtitle is the assistant-as-actor sentence", () => {
+    const c = card(
+      buildApprovalNotificationBlocks(buildToolPayload(TOOL_CTX), "msg"),
+    );
+    expect(text(c.title)).toBe("Tool approval");
+    expect(text(c.subtitle)).toBe(
+      'Assistant wants to use "web_fetch" in response to Noa Flaherty\'s message in #general.',
+    );
+  });
+
+  test("body shows the requester's words and the redacted command", () => {
+    const c = card(
+      buildApprovalNotificationBlocks(buildToolPayload(TOOL_CTX), "msg"),
+    );
+    const body = text(c.body);
+    expect(body).toContain('> _"can you pull this?"_');
+    expect(body).toContain("Will run: `GET https://example.com`");
+  });
+
+  test("actions encode the apr:<requestId>:<action> callback ids", () => {
+    const c = card(
+      buildApprovalNotificationBlocks(buildToolPayload(TOOL_CTX), "msg"),
+    );
+    const actions = c.actions as Array<Record<string, unknown>>;
+    expect(actions).toHaveLength(2);
+    expect(actions[0].action_id).toBe("apr:req-123:approve_once");
+    expect(actions[1].action_id).toBe("apr:req-123:reject");
+    expect(actions[1].style).toBe("danger");
+  });
+
+  test("source context renders the channel mention + exact-message permalink", () => {
+    const texts = contextTexts(
+      buildApprovalNotificationBlocks(buildToolPayload(TOOL_CTX), "msg"),
+    );
+    expect(texts).toContain(
+      "Source: Slack — <#C01ABC> · <https://slack.com/archives/C01ABC/p1700000000000100|View in Slack →>",
+    );
+  });
+
+  test("DM source drops the channel and reads Direct message", () => {
+    const texts = contextTexts(
+      buildApprovalNotificationBlocks(
+        buildToolPayload({
+          ...TOOL_CTX,
+          conversationExternalId: "D01XYZ",
+          channelName: undefined,
+        }),
+        "msg",
+      ),
+    );
+    expect(
+      texts.some(
+        (t) =>
+          t.startsWith("Source: Slack — Direct message") &&
+          t.includes("View in Slack →"),
+      ),
+    ).toBe(true);
+  });
+
+  test("no inbound trigger: title only, no source context block", () => {
+    const blocks = buildApprovalNotificationBlocks(
+      buildToolPayload({
+        requestId: "req-self",
+        requestCode: "AAA111",
+        requestKind: "tool_approval",
+        toolName: "bash",
+        questionText: "ignored",
+      }),
+      "msg",
+    );
+    expect(text(card(blocks).subtitle)).toBe('Assistant wants to use "bash".');
+    expect(contextTexts(blocks).some((t) => t.startsWith("Source:"))).toBe(
+      false,
+    );
+  });
+});

--- a/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
@@ -2,36 +2,40 @@ import { describe, expect, test } from "bun:test";
 
 import { buildToolApprovalSeedContentBlocks } from "../notifications/approval-card-data.js";
 
+type Block = Record<string, unknown>;
+
+function surfaceOf(blocks: unknown[]): Block {
+  return blocks[0] as Block;
+}
+function dataOf(blocks: unknown[]): Block {
+  return (blocks[0] as Block).data as Block;
+}
+function textOf(blocks: unknown[]): Block {
+  return blocks[1] as Block;
+}
+
+/**
+ * Pins the in-app tool-approval card seed content. The card is reframed
+ * assistant-as-actor: the primary line names the tool (not the contact), a
+ * connective attributes the action to the triggering message, the body shows
+ * the requester's words + an exact-message Slack link, and the same one-line
+ * phrasing feeds the plain-text fallback.
+ */
 describe("buildToolApprovalSeedContentBlocks", () => {
-  const toolApprovalPayload: Record<string, unknown> = {
-    requestId: "req-tool-456",
+  const slackChannelGrant: Record<string, unknown> = {
+    requestId: "req-grant-1",
     requestCode: "XYZ789",
-    requestKind: "tool_approval",
-    toolName: "bash",
-    questionText:
-      'Bob wants to use "bash": mkdir -p scratch && assistant credentials reveal --service slack',
-    sourceChannel: "slack",
-    requesterIdentifier: "Bob",
-  };
-
-  const toolGrantPayload: Record<string, unknown> = {
-    requestId: "req-grant-789",
-    requestCode: "GHI012",
     requestKind: "tool_grant_request",
-    toolName: "web_search",
-    questionText: 'Alice wants to use "web_search": search for latest news',
-    sourceChannel: "telegram",
-    requesterIdentifier: "Alice",
-  };
-
-  const voiceToolApprovalPayload: Record<string, unknown> = {
-    requestId: "req-voice-101",
-    requestCode: "VOICE1",
-    requestKind: "pending_question",
-    toolName: "bash",
-    questionText: 'Bob wants to use "bash": echo hello',
-    sourceChannel: "phone",
-    requesterIdentifier: "Bob",
+    toolName: "web_fetch",
+    questionText:
+      'Assistant wants to use "web_fetch" in response to Noa Flaherty\'s message in #general.',
+    sourceChannel: "slack",
+    requesterIdentifier: "Noa Flaherty",
+    conversationExternalId: "C01ABC",
+    channelName: "general",
+    messageTs: "1700000000.000100",
+    messagePreview: "can you pull this? https://example.com/article",
+    commandPreview: "GET https://example.com/article",
   };
 
   test("returns null for non-tool-approval request kinds", () => {
@@ -44,168 +48,145 @@ describe("buildToolApprovalSeedContentBlocks", () => {
     expect(buildToolApprovalSeedContentBlocks({})).toBeNull();
   });
 
-  test("produces blocks for pending_question with toolName (voice tool approval)", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(
-      voiceToolApprovalPayload,
-    )!;
+  test("emits a ui_surface card + flagged text fallback", () => {
+    const blocks = buildToolApprovalSeedContentBlocks(slackChannelGrant)!;
     expect(blocks).toHaveLength(2);
-    expect((blocks[0] as Record<string, unknown>).type).toBe("ui_surface");
-    const surface = blocks[0] as Record<string, unknown>;
-    expect(surface.surfaceType).toBe("card");
-    expect(surface.surfaceId).toBe("tool-approval-req-voice-101");
-    const data = surface.data as Record<string, unknown>;
-    expect(data.subtitle).toBe("Requesting approval to run this tool");
-    const metadata = data.metadata as Array<{ label: string; value: string }>;
+    expect(surfaceOf(blocks).type).toBe("ui_surface");
+    expect(surfaceOf(blocks).surfaceType).toBe("card");
+    expect(surfaceOf(blocks).surfaceId).toBe("tool-approval-req-grant-1");
+    expect(textOf(blocks).type).toBe("text");
+    expect(textOf(blocks)._surfaceFallback).toBe(true);
+  });
+
+  test("primary line is the assistant-as-actor title, not the contact", () => {
+    const data = dataOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!);
+    expect(data.title).toBe('Assistant wants to use "web_fetch"');
+    expect(data.title).not.toContain("Noa");
+    // Generic category header lives in surface.title, not the contact's name.
+    expect(
+      surfaceOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!).title,
+    ).toBe("Tool approval");
+  });
+
+  test("channel message: subtitle attributes the sender + channel", () => {
+    const data = dataOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!);
+    expect(data.subtitle).toBe(
+      "in response to Noa Flaherty's message in #general",
+    );
+  });
+
+  test("body shows the requester's words, the command, and a Slack link", () => {
+    const data = dataOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!);
+    const body = data.body as string;
+    expect(body).toContain(
+      '> "can you pull this? https://example.com/article"',
+    );
+    expect(body).toContain("Will run: `GET https://example.com/article`");
+    expect(body).toContain(
+      "[View in Slack →](https://slack.com/archives/C01ABC/p1700000000000100)",
+    );
+  });
+
+  test("metadata carries the tool and a resolved Slack source", () => {
+    const metadata = dataOf(
+      buildToolApprovalSeedContentBlocks(slackChannelGrant)!,
+    ).metadata as Array<{ label: string; value: string }>;
+    expect(metadata).toContainEqual({ label: "Tool", value: "web_fetch" });
+    expect(metadata).toContainEqual({
+      label: "Source",
+      value: "Slack — #general",
+    });
+  });
+
+  test("approve/reject actions are wired to the request id", () => {
+    const surface = surfaceOf(
+      buildToolApprovalSeedContentBlocks(slackChannelGrant)!,
+    );
+    expect(surface.actions).toEqual([
+      {
+        id: "apr:req-grant-1:approve_once",
+        label: "Approve",
+        style: "primary",
+      },
+      { id: "apr:req-grant-1:reject", label: "Reject", style: "destructive" },
+    ]);
+  });
+
+  test("text fallback reuses the one-line phrasing + request-code instruction", () => {
+    const text = textOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!)
+      .text as string;
+    expect(text).toContain('Assistant wants to use "web_fetch"');
+    expect(text).toContain("in response to Noa Flaherty's message in #general");
+    expect(text).toContain("XYZ789");
+    expect(text).toContain("approve");
+  });
+
+  // ── Connective branch: DM (drop the channel) ───────────────────────────────
+  test("DM source: subtitle drops the channel; source reads Direct message", () => {
+    const blocks = buildToolApprovalSeedContentBlocks({
+      ...slackChannelGrant,
+      conversationExternalId: "D01XYZ",
+      channelName: undefined,
+    })!;
+    expect(dataOf(blocks).subtitle).toBe(
+      "in response to Noa Flaherty's message",
+    );
+    const metadata = dataOf(blocks).metadata as Array<{
+      label: string;
+      value: string;
+    }>;
+    expect(metadata).toContainEqual({
+      label: "Source",
+      value: "Slack — Direct message",
+    });
+  });
+
+  // ── Connective branch: no inbound trigger (self / scheduled) ────────────────
+  test("no requester: falls back to a generic subtitle, no connective", () => {
+    const blocks = buildToolApprovalSeedContentBlocks({
+      requestId: "req-self-1",
+      requestCode: "AAA111",
+      requestKind: "tool_approval",
+      toolName: "bash",
+      questionText: 'Assistant wants to use "bash".',
+      sourceChannel: "slack",
+    })!;
+    expect(dataOf(blocks).title).toBe('Assistant wants to use "bash"');
+    expect(dataOf(blocks).subtitle).toBe(
+      "Requesting approval to run this tool",
+    );
+  });
+
+  // ── Connective branch: voice (caller, but no "message") ─────────────────────
+  test("voice (pending_question, phone): generic subtitle, no permalink", () => {
+    const blocks = buildToolApprovalSeedContentBlocks({
+      requestId: "req-voice-1",
+      requestCode: "VOICE1",
+      requestKind: "pending_question",
+      toolName: "bash",
+      questionText: 'Assistant wants to use "bash".',
+      sourceChannel: "phone",
+      requesterIdentifier: "Bob",
+    })!;
+    expect(dataOf(blocks).subtitle).toBe(
+      "Requesting approval to run this tool",
+    );
+    const metadata = dataOf(blocks).metadata as Array<{
+      label: string;
+      value: string;
+    }>;
     expect(metadata).toContainEqual({ label: "Tool", value: "bash" });
     expect(metadata).toContainEqual({ label: "Source", value: "phone" });
   });
 
-  test("returns null for pending_question without toolName", () => {
-    const payload = { ...voiceToolApprovalPayload, toolName: undefined };
-    expect(buildToolApprovalSeedContentBlocks(payload)).toBeNull();
-  });
-
-  test("produces a ui_surface block and a text fallback block for tool_approval", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    expect(blocks).toHaveLength(2);
-    expect((blocks[0] as Record<string, unknown>).type).toBe("ui_surface");
-    expect((blocks[1] as Record<string, unknown>).type).toBe("text");
-    // The fallback block is flagged so surface-capable clients skip it.
-    expect((blocks[1] as Record<string, unknown>)._surfaceFallback).toBe(true);
-  });
-
-  test("produces a ui_surface block and a text fallback block for tool_grant_request", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolGrantPayload)!;
-    expect(blocks).toHaveLength(2);
-    expect((blocks[0] as Record<string, unknown>).type).toBe("ui_surface");
-    expect((blocks[1] as Record<string, unknown>).type).toBe("text");
-  });
-
-  test("card surface has correct surfaceType and surfaceId for tool_approval", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    const surface = blocks[0] as Record<string, unknown>;
-    expect(surface.surfaceType).toBe("card");
-    expect(surface.surfaceId).toBe("tool-approval-req-tool-456");
-    expect(surface.title).toBe("Tool Approval");
-  });
-
-  test("card surface has correct title for tool_grant_request", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolGrantPayload)!;
-    const surface = blocks[0] as Record<string, unknown>;
-    expect(surface.title).toBe("Tool Grant Request");
-  });
-
-  test("card data uses requesterIdentifier as title", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    expect(data.title).toBe("Bob");
-  });
-
-  test("card data falls back to 'Someone' when no requesterIdentifier", () => {
-    const payload = { ...toolApprovalPayload, requesterIdentifier: undefined };
-    const blocks = buildToolApprovalSeedContentBlocks(payload)!;
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    expect(data.title).toBe("Someone");
-  });
-
-  test("card subtitle differs for tool_approval vs tool_grant_request", () => {
-    const approvalBlocks =
-      buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    const grantBlocks = buildToolApprovalSeedContentBlocks(toolGrantPayload)!;
-    const approvalData = (approvalBlocks[0] as Record<string, unknown>)
-      .data as Record<string, unknown>;
-    const grantData = (grantBlocks[0] as Record<string, unknown>)
-      .data as Record<string, unknown>;
-    expect(approvalData.subtitle).toBe("Requesting approval to run this tool");
-    expect(grantData.subtitle).toBe("Requesting permission to use this tool");
-  });
-
-  test("includes tool name and source channel in metadata", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    const metadata = data.metadata as Array<{ label: string; value: string }>;
-    expect(metadata).toContainEqual({ label: "Tool", value: "bash" });
-    expect(metadata).toContainEqual({ label: "Source", value: "slack" });
-  });
-
-  test("body includes questionText as blockquote", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    expect(data.body).toContain("Bob wants to use");
-    expect(data.body).toContain("bash");
-  });
-
-  test("body shows fallback when no questionText", () => {
-    const payload = { ...toolApprovalPayload, questionText: undefined };
-    const blocks = buildToolApprovalSeedContentBlocks(payload)!;
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    expect(data.body).toBe("No additional context available.");
-  });
-
-  test("surface block includes approve/reject actions when requestId present", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    const surface = blocks[0] as Record<string, unknown>;
-    const actions = surface.actions as Array<{
-      id: string;
-      label: string;
-      style: string;
-    }>;
-    expect(actions).toHaveLength(2);
-    expect(actions[0]).toEqual({
-      id: "apr:req-tool-456:approve_once",
-      label: "Approve",
-      style: "primary",
-    });
-    expect(actions[1]).toEqual({
-      id: "apr:req-tool-456:reject",
-      label: "Reject",
-      style: "destructive",
-    });
-  });
-
-  test("surface block omits actions when requestId is missing", () => {
-    const payload = { ...toolApprovalPayload, requestId: undefined };
-    const blocks = buildToolApprovalSeedContentBlocks(payload)!;
-    const surface = blocks[0] as Record<string, unknown>;
-    expect(surface.actions).toBeUndefined();
-  });
-
-  test("text fallback block contains questionText and request-code instruction", () => {
-    const blocks = buildToolApprovalSeedContentBlocks(toolApprovalPayload)!;
-    const textBlock = blocks[1] as Record<string, unknown>;
-    expect(textBlock.type).toBe("text");
-    expect(textBlock.text).toContain("Bob wants to use");
-    expect(textBlock.text).toContain("XYZ789");
-    expect(textBlock.text).toContain("approve");
-  });
-
-  test("text fallback block omits request-code instruction when no requestCode", () => {
-    const payload = { ...toolApprovalPayload, requestCode: undefined };
-    const blocks = buildToolApprovalSeedContentBlocks(payload)!;
-    const textBlock = blocks[1] as Record<string, unknown>;
-    expect(textBlock.text).toContain("Bob wants to use");
-    expect(textBlock.text).not.toContain("XYZ789");
-  });
-
-  test("text fallback block uses generic text when no questionText", () => {
-    const payload = { ...toolApprovalPayload, questionText: undefined };
-    const blocks = buildToolApprovalSeedContentBlocks(payload)!;
-    const textBlock = blocks[1] as Record<string, unknown>;
-    expect(textBlock.text).toContain("requesting approval to use bash");
+  test("returns null for pending_question without a tool", () => {
+    expect(
+      buildToolApprovalSeedContentBlocks({
+        requestId: "x",
+        requestCode: "y",
+        requestKind: "pending_question",
+        questionText: "q",
+      }),
+    ).toBeNull();
   });
 });

--- a/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
@@ -1,17 +1,27 @@
 import { describe, expect, test } from "bun:test";
 
+import type {
+  ApprovalCardBlock,
+  ApprovalCardFallbackBlock,
+  ApprovalCardSurfaceBlock,
+} from "../notifications/approval-card-builder.js";
 import { buildToolApprovalSeedContentBlocks } from "../notifications/approval-card-data.js";
 
-type Block = Record<string, unknown>;
-
-function surfaceOf(blocks: unknown[]): Block {
-  return blocks[0] as Block;
+// The builder returns a schema-derived `ApprovalCardBlock[]`, so tests narrow by
+// the block's discriminant instead of casting to `Record<string, unknown>`.
+function surfaceOf(blocks: ApprovalCardBlock[]): ApprovalCardSurfaceBlock {
+  const block = blocks[0];
+  if (block?.type !== "ui_surface") {
+    throw new Error("expected a ui_surface block at index 0");
+  }
+  return block;
 }
-function dataOf(blocks: unknown[]): Block {
-  return (blocks[0] as Block).data as Block;
-}
-function textOf(blocks: unknown[]): Block {
-  return blocks[1] as Block;
+function textOf(blocks: ApprovalCardBlock[]): ApprovalCardFallbackBlock {
+  const block = blocks[1];
+  if (block?.type !== "text") {
+    throw new Error("expected a text fallback block at index 1");
+  }
+  return block;
 }
 
 /**
@@ -51,33 +61,34 @@ describe("buildToolApprovalSeedContentBlocks", () => {
   test("emits a ui_surface card + flagged text fallback", () => {
     const blocks = buildToolApprovalSeedContentBlocks(slackChannelGrant)!;
     expect(blocks).toHaveLength(2);
-    expect(surfaceOf(blocks).type).toBe("ui_surface");
     expect(surfaceOf(blocks).surfaceType).toBe("card");
     expect(surfaceOf(blocks).surfaceId).toBe("tool-approval-req-grant-1");
-    expect(textOf(blocks).type).toBe("text");
     expect(textOf(blocks)._surfaceFallback).toBe(true);
   });
 
   test("primary line is the assistant-as-actor title, not the contact", () => {
-    const data = dataOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!);
-    expect(data.title).toBe('Assistant wants to use "web_fetch"');
-    expect(data.title).not.toContain("Noa");
+    const surface = surfaceOf(
+      buildToolApprovalSeedContentBlocks(slackChannelGrant)!,
+    );
+    expect(surface.data.title).toBe('Assistant wants to use "web_fetch"');
+    expect(surface.data.title).not.toContain("Noa");
     // Generic category header lives in surface.title, not the contact's name.
-    expect(
-      surfaceOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!).title,
-    ).toBe("Tool approval");
+    expect(surface.title).toBe("Tool approval");
   });
 
   test("channel message: subtitle attributes the sender + channel", () => {
-    const data = dataOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!);
-    expect(data.subtitle).toBe(
+    const surface = surfaceOf(
+      buildToolApprovalSeedContentBlocks(slackChannelGrant)!,
+    );
+    expect(surface.data.subtitle).toBe(
       "in response to Noa Flaherty's message in #general",
     );
   });
 
   test("body shows the requester's words, the command, and a Slack link", () => {
-    const data = dataOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!);
-    const body = data.body as string;
+    const { body } = surfaceOf(
+      buildToolApprovalSeedContentBlocks(slackChannelGrant)!,
+    ).data;
     expect(body).toContain(
       '> "can you pull this? https://example.com/article"',
     );
@@ -88,9 +99,9 @@ describe("buildToolApprovalSeedContentBlocks", () => {
   });
 
   test("metadata carries the tool and a resolved Slack source", () => {
-    const metadata = dataOf(
+    const { metadata } = surfaceOf(
       buildToolApprovalSeedContentBlocks(slackChannelGrant)!,
-    ).metadata as Array<{ label: string; value: string }>;
+    ).data;
     expect(metadata).toContainEqual({ label: "Tool", value: "web_fetch" });
     expect(metadata).toContainEqual({
       label: "Source",
@@ -113,8 +124,9 @@ describe("buildToolApprovalSeedContentBlocks", () => {
   });
 
   test("text fallback reuses the one-line phrasing + request-code instruction", () => {
-    const text = textOf(buildToolApprovalSeedContentBlocks(slackChannelGrant)!)
-      .text as string;
+    const { text } = textOf(
+      buildToolApprovalSeedContentBlocks(slackChannelGrant)!,
+    );
     expect(text).toContain('Assistant wants to use "web_fetch"');
     expect(text).toContain("in response to Noa Flaherty's message in #general");
     expect(text).toContain("XYZ789");
@@ -123,19 +135,15 @@ describe("buildToolApprovalSeedContentBlocks", () => {
 
   // ── Connective branch: DM (drop the channel) ───────────────────────────────
   test("DM source: subtitle drops the channel; source reads Direct message", () => {
-    const blocks = buildToolApprovalSeedContentBlocks({
-      ...slackChannelGrant,
-      conversationExternalId: "D01XYZ",
-      channelName: undefined,
-    })!;
-    expect(dataOf(blocks).subtitle).toBe(
-      "in response to Noa Flaherty's message",
+    const surface = surfaceOf(
+      buildToolApprovalSeedContentBlocks({
+        ...slackChannelGrant,
+        conversationExternalId: "D01XYZ",
+        channelName: undefined,
+      })!,
     );
-    const metadata = dataOf(blocks).metadata as Array<{
-      label: string;
-      value: string;
-    }>;
-    expect(metadata).toContainEqual({
+    expect(surface.data.subtitle).toBe("in response to Noa Flaherty's message");
+    expect(surface.data.metadata).toContainEqual({
       label: "Source",
       value: "Slack — Direct message",
     });
@@ -143,40 +151,36 @@ describe("buildToolApprovalSeedContentBlocks", () => {
 
   // ── Connective branch: no inbound trigger (self / scheduled) ────────────────
   test("no requester: falls back to a generic subtitle, no connective", () => {
-    const blocks = buildToolApprovalSeedContentBlocks({
-      requestId: "req-self-1",
-      requestCode: "AAA111",
-      requestKind: "tool_approval",
-      toolName: "bash",
-      questionText: 'Assistant wants to use "bash".',
-      sourceChannel: "slack",
-    })!;
-    expect(dataOf(blocks).title).toBe('Assistant wants to use "bash"');
-    expect(dataOf(blocks).subtitle).toBe(
-      "Requesting approval to run this tool",
+    const surface = surfaceOf(
+      buildToolApprovalSeedContentBlocks({
+        requestId: "req-self-1",
+        requestCode: "AAA111",
+        requestKind: "tool_approval",
+        toolName: "bash",
+        questionText: 'Assistant wants to use "bash".',
+        sourceChannel: "slack",
+      })!,
     );
+    expect(surface.data.title).toBe('Assistant wants to use "bash"');
+    expect(surface.data.subtitle).toBe("Requesting approval to run this tool");
   });
 
   // ── Connective branch: voice (caller, but no "message") ─────────────────────
   test("voice (pending_question, phone): generic subtitle, no permalink", () => {
-    const blocks = buildToolApprovalSeedContentBlocks({
-      requestId: "req-voice-1",
-      requestCode: "VOICE1",
-      requestKind: "pending_question",
-      toolName: "bash",
-      questionText: 'Assistant wants to use "bash".',
-      sourceChannel: "phone",
-      requesterIdentifier: "Bob",
-    })!;
-    expect(dataOf(blocks).subtitle).toBe(
-      "Requesting approval to run this tool",
+    const { data } = surfaceOf(
+      buildToolApprovalSeedContentBlocks({
+        requestId: "req-voice-1",
+        requestCode: "VOICE1",
+        requestKind: "pending_question",
+        toolName: "bash",
+        questionText: 'Assistant wants to use "bash".',
+        sourceChannel: "phone",
+        requesterIdentifier: "Bob",
+      })!,
     );
-    const metadata = dataOf(blocks).metadata as Array<{
-      label: string;
-      value: string;
-    }>;
-    expect(metadata).toContainEqual({ label: "Tool", value: "bash" });
-    expect(metadata).toContainEqual({ label: "Source", value: "phone" });
+    expect(data.subtitle).toBe("Requesting approval to run this tool");
+    expect(data.metadata).toContainEqual({ label: "Tool", value: "bash" });
+    expect(data.metadata).toContainEqual({ label: "Source", value: "phone" });
   });
 
   test("returns null for pending_question without a tool", () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1709,33 +1709,6 @@ export function getMessages(conversationId: string): MessageRow[] {
 }
 
 /**
- * Return up to `limit` of a conversation's most recent `user`-role messages,
- * newest first. A bounded, indexed seek (the `(role, created_at)` index backs
- * the ordering) so callers that only need the latest inbound message — e.g.
- * resolving a guardian card's triggering message — don't materialize the whole
- * history.
- */
-export function getRecentUserMessages(
-  conversationId: string,
-  limit: number,
-): MessageRow[] {
-  const db = getDb();
-  return db
-    .select()
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.role, "user"),
-      ),
-    )
-    .orderBy(desc(messages.createdAt))
-    .limit(limit)
-    .all()
-    .map(parseMessage);
-}
-
-/**
  * Return raw `metadata` strings for messages whose metadata looks like it may
  * contain Slack metadata, capped at `limit` and skipping the first `offset`
  * matches. Pushes `LIKE` + `LIMIT`/`OFFSET` into SQL so warm Slack DM

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1709,6 +1709,33 @@ export function getMessages(conversationId: string): MessageRow[] {
 }
 
 /**
+ * Return up to `limit` of a conversation's most recent `user`-role messages,
+ * newest first. A bounded, indexed seek (the `(role, created_at)` index backs
+ * the ordering) so callers that only need the latest inbound message — e.g.
+ * resolving a guardian card's triggering message — don't materialize the whole
+ * history.
+ */
+export function getRecentUserMessages(
+  conversationId: string,
+  limit: number,
+): MessageRow[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "user"),
+      ),
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(limit)
+    .all()
+    .map(parseMessage);
+}
+
+/**
  * Return raw `metadata` strings for messages whose metadata looks like it may
  * contain Slack metadata, capped at `limit` and skipping the first `offset`
  * matches. Pushes `LIKE` + `LIMIT`/`OFFSET` into SQL so warm Slack DM

--- a/assistant/src/memory/recent-user-messages.ts
+++ b/assistant/src/memory/recent-user-messages.ts
@@ -1,0 +1,54 @@
+/**
+ * Bounded "recent user messages" query, deliberately kept out of the
+ * `conversation-crud` god-module.
+ *
+ * `conversation-crud` sits in a large import cycle (see `bun run lint:circular`),
+ * and the guardian tool-approval source resolver
+ * (`notifications/tool-approval-source.ts`) is reached *during* that module's own
+ * evaluation via the tool-handler import graph. A runtime import of a
+ * `conversation-crud` export from that path resolves against a half-initialized
+ * module ("Export named … not found"). This leaf module imports only the DB
+ * connection + schema (both outside the cycle), so the resolver can read recent
+ * messages without joining it. `MessageRow` is imported type-only (erased), so it
+ * adds no runtime edge.
+ */
+
+import { and, desc, eq } from "drizzle-orm";
+
+import type { MessageRow } from "./conversation-crud.js";
+import { getDb } from "./db-connection.js";
+import { messages } from "./schema.js";
+
+/**
+ * Return up to `limit` of a conversation's most recent `user`-role messages,
+ * newest first. A bounded, indexed seek (the `(role, created_at)` index backs the
+ * ordering) so callers that only need the latest inbound message — e.g. resolving
+ * a guardian card's triggering message — don't materialize the whole history.
+ */
+export function getRecentUserMessages(
+  conversationId: string,
+  limit: number,
+): MessageRow[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "user"),
+      ),
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(limit)
+    .all()
+    .map((row) => ({
+      id: row.id,
+      conversationId: row.conversationId,
+      role: row.role,
+      content: row.content,
+      createdAt: row.createdAt,
+      metadata: row.metadata,
+      clientMessageId: row.clientMessageId,
+    }));
+}

--- a/assistant/src/notifications/__tests__/tool-approval-copy.test.ts
+++ b/assistant/src/notifications/__tests__/tool-approval-copy.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildToolApprovalCardView } from "../tool-approval-copy.js";
+
+/**
+ * Pins the shared tool-approval view model: the assistant-as-actor copy, the
+ * three connective branches (channel message / DM / no inbound), the
+ * exact-message permalink, and the one-line sentence reused by Telegram / CLI.
+ */
+describe("buildToolApprovalCardView", () => {
+  const channelMessage = {
+    toolName: "web_fetch",
+    requesterIdentifier: "Noa Flaherty",
+    sourceChannel: "slack",
+    conversationExternalId: "C01ABC",
+    channelName: "general",
+    messageTs: "1700000000.000100",
+    messagePreview: "can you pull this? https://example.com/article",
+    commandPreview: "GET https://example.com/article",
+    requestId: "req-1",
+  };
+
+  test("titleLine names the tool, not the contact (assistant-as-actor)", () => {
+    const view = buildToolApprovalCardView(channelMessage);
+    expect(view.titleLine).toBe('Assistant wants to use "web_fetch"');
+    expect(view.titleLine).not.toContain("Noa");
+  });
+
+  test("channel message: connective names the sender + channel", () => {
+    const view = buildToolApprovalCardView(channelMessage);
+    expect(view.connectiveLine).toBe(
+      "in response to Noa Flaherty's message in #general",
+    );
+    expect(view.sentence).toBe(
+      'Assistant wants to use "web_fetch" in response to Noa Flaherty\'s message in #general.',
+    );
+  });
+
+  test("channel message: exact-message permalink from channel id + ts", () => {
+    const view = buildToolApprovalCardView(channelMessage);
+    expect(view.messagePermalink).toBe(
+      "https://slack.com/archives/C01ABC/p1700000000000100",
+    );
+  });
+
+  test("channel name falls back to the channel id when absent", () => {
+    const view = buildToolApprovalCardView({
+      ...channelMessage,
+      channelName: undefined,
+    });
+    expect(view.connectiveLine).toBe(
+      "in response to Noa Flaherty's message in #C01ABC",
+    );
+  });
+
+  test("DM: connective drops the channel and no permalink without ts", () => {
+    const view = buildToolApprovalCardView({
+      ...channelMessage,
+      conversationExternalId: "D01XYZ",
+      channelName: undefined,
+      messageTs: undefined,
+    });
+    expect(view.isSlackDm).toBe(true);
+    expect(view.connectiveLine).toBe("in response to Noa Flaherty's message");
+    expect(view.messagePermalink).toBeUndefined();
+  });
+
+  test("non-slack channel: connective without '#channel', no permalink", () => {
+    const view = buildToolApprovalCardView({
+      toolName: "web_search",
+      requesterIdentifier: "Alice",
+      sourceChannel: "telegram",
+      messagePreview: "search the news",
+      requestId: "req-2",
+    });
+    expect(view.connectiveLine).toBe("in response to Alice's message");
+    expect(view.messagePermalink).toBeUndefined();
+  });
+
+  test("no inbound trigger (no requester): connective omitted", () => {
+    const view = buildToolApprovalCardView({
+      toolName: "bash",
+      sourceChannel: "slack",
+      requestId: "req-3",
+    });
+    expect(view.connectiveLine).toBeUndefined();
+    expect(view.sentence).toBe('Assistant wants to use "bash".');
+  });
+
+  test("voice (phone) has a caller but no 'message' connective", () => {
+    const view = buildToolApprovalCardView({
+      toolName: "bash",
+      requesterIdentifier: "Bob",
+      sourceChannel: "phone",
+      requestId: "req-4",
+    });
+    expect(view.connectiveLine).toBeUndefined();
+  });
+
+  test("preview and command are sanitized / passed through", () => {
+    const view = buildToolApprovalCardView(channelMessage);
+    expect(view.messagePreview).toBe(
+      "can you pull this? https://example.com/article",
+    );
+    expect(view.commandPreview).toBe("GET https://example.com/article");
+  });
+
+  test("falls back to a placeholder tool name when missing", () => {
+    const view = buildToolApprovalCardView({ requestId: "req-5" });
+    expect(view.titleLine).toBe('Assistant wants to use "unknown tool"');
+  });
+});

--- a/assistant/src/notifications/__tests__/tool-approval-source.test.ts
+++ b/assistant/src/notifications/__tests__/tool-approval-source.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MessageRow } from "../../memory/conversation-crud.js";
+import { selectTriggeringMessageFacts } from "../tool-approval-source.js";
+
+/**
+ * Pins the pure triggering-message selection: actor-matched attribution, the
+ * fallback to the most recent message, Slack-metadata projection, and graceful
+ * emptiness. The store read is a thin wrapper exercised by integration paths.
+ */
+function userMessage(opts: {
+  content: string;
+  createdAt: number;
+  slack?: {
+    channelId: string;
+    channelTs: string;
+    channelName?: string;
+    displayName?: string;
+    actorExternalUserId?: string;
+  };
+}): MessageRow {
+  const metadata = opts.slack
+    ? JSON.stringify({
+        slackMeta: JSON.stringify({
+          source: "slack",
+          eventKind: "message",
+          ...opts.slack,
+        }),
+      })
+    : null;
+  return {
+    id: `m-${opts.createdAt}`,
+    conversationId: "c1",
+    role: "user",
+    content: opts.content,
+    createdAt: opts.createdAt,
+    metadata,
+    clientMessageId: null,
+  };
+}
+
+describe("selectTriggeringMessageFacts", () => {
+  test("returns empty facts when there are no messages", () => {
+    expect(selectTriggeringMessageFacts([])).toEqual({});
+  });
+
+  test("prefers the escalating actor's own message over a newer one", () => {
+    // newest first
+    const messages = [
+      userMessage({
+        content: "later message from someone else",
+        createdAt: 200,
+        slack: {
+          channelId: "C01",
+          channelTs: "200.0001",
+          actorExternalUserId: "UOTHER",
+        },
+      }),
+      userMessage({
+        content: "the contact's request",
+        createdAt: 100,
+        slack: {
+          channelId: "C01",
+          channelTs: "100.0002",
+          channelName: "general",
+          displayName: "Noa",
+          actorExternalUserId: "UNOA",
+        },
+      }),
+    ];
+    expect(selectTriggeringMessageFacts(messages, "UNOA")).toEqual({
+      messagePreview: "the contact's request",
+      conversationExternalId: "C01",
+      messageTs: "100.0002",
+      channelName: "general",
+      actorDisplayName: "Noa",
+    });
+  });
+
+  test("falls back to the most recent message when no actor match", () => {
+    const messages = [
+      userMessage({
+        content: "newest",
+        createdAt: 200,
+        slack: {
+          channelId: "C01",
+          channelTs: "200.0001",
+          displayName: "Sam",
+          actorExternalUserId: "USAM",
+        },
+      }),
+    ];
+    expect(selectTriggeringMessageFacts(messages, "UNOMATCH")).toMatchObject({
+      messagePreview: "newest",
+      messageTs: "200.0001",
+      actorDisplayName: "Sam",
+    });
+  });
+
+  test("non-slack message yields preview text only (no channel/ts)", () => {
+    const messages = [
+      userMessage({ content: "search the news", createdAt: 5 }),
+    ];
+    const facts = selectTriggeringMessageFacts(messages, "U1");
+    expect(facts.messagePreview).toBe("search the news");
+    expect(facts.conversationExternalId).toBeUndefined();
+    expect(facts.messageTs).toBeUndefined();
+  });
+});

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -22,7 +22,9 @@ import {
   buildAccessRequestCardView,
   buildAccessRequestInviteDirective,
 } from "../access-request-copy.js";
+import { LenientToolApprovalPayloadSchema } from "../guardian-question-mode.js";
 import { truncate } from "../notification-utils.js";
+import { buildToolApprovalCardView } from "../tool-approval-copy.js";
 import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
@@ -79,31 +81,45 @@ function buildAccessRequestBody(view: AccessRequestCardView): string {
   return "Requesting access to the assistant";
 }
 
-/** Source-channel context block with Slack permalink when available. */
-function buildSourceContextBlock(
-  view: AccessRequestCardView,
-): ContextBlock | undefined {
-  if (view.sourceChannel !== "slack" || !view.conversationExternalId) {
+/**
+ * Slack source-channel context block with an optional permalink, shared by the
+ * access-request and tool-approval cards so the `Source: Slack — <#channel> ·
+ * <link>` row is formatted in exactly one place. Only the link label differs
+ * between the two ("View message" vs "View in Slack →").
+ */
+function buildSlackSourceContextBlock(args: {
+  sourceChannel: string | undefined;
+  conversationExternalId: string | undefined;
+  isSlackDm: boolean;
+  permalink: string | undefined;
+  linkLabel: string;
+}): ContextBlock | undefined {
+  if (args.sourceChannel !== "slack" || !args.conversationExternalId) {
     return undefined;
   }
 
-  const permalink = view.messagePermalink;
-
-  let sourceText: string;
-  if (view.isSlackDm) {
-    sourceText = permalink
-      ? `Source: Slack — Direct message · <${permalink}|View message>`
-      : "Source: Slack — Direct message";
-  } else {
-    sourceText = permalink
-      ? `Source: Slack — <#${view.conversationExternalId}> · <${permalink}|View message>`
-      : `Source: Slack — <#${view.conversationExternalId}>`;
-  }
+  const channel = args.isSlackDm
+    ? "Direct message"
+    : `<#${args.conversationExternalId}>`;
+  const link = args.permalink ? ` · <${args.permalink}|${args.linkLabel}>` : "";
 
   return {
     type: "context",
-    elements: [{ type: "mrkdwn", text: sourceText }],
+    elements: [{ type: "mrkdwn", text: `Source: Slack — ${channel}${link}` }],
   };
+}
+
+/** Source-channel context block for an access request. */
+function buildSourceContextBlock(
+  view: AccessRequestCardView,
+): ContextBlock | undefined {
+  return buildSlackSourceContextBlock({
+    sourceChannel: view.sourceChannel,
+    conversationExternalId: view.conversationExternalId,
+    isSlackDm: view.isSlackDm,
+    permalink: view.messagePermalink,
+    linkLabel: "View message",
+  });
 }
 
 /** Stable requester identifier context block (external ID when it adds info). */
@@ -207,8 +223,14 @@ function buildAccessRequestCardBlocks(
 /**
  * Build Slack blocks for a tool approval notification using a native Card block.
  *
+ * Driven by the shared {@link buildToolApprovalCardView} (the same source the
+ * in-app card uses), so the assistant-as-actor copy, preview, and source link
+ * are authored once. Action buttons still come from `approvalContext`.
+ *
  * Layout:
- *   Card — title + subtitle (tool + requester) + body (notification text) + actions
+ *   Card    — title + subtitle (assistant-as-actor sentence) + body (preview +
+ *             command) + actions
+ *   Context — source channel + exact-message permalink (Slack sources)
  */
 function buildToolApprovalCardBlocks(
   payload: ChannelDeliveryPayload,
@@ -217,39 +239,45 @@ function buildToolApprovalCardBlocks(
   const approval = payload.approvalContext!;
   const blocks: KnownBlock[] = [];
 
-  const details = approval.permissionDetails;
-  const toolName = details?.toolName;
-  const requester = details?.requesterIdentifier;
-  let subtitle: string | undefined;
-  if (toolName && requester) {
-    subtitle = truncate(`${toolName} — requested by ${requester}`, 150);
-  } else if (toolName) {
-    subtitle = truncate(toolName, 150);
-  }
+  const parsed = LenientToolApprovalPayloadSchema.safeParse(
+    payload.contextPayload ?? {},
+  );
+  const view = parsed.success ? buildToolApprovalCardView(parsed.data) : null;
 
-  const needsOverflow = messageText.length > 200;
+  // Subtitle is the one-line assistant-as-actor sentence; fall back to the
+  // rendered notification text when the payload can't be parsed.
+  const subtitle = view ? truncate(view.sentence, 150) : undefined;
+
+  const bodyParts: string[] = [];
+  if (view?.messagePreview) {
+    bodyParts.push(`> _"${truncate(view.messagePreview, 180)}"_`);
+  }
+  if (view?.commandPreview) {
+    bodyParts.push(`Will run: \`${truncate(view.commandPreview, 180)}\``);
+  }
+  const body =
+    bodyParts.length > 0
+      ? bodyParts.join("\n")
+      : truncate(messageText, 200) || "Requesting approval to run this tool";
+
   const card: CardBlock = {
     type: "card",
-    title: {
-      type: "mrkdwn",
-      text: details ? "Tool Approval" : "Approval Request",
-    },
-    body: {
-      type: "mrkdwn",
-      text: needsOverflow ? truncate(messageText, 197) + " ↓" : messageText,
-    },
+    title: { type: "mrkdwn", text: "Tool approval" },
+    body: { type: "mrkdwn", text: body },
     actions: buildCardActions(approval),
   };
   if (subtitle) card.subtitle = { type: "mrkdwn", text: subtitle };
   blocks.push(card);
 
-  // When the message exceeds the card body limit, show the full text in a
-  // companion section so the approver can see the complete command/context.
-  if (needsOverflow) {
-    blocks.push({
-      type: "section",
-      text: { type: "mrkdwn", text: truncate(messageText, 3000) },
+  if (view) {
+    const sourceContext = buildSlackSourceContextBlock({
+      sourceChannel: view.sourceChannel,
+      conversationExternalId: view.conversationExternalId,
+      isSlackDm: view.isSlackDm,
+      permalink: view.messagePermalink,
+      linkLabel: "View in Slack →",
     });
+    if (sourceContext) blocks.push(sourceContext);
   }
 
   return blocks;

--- a/assistant/src/notifications/approval-card-data.ts
+++ b/assistant/src/notifications/approval-card-data.ts
@@ -32,7 +32,8 @@ import {
   resolveGuardianInstructionModeFromFields,
   resolveGuardianInstructionModeFromPayload,
 } from "./guardian-question-mode.js";
-import { nonEmpty, sanitizeIdentityField } from "./notification-utils.js";
+import { nonEmpty } from "./notification-utils.js";
+import { buildToolApprovalCardView } from "./tool-approval-copy.js";
 
 // ── Surface ids ──────────────────────────────────────────────────────────────
 
@@ -181,30 +182,49 @@ function isLenientToolApproval(payload: LenientToolApprovalPayload): boolean {
 function extractToolApprovalCard(
   p: GuardianQuestionPayload | LenientToolApprovalPayload,
 ): ApprovalCardParams {
-  const toolName =
-    ("toolName" in p ? nonEmpty(p.toolName) : undefined) ?? "unknown tool";
-  const rawRequester = nonEmpty(p.requesterIdentifier);
-  const requester = rawRequester
-    ? sanitizeIdentityField(rawRequester)
-    : "Someone";
+  const view = buildToolApprovalCardView({
+    toolName: "toolName" in p ? p.toolName : undefined,
+    requesterIdentifier: p.requesterIdentifier,
+    sourceChannel: p.sourceChannel,
+    conversationExternalId: p.conversationExternalId,
+    channelName: p.channelName,
+    messageTs: p.messageTs,
+    messagePreview: p.messagePreview,
+    commandPreview: "commandPreview" in p ? p.commandPreview : undefined,
+    requestId: p.requestId,
+  });
 
-  const isGrant = p.requestKind === "tool_grant_request";
-
-  const metadata: Array<{ label: string; value: string }> = [];
-  metadata.push({ label: "Tool", value: toolName });
-  const sourceChannel = nonEmpty(p.sourceChannel);
-  if (sourceChannel) {
-    metadata.push({ label: "Source", value: sourceChannel });
+  const metadata: Array<{ label: string; value: string }> = [
+    { label: "Tool", value: view.toolName },
+  ];
+  if (view.sourceChannel === "slack" && view.conversationExternalId) {
+    metadata.push({
+      label: "Source",
+      value: view.isSlackDm
+        ? "Slack — Direct message"
+        : `Slack — #${view.channelName ?? view.conversationExternalId}`,
+    });
+  } else if (view.sourceChannel) {
+    metadata.push({ label: "Source", value: view.sourceChannel });
   }
 
-  const body = p.questionText
-    ? `> ${p.questionText}`
-    : "No additional context available.";
+  // Body: the requester's triggering message (the trigger), the redacted
+  // command (the action), and an exact-message link to the source thread.
+  const bodyParts: string[] = [];
+  if (view.messagePreview) bodyParts.push(`> "${view.messagePreview}"`);
+  if (view.commandPreview)
+    bodyParts.push(`Will run: \`${view.commandPreview}\``);
+  if (view.messagePermalink) {
+    bodyParts.push(`[View in Slack →](${view.messagePermalink})`);
+  }
+  const body =
+    bodyParts.length > 0
+      ? bodyParts.join("\n\n")
+      : "No additional context available.";
 
-  // Fallback text with request-code instructions for older clients.
-  const baseFallback =
-    p.questionText ?? `${requester} is requesting approval to use ${toolName}`;
-  let fallbackText = baseFallback;
+  // Fallback text reuses the one-line phrasing, plus request-code instructions
+  // for older clients.
+  let fallbackText = view.sentence;
   const requestCode = nonEmpty(p.requestCode);
   if (requestCode) {
     const modeResolution = resolveGuardianInstructionModeFromFields(
@@ -216,19 +236,19 @@ function extractToolApprovalCard(
       requestCode.trim().toUpperCase(),
       mode,
     );
-    fallbackText = `${baseFallback}\n\n${instruction}`;
+    fallbackText = `${view.sentence}\n\n${instruction}`;
   }
 
   return {
     surfaceIdPrefix: TOOL_APPROVAL_SURFACE_PREFIX,
-    cardTitle: isGrant ? "Tool Grant Request" : "Tool Approval",
-    requesterName: requester,
-    subtitle: isGrant
-      ? "Requesting permission to use this tool"
-      : "Requesting approval to run this tool",
+    cardTitle: "Tool approval",
+    requesterName: view.titleLine,
+    // The connective attributes the action to the inbound message; when there
+    // is none (self / scheduled / voice) fall back to a generic line.
+    subtitle: view.connectiveLine ?? "Requesting approval to run this tool",
     body,
     metadata,
-    requestId: nonEmpty(p.requestId),
+    requestId: view.requestId,
     fallbackText,
   };
 }

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -68,6 +68,22 @@ const GuardianQuestionPayloadBaseSchema = z.object({
   requesterExternalUserId: z.string().optional(),
   /** External chat ID of the requester. */
   requesterChatId: z.string().nullable().optional(),
+  /**
+   * Source-message facts for guardian cards, captured from the triggering
+   * conversation message at request time (see `tool-approval-source.ts`).
+   * Optional because not every guardian request has an inbound message (voice,
+   * scheduled, self) or a Slack source. Carried in the payload so the pure card
+   * view model (`buildToolApprovalCardView`) projects them without re-reading
+   * the store — mirroring how `AccessRequestPayloadSchema` carries its own.
+   */
+  /** External conversation/channel id of the source (Slack channel id). */
+  conversationExternalId: z.string().optional(),
+  /** Native message timestamp of the triggering message (Slack `channelTs`). */
+  messageTs: z.string().optional(),
+  /** Human-readable channel name of the source (Slack `channelName`). */
+  channelName: z.string().optional(),
+  /** Preview text of the triggering message (the requester's own words). */
+  messagePreview: z.string().optional(),
 });
 
 export const PendingQuestionPayloadSchema =
@@ -134,6 +150,12 @@ export const LenientToolApprovalPayloadSchema = z.object({
   requesterChatId: z.string().nullable().optional(),
   riskLevel: z.string().nullable().optional(),
   commandPreview: z.string().nullable().optional(),
+  // Source-message facts (see base schema) — lenient so degraded payloads
+  // still render the assistant-as-actor card with whatever facts are present.
+  conversationExternalId: z.string().nullable().optional(),
+  messageTs: z.string().nullable().optional(),
+  channelName: z.string().nullable().optional(),
+  messagePreview: z.string().nullable().optional(),
 });
 
 export type LenientToolApprovalPayload = z.infer<

--- a/assistant/src/notifications/tool-approval-copy.ts
+++ b/assistant/src/notifications/tool-approval-copy.ts
@@ -1,0 +1,185 @@
+/**
+ * Deterministic, display-ready projection for guardian tool-approval cards.
+ *
+ * The companion to {@link AccessRequestCardView} in `access-request-copy.ts`:
+ * a single pure view model shared by every renderer (the Vellum Surface card,
+ * the Slack Card block) plus the flat one-line phrasing used for Telegram
+ * `deliveryText` / CLI fallback / clarification. Authoring the assistant-as-actor
+ * copy, the source link, and the preview in exactly one place is what keeps the
+ * three surfaces from drifting — the asymmetry this replaces had the copy spelled
+ * out in three independent builders.
+ *
+ * Pure: it reads only the facts the producer captured into the payload (see
+ * `tool-approval-source.ts`) and never touches the store, so it is exercised
+ * directly with `bun test`.
+ */
+
+import {
+  buildSlackMessagePermalink,
+  isSlackDmConversation,
+} from "./access-request-copy.js";
+import type { LenientToolApprovalPayload } from "./guardian-question-mode.js";
+import {
+  nonEmpty,
+  sanitizeIdentityField,
+  sanitizeMessagePreview,
+} from "./notification-utils.js";
+
+/**
+ * The facts a tool-approval card is projected from — the subset of the parsed
+ * guardian payload the view reads. Derived from the Zod-inferred payload type
+ * (not hand-declared) so it cannot drift from the schema the producers write
+ * and the renderers parse; callers pass the parsed payload directly.
+ */
+export type ToolApprovalCardInput = Pick<
+  LenientToolApprovalPayload,
+  | "toolName"
+  | "requesterIdentifier"
+  | "sourceChannel"
+  | "conversationExternalId"
+  | "channelName"
+  | "messageTs"
+  | "messagePreview"
+  | "commandPreview"
+  | "requestId"
+>;
+
+/**
+ * Display-ready projection of a tool-approval request, shared by every renderer.
+ * Carries the sanitized, pre-computed facts each surface needs plus the
+ * authored copy lines, so projection lives in exactly one place. Renderers lay
+ * these out in their channel-native shape without re-deriving them.
+ */
+export interface ToolApprovalCardView {
+  toolName: string;
+  /** Sanitized requester display name, or `undefined` (self / no inbound trigger). */
+  actorDisplayName: string | undefined;
+  sourceChannel: string | undefined;
+  conversationExternalId: string | undefined;
+  channelName: string | undefined;
+  /** Whether the source Slack conversation is a DM. */
+  isSlackDm: boolean;
+  /** Exact-message Slack permalink — present only for a slack source with channel + ts. */
+  messagePermalink: string | undefined;
+  /** Sanitized triggering-message preview (the requester's words). */
+  messagePreview: string | undefined;
+  /** Redacted tool-input summary (what the tool will do). */
+  commandPreview: string | undefined;
+  requestId: string | undefined;
+  /** Assistant-as-actor primary line, e.g. `Assistant wants to use "web_fetch"`. */
+  titleLine: string;
+  /**
+   * Connective line attributing the action to the inbound message, e.g.
+   * `in response to Noa Flaherty's message in #general`. `undefined` when there
+   * is no inbound trigger (self / scheduled / voice), in which case renderers
+   * fall back to a generic subtitle.
+   */
+  connectiveLine: string | undefined;
+  /**
+   * Flat one-line sentence (title + connective) for non-card surfaces —
+   * Telegram `deliveryText`, CLI fallback, clarification. The single phrasing
+   * source of truth, so every surface says the same thing.
+   */
+  sentence: string;
+}
+
+const FALLBACK_TOOL_NAME = "unknown tool";
+
+/** Channels that carry an inbound text message worth attributing in the connective. */
+function hasInboundTextMessage(sourceChannel: string | undefined): boolean {
+  // Voice has a caller but no "message"; scheduled/self/proactive have no
+  // requester at all (handled by the missing display name). Everything else
+  // that reaches a tool-grant escalation came from an inbound text message.
+  return sourceChannel != null && sourceChannel !== "phone";
+}
+
+/** The channel token shown inside the connective, or `undefined` to omit it. */
+function resolveConnectiveChannel(
+  view: Pick<
+    ToolApprovalCardView,
+    "sourceChannel" | "conversationExternalId" | "channelName" | "isSlackDm"
+  >,
+): string | undefined {
+  if (
+    view.sourceChannel !== "slack" ||
+    !view.conversationExternalId ||
+    view.isSlackDm
+  ) {
+    return undefined;
+  }
+  return `#${view.channelName ?? view.conversationExternalId}`;
+}
+
+/**
+ * Project a parsed tool-approval payload into display-ready card facts + the
+ * authored assistant-as-actor copy. Pure — every renderer calls this so the
+ * copy, source link, and preview are authored exactly once.
+ */
+export function buildToolApprovalCardView(
+  input: ToolApprovalCardInput,
+): ToolApprovalCardView {
+  const toolName = nonEmpty(input.toolName) ?? FALLBACK_TOOL_NAME;
+
+  const rawActor = nonEmpty(input.requesterIdentifier);
+  const actorDisplayName = rawActor
+    ? sanitizeIdentityField(rawActor)
+    : undefined;
+
+  const sourceChannel = nonEmpty(input.sourceChannel);
+  const conversationExternalId = nonEmpty(input.conversationExternalId);
+  const channelName = nonEmpty(input.channelName);
+  const messageTs = nonEmpty(input.messageTs);
+
+  const isSlackDm =
+    sourceChannel === "slack" && conversationExternalId != null
+      ? isSlackDmConversation(conversationExternalId)
+      : false;
+
+  const messagePermalink =
+    sourceChannel === "slack" && conversationExternalId && messageTs
+      ? buildSlackMessagePermalink(conversationExternalId, messageTs)
+      : undefined;
+
+  const rawPreview = nonEmpty(input.messagePreview);
+  const messagePreview = rawPreview
+    ? sanitizeMessagePreview(rawPreview) || undefined
+    : undefined;
+
+  const commandPreview = nonEmpty(input.commandPreview);
+
+  // ── Authored copy (the single phrasing source of truth) ──────────────────
+  const titleLine = `Assistant wants to use "${toolName}"`;
+
+  let connectiveLine: string | undefined;
+  if (actorDisplayName && hasInboundTextMessage(sourceChannel)) {
+    const channelToken = resolveConnectiveChannel({
+      sourceChannel,
+      conversationExternalId,
+      channelName,
+      isSlackDm,
+    });
+    connectiveLine = channelToken
+      ? `in response to ${actorDisplayName}'s message in ${channelToken}`
+      : `in response to ${actorDisplayName}'s message`;
+  }
+
+  const sentence = connectiveLine
+    ? `${titleLine} ${connectiveLine}.`
+    : `${titleLine}.`;
+
+  return {
+    toolName,
+    actorDisplayName,
+    sourceChannel,
+    conversationExternalId,
+    channelName,
+    isSlackDm,
+    messagePermalink,
+    messagePreview,
+    commandPreview,
+    requestId: nonEmpty(input.requestId),
+    titleLine,
+    connectiveLine,
+    sentence,
+  };
+}

--- a/assistant/src/notifications/tool-approval-source.ts
+++ b/assistant/src/notifications/tool-approval-source.ts
@@ -1,0 +1,93 @@
+/**
+ * Recover a tool-approval card's triggering-message facts from the source of
+ * truth — the persisted conversation message — at escalation time.
+ *
+ * A tool-grant escalation fires mid-turn, several steps removed from ingress,
+ * so (unlike an access request, which captures the live inbound at the ACL
+ * stage) the triggering message is not in hand. But it survives: every inbound
+ * Slack message is persisted as a conversation message carrying typed
+ * `SlackMessageMetadata` (`channelTs`, `channelId`, `channelName`, `displayName`,
+ * `actorExternalUserId`). This module reads it back by `conversationId` — the
+ * same conversation-keyed resolution pattern as `getBindingByConversation` —
+ * giving the guardian the requester's actual words and an exact-message
+ * permalink without threading message provenance through `ToolContext`.
+ *
+ * The selection is pure and unit-tested; the store read is a thin wrapper.
+ */
+
+import type { MessageRow } from "../memory/conversation-crud.js";
+import { getRecentUserMessages } from "../memory/conversation-crud.js";
+import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
+import type { ToolGrantGuardianPayload } from "./guardian-question-mode.js";
+import { nonEmpty } from "./notification-utils.js";
+
+/**
+ * Triggering-message facts for a guardian tool-approval card. The payload-shaped
+ * fields are derived from the Zod-inferred payload type (not hand-declared) so
+ * they can't drift from what the producer writes into the payload; the resolver
+ * spreads them straight in. `actorDisplayName` is the one extra — it feeds the
+ * payload's `requesterIdentifier` after the caller merges context fallbacks.
+ */
+export type ToolApprovalSourceFacts = Pick<
+  ToolGrantGuardianPayload,
+  "messagePreview" | "conversationExternalId" | "messageTs" | "channelName"
+> & {
+  /** Sender display name recorded on the source message (Slack `displayName`). */
+  actorDisplayName?: string;
+};
+
+/** How many recent user messages to scan when locating the triggering message. */
+const RECENT_USER_MESSAGE_SCAN_LIMIT = 10;
+
+/**
+ * Choose the message that triggered an escalation from a conversation's recent
+ * user messages (newest first) and project its facts.
+ *
+ * Prefer the escalating actor's own most-recent message (Slack metadata names
+ * them via `actorExternalUserId`) for exact attribution; otherwise fall back to
+ * the most recent user message, which is the trigger in the common single-turn
+ * case and supplies preview text even for non-Slack sources (no permalink).
+ */
+export function selectTriggeringMessageFacts(
+  recentUserMessages: MessageRow[],
+  requesterExternalUserId?: string,
+): ToolApprovalSourceFacts {
+  const withSlackMeta = recentUserMessages.map((row) => ({
+    row,
+    slackMeta: readSlackMetadataFromMessageMetadata(row.metadata),
+  }));
+
+  const chosen =
+    (requesterExternalUserId
+      ? withSlackMeta.find(
+          (m) => m.slackMeta?.actorExternalUserId === requesterExternalUserId,
+        )
+      : undefined) ?? withSlackMeta[0];
+
+  if (!chosen) return {};
+
+  const { row, slackMeta } = chosen;
+  return {
+    messagePreview: nonEmpty(row.content),
+    conversationExternalId: nonEmpty(slackMeta?.channelId),
+    messageTs: nonEmpty(slackMeta?.channelTs),
+    channelName: nonEmpty(slackMeta?.channelName),
+    actorDisplayName: nonEmpty(slackMeta?.displayName),
+  };
+}
+
+/**
+ * Resolve the triggering-message facts for a tool-approval escalation by
+ * reading the conversation's recent user messages. Returns empty facts when
+ * nothing is recoverable; callers degrade gracefully (no preview / no link).
+ */
+export function resolveToolApprovalSourceFacts(
+  conversationId: string,
+  requesterExternalUserId?: string,
+): ToolApprovalSourceFacts {
+  const recent = getRecentUserMessages(
+    conversationId,
+    RECENT_USER_MESSAGE_SCAN_LIMIT,
+  );
+  return selectTriggeringMessageFacts(recent, requesterExternalUserId);
+}

--- a/assistant/src/notifications/tool-approval-source.ts
+++ b/assistant/src/notifications/tool-approval-source.ts
@@ -16,7 +16,7 @@
  */
 
 import type { MessageRow } from "../memory/conversation-crud.js";
-import { getRecentUserMessages } from "../memory/conversation-crud.js";
+import { getRecentUserMessages } from "../memory/recent-user-messages.js";
 import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
 import type { ToolGrantGuardianPayload } from "./guardian-question-mode.js";
 import { nonEmpty } from "./notification-utils.js";

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -21,6 +21,8 @@ import {
   recordGuardianRequestDeliveries,
 } from "../notifications/canonical-delivery-recorder.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import type { ToolGrantGuardianPayload } from "../notifications/guardian-question-mode.js";
+import type { ToolApprovalSourceFacts } from "../notifications/tool-approval-source.js";
 import { getLogger } from "../util/logger.js";
 import { getGuardianBinding } from "./channel-verification-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "./routes/channel-route-shared.js";
@@ -41,6 +43,14 @@ export interface ToolGrantRequestParams {
   toolName: string;
   inputDigest: string;
   questionText: string;
+  /** Redacted summary of the tool invocation arguments (what the tool will do). */
+  commandPreview?: string;
+  /**
+   * Triggering-message facts (the requester's words + Slack source) resolved
+   * from the conversation by the caller, carried into the card payload so the
+   * guardian sees the source thread and an exact-message link.
+   */
+  source?: ToolApprovalSourceFacts;
 }
 
 export type ToolGrantRequestResult =
@@ -72,6 +82,8 @@ export function createOrReuseToolGrantRequest(
     toolName,
     inputDigest,
     questionText,
+    commandPreview,
+    source,
   } = params;
 
   if (!requesterExternalUserId) {
@@ -146,6 +158,29 @@ export function createOrReuseToolGrantRequest(
   // in-app client sees it immediately; the post-resolve recorder reuses it.
   let vellumDeliveryId: string | undefined;
 
+  // Typed to the inferred payload shape so the construction can't drift from
+  // the schema the renderers parse.
+  const contextPayload: ToolGrantGuardianPayload = {
+    requestId: canonicalRequest.id,
+    requestKind: "tool_grant_request",
+    requestCode,
+    sourceChannel,
+    requesterExternalUserId,
+    requesterChatId: requesterChatId ?? null,
+    requesterIdentifier: senderLabel,
+    toolName,
+    questionText,
+    ...(commandPreview ? { commandPreview } : {}),
+    ...(source?.conversationExternalId
+      ? { conversationExternalId: source.conversationExternalId }
+      : {}),
+    ...(source?.messageTs ? { messageTs: source.messageTs } : {}),
+    ...(source?.channelName ? { channelName: source.channelName } : {}),
+    ...(source?.messagePreview
+      ? { messagePreview: source.messagePreview }
+      : {}),
+  };
+
   // Emit notification so guardian is alerted. Uses 'guardian.question' as
   // sourceEventName so that existing request-code guidance in the notification
   // pipeline is preserved.
@@ -160,17 +195,7 @@ export function createOrReuseToolGrantRequest(
       isAsyncBackground: false,
       visibleInSourceNow: false,
     },
-    contextPayload: {
-      requestId: canonicalRequest.id,
-      requestKind: "tool_grant_request",
-      requestCode,
-      sourceChannel,
-      requesterExternalUserId,
-      requesterChatId: requesterChatId ?? null,
-      requesterIdentifier: senderLabel,
-      toolName,
-      questionText,
-    },
+    contextPayload,
     dedupeKey: `tool-grant-request:${canonicalRequest.id}`,
     onConversationCreated: (info) => {
       vellumDeliveryId = recordApprovalCardDelivery({

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -5,6 +5,8 @@ import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";
+import { buildToolApprovalCardView } from "../notifications/tool-approval-copy.js";
+import { resolveToolApprovalSourceFacts } from "../notifications/tool-approval-source.js";
 import {
   isUnparseableToolArgs,
   unparseableToolArgsMessage,
@@ -29,20 +31,41 @@ import { enforceVerificationControlPlanePolicy } from "./verification-control-pl
 
 const log = getLogger("tool-approval-handler");
 
-function buildToolGrantQuestionText(
+/**
+ * Build the guardian-facing content for a tool-grant escalation: the redacted
+ * command preview, the triggering-message facts recovered from the source of
+ * truth, and the assistant-as-actor `questionText` — all composed through the
+ * shared {@link buildToolApprovalCardView} so the one-line phrasing matches the
+ * card the guardian sees on every surface.
+ */
+function buildToolGrantEscalationContent(
   toolName: string,
   input: Record<string, unknown>,
   context: ToolContext,
-): string {
-  const senderLabel =
+) {
+  const commandPreview =
+    redactSecrets(summarizeToolInput(toolName, input)) || undefined;
+  const source = resolveToolApprovalSourceFacts(
+    context.conversationId,
+    context.requesterExternalUserId,
+  );
+  const requesterIdentifier =
+    source.actorDisplayName ||
     context.requesterDisplayName ||
     context.requesterIdentifier ||
     context.requesterExternalUserId ||
     "A trusted contact";
-  const inputSummary = redactSecrets(summarizeToolInput(toolName, input));
-  return inputSummary
-    ? `${senderLabel} wants to use "${toolName}": ${inputSummary}`
-    : `${senderLabel} is requesting permission to use "${toolName}"`;
+  const { sentence: questionText } = buildToolApprovalCardView({
+    toolName,
+    requesterIdentifier,
+    sourceChannel: context.executionChannel,
+    conversationExternalId: source.conversationExternalId,
+    channelName: source.channelName,
+    messageTs: source.messageTs,
+    messagePreview: source.messagePreview,
+    commandPreview,
+  });
+  return { questionText, commandPreview, source, requesterIdentifier };
 }
 
 /** Default polling interval for inline grant wait (ms). */
@@ -553,6 +576,11 @@ export class ToolApprovalHandler {
         const inputDigest =
           deferredConsumeParams?.inputDigest ??
           computeToolApprovalDigest(name, input);
+        const escalationContent = buildToolGrantEscalationContent(
+          name,
+          input,
+          context,
+        );
         const escalation = createOrReuseToolGrantRequest({
           assistantId: context.assistantId,
           sourceChannel: context.executionChannel as ChannelId,
@@ -561,9 +589,10 @@ export class ToolApprovalHandler {
           requesterChatId: context.requesterChatId,
           toolName: name,
           inputDigest,
-          questionText: buildToolGrantQuestionText(name, input, context),
-          requesterIdentifier:
-            context.requesterDisplayName || context.requesterIdentifier,
+          questionText: escalationContent.questionText,
+          requesterIdentifier: escalationContent.requesterIdentifier,
+          commandPreview: escalationContent.commandPreview,
+          source: escalationContent.source,
         });
 
         // Only wait inline if the escalation succeeded (created or deduped).

--- a/clients/web/src/domains/chat/components/surfaces/tool-approval-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/tool-approval-card.stories.tsx
@@ -21,6 +21,9 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
+// The card is reframed assistant-as-actor: `data.title` names the tool (the
+// action), `subtitle` attributes it to the triggering message, and `body`
+// carries the requester's words, the redacted command, and a Slack link.
 function toolApprovalSurface(
   requestId: string,
   data: {
@@ -33,10 +36,14 @@ function toolApprovalSurface(
   return {
     surfaceId: `tool-approval-${requestId}`,
     surfaceType: "card",
-    title: data.title,
+    title: "Tool approval",
     data,
     actions: [
-      { id: `apr:${requestId}:approve_once`, label: "Approve", style: "primary" },
+      {
+        id: `apr:${requestId}:approve_once`,
+        label: "Approve",
+        style: "primary",
+      },
       { id: `apr:${requestId}:reject`, label: "Reject", style: "destructive" },
     ],
   };
@@ -47,12 +54,12 @@ export const BasicToolApproval: Story = {
   render: () => (
     <SurfaceRouter
       surface={toolApprovalSurface("req-ta-001", {
-        title: "Tool Approval",
-        subtitle: "Requesting approval to run this tool",
-        body: "> Alex is requesting approval to use `bash` to run `npm install express`",
+        title: 'Assistant wants to use "bash"',
+        subtitle: "in response to Alex's message in #eng",
+        body: '> "can you set up the express server?"\n\nWill run: `npm install express`\n\n[View in Slack →](https://slack.com/archives/C01ABC/p1700000000000100)',
         metadata: [
           { label: "Tool", value: "bash" },
-          { label: "Source", value: "slack" },
+          { label: "Source", value: "Slack — #eng" },
         ],
       })}
       onAction={() => {}}
@@ -65,12 +72,12 @@ export const ToolGrantRequest: Story = {
   render: () => (
     <SurfaceRouter
       surface={toolApprovalSurface("req-tg-001", {
-        title: "Tool Grant Request",
-        subtitle: "Requesting permission to use this tool",
-        body: "> Jordan is requesting a grant to use `web_search` — this would allow the tool to be used without future approval prompts",
+        title: 'Assistant wants to use "web_search"',
+        subtitle: "in response to Jordan's message in #research",
+        body: '> "find the latest on the acquisition"\n\nWill run: `web_search("acme acquisition news")`\n\n[View in Slack →](https://slack.com/archives/C02DEF/p1700000000000200)',
         metadata: [
           { label: "Tool", value: "web_search" },
-          { label: "Source", value: "telegram" },
+          { label: "Source", value: "Slack — #research" },
         ],
       })}
       onAction={() => {}}
@@ -83,12 +90,10 @@ export const DangerousTool: Story = {
   render: () => (
     <SurfaceRouter
       surface={toolApprovalSurface("req-ta-002", {
-        title: "Tool Approval",
-        subtitle: "Requesting approval to run this tool",
-        body: "> Casey is requesting approval to use `file_write` to write to `/etc/hosts`",
-        metadata: [
-          { label: "Tool", value: "file_write" },
-        ],
+        title: 'Assistant wants to use "file_write"',
+        subtitle: "in response to Casey's message",
+        body: '> "update my hosts file"\n\nWill run: `file_write /etc/hosts`\n\n[View in Slack →](https://slack.com/archives/D03GHI/p1700000000000300)',
+        metadata: [{ label: "Tool", value: "file_write" }],
       })}
       onAction={() => {}}
     />
@@ -96,16 +101,16 @@ export const DangerousTool: Story = {
 };
 
 export const LongToolContext: Story = {
-  name: "Long command context (truncated)",
+  name: "Long command context",
   render: () => (
     <SurfaceRouter
       surface={toolApprovalSurface("req-ta-003", {
-        title: "Tool Approval",
-        subtitle: "Requesting approval to run this tool",
-        body: "> Sam is requesting approval to use `bash` to run `curl -X POST https://api.example.com/v1/deployments -H 'Authorization: Bearer ...' -d '{\"environment\": \"production\", \"version\": \"2.1.0\", \"rollback_on_failure\": true}'`",
+        title: 'Assistant wants to use "bash"',
+        subtitle: "in response to Sam's message in #deploys",
+        body: '> "ship 2.1.0 to prod"\n\nWill run: `curl -X POST https://api.example.com/v1/deployments -H \'Authorization: Bearer …\' -d \'{"environment":"production","version":"2.1.0"}\'`\n\n[View in Slack →](https://slack.com/archives/C04JKL/p1700000000000400)',
         metadata: [
           { label: "Tool", value: "bash" },
-          { label: "Source", value: "slack" },
+          { label: "Source", value: "Slack — #deploys" },
         ],
       })}
       onAction={() => {}}
@@ -113,35 +118,15 @@ export const LongToolContext: Story = {
   ),
 };
 
-export const MinimalToolApproval: Story = {
-  name: "Minimal info (no metadata, no source)",
+export const NoInboundTrigger: Story = {
+  name: "No inbound trigger (self / scheduled)",
   render: () => (
     <SurfaceRouter
       surface={toolApprovalSurface("req-ta-004", {
-        title: "Tool Approval",
+        title: 'Assistant wants to use "unknown tool"',
         subtitle: "Requesting approval to run this tool",
         body: "No additional context available.",
-        metadata: [
-          { label: "Tool", value: "unknown tool" },
-        ],
-      })}
-      onAction={() => {}}
-    />
-  ),
-};
-
-export const MultipleMetadataFields: Story = {
-  name: "Multiple metadata fields",
-  render: () => (
-    <SurfaceRouter
-      surface={toolApprovalSurface("req-ta-005", {
-        title: "Tool Approval",
-        subtitle: "Requesting approval to run this tool",
-        body: "> Alex is requesting approval to use `database_query` to run `SELECT * FROM users WHERE role = 'admin'`",
-        metadata: [
-          { label: "Tool", value: "database_query" },
-          { label: "Source", value: "slack" },
-        ],
+        metadata: [{ label: "Tool", value: "unknown tool" }],
       })}
       onAction={() => {}}
     />
@@ -157,12 +142,12 @@ export const ResolvedApproved: Story = {
     <SurfaceRouter
       surface={{
         ...toolApprovalSurface("req-ta-006", {
-          title: "Tool Approval",
-          subtitle: "Requesting approval to run this tool",
-          body: "> Alex is requesting approval to use `bash` to run `npm install express`",
+          title: 'Assistant wants to use "bash"',
+          subtitle: "in response to Alex's message in #eng",
+          body: '> "can you set up the express server?"\n\nWill run: `npm install express`',
           metadata: [
             { label: "Tool", value: "bash" },
-            { label: "Source", value: "slack" },
+            { label: "Source", value: "Slack — #eng" },
           ],
         }),
         completed: true,
@@ -179,12 +164,10 @@ export const ResolvedDenied: Story = {
     <SurfaceRouter
       surface={{
         ...toolApprovalSurface("req-ta-007", {
-          title: "Tool Approval",
-          subtitle: "Requesting approval to run this tool",
-          body: "> Casey is requesting approval to use `file_write` to write to `/etc/hosts`",
-          metadata: [
-            { label: "Tool", value: "file_write" },
-          ],
+          title: 'Assistant wants to use "file_write"',
+          subtitle: "in response to Casey's message",
+          body: '> "update my hosts file"\n\nWill run: `file_write /etc/hosts`',
+          metadata: [{ label: "Tool", value: "file_write" }],
         }),
         completed: true,
         completionSummary: "Denied",


### PR DESCRIPTION
## What & why

A `tool_grant_request` guardian card read **"Noa wants to use `web_fetch`"** with the contact as the card's primary name. This misattributes intent — the contact shared a link in Slack; the **assistant** chose the tool. The guardian also got no link to the source thread and no preview of what the contact actually said. (LUM-2529; aligns with the Slack Permissions PRD's "cards fire on the tool, not the actor".)

**Render-layer only.** This changes *what the card says*, not *when it fires* — the gate (`requiresGuardianApprovalForActor`) is untouched.

> **Built on #35706** (schema-derive seed blocks), which has since **merged**. This PR is rebased onto `main` and is standalone — the diff here is just the tool-approval card changes.

## Before → After (what the card renders)

*Scenario: Noa shares a link in Slack `#general` — "can you pull this? https://example.com/article" — and the assistant decides to call `web_fetch`, tripping the guardian gate.*

**Before (`main`)** — the card led with the **contact** as the actor, with no source context:

```
[ Tool Grant Request ]
Noa Flaherty
> Noa wants to use "web_fetch": GET https://example.com/article
[ Approve ]  [ Deny ]
```

- Primary name is **Noa** → misattributes intent (Noa shared a link; the *assistant* chose the tool).
- No link to the source thread; no preview of what Noa actually said.
- Telegram / CLI one-liner: `Noa wants to use "web_fetch": GET https://example.com/article`

**After (this PR)** — the card fires on the **tool**, attributes the trigger, and links the exact message:

```
[ Tool approval ]
Assistant wants to use "web_fetch"
in response to Noa Flaherty's message in #general

> "can you pull this? https://example.com/article"
Will run: `GET https://example.com/article`
[View in Slack →] → https://slack.com/archives/C01ABC/p1700000000000100

Tool: web_fetch   ·   Source: Slack — #general
[ Approve ]  [ Reject ]
```

- Primary line is the **tool**; the contact moves into the connective.
- Body carries Noa's **actual words** + the redacted command + an **exact-message** permalink.
- Telegram / CLI / text-fallback one-liner (single source of truth): `Assistant wants to use "web_fetch" in response to Noa Flaherty's message in #general.`

**Connective branches (after):**

| Source | Subtitle | Source meta / link |
|---|---|---|
| Slack channel | `in response to Noa Flaherty's message in #general` | `Slack — #general` + exact-message permalink |
| Slack DM | `in response to Noa Flaherty's message` (channel dropped) | `Slack — Direct message`, no link |
| Telegram / non-Slack | `in response to Alice's message` | no `#channel`, no link |
| Self / scheduled (no inbound) | `Requesting approval to run this tool` (generic) | — |
| Voice (phone) | `Requesting approval to run this tool` (caller, no "message") | `phone`, no link |
| Missing tool name | title falls back to `Assistant wants to use "unknown tool"` | — |

## The key call

The ticket assumed the triggering message was "lost by tool-execution time." Tracing it down, that's wrong: every inbound Slack message is **persisted as a conversation message** with typed `SlackMessageMetadata` (`channelTs`, `channelId`, `channelName`, `displayName`, `actorExternalUserId`). So it's recoverable by `conversationId` at escalation time — giving the contact's **actual words** and an **exact-message** permalink with **no `ToolContext` plumbing**.

## What changed

- **One shared view model** `buildToolApprovalCardView` consumed by both the in-app seed builder and the Slack adapter, plus the flat one-line phrasing for Telegram `deliveryText` / CLI / clarification — copy/source-link/preview authored once (kills the two-builder duplication).
- **Source-of-truth capture** (`tool-approval-source.ts`): resolves the triggering message via a bounded leaf query (`memory/recent-user-messages.ts`, kept out of the `conversation-crud` import cycle) + the existing typed slack reader.
- **New copy** — assistant-as-actor title, a connective that attributes the trigger, and a body with the requester's words + redacted command + a `[View in Slack →]` link (see **Before → After** above). DM drops the channel; self / scheduled / voice omit the connective.
- **Types derive from schema** — `guardian.question` construction typed to the inferred `ToolGrantGuardianPayload`; the view-model input / source-facts types are `Pick<>`s of the inferred payload; the seed blocks are the schema-derived `ApprovalCardBlock[]` from #35706.
- DRY the Slack source-context block across the access-request and tool-approval cards.

## Tests

- Rewrote the seed-content test for the assistant-as-actor copy + the three connective branches (channel / DM / no-inbound), narrowing by the schema-derived block discriminant (no casts).
- Added Slack tool-approval card coverage.
- Added pure unit tests for the view model and the triggering-message selector.

## Notes

- The Storybook fixture (`tool-approval-card.stories.tsx`) is refreshed to the new copy.
- No conflict/overlap with the LUM-2536 chat-state rearchitecture — that's client-side message *state storage*; this is server-side card *content*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)