### PR TITLE
fix(oauth): make managed Google connection resolution scope-aware (Gmail 403 on calendar-only connection)

### DIFF
--- a/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
+++ b/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
@@ -244,8 +244,12 @@ describe("Slack messaging token resolution", () => {
 
       const result = await getProviderConnection(gmailMessagingProvider);
       expect(result).toBe(oauthConn);
+      // Gmail forwards its requiredScopes so a narrowly-scoped (e.g.
+      // Calendar-only) Google connection is rejected at resolution time
+      // instead of 403-ing on the first Gmail API call.
       expect(resolveOAuthConnectionMock).toHaveBeenCalledWith("google", {
         account: undefined,
+        requiredScopes: gmailMessagingProvider.requiredScopes,
       });
     });
   });

--- a/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
+++ b/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
@@ -50,8 +50,11 @@ mock.module("../runtime/auth/token-service.js", () => ({}));
 // Slack client stubs (not exercised in these tests, but required on import)
 mock.module("../messaging/providers/slack/client.js", () => ({}));
 
-// Gmail client stubs
-mock.module("../messaging/providers/gmail/client.js", () => ({}));
+// Gmail client stubs. Re-export GMAIL_REQUIRED_SCOPES so the adapter's
+// `requiredScopes` is populated (and the forwarding assertion below is real).
+mock.module("../messaging/providers/gmail/client.js", () => ({
+  GMAIL_REQUIRED_SCOPES: ["https://www.googleapis.com/auth/gmail.readonly"],
+}));
 mock.module("../messaging/providers/gmail/people-client.js", () => ({}));
 
 // Telegram client stubs
@@ -246,10 +249,14 @@ describe("Slack messaging token resolution", () => {
       expect(result).toBe(oauthConn);
       // Gmail forwards its requiredScopes so a narrowly-scoped (e.g.
       // Calendar-only) Google connection is rejected at resolution time
-      // instead of 403-ing on the first Gmail API call.
+      // instead of 403-ing on the first Gmail API call. Asserted as a concrete
+      // value (not the provider property) so removing the forwarding fails.
+      expect(gmailMessagingProvider.requiredScopes).toEqual([
+        "https://www.googleapis.com/auth/gmail.readonly",
+      ]);
       expect(resolveOAuthConnectionMock).toHaveBeenCalledWith("google", {
         account: undefined,
-        requiredScopes: gmailMessagingProvider.requiredScopes,
+        requiredScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
       });
     });
   });

--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -137,5 +137,8 @@ export async function getProviderConnection(
 ): Promise<OAuthConnection | undefined> {
   if (provider.resolveConnection) return provider.resolveConnection(account);
   if (await provider.isConnected?.()) return undefined;
-  return resolveOAuthConnection(provider.credentialService, { account });
+  return resolveOAuthConnection(provider.credentialService, {
+    account,
+    requiredScopes: provider.requiredScopes,
+  });
 }

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -24,6 +24,7 @@ import {
   type OAuthConnectionRow,
   type OAuthProviderRow,
 } from "../oauth/oauth-store.js";
+import { scopeDifference } from "../oauth/scope-utils.js";
 import {
   TokenExpiredError,
   withValidToken,
@@ -75,11 +76,6 @@ function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
   } catch {
     return fallback;
   }
-}
-
-function scopeDifference(required: string[], granted: string[]): string[] {
-  const grantedSet = new Set(granted);
-  return required.filter((s) => !grantedSet.has(s));
 }
 
 // ── Liveness ping ─────────────────────────────────────────────────────

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -29,6 +29,16 @@ export interface MessagingProvider {
   /** Credential service name for token-manager (e.g. 'slack'). */
   credentialService: string;
 
+  /**
+   * Scopes a connection must carry for this provider's tools to work. Set when
+   * the credential service bundles several products behind one OAuth app and
+   * this provider only works with a subset (e.g. Gmail under the shared
+   * 'google' service needs Gmail scopes, not Calendar-only). Forwarded as
+   * `requiredScopes` to {@link resolveOAuthConnection} so a narrowly-scoped
+   * connection fails with an actionable "reconnect" error instead of a 403.
+   */
+  requiredScopes?: string[];
+
   // ── Universal operations (every platform must implement) ──────────
 
   testConnection(connection?: OAuthConnection): Promise<ConnectionInfo>;

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -100,6 +100,7 @@ export const gmailMessagingProvider: MessagingProvider = {
   id: "gmail",
   displayName: "Gmail",
   credentialService: "google",
+  requiredScopes: gmail.GMAIL_REQUIRED_SCOPES,
   capabilities: new Set([
     "threads",
     "labels",

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -16,6 +16,20 @@ import type {
 
 const GMAIL_BATCH_URL = "https://www.googleapis.com/batch/gmail/v1";
 
+/**
+ * Minimum Google OAuth scope a connection must carry to be usable for Gmail.
+ *
+ * The managed `google` OAuth app bundles Gmail + Calendar + Drive, but a
+ * connection can be granted a narrow subset (e.g. the onboarding check-in flow
+ * requests Calendar-only). Every Gmail read/search/send call needs at least
+ * `gmail.readonly`, so a connection lacking it cannot serve Gmail at all —
+ * resolving against this scope turns a downstream 403 into an actionable
+ * "reconnect Google and grant Gmail" error at resolution time.
+ */
+export const GMAIL_REQUIRED_SCOPES = [
+  "https://www.googleapis.com/auth/gmail.readonly",
+];
+
 /** Max sub-requests per batch HTTP call (Gmail API limit) */
 const BATCH_SUB_LIMIT = 100;
 /** Max concurrent batch calls */

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -113,6 +113,15 @@ mock.module("./oauth-store.js", () => ({
     if (opts?.account && conn.accountInfo !== opts.account) return undefined;
     return conn;
   },
+  getActiveConnections: (
+    service: string,
+    opts?: { clientId?: string; account?: string },
+  ) => {
+    const conn = mockConnections.get(service);
+    if (!conn) return [];
+    if (opts?.account && conn.accountInfo !== opts.account) return [];
+    return [conn];
+  },
   getConnection: (id: string) => {
     for (const conn of mockConnections.values()) {
       if (conn.id === id) return conn;

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -6,6 +6,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mockProvider: Record<string, unknown> | undefined;
 let mockConnection: Record<string, unknown> | undefined;
+let mockConnections:
+  | Array<Record<string, unknown> & { clientId?: string; accountInfo?: string }>
+  | undefined;
 let mockAccessToken: string | undefined;
 let mockConfig: Record<string, unknown> = {};
 let mockPlatformClient: Record<string, unknown> | null = null;
@@ -24,15 +27,17 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("./oauth-store.js", () => ({
   getProvider: () => mockProvider,
-  getActiveConnection: (
+  getActiveConnections: (
     _pk: string,
     opts?: { clientId?: string; account?: string },
   ) => {
-    if (opts?.clientId && mockConnection?.clientId !== opts.clientId)
-      return undefined;
-    if (opts?.account && mockConnection?.accountInfo !== opts.account)
-      return undefined;
-    return mockConnection;
+    // Default to the single mockConnection unless a test sets an explicit list.
+    const rows = mockConnections ?? (mockConnection ? [mockConnection] : []);
+    return rows.filter((row) => {
+      if (opts?.clientId && row.clientId !== opts.clientId) return false;
+      if (opts?.account && row.accountInfo !== opts.account) return false;
+      return true;
+    });
   },
 }));
 
@@ -131,6 +136,7 @@ function setupDefaults(): void {
       "google-oauth": { mode: "managed" },
     },
   };
+  mockConnections = undefined;
   mockPlatformClient = makeMockClient();
   syncManualTokenCalls = [];
 }
@@ -395,6 +401,36 @@ describe("resolveOAuthConnection scope-awareness", () => {
       requiredScopes: [GMAIL_SCOPE],
     });
     expect(result).toBeInstanceOf(BYOOAuthConnection);
+  });
+
+  test("BYO: picks an older scope-satisfying connection over a newer narrow one", async () => {
+    (mockConfig.services as Record<string, unknown>)["google-oauth"] = {
+      mode: "your-own",
+    };
+    // Newest first (matching the store's ordering): a Calendar-only row, then
+    // an older row that carries the Gmail scope. The narrow row must not win.
+    mockConnections = [
+      {
+        id: "cal-only",
+        provider: "google",
+        accountInfo: "user@example.com",
+        grantedScopes: JSON.stringify(CALENDAR_ONLY),
+        status: "active",
+      },
+      {
+        id: "full",
+        provider: "google",
+        accountInfo: "user@example.com",
+        grantedScopes: JSON.stringify(FULL_BUNDLE),
+        status: "active",
+      },
+    ];
+
+    const result = await resolveOAuthConnection("google", {
+      requiredScopes: [GMAIL_SCOPE],
+    });
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+    expect(result.id).toBe("full");
   });
 });
 

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -294,6 +294,110 @@ describe("resolveOAuthConnection", () => {
   });
 });
 
+describe("resolveOAuthConnection scope-awareness", () => {
+  const GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
+  const CALENDAR_ONLY = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ];
+  const FULL_BUNDLE = [GMAIL_SCOPE, ...CALENDAR_ONLY];
+
+  function clientReturning(results: unknown[]) {
+    return {
+      ...makeMockClient(),
+      fetch: mock(
+        async () => new Response(JSON.stringify({ results }), { status: 200 }),
+      ),
+    };
+  }
+
+  beforeEach(() => {
+    setupDefaults();
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+  });
+
+  test("managed: rejects a Calendar-only connection when Gmail scope is required", async () => {
+    mockPlatformClient = clientReturning([
+      { id: "cal-only", account_label: null, scopes_granted: CALENDAR_ONLY },
+    ]);
+
+    await expect(
+      resolveOAuthConnection("google", { requiredScopes: [GMAIL_SCOPE] }),
+    ).rejects.toThrow(/missing required access.*gmail\.readonly/s);
+  });
+
+  test("managed: resolves when a connection carries the required Gmail scope", async () => {
+    mockPlatformClient = clientReturning([
+      { id: "full", account_label: null, scopes_granted: FULL_BUNDLE },
+    ]);
+
+    const result = await resolveOAuthConnection("google", {
+      requiredScopes: [GMAIL_SCOPE],
+    });
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+  });
+
+  test("managed: unknown scope data never blocks (back-compat)", async () => {
+    // Older connections report no scopes_granted — must not be rejected.
+    mockPlatformClient = clientReturning([
+      { id: "legacy", account_label: null },
+    ]);
+
+    const result = await resolveOAuthConnection("google", {
+      requiredScopes: [GMAIL_SCOPE],
+    });
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+  });
+
+  test("managed: prefers a scope-satisfying connection over a narrow one", async () => {
+    const fullClient = clientReturning([
+      { id: "cal-only", account_label: null, scopes_granted: CALENDAR_ONLY },
+      { id: "full", account_label: null, scopes_granted: FULL_BUNDLE },
+    ]);
+    mockPlatformClient = fullClient;
+
+    const result = await resolveOAuthConnection("google", {
+      requiredScopes: [GMAIL_SCOPE],
+    });
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+    // PlatformOAuthConnection is keyed by provider, so assert resolution
+    // succeeded (it would have thrown if only the narrow connection matched).
+    expect(result.provider).toBe("google");
+  });
+
+  test("managed: no requiredScopes preserves prior behavior", async () => {
+    mockPlatformClient = clientReturning([
+      { id: "cal-only", account_label: null, scopes_granted: CALENDAR_ONLY },
+    ]);
+
+    const result = await resolveOAuthConnection("google");
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+  });
+
+  test("BYO: rejects when granted scopes are known and missing the requirement", async () => {
+    (mockConfig.services as Record<string, unknown>)["google-oauth"] = {
+      mode: "your-own",
+    };
+    mockConnection!.grantedScopes = JSON.stringify(CALENDAR_ONLY);
+
+    await expect(
+      resolveOAuthConnection("google", { requiredScopes: [GMAIL_SCOPE] }),
+    ).rejects.toThrow(/missing required access/);
+  });
+
+  test("BYO: unknown granted scopes never block", async () => {
+    (mockConfig.services as Record<string, unknown>)["google-oauth"] = {
+      mode: "your-own",
+    };
+    mockConnection!.grantedScopes = JSON.stringify([]);
+
+    const result = await resolveOAuthConnection("google", {
+      requiredScopes: [GMAIL_SCOPE],
+    });
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+  });
+});
+
 describe("resolveEffectiveBaseUrl", () => {
   const fallback = "https://login.salesforce.com";
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -12,6 +12,7 @@ import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
 import { syncManualTokenConnection } from "./manual-token-connection.js";
 import { getActiveConnection, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
+import { scopeDifference } from "./scope-utils.js";
 
 const log = getLogger("connection-resolver");
 
@@ -23,6 +24,17 @@ export interface ResolveOAuthConnectionOptions {
    *  accounts are connected for the same provider. Best-effort: not guaranteed
    *  to be present on all connections. */
   account?: string;
+  /**
+   * Scopes the caller needs the connection to actually carry. A single provider
+   * key can bundle several products behind one OAuth app (notably Google: Gmail
+   * + Calendar + Drive), and a connection may have been granted only a subset.
+   * When set, resolution prefers a connection whose granted scopes cover these,
+   * and fails with an actionable "reconnect to grant X" error — instead of
+   * returning a token that 403s downstream — when the only active connection(s)
+   * positively lack a required scope. Scope data that is simply unknown never
+   * blocks (see {@link selectConnectionByScopes}).
+   */
+  requiredScopes?: string[];
 }
 
 /**
@@ -46,7 +58,7 @@ export async function resolveOAuthConnection(
   provider: string,
   options?: ResolveOAuthConnectionOptions,
 ): Promise<OAuthConnection> {
-  const { clientId, account } = options ?? {};
+  const { clientId, account, requiredScopes } = options ?? {};
   const providerRow = getProvider(provider);
   const managedKey = providerRow?.managedServiceConfigKey;
 
@@ -68,6 +80,7 @@ export async function resolveOAuthConnection(
         client,
         provider,
         account,
+        requiredScopes,
       });
 
       return new PlatformOAuthConnection({
@@ -99,6 +112,20 @@ export async function resolveOAuthConnection(
     throw new Error(
       `No active OAuth connection found for "${provider}"${qualifier}. The ${provider} service needs to be connected before it can be used.`,
     );
+  }
+
+  // Scope guard: if the caller needs specific scopes and this connection
+  // positively lacks them (its granted-scope set is known and missing one),
+  // fail with an actionable error rather than returning a token that 403s
+  // downstream. Unknown scope data (empty set) never blocks.
+  if (requiredScopes?.length) {
+    const granted = parseGrantedScopes(conn.grantedScopes);
+    if (granted.length > 0) {
+      const missing = scopeDifference(requiredScopes, granted);
+      if (missing.length > 0) {
+        throw new Error(missingScopesMessage(provider, missing));
+      }
+    }
   }
 
   const tokenResult = await getConnectionAccessTokenResult({
@@ -188,11 +215,15 @@ interface ResolvePlatformConnectionIdOptions {
   client: VellumPlatformClient;
   provider: string;
   account?: string;
+  requiredScopes?: string[];
 }
 
 interface PlatformConnectionEntry {
   id: string;
   account_label?: string | null;
+  /** Scopes the platform actually granted this connection. May be absent for
+   *  older connections or providers that don't report scopes. */
+  scopes_granted?: string[] | null;
 }
 
 /**
@@ -241,7 +272,7 @@ async function fetchPlatformConnections(options: {
 async function resolvePlatformConnectionId(
   options: ResolvePlatformConnectionIdOptions,
 ): Promise<string> {
-  const { client, provider, account } = options;
+  const { client, provider, account, requiredScopes } = options;
 
   let connections = await fetchPlatformConnections({
     client,
@@ -268,15 +299,32 @@ async function resolvePlatformConnectionId(
     );
   }
 
-  if (connections.length > 1 && !account) {
-    const allAccounts = connections
-      .map((c) => c.account_label ?? c.id)
-      .join(", ");
+  // Narrow to connections that actually carry the scopes the caller needs.
+  // This is what keeps a narrowly-scoped Google connection (e.g. Calendar-only,
+  // created by the onboarding check-in flow) from being resolved as a full
+  // Gmail connection and 403-ing on the first Gmail API call.
+  const selection = selectConnectionByScopes(connections, requiredScopes ?? []);
+  if (selection.kind === "missing-scopes") {
     log.warn(
       {
         provider,
         count: connections.length,
-        selectedId: connections[0].id,
+        requiredScopes,
+        missingScopes: selection.missingScopes,
+      },
+      "Active platform connection(s) found but none carry the required scopes",
+    );
+    throw new Error(missingScopesMessage(provider, selection.missingScopes));
+  }
+
+  const eligible = selection.connections;
+  if (eligible.length > 1 && !account) {
+    const allAccounts = eligible.map((c) => c.account_label ?? c.id).join(", ");
+    log.warn(
+      {
+        provider,
+        count: eligible.length,
+        selectedId: eligible[0].id,
         allAccounts,
       },
       "Multiple active platform connections found; using the most recently created. " +
@@ -284,5 +332,84 @@ async function resolvePlatformConnectionId(
     );
   }
 
-  return connections[0].id;
+  return eligible[0].id;
+}
+
+type ScopeSelection =
+  | { kind: "ok"; connections: PlatformConnectionEntry[] }
+  | { kind: "missing-scopes"; missingScopes: string[] };
+
+/**
+ * Choose the connections eligible to serve a request needing `requiredScopes`.
+ *
+ * Scope data from the platform can be absent (older connections, providers that
+ * don't report granted scopes). We only ever REJECT a connection when we can
+ * positively see its granted-scope set AND that set is missing a required
+ * scope — never when scope data is simply unknown. This keeps the check from
+ * breaking existing working connections while still catching the real failure
+ * mode: a narrowly-scoped connection masquerading as a fully-capable one.
+ *
+ * Eligible connections are returned scope-satisfying first, then scope-unknown,
+ * preserving the platform's most-recent-first ordering within each group.
+ */
+function selectConnectionByScopes(
+  connections: PlatformConnectionEntry[],
+  requiredScopes: string[],
+): ScopeSelection {
+  if (requiredScopes.length === 0) {
+    return { kind: "ok", connections };
+  }
+
+  const satisfying: PlatformConnectionEntry[] = [];
+  const scopeUnknown: PlatformConnectionEntry[] = [];
+  const missingPerConnection: string[][] = [];
+
+  for (const conn of connections) {
+    const granted = conn.scopes_granted ?? [];
+    if (granted.length === 0) {
+      // Unknown scope coverage — don't block on it.
+      scopeUnknown.push(conn);
+      continue;
+    }
+    const missing = scopeDifference(requiredScopes, granted);
+    if (missing.length === 0) {
+      satisfying.push(conn);
+    } else {
+      missingPerConnection.push(missing);
+    }
+  }
+
+  const eligible = [...satisfying, ...scopeUnknown];
+  if (eligible.length > 0) {
+    return { kind: "ok", connections: eligible };
+  }
+
+  // Every active connection positively lacks a required scope.
+  const missingScopes = Array.from(new Set(missingPerConnection.flat()));
+  return { kind: "missing-scopes", missingScopes };
+}
+
+/** Best-effort parse of a connection row's JSON-encoded granted-scopes column. */
+function parseGrantedScopes(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((s): s is string => typeof s === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Actionable error shown when a connection is missing required scopes. */
+function missingScopesMessage(
+  provider: string,
+  missingScopes: string[],
+): string {
+  return (
+    `Your ${provider} account is connected but is missing required access ` +
+    `(${missingScopes.join(", ")}). Reconnect ${provider} and grant the ` +
+    `missing permission to continue.`
+  );
 }

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -10,7 +10,7 @@ import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
 import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
 import { syncManualTokenConnection } from "./manual-token-connection.js";
-import { getActiveConnection, getProvider } from "./oauth-store.js";
+import { getActiveConnections, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
 import { scopeDifference } from "./scope-utils.js";
 
@@ -100,8 +100,8 @@ export async function resolveOAuthConnection(
     await syncManualTokenConnection(provider);
   }
 
-  const conn = getActiveConnection(provider, { clientId, account });
-  if (!conn) {
+  const candidates = getActiveConnections(provider, { clientId, account });
+  if (candidates.length === 0) {
     const filters = [
       account && `account "${account}"`,
       clientId && `client ID "${clientId}"`,
@@ -114,18 +114,23 @@ export async function resolveOAuthConnection(
     );
   }
 
-  // Scope guard: if the caller needs specific scopes and this connection
-  // positively lacks them (its granted-scope set is known and missing one),
-  // fail with an actionable error rather than returning a token that 403s
-  // downstream. Unknown scope data (empty set) never blocks.
+  // Scope guard: when the caller needs specific scopes, pick a connection that
+  // actually carries them rather than blindly taking the newest row — a user
+  // may hold several active connections (e.g. one Calendar-only, one full).
+  // Only fail when EVERY active connection positively lacks a required scope;
+  // unknown scope data never blocks. Without requiredScopes, behavior is
+  // unchanged: take the most-recently-created connection.
+  let conn = candidates[0];
   if (requiredScopes?.length) {
-    const granted = parseGrantedScopes(conn.grantedScopes);
-    if (granted.length > 0) {
-      const missing = scopeDifference(requiredScopes, granted);
-      if (missing.length > 0) {
-        throw new Error(missingScopesMessage(provider, missing));
-      }
+    const { eligible, missingScopes } = partitionByScopes(
+      candidates,
+      requiredScopes,
+      (row) => parseGrantedScopes(row.grantedScopes),
+    );
+    if (eligible.length === 0) {
+      throw new Error(missingScopesMessage(provider, missingScopes));
     }
+    conn = eligible[0];
   }
 
   const tokenResult = await getConnectionAccessTokenResult({
@@ -303,28 +308,31 @@ async function resolvePlatformConnectionId(
   // This is what keeps a narrowly-scoped Google connection (e.g. Calendar-only,
   // created by the onboarding check-in flow) from being resolved as a full
   // Gmail connection and 403-ing on the first Gmail API call.
-  const selection = selectConnectionByScopes(connections, requiredScopes ?? []);
-  if (selection.kind === "missing-scopes") {
+  if (requiredScopes?.length) {
+    const { eligible, missingScopes } = partitionByScopes(
+      connections,
+      requiredScopes,
+      (c) => c.scopes_granted ?? [],
+    );
+    if (eligible.length === 0) {
+      log.warn(
+        { provider, count: connections.length, requiredScopes, missingScopes },
+        "Active platform connection(s) found but none carry the required scopes",
+      );
+      throw new Error(missingScopesMessage(provider, missingScopes));
+    }
+    connections = eligible;
+  }
+
+  if (connections.length > 1 && !account) {
+    const allAccounts = connections
+      .map((c) => c.account_label ?? c.id)
+      .join(", ");
     log.warn(
       {
         provider,
         count: connections.length,
-        requiredScopes,
-        missingScopes: selection.missingScopes,
-      },
-      "Active platform connection(s) found but none carry the required scopes",
-    );
-    throw new Error(missingScopesMessage(provider, selection.missingScopes));
-  }
-
-  const eligible = selection.connections;
-  if (eligible.length > 1 && !account) {
-    const allAccounts = eligible.map((c) => c.account_label ?? c.id).join(", ");
-    log.warn(
-      {
-        provider,
-        count: eligible.length,
-        selectedId: eligible[0].id,
+        selectedId: connections[0].id,
         allAccounts,
       },
       "Multiple active platform connections found; using the most recently created. " +
@@ -332,61 +340,53 @@ async function resolvePlatformConnectionId(
     );
   }
 
-  return eligible[0].id;
+  return connections[0].id;
 }
 
-type ScopeSelection =
-  | { kind: "ok"; connections: PlatformConnectionEntry[] }
-  | { kind: "missing-scopes"; missingScopes: string[] };
-
 /**
- * Choose the connections eligible to serve a request needing `requiredScopes`.
+ * Partition connections into those eligible to serve a request needing
+ * `requiredScopes` versus the scopes positively missing across all of them.
  *
- * Scope data from the platform can be absent (older connections, providers that
- * don't report granted scopes). We only ever REJECT a connection when we can
- * positively see its granted-scope set AND that set is missing a required
- * scope — never when scope data is simply unknown. This keeps the check from
- * breaking existing working connections while still catching the real failure
- * mode: a narrowly-scoped connection masquerading as a fully-capable one.
+ * Scope data can be absent (older connections, providers that don't report
+ * granted scopes). We only ever REJECT a connection when we can positively see
+ * its granted-scope set AND that set is missing a required scope — never when
+ * scope data is simply unknown. This keeps the check from breaking existing
+ * working connections while still catching the real failure mode: a narrowly-
+ * scoped connection masquerading as a fully-capable one.
  *
- * Eligible connections are returned scope-satisfying first, then scope-unknown,
- * preserving the platform's most-recent-first ordering within each group.
+ * `eligible` is ordered scope-satisfying first, then scope-unknown, preserving
+ * the caller's most-recent-first ordering within each group, so `eligible[0]`
+ * is the best connection to use. `missingScopes` is only meaningful when
+ * `eligible` is empty (every connection positively lacked a required scope).
  */
-function selectConnectionByScopes(
-  connections: PlatformConnectionEntry[],
+function partitionByScopes<T>(
+  items: T[],
   requiredScopes: string[],
-): ScopeSelection {
-  if (requiredScopes.length === 0) {
-    return { kind: "ok", connections };
-  }
+  getGranted: (item: T) => string[],
+): { eligible: T[]; missingScopes: string[] } {
+  const satisfying: T[] = [];
+  const scopeUnknown: T[] = [];
+  const missingPerItem: string[][] = [];
 
-  const satisfying: PlatformConnectionEntry[] = [];
-  const scopeUnknown: PlatformConnectionEntry[] = [];
-  const missingPerConnection: string[][] = [];
-
-  for (const conn of connections) {
-    const granted = conn.scopes_granted ?? [];
+  for (const item of items) {
+    const granted = getGranted(item);
     if (granted.length === 0) {
       // Unknown scope coverage — don't block on it.
-      scopeUnknown.push(conn);
+      scopeUnknown.push(item);
       continue;
     }
     const missing = scopeDifference(requiredScopes, granted);
     if (missing.length === 0) {
-      satisfying.push(conn);
+      satisfying.push(item);
     } else {
-      missingPerConnection.push(missing);
+      missingPerItem.push(missing);
     }
   }
 
-  const eligible = [...satisfying, ...scopeUnknown];
-  if (eligible.length > 0) {
-    return { kind: "ok", connections: eligible };
-  }
-
-  // Every active connection positively lacks a required scope.
-  const missingScopes = Array.from(new Set(missingPerConnection.flat()));
-  return { kind: "missing-scopes", missingScopes };
+  return {
+    eligible: [...satisfying, ...scopeUnknown],
+    missingScopes: Array.from(new Set(missingPerItem.flat())),
+  };
 }
 
 /** Best-effort parse of a connection row's JSON-encoded granted-scopes column. */

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -821,6 +821,20 @@ export function getActiveConnection(
   provider: string,
   options?: { clientId?: string; account?: string },
 ): OAuthConnectionRow | undefined {
+  return getActiveConnections(provider, options)[0];
+}
+
+/**
+ * Like {@link getActiveConnection}, but returns ALL matching active connections
+ * (most-recently-created first) instead of just the newest. Callers that must
+ * choose among multiple connections — e.g. picking the one that carries a
+ * specific set of granted scopes — use this; `getActiveConnection` is the
+ * single-result convenience over the same query.
+ */
+export function getActiveConnections(
+  provider: string,
+  options?: { clientId?: string; account?: string },
+): OAuthConnectionRow[] {
   const { clientId, account } = options ?? {};
   const db = getDb();
 
@@ -835,7 +849,7 @@ export function getActiveConnection(
 
   if (clientId) {
     const app = getAppByProviderAndClientId(provider, clientId);
-    if (!app) return undefined;
+    if (!app) return [];
     conditions.push(eq(oauthConnections.oauthAppId, app.id));
   }
 
@@ -844,8 +858,7 @@ export function getActiveConnection(
     .from(oauthConnections)
     .where(and(...conditions))
     .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
-    .limit(1)
-    .get();
+    .all();
 }
 
 /** @deprecated Use {@link getActiveConnection} instead. */

--- a/assistant/src/oauth/scope-utils.ts
+++ b/assistant/src/oauth/scope-utils.ts
@@ -19,8 +19,3 @@ export function scopeDifference(
   const grantedSet = new Set(granted);
   return required.filter((s) => !grantedSet.has(s));
 }
-
-/** True when every required scope is present in the granted set. */
-export function hasAllScopes(required: string[], granted: string[]): boolean {
-  return scopeDifference(required, granted).length === 0;
-}

--- a/assistant/src/oauth/scope-utils.ts
+++ b/assistant/src/oauth/scope-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared helpers for reasoning about OAuth scope coverage.
+ *
+ * A single provider key can bundle several products behind one OAuth app
+ * (notably Google: Gmail + Calendar + Drive + Contacts). A connection may be
+ * granted only a subset of those scopes, so callers that need a specific
+ * capability must compare what they require against what was actually granted
+ * rather than treating any active connection as fully capable.
+ */
+
+/**
+ * Return the required scopes that are NOT present in the granted set.
+ * An empty result means every required scope is granted.
+ */
+export function scopeDifference(
+  required: string[],
+  granted: string[],
+): string[] {
+  const grantedSet = new Set(granted);
+  return required.filter((s) => !grantedSet.has(s));
+}
+
+/** True when every required scope is present in the granted set. */
+export function hasAllScopes(required: string[], granted: string[]): boolean {
+  return scopeDifference(required, granted).length === 0;
+}

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -9,6 +9,7 @@
 import {
   batchGetMessages,
   getProfile,
+  GMAIL_REQUIRED_SCOPES,
   listMessages,
 } from "../../messaging/providers/gmail/client.js";
 import type { GmailMessage } from "../../messaging/providers/gmail/types.js";
@@ -118,7 +119,9 @@ export const gmailProvider: WatcherProvider = {
   requiredCredentialService: "google",
 
   async getInitialWatermark(credentialService: string): Promise<string> {
-    const connection = await resolveOAuthConnection(credentialService);
+    const connection = await resolveOAuthConnection(credentialService, {
+      requiredScopes: GMAIL_REQUIRED_SCOPES,
+    });
     const profile = await getProfile(connection);
     if (!profile.historyId) {
       throw new Error("Gmail profile did not return a historyId");
@@ -132,7 +135,9 @@ export const gmailProvider: WatcherProvider = {
     _config: Record<string, unknown>,
     _watcherKey: string,
   ): Promise<FetchResult> {
-    const connection = await resolveOAuthConnection(credentialService);
+    const connection = await resolveOAuthConnection(credentialService, {
+      requiredScopes: GMAIL_REQUIRED_SCOPES,
+    });
 
     if (!watermark) {
       // No watermark — get initial position, return no items


### PR DESCRIPTION
## The bug

Users who connect Google through the **onboarding Day-2 check-in flow** end up with Gmail silently broken: the assistant reports Gmail as *connected*, but every Gmail tool call 403s.

### Root cause

A single `google` OAuth app bundles Gmail + Calendar + Drive, and a connection can be granted only a subset. The check-in flow (`use-google-calendar-connect.ts`) connects under the shared `google` provider key while requesting **only** `calendar.events` + identity scopes — so it creates an active, *calendar-only* `google` connection.

When Gmail later resolves a connection, `resolvePlatformConnectionId` (and the BYO path) were **scope-blind** — they treated any `ACTIVE` `google` connection as a full Gmail connection:

- `fetchPlatformConnections` queried only `provider=google&status=ACTIVE` and returned `{ id, account_label }`, ignoring `scopes_granted`.
- Gmail resolved that calendar-only connection → status reports "connected" → first Gmail API call 403s far from the cause.

This is exactly the failure mode [#35162](https://github.com/vellum-ai/vellum-assistant/pull/35162) called out in its own commit message but left unguarded (it only kept the *Settings* calendar-only button hidden; the onboarding check-in path shipped the narrow-scope connection anyway).

Scope-diffing already existed (`credential-health` `scopeDifference`) but ran **only in the background heartbeat** — never on the runtime resolution path.

## The fix

Wire scope-awareness into the path that actually matters — `resolveOAuthConnection`:

- New optional `requiredScopes` on `resolveOAuthConnection`. The **managed** path narrows platform connections by `scopes_granted`; the **BYO** path checks the row's `grantedScopes`. When the only active connection(s) positively lack a required scope, it throws an actionable **"Your google account is connected but is missing required access (…). Reconnect google and grant the missing permission"** error instead of returning a doomed token.
- **Backward-compatible by design:** unknown scope data (absent/empty `scopes_granted`) **never blocks** — only a *known* granted-scope set that's *missing* a requirement is rejected. Older connections and providers that don't report scopes keep working.
- **Prefers** a scope-satisfying connection over a narrow one when both exist.
- Gmail declares its required scope (`gmail.readonly`) via a new optional `MessagingProvider.requiredScopes`, forwarded from the messaging tool seam (`getProviderConnection`) and the Gmail watcher.
- Extracted `scopeDifference`/`hasAllScopes` into shared `oauth/scope-utils.ts`; `credential-health` now imports it (DRY).

## Testing

- `connection-resolver.test.ts`: +7 cases — calendar-only rejected, full bundle resolves, unknown-scope back-compat, prefers satisfying connection, no-requiredScopes preserves prior behavior, BYO reject + BYO unknown-scope. All 25 pass.
- `credential-health-service.test.ts`: 31 pass (DRY refactor).
- `slack-messaging-token-resolution.test.ts`: updated the Gmail regression-check to assert the forwarded `requiredScopes`. 18 pass.

## Scope / follow-ups

Targeted at the reported Gmail failure. Not in this PR (intentionally, to keep it focused):
- Making the **connected-status** surface scope-aware end-to-end (so a calendar-only connection never *displays* as Gmail-connected) — this PR makes the use-path fail loudly and actionably, which resolves the user-facing breakage.
- Applying the same `requiredScopes` guard to Google Contacts (People API) and Drive.
- Modeling Calendar as its own provider key (the clean long-term fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->