### PR TITLE
feat(macos): add Choose Assistant item to Developer menu

### DIFF
--- a/clients/macos/src/main/commands.ts
+++ b/clients/macos/src/main/commands.ts
@@ -41,6 +41,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   zoomOut: "",
   actualSize: "",
   selectAssistant: "",
+  chooseAssistant: "",
   createAssistant: "",
   retireAssistant: "",
   quickInputSubmit: "",

--- a/clients/macos/src/main/menu.ts
+++ b/clients/macos/src/main/menu.ts
@@ -250,6 +250,11 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
             label: "Developer",
             submenu: [
               {
+                label: "Choose Assistant…",
+                click: () => dispatchMenuCommand({ kind: "chooseAssistant" }),
+              },
+              { type: "separator" as const },
+              {
                 label: "Replay Onboarding",
                 click: () => dispatchMenuCommand({ kind: "replayOnboarding" }),
               },

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -45,7 +45,7 @@ export function SelectAssistantScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fromLogin = searchParams.get("fromLogin") === "1";
-  const fromSettings = searchParams.get("fromSettings") === "1";
+  const noAutoSkip = searchParams.get("noAutoSkip") === "1";
   const electron = isElectron();
   const hasPlatformSession = useHasPlatformSession();
   const assistants = useResolvedAssistantsStore.use.assistants();
@@ -184,10 +184,10 @@ export function SelectAssistantScreen() {
 
   // Auto-skip when there's exactly one assistant and it's accessible.
   // Don't skip when the user just logged in or navigated here deliberately
-  // from settings — let them see the chooser.
+  // (e.g. from settings or the Developer menu) — let them see the chooser.
   // Reactive to assistants so it fires when the store populates after mount.
   useEffect(() => {
-    if (fromLogin || fromSettings) return;
+    if (fromLogin || noAutoSkip) return;
     if (connecting || autoSkipping) return;
     if (assistants.length === 0) return;
     if (assistants.length === 1 && accessibleAssistants.length === 1) {

--- a/clients/web/src/domains/settings/pages/developer-page.tsx
+++ b/clients/web/src/domains/settings/pages/developer-page.tsx
@@ -80,7 +80,7 @@ export function DeveloperPage() {
           <Button
             variant="outlined"
             className="mb-1 shrink-0"
-            onClick={() => void navigate(`${routes.selectAssistant}?fromSettings=1`)}
+            onClick={() => void navigate(`${routes.selectAssistant}?noAutoSkip=1`)}
           >
             Choose Assistant
           </Button>

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -15,7 +15,7 @@ import {
   useHasPlatformSession,
 } from "@/stores/auth-store";
 import { handleLogout } from "@/lib/auth/handle-logout";
-import { getSelectedAssistant } from "@/lib/local-mode";
+import { getSelectedAssistant, isLocalMode } from "@/lib/local-mode";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { useVellumCommands } from "@/runtime/vellum-commands";
@@ -202,7 +202,14 @@ export function RootLayout() {
       }
     },
     chooseAssistant: () => {
-      void navigate(`${routes.selectAssistant}?noAutoSkip=1`);
+      // The chooser route is local-only — navigation-resolver redirects
+      // platform users away — so platform sessions switch via the Switch
+      // Assistant picker on the settings page instead.
+      if (isLocalMode()) {
+        void navigate(`${routes.selectAssistant}?noAutoSkip=1`);
+      } else {
+        void navigate(routes.settings.general);
+      }
     },
     createAssistant: () => {
       setCreateOpen(true);

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -202,7 +202,7 @@ export function RootLayout() {
       }
     },
     chooseAssistant: () => {
-      void navigate(`${routes.selectAssistant}?fromSettings=1`);
+      void navigate(`${routes.selectAssistant}?noAutoSkip=1`);
     },
     createAssistant: () => {
       setCreateOpen(true);

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -201,6 +201,9 @@ export function RootLayout() {
         void setSelectedAssistant(command.assistantId);
       }
     },
+    chooseAssistant: () => {
+      void navigate(`${routes.selectAssistant}?fromSettings=1`);
+    },
     createAssistant: () => {
       setCreateOpen(true);
     },

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -51,6 +51,7 @@ export type VellumCommand =
   | { kind: "zoomOut" }
   | { kind: "actualSize" }
   | { kind: "selectAssistant"; assistantId: string }
+  | { kind: "chooseAssistant" }
   | { kind: "createAssistant" }
   | { kind: "retireAssistant"; assistantId: string }
   | { kind: "quickInputSubmit"; message: string }


### PR DESCRIPTION
## Summary
- Add a payload-free `chooseAssistant` command to the IPC contract (`VellumCommand`) and register it in `DEFAULT_ACCELERATORS`.
- Add a "Choose Assistant…" item to the Electron app's **Developer** menu (gated by the existing `developer-menu-items` flag), dispatching `chooseAssistant`.
- Handle `chooseAssistant` in the renderer by navigating to `routes.selectAssistant?fromSettings=1` — the same destination as the web Developer page's existing "Choose Assistant" button.

## Original prompt
The user wanted the Electron app's **Developer** menu to expose the same assistant-switching action that lives on the web app's Developer page (the assistant chooser / "Switch Assistant" experience). This adds a native menu item that triggers that same flow rather than duplicating UI.