### PR TITLE
fix(gateway): adopt the assistant guardian instead of minting a duplicate principal

### DIFF
--- a/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
@@ -1,11 +1,19 @@
 /**
  * Tests for guardian-bootstrap pure guardian lookups
  * (findVellumGuardian + findGuardianForChannelActor) after they were
- * repointed to read the gateway DB directly.
+ * repointed to read the gateway DB directly, plus the adopt-before-mint
+ * path in resolveOrCreateVellumGuardian (via ensureVellumGuardianBinding /
+ * bootstrapGuardian).
  *
- * Guardian rows are seeded ONLY in the gateway DB. The assistant DB proxy is
- * mocked to throw, proving the lookups no longer depend on the assistant mirror.
+ * Guardian rows are seeded ONLY in the gateway DB. By default the assistant
+ * DB proxy is swapped for a backend that throws, proving the pure lookups no
+ * longer depend on the assistant mirror; adopt/mint tests install a real
+ * in-memory assistant store instead.
  */
+
+import { Database } from "bun:sqlite";
+
+import { and, eq } from "drizzle-orm";
 
 import {
   describe,
@@ -19,25 +27,112 @@ import {
 
 import "./test-preload.js";
 
-// Assistant DB proxy throws — the gateway reads must not touch it.
-mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: mock(async () => {
+// Swappable assistant-DB backend. Default: throw (the pure gateway reads must
+// not touch the assistant mirror). Adopt/mint tests install an in-memory DB.
+type AssistantBackend = {
+  query: (sql: string, params?: unknown[]) => unknown[];
+  run: (sql: string, params?: unknown[]) => { changes: number };
+  exec: (sql: string) => void;
+};
+
+const throwingBackend: AssistantBackend = {
+  query: () => {
     throw new Error("assistant DB must not be read by guardian lookups");
-  }),
-  assistantDbRun: mock(async () => ({ changes: 0, lastInsertRowid: 0 })),
-  assistantDbExec: mock(async () => undefined),
+  },
+  run: () => {
+    throw new Error("assistant DB must not be written by guardian lookups");
+  },
+  exec: () => {
+    throw new Error("assistant DB must not be touched by guardian lookups");
+  },
+};
+
+let assistantBackend: AssistantBackend = throwingBackend;
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(async (sql: string, params?: unknown[]) =>
+    assistantBackend.query(sql, params),
+  ),
+  assistantDbRun: mock(async (sql: string, params?: unknown[]) =>
+    assistantBackend.run(sql, params),
+  ),
+  assistantDbExec: mock(async (sql: string) => assistantBackend.exec(sql)),
 }));
 
 import {
   findVellumGuardian,
   findGuardianForChannelActor,
+  ensureVellumGuardianBinding,
+  bootstrapGuardian,
 } from "../auth/guardian-bootstrap.js";
+import { initSigningKey } from "../auth/token-service.js";
 import {
   initGatewayDb,
   getGatewayDb,
   resetGatewayDb,
 } from "../db/connection.js";
 import { contacts, contactChannels } from "../db/schema.js";
+
+// Initialize signing key so bootstrapGuardian's JWT minting works.
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
+
+/** Minimal in-memory assistant DB mirroring the contacts/contact_channels schema. */
+function makeAssistantBackend(): AssistantBackend {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE contacts (
+      id TEXT PRIMARY KEY, display_name TEXT, role TEXT, principal_id TEXT,
+      notes TEXT, created_at INTEGER, updated_at INTEGER
+    );
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY, contact_id TEXT, type TEXT, address TEXT,
+      external_chat_id TEXT, is_primary INTEGER, status TEXT, policy TEXT,
+      verified_at INTEGER, verified_via TEXT, revoked_reason TEXT,
+      blocked_reason TEXT, interaction_count INTEGER, created_at INTEGER,
+      updated_at INTEGER
+    );
+  `);
+  return {
+    query: (sql, params = []) => db.query(sql).all(...(params as never[])),
+    run: (sql, params = []) => {
+      const r = db.query(sql).run(...(params as never[]));
+      return { changes: Number(r.changes) };
+    },
+    exec: (sql) => db.exec(sql),
+  };
+}
+
+function seedAssistantGuardian(
+  backend: AssistantBackend,
+  opts: {
+    principalId: string;
+    address: string;
+    deliveryChatId?: string;
+    displayName?: string;
+    verifiedAt?: number;
+  },
+): void {
+  const now = opts.verifiedAt ?? Date.now();
+  backend.run(
+    `INSERT INTO contacts (id, display_name, role, principal_id, created_at, updated_at)
+     VALUES (?, ?, 'guardian', ?, ?, ?)`,
+    ["asst-contact", opts.displayName ?? null, opts.principalId, now, now],
+  );
+  backend.run(
+    `INSERT INTO contact_channels
+       (id, contact_id, type, address, external_chat_id, is_primary, status,
+        policy, verified_at, interaction_count, created_at, updated_at)
+     VALUES (?, 'asst-contact', 'vellum', ?, ?, 1, 'active', 'allow', ?, 0, ?, ?)`,
+    [
+      "asst-channel",
+      opts.address,
+      opts.deliveryChatId ?? "local",
+      now,
+      now,
+      now,
+    ],
+  );
+}
 
 function seedGuardianChannel(opts: {
   type: string;
@@ -89,6 +184,7 @@ beforeEach(() => {
   const db = getGatewayDb();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
+  assistantBackend = throwingBackend;
 });
 
 afterAll(() => {
@@ -194,5 +290,105 @@ describe("findGuardianForChannelActor (gateway DB)", () => {
   test("returns null for empty inputs without reading any DB", async () => {
     expect(await findGuardianForChannelActor("", "U_OWNER")).toBeNull();
     expect(await findGuardianForChannelActor("slack", "")).toBeNull();
+  });
+});
+
+describe("adopt-before-mint (resolveOrCreateVellumGuardian)", () => {
+  function gatewayVellumGuardians() {
+    return getGatewayDb()
+      .select({
+        principalId: contacts.principalId,
+        address: contactChannels.address,
+        status: contactChannels.status,
+      })
+      .from(contacts)
+      .innerJoin(contactChannels, eq(contactChannels.contactId, contacts.id))
+      .where(
+        and(eq(contacts.role, "guardian"), eq(contactChannels.type, "vellum")),
+      )
+      .all();
+  }
+
+  test("adopts the assistant guardian when the gateway DB lacks it", async () => {
+    const backend = makeAssistantBackend();
+    seedAssistantGuardian(backend, {
+      principalId: "principal-existing",
+      address: "vellum-principal-existing",
+      deliveryChatId: "local",
+      displayName: "Owner",
+    });
+    assistantBackend = backend;
+
+    const principalId = await ensureVellumGuardianBinding();
+
+    // Existing principal returned — no fresh vellum-principal-<uuid> minted.
+    expect(principalId).toBe("principal-existing");
+
+    // Gateway mirror is repaired under the existing principal.
+    const gwRows = gatewayVellumGuardians();
+    expect(gwRows).toHaveLength(1);
+    expect(gwRows[0]).toMatchObject({
+      principalId: "principal-existing",
+      address: "vellum-principal-existing",
+      status: "active",
+    });
+  });
+
+  test("second call hits the gateway fast path (idempotent)", async () => {
+    const backend = makeAssistantBackend();
+    seedAssistantGuardian(backend, {
+      principalId: "principal-existing",
+      address: "vellum-principal-existing",
+    });
+    assistantBackend = backend;
+
+    expect(await ensureVellumGuardianBinding()).toBe("principal-existing");
+
+    // Gateway now has the row; the assistant DB must not be read again.
+    assistantBackend = throwingBackend;
+    expect(await ensureVellumGuardianBinding()).toBe("principal-existing");
+    expect(gatewayVellumGuardians()).toHaveLength(1);
+  });
+
+  test("mints a fresh principal when neither DB has a guardian", async () => {
+    assistantBackend = makeAssistantBackend();
+
+    const principalId = await ensureVellumGuardianBinding();
+
+    expect(principalId).toMatch(/^vellum-principal-/);
+    const gwRows = gatewayVellumGuardians();
+    expect(gwRows).toHaveLength(1);
+    expect(gwRows[0]?.principalId).toBe(principalId);
+  });
+
+  test("bootstrapGuardian adopts the assistant guardian (isNew=false)", async () => {
+    const backend = makeAssistantBackend();
+    seedAssistantGuardian(backend, {
+      principalId: "principal-existing",
+      address: "vellum-principal-existing",
+    });
+    assistantBackend = backend;
+
+    const result = await bootstrapGuardian({
+      platform: "macos",
+      deviceId: "device-1",
+    });
+
+    expect(result.guardianPrincipalId).toBe("principal-existing");
+    expect(result.isNew).toBe(false);
+    expect(result.accessToken).toBeTruthy();
+    expect(result.refreshToken).toBeTruthy();
+  });
+
+  test("bootstrapGuardian mints a fresh principal when neither DB has one (isNew=true)", async () => {
+    assistantBackend = makeAssistantBackend();
+
+    const result = await bootstrapGuardian({
+      platform: "macos",
+      deviceId: "device-1",
+    });
+
+    expect(result.guardianPrincipalId).toMatch(/^vellum-principal-/);
+    expect(result.isNew).toBe(true);
   });
 });

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -124,6 +124,43 @@ export async function findVellumGuardian(): Promise<{
 }
 
 /**
+ * Pre-repoint assistant-DB lookup for an active vellum guardian. Used to
+ * adopt an existing guardian whose row never reached the gateway mirror
+ * (skipped m0006 or a dropped dual-write), so we repair instead of minting
+ * a duplicate principal. Returns null when no row or no principalId.
+ */
+export async function findVellumGuardianFromAssistant(): Promise<{
+  principalId: string;
+  address: string;
+  deliveryChatId: string | null;
+  displayName: string | null;
+} | null> {
+  const rows = await assistantDbQuery<{
+    principalId: string | null;
+    address: string;
+    deliveryChatId: string | null;
+    displayName: string | null;
+  }>(
+    `SELECT c.principal_id AS principalId, cc.address AS address,
+            cc.external_chat_id AS deliveryChatId, c.display_name AS displayName
+     FROM contacts c
+     INNER JOIN contact_channels cc ON cc.contact_id = c.id
+     WHERE c.role = 'guardian' AND cc.type = 'vellum' AND cc.status = 'active'
+     ORDER BY cc.verified_at DESC
+     LIMIT 1`,
+  );
+
+  const row = rows[0];
+  if (!row?.principalId) return null;
+  return {
+    principalId: row.principalId,
+    address: row.address,
+    deliveryChatId: row.deliveryChatId,
+    displayName: row.displayName,
+  };
+}
+
+/**
  * Look up the guardian binding for a given external user on a specific
  * channel type (e.g. `"slack"`, `"telegram"`, `"whatsapp"`). Returns the
  * guardian's principal ID when the actor is bound as a guardian on an
@@ -697,22 +734,46 @@ async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
 }
 
 /**
- * Ensure a vellum guardian binding exists. If one already exists, returns
- * its principalId. Otherwise creates a new binding with a fresh principal
- * and dual-writes to both the assistant and gateway DBs.
+ * Resolve the vellum guardian principal, in order: (a) gateway fast path,
+ * (b) adopt an assistant guardian the gateway is missing — repairs the
+ * gateway row under its EXISTING principal via the logical-key dual-write,
+ * (c) mint a fresh principal when neither DB has a guardian.
  *
- * Called during gateway startup to backfill existing installations.
+ * Shared by ensureVellumGuardianBinding + bootstrapGuardian. `isNew` is true
+ * only on the mint path.
  */
-export async function ensureVellumGuardianBinding(): Promise<string> {
-  const existing = await findVellumGuardian();
-  if (existing) {
+async function resolveOrCreateVellumGuardian(): Promise<{
+  guardianPrincipalId: string;
+  isNew: boolean;
+}> {
+  const gw = await findVellumGuardian();
+  if (gw) {
     log.debug(
-      { guardianPrincipalId: existing.principalId },
+      { guardianPrincipalId: gw.principalId },
       "Vellum guardian binding already exists",
     );
-    return existing.principalId;
+    return { guardianPrincipalId: gw.principalId, isNew: false };
   }
 
+  // Adopt an assistant guardian the gateway mirror is missing.
+  const asst = await findVellumGuardianFromAssistant();
+  if (asst) {
+    log.info(
+      { guardianPrincipalId: asst.principalId },
+      "Adopting assistant guardian — repairing gateway mirror",
+    );
+    await createGuardianBinding({
+      channel: "vellum",
+      externalUserId: asst.address,
+      deliveryChatId: asst.deliveryChatId ?? "local",
+      guardianPrincipalId: asst.principalId,
+      verifiedVia: "bootstrap",
+      ...(asst.displayName ? { displayName: asst.displayName } : {}),
+    });
+    return { guardianPrincipalId: asst.principalId, isNew: false };
+  }
+
+  // Neither DB has a guardian — mint a fresh principal.
   const displayName = await fetchPlatformOwnerDisplayName();
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
   await createGuardianBinding({
@@ -723,6 +784,18 @@ export async function ensureVellumGuardianBinding(): Promise<string> {
     verifiedVia: "bootstrap",
     ...(displayName ? { displayName } : {}),
   });
+  return { guardianPrincipalId, isNew: true };
+}
+
+/**
+ * Ensure a vellum guardian binding exists, returning its principalId.
+ * Adopts an existing assistant guardian before minting (see
+ * resolveOrCreateVellumGuardian).
+ *
+ * Called during gateway startup to backfill existing installations.
+ */
+export async function ensureVellumGuardianBinding(): Promise<string> {
+  const { guardianPrincipalId } = await resolveOrCreateVellumGuardian();
   return guardianPrincipalId;
 }
 
@@ -737,24 +810,8 @@ export async function bootstrapGuardian(params: {
   platform: string;
   deviceId: string;
 }): Promise<GuardianBootstrapResult> {
-  // 1. Ensure guardian principal
-  let isNew = false;
-  let guardianPrincipalId: string;
-
-  const existing = await findVellumGuardian();
-  if (existing) {
-    guardianPrincipalId = existing.principalId;
-  } else {
-    guardianPrincipalId = `vellum-principal-${uuid()}`;
-    await createGuardianBinding({
-      channel: "vellum",
-      externalUserId: guardianPrincipalId,
-      deliveryChatId: "local",
-      guardianPrincipalId,
-      verifiedVia: "bootstrap",
-    });
-    isNew = true;
-  }
+  // 1. Resolve (or adopt/mint) the guardian principal.
+  const { guardianPrincipalId, isNew } = await resolveOrCreateVellumGuardian();
 
   // 2. Revoke existing credentials for this device and mint a fresh pair.
   const pair = mintAndRecordDeviceBoundTokenPair({


### PR DESCRIPTION
## Summary
- Before minting a new vellum guardian principal, consult the assistant DB; if a guardian exists there, adopt it (repair the gateway row via the logical-key dual-write) and return its existing principal. Mint only when neither DB has a guardian. Prevents duplicate-guardian lockout of paired clients.

Part of plan: gateway-acl-write-hardening.md (PR 3 of 3)