### PR TITLE
refactor(notifications): schema-derive guardian approval card seed blocks

### DIFF
--- a/assistant/src/__tests__/access-request-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/access-request-seed-content-blocks.test.ts
@@ -1,7 +1,29 @@
 import { describe, expect, test } from "bun:test";
 
 import { parseAccessRequestPayload } from "../notifications/access-request-copy.js";
+import type {
+  ApprovalCardBlock,
+  ApprovalCardFallbackBlock,
+  ApprovalCardSurfaceBlock,
+} from "../notifications/approval-card-builder.js";
 import { buildAccessRequestSeedContentBlocks } from "../notifications/approval-card-data.js";
+
+// The builder returns a schema-derived `ApprovalCardBlock[]`, so tests narrow by
+// the block's discriminant instead of casting to `Record<string, unknown>`.
+function surfaceOf(blocks: ApprovalCardBlock[]): ApprovalCardSurfaceBlock {
+  const block = blocks[0];
+  if (block?.type !== "ui_surface") {
+    throw new Error("expected a ui_surface block at index 0");
+  }
+  return block;
+}
+function textOf(blocks: ApprovalCardBlock[]): ApprovalCardFallbackBlock {
+  const block = blocks[1];
+  if (block?.type !== "text") {
+    throw new Error("expected a text fallback block at index 1");
+  }
+  return block;
+}
 
 describe("buildAccessRequestSeedContentBlocks", () => {
   const basePayload: Record<string, unknown> = {
@@ -20,175 +42,131 @@ describe("buildAccessRequestSeedContentBlocks", () => {
   test("produces a ui_surface block and a text fallback block", () => {
     const blocks = buildAccessRequestSeedContentBlocks(basePayload);
     expect(blocks).toHaveLength(2);
-    expect((blocks[0] as Record<string, unknown>).type).toBe("ui_surface");
-    expect((blocks[1] as Record<string, unknown>).type).toBe("text");
+    expect(surfaceOf(blocks).type).toBe("ui_surface");
+    expect(textOf(blocks).type).toBe("text");
     // The fallback block is flagged so surface-capable clients skip it.
-    expect((blocks[1] as Record<string, unknown>)._surfaceFallback).toBe(true);
+    expect(textOf(blocks)._surfaceFallback).toBe(true);
   });
 
   test("card surface has correct surfaceType and surfaceId", () => {
-    const blocks = buildAccessRequestSeedContentBlocks(basePayload);
-    const surface = blocks[0] as Record<string, unknown>;
+    const surface = surfaceOf(buildAccessRequestSeedContentBlocks(basePayload));
     expect(surface.surfaceType).toBe("card");
     expect(surface.surfaceId).toBe("access-request-req-123");
     expect(surface.title).toBe("Access Request");
   });
 
   test("card data uses actorDisplayName as title", () => {
-    const blocks = buildAccessRequestSeedContentBlocks(basePayload);
-    const surface = blocks[0] as Record<string, unknown>;
-    const data = surface.data as Record<string, unknown>;
+    const { data } = surfaceOf(
+      buildAccessRequestSeedContentBlocks(basePayload),
+    );
     expect(data.title).toBe("Alice");
     expect(data.subtitle).toBe("Requesting access to the assistant");
   });
 
   test("card data falls back to senderIdentifier when no displayName", () => {
-    const payload = { ...basePayload, actorDisplayName: undefined };
-    const blocks = buildAccessRequestSeedContentBlocks(payload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    expect(data.title).toBe("U999");
+    const blocks = buildAccessRequestSeedContentBlocks({
+      ...basePayload,
+      actorDisplayName: undefined,
+    });
+    expect(surfaceOf(blocks).data.title).toBe("U999");
   });
 
   test("card data falls back to 'Someone' when no identity", () => {
-    const payload = {
+    const blocks = buildAccessRequestSeedContentBlocks({
       ...basePayload,
       actorDisplayName: undefined,
       senderIdentifier: undefined,
-    };
-    const blocks = buildAccessRequestSeedContentBlocks(payload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    expect(data.title).toBe("Someone");
+    });
+    expect(surfaceOf(blocks).data.title).toBe("Someone");
   });
 
   test("includes username and source in metadata", () => {
-    const blocks = buildAccessRequestSeedContentBlocks(basePayload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    const metadata = data.metadata as Array<{ label: string; value: string }>;
-    expect(metadata).toContainEqual({
+    const { data } = surfaceOf(
+      buildAccessRequestSeedContentBlocks(basePayload),
+    );
+    expect(data.metadata).toContainEqual({
       label: "Username",
       value: "@alice",
     });
-    expect(metadata).toContainEqual({
+    expect(data.metadata).toContainEqual({
       label: "Source",
       value: "Slack — #C01ABC",
     });
   });
 
   test("DM channel renders as Direct message", () => {
-    const payload = { ...basePayload, conversationExternalId: "D01XYZ" };
-    const blocks = buildAccessRequestSeedContentBlocks(payload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    const metadata = data.metadata as Array<{ label: string; value: string }>;
-    expect(metadata).toContainEqual({
+    const blocks = buildAccessRequestSeedContentBlocks({
+      ...basePayload,
+      conversationExternalId: "D01XYZ",
+    });
+    expect(surfaceOf(blocks).data.metadata).toContainEqual({
       label: "Source",
       value: "Slack — Direct message",
     });
   });
 
   test("body includes message preview when present", () => {
-    const blocks = buildAccessRequestSeedContentBlocks(basePayload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
+    const { data } = surfaceOf(
+      buildAccessRequestSeedContentBlocks(basePayload),
+    );
     expect(data.body).toContain("Hello, I need help with something");
   });
 
   test("body includes trust signal warnings", () => {
-    const payload = {
-      ...basePayload,
-      isStranger: true,
-      isRestricted: true,
-      previousMemberStatus: "revoked",
-    };
-    const blocks = buildAccessRequestSeedContentBlocks(payload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    const body = data.body as string;
-    expect(body).toContain("External Slack user");
-    expect(body).toContain("Guest / restricted account");
-    expect(body).toContain("previously revoked");
+    const { data } = surfaceOf(
+      buildAccessRequestSeedContentBlocks({
+        ...basePayload,
+        isStranger: true,
+        isRestricted: true,
+        previousMemberStatus: "revoked",
+      }),
+    );
+    expect(data.body).toContain("External Slack user");
+    expect(data.body).toContain("Guest / restricted account");
+    expect(data.body).toContain("previously revoked");
   });
 
   test("body includes Slack message permalink", () => {
-    const blocks = buildAccessRequestSeedContentBlocks(basePayload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    const body = data.body as string;
-    expect(body).toContain("View message");
-    expect(body).toContain(
+    const { data } = surfaceOf(
+      buildAccessRequestSeedContentBlocks(basePayload),
+    );
+    expect(data.body).toContain("View message");
+    expect(data.body).toContain(
       "https://slack.com/archives/C01ABC/p1700000000000100",
     );
   });
 
   test("text fallback block contains contract text", () => {
-    const blocks = buildAccessRequestSeedContentBlocks(basePayload);
-    const textBlock = blocks[1] as Record<string, unknown>;
-    expect(textBlock.type).toBe("text");
-    const text = textBlock.text as string;
-    expect(text).toContain("requesting access to the assistant");
-    expect(text).toContain("ABC123");
+    const textBlock = textOf(buildAccessRequestSeedContentBlocks(basePayload));
+    expect(textBlock.text).toContain("requesting access to the assistant");
+    expect(textBlock.text).toContain("ABC123");
   });
 
   test("body shows fallback when no preview/warnings/permalink", () => {
-    const payload = {
+    const blocks = buildAccessRequestSeedContentBlocks({
       requestId: "req-456",
       requestCode: "XYZ",
       senderIdentifier: "someone",
-    };
-    const blocks = buildAccessRequestSeedContentBlocks(payload);
-    const data = (blocks[0] as Record<string, unknown>).data as Record<
-      string,
-      unknown
-    >;
-    expect(data.body).toBe("No additional context available.");
+    });
+    expect(surfaceOf(blocks).data.body).toBe(
+      "No additional context available.",
+    );
   });
 
   test("surface block includes approve/reject actions when requestId present", () => {
-    const blocks = buildAccessRequestSeedContentBlocks(basePayload);
-    const surface = blocks[0] as Record<string, unknown>;
-    const actions = surface.actions as Array<{
-      id: string;
-      label: string;
-      style: string;
-    }>;
-    expect(actions).toHaveLength(2);
-    expect(actions[0]).toEqual({
-      id: "apr:req-123:approve_once",
-      label: "Approve",
-      style: "primary",
-    });
-    expect(actions[1]).toEqual({
-      id: "apr:req-123:reject",
-      label: "Reject",
-      style: "destructive",
-    });
+    const surface = surfaceOf(buildAccessRequestSeedContentBlocks(basePayload));
+    expect(surface.actions).toEqual([
+      { id: "apr:req-123:approve_once", label: "Approve", style: "primary" },
+      { id: "apr:req-123:reject", label: "Reject", style: "destructive" },
+    ]);
   });
 
   test("surface block omits actions when requestId is missing", () => {
-    const payload = {
+    const blocks = buildAccessRequestSeedContentBlocks({
       ...basePayload,
       requestId: undefined,
-    };
-    const blocks = buildAccessRequestSeedContentBlocks(payload);
-    const surface = blocks[0] as Record<string, unknown>;
-    expect(surface.actions).toBeUndefined();
+    });
+    expect(surfaceOf(blocks).actions).toBeUndefined();
   });
 
   test("parseAccessRequestPayload extracts typed fields", () => {

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -1,5 +1,7 @@
 // Surface types, UI surface lifecycle messages.
 
+import { z } from "zod";
+
 // === Surface type definitions ===
 
 export type SurfaceType =
@@ -35,16 +37,24 @@ export interface SurfaceAction {
   data?: Record<string, unknown>;
 }
 
-export interface CardSurfaceData {
-  title: string;
-  subtitle?: string;
-  body: string;
-  metadata?: Array<{ label: string; value: string }>;
+/**
+ * Card surface data. Defined as a Zod schema so the type is derived (not
+ * hand-maintained) and the seed-content-block schema can compose it directly
+ * instead of treating card `data` as an opaque record.
+ */
+export const CardSurfaceDataSchema = z.object({
+  title: z.string(),
+  subtitle: z.string().optional(),
+  body: z.string(),
+  metadata: z
+    .array(z.object({ label: z.string(), value: z.string() }))
+    .optional(),
   /** Optional template name for specialized rendering (e.g. "weather_forecast"). */
-  template?: string;
+  template: z.string().optional(),
   /** Arbitrary data consumed by the template renderer. Shape depends on template. */
-  templateData?: Record<string, unknown>;
-}
+  templateData: z.record(z.string(), z.unknown()).optional(),
+});
+export type CardSurfaceData = z.infer<typeof CardSurfaceDataSchema>;
 
 export interface ChoiceOption {
   id: string;

--- a/assistant/src/notifications/approval-card-builder.ts
+++ b/assistant/src/notifications/approval-card-builder.ts
@@ -7,18 +7,73 @@
  * supplies its domain-specific data (title, subtitle, metadata, etc.)
  * without duplicating the card structure or action wiring.
  *
- * The card data shape matches `CardSurfaceData` from
- * `daemon/message-types/surfaces.ts`: `{ title, subtitle, body, metadata }`.
- * Actions use the canonical `apr:<requestId>:<action>` callback format
- * consumed by `surface-action-routes.ts` → `processGuardianDecision`.
+ * The `[ui_surface, text]` block pair is described by {@link ApprovalCardBlockSchema}
+ * so the builder returns a schema-derived type rather than `unknown[]`: the card
+ * `data` composes the canonical {@link CardSurfaceDataSchema} and actions reuse
+ * the canonical {@link SurfaceActionSchema}. Actions use the
+ * `apr:<requestId>:<action>` callback format consumed by
+ * `surface-action-routes.ts` → `processGuardianDecision`.
  */
+
+import { z } from "zod";
+
+import {
+  type SurfaceAction,
+  SurfaceActionSchema,
+} from "../api/events/ui-surface-show.js";
+import {
+  type CardSurfaceData,
+  CardSurfaceDataSchema,
+} from "../daemon/message-types/surfaces.js";
+
+// ── Seed content block schema ─────────────────────────────────────────────────
+
+/**
+ * The interactive `ui_surface` card block clients render via
+ * `SurfaceRouter → CardSurface`. `data` is the canonical card surface data;
+ * `actions` reuse the canonical surface action schema.
+ */
+export const ApprovalCardSurfaceBlockSchema = z.object({
+  type: z.literal("ui_surface"),
+  surfaceId: z.string(),
+  surfaceType: z.literal("card"),
+  title: z.string(),
+  data: CardSurfaceDataSchema,
+  actions: z.array(SurfaceActionSchema).optional(),
+});
+
+/**
+ * The plain-text fallback block, flagged so the display projector
+ * (`renderHistoryContent`) keeps it in flat `.text` but omits it from the
+ * rendered `contentBlocks` — without it a surface-capable client would render
+ * the card AND a duplicate text line.
+ */
+export const ApprovalCardFallbackBlockSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+  _surfaceFallback: z.literal(true),
+});
+
+/** The `[ui_surface, text]` seed block pair produced for a guardian card. */
+export const ApprovalCardBlockSchema = z.discriminatedUnion("type", [
+  ApprovalCardSurfaceBlockSchema,
+  ApprovalCardFallbackBlockSchema,
+]);
+
+export type ApprovalCardSurfaceBlock = z.infer<
+  typeof ApprovalCardSurfaceBlockSchema
+>;
+export type ApprovalCardFallbackBlock = z.infer<
+  typeof ApprovalCardFallbackBlockSchema
+>;
+export type ApprovalCardBlock = z.infer<typeof ApprovalCardBlockSchema>;
 
 // ── Public types ────────────────────────────────────────────────────────────
 
 export interface ApprovalCardParams {
   /** Prefix for `surfaceId` — combined with `requestId` to form e.g. "access-request-abc123". */
   surfaceIdPrefix: string;
-  /** Top-level card title shown in the surface header (e.g. "Access Request", "Tool Approval"). */
+  /** Top-level card title shown in the surface header (e.g. "Access Request", "Tool approval"). */
   cardTitle: string;
   /** Primary line inside the card (typically the requester's display name). */
   requesterName: string;
@@ -43,13 +98,10 @@ export interface ApprovalCardParams {
  * clients that support Surface rendering. The `text` block is the card's
  * plain-text fallback — it feeds the model, search indexing, CLI display, and
  * channel replies, which read it as ordinary text.
- *
- * The fallback block is flagged `_surfaceFallback` so the display projector
- * (`renderHistoryContent`) keeps it in the flat `.text` body but omits it from
- * `contentBlocks`/`textSegments`. Without that, a surface-capable client would
- * render the card AND its fallback text — the duplicate this flag prevents.
  */
-export function buildApprovalCardBlocks(params: ApprovalCardParams): unknown[] {
+export function buildApprovalCardBlocks(
+  params: ApprovalCardParams,
+): ApprovalCardBlock[] {
   const {
     surfaceIdPrefix,
     cardTitle,
@@ -61,7 +113,7 @@ export function buildApprovalCardBlocks(params: ApprovalCardParams): unknown[] {
     fallbackText,
   } = params;
 
-  const actions = requestId
+  const actions: SurfaceAction[] | undefined = requestId
     ? [
         {
           id: `apr:${requestId}:approve_once`,
@@ -76,27 +128,25 @@ export function buildApprovalCardBlocks(params: ApprovalCardParams): unknown[] {
       ]
     : undefined;
 
-  const surfaceBlock = {
-    type: "ui_surface" as const,
+  const data: CardSurfaceData = {
+    title: requesterName,
+    subtitle,
+    body,
+    metadata,
+  };
+
+  const surfaceBlock: ApprovalCardSurfaceBlock = {
+    type: "ui_surface",
     surfaceId: `${surfaceIdPrefix}-${requestId ?? "unknown"}`,
-    surfaceType: "card" as const,
+    surfaceType: "card",
     title: cardTitle,
-    data: {
-      title: requesterName,
-      subtitle,
-      body,
-      metadata,
-    },
+    data,
     ...(actions ? { actions } : {}),
   };
 
-  const textBlock = {
-    type: "text" as const,
+  const textBlock: ApprovalCardFallbackBlock = {
+    type: "text",
     text: fallbackText,
-    // Display-only hint: surface-capable clients render the card from
-    // `surfaceBlock` and must skip this block (see `renderHistoryContent`), or
-    // they show the card and a duplicate text line. Non-display consumers
-    // (model, search, CLI `.text`) read it as ordinary text.
     _surfaceFallback: true,
   };
 

--- a/assistant/src/notifications/approval-card-data.ts
+++ b/assistant/src/notifications/approval-card-data.ts
@@ -19,6 +19,7 @@ import {
   parseAccessRequestPayload,
 } from "./access-request-copy.js";
 import {
+  type ApprovalCardBlock,
   type ApprovalCardParams,
   buildApprovalCardBlocks,
 } from "./approval-card-builder.js";
@@ -285,7 +286,9 @@ export function resolveApprovalCardData(
 }
 
 /** Render resolved approval card data into Surface `[ui_surface, text]` blocks. */
-export function renderApprovalCardData(data: ApprovalCardData): unknown[] {
+export function renderApprovalCardData(
+  data: ApprovalCardData,
+): ApprovalCardBlock[] {
   return buildApprovalCardBlocks(data.card);
 }
 
@@ -300,7 +303,7 @@ export function renderApprovalCardData(data: ApprovalCardData): unknown[] {
  */
 export function buildAccessRequestSeedContentBlocks(
   payload: Record<string, unknown>,
-): unknown[] {
+): ApprovalCardBlock[] {
   return renderApprovalCardData({
     kind: "access_request",
     card: resolveAccessRequestCard(payload),
@@ -318,13 +321,13 @@ export function buildAccessRequestSeedContentBlocks(
  */
 export function buildToolApprovalSeedContentBlocks(
   payload: GuardianQuestionPayload,
-): unknown[] | null;
+): ApprovalCardBlock[] | null;
 export function buildToolApprovalSeedContentBlocks(
   payload: Record<string, unknown>,
-): unknown[] | null;
+): ApprovalCardBlock[] | null;
 export function buildToolApprovalSeedContentBlocks(
   payload: GuardianQuestionPayload | Record<string, unknown>,
-): unknown[] | null {
+): ApprovalCardBlock[] | null {
   const data = resolveApprovalCardData(
     "guardian.question",
     payload as Record<string, unknown>,


### PR DESCRIPTION
## What & why

The shared guardian approval-card builder returned `unknown[]` and constructed loose object literals, so every consumer and test had to cast (`as Record<string, unknown>`, `as Array<…>`). This schema-derives the seed content blocks so they're typed end to end — no handwritten block type, no `unknown[]`, no casts.

This is a **prerequisite** extracted ahead of LUM-2529 (tool-approval card reframe, #35698), which will rebase onto this branch so its builder and tests consume the same schema-derived type.

## Changes

- **`CardSurfaceData` → Zod schema.** `CardSurfaceDataSchema` + `type CardSurfaceData = z.infer<…>` in `daemon/message-types/surfaces.ts` — the card data shape is now derived from one source instead of a hand-maintained interface (consumers are structurally unchanged).
- **`ApprovalCardBlockSchema`** (the `[ui_surface, text]` seed pair) in `approval-card-builder.ts`:
  - `data` composes the canonical `CardSurfaceDataSchema` (not an opaque `Record<string, unknown>`).
  - `actions` reuse the **generated** `SurfaceActionSchema` from `api/events/ui-surface-show.ts`.
  - `ApprovalCardBlock = z.infer<…>` exported.
- **`buildApprovalCardBlocks` / `renderApprovalCardData` / the seed builders** now return `ApprovalCardBlock[]` — the `unknown[]` returns and `as const` assertions are gone; construction is checked against the schema-derived types.
- **Access-request seed test** rewritten to narrow by the block discriminant instead of casting to `Record<string, unknown>`.

## Verification

- `tsc --noEmit` clean; eslint clean; no new import cycle (`lint:circular`).
- `access-request-seed-content-blocks` (16), `tool-approval-seed-content-blocks` (18), `slack-notification-approval-card` (10), `deterministic-checks` (17) all pass.

## Scope note

The *wire* surface schemas (`UISurfaceShowEventSchema`, `ConversationSurfaceBlock`) intentionally keep `data` opaque (`z.record`) because it varies across 14 surface types — that's a deliberate convention and out of scope here. This PR only schema-derives the **seed/stored** approval-card blocks the builder produces. Converting the full `SurfaceData` union to Zod is a larger follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YR1eM2jvwurYnnpqV2NetY)_