### PR TITLE
feat(gateway-client): add TrustVerdict contract + optional sourceMetadata field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3959,6 +3959,59 @@ paths:
                         - trusted_contacts
                         - any_contact
                         - strangers
+                    trustVerdict:
+                      type: object
+                      properties:
+                        trustClass:
+                          type: string
+                          enum:
+                            - guardian
+                            - trusted_contact
+                            - unverified_contact
+                            - unknown
+                        canonicalSenderId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        guardianExternalUserId:
+                          type: string
+                        guardianDeliveryChatId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        guardianPrincipalId:
+                          type: string
+                        guardianDisplayName:
+                          type: string
+                        contactId:
+                          type: string
+                        channelId:
+                          type: string
+                        type:
+                          type: string
+                        address:
+                          type: string
+                        externalChatId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        status:
+                          type: string
+                        policy:
+                          type: string
+                        verifiedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        verifiedVia:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        memberDisplayName:
+                          type: string
+                      required:
+                        - trustClass
+                        - canonicalSenderId
                     emailSubject:
                       type: string
                     emailRecipient:

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -36,7 +36,10 @@ describe("TrustVerdictSchema", () => {
   });
 
   test("parses a minimal verdict", () => {
-    const minimal = { trustClass: "unknown", canonicalSenderId: null };
+    const minimal = {
+      trustClass: "unknown",
+      canonicalSenderId: null,
+    } satisfies TrustVerdict;
     expect(TrustVerdictSchema.parse(minimal)).toEqual(minimal);
   });
 

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the shared trust verdict contract and its optional placement on
+ * the inbound payload's sourceMetadata.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { SourceMetadataSchema } from "../inbound-contract.js";
+import {
+  TrustVerdictSchema,
+  type TrustVerdict,
+} from "../trust-verdict-contract.js";
+
+const fullVerdict: TrustVerdict = {
+  trustClass: "trusted_contact",
+  canonicalSenderId: "+15555550100",
+  guardianExternalUserId: "g-ext-1",
+  guardianDeliveryChatId: "chat-1",
+  guardianPrincipalId: "g-principal-1",
+  guardianDisplayName: "Guardian Name",
+  contactId: "c1",
+  channelId: "ch1",
+  type: "imessage",
+  address: "+15555550100",
+  externalChatId: "ext-chat-1",
+  status: "active",
+  policy: "allow",
+  verifiedAt: 1699999999,
+  verifiedVia: "voice",
+  memberDisplayName: "Member Name",
+};
+
+describe("TrustVerdictSchema", () => {
+  test("round-trips a fully-populated verdict", () => {
+    expect(TrustVerdictSchema.parse(fullVerdict)).toEqual(fullVerdict);
+  });
+
+  test("parses a minimal verdict", () => {
+    const minimal = { trustClass: "unknown", canonicalSenderId: null };
+    expect(TrustVerdictSchema.parse(minimal)).toEqual(minimal);
+  });
+
+  test("rejects an invalid trustClass", () => {
+    expect(() =>
+      TrustVerdictSchema.parse({
+        trustClass: "definitely_not_a_class",
+        canonicalSenderId: null,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("SourceMetadataSchema trustVerdict back-compat", () => {
+  test("parses an empty payload (no trustVerdict)", () => {
+    expect(SourceMetadataSchema.parse({})).toEqual({});
+  });
+
+  test("round-trips a payload carrying trustVerdict", () => {
+    const parsed = SourceMetadataSchema.parse({ trustVerdict: fullVerdict });
+    expect(parsed.trustVerdict).toEqual(fullVerdict);
+  });
+});

--- a/packages/gateway-client/src/inbound-contract.ts
+++ b/packages/gateway-client/src/inbound-contract.ts
@@ -13,6 +13,7 @@
 import { z } from "zod";
 
 import { AdmissionPolicySchema } from "./admission-policy-contract.js";
+import { TrustVerdictSchema } from "./trust-verdict-contract.js";
 
 // ---------------------------------------------------------------------------
 // Command intent (channel-initiated commands, e.g. Telegram /start)
@@ -76,6 +77,13 @@ export const SourceMetadataSchema = z
      * `ADMISSION_POLICY_DEFAULT` (`trusted_contacts`).
      */
     admissionPolicy: AdmissionPolicySchema.optional(),
+
+    /**
+     * Per-actor trust verdict resolved by the gateway from its ACL DB;
+     * absent until the gateway stamps it. Consumers must treat absence as
+     * "not provided", never as a decision.
+     */
+    trustVerdict: TrustVerdictSchema.optional(),
 
     // Email-specific fields
     /** Email subject line. */

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -70,3 +70,12 @@ export {
 } from "./admission-policy-contract.js";
 
 export type { AdmissionPolicy } from "./admission-policy-contract.js";
+
+// Trust verdict contract (gateway → daemon) — Zod schemas + derived types
+export {
+  TRUST_CLASS_VALUES,
+  TrustClassSchema,
+  TrustVerdictSchema,
+} from "./trust-verdict-contract.js";
+
+export type { TrustClass, TrustVerdict } from "./trust-verdict-contract.js";

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared per-actor trust verdict carried on the gateway→runtime wire.
+ *
+ * The gateway resolves this verdict from its ACL DB and stamps it onto the
+ * inbound payload's `sourceMetadata`; the runtime consumes it. Keeping the
+ * type here avoids the runtime importing from `gateway/src` and lets the
+ * daemon's `trustClass` union (`actor-trust-resolver.ts`) converge on this
+ * one source of truth.
+ *
+ * This contract carries ACL + identity keys + minimal labels only — never
+ * info fields (notes, userFile, contactType). `status` / `policy` / `type`
+ * stay loose `z.string()` to match the gateway schema columns and avoid
+ * coupling to a still-evolving status vocabulary; the consumer interprets
+ * them.
+ */
+
+import { z } from "zod";
+
+/**
+ * Verification-purpose trust classification. Mirrors the daemon's
+ * `TrustClass` union (`actor-trust-resolver.ts`), ordered most- to
+ * least-trusted.
+ */
+export const TRUST_CLASS_VALUES = [
+  "guardian",
+  "trusted_contact",
+  "unverified_contact",
+  "unknown",
+] as const;
+
+export const TrustClassSchema = z.enum(TRUST_CLASS_VALUES);
+
+export type TrustClass = (typeof TRUST_CLASS_VALUES)[number];
+
+/**
+ * Per-actor trust verdict resolved by the gateway from its ACL DB. ACL +
+ * identity keys + minimal labels only. Guardian binding and member
+ * identity/ACL fields are optional — present only when the corresponding
+ * record resolves.
+ */
+export const TrustVerdictSchema = z.object({
+  trustClass: TrustClassSchema,
+  canonicalSenderId: z.string().nullable(),
+
+  // Guardian binding — present only when a guardian binding matches.
+  guardianExternalUserId: z.string().optional(),
+  guardianDeliveryChatId: z.string().nullable().optional(),
+  guardianPrincipalId: z.string().optional(),
+  guardianDisplayName: z.string().optional(),
+
+  // Member identity + ACL — present only when a member channel resolves.
+  contactId: z.string().optional(),
+  channelId: z.string().optional(),
+  type: z.string().optional(),
+  address: z.string().optional(),
+  externalChatId: z.string().nullable().optional(),
+  status: z.string().optional(),
+  policy: z.string().optional(),
+  verifiedAt: z.number().nullable().optional(),
+  verifiedVia: z.string().nullable().optional(),
+  memberDisplayName: z.string().optional(),
+});
+
+export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;


### PR DESCRIPTION
## Summary
- Add shared TrustVerdictSchema/TrustClassSchema (+ types) in gateway-client
- Stamp slot: optional trustVerdict field on SourceMetadataSchema (back-compatible)
- Contract-only — no producer/consumer yet

Part of plan: gateway-produces-trust-verdict.md (PR 1 of 4)