### PR TITLE
Add local runtime upgrade banner

### DIFF
--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -50,7 +50,7 @@ export function LocalRuntimeUpgradeBanner({
       : null,
   );
   const effectiveCurrentVersion =
-    currentVersion ?? activeAssistant?.runtimeVersion ?? null;
+    activeAssistant?.runtimeVersion ?? currentVersion ?? null;
   const isBunLocalAssistant = activeAssistant?.cloud === "local";
   const canUpgradeActiveBunLocalAssistant =
     isBunLocalAssistant && activeAssistant?.isActiveLockfileAssistant === true;

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -3,7 +3,10 @@ import { Loader2, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
-import { StatusBannerNotice } from "@/components/status-banner";
+import {
+  StatusBannerNotice,
+  type StatusBannerPlacement,
+} from "@/components/status-banner";
 import { releasesListOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { useLocalRuntimeUpgrade } from "@/hooks/use-local-runtime-upgrade";
 import { subscribe } from "@/lib/event-bus";
@@ -15,23 +18,32 @@ import {
   LOCAL_RUNTIME_RELEASES_REFETCH_INTERVAL_MS,
 } from "@/lib/local-runtime-upgrade";
 import { isLocalModeHostAvailable } from "@/runtime/local-mode-host";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
 
 interface LocalRuntimeUpgradeBannerProps {
-  assistantId: string | null;
-  currentVersion: string | null;
+  assistantId?: string | null;
+  currentVersion?: string | null;
+  placement?: StatusBannerPlacement;
+  className?: string;
 }
 
 export function LocalRuntimeUpgradeBanner({
-  assistantId,
-  currentVersion,
+  assistantId: assistantIdProp,
+  currentVersion: currentVersionProp,
+  placement = "web",
+  className,
 }: LocalRuntimeUpgradeBannerProps) {
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [dismissedScope, setDismissedScope] = useState<string | null>(null);
   const assistantState = useAssistantLifecycleStore((s) => s.assistantState);
+  const fallbackAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const fallbackCurrentVersion = useAssistantIdentityStore.use.version();
+  const assistantId = assistantIdProp ?? fallbackAssistantId;
+  const currentVersion = currentVersionProp ?? fallbackCurrentVersion;
   const activeAssistant = useResolvedAssistantsStore((s) =>
     assistantId
       ? s.assistants.find((assistant) => assistant.id === assistantId)
@@ -148,6 +160,8 @@ export function LocalRuntimeUpgradeBanner({
       <StatusBannerNotice
         tone="info"
         title={`Assistant runtime ${targetVersion} is ready`}
+        placement={placement}
+        className={className}
         icon={
           upgrade.isPending ? (
             <Loader2 className="animate-spin" aria-hidden="true" />

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -159,7 +159,7 @@ export function LocalRuntimeUpgradeBanner({
     <>
       <StatusBannerNotice
         tone="info"
-        title={`Assistant runtime ${targetVersion} is ready`}
+        title={`New assistant version available: ${targetVersion}`}
         placement={placement}
         className={className}
         icon={
@@ -189,9 +189,7 @@ export function LocalRuntimeUpgradeBanner({
             </Button>
           </>
         }
-      >
-        Updates assistant, gateway, and CES from the stable release feed.
-      </StatusBannerNotice>
+      />
       <ConfirmDialog
         open={showConfirmation}
         title="Update assistant runtime"

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -15,6 +15,7 @@ import {
   getLatestRuntimeRelease,
   isLocalRuntimeUpgradeDismissed,
   isRuntimeUpgradeAvailable,
+  LOCAL_RUNTIME_RELEASES_FETCH_LIMIT,
   LOCAL_RUNTIME_RELEASES_REFETCH_INTERVAL_MS,
 } from "@/lib/local-runtime-upgrade";
 import { isLocalModeHostAvailable } from "@/runtime/local-mode-host";
@@ -72,7 +73,7 @@ export function LocalRuntimeUpgradeBanner({
 
   const { data: releases, refetch: refetchReleases } = useQuery({
     ...releasesListOptions({
-      query: { channel: "stable" },
+      query: { stable: true, limit: LOCAL_RUNTIME_RELEASES_FETCH_LIMIT },
     }),
     enabled: shouldCheck,
     refetchInterval: LOCAL_RUNTIME_RELEASES_REFETCH_INTERVAL_MS,

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -37,8 +37,9 @@ export function LocalRuntimeUpgradeBanner({
       ? s.assistants.find((assistant) => assistant.id === assistantId)
       : null,
   );
-  const isActiveLocalAssistant =
-    assistantState.kind === "active" && assistantState.isLocal;
+  const isLocalRuntimeState =
+    assistantState.kind === "self_hosted" ||
+    (assistantState.kind === "active" && assistantState.isLocal);
   const isUpgrading =
     (assistantState.kind === "active" ||
       assistantState.kind === "self_hosted") &&
@@ -47,7 +48,7 @@ export function LocalRuntimeUpgradeBanner({
     !!assistantId &&
     !!currentVersion &&
     !!activeAssistant?.isLocal &&
-    isActiveLocalAssistant &&
+    isLocalRuntimeState &&
     isLocalModeHostAvailable();
 
   const { data: releases, refetch: refetchReleases } = useQuery({

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -20,6 +20,7 @@ import {
 import { isLocalModeHostAvailable } from "@/runtime/local-mode-host";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { cn } from "@/utils/misc";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -157,39 +158,45 @@ export function LocalRuntimeUpgradeBanner({
 
   return (
     <>
-      <StatusBannerNotice
-        tone="info"
-        title={`New assistant version available: ${targetVersion}`}
-        placement={placement}
-        className={className}
-        icon={
-          upgrade.isPending ? (
-            <Loader2 className="animate-spin" aria-hidden="true" />
-          ) : (
-            <RefreshCw aria-hidden="true" />
-          )
-        }
-        actions={
-          <>
-            <Button
-              variant="ghost"
-              size="compact"
-              onClick={() => setShowConfirmation(true)}
-              disabled={upgrade.isPending}
-            >
-              Update
-            </Button>
-            <Button
-              variant="ghost"
-              size="compact"
-              onClick={handleDismiss}
-              disabled={upgrade.isPending}
-            >
-              Later
-            </Button>
-          </>
-        }
-      />
+      <div
+        className={cn(
+          placement === "electron" ? "px-4 pt-2" : "px-0 pt-0",
+          className,
+        )}
+      >
+        <StatusBannerNotice
+          tone="info"
+          title={`New assistant version available: ${targetVersion}`}
+          placement={placement}
+          icon={
+            upgrade.isPending ? (
+              <Loader2 className="animate-spin" aria-hidden="true" />
+            ) : (
+              <RefreshCw aria-hidden="true" />
+            )
+          }
+          actions={
+            <>
+              <Button
+                variant="ghost"
+                size="compact"
+                onClick={() => setShowConfirmation(true)}
+                disabled={upgrade.isPending}
+              >
+                Update
+              </Button>
+              <Button
+                variant="ghost"
+                size="compact"
+                onClick={handleDismiss}
+                disabled={upgrade.isPending}
+              >
+                Later
+              </Button>
+            </>
+          }
+        />
+      </div>
       <ConfirmDialog
         open={showConfirmation}
         title="Update assistant runtime"

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -37,6 +37,8 @@ export function LocalRuntimeUpgradeBanner({
       ? s.assistants.find((assistant) => assistant.id === assistantId)
       : null,
   );
+  const effectiveCurrentVersion =
+    currentVersion ?? activeAssistant?.runtimeVersion ?? null;
   const isHealthyLocalRuntimeState =
     assistantState.kind === "self_hosted"
       ? !assistantState.health || assistantState.health === "healthy"
@@ -46,7 +48,7 @@ export function LocalRuntimeUpgradeBanner({
         : false;
   const shouldCheck =
     !!assistantId &&
-    !!currentVersion &&
+    !!effectiveCurrentVersion &&
     !!activeAssistant?.isLocal &&
     isHealthyLocalRuntimeState &&
     isLocalModeHostAvailable();
@@ -84,7 +86,7 @@ export function LocalRuntimeUpgradeBanner({
   const dismissalScope =
     assistantId && targetVersion ? `${assistantId}:${targetVersion}` : null;
   const upgradeAvailable = isRuntimeUpgradeAvailable(
-    currentVersion,
+    effectiveCurrentVersion,
     targetVersion,
   );
   const upgrade = useLocalRuntimeUpgrade({

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -1,0 +1,185 @@
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, RefreshCw } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { StatusBannerNotice } from "@/components/status-banner";
+import { releasesListOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { useLocalRuntimeUpgrade } from "@/hooks/use-local-runtime-upgrade";
+import { subscribe } from "@/lib/event-bus";
+import {
+  dismissLocalRuntimeUpgrade,
+  getLatestRuntimeRelease,
+  isLocalRuntimeUpgradeDismissed,
+  isRuntimeUpgradeAvailable,
+  LOCAL_RUNTIME_RELEASES_REFETCH_INTERVAL_MS,
+} from "@/lib/local-runtime-upgrade";
+import { isLocalModeHostAvailable } from "@/runtime/local-mode-host";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { toast } from "@vellumai/design-library/components/toast";
+
+interface LocalRuntimeUpgradeBannerProps {
+  assistantId: string | null;
+  currentVersion: string | null;
+}
+
+export function LocalRuntimeUpgradeBanner({
+  assistantId,
+  currentVersion,
+}: LocalRuntimeUpgradeBannerProps) {
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const [dismissedScope, setDismissedScope] = useState<string | null>(null);
+  const assistantState = useAssistantLifecycleStore((s) => s.assistantState);
+  const activeAssistant = useResolvedAssistantsStore((s) =>
+    assistantId
+      ? s.assistants.find((assistant) => assistant.id === assistantId)
+      : null,
+  );
+  const isActiveLocalAssistant =
+    assistantState.kind === "active" && assistantState.isLocal;
+  const isUpgrading =
+    (assistantState.kind === "active" ||
+      assistantState.kind === "self_hosted") &&
+    assistantState.health === "upgrading";
+  const shouldCheck =
+    !!assistantId &&
+    !!currentVersion &&
+    !!activeAssistant?.isLocal &&
+    isActiveLocalAssistant &&
+    isLocalModeHostAvailable();
+
+  const { data: releases, refetch: refetchReleases } = useQuery({
+    ...releasesListOptions({
+      query: { channel: "stable" },
+    }),
+    enabled: shouldCheck,
+    refetchInterval: LOCAL_RUNTIME_RELEASES_REFETCH_INTERVAL_MS,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+  });
+
+  useEffect(() => {
+    if (!shouldCheck) return;
+    const refetch = () => {
+      void refetchReleases();
+    };
+    const unsubscribers = [
+      subscribe("app.resume", refetch),
+      subscribe("power.resume", refetch),
+      subscribe("power.unlock", refetch),
+    ];
+    return () => {
+      for (const unsubscribe of unsubscribers) unsubscribe();
+    };
+  }, [refetchReleases, shouldCheck]);
+
+  const latestRelease = useMemo(
+    () => getLatestRuntimeRelease(releases),
+    [releases],
+  );
+  const targetVersion = latestRelease?.version ?? null;
+  const dismissalScope =
+    assistantId && targetVersion ? `${assistantId}:${targetVersion}` : null;
+  const upgradeAvailable = isRuntimeUpgradeAvailable(
+    currentVersion,
+    targetVersion,
+  );
+  const upgrade = useLocalRuntimeUpgrade({
+    assistantId,
+    targetVersion: targetVersion ?? undefined,
+  });
+
+  useEffect(() => {
+    if (!assistantId || !targetVersion) {
+      setDismissedScope(null);
+      return;
+    }
+    setDismissedScope(
+      isLocalRuntimeUpgradeDismissed(assistantId, targetVersion)
+        ? `${assistantId}:${targetVersion}`
+        : null,
+    );
+  }, [assistantId, targetVersion]);
+
+  const dismissed = dismissalScope !== null && dismissalScope === dismissedScope;
+
+  const handleConfirmUpgrade = async () => {
+    if (!assistantId || !targetVersion) return;
+    setShowConfirmation(false);
+    try {
+      await upgrade.upgrade();
+      toast.success("Update complete — assistant is healthy.");
+      setDismissedScope(`${assistantId}:${targetVersion}`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to trigger update. Please try again.",
+      );
+    }
+  };
+
+  const handleDismiss = () => {
+    if (!assistantId || !targetVersion) return;
+    dismissLocalRuntimeUpgrade(assistantId, targetVersion);
+    setDismissedScope(`${assistantId}:${targetVersion}`);
+  };
+
+  if (
+    !shouldCheck ||
+    !targetVersion ||
+    !upgradeAvailable ||
+    dismissed ||
+    isUpgrading
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <StatusBannerNotice
+        tone="info"
+        title={`Assistant runtime ${targetVersion} is ready`}
+        icon={
+          upgrade.isPending ? (
+            <Loader2 className="animate-spin" aria-hidden="true" />
+          ) : (
+            <RefreshCw aria-hidden="true" />
+          )
+        }
+        actions={
+          <>
+            <Button
+              variant="ghost"
+              size="compact"
+              onClick={() => setShowConfirmation(true)}
+              disabled={upgrade.isPending}
+            >
+              Update
+            </Button>
+            <Button
+              variant="ghost"
+              size="compact"
+              onClick={handleDismiss}
+              disabled={upgrade.isPending}
+            >
+              Later
+            </Button>
+          </>
+        }
+      >
+        Updates assistant, gateway, and CES from the stable release feed.
+      </StatusBannerNotice>
+      <ConfirmDialog
+        open={showConfirmation}
+        title="Update assistant runtime"
+        message={`Update to version ${targetVersion}? The assistant will be briefly unavailable while the assistant, gateway, and CES restart.`}
+        confirmLabel="Update"
+        onConfirm={handleConfirmUpgrade}
+        onCancel={() => setShowConfirmation(false)}
+      />
+    </>
+  );
+}

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -39,6 +39,9 @@ export function LocalRuntimeUpgradeBanner({
   );
   const effectiveCurrentVersion =
     currentVersion ?? activeAssistant?.runtimeVersion ?? null;
+  const isBunLocalAssistant = activeAssistant?.cloud === "local";
+  const canUpgradeActiveBunLocalAssistant =
+    isBunLocalAssistant && activeAssistant?.isActiveLockfileAssistant === true;
   const isHealthyLocalRuntimeState =
     assistantState.kind === "self_hosted"
       ? !assistantState.health || assistantState.health === "healthy"
@@ -50,6 +53,7 @@ export function LocalRuntimeUpgradeBanner({
     !!assistantId &&
     !!effectiveCurrentVersion &&
     !!activeAssistant?.isLocal &&
+    canUpgradeActiveBunLocalAssistant &&
     isHealthyLocalRuntimeState &&
     isLocalModeHostAvailable();
 

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -186,6 +186,10 @@ export function LocalRuntimeUpgradeBanner({
               >
                 Update
               </Button>
+              <span
+                aria-hidden="true"
+                className="h-3 w-px bg-[color-mix(in_srgb,var(--status-banner-action-color)_35%,transparent)]"
+              />
               <Button
                 variant="ghost"
                 size="compact"

--- a/clients/web/src/components/local-runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/local-runtime-upgrade-banner.tsx
@@ -37,18 +37,18 @@ export function LocalRuntimeUpgradeBanner({
       ? s.assistants.find((assistant) => assistant.id === assistantId)
       : null,
   );
-  const isLocalRuntimeState =
-    assistantState.kind === "self_hosted" ||
-    (assistantState.kind === "active" && assistantState.isLocal);
-  const isUpgrading =
-    (assistantState.kind === "active" ||
-      assistantState.kind === "self_hosted") &&
-    assistantState.health === "upgrading";
+  const isHealthyLocalRuntimeState =
+    assistantState.kind === "self_hosted"
+      ? !assistantState.health || assistantState.health === "healthy"
+      : assistantState.kind === "active" && assistantState.isLocal
+        ? assistantState.reachable !== false &&
+          (!assistantState.health || assistantState.health === "healthy")
+        : false;
   const shouldCheck =
     !!assistantId &&
     !!currentVersion &&
     !!activeAssistant?.isLocal &&
-    isLocalRuntimeState &&
+    isHealthyLocalRuntimeState &&
     isLocalModeHostAvailable();
 
   const { data: releases, refetch: refetchReleases } = useQuery({
@@ -132,8 +132,7 @@ export function LocalRuntimeUpgradeBanner({
     !shouldCheck ||
     !targetVersion ||
     !upgradeAvailable ||
-    dismissed ||
-    isUpgrading
+    dismissed
   ) {
     return null;
   }

--- a/clients/web/src/components/sidebar-shell.tsx
+++ b/clients/web/src/components/sidebar-shell.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useCallback, useRef } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { Button, Typography } from "@vellumai/design-library";
 
+import { LocalRuntimeUpgradeBanner } from "@/components/local-runtime-upgrade-banner";
 import { StatusBanner } from "@/components/status-banner";
 import { useEdgeSwipeBack } from "@/hooks/use-edge-swipe-back";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -116,8 +117,12 @@ export function SidebarShell({
       </div>
 
       {electron ? (
-        <div className="shrink-0 pb-4 empty:hidden">
+        <div className="flex shrink-0 flex-col gap-2 pb-4 empty:hidden">
           <StatusBanner placement="electron" className="px-0 pt-0" />
+          <LocalRuntimeUpgradeBanner
+            placement="electron"
+            className="px-0 pt-0"
+          />
         </div>
       ) : null}
 

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -53,6 +53,7 @@ import type { Conversation } from "@/types/conversation-types";
 import { requestComposerFocus } from "./composer-focus";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
+import { LocalRuntimeUpgradeBanner } from "@/components/local-runtime-upgrade-banner";
 import { StatusBanner } from "@/components/status-banner";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
@@ -615,7 +616,16 @@ export function ChatLayout() {
         />
       )}
 
-      {!isPopout && electron ? <StatusBanner placement="electron" /> : null}
+      {!isPopout && electron ? (
+        <div className="flex shrink-0 flex-col gap-2 empty:hidden">
+          <StatusBanner placement="electron" />
+          <LocalRuntimeUpgradeBanner
+            assistantId={assistantId}
+            currentVersion={assistantVersion}
+            placement="electron"
+          />
+        </div>
+      ) : null}
 
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">

--- a/clients/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/clients/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -19,6 +19,7 @@ import { useLocalRuntimeUpgrade } from "@/hooks/use-local-runtime-upgrade";
 import {
   getLatestRuntimeRelease,
   isRuntimeUpgradeAvailable,
+  LOCAL_RUNTIME_RELEASES_FETCH_LIMIT,
 } from "@/lib/local-runtime-upgrade";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
@@ -380,7 +381,7 @@ export function LocalAssistantUpgrades({
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const { data: releases, isLoading: releasesLoading } = useQuery(
     releasesListOptions({
-      query: { channel: "stable" },
+      query: { stable: true, limit: LOCAL_RUNTIME_RELEASES_FETCH_LIMIT },
     }),
   );
 

--- a/clients/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/clients/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -15,11 +15,12 @@ import type {
   ReleaseChannelEnum,
   ReleaseListItem,
 } from "@/generated/api/types.gen";
-import { lifecycleService } from "@/assistant/lifecycle-service";
-import { clearGatewayToken } from "@/lib/auth/gateway-session";
-import { upgradeLocalAssistantHost } from "@/runtime/local-mode-host";
+import { useLocalRuntimeUpgrade } from "@/hooks/use-local-runtime-upgrade";
+import {
+  getLatestRuntimeRelease,
+  isRuntimeUpgradeAvailable,
+} from "@/lib/local-runtime-upgrade";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { compareParsed, parseSemver } from "@/utils/semver";
 import { Button } from "@vellumai/design-library/components/button";
@@ -37,11 +38,6 @@ function releaseLabel(
   if (currentVersion && release.version === currentVersion)
     parts.push("(current)");
   return parts.join(" ");
-}
-
-function isLocalBuildVersion(version: string | null | undefined): boolean {
-  const parsed = version ? parseSemver(version) : null;
-  return parsed?.pre?.split(".")[0] === "local";
 }
 
 const POLL_INTERVAL_MS = 3000;
@@ -388,46 +384,21 @@ export function LocalAssistantUpgrades({
     }),
   );
 
-  const runtimeReleases = useMemo(
-    () => releases?.filter((r) => !isLocalBuildVersion(r.version)) ?? [],
+  const latestRelease = useMemo(
+    () => getLatestRuntimeRelease(releases),
     [releases],
   );
-  const latestRelease =
-    runtimeReleases.find((r) => r.is_stable !== false) ?? runtimeReleases[0];
   const targetVersion = latestRelease?.version;
-  const upgradeAvailable = useMemo(() => {
-    if (!targetVersion) return false;
-    if (!currentVersion) return true;
-    const target = parseSemver(targetVersion);
-    const current = parseSemver(currentVersion);
-    if (!target || !current) return targetVersion !== currentVersion;
-    return compareParsed(target, current) > 0;
-  }, [currentVersion, targetVersion]);
-
-  const upgradeCreate = useMutation({
-    mutationFn: async () => {
-      lifecycleService.setLocalAssistantUpgradeInProgress(assistantId, true);
-      try {
-        const result = await upgradeLocalAssistantHost(assistantId, {
-          ...(targetVersion ? { version: targetVersion } : { latest: true }),
-        });
-        if (!result.ok) {
-          throw new Error(result.error ?? "Failed to trigger update.");
-        }
-        return result;
-      } finally {
-        lifecycleService.setLocalAssistantUpgradeInProgress(assistantId, false);
-      }
-    },
-  });
+  const upgradeAvailable = !currentVersion
+    ? !!targetVersion
+    : isRuntimeUpgradeAvailable(currentVersion, targetVersion);
+  const upgradeCreate = useLocalRuntimeUpgrade({ assistantId, targetVersion });
 
   const handleUpgrade = async () => {
     setShowConfirmation(false);
     setSuccessMessage(null);
     try {
-      const result = await upgradeCreate.mutateAsync();
-      clearGatewayToken();
-      await useAuthStore.getState().connectLocalAssistant(assistantId);
+      const result = await upgradeCreate.upgrade();
       setSuccessMessage(
         result.version
           ? `Successfully updated to version ${result.version}.`

--- a/clients/web/src/hooks/use-local-runtime-upgrade.ts
+++ b/clients/web/src/hooks/use-local-runtime-upgrade.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
+import { loadLockfile } from "@/lib/local-mode";
 import { upgradeLocalAssistantHost } from "@/runtime/local-mode-host";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -41,6 +42,7 @@ export function useLocalRuntimeUpgrade({
         throw new Error("No local assistant is active.");
       }
       const result = await mutation.mutateAsync();
+      await loadLockfile();
       clearGatewayToken();
       await useAuthStore.getState().connectLocalAssistant(assistantId);
       return result;

--- a/clients/web/src/hooks/use-local-runtime-upgrade.ts
+++ b/clients/web/src/hooks/use-local-runtime-upgrade.ts
@@ -1,0 +1,49 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { lifecycleService } from "@/assistant/lifecycle-service";
+import { clearGatewayToken } from "@/lib/auth/gateway-session";
+import { upgradeLocalAssistantHost } from "@/runtime/local-mode-host";
+import { useAuthStore } from "@/stores/auth-store";
+
+interface UseLocalRuntimeUpgradeOptions {
+  assistantId: string | null;
+  targetVersion?: string;
+}
+
+export function useLocalRuntimeUpgrade({
+  assistantId,
+  targetVersion,
+}: UseLocalRuntimeUpgradeOptions) {
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!assistantId) {
+        throw new Error("No local assistant is active.");
+      }
+      lifecycleService.setLocalAssistantUpgradeInProgress(assistantId, true);
+      try {
+        const result = await upgradeLocalAssistantHost(assistantId, {
+          ...(targetVersion ? { version: targetVersion } : { latest: true }),
+        });
+        if (!result.ok) {
+          throw new Error(result.error ?? "Failed to trigger update.");
+        }
+        return result;
+      } finally {
+        lifecycleService.setLocalAssistantUpgradeInProgress(assistantId, false);
+      }
+    },
+  });
+
+  return {
+    ...mutation,
+    upgrade: async () => {
+      if (!assistantId) {
+        throw new Error("No local assistant is active.");
+      }
+      const result = await mutation.mutateAsync();
+      clearGatewayToken();
+      await useAuthStore.getState().connectLocalAssistant(assistantId);
+      return result;
+    },
+  };
+}

--- a/clients/web/src/lib/local-runtime-upgrade.ts
+++ b/clients/web/src/lib/local-runtime-upgrade.ts
@@ -1,0 +1,54 @@
+import type { ReleaseListItem } from "@/generated/api/types.gen";
+import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
+import { compareParsed, parseSemver } from "@/utils/semver";
+
+export const LOCAL_RUNTIME_RELEASES_REFETCH_INTERVAL_MS = 20 * 60 * 1000;
+
+const DISMISSED_KEY_PREFIX = "vellum:localRuntimeUpgradeDismissed";
+
+export function isLocalBuildVersion(
+  version: string | null | undefined,
+): boolean {
+  const parsed = version ? parseSemver(version) : null;
+  return parsed?.pre?.split(".")[0] === "local";
+}
+
+export function getLatestRuntimeRelease(
+  releases: ReleaseListItem[] | undefined,
+): ReleaseListItem | undefined {
+  const runtimeReleases =
+    releases?.filter((release) => !isLocalBuildVersion(release.version)) ?? [];
+  return (
+    runtimeReleases.find((release) => release.is_stable !== false) ??
+    runtimeReleases[0]
+  );
+}
+
+export function isRuntimeUpgradeAvailable(
+  currentVersion: string | null | undefined,
+  targetVersion: string | null | undefined,
+): boolean {
+  if (!currentVersion || !targetVersion) return false;
+  const target = parseSemver(targetVersion);
+  const current = parseSemver(currentVersion);
+  if (!target || !current) return targetVersion !== currentVersion;
+  return compareParsed(target, current) > 0;
+}
+
+function dismissedKey(assistantId: string, targetVersion: string): string {
+  return `${DISMISSED_KEY_PREFIX}:${assistantId}:${targetVersion}`;
+}
+
+export function isLocalRuntimeUpgradeDismissed(
+  assistantId: string,
+  targetVersion: string,
+): boolean {
+  return getLocalSetting(dismissedKey(assistantId, targetVersion), "") === "true";
+}
+
+export function dismissLocalRuntimeUpgrade(
+  assistantId: string,
+  targetVersion: string,
+): void {
+  setLocalSetting(dismissedKey(assistantId, targetVersion), "true");
+}

--- a/clients/web/src/lib/local-runtime-upgrade.ts
+++ b/clients/web/src/lib/local-runtime-upgrade.ts
@@ -3,6 +3,7 @@ import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { compareParsed, parseSemver } from "@/utils/semver";
 
 export const LOCAL_RUNTIME_RELEASES_REFETCH_INTERVAL_MS = 20 * 60 * 1000;
+export const LOCAL_RUNTIME_RELEASES_FETCH_LIMIT = 100;
 
 const DISMISSED_KEY_PREFIX = "vellum:localRuntimeUpgradeDismissed";
 

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -48,7 +48,6 @@ import { GlobalPushToTalkBridge } from "@/domains/chat/voice/global-push-to-talk
 import { TimezoneSync } from "@/components/timezone-sync";
 import { StatusBanner } from "@/components/status-banner";
 import { UpdateToast } from "@/components/update-toast";
-import { LocalRuntimeUpgradeBanner } from "@/components/local-runtime-upgrade-banner";
 import { retireAssistant } from "@/assistant/retire-service";
 import { setSelectedAssistant } from "@/assistant/selection";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
@@ -304,12 +303,6 @@ export function RootLayout() {
       }}
     >
       <UpdateToast />
-      {!electron && !isPopout && !suppressStatusBanner ? (
-        <LocalRuntimeUpgradeBanner
-          assistantId={assistantId}
-          currentVersion={assistantVersion}
-        />
-      ) : null}
       {!electron && !isPopout && !suppressStatusBanner ? (
         <StatusBanner placement="web" />
       ) : null}

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -304,7 +304,7 @@ export function RootLayout() {
       }}
     >
       <UpdateToast />
-      {!isPopout && !suppressStatusBanner ? (
+      {!electron && !isPopout && !suppressStatusBanner ? (
         <LocalRuntimeUpgradeBanner
           assistantId={assistantId}
           currentVersion={assistantVersion}

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -304,7 +304,7 @@ export function RootLayout() {
       }}
     >
       <UpdateToast />
-      {!isPopout ? (
+      {!isPopout && !suppressStatusBanner ? (
         <LocalRuntimeUpgradeBanner
           assistantId={assistantId}
           currentVersion={assistantVersion}

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -48,6 +48,7 @@ import { GlobalPushToTalkBridge } from "@/domains/chat/voice/global-push-to-talk
 import { TimezoneSync } from "@/components/timezone-sync";
 import { StatusBanner } from "@/components/status-banner";
 import { UpdateToast } from "@/components/update-toast";
+import { LocalRuntimeUpgradeBanner } from "@/components/local-runtime-upgrade-banner";
 import { retireAssistant } from "@/assistant/retire-service";
 import { setSelectedAssistant } from "@/assistant/selection";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
@@ -303,6 +304,12 @@ export function RootLayout() {
       }}
     >
       <UpdateToast />
+      {!isPopout ? (
+        <LocalRuntimeUpgradeBanner
+          assistantId={assistantId}
+          currentVersion={assistantVersion}
+        />
+      ) : null}
       {!electron && !isPopout && !suppressStatusBanner ? (
         <StatusBanner placement="web" />
       ) : null}

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -22,7 +22,11 @@ const localAssistant: LockfileAssistant = {
   assistantId: "asst-local",
   name: "Local",
   cloud: "local",
-  resources: { gatewayPort: 7830, daemonPort: 7831 },
+  resources: {
+    gatewayPort: 7830,
+    daemonPort: 7831,
+    runtimeVersion: "v0.8.13",
+  },
 };
 
 beforeEach(() => {
@@ -60,6 +64,7 @@ describe("setFromLockfile", () => {
     expect(entry.id).toBe("asst-local");
     expect(entry.isLocal).toBe(true);
     expect(entry.organizationId).toBeUndefined();
+    expect(entry.runtimeVersion).toBe("v0.8.13");
   });
 });
 
@@ -86,11 +91,32 @@ describe("upsertFromApi", () => {
     expect(entry.organizationId).toBe("org-1");
   });
 
-  it("seeds organizationId from the lockfile cache when inserting a new entry", () => {
+  it("preserves a lockfile-seeded runtimeVersion on refresh", () => {
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [localAssistant],
+      activeAssistant: null,
+    });
+
+    useResolvedAssistantsStore.getState().upsertFromApi({
+      id: "asst-local",
+      name: "Local (refreshed)",
+      created: "2026-01-01T00:00:00Z",
+      is_local: true,
+    } as Parameters<
+      ReturnType<typeof useResolvedAssistantsStore.getState>["upsertFromApi"]
+    >[0]);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-local");
+    expect(entry.name).toBe("Local (refreshed)");
+    expect(entry.runtimeVersion).toBe("v0.8.13");
+  });
+
+  it("seeds lockfile fields from the cache when inserting a new entry", () => {
     // A lifecycle refresh can land before the lockfile subscription has seeded
-    // the resolved list; the insert must still pick up the org the lockfile knows.
+    // the resolved list; the insert must still pick up the fields the lockfile knows.
     useLockfileStore.getState().setLockfile({
-      assistants: [platformAssistant],
+      assistants: [platformAssistant, localAssistant],
       activeAssistant: null,
     });
 
@@ -106,6 +132,19 @@ describe("upsertFromApi", () => {
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-platform");
     expect(entry.organizationId).toBe("org-1");
+
+    useResolvedAssistantsStore.getState().upsertFromApi({
+      id: "asst-local",
+      name: "Local",
+      created: "2026-01-01T00:00:00Z",
+      is_local: true,
+    } as Parameters<
+      ReturnType<typeof useResolvedAssistantsStore.getState>["upsertFromApi"]
+    >[0]);
+
+    const localEntry = useResolvedAssistantsStore.getState().assistants[1];
+    expect(localEntry.id).toBe("asst-local");
+    expect(localEntry.runtimeVersion).toBe("v0.8.13");
   });
 });
 

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -43,32 +43,74 @@ describe("setFromLockfile", () => {
   it("copies organizationId for platform entries", () => {
     const lockfile: Lockfile = {
       assistants: [platformAssistant],
-      activeAssistant: null,
+      activeAssistant: "asst-platform",
     };
     useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
 
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-platform");
+    expect(entry.cloud).toBe("vellum");
     expect(entry.isPlatformHosted).toBe(true);
     expect(entry.organizationId).toBe("org-1");
+    expect(entry.isActiveLockfileAssistant).toBe(true);
   });
 
-  it("leaves organizationId undefined for local entries", () => {
+  it("copies Bun-local fields for local entries", () => {
     const lockfile: Lockfile = {
       assistants: [localAssistant],
-      activeAssistant: null,
+      activeAssistant: "asst-local",
     };
     useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
 
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-local");
+    expect(entry.cloud).toBe("local");
     expect(entry.isLocal).toBe(true);
     expect(entry.organizationId).toBeUndefined();
     expect(entry.runtimeVersion).toBe("v0.8.13");
+    expect(entry.isActiveLockfileAssistant).toBe(true);
+  });
+
+  it("marks local entries inactive when the lockfile active pointer differs", () => {
+    const lockfile: Lockfile = {
+      assistants: [localAssistant],
+      activeAssistant: "asst-other",
+    };
+    useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-local");
+    expect(entry.cloud).toBe("local");
+    expect(entry.isActiveLockfileAssistant).toBe(false);
   });
 });
 
 describe("upsertFromApi", () => {
+  it("hydrates lockfile fields when replacing the list from the API", () => {
+    useLockfileStore.getState().setLockfile({
+      assistants: [localAssistant],
+      activeAssistant: "asst-local",
+    });
+
+    useResolvedAssistantsStore.getState().setFromApi([
+      {
+        id: "asst-local",
+        name: "Local",
+        created: "2026-01-01T00:00:00Z",
+        is_local: true,
+      } as Parameters<
+        ReturnType<typeof useResolvedAssistantsStore.getState>["setFromApi"]
+      >[0][number],
+    ]);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-local");
+    expect(entry.cloud).toBe("local");
+    expect(entry.runtimeVersion).toBe("v0.8.13");
+    expect(entry.isActiveLockfileAssistant).toBe(true);
+    expect(entry.organizationId).toBeUndefined();
+  });
+
   it("preserves a lockfile-seeded organizationId on refresh (API has no org)", () => {
     useResolvedAssistantsStore.getState().setFromLockfile({
       assistants: [platformAssistant],
@@ -94,7 +136,7 @@ describe("upsertFromApi", () => {
   it("preserves a lockfile-seeded runtimeVersion on refresh", () => {
     useResolvedAssistantsStore.getState().setFromLockfile({
       assistants: [localAssistant],
-      activeAssistant: null,
+      activeAssistant: "asst-local",
     });
 
     useResolvedAssistantsStore.getState().upsertFromApi({
@@ -109,7 +151,9 @@ describe("upsertFromApi", () => {
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-local");
     expect(entry.name).toBe("Local (refreshed)");
+    expect(entry.cloud).toBe("local");
     expect(entry.runtimeVersion).toBe("v0.8.13");
+    expect(entry.isActiveLockfileAssistant).toBe(true);
   });
 
   it("seeds lockfile fields from the cache when inserting a new entry", () => {
@@ -117,7 +161,7 @@ describe("upsertFromApi", () => {
     // the resolved list; the insert must still pick up the fields the lockfile knows.
     useLockfileStore.getState().setLockfile({
       assistants: [platformAssistant, localAssistant],
-      activeAssistant: null,
+      activeAssistant: "asst-local",
     });
 
     useResolvedAssistantsStore.getState().upsertFromApi({
@@ -131,7 +175,9 @@ describe("upsertFromApi", () => {
 
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-platform");
+    expect(entry.cloud).toBe("vellum");
     expect(entry.organizationId).toBe("org-1");
+    expect(entry.isActiveLockfileAssistant).toBe(false);
 
     useResolvedAssistantsStore.getState().upsertFromApi({
       id: "asst-local",
@@ -144,7 +190,9 @@ describe("upsertFromApi", () => {
 
     const localEntry = useResolvedAssistantsStore.getState().assistants[1];
     expect(localEntry.id).toBe("asst-local");
+    expect(localEntry.cloud).toBe("local");
     expect(localEntry.runtimeVersion).toBe("v0.8.13");
+    expect(localEntry.isActiveLockfileAssistant).toBe(true);
   });
 });
 

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -29,6 +29,17 @@ const localAssistant: LockfileAssistant = {
   },
 };
 
+const otherLocalAssistant: LockfileAssistant = {
+  assistantId: "asst-other",
+  name: "Other Local",
+  cloud: "local",
+  resources: {
+    gatewayPort: 7930,
+    daemonPort: 7931,
+    runtimeVersion: "v0.8.12",
+  },
+};
+
 beforeEach(() => {
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   useLockfileStore.setState({ lockfile: null, committed: false });
@@ -73,15 +84,43 @@ describe("setFromLockfile", () => {
 
   it("marks local entries inactive when the lockfile active pointer differs", () => {
     const lockfile: Lockfile = {
-      assistants: [localAssistant],
+      assistants: [localAssistant, otherLocalAssistant],
       activeAssistant: "asst-other",
+    };
+    useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
+
+    const [entry, otherEntry] = useResolvedAssistantsStore.getState().assistants;
+    expect(entry?.id).toBe("asst-local");
+    expect(entry?.cloud).toBe("local");
+    expect(entry?.isActiveLockfileAssistant).toBe(false);
+    expect(otherEntry?.id).toBe("asst-other");
+    expect(otherEntry?.isActiveLockfileAssistant).toBe(true);
+  });
+
+  it("treats a sole local entry as active when the lockfile active pointer is empty", () => {
+    const lockfile: Lockfile = {
+      assistants: [localAssistant],
+      activeAssistant: null,
     };
     useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
 
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-local");
     expect(entry.cloud).toBe("local");
-    expect(entry.isActiveLockfileAssistant).toBe(false);
+    expect(entry.isActiveLockfileAssistant).toBe(true);
+  });
+
+  it("treats a sole local entry as active when the lockfile active pointer is stale", () => {
+    const lockfile: Lockfile = {
+      assistants: [localAssistant],
+      activeAssistant: "asst-stale",
+    };
+    useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-local");
+    expect(entry.cloud).toBe("local");
+    expect(entry.isActiveLockfileAssistant).toBe(true);
   });
 });
 

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -44,7 +44,9 @@ export interface ResolvedAssistant {
   id: string;
   name?: string;
   hatchedAt?: string;
+  cloud?: string;
   runtimeVersion?: string;
+  isActiveLockfileAssistant?: boolean;
   isLocal: boolean;
   isPlatformHosted: boolean;
   /** Owning org for platform entries; only the lockfile carries it, so
@@ -109,7 +111,9 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
+        cloud: a.cloud,
         runtimeVersion: a.resources?.runtimeVersion,
+        isActiveLockfileAssistant: lockfile.activeAssistant === a.assistantId,
         isLocal: isLocalAssistant(a),
         isPlatformHosted: isPlatformAssistant(a),
         organizationId: a.organizationId,
@@ -128,13 +132,20 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
     setFromApi: (assistants) =>
       set({
         assistantsHydrated: true,
-        assistants: assistants.map((a) => ({
-          id: a.id,
-          name: a.name,
-          hatchedAt: a.created,
-          isLocal: a.is_local,
-          isPlatformHosted: !a.is_local,
-        })),
+        assistants: assistants.map((a) => {
+          const lockfileFields = getLockfileFields(a.id);
+          return {
+            id: a.id,
+            name: a.name,
+            hatchedAt: a.created,
+            cloud: lockfileFields.cloud,
+            runtimeVersion: lockfileFields.runtimeVersion,
+            isActiveLockfileAssistant:
+              lockfileFields.isActiveLockfileAssistant,
+            isLocal: a.is_local,
+            isPlatformHosted: !a.is_local,
+          };
+        }),
       }),
 
     upsertFromApi: (assistant) =>
@@ -149,27 +160,34 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         const idx = state.assistants.findIndex((a) => a.id === assistant.id);
         if (idx >= 0) {
           const next = [...state.assistants];
+          const lockfileFields = getLockfileFields(assistant.id);
           // The API payload omits lockfile-sourced fields; preserve them across
           // lifecycle refreshes.
           next[idx] = {
             ...entry,
+            cloud: lockfileFields.cloud ?? next[idx]!.cloud,
             organizationId: next[idx]!.organizationId,
-            runtimeVersion: next[idx]!.runtimeVersion,
+            runtimeVersion:
+              lockfileFields.runtimeVersion ?? next[idx]!.runtimeVersion,
+            isActiveLockfileAssistant:
+              lockfileFields.isActiveLockfileAssistant ??
+              next[idx]!.isActiveLockfileAssistant,
           };
           return { assistants: next };
         }
         // New entry: the API payload omits lockfile-sourced fields, but the
         // lockfile may already know them.
-        const lockfileEntry = useLockfileStore
-          .getState()
-          .lockfile?.assistants.find((a) => a.assistantId === assistant.id);
+        const lockfileFields = getLockfileFields(assistant.id);
         return {
           assistants: [
             ...state.assistants,
             {
               ...entry,
-              organizationId: lockfileEntry?.organizationId,
-              runtimeVersion: lockfileEntry?.resources?.runtimeVersion,
+              cloud: lockfileFields.cloud,
+              organizationId: lockfileFields.organizationId,
+              runtimeVersion: lockfileFields.runtimeVersion,
+              isActiveLockfileAssistant:
+                lockfileFields.isActiveLockfileAssistant,
             },
           ],
         };
@@ -221,6 +239,24 @@ function reconcileSelection(
 export const useResolvedAssistantsStore = createSelectors(
   useResolvedAssistantsStoreBase,
 );
+
+function getLockfileFields(assistantId: string): {
+  cloud?: string;
+  organizationId?: string;
+  runtimeVersion?: string;
+  isActiveLockfileAssistant?: boolean;
+} {
+  const lockfile = useLockfileStore.getState().lockfile;
+  const entry = lockfile?.assistants.find((a) => a.assistantId === assistantId);
+  return {
+    cloud: entry?.cloud,
+    organizationId: entry?.organizationId,
+    runtimeVersion: entry?.resources?.runtimeVersion,
+    isActiveLockfileAssistant: lockfile
+      ? lockfile.activeAssistant === assistantId
+      : undefined,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Subscriptions

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -107,13 +107,16 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
     assistantsHydrated: false,
 
     setFromLockfile: (lockfile) => {
+      const activeLockfileAssistantId = getEffectiveActiveLockfileAssistantId(
+        lockfile,
+      );
       const assistants = lockfile.assistants.map((a) => ({
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
         cloud: a.cloud,
         runtimeVersion: a.resources?.runtimeVersion,
-        isActiveLockfileAssistant: lockfile.activeAssistant === a.assistantId,
+        isActiveLockfileAssistant: activeLockfileAssistantId === a.assistantId,
         isLocal: isLocalAssistant(a),
         isPlatformHosted: isPlatformAssistant(a),
         organizationId: a.organizationId,
@@ -248,14 +251,33 @@ function getLockfileFields(assistantId: string): {
 } {
   const lockfile = useLockfileStore.getState().lockfile;
   const entry = lockfile?.assistants.find((a) => a.assistantId === assistantId);
+  const activeLockfileAssistantId = lockfile
+    ? getEffectiveActiveLockfileAssistantId(lockfile)
+    : null;
   return {
     cloud: entry?.cloud,
     organizationId: entry?.organizationId,
     runtimeVersion: entry?.resources?.runtimeVersion,
     isActiveLockfileAssistant: lockfile
-      ? lockfile.activeAssistant === assistantId
+      ? activeLockfileAssistantId === assistantId
       : undefined,
   };
+}
+
+function getEffectiveActiveLockfileAssistantId(
+  lockfile: Lockfile,
+): string | null {
+  if (
+    lockfile.activeAssistant &&
+    lockfile.assistants.some(
+      (assistant) => assistant.assistantId === lockfile.activeAssistant,
+    )
+  ) {
+    return lockfile.activeAssistant;
+  }
+  return lockfile.assistants.length === 1
+    ? (lockfile.assistants[0]?.assistantId ?? null)
+    : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -44,6 +44,7 @@ export interface ResolvedAssistant {
   id: string;
   name?: string;
   hatchedAt?: string;
+  runtimeVersion?: string;
   isLocal: boolean;
   isPlatformHosted: boolean;
   /** Owning org for platform entries; only the lockfile carries it, so
@@ -108,6 +109,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
+        runtimeVersion: a.resources?.runtimeVersion,
         isLocal: isLocalAssistant(a),
         isPlatformHosted: isPlatformAssistant(a),
         organizationId: a.organizationId,
@@ -147,23 +149,28 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         const idx = state.assistants.findIndex((a) => a.id === assistant.id);
         if (idx >= 0) {
           const next = [...state.assistants];
-          // The API payload has no org field; preserve the org the lockfile
-          // seeded so a lifecycle refresh doesn't erase it.
-          next[idx] = { ...entry, organizationId: next[idx]!.organizationId };
+          // The API payload omits lockfile-sourced fields; preserve them across
+          // lifecycle refreshes.
+          next[idx] = {
+            ...entry,
+            organizationId: next[idx]!.organizationId,
+            runtimeVersion: next[idx]!.runtimeVersion,
+          };
           return { assistants: next };
         }
-        // New entry: the API payload has no org field, but the lockfile may
-        // already know it (a lifecycle refresh can land before the lockfile
-        // subscription seeds the list).
-        const lockfileOrg = useLockfileStore
+        // New entry: the API payload omits lockfile-sourced fields, but the
+        // lockfile may already know them.
+        const lockfileEntry = useLockfileStore
           .getState()
-          .lockfile?.assistants.find(
-            (a) => a.assistantId === assistant.id,
-          )?.organizationId;
+          .lockfile?.assistants.find((a) => a.assistantId === assistant.id);
         return {
           assistants: [
             ...state.assistants,
-            { ...entry, organizationId: lockfileOrg },
+            {
+              ...entry,
+              organizationId: lockfileEntry?.organizationId,
+              runtimeVersion: lockfileEntry?.resources?.runtimeVersion,
+            },
           ],
         };
       }),

--- a/packages/local-mode/src/__tests__/loopback-auth.test.ts
+++ b/packages/local-mode/src/__tests__/loopback-auth.test.ts
@@ -69,6 +69,32 @@ describe("isActiveAssistant", () => {
     expect(isActiveAssistant([lockfilePath], "active")).toBe(true);
   });
 
+  test("returns true for the sole assistant when activeAssistant is empty", () => {
+    const dir = makeTempDir();
+    const lockfilePath = path.join(dir, "lockfile.json");
+    fs.writeFileSync(
+      lockfilePath,
+      JSON.stringify({
+        assistants: [{ assistantId: "only" }],
+        activeAssistant: null,
+      }),
+    );
+    expect(isActiveAssistant([lockfilePath], "only")).toBe(true);
+  });
+
+  test("returns true for the sole assistant when activeAssistant is stale", () => {
+    const dir = makeTempDir();
+    const lockfilePath = path.join(dir, "lockfile.json");
+    fs.writeFileSync(
+      lockfilePath,
+      JSON.stringify({
+        assistants: [{ assistantId: "only" }],
+        activeAssistant: "missing",
+      }),
+    );
+    expect(isActiveAssistant([lockfilePath], "only")).toBe(true);
+  });
+
   test("returns false for a non-active assistant", () => {
     const dir = makeTempDir();
     const lockfilePath = path.join(dir, "lockfile.json");

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -94,8 +94,15 @@ export function isActiveAssistant(
 ): boolean {
   for (const candidate of lockfilePaths) {
     try {
-      const data = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
-      return data.activeAssistant === assistantId;
+      const data = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      if (data.activeAssistant === assistantId) return true;
+      const assistants = data.assistants;
+      if (!Array.isArray(assistants) || assistants.length !== 1) return false;
+      const [onlyAssistant] = assistants as Array<Record<string, unknown>>;
+      return onlyAssistant?.assistantId === assistantId;
     } catch {
       continue;
     }


### PR DESCRIPTION
## Summary
- Add a root-level banner for local assistant runtime updates using the existing stable releases feed.
- Reuse the local upgrade path shared with Settings so upgrades still restart/reconnect the assistant through existing host plumbing.
- Store per-assistant/per-target dismissals in localStorage and poll releases every 20 minutes with resume/wake refetches.

## Original prompt
The goal was to surface available upgrades for local self-hosted assistant runtimes, not the Electron app itself. We had established that the existing platform releases endpoint is the right source of truth, that `vellum upgrade` installs assistant, gateway, and CES together, and that the UI should reuse the existing local upgrade pathway. The banner needed to use shared UI/theme components, poll every 20 minutes, refresh after laptop wake/resume, and dismiss only for the specific assistant plus target version.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->