### PR TITLE
Normalize chat messages [1/4]: the entity-store primitive (LUM-2537)

### DIFF
--- a/clients/web/src/domains/chat/utils/message-entities.test.ts
+++ b/clients/web/src/domains/chat/utils/message-entities.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import {
+  appendRow,
+  deriveRowKey,
+  emptyEntityState,
+  patch,
+  rebuildFromArray,
+  removeRow,
+  rowKeyForServerId,
+  setLiveAssistantRowKey,
+  toArray,
+} from "./message-entities";
+
+const msg = (m: Partial<DisplayMessage> & Pick<DisplayMessage, "id" | "role">): DisplayMessage => m;
+
+describe("deriveRowKey", () => {
+  test("prefers clientMessageId, falls back to id", () => {
+    expect(deriveRowKey(msg({ id: "srv", role: "user", clientMessageId: "nonce" }))).toBe("nonce");
+    expect(deriveRowKey(msg({ id: "srv", role: "assistant" }))).toBe("srv");
+  });
+});
+
+describe("rebuildFromArray / toArray", () => {
+  test("keys by clientMessageId|id, preserves order, indexes ids + aliases", () => {
+    const msgs = [
+      msg({ id: "u1", role: "user", clientMessageId: "cu1" }),
+      msg({ id: "a1", role: "assistant", mergedMessageIds: ["a1b"] }),
+    ];
+    const s = rebuildFromArray(msgs);
+
+    expect(s.order).toEqual(["cu1", "a1"]);
+    expect(toArray(s)).toEqual(msgs);
+    expect(rowKeyForServerId(s, "u1")).toBe("cu1");
+    expect(rowKeyForServerId(s, "a1")).toBe("a1");
+    expect(rowKeyForServerId(s, "a1b")).toBe("a1"); // folded alias
+  });
+});
+
+describe("patch — the no-remount invariant", () => {
+  test("optimistic assistant id swap keeps rowKey + order stable, re-points the index", () => {
+    // Born with only a client nonce (no clientMessageId) — rowKey = the nonce.
+    let s = appendRow(emptyEntityState(), msg({ id: "nonce-1", role: "assistant", isOptimistic: true }));
+    const rowKey = s.order[0]!;
+    expect(rowKey).toBe("nonce-1");
+
+    // finalizeMessageComplete adopts the server id.
+    s = patch(s, rowKey, (row) => ({ ...row, id: "srv-9", isOptimistic: false }));
+
+    expect(s.order).toEqual([rowKey]); // React key unchanged → no remount
+    expect(s.byId[rowKey]!.id).toBe("srv-9");
+    expect(rowKeyForServerId(s, "srv-9")).toBe(rowKey); // index re-points
+    expect(rowKeyForServerId(s, "nonce-1")).toBeUndefined(); // stale id dropped
+  });
+
+  test("optimistic user row keyed by clientMessageId survives the echo id swap", () => {
+    let s = appendRow(
+      emptyEntityState(),
+      msg({ id: "tmp", role: "user", clientMessageId: "nonce-u", isOptimistic: true }),
+    );
+    const rowKey = s.order[0]!;
+    expect(rowKey).toBe("nonce-u");
+
+    s = patch(s, rowKey, (row) => ({ ...row, id: "srv-u", isOptimistic: false }));
+
+    expect(s.order).toEqual(["nonce-u"]);
+    expect(rowKeyForServerId(s, "srv-u")).toBe("nonce-u");
+  });
+
+  test("folding an alias indexes the new id to the same row", () => {
+    let s = appendRow(emptyEntityState(), msg({ id: "a1", role: "assistant" }));
+    const rk = s.order[0]!;
+    s = patch(s, rk, (row) => ({ ...row, mergedMessageIds: [...(row.mergedMessageIds ?? []), "a2"] }));
+
+    expect(rowKeyForServerId(s, "a1")).toBe(rk);
+    expect(rowKeyForServerId(s, "a2")).toBe(rk);
+  });
+
+  test("a content-only delta does no index work (hot path stays O(1))", () => {
+    let s = appendRow(emptyEntityState(), msg({ id: "a1", role: "assistant", textSegments: ["hi"] }));
+    const rk = s.order[0]!;
+    const indexBefore = s.serverIdToRowKey;
+
+    s = patch(s, rk, (row) => ({ ...row, textSegments: [...(row.textSegments ?? []), " there"] }));
+
+    expect(s.serverIdToRowKey).toBe(indexBefore); // same ref → no rebuild
+    expect(s.order).toEqual([rk]);
+    expect(s.byId[rk]!.textSegments).toEqual(["hi", " there"]);
+  });
+
+  test("no-op transform returns the same state ref; unknown rowKey is a no-op", () => {
+    const s0 = appendRow(emptyEntityState(), msg({ id: "a1", role: "assistant" }));
+    expect(patch(s0, s0.order[0]!, (row) => row)).toBe(s0);
+    expect(patch(s0, "missing", (row) => ({ ...row, id: "x" }))).toBe(s0);
+  });
+});
+
+describe("removeRow / live pointer", () => {
+  test("drops the row, its index entries, and clears the live pointer", () => {
+    let s = appendRow(emptyEntityState(), msg({ id: "a1", role: "assistant", mergedMessageIds: ["a2"] }));
+    const rk = s.order[0]!;
+    s = setLiveAssistantRowKey(s, rk);
+
+    s = removeRow(s, rk);
+
+    expect(s.order).toEqual([]);
+    expect(s.byId[rk]).toBeUndefined();
+    expect(rowKeyForServerId(s, "a1")).toBeUndefined();
+    expect(rowKeyForServerId(s, "a2")).toBeUndefined();
+    expect(s.liveAssistantRowKey).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/utils/message-entities.test.ts
+++ b/clients/web/src/domains/chat/utils/message-entities.test.ts
@@ -36,6 +36,24 @@ describe("rebuildFromArray / toArray", () => {
     expect(rowKeyForServerId(s, "a1")).toBe("a1");
     expect(rowKeyForServerId(s, "a1b")).toBe("a1"); // folded alias
   });
+
+  test("reuses a prior rowKey when a snapshot reapplies an adopted server id (no remount)", () => {
+    // A nonce-born optimistic assistant row that adopted its server id mid-turn:
+    // prior maps the server id back to the nonce key the mounted row uses.
+    let prior = appendRow(emptyEntityState(), msg({ id: "nonce-1", role: "assistant", isOptimistic: true }));
+    prior = patch(prior, "nonce-1", (row) => ({ ...row, id: "srv-9", isOptimistic: false }));
+
+    // The reconcile / history snapshot carries the row under its server id.
+    const snapshot = [msg({ id: "srv-9", role: "assistant" })];
+
+    const withPrior = rebuildFromArray(snapshot, prior);
+    expect(withPrior.order).toEqual(["nonce-1"]); // keeps the mounted key → no remount
+    expect(rowKeyForServerId(withPrior, "srv-9")).toBe("nonce-1");
+
+    // A cold load (no prior) derives the key straight from the message.
+    const cold = rebuildFromArray(snapshot);
+    expect(cold.order).toEqual(["srv-9"]);
+  });
 });
 
 describe("patch — the no-remount invariant", () => {

--- a/clients/web/src/domains/chat/utils/message-entities.ts
+++ b/clients/web/src/domains/chat/utils/message-entities.ts
@@ -88,8 +88,7 @@ function resolveRowKey(m: DisplayMessage, prior: MessageEntityState | undefined)
 
 /**
  * Rebuild the whole entity state from a flat message array — the bulk path
- * for a history load / reconcile snapshot apply (Phase 1 keeps these going
- * through the store; Phase 2 moves history to the Query cache).
+ * for a history load / reconcile snapshot apply.
  *
  * Pass `prior` (the state being replaced) on a mid-turn reapply so a row keeps
  * the rowKey it already has: a nonce-born optimistic row that adopts its server

--- a/clients/web/src/domains/chat/utils/message-entities.ts
+++ b/clients/web/src/domains/chat/utils/message-entities.ts
@@ -28,9 +28,14 @@ export interface MessageEntityState {
   serverIdToRowKey: Record<string, string>;
   /**
    * rowKey of the assistant row currently being streamed into, or `null`.
-   * Set synchronously by the streaming producer (replacing the async
-   * `currentAssistantMessageIdRef` mirror) so `subagent_spawned` can read its
-   * parent before React commits; cleared at turn end.
+   * The streaming producer sets it synchronously as each assistant delta
+   * lands, so a `subagent_spawned` event can resolve its parent row before
+   * React commits; it is cleared at turn end.
+   *
+   * Per-build invariant: `rebuildFromArray` resets this to `null` (a bulk
+   * snapshot apply carries no in-flight turn), so a caller that rebuilds
+   * mid-turn must re-derive and reattach it rather than read it back from the
+   * rebuilt state.
    */
   liveAssistantRowKey: string | null;
 }

--- a/clients/web/src/domains/chat/utils/message-entities.ts
+++ b/clients/web/src/domains/chat/utils/message-entities.ts
@@ -69,18 +69,49 @@ function indexRow(index: Record<string, string>, rowKey: string, m: DisplayMessa
 }
 
 /**
+ * The rowKey a message takes during a bulk rebuild.
+ *
+ * When `prior` already indexes one of the message's server ids, that existing
+ * rowKey wins — so a nonce-born assistant row that adopts its server id keeps
+ * the key the mounted row renders under when a snapshot reapplies it under the
+ * server id. Otherwise the key comes from the message (`deriveRowKey`).
+ */
+function resolveRowKey(m: DisplayMessage, prior: MessageEntityState | undefined): string {
+  if (prior !== undefined) {
+    for (const sid of serverIdsOf(m)) {
+      const existing = prior.serverIdToRowKey[sid];
+      if (existing !== undefined) return existing;
+    }
+  }
+  return deriveRowKey(m);
+}
+
+/**
  * Rebuild the whole entity state from a flat message array — the bulk path
  * for a history load / reconcile snapshot apply (Phase 1 keeps these going
- * through the store; Phase 2 moves history to the Query cache). Deterministic:
- * a re-applied snapshot of the same rows yields the same rowKeys, so a refetch
- * does not remount stable rows.
+ * through the store; Phase 2 moves history to the Query cache).
+ *
+ * Pass `prior` (the state being replaced) on a mid-turn reapply so a row keeps
+ * the rowKey it already has: a nonce-born optimistic row that adopts its server
+ * id is reapplied under that server id, and `prior` maps it back to the nonce
+ * key the mounted row renders under — without it the row re-keys and remounts.
+ * A cold load passes no `prior` and derives keys from the messages, which is
+ * deterministic: the same rows yield the same keys, so a refetch does not
+ * remount stable rows.
+ *
+ * Resets `liveAssistantRowKey` to null (a fresh build has no live turn);
+ * callers that rebuild mid-turn (`setMessages`) re-preserve it when the live
+ * row survives.
  */
-export function rebuildFromArray(messages: DisplayMessage[]): MessageEntityState {
+export function rebuildFromArray(
+  messages: DisplayMessage[],
+  prior?: MessageEntityState,
+): MessageEntityState {
   const byId: Record<string, DisplayMessage> = {};
   const order: string[] = [];
   const serverIdToRowKey: Record<string, string> = {};
   for (const m of messages) {
-    const rowKey = deriveRowKey(m);
+    const rowKey = resolveRowKey(m, prior);
     if (byId[rowKey] === undefined) order.push(rowKey);
     byId[rowKey] = m;
     indexRow(serverIdToRowKey, rowKey, m);

--- a/clients/web/src/domains/chat/utils/message-entities.ts
+++ b/clients/web/src/domains/chat/utils/message-entities.ts
@@ -1,0 +1,174 @@
+/**
+ * Normalized message-entity state for the chat session store.
+ *
+ * The in-flight conversation is held as a `byId` map keyed by a stable,
+ * immutable `rowKey` plus an `order` list of those keys — so a streaming
+ * token patches one entity (O(1)) instead of replacing the whole array.
+ *
+ * `rowKey` is assigned once at row creation (`deriveRowKey`) and **never
+ * recomputed**: the server `id` is a mutable field (the optimistic→server
+ * swap, alias folds), and recomputing the key from a mutated `id` would
+ * change a row's React key and remount it at the swap — the exact bug this
+ * normalization removes. The `serverIdToRowKey` index absorbs id changes so
+ * a lookup by a server `messageId` (or a folded `mergedMessageIds` alias)
+ * still resolves to the owning row.
+ *
+ * These are pure functions over an immutable `MessageEntityState`; the
+ * Zustand store holds the state and the React layer never sees this module.
+ */
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+export interface MessageEntityState {
+  /** rowKey → message. */
+  byId: Record<string, DisplayMessage>;
+  /** rowKeys in transcript order. */
+  order: string[];
+  /** server `id` and every `mergedMessageIds` alias → owning rowKey. */
+  serverIdToRowKey: Record<string, string>;
+  /**
+   * rowKey of the assistant row currently being streamed into, or `null`.
+   * Set synchronously by the streaming producer (replacing the async
+   * `currentAssistantMessageIdRef` mirror) so `subagent_spawned` can read its
+   * parent before React commits; cleared at turn end.
+   */
+  liveAssistantRowKey: string | null;
+}
+
+export function emptyEntityState(): MessageEntityState {
+  return { byId: {}, order: [], serverIdToRowKey: {}, liveAssistantRowKey: null };
+}
+
+/**
+ * The rowKey for a freshly created row — assigned once, never recomputed.
+ *
+ * `clientMessageId` for user-originated rows (this client minted it at send
+ * and the daemon echoes it on the user_message_echo and the history snapshot,
+ * so it is identical at optimistic-create → echo → refetch); otherwise the
+ * row's `id` (a stable server id for server-born rows, or a transient client
+ * nonce for an optimistic assistant row born before its server id arrives —
+ * which the index then re-points on the swap, leaving this key untouched).
+ */
+export function deriveRowKey(m: DisplayMessage): string {
+  return m.clientMessageId ?? m.id;
+}
+
+/** The server ids a row answers to: its primary `id` plus folded aliases. */
+function serverIdsOf(m: DisplayMessage): string[] {
+  return m.mergedMessageIds ? [m.id, ...m.mergedMessageIds] : [m.id];
+}
+
+/** Index a row's server ids → its rowKey, mutating `index` in place. */
+function indexRow(index: Record<string, string>, rowKey: string, m: DisplayMessage): void {
+  for (const sid of serverIdsOf(m)) index[sid] = rowKey;
+}
+
+/**
+ * Rebuild the whole entity state from a flat message array — the bulk path
+ * for a history load / reconcile snapshot apply (Phase 1 keeps these going
+ * through the store; Phase 2 moves history to the Query cache). Deterministic:
+ * a re-applied snapshot of the same rows yields the same rowKeys, so a refetch
+ * does not remount stable rows.
+ */
+export function rebuildFromArray(messages: DisplayMessage[]): MessageEntityState {
+  const byId: Record<string, DisplayMessage> = {};
+  const order: string[] = [];
+  const serverIdToRowKey: Record<string, string> = {};
+  for (const m of messages) {
+    const rowKey = deriveRowKey(m);
+    if (byId[rowKey] === undefined) order.push(rowKey);
+    byId[rowKey] = m;
+    indexRow(serverIdToRowKey, rowKey, m);
+  }
+  return { byId, order, serverIdToRowKey, liveAssistantRowKey: null };
+}
+
+/** Materialize the transcript array in order — the `selectTranscriptMessages` seam. */
+export function toArray(state: MessageEntityState): DisplayMessage[] {
+  const out: DisplayMessage[] = new Array(state.order.length);
+  for (let i = 0; i < state.order.length; i++) out[i] = state.byId[state.order[i]!]!;
+  return out;
+}
+
+/** Resolve the rowKey owning a server `messageId` (primary id or alias), or `undefined`. */
+export function rowKeyForServerId(
+  state: MessageEntityState,
+  serverId: string,
+): string | undefined {
+  return state.serverIdToRowKey[serverId];
+}
+
+/** Append a new row at the tail. The rowKey is derived once here. */
+export function appendRow(
+  state: MessageEntityState,
+  message: DisplayMessage,
+): MessageEntityState {
+  const rowKey = deriveRowKey(message);
+  const byId = { ...state.byId, [rowKey]: message };
+  const order = state.byId[rowKey] === undefined ? [...state.order, rowKey] : state.order;
+  const serverIdToRowKey = { ...state.serverIdToRowKey };
+  indexRow(serverIdToRowKey, rowKey, message);
+  return { ...state, byId, order, serverIdToRowKey };
+}
+
+/**
+ * The universal row patch: replace `byId[rowKey]` with `transform(row)`.
+ *
+ * Re-indexes the row **only when its identity actually changed** — i.e. the
+ * primary `id` was swapped (optimistic→server) or an alias was folded
+ * (`mergedMessageIds` got a new ref). A pure content delta (text/thinking
+ * token, tool/surface patch) leaves identity untouched, so the hot path does
+ * no index work and stays O(1). No-ops (`transform` returns the same ref) and
+ * unknown rowKeys return the input state unchanged.
+ */
+export function patch(
+  state: MessageEntityState,
+  rowKey: string,
+  transform: (row: DisplayMessage) => DisplayMessage,
+): MessageEntityState {
+  const prev = state.byId[rowKey];
+  if (prev === undefined) return state;
+  const next = transform(prev);
+  if (next === prev) return state;
+
+  const byId = { ...state.byId, [rowKey]: next };
+
+  const identityChanged =
+    next.id !== prev.id || next.mergedMessageIds !== prev.mergedMessageIds;
+  if (!identityChanged) {
+    return { ...state, byId };
+  }
+
+  // Drop this row's stale id entries, then re-index its current ids. Other
+  // rows' entries are untouched (a row never indexes another row's ids).
+  const serverIdToRowKey: Record<string, string> = {};
+  for (const [sid, owner] of Object.entries(state.serverIdToRowKey)) {
+    if (owner !== rowKey) serverIdToRowKey[sid] = owner;
+  }
+  indexRow(serverIdToRowKey, rowKey, next);
+  return { ...state, byId, serverIdToRowKey };
+}
+
+/** Remove a row (e.g. a content-less assistant bubble dropped on error). */
+export function removeRow(state: MessageEntityState, rowKey: string): MessageEntityState {
+  if (state.byId[rowKey] === undefined) return state;
+  const byId = { ...state.byId };
+  delete byId[rowKey];
+  const order = state.order.filter((k) => k !== rowKey);
+  const serverIdToRowKey: Record<string, string> = {};
+  for (const [sid, owner] of Object.entries(state.serverIdToRowKey)) {
+    if (owner !== rowKey) serverIdToRowKey[sid] = owner;
+  }
+  const liveAssistantRowKey =
+    state.liveAssistantRowKey === rowKey ? null : state.liveAssistantRowKey;
+  return { byId, order, serverIdToRowKey, liveAssistantRowKey };
+}
+
+/** Set (or clear) the live-assistant pointer. */
+export function setLiveAssistantRowKey(
+  state: MessageEntityState,
+  rowKey: string | null,
+): MessageEntityState {
+  if (state.liveAssistantRowKey === rowKey) return state;
+  return { ...state, liveAssistantRowKey: rowKey };
+}


### PR DESCRIPTION
**Linear:** [LUM-2537](https://linear.app/vellum/issue/LUM-2537) · **Stack 1 of 4** · Phase 1 of the chat message-state re-architecture.

> Pure normalized-store primitive — nothing imports it yet, so it reviews in isolation. The visible win lands in [3/4] (#35723); this is the substrate it builds on.

### Why
The transcript re-renders **every message on every streaming token**, and the streaming row **remounts mid-turn**. Two structural causes:
1. Messages live as a flat array, so a per-token update replaces the whole array — every row becomes a new object and re-renders.
2. The React `key` is the message's **mutable** server `id`, so the optimistic→server swap at completion changes the key and remounts the row.

Both need a **stable, immutable row identity** to fix. This slice adds it; slices 2–4 build on it.

### What it adds
`message-entities.ts` — the in-flight conversation as `byId` (keyed by `rowKey`) + `order` + `serverIdToRowKey` (alias-aware index: primary id and every `mergedMessageIds` alias → owning row) + `liveAssistantRowKey`. Two semantics carry the design:

- **`rowKey = clientMessageId ?? id`, derived once and never recomputed.** The server `id` stays a separate mutable field, so the id-swap and alias-merge are field patches that leave the React key untouched.
- **`patch()` re-indexes only when identity changes.** A pure content delta — the per-token hot path — is **O(1)**: no array rebuild, no reindex.

### Invariants (pinned by tests)
- **No-remount swap:** swapping a row's `id` leaves its `rowKey` unchanged.
- **O(1) content patch:** a content delta does no index work.
- **Reconcile continuity** (Codex review): a *nonce-born* assistant row — created before its server id arrives, then adopting it — is the one rowKey not recomputable from wire identity. `rebuildFromArray(messages, prior?)` reuses an existing rowKey when an incoming server id is already indexed, so a reconcile/history snapshot keeps the mounted key; a cold load passes no `prior` and derives deterministically. The reconcile path passes `prior` in [2/4] (#35722).

### Safety
Pure functions over immutable state, fully unit-tested. With no runtime consumers it cannot change behavior — and because the rowKey is deterministic from wire identity, there is nothing to persist across the store↔Query-cache boundary in Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh1GBRgSSWtkxgCnMw9sR5