### PR TITLE
feat(gateway): add resolveTrustVerdict reading per-actor ACL from gateway DB

### DIFF
--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the gateway-side per-actor trust verdict resolver.
+ *
+ * Seeds the gateway ACL DB directly (contacts + contact_channels) and asserts
+ * the resolved {@link TrustVerdict} for guardian / trusted / unverified /
+ * unknown / blocked actors, plus id-divergence and case-insensitive address
+ * matching.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+await import("../../__tests__/test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../../db/connection.js"
+);
+const { contacts: gwContacts, contactChannels: gwContactChannels } =
+  await import("../../db/schema.js");
+const { resolveTrustVerdict } = await import("../trust-verdict-resolver.js");
+
+const CHANNEL = "telegram";
+
+function insertContact(args: {
+  id: string;
+  displayName: string;
+  role?: string;
+  principalId?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: args.id,
+      displayName: args.displayName,
+      role: args.role ?? "contact",
+      principalId: args.principalId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address: string;
+  externalChatId?: string | null;
+  status?: string;
+  policy?: string;
+  verifiedAt?: number | null;
+  verifiedVia?: string | null;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: args.type ?? CHANNEL,
+      address: args.address,
+      externalChatId: args.externalChatId ?? null,
+      status: args.status ?? "active",
+      policy: args.policy ?? "allow",
+      verifiedAt: args.verifiedAt ?? now,
+      verifiedVia: args.verifiedVia ?? "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  // initGatewayDb reconnects to the same on-disk DB, so clear any rows a
+  // prior test left behind (channels first — FK cascade from contacts).
+  getGatewayDb().delete(gwContactChannels).run();
+  getGatewayDb().delete(gwContacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("resolveTrustVerdict", () => {
+  test("guardian actor → trustClass guardian, guardian fields populated", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_GUARDIAN",
+    });
+
+    expect(verdict.trustClass).toBe("guardian");
+    expect(verdict.canonicalSenderId).toBe("U_GUARDIAN");
+    expect(verdict.guardianExternalUserId).toBe("U_GUARDIAN");
+    expect(verdict.guardianDeliveryChatId).toBe("chat-guardian");
+    expect(verdict.guardianPrincipalId).toBe("principal-1");
+    expect(verdict.guardianDisplayName).toBe("The Guardian");
+    expect(verdict.contactId).toBe("c-guardian");
+    expect(verdict.status).toBe("active");
+  });
+
+  test("active non-guardian member → trusted_contact, member ACL fields populated", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN",
+    });
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_MEMBER",
+      externalChatId: "chat-member",
+      status: "active",
+      verifiedVia: "manual",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_MEMBER",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.status).toBe("active");
+    expect(verdict.policy).toBe("allow");
+    expect(verdict.contactId).toBe("c-member");
+    expect(verdict.channelId).toBe("ch-member");
+    expect(verdict.address).toBe("U_MEMBER");
+    expect(verdict.externalChatId).toBe("chat-member");
+    expect(verdict.memberDisplayName).toBe("Trusted Member");
+    expect(verdict.verifiedVia).toBe("manual");
+    // Guardian fields still populated from the channel binding.
+    expect(verdict.guardianExternalUserId).toBe("U_GUARDIAN");
+  });
+
+  test("pending/unverified member → unverified_contact", async () => {
+    insertContact({ id: "c-member", displayName: "Pending Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_PENDING",
+      status: "unverified",
+      verifiedAt: null,
+      verifiedVia: null,
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_PENDING",
+    });
+
+    expect(verdict.trustClass).toBe("unverified_contact");
+    expect(verdict.status).toBe("unverified");
+    expect(verdict.contactId).toBe("c-member");
+  });
+
+  test("no matching channel → unknown, canonicalSenderId reflects input, member fields undefined", async () => {
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.canonicalSenderId).toBe("U_STRANGER");
+    expect(verdict.contactId).toBeUndefined();
+    expect(verdict.channelId).toBeUndefined();
+    expect(verdict.status).toBeUndefined();
+    expect(verdict.guardianExternalUserId).toBeUndefined();
+  });
+
+  test("no actorExternalId → unknown, canonicalSenderId null", async () => {
+    const verdict = await resolveTrustVerdict({ channelType: CHANNEL });
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.canonicalSenderId).toBeNull();
+  });
+
+  test("blocked member → status/policy surfaced verbatim, no reclassification", async () => {
+    insertContact({ id: "c-blocked", displayName: "Blocked Member" });
+    insertChannel({
+      id: "ch-blocked",
+      contactId: "c-blocked",
+      address: "U_BLOCKED",
+      status: "blocked",
+      policy: "deny",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_BLOCKED",
+    });
+
+    // Per status rules: a member channel that is not active falls into the
+    // unverified_contact tier — but the raw status/policy carry through so the
+    // consumer enforces. Proves the resolver never reclassifies.
+    expect(verdict.trustClass).toBe("unverified_contact");
+    expect(verdict.status).toBe("blocked");
+    expect(verdict.policy).toBe("deny");
+    expect(verdict.contactId).toBe("c-blocked");
+  });
+
+  test("id-divergent row resolves by (type,address)", async () => {
+    // Channel id intentionally unrelated to any assistant-side id — lookup is
+    // keyed on (type,address), so it still resolves.
+    insertContact({ id: "gw-only-contact", displayName: "Mirror Member" });
+    insertChannel({
+      id: "gw-only-channel-id-9999",
+      contactId: "gw-only-contact",
+      address: "U_DIVERGENT",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_DIVERGENT",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.channelId).toBe("gw-only-channel-id-9999");
+    expect(verdict.contactId).toBe("gw-only-contact");
+  });
+
+  test("case-insensitive address match (COLLATE NOCASE)", async () => {
+    insertContact({ id: "c-member", displayName: "Case Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_MixedCase",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "u_mixedcase",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.channelId).toBe("ch-member");
+  });
+
+  test("guardian classification by member contact role, even without channel binding row match", async () => {
+    // Guardian's own member channel has role=guardian; even if address differs
+    // from the (separately-resolved) channel guardian binding, role wins.
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN_ROLE",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_GUARDIAN_ROLE",
+    });
+
+    expect(verdict.trustClass).toBe("guardian");
+  });
+});

--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -193,7 +193,7 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.canonicalSenderId).toBeNull();
   });
 
-  test("blocked member → status/policy surfaced verbatim, no reclassification", async () => {
+  test("blocked member → unknown, status/policy surfaced verbatim", async () => {
     insertContact({ id: "c-blocked", displayName: "Blocked Member" });
     insertChannel({
       id: "ch-blocked",
@@ -208,13 +208,33 @@ describe("resolveTrustVerdict", () => {
       actorExternalId: "U_BLOCKED",
     });
 
-    // Per status rules: a member channel that is not active falls into the
-    // unverified_contact tier — but the raw status/policy carry through so the
-    // consumer enforces. Proves the resolver never reclassifies.
-    expect(verdict.trustClass).toBe("unverified_contact");
+    // Mirrors the canonical resolver: blocked → unknown. Raw status/policy
+    // still carry through so the consumer enforces member_blocked hard-deny.
+    expect(verdict.trustClass).toBe("unknown");
     expect(verdict.status).toBe("blocked");
     expect(verdict.policy).toBe("deny");
     expect(verdict.contactId).toBe("c-blocked");
+  });
+
+  test("revoked member → unknown, status/policy surfaced verbatim", async () => {
+    insertContact({ id: "c-revoked", displayName: "Revoked Member" });
+    insertChannel({
+      id: "ch-revoked",
+      contactId: "c-revoked",
+      address: "U_REVOKED",
+      status: "revoked",
+      policy: "deny",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_REVOKED",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.status).toBe("revoked");
+    expect(verdict.policy).toBe("deny");
+    expect(verdict.contactId).toBe("c-revoked");
   });
 
   test("id-divergent row resolves by (type,address)", async () => {
@@ -256,9 +276,7 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.channelId).toBe("ch-member");
   });
 
-  test("guardian classification by member contact role, even without channel binding row match", async () => {
-    // Guardian's own member channel has role=guardian; even if address differs
-    // from the (separately-resolved) channel guardian binding, role wins.
+  test("sender matching the active guardian binding address → guardian", async () => {
     insertContact({
       id: "c-guardian",
       displayName: "Guardian",
@@ -268,15 +286,44 @@ describe("resolveTrustVerdict", () => {
     insertChannel({
       id: "ch-guardian",
       contactId: "c-guardian",
-      address: "U_GUARDIAN_ROLE",
+      address: "U_GUARDIAN_ACTIVE",
       status: "active",
     });
 
     const verdict = await resolveTrustVerdict({
       channelType: CHANNEL,
-      actorExternalId: "U_GUARDIAN_ROLE",
+      actorExternalId: "U_GUARDIAN_ACTIVE",
     });
 
     expect(verdict.trustClass).toBe("guardian");
+  });
+
+  test("revoked guardian channel does NOT confer guardian → unknown", async () => {
+    // P1 regression: a guardian contact whose only channel is revoked must not
+    // re-acquire guardian privileges by code-match. The status='active' filter
+    // on the guardian binding excludes it, so the sender resolves to unknown.
+    insertContact({
+      id: "c-old-guardian",
+      displayName: "Former Guardian",
+      role: "guardian",
+      principalId: "principal-old",
+    });
+    insertChannel({
+      id: "ch-old-guardian",
+      contactId: "c-old-guardian",
+      address: "U_OLD_GUARDIAN",
+      status: "revoked",
+      policy: "deny",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_OLD_GUARDIAN",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.status).toBe("revoked");
+    // No active guardian binding exists, so guardian label fields are absent.
+    expect(verdict.guardianExternalUserId).toBeUndefined();
   });
 });

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -6,8 +6,9 @@
  * (`actor-trust-resolver.ts`) and the Combo-7 `(type,address)` COLLATE NOCASE
  * read pattern. Read-only — no writes, no assistant DB, no IPC.
  *
- * Blocked/revoked channels are NOT reclassified: their raw `status`/`policy`
- * are surfaced verbatim so the consumer enforces hard-deny semantics.
+ * Blocked/revoked member channels classify as `unknown` (mirroring the
+ * daemon), while their raw `status`/`policy` are surfaced verbatim so the
+ * consumer enforces the member_blocked / member_revoked hard-deny.
  */
 
 import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
@@ -88,7 +89,6 @@ export async function resolveTrustVerdict(
           policy: gwContactChannels.policy,
           verifiedAt: gwContactChannels.verifiedAt,
           verifiedVia: gwContactChannels.verifiedVia,
-          role: gwContacts.role,
           memberDisplayName: gwContacts.displayName,
         })
         .from(gwContactChannels)
@@ -104,22 +104,30 @@ export async function resolveTrustVerdict(
     : undefined;
 
   // --- Classification (mirrors resolveActorTrust precedence) ---
+  // The guardian binding is the ACTIVE guardian channel for this channel type
+  // (the status='active' filter above excludes revoked/blocked guardian
+  // channels). A sender is the guardian only when their canonical id matches
+  // that active address — a stale revoked channel never confers guardian.
   const isGuardian =
-    !!memberRow &&
-    (memberRow.role === "guardian" ||
-      (!!guardianRow &&
-        guardianRow.address.toLowerCase() ===
-          memberRow.address.toLowerCase()));
+    !!guardianRow &&
+    !!canonicalSenderId &&
+    guardianRow.address.toLowerCase() === canonicalSenderId.toLowerCase();
 
   let trustClass: TrustClass;
   if (isGuardian) {
     trustClass = "guardian";
-  } else if (memberRow && memberRow.status === "active") {
-    trustClass = "trusted_contact";
   } else if (memberRow) {
-    // Any other status (pending/unverified/blocked/revoked) — never
-    // reclassified; raw status/policy below let the consumer enforce.
-    trustClass = "unverified_contact";
+    const status = memberRow.status;
+    if (status === "active") {
+      trustClass = "trusted_contact";
+    } else if (status === "unverified" || status === "pending") {
+      trustClass = "unverified_contact";
+    } else {
+      // blocked/revoked → unknown, matching the canonical resolver. Raw
+      // status/policy are still surfaced below so the consumer enforces the
+      // member_blocked / member_revoked hard-deny.
+      trustClass = "unknown";
+    }
   } else {
     trustClass = "unknown";
   }

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -1,0 +1,151 @@
+/**
+ * Gateway-side per-actor trust verdict resolver.
+ *
+ * Reads ONLY the gateway ACL DB to produce a {@link TrustVerdict} for an
+ * inbound actor. Mirrors the daemon's classification precedence
+ * (`actor-trust-resolver.ts`) and the Combo-7 `(type,address)` COLLATE NOCASE
+ * read pattern. Read-only — no writes, no assistant DB, no IPC.
+ *
+ * Blocked/revoked channels are NOT reclassified: their raw `status`/`policy`
+ * are surfaced verbatim so the consumer enforces hard-deny semantics.
+ */
+
+import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
+import { and, desc, eq, sql } from "drizzle-orm";
+
+import { getGatewayDb } from "../db/connection.js";
+import {
+  contacts as gwContacts,
+  contactChannels as gwContactChannels,
+} from "../db/schema.js";
+import { canonicalizeInboundIdentity } from "../verification/identity.js";
+
+export interface ResolveTrustVerdictInput {
+  channelType: string;
+  actorExternalId?: string;
+  actorUsername?: string;
+  actorDisplayName?: string;
+  conversationExternalId?: string;
+}
+
+/**
+ * Resolve the per-actor trust verdict from the gateway ACL DB.
+ *
+ * 1. Canonicalize `actorExternalId` for this channel (E.164 for phone-like).
+ * 2. Resolve the channel's active guardian binding (label/identity fields).
+ * 3. Resolve THIS actor's member channel by `(type,address)` COLLATE NOCASE.
+ * 4. Classify guardian > trusted_contact > unverified_contact > unknown.
+ */
+export async function resolveTrustVerdict(
+  input: ResolveTrustVerdictInput,
+): Promise<TrustVerdict> {
+  const db = getGatewayDb();
+
+  const rawActorId =
+    typeof input.actorExternalId === "string" &&
+    input.actorExternalId.trim().length > 0
+      ? input.actorExternalId.trim()
+      : undefined;
+
+  const canonicalSenderId = rawActorId
+    ? canonicalizeInboundIdentity(input.channelType, rawActorId)
+    : null;
+
+  // --- Guardian-for-channel binding (independent of THIS actor) ---
+  const guardianRow = db
+    .select({
+      address: gwContactChannels.address,
+      externalChatId: gwContactChannels.externalChatId,
+      principalId: gwContacts.principalId,
+      displayName: gwContacts.displayName,
+    })
+    .from(gwContacts)
+    .innerJoin(
+      gwContactChannels,
+      eq(gwContactChannels.contactId, gwContacts.id),
+    )
+    .where(
+      and(
+        eq(gwContacts.role, "guardian"),
+        eq(gwContactChannels.type, input.channelType),
+        eq(gwContactChannels.status, "active"),
+      ),
+    )
+    .orderBy(desc(gwContactChannels.verifiedAt))
+    .limit(1)
+    .get();
+
+  // --- Member channel for THIS actor (address-keyed, COLLATE NOCASE) ---
+  const memberRow = canonicalSenderId
+    ? db
+        .select({
+          contactId: gwContactChannels.contactId,
+          channelId: gwContactChannels.id,
+          type: gwContactChannels.type,
+          address: gwContactChannels.address,
+          externalChatId: gwContactChannels.externalChatId,
+          status: gwContactChannels.status,
+          policy: gwContactChannels.policy,
+          verifiedAt: gwContactChannels.verifiedAt,
+          verifiedVia: gwContactChannels.verifiedVia,
+          role: gwContacts.role,
+          memberDisplayName: gwContacts.displayName,
+        })
+        .from(gwContactChannels)
+        .innerJoin(gwContacts, eq(gwContactChannels.contactId, gwContacts.id))
+        .where(
+          and(
+            eq(gwContactChannels.type, input.channelType),
+            sql`${gwContactChannels.address} = ${canonicalSenderId} COLLATE NOCASE`,
+          ),
+        )
+        .limit(1)
+        .get()
+    : undefined;
+
+  // --- Classification (mirrors resolveActorTrust precedence) ---
+  const isGuardian =
+    !!memberRow &&
+    (memberRow.role === "guardian" ||
+      (!!guardianRow &&
+        guardianRow.address.toLowerCase() ===
+          memberRow.address.toLowerCase()));
+
+  let trustClass: TrustClass;
+  if (isGuardian) {
+    trustClass = "guardian";
+  } else if (memberRow && memberRow.status === "active") {
+    trustClass = "trusted_contact";
+  } else if (memberRow) {
+    // Any other status (pending/unverified/blocked/revoked) — never
+    // reclassified; raw status/policy below let the consumer enforce.
+    trustClass = "unverified_contact";
+  } else {
+    trustClass = "unknown";
+  }
+
+  const verdict: TrustVerdict = { trustClass, canonicalSenderId };
+
+  if (guardianRow) {
+    verdict.guardianExternalUserId = guardianRow.address;
+    verdict.guardianDeliveryChatId = guardianRow.externalChatId;
+    if (guardianRow.principalId)
+      verdict.guardianPrincipalId = guardianRow.principalId;
+    verdict.guardianDisplayName = guardianRow.displayName;
+  }
+
+  if (memberRow) {
+    verdict.contactId = memberRow.contactId;
+    verdict.channelId = memberRow.channelId;
+    verdict.type = memberRow.type;
+    verdict.address = memberRow.address;
+    verdict.externalChatId = memberRow.externalChatId;
+    verdict.status = memberRow.status;
+    verdict.policy = memberRow.policy;
+    verdict.verifiedAt = memberRow.verifiedAt;
+    verdict.verifiedVia = memberRow.verifiedVia;
+    verdict.memberDisplayName = memberRow.memberDisplayName;
+  }
+
+  return verdict;
+}


### PR DESCRIPTION
## Summary
- Add gateway-side resolveTrustVerdict: read-only per-actor trust verdict from the gateway DB
- Mirrors Combo-7 (type,address) COLLATE NOCASE reads; no reclassification of blocked/revoked
- Shared producer for the text (PR 3) and voice (PR 4) transports

Part of plan: gateway-produces-trust-verdict.md (PR 2 of 4)