### PR TITLE
feat(gateway): add resolve_inbound_trust IPC + unwired daemon reader

### DIFF
--- a/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
+++ b/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the gateway-backed per-actor inbound trust reader.
+ *
+ * The reader returns `null` on ANY failure (transport failure, undefined,
+ * malformed shape, thrown error); the Combo 9/10 consumer decides fail-open
+ * vs fail-closed. These tests pin that contract plus the forwarded method +
+ * params.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Controllable IPC mock ────────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+
+const ipcHandlers = new Map<string, IpcHandler>();
+const ipcCallLog: Array<{
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+}> = [];
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCallLog.push({ method, params, timeoutMs });
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+import { getInboundTrustVerdict } from "../inbound-trust-reader.js";
+
+const METHOD = "resolve_inbound_trust";
+
+const VALID_VERDICT = {
+  trustClass: "trusted_contact",
+  canonicalSenderId: "U_MEMBER",
+  contactId: "c-member",
+  status: "active",
+};
+
+describe("getInboundTrustVerdict", () => {
+  beforeEach(() => {
+    ipcHandlers.clear();
+    ipcCallLog.length = 0;
+  });
+
+  test("returns the gateway-resolved verdict on a valid response", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+
+    const verdict = await getInboundTrustVerdict({
+      channelType: "telegram",
+      actorExternalId: "U_MEMBER",
+    });
+
+    expect(verdict).toEqual(VALID_VERDICT);
+  });
+
+  test("forwards the correct method, params, and timeout to ipcCall", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+
+    const input = {
+      channelType: "telegram" as const,
+      actorExternalId: "U_MEMBER",
+      actorUsername: "member",
+      actorDisplayName: "Member",
+      conversationExternalId: "C_CHAT",
+    };
+    await getInboundTrustVerdict(input);
+
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.params).toEqual(input);
+    expect(call?.timeoutMs).toBe(2_000);
+  });
+
+  test("returns null when IPC transport fails (undefined)", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+
+  test("returns null for a malformed verdict shape", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: { trustClass: "bogus" } }));
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+
+  test("returns null when the verdict field is missing", async () => {
+    ipcHandlers.set(METHOD, () => ({}));
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+
+  test("returns null when the IPC call throws", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("socket exploded");
+    });
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
+++ b/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
@@ -34,6 +34,8 @@ mock.module("../../ipc/gateway-client.js", () => ({
   resetPersistentClient: () => {},
 }));
 
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
 import { getInboundTrustVerdict } from "../inbound-trust-reader.js";
 
 const METHOD = "resolve_inbound_trust";
@@ -43,7 +45,7 @@ const VALID_VERDICT = {
   canonicalSenderId: "U_MEMBER",
   contactId: "c-member",
   status: "active",
-};
+} satisfies TrustVerdict;
 
 describe("getInboundTrustVerdict", () => {
   beforeEach(() => {

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -1,0 +1,43 @@
+/**
+ * Gateway-backed per-actor inbound trust verdict reader.
+ *
+ * Resolves the inbound sender's {@link TrustVerdict} from the gateway via the
+ * `resolve_inbound_trust` IPC route. Unlike the channel-admission reader this
+ * is per-actor, NOT per-channel, so there is NO caching.
+ *
+ * Returns `null` on ANY failure (transport failure, `undefined`, malformed
+ * shape, or thrown error). The Combo 9/10 consumer decides fail-open vs
+ * fail-closed — this reader does not.
+ */
+
+import { type TrustVerdict, TrustVerdictSchema } from "@vellumai/gateway-client";
+
+import type { ChannelId } from "../channels/types.js";
+import { ipcCall } from "../ipc/gateway-client.js";
+
+// Short IPC timeout so the read resolves promptly rather than stalling call
+// setup on a gateway that accepts the socket but hangs.
+const TRUST_IPC_TIMEOUT_MS = 2_000;
+
+export async function getInboundTrustVerdict(input: {
+  channelType: ChannelId;
+  actorExternalId?: string;
+  actorUsername?: string;
+  actorDisplayName?: string;
+  conversationExternalId?: string;
+}): Promise<TrustVerdict | null> {
+  try {
+    const result = (await ipcCall(
+      "resolve_inbound_trust",
+      input,
+      TRUST_IPC_TIMEOUT_MS,
+    )) as { verdict?: unknown } | null | undefined;
+
+    if (!result) return null;
+
+    const parsed = TrustVerdictSchema.safeParse(result.verdict);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -190,6 +190,7 @@ import { contactRoutes } from "./ipc/contact-handlers.js";
 import { inviteRoutes } from "./ipc/invite-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
+import { trustVerdictRoutes } from "./ipc/trust-verdict-handlers.js";
 import { createLogTailRoutes } from "./ipc/log-tail-handlers.js";
 import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
@@ -2466,6 +2467,7 @@ async function main() {
     ...slackThreadRoutes,
     ...thresholdRoutes,
     ...admissionPolicyRoutes,
+    ...trustVerdictRoutes,
     ...riskClassificationRoutes,
     ...createLogTailRoutes(config),
     ...trustRulesRoutes,

--- a/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the `resolve_inbound_trust` IPC route.
+ *
+ * Seeds the gateway ACL DB directly (contacts + contact_channels) and invokes
+ * the route handler with params, asserting the returned `{ verdict }` matches
+ * the resolver output for guardian / member / unknown actors.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+await import("../../__tests__/test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../../db/connection.js"
+);
+const { contacts: gwContacts, contactChannels: gwContactChannels } =
+  await import("../../db/schema.js");
+const { resolveTrustVerdict } = await import(
+  "../../risk/trust-verdict-resolver.js"
+);
+const { trustVerdictRoutes } = await import("../trust-verdict-handlers.js");
+
+const CHANNEL = "telegram";
+
+const route = trustVerdictRoutes.find(
+  (r) => r.method === "resolve_inbound_trust",
+)!;
+
+function insertContact(args: {
+  id: string;
+  displayName: string;
+  role?: string;
+  principalId?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: args.id,
+      displayName: args.displayName,
+      role: args.role ?? "contact",
+      principalId: args.principalId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address: string;
+  externalChatId?: string | null;
+  status?: string;
+  policy?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: args.type ?? CHANNEL,
+      address: args.address,
+      externalChatId: args.externalChatId ?? null,
+      status: args.status ?? "active",
+      policy: args.policy ?? "allow",
+      verifiedAt: now,
+      verifiedVia: "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(gwContactChannels).run();
+  getGatewayDb().delete(gwContacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("resolve_inbound_trust route", () => {
+  test("registers the resolve_inbound_trust method with a schema", () => {
+    expect(route.method).toBe("resolve_inbound_trust");
+    expect(route.schema).toBeDefined();
+  });
+
+  test("guardian actor → { verdict } matching the resolver output", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+    });
+
+    const params = { channelType: CHANNEL, actorExternalId: "U_GUARDIAN" };
+    const result = (await route.handler(params)) as { verdict: unknown };
+    const expected = await resolveTrustVerdict(params);
+
+    expect(result.verdict).toEqual(expected);
+    expect((result.verdict as { trustClass: string }).trustClass).toBe(
+      "guardian",
+    );
+  });
+
+  test("active member → trusted_contact verdict matching the resolver", async () => {
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_MEMBER",
+      status: "active",
+    });
+
+    const params = { channelType: CHANNEL, actorExternalId: "U_MEMBER" };
+    const result = (await route.handler(params)) as { verdict: unknown };
+    const expected = await resolveTrustVerdict(params);
+
+    expect(result.verdict).toEqual(expected);
+    expect((result.verdict as { trustClass: string }).trustClass).toBe(
+      "trusted_contact",
+    );
+  });
+
+  test("unknown actor → unknown verdict matching the resolver", async () => {
+    const params = { channelType: CHANNEL, actorExternalId: "U_STRANGER" };
+    const result = (await route.handler(params)) as { verdict: unknown };
+    const expected = await resolveTrustVerdict(params);
+
+    expect(result.verdict).toEqual(expected);
+    expect((result.verdict as { trustClass: string }).trustClass).toBe(
+      "unknown",
+    );
+  });
+});

--- a/gateway/src/ipc/trust-verdict-handlers.ts
+++ b/gateway/src/ipc/trust-verdict-handlers.ts
@@ -1,0 +1,25 @@
+/**
+ * IPC route definitions for gateway-owned per-actor trust verdict reads.
+ *
+ * Exposes `resolve_inbound_trust` to the assistant daemon over the IPC socket.
+ * Resolves the per-actor {@link TrustVerdict} from the gateway ACL DB. This is
+ * deliberately a SEPARATE method from `get_channel_admission_policy`: the
+ * admission read is channel-scoped + TTL-cached, while this verdict is
+ * per-actor and must not share that cache or widen that response.
+ */
+
+import { ResolveInboundTrustRequestSchema } from "@vellumai/gateway-client";
+
+import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
+import type { IpcRoute } from "./server.js";
+
+export const trustVerdictRoutes: IpcRoute[] = [
+  {
+    method: "resolve_inbound_trust",
+    schema: ResolveInboundTrustRequestSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const input = ResolveInboundTrustRequestSchema.parse(params);
+      return { verdict: await resolveTrustVerdict(input) };
+    },
+  },
+];

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -73,9 +73,14 @@ export type { AdmissionPolicy } from "./admission-policy-contract.js";
 
 // Trust verdict contract (gateway → daemon) — Zod schemas + derived types
 export {
+  ResolveInboundTrustRequestSchema,
   TRUST_CLASS_VALUES,
   TrustClassSchema,
   TrustVerdictSchema,
 } from "./trust-verdict-contract.js";
 
-export type { TrustClass, TrustVerdict } from "./trust-verdict-contract.js";
+export type {
+  ResolveInboundTrustRequest,
+  TrustClass,
+  TrustVerdict,
+} from "./trust-verdict-contract.js";

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -62,3 +62,20 @@ export const TrustVerdictSchema = z.object({
 });
 
 export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;
+
+/**
+ * IPC request for `resolve_inbound_trust`. Per-actor identity keys the
+ * gateway resolver needs to classify the inbound sender. The response reuses
+ * {@link TrustVerdictSchema}.
+ */
+export const ResolveInboundTrustRequestSchema = z.object({
+  channelType: z.string().min(1),
+  actorExternalId: z.string().optional(),
+  actorUsername: z.string().optional(),
+  actorDisplayName: z.string().optional(),
+  conversationExternalId: z.string().optional(),
+});
+
+export type ResolveInboundTrustRequest = z.infer<
+  typeof ResolveInboundTrustRequestSchema
+>;


### PR DESCRIPTION
## Summary
- New gateway IPC method resolve_inbound_trust returns the per-actor TrustVerdict from the gateway DB
- New daemon reader getInboundTrustVerdict (fail-soft to null), NOT wired into call setup yet (Combo 9/10)
- get_channel_admission_policy unchanged

Part of plan: gateway-produces-trust-verdict.md (PR 4 of 4)