### PR TITLE
inference: flag-gate the managed MiniMax M3 provider (Fireworks vs Together)

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guard.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guard.test.ts
@@ -40,7 +40,9 @@ interface RegistryFlag {
   key: string;
   label: string;
   description: string;
-  defaultEnabled: boolean;
+  // Boolean flags, or multivariate string flags whose value is one of `values`.
+  defaultEnabled: boolean | string;
+  values?: string[];
 }
 
 interface Registry {
@@ -175,8 +177,21 @@ describe("assistant feature flag guard", () => {
     const violations: string[] = [];
 
     for (const flag of assistantFlags) {
-      if (typeof flag.defaultEnabled !== "boolean") {
-        violations.push(`${flag.key}: missing or non-boolean 'defaultEnabled'`);
+      // Flags are boolean or multivariate string (e.g.
+      // managed-minimax-m3-provider). A string flag must enumerate its
+      // variations and the default must be one of them.
+      if (typeof flag.defaultEnabled === "string") {
+        if (
+          !Array.isArray(flag.values) ||
+          flag.values.length < 2 ||
+          !flag.values.includes(flag.defaultEnabled)
+        ) {
+          violations.push(
+            `${flag.key}: string 'defaultEnabled' must be one of a 'values' list of >= 2`,
+          );
+        }
+      } else if (typeof flag.defaultEnabled !== "boolean") {
+        violations.push(`${flag.key}: missing or invalid 'defaultEnabled'`);
       }
       if (
         typeof flag.description !== "string" ||

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -187,7 +187,12 @@ describe("reconcileFlagGatedProfiles", () => {
   test("flag off with no os-beta present is a no-op", () => {
     process.env.IS_PLATFORM = "true";
     seedBalancedConfig();
-    setOverridesForTesting({ "os-beta": false });
+    // Pin the Balanced provider flag to the seeded value (together) so the
+    // Balanced reconcile is also a no-op, isolating the os-beta behavior.
+    setOverridesForTesting({
+      "os-beta": false,
+      "managed-minimax-m3-provider": "together",
+    });
 
     expect(reconcileFlagGatedProfiles()).toBe(false);
   });
@@ -364,5 +369,109 @@ describe("reconcileFlagGatedProfiles", () => {
     setOverridesForTesting({ "os-beta": false });
     expect(reconcileFlagGatedProfiles()).toBe(false);
     expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+  });
+});
+
+describe("reconcileFlagGatedProfiles — managed Balanced provider", () => {
+  const FLAG = "managed-minimax-m3-provider";
+
+  beforeEach(() => {
+    ensureTestDir();
+    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    delete process.env.IS_PLATFORM;
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  function balanced(): Record<string, unknown> {
+    return readConfig().llm.profiles["balanced"]!;
+  }
+
+  test("defaults to Fireworks when the flag is unset (safe hold state)", () => {
+    seedBalancedConfig(); // seeds the Together template
+    setOverridesForTesting({}); // no override -> registry default "fireworks"
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const b = balanced();
+    expect(b.provider).toBe("fireworks");
+    expect(b.provider_connection).toBe("fireworks-managed");
+    expect(b.model).toBe("accounts/fireworks/models/minimax-m3");
+  });
+
+  test("flag = together keeps Balanced on Together", () => {
+    seedBalancedConfig();
+    setOverridesForTesting({ [FLAG]: "together" });
+
+    reconcileFlagGatedProfiles();
+
+    const b = balanced();
+    expect(b.provider).toBe("together");
+    expect(b.provider_connection).toBe("together-managed");
+    expect(b.model).toBe("MiniMaxAI/MiniMax-M3");
+  });
+
+  test("flag = fireworks routes Balanced to Fireworks", () => {
+    seedBalancedConfig();
+    setOverridesForTesting({ [FLAG]: "fireworks" });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const b = balanced();
+    expect(b.provider).toBe("fireworks");
+    expect(b.provider_connection).toBe("fireworks-managed");
+    expect(b.model).toBe("accounts/fireworks/models/minimax-m3");
+  });
+
+  test("live flip: together -> fireworks re-routes on the next reconcile", () => {
+    seedBalancedConfig();
+    setOverridesForTesting({ [FLAG]: "together" });
+    reconcileFlagGatedProfiles();
+    expect(balanced().provider).toBe("together");
+
+    // Operator flips the flag in LaunchDarkly; the gateway pushes the new value
+    // and the flag listener re-runs this reconcile without a reboot.
+    setOverridesForTesting({ [FLAG]: "fireworks" });
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+    expect(balanced().provider).toBe("fireworks");
+  });
+
+  test("idempotent — no second write once routed", () => {
+    seedBalancedConfig();
+    setOverridesForTesting({ [FLAG]: "fireworks" });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("never touches a user-owned balanced profile", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "user",
+            provider: "anthropic",
+            provider_connection: "anthropic-personal",
+            model: "claude-sonnet-4-6",
+          },
+        },
+        profileOrder: ["balanced"],
+      },
+    });
+    invalidateConfigCache();
+    setOverridesForTesting({ [FLAG]: "fireworks" });
+
+    reconcileFlagGatedProfiles();
+
+    const b = balanced();
+    expect(b.source).toBe("user");
+    expect(b.provider).toBe("anthropic");
+    expect(b.model).toBe("claude-sonnet-4-6");
   });
 });

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -1,7 +1,10 @@
 import { isDeepStrictEqual } from "node:util";
 
 import { getLogger } from "../util/logger.js";
-import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
+import {
+  getAssistantFeatureFlagValue,
+  isAssistantFeatureFlagEnabled,
+} from "./assistant-feature-flags.js";
 import {
   getConfigReadOnly,
   invalidateConfigCache,
@@ -18,6 +21,73 @@ import {
 } from "./seed-inference-profiles.js";
 
 const log = getLogger("sync-gated-profiles");
+
+export const MANAGED_BALANCED_PROFILE_KEY = "balanced";
+export const MINIMAX_M3_PROVIDER_FLAG_KEY = "managed-minimax-m3-provider";
+
+/**
+ * Routing targets for the managed Balanced profile, keyed by the
+ * `managed-minimax-m3-provider` flag value. Provider slug, managed connection,
+ * and model id move together — each provider serves MiniMax M3 under its own
+ * model id.
+ */
+const BALANCED_PROVIDER_TARGETS = {
+  fireworks: {
+    provider: "fireworks",
+    provider_connection: "fireworks-managed",
+    model: "accounts/fireworks/models/minimax-m3",
+  },
+  together: {
+    provider: "together",
+    provider_connection: "together-managed",
+    model: "MiniMaxAI/MiniMax-M3",
+  },
+} as const;
+
+/**
+ * Reconcile the managed Balanced profile's provider against the
+ * `managed-minimax-m3-provider` flag — the policy lever for moving MiniMax M3
+ * between Fireworks and Together without a redeploy or migration. The seed
+ * template owns Balanced's content; this override runs after the seed (on boot
+ * and on every live flag change) and is the final authority on which provider
+ * serves it. Any value other than `"together"` — including an unreachable flag
+ * — holds on Fireworks, the safe default.
+ *
+ * Only the three routing fields are patched; everything else on Balanced is
+ * shared across providers and owned by the seed template. A user-owned
+ * `balanced` (`source: "user"`) is never touched.
+ */
+function reconcileBalancedProvider(
+  profiles: Record<string, Record<string, unknown>>,
+): boolean {
+  const balanced = readObject(profiles[MANAGED_BALANCED_PROFILE_KEY]);
+  // Absent → the seeder hasn't materialized it yet this boot; nothing to steer.
+  // Only an explicit `source: "user"` opts out (mirrors the migration
+  // convention; a source-less legacy managed entry is still ours).
+  if (balanced == null || balanced.source === "user") return false;
+
+  const value = getAssistantFeatureFlagValue(
+    MINIMAX_M3_PROVIDER_FLAG_KEY,
+    getConfigReadOnly(),
+  );
+  const target =
+    value === "together"
+      ? BALANCED_PROVIDER_TARGETS.together
+      : BALANCED_PROVIDER_TARGETS.fireworks;
+
+  if (
+    balanced.provider === target.provider &&
+    balanced.provider_connection === target.provider_connection &&
+    balanced.model === target.model
+  ) {
+    return false;
+  }
+
+  balanced.provider = target.provider;
+  balanced.provider_connection = target.provider_connection;
+  balanced.model = target.model;
+  return true;
+}
 
 /**
  * Reconcile flag-gated managed profiles against the current feature-flag state.
@@ -67,21 +137,24 @@ export function reconcileFlagGatedProfiles(): boolean {
   // Never clobber a user-owned profile that happens to be named `os-beta`. The
   // entry is ours to manage only when it is absent or already managed; a
   // user-sourced entry of the same name is left untouched on every path.
-  const isOursToManage = previous == null || previous.source === "managed";
-  if (!isOursToManage) {
-    return false;
-  }
+  const osBetaIsOurs = previous == null || previous.source === "managed";
+  const osBetaChanged = osBetaIsOurs
+    ? enabled
+      ? enableProfile(profiles, profileOrder, previous, isByokMode)
+      : disableProfile(llm, profiles, profileOrder, previous)
+    : false;
 
-  const changed = enabled
-    ? enableProfile(profiles, profileOrder, previous, isByokMode)
-    : disableProfile(llm, profiles, profileOrder, previous);
+  // Steer the managed Balanced profile's provider from the flag. Independent of
+  // the os-beta path above, so it runs even when os-beta is user-owned.
+  const balancedChanged = reconcileBalancedProvider(profiles);
 
+  const changed = osBetaChanged || balancedChanged;
   if (changed) {
     saveRawConfig(config);
     invalidateConfigCache();
     log.info(
-      { profile: OS_BETA_PROFILE_KEY, enabled },
-      "Reconciled flag-gated profile",
+      { osBetaEnabled: enabled, osBetaChanged, balancedChanged },
+      "Reconciled flag-gated profiles",
     );
   }
   return changed;

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -63,7 +63,7 @@
       "scope": "assistant",
       "key": "trace-collection",
       "label": "Trace Collection",
-      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) — the live value is delivered from LaunchDarkly.",
+      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) \u2014 the live value is delivered from LaunchDarkly.",
       "defaultEnabled": false
     },
     {
@@ -433,6 +433,18 @@
       "label": "OS Beta",
       "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
       "defaultEnabled": false
+    },
+    {
+      "id": "managed-minimax-m3-provider",
+      "scope": "assistant",
+      "key": "managed-minimax-m3-provider",
+      "label": "Managed MiniMax M3 Provider",
+      "description": "Which managed provider serves MiniMax M3 for the Balanced profile. fireworks = route via Fireworks; together = route via Together AI.",
+      "defaultEnabled": "fireworks",
+      "values": [
+        "fireworks",
+        "together"
+      ]
     }
   ]
 }

--- a/gateway/src/__tests__/feature-flag-defaults-sync.test.ts
+++ b/gateway/src/__tests__/feature-flag-defaults-sync.test.ts
@@ -30,7 +30,15 @@ describe("feature flag registry availability", () => {
       expect(typeof flag.key).toBe("string");
       expect(typeof flag.label).toBe("string");
       expect(typeof flag.description).toBe("string");
-      expect(typeof flag.defaultEnabled).toBe("boolean");
+      // Flags are boolean or multivariate string (e.g.
+      // managed-minimax-m3-provider). String flags must enumerate their
+      // variations and the default must be one of them.
+      expect(["boolean", "string"]).toContain(typeof flag.defaultEnabled);
+      if (typeof flag.defaultEnabled === "string") {
+        expect(Array.isArray(flag.values)).toBe(true);
+        expect(flag.values.length).toBeGreaterThanOrEqual(2);
+        expect(flag.values).toContain(flag.defaultEnabled);
+      }
       expect(flag.scope).toBe("assistant");
     }
   });

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -63,7 +63,7 @@
       "scope": "assistant",
       "key": "trace-collection",
       "label": "Trace Collection",
-      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) — the live value is delivered from LaunchDarkly.",
+      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) \u2014 the live value is delivered from LaunchDarkly.",
       "defaultEnabled": false
     },
     {
@@ -433,6 +433,18 @@
       "label": "OS Beta",
       "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
       "defaultEnabled": false
+    },
+    {
+      "id": "managed-minimax-m3-provider",
+      "scope": "assistant",
+      "key": "managed-minimax-m3-provider",
+      "label": "Managed MiniMax M3 Provider",
+      "description": "Which managed provider serves MiniMax M3 for the Balanced profile. fireworks = route via Fireworks; together = route via Together AI.",
+      "defaultEnabled": "fireworks",
+      "values": [
+        "fireworks",
+        "together"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a flag-gated reconcile that steers the managed **Balanced** profile's provider from a string flag `managed-minimax-m3-provider` (`fireworks` | `together`), **defaulting to Fireworks** — the safe hold state — for any value other than `together` (including an unreachable flag).

| File | Change |
|------|--------|
| `meta/feature-flags/feature-flag-registry.json` | declare `managed-minimax-m3-provider` (assistant scope, default `"fireworks"`, values `[fireworks, together]`) + synced web copy |
| `assistant/src/config/sync-gated-profiles.ts` | `reconcileBalancedProvider` + wire into `reconcileFlagGatedProfiles` |
| `assistant/src/config/__tests__/sync-gated-profiles.test.ts` | default / together / fireworks / live-flip / idempotent / user-owned |

## Why

We want MiniMax M3 to stay on **Fireworks until we're ready** to switch to Together, then flip with a LaunchDarkly dashboard change — **no redeploy, no migration churn, and no revert** (so the never-delete-migration rule stays satisfied; #35669 + #35694 remain intact).

## How it works

- The seed template still owns Balanced's content (Together, from #35694). This override runs **after** the seed via `reconcileFlagGatedProfiles`, which already fires both at **boot** (`daemon/lifecycle.ts`) and on **every live flag change** (`ipc/gateway-flag-listener.ts`). So flipping the flag in LD re-routes the Balanced profile **without a reboot**.
- It's the final authority on the three routing fields (`provider` / `provider_connection` / `model`); everything else on Balanced is shared across providers and owned by the seed. A **user-owned** `balanced` is never touched.
- Both providers are fully wired already (catalog entries, `together-managed` + `fireworks-managed` connections, both rate cards on the platform), so this is purely a resolution-time switch.

## Default behavior

With the flag unset/unreachable → registry default `"fireworks"` → every install reconciles Balanced to Fireworks on its next boot. To go live on Together, set the flag to `together` (globally or per-org) in the dashboard.

## Checks

- `bunx tsc --noEmit` ✅ · lint ✅ · format ✅ (pre-push hook green)
- `sync-gated-profiles.test.ts` ✅ 17/17 (11 os-beta + 6 new) · `config-loader-backfill.test.ts` ✅ 56/56 (seed unaffected)

## Dependencies & merge order

Depends on the Terraform flag PR **vellum-assistant-platform#8598** (declares the LD flag). Merge + apply that first, then this; then configure targeting in the LaunchDarkly dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->