### PR TITLE
refactor(trust-verdict): drop unused request fields

### DIFF
--- a/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
+++ b/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
@@ -70,9 +70,6 @@ describe("getInboundTrustVerdict", () => {
     const input = {
       channelType: "telegram" as const,
       actorExternalId: "U_MEMBER",
-      actorUsername: "member",
-      actorDisplayName: "Member",
-      conversationExternalId: "C_CHAT",
     };
     await getInboundTrustVerdict(input);
 

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -22,9 +22,6 @@ const TRUST_IPC_TIMEOUT_MS = 2_000;
 export async function getInboundTrustVerdict(input: {
   channelType: ChannelId;
   actorExternalId?: string;
-  actorUsername?: string;
-  actorDisplayName?: string;
-  conversationExternalId?: string;
 }): Promise<TrustVerdict | null> {
   try {
     const result = (await ipcCall(

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -164,9 +164,6 @@ export async function handleInbound(
     trustVerdict = await resolveTrustVerdict({
       channelType: event.sourceChannel,
       actorExternalId: event.actor.actorExternalId,
-      actorUsername: event.actor.username,
-      actorDisplayName: displayName,
-      conversationExternalId: event.message.conversationExternalId,
     });
   } catch (err) {
     // Producer fails soft — resolution never breaks ingress. trustVerdict

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -24,9 +24,6 @@ import { canonicalizeInboundIdentity } from "../verification/identity.js";
 export interface ResolveTrustVerdictInput {
   channelType: string;
   actorExternalId?: string;
-  actorUsername?: string;
-  actorDisplayName?: string;
-  conversationExternalId?: string;
 }
 
 /**

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -71,9 +71,6 @@ export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;
 export const ResolveInboundTrustRequestSchema = z.object({
   channelType: z.string().min(1),
   actorExternalId: z.string().optional(),
-  actorUsername: z.string().optional(),
-  actorDisplayName: z.string().optional(),
-  conversationExternalId: z.string().optional(),
 });
 
 export type ResolveInboundTrustRequest = z.infer<


### PR DESCRIPTION
## Summary
Fixes a slop gap from plan self-review for gateway-produces-trust-verdict.md.

**Gap:** the trust-verdict request carried actorUsername/actorDisplayName/conversationExternalId across 4 layers but resolveTrustVerdict reads only channelType + actorExternalId. The info fields also violated the 2×2 ACL/info invariant (gateway derives labels from its own DB).
**Fix:** request now carries only channelType (required) + actorExternalId (optional); tests updated.