### PR TITLE
Combo 8 — Gateway PRODUCES the per-actor trust verdict (text stamp + voice IPC)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3959,6 +3959,59 @@ paths:
                         - trusted_contacts
                         - any_contact
                         - strangers
+                    trustVerdict:
+                      type: object
+                      properties:
+                        trustClass:
+                          type: string
+                          enum:
+                            - guardian
+                            - trusted_contact
+                            - unverified_contact
+                            - unknown
+                        canonicalSenderId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        guardianExternalUserId:
+                          type: string
+                        guardianDeliveryChatId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        guardianPrincipalId:
+                          type: string
+                        guardianDisplayName:
+                          type: string
+                        contactId:
+                          type: string
+                        channelId:
+                          type: string
+                        type:
+                          type: string
+                        address:
+                          type: string
+                        externalChatId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        status:
+                          type: string
+                        policy:
+                          type: string
+                        verifiedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        verifiedVia:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        memberDisplayName:
+                          type: string
+                      required:
+                        - trustClass
+                        - canonicalSenderId
                     emailSubject:
                       type: string
                     emailRecipient:

--- a/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
+++ b/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
@@ -70,9 +70,6 @@ describe("getInboundTrustVerdict", () => {
     const input = {
       channelType: "telegram" as const,
       actorExternalId: "U_MEMBER",
-      actorUsername: "member",
-      actorDisplayName: "Member",
-      conversationExternalId: "C_CHAT",
     };
     await getInboundTrustVerdict(input);
 

--- a/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
+++ b/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the gateway-backed per-actor inbound trust reader.
+ *
+ * The reader returns `null` on ANY failure (transport failure, undefined,
+ * malformed shape, thrown error); the Combo 9/10 consumer decides fail-open
+ * vs fail-closed. These tests pin that contract plus the forwarded method +
+ * params.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Controllable IPC mock ────────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+
+const ipcHandlers = new Map<string, IpcHandler>();
+const ipcCallLog: Array<{
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+}> = [];
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCallLog.push({ method, params, timeoutMs });
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import { getInboundTrustVerdict } from "../inbound-trust-reader.js";
+
+const METHOD = "resolve_inbound_trust";
+
+const VALID_VERDICT = {
+  trustClass: "trusted_contact",
+  canonicalSenderId: "U_MEMBER",
+  contactId: "c-member",
+  status: "active",
+} satisfies TrustVerdict;
+
+describe("getInboundTrustVerdict", () => {
+  beforeEach(() => {
+    ipcHandlers.clear();
+    ipcCallLog.length = 0;
+  });
+
+  test("returns the gateway-resolved verdict on a valid response", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+
+    const verdict = await getInboundTrustVerdict({
+      channelType: "telegram",
+      actorExternalId: "U_MEMBER",
+    });
+
+    expect(verdict).toEqual(VALID_VERDICT);
+  });
+
+  test("forwards the correct method, params, and timeout to ipcCall", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+
+    const input = {
+      channelType: "telegram" as const,
+      actorExternalId: "U_MEMBER",
+      actorUsername: "member",
+      actorDisplayName: "Member",
+      conversationExternalId: "C_CHAT",
+    };
+    await getInboundTrustVerdict(input);
+
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.params).toEqual(input);
+    expect(call?.timeoutMs).toBe(2_000);
+  });
+
+  test("returns null when IPC transport fails (undefined)", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+
+  test("returns null for a malformed verdict shape", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: { trustClass: "bogus" } }));
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+
+  test("returns null when the verdict field is missing", async () => {
+    ipcHandlers.set(METHOD, () => ({}));
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+
+  test("returns null when the IPC call throws", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("socket exploded");
+    });
+    expect(
+      await getInboundTrustVerdict({ channelType: "telegram" }),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -6,8 +6,8 @@
  * is per-actor, NOT per-channel, so there is NO caching.
  *
  * Returns `null` on ANY failure (transport failure, `undefined`, malformed
- * shape, or thrown error). The Combo 9/10 consumer decides fail-open vs
- * fail-closed — this reader does not.
+ * shape, or thrown error). The caller owns the deny policy (fail-open vs
+ * fail-closed); this reader only reports the verdict or `null`.
  */
 
 import { type TrustVerdict, TrustVerdictSchema } from "@vellumai/gateway-client";

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -1,0 +1,43 @@
+/**
+ * Gateway-backed per-actor inbound trust verdict reader.
+ *
+ * Resolves the inbound sender's {@link TrustVerdict} from the gateway via the
+ * `resolve_inbound_trust` IPC route. Unlike the channel-admission reader this
+ * is per-actor, NOT per-channel, so there is NO caching.
+ *
+ * Returns `null` on ANY failure (transport failure, `undefined`, malformed
+ * shape, or thrown error). The Combo 9/10 consumer decides fail-open vs
+ * fail-closed — this reader does not.
+ */
+
+import { type TrustVerdict, TrustVerdictSchema } from "@vellumai/gateway-client";
+
+import type { ChannelId } from "../channels/types.js";
+import { ipcCall } from "../ipc/gateway-client.js";
+
+// Short IPC timeout so the read resolves promptly rather than stalling call
+// setup on a gateway that accepts the socket but hangs.
+const TRUST_IPC_TIMEOUT_MS = 2_000;
+
+export async function getInboundTrustVerdict(input: {
+  channelType: ChannelId;
+  actorExternalId?: string;
+  actorUsername?: string;
+  actorDisplayName?: string;
+  conversationExternalId?: string;
+}): Promise<TrustVerdict | null> {
+  try {
+    const result = (await ipcCall(
+      "resolve_inbound_trust",
+      input,
+      TRUST_IPC_TIMEOUT_MS,
+    )) as { verdict?: unknown } | null | undefined;
+
+    if (!result) return null;
+
+    const parsed = TrustVerdictSchema.safeParse(result.verdict);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -22,9 +22,6 @@ const TRUST_IPC_TIMEOUT_MS = 2_000;
 export async function getInboundTrustVerdict(input: {
   channelType: ChannelId;
   actorExternalId?: string;
-  actorUsername?: string;
-  actorDisplayName?: string;
-  conversationExternalId?: string;
 }): Promise<TrustVerdict | null> {
   try {
     const result = (await ipcCall(

--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Gateway-side trust-verdict stamping tests for `handle-inbound.ts`:
+ *
+ *  - A normal inbound carries `sourceMetadata.trustVerdict` matching the
+ *    actor's gateway-DB ACL (guardian / trusted_contact / unknown).
+ *  - The `admissionPolicy` floor stamp coexists unchanged with the new verdict.
+ *  - The verification-code intercept short-circuits — no forward, no stamp.
+ *  - A resolver failure omits the stamp and still forwards (fail-soft).
+ *
+ * Module mocks isolate the test from the live runtime client. The
+ * verification intercept is mocked per-test so the default path forwards.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import type {
+  RuntimeInboundPayload,
+  RuntimeInboundResponse,
+} from "../runtime/client.js";
+import type { GatewayInboundEvent } from "../types.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+const fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+let runtimePayloads: RuntimeInboundPayload[] = [];
+const forwardToRuntimeMock = mock(
+  async (
+    _config: GatewayConfig,
+    payload: RuntimeInboundPayload,
+  ): Promise<RuntimeInboundResponse> => {
+    runtimePayloads.push(payload);
+    return { accepted: true, duplicate: false, eventId: "runtime-event-1" };
+  },
+);
+
+let interceptResult: { intercepted: boolean; [k: string]: unknown } = {
+  intercepted: false,
+};
+const tryTextVerificationInterceptMock = mock(async () => interceptResult);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+mock.module("../runtime/client.js", () => ({
+  CircuitBreakerOpenError: class CircuitBreakerOpenError extends Error {
+    readonly retryAfterSecs: number;
+    constructor(retryAfterSecs: number) {
+      super("Circuit breaker is open");
+      this.retryAfterSecs = retryAfterSecs;
+    }
+  },
+  forwardToRuntime: (...args: Parameters<typeof forwardToRuntimeMock>) =>
+    forwardToRuntimeMock(...args),
+}));
+
+mock.module("../verification/text-verification.js", () => ({
+  tryTextVerificationIntercept: (...args: unknown[]) =>
+    tryTextVerificationInterceptMock(...(args as [])),
+}));
+
+// Admission enforcement is gated behind `channel-trust-floors`; enable it so
+// the floor stamp coexists with the new verdict stamp.
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (key: string) => key === "channel-trust-floors",
+}));
+
+await import("./test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../db/connection.js"
+);
+const { AdmissionPolicyStore } = await import("../db/admission-policy-store.js");
+const {
+  initAdmissionPolicyCache,
+  resetAdmissionPolicyCache,
+} = await import("../risk/admission-policy-cache.js");
+const { contacts: gwContacts, contactChannels: gwContactChannels } =
+  await import("../db/schema.js");
+const { handleInbound } = await import("../handlers/handle-inbound.js");
+
+const CHANNEL = "telegram";
+
+function insertContact(args: {
+  id: string;
+  displayName: string;
+  role?: string;
+  principalId?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: args.id,
+      displayName: args.displayName,
+      role: args.role ?? "contact",
+      principalId: args.principalId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address: string;
+  externalChatId?: string | null;
+  status?: string;
+  policy?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: args.type ?? CHANNEL,
+      address: args.address,
+      externalChatId: args.externalChatId ?? null,
+      status: args.status ?? "active",
+      policy: args.policy ?? "allow",
+      verifiedAt: now,
+      verifiedVia: "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+function makeConfig(): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: "default-assistant",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: { default: 50 * 1024 * 1024 },
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1048576,
+    port: 7830,
+    routingEntries: [],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    unmappedPolicy: "default",
+    trustProxy: false,
+  } as unknown as GatewayConfig;
+}
+
+function makeEvent(
+  overrides: Record<string, unknown> = {},
+): GatewayInboundEvent {
+  return {
+    sourceChannel: CHANNEL,
+    source: { updateId: "u1", messageId: "m1", chatType: "private" },
+    actor: {
+      actorExternalId: "U_USER_1",
+      displayName: "User One",
+      username: "userone",
+    },
+    message: {
+      conversationExternalId: "C_CHAT_1",
+      externalMessageId: "extmsg-1",
+      content: "hi",
+    },
+    ...overrides,
+  } as GatewayInboundEvent;
+}
+
+const ROUTING = {
+  routingOverride: { assistantId: "asst-1", routeSource: "default" as const },
+};
+
+beforeEach(async () => {
+  resetGatewayDb();
+  resetAdmissionPolicyCache();
+  await initGatewayDb();
+  // initGatewayDb reconnects to the same on-disk DB; clear leftover rows
+  // (channels first — FK cascade from contacts).
+  getGatewayDb().delete(gwContactChannels).run();
+  getGatewayDb().delete(gwContacts).run();
+  const store = new AdmissionPolicyStore();
+  for (const row of store.list()) store.remove(row.channelType);
+  initAdmissionPolicyCache();
+  runtimePayloads = [];
+  forwardToRuntimeMock.mockClear();
+  interceptResult = { intercepted: false };
+});
+
+afterEach(() => {
+  resetAdmissionPolicyCache();
+  resetGatewayDb();
+});
+
+describe("handle-inbound trust verdict stamping", () => {
+  test("active guardian actor → sourceMetadata.trustVerdict.trustClass === 'guardian'", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_USER_1",
+      externalChatId: "chat-guardian",
+      status: "active",
+    });
+
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.forwarded).toBe(true);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(1);
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("guardian");
+    expect(verdict.canonicalSenderId).toBe("U_USER_1");
+    expect(verdict.guardianExternalUserId).toBe("U_USER_1");
+  });
+
+  test("active member channel → trustVerdict 'trusted_contact' with member ACL fields", async () => {
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_USER_1",
+      externalChatId: "chat-member",
+      status: "active",
+    });
+
+    await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.status).toBe("active");
+    expect(verdict.policy).toBe("allow");
+    expect(verdict.contactId).toBe("c-member");
+    expect(verdict.channelId).toBe("ch-member");
+    expect(verdict.memberDisplayName).toBe("Trusted Member");
+  });
+
+  test("unknown actor (no rows) → trustVerdict 'unknown', canonicalSenderId set", async () => {
+    await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.canonicalSenderId).toBe("U_USER_1");
+    expect(verdict.contactId).toBeUndefined();
+  });
+
+  test("admissionPolicy stamp present and unchanged alongside the new trustVerdict", async () => {
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.forwarded).toBe(true);
+    const sm = runtimePayloads[0]!.sourceMetadata!;
+    // Default floor (no persisted row) is still attached.
+    expect(sm.admissionPolicy).toBe("trusted_contacts");
+    expect(sm.trustVerdict!.trustClass).toBe("unknown");
+  });
+
+  test("verification-code intercept short-circuits — no forward, no stamp", async () => {
+    interceptResult = {
+      intercepted: true,
+      outcome: "verified",
+      trustClass: "guardian",
+      pendingReplyText: "Verified!",
+    };
+
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.verificationIntercepted).toBe(true);
+    expect(result.forwarded).toBe(false);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("resolver throw → inbound still forwards, trustVerdict absent (fail-soft)", async () => {
+    // Drop the gateway DB connection so resolveTrustVerdict's getGatewayDb()
+    // throws. The admission cache is in-memory and unaffected, so its floor
+    // stamp still flows.
+    resetGatewayDb();
+
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.forwarded).toBe(true);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(runtimePayloads[0]!.sourceMetadata!.trustVerdict).toBeUndefined();
+    // The floor stamp still flows even when verdict resolution fails.
+    expect(runtimePayloads[0]!.sourceMetadata!.admissionPolicy).toBe(
+      "trusted_contacts",
+    );
+  });
+});

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,11 +1,12 @@
 import { existsSync } from "node:fs";
-import type { SourceMetadata } from "@vellumai/gateway-client";
+import type { SourceMetadata, TrustVerdict } from "@vellumai/gateway-client";
 import type { GatewayConfig } from "../config.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 import { ContactStore } from "../db/contact-store.js";
 import { getLogger } from "../logger.js";
 import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
+import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
 import { canonicalizeInboundIdentity } from "../verification/identity.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
@@ -155,6 +156,24 @@ export async function handleInbound(
   const transportUxBrief = options?.transportMetadata?.uxBrief?.trim();
   const sourceChannelName = event.source.channelName?.trim();
 
+  // ── Per-actor trust verdict ──
+  // Resolved from the gateway ACL DB and stamped on sourceMetadata for the
+  // runtime to consume.
+  let trustVerdict: TrustVerdict | undefined;
+  try {
+    trustVerdict = await resolveTrustVerdict({
+      channelType: event.sourceChannel,
+      actorExternalId: event.actor.actorExternalId,
+      actorUsername: event.actor.username,
+      actorDisplayName: displayName,
+      conversationExternalId: event.message.conversationExternalId,
+    });
+  } catch (err) {
+    // Producer fails soft — resolution never breaks ingress. trustVerdict
+    // stays undefined so the stamp is omitted; the consumer owns deny policy.
+    log.warn({ err }, "trust verdict resolution failed; omitting stamp");
+  }
+
   try {
     const response = await forwardToRuntime(
       config,
@@ -194,6 +213,7 @@ export async function handleInbound(
           // admits unconditionally. Non-exempt channels always carry the
           // cache value (default `trusted_contacts` when the row is absent).
           ...(admissionPolicy ? { admissionPolicy } : {}),
+          ...(trustVerdict ? { trustVerdict } : {}),
           ...(options?.sourceMetadata ?? {}),
         },
         ...(options?.attachmentIds?.length

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -164,9 +164,6 @@ export async function handleInbound(
     trustVerdict = await resolveTrustVerdict({
       channelType: event.sourceChannel,
       actorExternalId: event.actor.actorExternalId,
-      actorUsername: event.actor.username,
-      actorDisplayName: displayName,
-      conversationExternalId: event.message.conversationExternalId,
     });
   } catch (err) {
     // Producer fails soft — resolution never breaks ingress. trustVerdict

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -190,6 +190,7 @@ import { contactRoutes } from "./ipc/contact-handlers.js";
 import { inviteRoutes } from "./ipc/invite-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
+import { trustVerdictRoutes } from "./ipc/trust-verdict-handlers.js";
 import { createLogTailRoutes } from "./ipc/log-tail-handlers.js";
 import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
@@ -2466,6 +2467,7 @@ async function main() {
     ...slackThreadRoutes,
     ...thresholdRoutes,
     ...admissionPolicyRoutes,
+    ...trustVerdictRoutes,
     ...riskClassificationRoutes,
     ...createLogTailRoutes(config),
     ...trustRulesRoutes,

--- a/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the `resolve_inbound_trust` IPC route.
+ *
+ * Seeds the gateway ACL DB directly (contacts + contact_channels) and invokes
+ * the route handler with params, asserting the returned `{ verdict }` matches
+ * the resolver output for guardian / member / unknown actors.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+await import("../../__tests__/test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../../db/connection.js"
+);
+const { contacts: gwContacts, contactChannels: gwContactChannels } =
+  await import("../../db/schema.js");
+const { resolveTrustVerdict } = await import(
+  "../../risk/trust-verdict-resolver.js"
+);
+const { trustVerdictRoutes } = await import("../trust-verdict-handlers.js");
+
+const CHANNEL = "telegram";
+
+const route = trustVerdictRoutes.find(
+  (r) => r.method === "resolve_inbound_trust",
+)!;
+
+function insertContact(args: {
+  id: string;
+  displayName: string;
+  role?: string;
+  principalId?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: args.id,
+      displayName: args.displayName,
+      role: args.role ?? "contact",
+      principalId: args.principalId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address: string;
+  externalChatId?: string | null;
+  status?: string;
+  policy?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: args.type ?? CHANNEL,
+      address: args.address,
+      externalChatId: args.externalChatId ?? null,
+      status: args.status ?? "active",
+      policy: args.policy ?? "allow",
+      verifiedAt: now,
+      verifiedVia: "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(gwContactChannels).run();
+  getGatewayDb().delete(gwContacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("resolve_inbound_trust route", () => {
+  test("registers the resolve_inbound_trust method with a schema", () => {
+    expect(route.method).toBe("resolve_inbound_trust");
+    expect(route.schema).toBeDefined();
+  });
+
+  test("guardian actor → { verdict } matching the resolver output", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+    });
+
+    const params = { channelType: CHANNEL, actorExternalId: "U_GUARDIAN" };
+    const result = (await route.handler(params)) as { verdict: unknown };
+    const expected = await resolveTrustVerdict(params);
+
+    expect(result.verdict).toEqual(expected);
+    expect((result.verdict as { trustClass: string }).trustClass).toBe(
+      "guardian",
+    );
+  });
+
+  test("active member → trusted_contact verdict matching the resolver", async () => {
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_MEMBER",
+      status: "active",
+    });
+
+    const params = { channelType: CHANNEL, actorExternalId: "U_MEMBER" };
+    const result = (await route.handler(params)) as { verdict: unknown };
+    const expected = await resolveTrustVerdict(params);
+
+    expect(result.verdict).toEqual(expected);
+    expect((result.verdict as { trustClass: string }).trustClass).toBe(
+      "trusted_contact",
+    );
+  });
+
+  test("unknown actor → unknown verdict matching the resolver", async () => {
+    const params = { channelType: CHANNEL, actorExternalId: "U_STRANGER" };
+    const result = (await route.handler(params)) as { verdict: unknown };
+    const expected = await resolveTrustVerdict(params);
+
+    expect(result.verdict).toEqual(expected);
+    expect((result.verdict as { trustClass: string }).trustClass).toBe(
+      "unknown",
+    );
+  });
+});

--- a/gateway/src/ipc/trust-verdict-handlers.ts
+++ b/gateway/src/ipc/trust-verdict-handlers.ts
@@ -1,0 +1,25 @@
+/**
+ * IPC route definitions for gateway-owned per-actor trust verdict reads.
+ *
+ * Exposes `resolve_inbound_trust` to the assistant daemon over the IPC socket.
+ * Resolves the per-actor {@link TrustVerdict} from the gateway ACL DB. This is
+ * deliberately a SEPARATE method from `get_channel_admission_policy`: the
+ * admission read is channel-scoped + TTL-cached, while this verdict is
+ * per-actor and must not share that cache or widen that response.
+ */
+
+import { ResolveInboundTrustRequestSchema } from "@vellumai/gateway-client";
+
+import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
+import type { IpcRoute } from "./server.js";
+
+export const trustVerdictRoutes: IpcRoute[] = [
+  {
+    method: "resolve_inbound_trust",
+    schema: ResolveInboundTrustRequestSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const input = ResolveInboundTrustRequestSchema.parse(params);
+      return { verdict: await resolveTrustVerdict(input) };
+    },
+  },
+];

--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for the gateway-side per-actor trust verdict resolver.
+ *
+ * Seeds the gateway ACL DB directly (contacts + contact_channels) and asserts
+ * the resolved {@link TrustVerdict} for guardian / trusted / unverified /
+ * unknown / blocked actors, plus id-divergence and case-insensitive address
+ * matching.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+await import("../../__tests__/test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../../db/connection.js"
+);
+const { contacts: gwContacts, contactChannels: gwContactChannels } =
+  await import("../../db/schema.js");
+const { resolveTrustVerdict } = await import("../trust-verdict-resolver.js");
+
+const CHANNEL = "telegram";
+
+function insertContact(args: {
+  id: string;
+  displayName: string;
+  role?: string;
+  principalId?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: args.id,
+      displayName: args.displayName,
+      role: args.role ?? "contact",
+      principalId: args.principalId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address: string;
+  externalChatId?: string | null;
+  status?: string;
+  policy?: string;
+  verifiedAt?: number | null;
+  verifiedVia?: string | null;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: args.type ?? CHANNEL,
+      address: args.address,
+      externalChatId: args.externalChatId ?? null,
+      status: args.status ?? "active",
+      policy: args.policy ?? "allow",
+      verifiedAt: args.verifiedAt ?? now,
+      verifiedVia: args.verifiedVia ?? "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  // initGatewayDb reconnects to the same on-disk DB, so clear any rows a
+  // prior test left behind (channels first — FK cascade from contacts).
+  getGatewayDb().delete(gwContactChannels).run();
+  getGatewayDb().delete(gwContacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("resolveTrustVerdict", () => {
+  test("guardian actor → trustClass guardian, guardian fields populated", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_GUARDIAN",
+    });
+
+    expect(verdict.trustClass).toBe("guardian");
+    expect(verdict.canonicalSenderId).toBe("U_GUARDIAN");
+    expect(verdict.guardianExternalUserId).toBe("U_GUARDIAN");
+    expect(verdict.guardianDeliveryChatId).toBe("chat-guardian");
+    expect(verdict.guardianPrincipalId).toBe("principal-1");
+    expect(verdict.guardianDisplayName).toBe("The Guardian");
+    expect(verdict.contactId).toBe("c-guardian");
+    expect(verdict.status).toBe("active");
+  });
+
+  test("active non-guardian member → trusted_contact, member ACL fields populated", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN",
+    });
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_MEMBER",
+      externalChatId: "chat-member",
+      status: "active",
+      verifiedVia: "manual",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_MEMBER",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.status).toBe("active");
+    expect(verdict.policy).toBe("allow");
+    expect(verdict.contactId).toBe("c-member");
+    expect(verdict.channelId).toBe("ch-member");
+    expect(verdict.address).toBe("U_MEMBER");
+    expect(verdict.externalChatId).toBe("chat-member");
+    expect(verdict.memberDisplayName).toBe("Trusted Member");
+    expect(verdict.verifiedVia).toBe("manual");
+    // Guardian fields still populated from the channel binding.
+    expect(verdict.guardianExternalUserId).toBe("U_GUARDIAN");
+  });
+
+  test("pending/unverified member → unverified_contact", async () => {
+    insertContact({ id: "c-member", displayName: "Pending Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_PENDING",
+      status: "unverified",
+      verifiedAt: null,
+      verifiedVia: null,
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_PENDING",
+    });
+
+    expect(verdict.trustClass).toBe("unverified_contact");
+    expect(verdict.status).toBe("unverified");
+    expect(verdict.contactId).toBe("c-member");
+  });
+
+  test("no matching channel → unknown, canonicalSenderId reflects input, member fields undefined", async () => {
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.canonicalSenderId).toBe("U_STRANGER");
+    expect(verdict.contactId).toBeUndefined();
+    expect(verdict.channelId).toBeUndefined();
+    expect(verdict.status).toBeUndefined();
+    expect(verdict.guardianExternalUserId).toBeUndefined();
+  });
+
+  test("no actorExternalId → unknown, canonicalSenderId null", async () => {
+    const verdict = await resolveTrustVerdict({ channelType: CHANNEL });
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.canonicalSenderId).toBeNull();
+  });
+
+  test("blocked member → unknown, status/policy surfaced verbatim", async () => {
+    insertContact({ id: "c-blocked", displayName: "Blocked Member" });
+    insertChannel({
+      id: "ch-blocked",
+      contactId: "c-blocked",
+      address: "U_BLOCKED",
+      status: "blocked",
+      policy: "deny",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_BLOCKED",
+    });
+
+    // Mirrors the canonical resolver: blocked → unknown. Raw status/policy
+    // still carry through so the consumer enforces member_blocked hard-deny.
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.status).toBe("blocked");
+    expect(verdict.policy).toBe("deny");
+    expect(verdict.contactId).toBe("c-blocked");
+  });
+
+  test("revoked member → unknown, status/policy surfaced verbatim", async () => {
+    insertContact({ id: "c-revoked", displayName: "Revoked Member" });
+    insertChannel({
+      id: "ch-revoked",
+      contactId: "c-revoked",
+      address: "U_REVOKED",
+      status: "revoked",
+      policy: "deny",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_REVOKED",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.status).toBe("revoked");
+    expect(verdict.policy).toBe("deny");
+    expect(verdict.contactId).toBe("c-revoked");
+  });
+
+  test("id-divergent row resolves by (type,address)", async () => {
+    // Channel id intentionally unrelated to any assistant-side id — lookup is
+    // keyed on (type,address), so it still resolves.
+    insertContact({ id: "gw-only-contact", displayName: "Mirror Member" });
+    insertChannel({
+      id: "gw-only-channel-id-9999",
+      contactId: "gw-only-contact",
+      address: "U_DIVERGENT",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_DIVERGENT",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.channelId).toBe("gw-only-channel-id-9999");
+    expect(verdict.contactId).toBe("gw-only-contact");
+  });
+
+  test("case-insensitive address match (COLLATE NOCASE)", async () => {
+    insertContact({ id: "c-member", displayName: "Case Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_MixedCase",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "u_mixedcase",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.channelId).toBe("ch-member");
+  });
+
+  test("sender matching the active guardian binding address → guardian", async () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      address: "U_GUARDIAN_ACTIVE",
+      status: "active",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_GUARDIAN_ACTIVE",
+    });
+
+    expect(verdict.trustClass).toBe("guardian");
+  });
+
+  test("revoked guardian channel does NOT confer guardian → unknown", async () => {
+    // P1 regression: a guardian contact whose only channel is revoked must not
+    // re-acquire guardian privileges by code-match. The status='active' filter
+    // on the guardian binding excludes it, so the sender resolves to unknown.
+    insertContact({
+      id: "c-old-guardian",
+      displayName: "Former Guardian",
+      role: "guardian",
+      principalId: "principal-old",
+    });
+    insertChannel({
+      id: "ch-old-guardian",
+      contactId: "c-old-guardian",
+      address: "U_OLD_GUARDIAN",
+      status: "revoked",
+      policy: "deny",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_OLD_GUARDIAN",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.status).toBe("revoked");
+    // No active guardian binding exists, so guardian label fields are absent.
+    expect(verdict.guardianExternalUserId).toBeUndefined();
+  });
+});

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -1,0 +1,159 @@
+/**
+ * Gateway-side per-actor trust verdict resolver.
+ *
+ * Reads ONLY the gateway ACL DB to produce a {@link TrustVerdict} for an
+ * inbound actor. Mirrors the daemon's classification precedence
+ * (`actor-trust-resolver.ts`) and the Combo-7 `(type,address)` COLLATE NOCASE
+ * read pattern. Read-only — no writes, no assistant DB, no IPC.
+ *
+ * Blocked/revoked member channels classify as `unknown` (mirroring the
+ * daemon), while their raw `status`/`policy` are surfaced verbatim so the
+ * consumer enforces the member_blocked / member_revoked hard-deny.
+ */
+
+import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
+import { and, desc, eq, sql } from "drizzle-orm";
+
+import { getGatewayDb } from "../db/connection.js";
+import {
+  contacts as gwContacts,
+  contactChannels as gwContactChannels,
+} from "../db/schema.js";
+import { canonicalizeInboundIdentity } from "../verification/identity.js";
+
+export interface ResolveTrustVerdictInput {
+  channelType: string;
+  actorExternalId?: string;
+  actorUsername?: string;
+  actorDisplayName?: string;
+  conversationExternalId?: string;
+}
+
+/**
+ * Resolve the per-actor trust verdict from the gateway ACL DB.
+ *
+ * 1. Canonicalize `actorExternalId` for this channel (E.164 for phone-like).
+ * 2. Resolve the channel's active guardian binding (label/identity fields).
+ * 3. Resolve THIS actor's member channel by `(type,address)` COLLATE NOCASE.
+ * 4. Classify guardian > trusted_contact > unverified_contact > unknown.
+ */
+export async function resolveTrustVerdict(
+  input: ResolveTrustVerdictInput,
+): Promise<TrustVerdict> {
+  const db = getGatewayDb();
+
+  const rawActorId =
+    typeof input.actorExternalId === "string" &&
+    input.actorExternalId.trim().length > 0
+      ? input.actorExternalId.trim()
+      : undefined;
+
+  const canonicalSenderId = rawActorId
+    ? canonicalizeInboundIdentity(input.channelType, rawActorId)
+    : null;
+
+  // --- Guardian-for-channel binding (independent of THIS actor) ---
+  const guardianRow = db
+    .select({
+      address: gwContactChannels.address,
+      externalChatId: gwContactChannels.externalChatId,
+      principalId: gwContacts.principalId,
+      displayName: gwContacts.displayName,
+    })
+    .from(gwContacts)
+    .innerJoin(
+      gwContactChannels,
+      eq(gwContactChannels.contactId, gwContacts.id),
+    )
+    .where(
+      and(
+        eq(gwContacts.role, "guardian"),
+        eq(gwContactChannels.type, input.channelType),
+        eq(gwContactChannels.status, "active"),
+      ),
+    )
+    .orderBy(desc(gwContactChannels.verifiedAt))
+    .limit(1)
+    .get();
+
+  // --- Member channel for THIS actor (address-keyed, COLLATE NOCASE) ---
+  const memberRow = canonicalSenderId
+    ? db
+        .select({
+          contactId: gwContactChannels.contactId,
+          channelId: gwContactChannels.id,
+          type: gwContactChannels.type,
+          address: gwContactChannels.address,
+          externalChatId: gwContactChannels.externalChatId,
+          status: gwContactChannels.status,
+          policy: gwContactChannels.policy,
+          verifiedAt: gwContactChannels.verifiedAt,
+          verifiedVia: gwContactChannels.verifiedVia,
+          memberDisplayName: gwContacts.displayName,
+        })
+        .from(gwContactChannels)
+        .innerJoin(gwContacts, eq(gwContactChannels.contactId, gwContacts.id))
+        .where(
+          and(
+            eq(gwContactChannels.type, input.channelType),
+            sql`${gwContactChannels.address} = ${canonicalSenderId} COLLATE NOCASE`,
+          ),
+        )
+        .limit(1)
+        .get()
+    : undefined;
+
+  // --- Classification (mirrors resolveActorTrust precedence) ---
+  // The guardian binding is the ACTIVE guardian channel for this channel type
+  // (the status='active' filter above excludes revoked/blocked guardian
+  // channels). A sender is the guardian only when their canonical id matches
+  // that active address — a stale revoked channel never confers guardian.
+  const isGuardian =
+    !!guardianRow &&
+    !!canonicalSenderId &&
+    guardianRow.address.toLowerCase() === canonicalSenderId.toLowerCase();
+
+  let trustClass: TrustClass;
+  if (isGuardian) {
+    trustClass = "guardian";
+  } else if (memberRow) {
+    const status = memberRow.status;
+    if (status === "active") {
+      trustClass = "trusted_contact";
+    } else if (status === "unverified" || status === "pending") {
+      trustClass = "unverified_contact";
+    } else {
+      // blocked/revoked → unknown, matching the canonical resolver. Raw
+      // status/policy are still surfaced below so the consumer enforces the
+      // member_blocked / member_revoked hard-deny.
+      trustClass = "unknown";
+    }
+  } else {
+    trustClass = "unknown";
+  }
+
+  const verdict: TrustVerdict = { trustClass, canonicalSenderId };
+
+  if (guardianRow) {
+    verdict.guardianExternalUserId = guardianRow.address;
+    verdict.guardianDeliveryChatId = guardianRow.externalChatId;
+    if (guardianRow.principalId)
+      verdict.guardianPrincipalId = guardianRow.principalId;
+    verdict.guardianDisplayName = guardianRow.displayName;
+  }
+
+  if (memberRow) {
+    verdict.contactId = memberRow.contactId;
+    verdict.channelId = memberRow.channelId;
+    verdict.type = memberRow.type;
+    verdict.address = memberRow.address;
+    verdict.externalChatId = memberRow.externalChatId;
+    verdict.status = memberRow.status;
+    verdict.policy = memberRow.policy;
+    verdict.verifiedAt = memberRow.verifiedAt;
+    verdict.verifiedVia = memberRow.verifiedVia;
+    verdict.memberDisplayName = memberRow.memberDisplayName;
+  }
+
+  return verdict;
+}

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -24,9 +24,6 @@ import { canonicalizeInboundIdentity } from "../verification/identity.js";
 export interface ResolveTrustVerdictInput {
   channelType: string;
   actorExternalId?: string;
-  actorUsername?: string;
-  actorDisplayName?: string;
-  conversationExternalId?: string;
 }
 
 /**

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -3,8 +3,8 @@
  *
  * Reads ONLY the gateway ACL DB to produce a {@link TrustVerdict} for an
  * inbound actor. Mirrors the daemon's classification precedence
- * (`actor-trust-resolver.ts`) and the Combo-7 `(type,address)` COLLATE NOCASE
- * read pattern. Read-only — no writes, no assistant DB, no IPC.
+ * (`actor-trust-resolver.ts`) and resolves channels by `(type,address)`
+ * COLLATE NOCASE. Read-only — no writes, no assistant DB, no IPC.
  *
  * Blocked/revoked member channels classify as `unknown` (mirroring the
  * daemon), while their raw `status`/`policy` are surfaced verbatim so the

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the shared trust verdict contract and its optional placement on
+ * the inbound payload's sourceMetadata.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { SourceMetadataSchema } from "../inbound-contract.js";
+import {
+  TrustVerdictSchema,
+  type TrustVerdict,
+} from "../trust-verdict-contract.js";
+
+const fullVerdict: TrustVerdict = {
+  trustClass: "trusted_contact",
+  canonicalSenderId: "+15555550100",
+  guardianExternalUserId: "g-ext-1",
+  guardianDeliveryChatId: "chat-1",
+  guardianPrincipalId: "g-principal-1",
+  guardianDisplayName: "Guardian Name",
+  contactId: "c1",
+  channelId: "ch1",
+  type: "imessage",
+  address: "+15555550100",
+  externalChatId: "ext-chat-1",
+  status: "active",
+  policy: "allow",
+  verifiedAt: 1699999999,
+  verifiedVia: "voice",
+  memberDisplayName: "Member Name",
+};
+
+describe("TrustVerdictSchema", () => {
+  test("round-trips a fully-populated verdict", () => {
+    expect(TrustVerdictSchema.parse(fullVerdict)).toEqual(fullVerdict);
+  });
+
+  test("parses a minimal verdict", () => {
+    const minimal = {
+      trustClass: "unknown",
+      canonicalSenderId: null,
+    } satisfies TrustVerdict;
+    expect(TrustVerdictSchema.parse(minimal)).toEqual(minimal);
+  });
+
+  test("rejects an invalid trustClass", () => {
+    expect(() =>
+      TrustVerdictSchema.parse({
+        trustClass: "definitely_not_a_class",
+        canonicalSenderId: null,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("SourceMetadataSchema trustVerdict back-compat", () => {
+  test("parses an empty payload (no trustVerdict)", () => {
+    expect(SourceMetadataSchema.parse({})).toEqual({});
+  });
+
+  test("round-trips a payload carrying trustVerdict", () => {
+    const parsed = SourceMetadataSchema.parse({ trustVerdict: fullVerdict });
+    expect(parsed.trustVerdict).toEqual(fullVerdict);
+  });
+});

--- a/packages/gateway-client/src/inbound-contract.ts
+++ b/packages/gateway-client/src/inbound-contract.ts
@@ -13,6 +13,7 @@
 import { z } from "zod";
 
 import { AdmissionPolicySchema } from "./admission-policy-contract.js";
+import { TrustVerdictSchema } from "./trust-verdict-contract.js";
 
 // ---------------------------------------------------------------------------
 // Command intent (channel-initiated commands, e.g. Telegram /start)
@@ -76,6 +77,13 @@ export const SourceMetadataSchema = z
      * `ADMISSION_POLICY_DEFAULT` (`trusted_contacts`).
      */
     admissionPolicy: AdmissionPolicySchema.optional(),
+
+    /**
+     * Per-actor trust verdict resolved by the gateway from its ACL DB;
+     * absent until the gateway stamps it. Consumers must treat absence as
+     * "not provided", never as a decision.
+     */
+    trustVerdict: TrustVerdictSchema.optional(),
 
     // Email-specific fields
     /** Email subject line. */

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -70,3 +70,12 @@ export {
 } from "./admission-policy-contract.js";
 
 export type { AdmissionPolicy } from "./admission-policy-contract.js";
+
+// Trust verdict contract (gateway → daemon) — Zod schemas + derived types
+export {
+  TRUST_CLASS_VALUES,
+  TrustClassSchema,
+  TrustVerdictSchema,
+} from "./trust-verdict-contract.js";
+
+export type { TrustClass, TrustVerdict } from "./trust-verdict-contract.js";

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -73,9 +73,14 @@ export type { AdmissionPolicy } from "./admission-policy-contract.js";
 
 // Trust verdict contract (gateway → daemon) — Zod schemas + derived types
 export {
+  ResolveInboundTrustRequestSchema,
   TRUST_CLASS_VALUES,
   TrustClassSchema,
   TrustVerdictSchema,
 } from "./trust-verdict-contract.js";
 
-export type { TrustClass, TrustVerdict } from "./trust-verdict-contract.js";
+export type {
+  ResolveInboundTrustRequest,
+  TrustClass,
+  TrustVerdict,
+} from "./trust-verdict-contract.js";

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -71,9 +71,6 @@ export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;
 export const ResolveInboundTrustRequestSchema = z.object({
   channelType: z.string().min(1),
   actorExternalId: z.string().optional(),
-  actorUsername: z.string().optional(),
-  actorDisplayName: z.string().optional(),
-  conversationExternalId: z.string().optional(),
 });
 
 export type ResolveInboundTrustRequest = z.infer<

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -62,3 +62,20 @@ export const TrustVerdictSchema = z.object({
 });
 
 export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;
+
+/**
+ * IPC request for `resolve_inbound_trust`. Per-actor identity keys the
+ * gateway resolver needs to classify the inbound sender. The response reuses
+ * {@link TrustVerdictSchema}.
+ */
+export const ResolveInboundTrustRequestSchema = z.object({
+  channelType: z.string().min(1),
+  actorExternalId: z.string().optional(),
+  actorUsername: z.string().optional(),
+  actorDisplayName: z.string().optional(),
+  conversationExternalId: z.string().optional(),
+});
+
+export type ResolveInboundTrustRequest = z.infer<
+  typeof ResolveInboundTrustRequestSchema
+>;

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared per-actor trust verdict carried on the gateway→runtime wire.
+ *
+ * The gateway resolves this verdict from its ACL DB and stamps it onto the
+ * inbound payload's `sourceMetadata`; the runtime consumes it. Keeping the
+ * type here avoids the runtime importing from `gateway/src` and lets the
+ * daemon's `trustClass` union (`actor-trust-resolver.ts`) converge on this
+ * one source of truth.
+ *
+ * This contract carries ACL + identity keys + minimal labels only — never
+ * info fields (notes, userFile, contactType). `status` / `policy` / `type`
+ * stay loose `z.string()` to match the gateway schema columns and avoid
+ * coupling to a still-evolving status vocabulary; the consumer interprets
+ * them.
+ */
+
+import { z } from "zod";
+
+/**
+ * Verification-purpose trust classification. Mirrors the daemon's
+ * `TrustClass` union (`actor-trust-resolver.ts`), ordered most- to
+ * least-trusted.
+ */
+export const TRUST_CLASS_VALUES = [
+  "guardian",
+  "trusted_contact",
+  "unverified_contact",
+  "unknown",
+] as const;
+
+export const TrustClassSchema = z.enum(TRUST_CLASS_VALUES);
+
+export type TrustClass = (typeof TRUST_CLASS_VALUES)[number];
+
+/**
+ * Per-actor trust verdict resolved by the gateway from its ACL DB. ACL +
+ * identity keys + minimal labels only. Guardian binding and member
+ * identity/ACL fields are optional — present only when the corresponding
+ * record resolves.
+ */
+export const TrustVerdictSchema = z.object({
+  trustClass: TrustClassSchema,
+  canonicalSenderId: z.string().nullable(),
+
+  // Guardian binding — present only when a guardian binding matches.
+  guardianExternalUserId: z.string().optional(),
+  guardianDeliveryChatId: z.string().nullable().optional(),
+  guardianPrincipalId: z.string().optional(),
+  guardianDisplayName: z.string().optional(),
+
+  // Member identity + ACL — present only when a member channel resolves.
+  contactId: z.string().optional(),
+  channelId: z.string().optional(),
+  type: z.string().optional(),
+  address: z.string().optional(),
+  externalChatId: z.string().nullable().optional(),
+  status: z.string().optional(),
+  policy: z.string().optional(),
+  verifiedAt: z.number().nullable().optional(),
+  verifiedVia: z.string().nullable().optional(),
+  memberDisplayName: z.string().optional(),
+});
+
+export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;


### PR DESCRIPTION
## Summary
Makes the gateway emit a full per-actor **trust verdict** on both ingress transports — stamped on the text inbound relay (`sourceMetadata.trustVerdict`) and served over a new voice call-setup IPC (`resolve_inbound_trust`) — sourced **only** from the gateway's own ACL DB (per Combo 7). Purely **additive**: nothing consumes the verdict yet (Combos 9/10), all new wire fields are optional, and zero current admission/deny/challenge decisions change. The verdict shape mirrors the daemon's `ActorTrustContext` so Combo 9 can consume it 1:1.

## Self-review result
PASS — 4 fresh-eyes passes (external feedback, plan faithfulness, repo integration, slop/reuse). 1 slop gap found and fixed (#35717: dropped unused request fields, keeping `channelType` + `actorExternalId`). All Codex P1/P2 findings during execution were addressed (typecheck `satisfies` fixes; blocked/revoked→`unknown` + active-guardian-binding classification fix; present-tense comment wording).

## PRs merged into feature branch
- #35708: TrustVerdict contract + optional `sourceMetadata.trustVerdict`
- #35712: `resolveTrustVerdict` — read-only per-actor verdict from the gateway DB
- #35714: `resolve_inbound_trust` IPC + unwired daemon reader
- #35716: text producer — stamp the verdict in `handleInbound` (fail-soft)

### Fix PRs
- #35717: drop unused request fields (self-review slop fix)

## Key invariants
- Reads **only** the gateway DB; classification mirrors `actor-trust-resolver.ts` (blocked/revoked → `unknown`; guardian keyed on the **active** guardian binding).
- Producers fail **soft** (text omits stamp on error; IPC reader returns `null`) — fail-CLOSED is deferred to the Combo 9 consumer.
- `getInboundTrustVerdict` is intentionally **unwired** (Combo 9/10 consumes it); `get_channel_admission_policy` and the verification-code intercept are unchanged.

Part of plan: gateway-produces-trust-verdict.md