### PR TITLE
feat(daemon): event-loop block watchdog for main-thread freeze visibility

### DIFF
--- a/assistant/src/daemon/event-loop-watchdog.test.ts
+++ b/assistant/src/daemon/event-loop-watchdog.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the event-loop block watchdog.
+ *
+ * - `evaluateTick` must derive the blocked duration as elapsed-beyond-interval
+ *   and apply the threshold inclusively, clamping early/normal ticks to zero so
+ *   a healthy loop never reports.
+ * - `start`/`stop` must be idempotent and safe to call in any order so daemon
+ *   startup and the two shutdown paths can call them unconditionally.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+const { evaluateTick, startEventLoopWatchdog, stopEventLoopWatchdog } =
+  await import("./event-loop-watchdog.js");
+
+describe("evaluateTick", () => {
+  const INTERVAL = 1_000;
+  const THRESHOLD = 5_000;
+
+  test("a healthy tick at the scheduled interval is not a block", () => {
+    // GIVEN the timer fired right on schedule
+    // WHEN the tick is evaluated
+    const { blockedMs, exceeded } = evaluateTick(INTERVAL, INTERVAL, THRESHOLD);
+    // THEN no block is observed
+    expect(blockedMs).toBe(0);
+    expect(exceeded).toBe(false);
+  });
+
+  test("an early tick clamps the blocked duration to zero", () => {
+    // GIVEN the timer fired sooner than the interval (e.g. clock jitter)
+    // WHEN the tick is evaluated
+    const { blockedMs, exceeded } = evaluateTick(200, INTERVAL, THRESHOLD);
+    // THEN the blocked duration never goes negative
+    expect(blockedMs).toBe(0);
+    expect(exceeded).toBe(false);
+  });
+
+  test("lateness under the threshold is measured but not reported", () => {
+    // GIVEN the loop was blocked ~2s (below the 5s threshold)
+    // WHEN the tick is evaluated
+    const { blockedMs, exceeded } = evaluateTick(3_000, INTERVAL, THRESHOLD);
+    // THEN the block is quantified but does not trip a report
+    expect(blockedMs).toBe(2_000);
+    expect(exceeded).toBe(false);
+  });
+
+  test("the threshold is inclusive", () => {
+    // GIVEN the blocked duration lands exactly on the threshold
+    // WHEN the tick is evaluated
+    const { blockedMs, exceeded } = evaluateTick(
+      INTERVAL + THRESHOLD,
+      INTERVAL,
+      THRESHOLD,
+    );
+    // THEN it counts as exceeded
+    expect(blockedMs).toBe(THRESHOLD);
+    expect(exceeded).toBe(true);
+  });
+
+  test("a multi-minute freeze reports the full blocked duration", () => {
+    // GIVEN a ~123s freeze (the observed daemon-freeze magnitude) with a 1s tick
+    // WHEN the first tick after unblock is evaluated
+    const { blockedMs, exceeded } = evaluateTick(124_000, INTERVAL, THRESHOLD);
+    // THEN the reported block excludes the one normal interval of wait
+    expect(blockedMs).toBe(123_000);
+    expect(exceeded).toBe(true);
+  });
+});
+
+describe("start/stop lifecycle", () => {
+  test("start and stop are idempotent and order-independent", () => {
+    // GIVEN a fresh module
+    // WHEN start/stop are called repeatedly and out of order
+    // THEN none of the calls throw (daemon boot + both shutdown paths are safe)
+    expect(() => stopEventLoopWatchdog()).not.toThrow();
+    expect(() => startEventLoopWatchdog()).not.toThrow();
+    expect(() => startEventLoopWatchdog()).not.toThrow();
+    expect(() => stopEventLoopWatchdog()).not.toThrow();
+    expect(() => stopEventLoopWatchdog()).not.toThrow();
+  });
+});

--- a/assistant/src/daemon/event-loop-watchdog.ts
+++ b/assistant/src/daemon/event-loop-watchdog.ts
@@ -1,0 +1,133 @@
+/**
+ * Event-loop block watchdog.
+ *
+ * The daemon runs all request handling, synchronous `bun:sqlite` access, and
+ * background jobs on a single event-loop thread. Any synchronous operation that
+ * runs long — a large conversation-history load, a memory retrospective
+ * assembling an oversized conversation, a VACUUM or WAL checkpoint — blocks that
+ * thread, so the daemon stops answering health probes and SSE for the duration
+ * (a proxied `vellum ps` health check then reports `timeout` even though the
+ * process is alive). Such a freeze is otherwise invisible: the blocked thread is
+ * too busy to emit logs, so it leaves only a gap that self-heals when the
+ * operation returns, and is noticed only by chance.
+ *
+ * This watchdog makes those freezes observable. It schedules a timer every
+ * `TICK_INTERVAL_MS`; when the loop is blocked the callback cannot run, so it
+ * fires late by roughly the block duration. On the first tick after the loop
+ * frees up, the elapsed-since-last-tick beyond a normal interval is how long the
+ * loop was unavailable; above a threshold it emits a warn log + Sentry capture.
+ *
+ * What it does NOT do: capture the JS stack of the blocking operation. JS is
+ * single-threaded, so while the loop is blocked no callback — including this one
+ * — can run; by the time the tick fires, the offending synchronous call has
+ * returned and its stack is gone. The watchdog reports *that* and *how long* a
+ * freeze happened, not *what* caused it. The report lands at unblock, so the
+ * surrounding log lines (which job or turn was active) are the correlation
+ * handle. For deterministic attribution of a specific subsystem, time that
+ * subsystem's synchronous calls at their source.
+ *
+ * A cumulative event-loop-delay histogram is separately exposed pull-based over
+ * SSE diagnostics (`runtime/routes/events-routes.ts`); this watchdog is the
+ * push/alert counterpart and runs unconditionally for the daemon's lifetime.
+ */
+
+import * as Sentry from "@sentry/node";
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("event-loop-watchdog");
+
+/** How often the probe timer is scheduled. */
+const TICK_INTERVAL_MS = 1_000;
+
+/**
+ * Report only when the loop was unavailable for at least this long beyond a
+ * normal tick. Set above the floor of the daemon's known-legitimate
+ * multi-second main-thread operations so the signal stays actionable rather than
+ * noisy; tune here.
+ */
+const DEFAULT_BLOCK_THRESHOLD_MS = 5_000;
+
+/**
+ * Minimum spacing between reports. A single long freeze fires the timer once on
+ * unblock (an overdue interval is not replayed per missed tick), but a loop that
+ * blocks repeatedly could trip every tick; the cooldown bounds that to one
+ * report per window.
+ */
+const REPORT_COOLDOWN_MS = 30_000;
+
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+let lastTickAt = 0;
+let lastReportAt = Number.NEGATIVE_INFINITY;
+
+/**
+ * Given the wall-clock elapsed since the previous tick and the scheduled tick
+ * interval, the loop was blocked for the excess over the interval. Pure so the
+ * threshold decision is unit-testable without real timers or a blocked loop.
+ */
+export function evaluateTick(
+  elapsedMs: number,
+  intervalMs: number,
+  thresholdMs: number,
+): { blockedMs: number; exceeded: boolean } {
+  const blockedMs = Math.max(0, elapsedMs - intervalMs);
+  return { blockedMs, exceeded: blockedMs >= thresholdMs };
+}
+
+function reportBlock(blockedMs: number, thresholdMs: number): void {
+  log.warn(
+    { blockedMs, thresholdMs, tickIntervalMs: TICK_INTERVAL_MS },
+    "event loop blocked",
+  );
+  try {
+    Sentry.withScope((scope) => {
+      scope.setLevel("warning");
+      scope.setTag("event_loop_blocked_ms", String(blockedMs));
+      scope.setContext("event_loop_block", {
+        blocked_ms: blockedMs,
+        threshold_ms: thresholdMs,
+        tick_interval_ms: TICK_INTERVAL_MS,
+      });
+      Sentry.captureMessage("event_loop_blocked");
+    });
+  } catch {
+    // Never let a telemetry failure escape the timer callback.
+  }
+}
+
+/**
+ * Start the event-loop block watchdog. Idempotent. The timer is `unref`'d so it
+ * never keeps the process alive on its own.
+ */
+export function startEventLoopWatchdog(
+  thresholdMs: number = DEFAULT_BLOCK_THRESHOLD_MS,
+): void {
+  if (tickTimer) return;
+  lastTickAt = performance.now();
+  lastReportAt = Number.NEGATIVE_INFINITY;
+  tickTimer = setInterval(() => {
+    const now = performance.now();
+    const { blockedMs, exceeded } = evaluateTick(
+      now - lastTickAt,
+      TICK_INTERVAL_MS,
+      thresholdMs,
+    );
+    lastTickAt = now;
+    if (exceeded && now - lastReportAt >= REPORT_COOLDOWN_MS) {
+      lastReportAt = now;
+      reportBlock(blockedMs, thresholdMs);
+    }
+  }, TICK_INTERVAL_MS);
+  tickTimer.unref?.();
+  log.info(
+    { tickIntervalMs: TICK_INTERVAL_MS, thresholdMs },
+    "Event-loop watchdog started",
+  );
+}
+
+export function stopEventLoopWatchdog(): void {
+  if (tickTimer) {
+    clearInterval(tickTimer);
+    tickTimer = null;
+  }
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -121,6 +121,10 @@ import {
   startDiskPressureGuard,
   stopDiskPressureGuard,
 } from "./disk-pressure-guard.js";
+import {
+  startEventLoopWatchdog,
+  stopEventLoopWatchdog,
+} from "./event-loop-watchdog.js";
 import { initializePlugins } from "./external-plugins-bootstrap.js";
 import { backfillSlackInjectionTemplates } from "./handlers/config-slack-channel.js";
 import { installAssistantSymlink } from "./install-symlink.js";
@@ -822,6 +826,7 @@ export async function runDaemon(): Promise<void> {
     log.info("Daemon startup: DaemonServer started");
     startDiskPressureGuardForLifecycle();
     startOrphanReaper();
+    startEventLoopWatchdog();
 
     // Mutable refs for Qdrant and memory worker so background
     // init can assign them and the shutdown handler always sees the latest value.
@@ -1422,6 +1427,7 @@ export async function runDaemon(): Promise<void> {
         stopGatewayFlagListener();
         stopDiskPressureGuardForLifecycle();
         stopOrphanReaper();
+        stopEventLoopWatchdog();
         cleanupPidFile();
       },
     });
@@ -1437,6 +1443,7 @@ export async function runDaemon(): Promise<void> {
     log.error({ err }, "Daemon startup failed — cleaning up");
     stopDiskPressureGuardForLifecycle();
     stopOrphanReaper();
+    stopEventLoopWatchdog();
     cleanupPidFileIfOwner(process.pid);
     throw err;
   }


### PR DESCRIPTION
## Why

A live daemon can show `🟡 timeout` in `vellum ps` while its process sits at 100% CPU. Root cause of a recent instance: the daemon's **single event-loop thread was blocked for ~123s** by a synchronous `bun:sqlite` btree-scan over large JSON message content (triggered by a memory-retrospective + heartbeat stacking on an oversized conversation). Because `bun:sqlite` is synchronous and the daemon is single-threaded, one heavy operation freezes **all** request handling — health probes included — so the gateway's proxied health check times out even though the process is alive.

These freezes are currently **invisible**: the blocked thread can't emit logs, so they leave only a gap in the log that self-heals when the operation returns. The one in question was noticed only because someone happened to look at Activity Monitor.

## What

An always-on event-loop block watchdog (`assistant/src/daemon/event-loop-watchdog.ts`), started/stopped alongside the existing `disk-pressure-guard` and `orphan-reaper` in the daemon lifecycle:

- Schedules a 1s timer. When the loop is blocked, the callback fires late by ~the block duration.
- On the first tick after unblock, computes elapsed-beyond-interval and, above a 5s threshold, emits a `warn` log + Sentry capture (`event_loop_blocked`, level `warning`) with the blocked duration. 30s report cooldown.
- Timer is `unref`'d; start/stop are idempotent and safe in any order (daemon boot + both shutdown paths call them unconditionally).

## Scope / honest limitation

This **detects and times** freezes — it does **not** capture the blocking JS stack. JS is single-threaded, so no callback (including the watchdog's) can run during the freeze, and the offending synchronous call has returned by the time the tick fires. The report lands at unblock, so the **surrounding log lines** (which job/turn was active) are the correlation handle — exactly how the original incident was diagnosed by hand.

For deterministic per-subsystem attribution (i.e. "which query"), the complementary follow-up is **source-level timing** around the suspect synchronous call sites (the `bun:sqlite` executor, the history-load / retrospective-assemble paths). That's intentionally **not** in this PR to keep it one focused change.

A cumulative event-loop-delay histogram already exists pull-based over SSE diagnostics (`runtime/routes/events-routes.ts`); this watchdog is the push/alert counterpart.

## Testing

- `bun test src/daemon/event-loop-watchdog.test.ts` — 6 pass (threshold math: inclusive boundary, early-tick clamp, sub-threshold, multi-minute freeze; start/stop idempotency).
- `bunx tsc --noEmit` clean; `eslint` + `prettier` clean.

## Follow-ups (not in this PR)

- Source-level timing on `bun:sqlite` / retrospective-assemble paths for query-level attribution.
- Cheap indexed size pre-gate before the memory-retrospective materializes an over-cap `runInput` (the retrospective repeatedly forks 500K–720K-token conversations).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
