### PR TITLE
feat(consent): split data-capture toggle versions + per-version policy changelog (privacy → 2026-06-22)

### DIFF
--- a/clients/web/src/domains/onboarding/components/consent-controls.tsx
+++ b/clients/web/src/domains/onboarding/components/consent-controls.tsx
@@ -80,19 +80,36 @@ function Divider() {
 }
 
 // A short "what's changed" summary shown above a consent checkbox when the
-// policy version was bumped. Renders nothing when there are no notes.
+// policy version was bumped. A recessed, left-ruled callout that promotes the
+// change itself to the most legible line in the card — it's why the user is
+// here. Renders nothing when there are no notes.
 function PolicyChangeNotes({ notes }: { notes?: string[] }) {
   if (!notes || notes.length === 0) return null;
   return (
-    <div className="flex flex-col gap-1 text-[var(--content-tertiary)]">
-      <p className="text-body-small-default font-medium uppercase tracking-wider">
+    <div className="rounded-r-md border-l-2 border-[var(--content-secondary)] bg-[var(--surface-base)] py-3 pl-3.5 pr-3.5">
+      <p className="text-body-small-default font-medium text-[var(--content-secondary)]">
         What&apos;s changed
       </p>
-      <ul className="ml-4 list-disc text-body-medium-lighter">
-        {notes.map((note) => (
-          <li key={note}>{note}</li>
-        ))}
-      </ul>
+      {notes.length === 1 ? (
+        <p className="mt-1.5 text-body-medium-lighter text-[var(--content-default)]">
+          {notes[0]}
+        </p>
+      ) : (
+        <ul className="mt-2 flex flex-col gap-1.5">
+          {notes.map((note) => (
+            <li
+              key={note}
+              className="flex gap-2.5 text-body-medium-lighter text-[var(--content-default)]"
+            >
+              <span
+                aria-hidden
+                className="mt-[0.5em] h-1 w-1 flex-none rounded-full bg-[var(--content-tertiary)]"
+              />
+              <span>{note}</span>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }
@@ -177,24 +194,24 @@ export function AgreementsCard({
       <Card padding={electron ? "sm" : "md"} className="w-full">
         <div className={`flex flex-col ${electron ? "gap-3.5" : "gap-4"}`}>
           {showPrivacy && (
-            <>
+            <div className="flex flex-col gap-2">
               <PolicyChangeNotes notes={privacyNotes} />
               <ConsentCheckbox
                 kind="privacy"
                 checked={privacyConsent}
                 onChange={onPrivacyChange}
               />
-            </>
+            </div>
           )}
           {showTos && (
-            <>
+            <div className="flex flex-col gap-2">
               <PolicyChangeNotes notes={tosNotes} />
               <ConsentCheckbox
                 kind="tos"
                 checked={tosAccepted}
                 onChange={onTosChange}
               />
-            </>
+            </div>
           )}
         </div>
       </Card>

--- a/clients/web/src/domains/onboarding/components/consent-controls.tsx
+++ b/clients/web/src/domains/onboarding/components/consent-controls.tsx
@@ -79,6 +79,24 @@ function Divider() {
   return <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />;
 }
 
+// A short "what's changed" summary shown above a consent checkbox when the
+// policy version was bumped. Renders nothing when there are no notes.
+function PolicyChangeNotes({ notes }: { notes?: string[] }) {
+  if (!notes || notes.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1 text-[var(--content-tertiary)]">
+      <p className="text-body-small-default font-medium uppercase tracking-wider">
+        What&apos;s changed
+      </p>
+      <ul className="ml-4 list-disc text-body-medium-lighter">
+        {notes.map((note) => (
+          <li key={note}>{note}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export function PrivacyPreferencesCard({
   electron,
   showAnalytics = true,
@@ -136,6 +154,8 @@ export function AgreementsCard({
   tosAccepted,
   onPrivacyChange,
   onTosChange,
+  privacyNotes,
+  tosNotes,
   className,
   style,
 }: {
@@ -146,6 +166,8 @@ export function AgreementsCard({
   tosAccepted: boolean;
   onPrivacyChange: (next: boolean) => void;
   onTosChange: (next: boolean) => void;
+  privacyNotes?: string[];
+  tosNotes?: string[];
   className?: string;
   style?: CSSProperties;
 }) {
@@ -155,18 +177,24 @@ export function AgreementsCard({
       <Card padding={electron ? "sm" : "md"} className="w-full">
         <div className={`flex flex-col ${electron ? "gap-3.5" : "gap-4"}`}>
           {showPrivacy && (
-            <ConsentCheckbox
-              kind="privacy"
-              checked={privacyConsent}
-              onChange={onPrivacyChange}
-            />
+            <>
+              <PolicyChangeNotes notes={privacyNotes} />
+              <ConsentCheckbox
+                kind="privacy"
+                checked={privacyConsent}
+                onChange={onPrivacyChange}
+              />
+            </>
           )}
           {showTos && (
-            <ConsentCheckbox
-              kind="tos"
-              checked={tosAccepted}
-              onChange={onTosChange}
-            />
+            <>
+              <PolicyChangeNotes notes={tosNotes} />
+              <ConsentCheckbox
+                kind="tos"
+                checked={tosAccepted}
+                onChange={onTosChange}
+              />
+            </>
           )}
         </div>
       </Card>

--- a/clients/web/src/domains/onboarding/consent-changelog.test.ts
+++ b/clients/web/src/domains/onboarding/consent-changelog.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { PRIVACY_CONSENT_VERSION } from "@/utils/onboarding-cleanup";
+import {
+  privacyChangeNotes,
+  tosChangeNotes,
+} from "@/domains/onboarding/consent-changelog";
+
+describe("consent-changelog", () => {
+  test("the current privacy version has change notes", () => {
+    const notes = privacyChangeNotes(PRIVACY_CONSENT_VERSION);
+    expect(notes.length).toBeGreaterThan(0);
+    expect(notes).toContain("Introduces Together AI as a new managed model provider");
+  });
+
+  test("an unknown version yields no notes", () => {
+    expect(privacyChangeNotes("1999-01-01")).toEqual([]);
+    expect(tosChangeNotes("1999-01-01")).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/onboarding/consent-changelog.ts
+++ b/clients/web/src/domains/onboarding/consent-changelog.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-version "what changed" notes for each consent axis.
+ *
+ * Each map is keyed by the version string (e.g. "2026-06-22") and holds a short
+ * list of bullet points summarizing what changed in that version. The notes are
+ * a courtesy summary shown on the review-terms screen — the canonical, complete
+ * policy is always the linked document.
+ *
+ * Bump recipe: when you bump a `*_CONSENT_VERSION` in `onboarding-cleanup.ts`,
+ * add a matching dated entry to the corresponding map here describing the
+ * change. A missing entry is harmless (renders nothing).
+ */
+
+export const TOS_CHANGE_NOTES: Record<string, string[]> = {};
+
+export const PRIVACY_CHANGE_NOTES: Record<string, string[]> = {
+  "2026-06-22": ["Introduces Together AI as a new managed model provider"],
+};
+
+export const ANALYTICS_CHANGE_NOTES: Record<string, string[]> = {};
+
+export const DIAGNOSTICS_CHANGE_NOTES: Record<string, string[]> = {};
+
+export function tosChangeNotes(version: string): string[] {
+  return TOS_CHANGE_NOTES[version] ?? [];
+}
+
+export function privacyChangeNotes(version: string): string[] {
+  return PRIVACY_CHANGE_NOTES[version] ?? [];
+}
+
+export function analyticsChangeNotes(version: string): string[] {
+  return ANALYTICS_CHANGE_NOTES[version] ?? [];
+}
+
+export function diagnosticsChangeNotes(version: string): string[] {
+  return DIAGNOSTICS_CHANGE_NOTES[version] ?? [];
+}

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
@@ -40,6 +40,8 @@ mock.module("@/domains/onboarding/prefs", () => ({
 const saveConsentMock = mock((_args: unknown) => {});
 mock.module("@/utils/onboarding-cleanup", () => ({
   saveConsent: saveConsentMock,
+  PRIVACY_CONSENT_VERSION: "2026-06-22",
+  TOS_CONSENT_VERSION: "2026-06-08",
 }));
 
 mock.module("@/lib/auth/hard-navigate", () => ({

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -6,6 +6,10 @@ import {
     AgreementsCard,
     PrivacyPreferencesCard,
 } from "@/domains/onboarding/components/consent-controls";
+import {
+    privacyChangeNotes,
+    tosChangeNotes,
+} from "@/domains/onboarding/consent-changelog";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import {
     useAnalyticsConsentCurrent,
@@ -18,7 +22,11 @@ import {
 import { hardNavigate } from "@/lib/auth/hard-navigate";
 import { isElectron } from "@/runtime/is-electron";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
-import { saveConsent } from "@/utils/onboarding-cleanup";
+import {
+    PRIVACY_CONSENT_VERSION,
+    TOS_CONSENT_VERSION,
+    saveConsent,
+} from "@/utils/onboarding-cleanup";
 import { sanitizeReturnTo } from "@/utils/return-to";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -148,6 +156,8 @@ export function ReviewTermsScreen() {
             tosAccepted={tosAccepted}
             onPrivacyChange={setPrivacyConsent}
             onTosChange={setTosAccepted}
+            privacyNotes={showPrivacy ? privacyChangeNotes(PRIVACY_CONSENT_VERSION) : []}
+            tosNotes={showTos ? tosChangeNotes(TOS_CONSENT_VERSION) : []}
             className="mt-6 w-full"
             style={{ animation: "fadeInUp 0.5s ease-out 0.36s both" }}
           />

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -55,7 +55,7 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: { getState: () => ({ setShareDiagnostics }) },
 }));
 
-const { PRIVACY_CONSENT_VERSION } = await import("@/utils/onboarding-cleanup");
+const { DIAGNOSTICS_CONSENT_VERSION } = await import("@/utils/onboarding-cleanup");
 const { refreshDiagnosticsConsent, installConsentRefreshListeners } =
   await import("./consent-refresh");
 
@@ -81,7 +81,7 @@ function consentRecord(overrides: Partial<UserConsent> = {}): UserConsent {
 function revokeRecord(): UserConsent {
   return consentRecord({
     share_diagnostics: false,
-    share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
+    share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
   });
 }
 

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -205,6 +205,8 @@ mock.module("@/utils/onboarding-cleanup", () => ({
   resolveServerConsent: resolveServerConsentMock,
   TOS_CONSENT_VERSION: "2026-06-08",
   PRIVACY_CONSENT_VERSION: "2026-06-08",
+  ANALYTICS_CONSENT_VERSION: "2026-06-08",
+  DIAGNOSTICS_CONSENT_VERSION: "2026-06-08",
 }));
 
 const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -63,6 +63,8 @@ import {
   resolveServerConsent,
   TOS_CONSENT_VERSION,
   PRIVACY_CONSENT_VERSION,
+  ANALYTICS_CONSENT_VERSION,
+  DIAGNOSTICS_CONSENT_VERSION,
 } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import {
@@ -323,13 +325,13 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
             ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
             ...(analyticsCurrent
               ? {
-                  share_analytics_accepted_version: PRIVACY_CONSENT_VERSION,
+                  share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
                   share_analytics: store.shareAnalytics,
                 }
               : {}),
             ...(diagnosticsCurrent
               ? {
-                  share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
+                  share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
                   share_diagnostics: store.shareDiagnostics,
                 }
               : {}),

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -50,6 +50,8 @@ mock.module("@/utils/device-settings", () => ({
 import {
   TOS_CONSENT_VERSION,
   PRIVACY_CONSENT_VERSION,
+  ANALYTICS_CONSENT_VERSION,
+  DIAGNOSTICS_CONSENT_VERSION,
   clearConsentForUser,
   persistToggleConsent,
   resolveServerConsent,
@@ -69,18 +71,18 @@ function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
     ai_data_sharing_accepted_at: null,
     share_analytics: true,
     share_diagnostics: true,
-    share_analytics_accepted_version: PRIVACY_CONSENT_VERSION,
+    share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
     share_analytics_accepted_at: null,
-    share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
+    share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
     share_diagnostics_accepted_at: null,
     ...overrides,
   };
 }
 
 const analyticsKey = (userId: string) =>
-  `device:consent:share_analytics:v${PRIVACY_CONSENT_VERSION}:${userId}`;
+  `device:consent:share_analytics:v${ANALYTICS_CONSENT_VERSION}:${userId}`;
 const diagnosticsKey = (userId: string) =>
-  `device:consent:share_diagnostics:v${PRIVACY_CONSENT_VERSION}:${userId}`;
+  `device:consent:share_diagnostics:v${DIAGNOSTICS_CONSENT_VERSION}:${userId}`;
 
 beforeEach(() => {
   storeState.setTosAccepted.mockReset();
@@ -95,10 +97,51 @@ beforeEach(() => {
 });
 
 describe("resolveServerConsent", () => {
-  test("reports current toggles when versions match PRIVACY_CONSENT_VERSION", () => {
+  test("reports current toggles when versions match their own version constants", () => {
     const r = resolveServerConsent(makeConsent());
     expect(r.analyticsCurrent).toBe(true);
     expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("a privacy bump leaves the data-capture toggles current (frozen versions)", () => {
+    // The toggle versions are frozen at the prior privacy version "2026-06-18".
+    // A user who consented under it has stale privacy artifacts after the bump,
+    // but their capture-consent stays current and must not be re-prompted.
+    const r = resolveServerConsent(
+      makeConsent({
+        privacy_policy_accepted_version: "2026-06-18",
+        ai_data_sharing_accepted_version: "2026-06-18",
+        share_analytics_accepted_version: "2026-06-18",
+        share_diagnostics_accepted_version: "2026-06-18",
+        tos_accepted_version: "2026-06-08",
+      }),
+    );
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+    expect(r.privacy).toBe(false);
+    expect(r.tos).toBe(true);
+  });
+
+  test("a record fully at the current versions resolves every axis current", () => {
+    const r = resolveServerConsent(makeConsent());
+    expect(r.tos).toBe(true);
+    expect(r.privacy).toBe(true);
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("the data-capture toggles freeze at the prior privacy version (no re-prompt)", () => {
+    // Guards the no-re-prompt guarantee: the toggle versions must stay pinned to
+    // the value existing acks/device keys were stamped under. A careless future
+    // edit that re-points them at the bumped privacy version fails here.
+    expect(ANALYTICS_CONSENT_VERSION).toBe("2026-06-18");
+    expect(DIAGNOSTICS_CONSENT_VERSION).toBe("2026-06-18");
+    expect(analyticsKey("user-1")).toBe(
+      "device:consent:share_analytics:v2026-06-18:user-1",
+    );
+    expect(diagnosticsKey("user-1")).toBe(
+      "device:consent:share_diagnostics:v2026-06-18:user-1",
+    );
   });
 
   test("reports stale toggles for mismatched versions", () => {
@@ -332,8 +375,8 @@ describe("saveConsent", () => {
     });
     expect(patchConsentMock).toHaveBeenCalledTimes(1);
     const body = patchConsentMock.mock.calls[0][0];
-    expect(body.share_analytics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
-    expect(body.share_diagnostics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
+    expect(body.share_analytics_accepted_version).toBe(ANALYTICS_CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
   });
 
   test("ToS stamps the ToS version; the privacy checkbox stamps privacy policy + AI data sharing", () => {
@@ -392,7 +435,7 @@ describe("savePreferenceToggle", () => {
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_analytics).toBe(true);
-    expect(body.share_analytics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
+    expect(body.share_analytics_accepted_version).toBe(ANALYTICS_CONSENT_VERSION);
   });
 
   test("stamps the diagnostics version and sets its flag only", () => {
@@ -401,7 +444,7 @@ describe("savePreferenceToggle", () => {
     expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_diagnostics).toBe(false);
-    expect(body.share_diagnostics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
   });
 
   test("offline persists the on/off value but skips the currency stamp, ack key, and server patch", () => {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -4,9 +4,11 @@
  * Consent flags live in `device:consent:{tos,privacy,share_analytics,share_diagnostics}:v<VERSION>:<userId>`.
  * The `device:` prefix survives logout; the userId makes them per-user;
  * the version lets us force re-consent by bumping the relevant version
- * constant. The ToS legal terms version independently from the privacy
- * artifacts (privacy policy, AI data sharing, the share toggles), so each can
- * be re-reviewed without forcing the other.
+ * constant. The four consent axes version independently — ToS, the privacy
+ * checkbox (privacy policy + AI data sharing), share-analytics, and
+ * share-diagnostics — so any one can be re-reviewed without forcing the
+ * others. Bumping the privacy policy, in particular, must not re-prompt the
+ * two data-capture toggles, so those carry their own frozen versions.
  *
  * The `share_analytics`/`share_diagnostics` ack keys record the version under
  * which the toggle was last confirmed (its currency), independent of the
@@ -31,7 +33,14 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
 export const TOS_CONSENT_VERSION = "2026-06-08";
-export const PRIVACY_CONSENT_VERSION = "2026-06-18";
+export const PRIVACY_CONSENT_VERSION = "2026-06-22";
+
+// The two data-capture toggles version independently from the privacy policy.
+// Frozen at the prior privacy version (the value existing toggle acks/device
+// keys are stamped under) so bumping the privacy policy doesn't re-prompt
+// capture consent. Bump each independently when its own disclosure changes.
+export const ANALYTICS_CONSENT_VERSION = "2026-06-18";
+export const DIAGNOSTICS_CONSENT_VERSION = "2026-06-18";
 
 // The privacy version that the legacy "ai"-named device key was last written
 // under, before that field was folded into "privacy". Frozen as a literal (not
@@ -40,14 +49,14 @@ export const PRIVACY_CONSENT_VERSION = "2026-06-18";
 // key rather than treating it as current consent.
 const LEGACY_AI_PRIVACY_CONSENT_VERSION = "2026-06-08";
 
-// Version stamp embedded in each field's device-cache key. ToS tracks its own
-// version; the privacy checkbox (privacy policy + AI data sharing) and the two
-// share toggles track the privacy version.
+// Version stamp embedded in each field's device-cache key. ToS, the privacy
+// checkbox (privacy policy + AI data sharing), and each share toggle track
+// their own version constant.
 const CONSENT_KEY_VERSION = {
   tos: TOS_CONSENT_VERSION,
   privacy: PRIVACY_CONSENT_VERSION,
-  share_analytics: PRIVACY_CONSENT_VERSION,
-  share_diagnostics: PRIVACY_CONSENT_VERSION,
+  share_analytics: ANALYTICS_CONSENT_VERSION,
+  share_diagnostics: DIAGNOSTICS_CONSENT_VERSION,
 } as const;
 
 function consentKey(field: keyof typeof CONSENT_KEY_VERSION, userId: string): string {
@@ -202,8 +211,8 @@ export function resolveServerConsent(
       && consent.ai_data_sharing_accepted_version === PRIVACY_CONSENT_VERSION,
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
-    analyticsCurrent: consent.share_analytics_accepted_version === PRIVACY_CONSENT_VERSION,
-    diagnosticsCurrent: consent.share_diagnostics_accepted_version === PRIVACY_CONSENT_VERSION,
+    analyticsCurrent: consent.share_analytics_accepted_version === ANALYTICS_CONSENT_VERSION,
+    diagnosticsCurrent: consent.share_diagnostics_accepted_version === DIAGNOSTICS_CONSENT_VERSION,
     hasServerRecord,
   };
 }
@@ -240,8 +249,8 @@ export function saveConsent(opts: {
       ai_data_sharing_accepted_version: opts.privacy ? PRIVACY_CONSENT_VERSION : "",
       share_analytics: opts.shareAnalytics,
       share_diagnostics: opts.shareDiagnostics,
-      share_analytics_accepted_version: PRIVACY_CONSENT_VERSION,
-      share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
+      share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
+      share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
     }).catch(() => {});
   }
 }
@@ -283,7 +292,7 @@ export function savePreferenceToggle(
   if (hasPlatformSession) {
     void patchConsent({
       [field]: value,
-      [`${field}_accepted_version`]: PRIVACY_CONSENT_VERSION,
+      [`${field}_accepted_version`]: CONSENT_KEY_VERSION[field],
     }).catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary
- **Split the two data-capture toggles into independent version axes.** `share_analytics` and `share_diagnostics` now track their own `ANALYTICS_CONSENT_VERSION` / `DIAGNOSTICS_CONSENT_VERSION` instead of riding on `PRIVACY_CONSENT_VERSION`. Both are **frozen at `2026-06-18`** — the value existing toggle acks and device keys are already stamped under — so bumping the privacy policy does **not** re-prompt capture consent for existing users. The device-key strings are unchanged (`device:consent:share_analytics:v2026-06-18:<uid>`), and existing server records (`share_*_accepted_version = "2026-06-18"`) still resolve current.
- **Bumped `PRIVACY_CONSENT_VERSION` to `2026-06-22`.** Only the privacy checkbox (privacy policy + AI data sharing) goes stale; the toggles stay current, so the review-terms screen shows only the privacy section.
- **Added a per-version consent changelog framework.** New `consent-changelog.ts` holds one `version → bullets` map per axis (ToS, privacy, analytics, diagnostics). Seeded the `2026-06-22` privacy entry with *"Introduces Together AI as a new managed model provider"*. A new `PolicyChangeNotes` block renders these bullets above the relevant checkbox on `/review-terms` (ToS + privacy this round). Bump recipe documented in-file: bump a `*_CONSENT_VERSION`, add a matching dated entry.
- **Regression guards** assert the frozen toggle versions stay at `2026-06-18`, that a privacy bump keeps `analyticsCurrent`/`diagnosticsCurrent` true while `privacy` goes false, and that the device-key strings are unchanged.

## Original prompt
Bump the privacy policy consent version and introduce a framework for showing a short bullet list of what changed in each policy version, surfaced on the `/review-terms` re-consent screen. While doing so, split the two data-collection consent toggles (analytics, diagnostics) into their own independently-versioned axes so the privacy-policy bump wouldn't re-trigger data-capture consent for existing users. The new privacy version is `2026-06-22` with one change note: "Introduces Together AI as a new managed model provider".

## Test plan
- `bunx tsc --noEmit` clean.
- `onboarding-cleanup`, `consent-changelog`, `consent-refresh`, `auth-store`, and `review-terms-screen` test files pass (run per-file via `scripts/run-tests.ts` for mock isolation).
- Note: unrelated suites fail locally only due to the known worktree cross-package `zod` resolution issue; CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)