### PR TITLE
Normalize chat messages [3/4]: isolate streaming re-renders to the changed row (LUM-2537)

### DIFF
--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -59,6 +59,27 @@ describe("buildTranscriptItems", () => {
     expectDistinctNonEmptyKeys(items);
   });
 
+  test("reuses the MessageItem ref for an unchanged message, mints a new one for a changed message (row isolation)", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+    const assistant = makeMessage({ id: "m2", role: "assistant", ...textBody("Hi") });
+
+    const first = buildTranscriptItems({ ...emptyInput(), messages: [user, assistant] });
+
+    // Mirror an entity patch: only the assistant row gets a new ref (a token
+    // landed); the user row keeps its ref.
+    const assistantPatched = { ...assistant, ...textBody("Hi there") };
+    const second = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user, assistantPatched],
+    });
+
+    // Unchanged message -> same item ref -> the memoized TranscriptRow skips it.
+    expect(second[0]).toBe(first[0]);
+    // Changed message -> new item ref -> only that row re-renders.
+    expect(second[1]).not.toBe(first[1]);
+    expect((second[1] as MessageItem).message).toBe(assistantPatched);
+  });
+
   test("emits empty list when there is no state", () => {
     const items = buildTranscriptItems(emptyInput());
     expect(items).toEqual([]);

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -35,6 +35,24 @@ export interface BuildTranscriptItemsInput {
 }
 
 /**
+ * Cache of `MessageItem`s keyed by their `DisplayMessage` ref, so an unchanged
+ * message yields the **same** item ref across builds. This is what isolates a
+ * streaming token to its own row: the normalized store replaces only the
+ * patched message's ref, so every other message reuses its cached item and the
+ * memoized `TranscriptRow` skips re-rendering. A `WeakMap` keeps it leak-free —
+ * entries drop when a message object is garbage-collected.
+ */
+const messageItemCache = new WeakMap<DisplayMessage, MessageItem>();
+
+function messageItemFor(message: DisplayMessage): MessageItem {
+  const cached = messageItemCache.get(message);
+  if (cached !== undefined) return cached;
+  const item: MessageItem = { kind: "message", key: message.id, message };
+  messageItemCache.set(message, item);
+  return item;
+}
+
+/**
  * Project the chat state into an ordered flat list of transcript items.
  *
  * Rules:
@@ -78,12 +96,7 @@ export function buildTranscriptItems(
       continue;
     }
 
-    const messageItem: MessageItem = {
-      kind: "message",
-      key: message.id,
-      message,
-    };
-    items.push(messageItem);
+    items.push(messageItemFor(message));
   }
 
   for (const result of input.ephemeralMetaResults ?? []) {


### PR DESCRIPTION
**Linear:** [LUM-2537](https://linear.app/vellum/issue/LUM-2537) · **Stack 3 of 4** · stacked on [2/4] (#35722).

### Why — the visible re-render win
[2/4] made the store replace **only the changed row's object** per token. But `buildTranscriptItems` minted a **new `MessageItem` per row on every build**, so memoized `TranscriptRow`s saw new props and the whole list re-rendered anyway. `TranscriptRow` was already memoized and `sanitizeDisplayMessages` already preserves refs for unchanged rows — the builder was the one broken link.

### What it does
`buildTranscriptItems` caches each `MessageItem` by its `DisplayMessage` ref in a `WeakMap`: an unchanged message yields the **same item ref**, a changed message a new one. This restores the memo with the least surface area — no component rewrites, no new context.

### What changes for users
**A streaming token re-renders its own row, not the whole transcript.** Long conversations stay smooth under a fast token stream — same visible content, far less work.

### Why it's safe
A contained change keyed by object identity: the cache can only return an item equal to what it would otherwise build, because the cache key *is* the message ref. It covers **every event path** — the `setMessages` bulk rebuild reuses the existing message objects, so their items stay cached — and is proven at the data level (unchanged → same ref; changed → new ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh1GBRgSSWtkxgCnMw9sR5