### PR TITLE
Normalize chat messages [4/4]: swap no-remount (message_complete / user_echo) (LUM-2537)

### DIFF
--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -157,7 +157,7 @@ describe("handleAssistantActivityState", () => {
       ctx,
     );
     expect(ctx.lastActivityVersionRef.current.get("conv-1")).toBe(1);
-    expect(ctx.setMessages).toHaveBeenCalled();
+    expect(ctx.updateMessages).toHaveBeenCalled();
     expect(ctx.endTurn).toHaveBeenCalledWith({
       conversationId: "conv-1",
       reason: "complete",
@@ -233,7 +233,7 @@ describe("handleMessageComplete", () => {
       { type: "message_complete", messageId: "msg-1" },
       ctx,
     );
-    expect(ctx.setMessages).toHaveBeenCalled();
+    expect(ctx.updateMessages).toHaveBeenCalled();
     expect(ctx.endTurn).toHaveBeenCalledWith({
       conversationId: "conv-1",
       reason: "complete",

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -1,12 +1,10 @@
 import { recordDiagnostic } from "@/lib/diagnostics";
 import {
-  applyUserMessageEcho,
-  finalizeMessageComplete,
-  finalizeOnIdle,
-} from "@/domains/chat/utils/stream-updaters/message-updaters";
-import {
+  applyMessageComplete,
   applyTextDelta,
   applyThinkingDelta,
+  applyUserMessageEcho,
+  finalizeOnIdle,
 } from "@/domains/chat/utils/stream-updaters/entity-updaters";
 import type { MessageEntityState } from "@/domains/chat/utils/message-entities";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
@@ -213,7 +211,7 @@ export function handleAssistantActivityState(
     return;
   }
 
-  ctx.setMessages(finalizeOnIdle);
+  ctx.updateMessages(finalizeOnIdle);
   if (convId) {
     // Mirrors the cache patch in `handleMessageComplete` /
     // `handleGenerationCancelled` — see those handlers for the
@@ -236,7 +234,7 @@ export function handleMessageComplete(
   event: MessageCompleteEvent,
   ctx: StreamHandlerContext,
 ): void {
-  ctx.setMessages((prev) => finalizeMessageComplete(prev, event));
+  ctx.updateMessages((s) => applyMessageComplete(s, event));
 
   // Re-anchor subagents spawned in this turn from the optimistic streaming
   // bubble id (`currentAssistantMessageIdRef`, the same id used as
@@ -292,7 +290,7 @@ export function handleUserMessageEcho(
   event: UserMessageEchoEvent,
   ctx: StreamHandlerContext,
 ): void {
-  ctx.setMessages((prev) => applyUserMessageEcho(prev, event));
+  ctx.updateMessages((s) => applyUserMessageEcho(s, event));
 }
 
 export function handleGenerationHandoff(

--- a/clients/web/src/domains/chat/utils/stream-updaters/entity-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/entity-updaters.test.ts
@@ -9,9 +9,12 @@ import {
   toArray,
 } from "@/domains/chat/utils/message-entities";
 import {
+  applyMessageComplete,
   applyTextDelta,
   applyThinkingDelta,
+  applyUserMessageEcho,
 } from "@/domains/chat/utils/stream-updaters/entity-updaters";
+import type { MessageCompleteEvent } from "@vellumai/assistant-api";
 
 const userRow = (id: string): DisplayMessage => ({ id, role: "user", textSegments: ["hi"] });
 
@@ -75,5 +78,50 @@ describe("history rows are addressable by the same routing", () => {
     const s1 = applyTextDelta(s0, "streamed", "a1");
     expect(s1.order).toEqual(["u1", "a1"]); // no duplicate bubble
     expect(toArray(s1)[1]!.textSegments).toEqual(["streamed"]);
+  });
+});
+
+describe("applyMessageComplete — the swap no-remount", () => {
+  test("adopting the server id on an optimistic bubble keeps rowKey + order stable", () => {
+    // An optimistic streaming bubble (no messageId on the delta).
+    let s = applyTextDelta(emptyEntityState(), "answer");
+    const rowKey = s.order[0]!;
+    expect(s.byId[rowKey]!.isOptimistic).toBe(true);
+
+    const event = { type: "message_complete", messageId: "srv-1" } as MessageCompleteEvent;
+    s = applyMessageComplete(s, event);
+
+    expect(s.order).toEqual([rowKey]); // React key unchanged -> no remount at completion
+    expect(s.byId[rowKey]!.id).toBe("srv-1");
+    expect(s.byId[rowKey]!.isOptimistic).toBe(false);
+    expect(rowKeyForServerId(s, "srv-1")).toBe(rowKey);
+  });
+});
+
+describe("applyUserMessageEcho", () => {
+  test("swaps an optimistic user row's id by clientMessageId, keeping its rowKey", () => {
+    let s = appendRow(
+      emptyEntityState(),
+      { id: "tmp", role: "user", clientMessageId: "n1", isOptimistic: true, textSegments: ["hi"] },
+    );
+    expect(s.order).toEqual(["n1"]);
+
+    s = applyUserMessageEcho(s, { text: "hi", messageId: "srv-u", clientMessageId: "n1" });
+
+    expect(s.order).toEqual(["n1"]); // rowKey unchanged
+    expect(s.byId.n1!.id).toBe("srv-u");
+    expect(s.byId.n1!.isOptimistic).toBe(false);
+  });
+
+  test("dedupes an echo whose server id is already present", () => {
+    const before = appendRow(emptyEntityState(), { id: "srv-u", role: "user", textSegments: ["hi"] });
+    const after = applyUserMessageEcho(before, { text: "hi", messageId: "srv-u" });
+    expect(after).toBe(before); // no-op
+  });
+
+  test("appends a passive-viewer user row when there is no optimistic row", () => {
+    const s = applyUserMessageEcho(emptyEntityState(), { text: "yo", messageId: "srv-x" });
+    expect(s.order).toEqual(["srv-x"]);
+    expect(s.byId["srv-x"]!.role).toBe("user");
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-updaters/entity-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/entity-updaters.ts
@@ -24,6 +24,9 @@ import {
   newAssistantTextBubble,
   newAssistantThinkingBubble,
 } from "@/domains/chat/utils/stream-updaters/message-updaters";
+import { finalizeRunningToolCalls } from "@/domains/chat/utils/stream-updaters/shared";
+import { toDisplayAttachments } from "@/utils/display-attachments";
+import type { MessageCompleteEvent } from "@vellumai/assistant-api";
 
 /** The tail row's rowKey when it is an assistant row, else `undefined`. */
 function assistantTailRowKey(state: MessageEntityState): string | undefined {
@@ -88,4 +91,130 @@ export function applyThinkingDelta(
   }
   const bubble = newAssistantThinkingBubble(thinking, messageId);
   return setLiveAssistantRowKey(appendRow(state, bubble), deriveRowKey(bubble));
+}
+
+// ---------------------------------------------------------------------------
+// assistant_activity_state (idle)
+// ---------------------------------------------------------------------------
+
+/** Finalize any running tool calls across all assistant rows on turn-idle. */
+export function finalizeOnIdle(state: MessageEntityState): MessageEntityState {
+  let next = state;
+  for (const rowKey of state.order) {
+    const row = next.byId[rowKey];
+    if (row?.role !== "assistant") continue;
+    const finalized = finalizeRunningToolCalls(row);
+    if (finalized) {
+      next = patch(next, rowKey, (r) => ({ ...r, ...finalized }));
+    }
+  }
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// message_complete
+// ---------------------------------------------------------------------------
+
+/**
+ * Finalize the live assistant turn on `message_complete`: complete running
+ * tool calls, merge attachments, and adopt the server `messageId` on an
+ * optimistic row. The adopt is an in-place `patch` — `rowKey` is unchanged, so
+ * the row does NOT remount at completion (the array path re-derived the key
+ * from the swapped id and could not give this).
+ */
+export function applyMessageComplete(
+  state: MessageEntityState,
+  event: MessageCompleteEvent,
+): MessageEntityState {
+  const tailKey = assistantTailRowKey(state);
+  const attachments = toDisplayAttachments(event.attachments);
+
+  if (tailKey === undefined) {
+    // No assistant tail (tool-only / aux turn): push a finalized bubble only
+    // when there are attachments to carry.
+    if (!attachments) return state;
+    return appendRow(state, {
+      id: event.messageId ?? crypto.randomUUID(),
+      ...(event.messageId ? {} : { isOptimistic: true }),
+      role: "assistant",
+      timestamp: Date.now(),
+      attachments,
+    });
+  }
+
+  return patch(state, tailKey, (row) => {
+    const finalized = finalizeRunningToolCalls(row);
+    const adoptServerId = row.isOptimistic === true && !!event.messageId;
+    return {
+      ...row,
+      ...(adoptServerId ? { id: event.messageId!, isOptimistic: false } : {}),
+      ...(attachments ? { attachments } : {}),
+      ...(finalized ?? {}),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// user_message_echo
+// ---------------------------------------------------------------------------
+
+/** The rowKey of the optimistic user row this echo confirms, if any. */
+function optimisticUserRowKey(
+  state: MessageEntityState,
+  clientMessageId: string | undefined,
+): string | undefined {
+  // User-originated rows are keyed by their `clientMessageId`, so the nonce is
+  // a direct lookup.
+  if (clientMessageId !== undefined) {
+    return state.byId[clientMessageId]?.role === "user"
+      ? clientMessageId
+      : undefined;
+  }
+  // No nonce (pre-idempotency daemon / synthetic echo): the most recent
+  // still-optimistic user row.
+  for (let i = state.order.length - 1; i >= 0; i--) {
+    const key = state.order[i]!;
+    const row = state.byId[key];
+    if (row?.role === "user" && row.isOptimistic === true) return key;
+  }
+  return undefined;
+}
+
+/** Apply a `user_message_echo`: dedupe, swap an optimistic row's id, or append. */
+export function applyUserMessageEcho(
+  state: MessageEntityState,
+  event: { text: string; messageId?: string; clientMessageId?: string },
+): MessageEntityState {
+  const serverId = event.messageId;
+
+  // Already rendered (the originating client's POST resolved, or a prior echo /
+  // reconcile pulled the row in).
+  if (serverId !== undefined) {
+    const ownerKey = rowKeyForServerId(state, serverId);
+    if (ownerKey !== undefined && state.byId[ownerKey]?.role === "user") {
+      return state;
+    }
+  }
+
+  const targetKey = optimisticUserRowKey(state, event.clientMessageId);
+  if (targetKey !== undefined) {
+    // Synthetic echo with no server id to upgrade to — leave the row as-is.
+    if (serverId === undefined) return state;
+    return patch(state, targetKey, (row) => ({
+      ...row,
+      id: serverId,
+      isOptimistic: false,
+    }));
+  }
+
+  // Passive viewer / synthetic prompt: render the user turn.
+  return appendRow(state, {
+    id: serverId ?? crypto.randomUUID(),
+    ...(serverId === undefined ? { isOptimistic: true } : {}),
+    role: "user",
+    textSegments: [event.text],
+    contentOrder: [{ type: "text", id: "0" }],
+    contentBlocks: [{ type: "text", text: event.text }],
+    timestamp: Date.now(),
+  });
 }


### PR DESCRIPTION
**Linear:** [LUM-2537](https://linear.app/vellum/issue/LUM-2537) · **Stack 4 of 4** · stacked on [3/4] (#35723).

### Why
The terminal events still went through the array path — including the **optimistic→server id swap** at `message_complete` and `user_message_echo`, the exact operation that **remounted the streaming row** (the array path re-derived the React key from the swapped id). This is the second of the two root causes from [1/4].

### What it does
Routes `message_complete`, `user_message_echo`, and `assistant_activity_state` (idle) through the entity path; `message-handlers` no longer calls `setMessages`. The id swap becomes an in-place `patch` that **changes the `id` field and re-points the index, leaving `rowKey` and `order` untouched** — so the row keeps its React key across completion.

### What changes for users
**The assistant bubble no longer flickers/remounts when a turn completes** — it stays the same DOM node from first token through finalization, so scroll anchoring and in-row transient state survive the optimistic→server transition.

### Why it's safe
The swap touches only the `id` field and the index; `rowKey` and `order` are untouched, and finalize / idle / echo semantics are otherwise preserved — verified by tests: swap-keeps-rowKey, echo dedupe by server id, and passive-viewer append (a viewer that never sent the message still renders the user turn). Landing this **last**, after the hot path ([2/4]) and render isolation ([3/4]) are proven, puts the highest-stakes event on an already-exercised path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh1GBRgSSWtkxgCnMw9sR5