### PR TITLE
fix(web-login): make loopback login robust to localhost/127.0.0.1 host inconsistency

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -661,17 +661,18 @@ function getBaseDir(): string {
   return path.resolve(import.meta.dir, "..", "..", "..");
 }
 
-// Minimal structural view of a Bun server — kept as a supertype of Bun's
-// `Server` (rather than importing it) so the shared `fetchHandler` only
-// depends on what it actually uses, matching `handleLocalEndpoints`'s arg.
-type LoopbackServer = {
-  hostname: string;
-  port: number;
+// Just the slice of a Bun server `fetchHandler` needs — matches the structural
+// arg `handleLocalEndpoints` accepts, so Bun's `Server` is assignable to it.
+type RequestPeerServer = {
   requestIP(req: Request): { address: string } | null;
-  stop(closeActiveConnections?: boolean): void;
 };
 
 const WEB_PORT_SCAN_LIMIT = 50;
+
+type WebFetchHandler = (
+  req: Request,
+  server: RequestPeerServer,
+) => Promise<Response>;
 
 function isAddrInUse(err: unknown): boolean {
   const e = err as { code?: string; message?: string } | undefined;
@@ -679,6 +680,21 @@ function isAddrInUse(err: unknown): boolean {
     e?.code === "EADDRINUSE" ||
     /EADDRINUSE|address already in use/i.test(e?.message ?? "")
   );
+}
+
+// Bind one loopback family; returns the server, or null when the port is in
+// use. Server type is inferred from `Bun.serve` (avoids a generic mismatch).
+function tryBindLoopback(
+  port: number,
+  hostname: string,
+  fetchHandler: WebFetchHandler,
+) {
+  try {
+    return Bun.serve({ port, hostname, fetch: fetchHandler });
+  } catch (err) {
+    if (isAddrInUse(err)) return null;
+    throw err;
+  }
 }
 
 /**
@@ -695,36 +711,33 @@ function isAddrInUse(err: unknown): boolean {
  * Never binds wildcard interfaces (`0.0.0.0`/`::`): the server exposes
  * `/__local/*` control endpoints, so it must stay loopback-only.
  */
-function serveLoopback(
-  preferredPort: number,
-  fetchHandler: (req: Request, server: LoopbackServer) => Promise<Response>,
-): { port: number; servers: LoopbackServer[] } {
+function serveLoopback(preferredPort: number, fetchHandler: WebFetchHandler) {
   for (
     let port = preferredPort;
     port < preferredPort + WEB_PORT_SCAN_LIMIT;
     port++
   ) {
-    let primary: LoopbackServer;
-    try {
-      primary = Bun.serve({ port, hostname: "127.0.0.1", fetch: fetchHandler });
-    } catch (err) {
-      if (isAddrInUse(err)) continue;
-      throw err;
-    }
+    const primary = tryBindLoopback(port, "127.0.0.1", fetchHandler);
+    if (!primary) continue;
 
-    let secondary: LoopbackServer | null = null;
     try {
-      secondary = Bun.serve({ port, hostname: "::1", fetch: fetchHandler });
+      const secondary = Bun.serve({
+        port,
+        hostname: "::1",
+        fetch: fetchHandler,
+      });
+      return { port, servers: [primary, secondary] };
     } catch (err) {
       if (isAddrInUse(err)) {
+        // `::1` is contested (e.g. `vel up`) — move ports so `localhost`
+        // doesn't resolve to that other server.
         primary.stop(true);
         continue;
       }
       // IPv6 unavailable (e.g. EADDRNOTAVAIL) — IPv4-only is acceptable since
       // `localhost` then resolves to 127.0.0.1 anyway.
+      return { port, servers: [primary] };
     }
-
-    return { port, servers: secondary ? [primary, secondary] : [primary] };
   }
   throw new Error(
     `Could not bind a free loopback port in [${preferredPort}, ${preferredPort + WEB_PORT_SCAN_LIMIT - 1}]`,
@@ -805,10 +818,7 @@ async function runWebInterface(
     `<script>window.__VELLUM_CONFIG__=${configJson}${flagOverridesSnippet}</script></head>`,
   );
 
-  const fetchHandler = async (
-    req: Request,
-    server: LoopbackServer,
-  ): Promise<Response> => {
+  const fetchHandler: WebFetchHandler = async (req, server) => {
     const url = new URL(req.url);
     const { pathname } = url;
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -409,6 +409,17 @@ function currentPlatformToken(): string | null {
   return platformSessionToken;
 }
 
+// Whether to attach the platform credential to a proxied request. Only
+// same-origin (SPA) traffic qualifies — a cross-site page must not be able to
+// use the local proxy as a confused deputy for authenticated platform calls.
+// Cross-origin fetches always send an Origin; `Sec-Fetch-Site` is a belt-and-
+// braces check for browsers that send it.
+function isSameOriginRequest(req: Request): boolean {
+  if (!originIsAllowed(req.headers.get("origin") ?? undefined)) return false;
+  const site = req.headers.get("sec-fetch-site");
+  return !site || site === "same-origin" || site === "none";
+}
+
 function getEnvRecord(): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [k, v] of Object.entries(process.env)) {
@@ -886,8 +897,11 @@ async function runWebInterface(
 
       // Authenticate with the loopback session token the SPA registered. The
       // platform expects it both as the Django session cookie and as
-      // X-Session-Token (for DRF views that accept header-based auth).
-      const sessionToken = currentPlatformToken();
+      // X-Session-Token (for DRF views that accept header-based auth). Only
+      // same-origin SPA traffic gets the credential — never a cross-site caller.
+      const sessionToken = isSameOriginRequest(req)
+        ? currentPlatformToken()
+        : null;
       if (sessionToken) {
         headers.set(
           "Cookie",

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -57,6 +57,7 @@ import {
 } from "../lib/platform-client";
 import { tuiLog } from "../lib/tui-log";
 import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
+import { probePort } from "../lib/port-probe.js";
 
 const SUPPORTED_INTERFACES = ["cli", "web"] as const;
 type SupportedInterface = (typeof SUPPORTED_INTERFACES)[number];
@@ -101,8 +102,10 @@ export function parseArgs(): ParsedArgs {
   const { envVars: cliFlagVars, remaining: argsWithoutFlags } =
     parseFeatureFlagArgs(process.argv.slice(3));
   const flagEnvVars = { ...readAmbientFlagEnvVars(), ...cliFlagVars };
-  const disablePlatformAmbient = process.env.VELLUM_DISABLE_PLATFORM?.trim().toLowerCase();
-  let disablePlatform = disablePlatformAmbient === "true" || disablePlatformAmbient === "1";
+  const disablePlatformAmbient =
+    process.env.VELLUM_DISABLE_PLATFORM?.trim().toLowerCase();
+  let disablePlatform =
+    disablePlatformAmbient === "true" || disablePlatformAmbient === "1";
   const args = argsWithoutFlags;
 
   // Build parsedFlagOverrides from the extracted env vars:
@@ -658,6 +661,109 @@ function getBaseDir(): string {
   return path.resolve(import.meta.dir, "..", "..", "..");
 }
 
+// Minimal structural view of a Bun server — kept as a supertype of Bun's
+// `Server` (rather than importing it) so the shared `fetchHandler` only
+// depends on what it actually uses, matching `handleLocalEndpoints`'s arg.
+type LoopbackServer = {
+  hostname: string;
+  port: number;
+  requestIP(req: Request): { address: string } | null;
+  stop(closeActiveConnections?: boolean): void;
+};
+
+const WEB_PORT_SCAN_LIMIT = 50;
+
+function isAddrInUse(err: unknown): boolean {
+  const e = err as { code?: string; message?: string } | undefined;
+  return (
+    e?.code === "EADDRINUSE" ||
+    /EADDRINUSE|address already in use/i.test(e?.message ?? "")
+  );
+}
+
+/**
+ * Bind the local web server on BOTH loopback families (`127.0.0.1` and `::1`)
+ * so the app can be reached at `http://localhost:<port>` regardless of whether
+ * the browser resolves `localhost` to IPv4 or IPv6 — matching the host the
+ * platform hardcodes in its loopback login callback.
+ *
+ * IPv4 is mandatory. IPv6 is best-effort: if `::1` is already taken (e.g. the
+ * local platform's `vel up` edge-proxy owns `[::]:<port>`), the port is
+ * contested and we advance — otherwise `localhost` would resolve to that other
+ * server. If IPv6 is simply unavailable on the host, we proceed IPv4-only.
+ *
+ * Never binds wildcard interfaces (`0.0.0.0`/`::`): the server exposes
+ * `/__local/*` control endpoints, so it must stay loopback-only.
+ */
+function serveLoopback(
+  preferredPort: number,
+  fetchHandler: (req: Request, server: LoopbackServer) => Promise<Response>,
+): { port: number; servers: LoopbackServer[] } {
+  for (
+    let port = preferredPort;
+    port < preferredPort + WEB_PORT_SCAN_LIMIT;
+    port++
+  ) {
+    let primary: LoopbackServer;
+    try {
+      primary = Bun.serve({ port, hostname: "127.0.0.1", fetch: fetchHandler });
+    } catch (err) {
+      if (isAddrInUse(err)) continue;
+      throw err;
+    }
+
+    let secondary: LoopbackServer | null = null;
+    try {
+      secondary = Bun.serve({ port, hostname: "::1", fetch: fetchHandler });
+    } catch (err) {
+      if (isAddrInUse(err)) {
+        primary.stop(true);
+        continue;
+      }
+      // IPv6 unavailable (e.g. EADDRNOTAVAIL) — IPv4-only is acceptable since
+      // `localhost` then resolves to 127.0.0.1 anyway.
+    }
+
+    return { port, servers: secondary ? [primary, secondary] : [primary] };
+  }
+  throw new Error(
+    `Could not bind a free loopback port in [${preferredPort}, ${preferredPort + WEB_PORT_SCAN_LIMIT - 1}]`,
+  );
+}
+
+/**
+ * Find the first port at/above `preferred` with nothing listening on either
+ * loopback family. Used for the Vite dev server, which binds the port itself
+ * (via the `PORT` env). Connect-probe based, so there's a small TOCTOU window
+ * before Vite binds — acceptable for dev.
+ */
+async function findFreeDualLoopbackPort(preferred: number): Promise<number> {
+  for (let port = preferred; port < preferred + WEB_PORT_SCAN_LIMIT; port++) {
+    const [busyV4, busyV6] = await Promise.all([
+      probePort(port, "127.0.0.1"),
+      probePort(port, "::1"),
+    ]);
+    if (!busyV4 && !busyV6) return port;
+  }
+  return preferred;
+}
+
+/**
+ * Drop `Set-Cookie` headers for the Django session cookie from a proxied
+ * upstream response so the loopback-managed session cookie stays authoritative
+ * (the platform must not clobber the cookie the `/callback` handler installed).
+ */
+function stripSessionSetCookies(headers: Headers): void {
+  const setCookies = headers.getSetCookie?.() ?? [];
+  if (setCookies.length === 0) return;
+  headers.delete("set-cookie");
+  for (const cookie of setCookies) {
+    if (!/^\s*(sessionid|__Secure-sessionid)=/i.test(cookie)) {
+      headers.append("set-cookie", cookie);
+    }
+  }
+}
+
 async function runWebInterface(
   flagEnvVars: Record<string, string>,
   parsedFlagOverrides: Record<string, boolean | string>,
@@ -699,120 +805,139 @@ async function runWebInterface(
     `<script>window.__VELLUM_CONFIG__=${configJson}${flagOverridesSnippet}</script></head>`,
   );
 
-  const server = Bun.serve({
-    port: 3000,
-    hostname: "127.0.0.1",
-    fetch: async (req) => {
-      const url = new URL(req.url);
-      const { pathname } = url;
+  const fetchHandler = async (
+    req: Request,
+    server: LoopbackServer,
+  ): Promise<Response> => {
+    const url = new URL(req.url);
+    const { pathname } = url;
 
-      if (pathname === "/" || pathname === "/assistant") {
-        return Response.redirect(SPA_BASE, 302);
-      }
+    if (pathname === "/" || pathname === "/assistant") {
+      return Response.redirect(SPA_BASE, 302);
+    }
 
-      // Loopback auth: the platform redirects here after login with
-      // ?state=...&session_token=... — forward into the SPA.
-      if (pathname === "/callback") {
-        return Response.redirect(
-          `/account/platform-callback${url.search}`,
-          302,
+    // Loopback auth: the platform redirects here after login with
+    // ?state=...&session_token=... — install the session cookie server-side
+    // (a server Set-Cookie overwrites an HttpOnly squatter that the SPA's
+    // document.cookie write cannot) and forward into the SPA.
+    if (pathname === "/callback") {
+      const headers = new Headers({
+        Location: `/account/platform-callback${url.search}`,
+      });
+      const token = url.searchParams.get("session_token");
+      if (token && /^[A-Za-z0-9]+$/.test(token)) {
+        // Loopback http:// → no Secure; SameSite=Lax survives the cross-site
+        // login redirect. The proxy below mirrors sessionid →
+        // __Secure-sessionid when forwarding upstream, so the single cookie
+        // is sufficient locally.
+        headers.append(
+          "Set-Cookie",
+          `sessionid=${token}; Path=/; SameSite=Lax; Max-Age=1209600`,
         );
       }
+      return new Response(null, { status: 302, headers });
+    }
 
-      // Expose environment config to the SPA.
-      if (pathname === "/assistant/__config" || pathname === "/__config") {
-        return new Response(configJson, {
-          headers: { "Content-Type": "application/json" },
+    // Expose environment config to the SPA.
+    if (pathname === "/assistant/__config" || pathname === "/__config") {
+      return new Response(configJson, {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // __local endpoints for local-mode (lockfile, hatch, retire, guardian-token, gateway-proxy).
+    const localResponse = await handleLocalEndpoints(req, url, server);
+    if (localResponse) return localResponse;
+
+    // Reverse-proxy platform API requests.
+    if (
+      pathname.startsWith("/v1/") ||
+      pathname.startsWith("/_allauth/") ||
+      pathname.startsWith("/accounts/")
+    ) {
+      const target = new URL(pathname + url.search, platformUrl);
+      const headers = new Headers(req.headers);
+      headers.set("Host", new URL(platformUrl).host);
+      headers.delete("Origin");
+      headers.delete("Referer");
+
+      // Forward the session token — the loopback flow stores it in
+      // the browser cookie jar for localhost, but the platform backend
+      // expects it on its own domain. Set both the Cookie (for Django
+      // session middleware / allauth) and X-Session-Token (for DRF
+      // views that accept header-based auth).
+      const sessionToken = /sessionid=([^;]+)/.exec(
+        req.headers.get("Cookie") ?? "",
+      )?.[1];
+      if (sessionToken) {
+        headers.set(
+          "Cookie",
+          `sessionid=${sessionToken}; __Secure-sessionid=${sessionToken}`,
+        );
+        headers.set("X-Session-Token", sessionToken);
+      }
+
+      try {
+        const hasBody = req.method !== "GET" && req.method !== "HEAD";
+        const body = hasBody ? await req.arrayBuffer() : undefined;
+        const proxyRes = await loopbackSafeFetch(target.toString(), {
+          method: req.method,
+          headers,
+          body,
+          redirect: "manual",
         });
-      }
-
-      // __local endpoints for local-mode (lockfile, hatch, retire, guardian-token, gateway-proxy).
-      const localResponse = await handleLocalEndpoints(req, url, server);
-      if (localResponse) return localResponse;
-
-      // Reverse-proxy platform API requests.
-      if (
-        pathname.startsWith("/v1/") ||
-        pathname.startsWith("/_allauth/") ||
-        pathname.startsWith("/accounts/")
-      ) {
-        const target = new URL(pathname + url.search, platformUrl);
-        const headers = new Headers(req.headers);
-        headers.set("Host", new URL(platformUrl).host);
-        headers.delete("Origin");
-        headers.delete("Referer");
-
-        // Forward the session token — the loopback flow stores it in
-        // the browser cookie jar for localhost, but the platform backend
-        // expects it on its own domain. Set both the Cookie (for Django
-        // session middleware / allauth) and X-Session-Token (for DRF
-        // views that accept header-based auth).
-        const sessionToken = /sessionid=([^;]+)/.exec(
-          req.headers.get("Cookie") ?? "",
-        )?.[1];
-        if (sessionToken) {
-          headers.set(
-            "Cookie",
-            `sessionid=${sessionToken}; __Secure-sessionid=${sessionToken}`,
-          );
-          headers.set("X-Session-Token", sessionToken);
-        }
-
-        try {
-          const hasBody = req.method !== "GET" && req.method !== "HEAD";
-          const body = hasBody ? await req.arrayBuffer() : undefined;
-          const proxyRes = await loopbackSafeFetch(target.toString(), {
-            method: req.method,
-            headers,
-            body,
-            redirect: "manual",
-          });
-          const resHeaders = new Headers(proxyRes.headers);
-          resHeaders.delete("transfer-encoding");
-          return new Response(proxyRes.body, {
-            status: proxyRes.status,
-            statusText: proxyRes.statusText,
-            headers: resHeaders,
-          });
-        } catch (err) {
-          return new Response(
-            JSON.stringify({ error: `Platform proxy error: ${err}` }),
-            { status: 502, headers: { "Content-Type": "application/json" } },
-          );
-        }
-      }
-
-      if (pathname.startsWith(SPA_BASE)) {
-        const relPath = pathname.slice(SPA_BASE.length);
-        if (relPath) {
-          const filePath = path.join(distDir, relPath);
-          const file = Bun.file(filePath);
-          if (await file.exists()) {
-            return new Response(file);
-          }
-        }
-        return new Response(indexHtml, {
-          headers: { "Content-Type": "text/html; charset=utf-8" },
+        const resHeaders = new Headers(proxyRes.headers);
+        resHeaders.delete("transfer-encoding");
+        // Keep the loopback-managed session cookie authoritative.
+        stripSessionSetCookies(resHeaders);
+        return new Response(proxyRes.body, {
+          status: proxyRes.status,
+          statusText: proxyRes.statusText,
+          headers: resHeaders,
         });
+      } catch (err) {
+        return new Response(
+          JSON.stringify({ error: `Platform proxy error: ${err}` }),
+          { status: 502, headers: { "Content-Type": "application/json" } },
+        );
       }
+    }
 
-      // SPA fallback for /account/* routes (login, callback, etc.)
-      if (pathname.startsWith("/account/")) {
-        return new Response(indexHtml, {
-          headers: { "Content-Type": "text/html; charset=utf-8" },
-        });
+    if (pathname.startsWith(SPA_BASE)) {
+      const relPath = pathname.slice(SPA_BASE.length);
+      if (relPath) {
+        const filePath = path.join(distDir, relPath);
+        const file = Bun.file(filePath);
+        if (await file.exists()) {
+          return new Response(file);
+        }
       }
+      return new Response(indexHtml, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
 
-      return new Response("Not Found", { status: 404 });
-    },
-  });
+    // SPA fallback for /account/* routes (login, callback, etc.)
+    if (pathname.startsWith("/account/")) {
+      return new Response(indexHtml, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
 
-  console.log(
-    `Vellum web interface: http://${server.hostname}:${server.port}${SPA_BASE}`,
-  );
+    return new Response("Not Found", { status: 404 });
+  };
+
+  const { port, servers } = serveLoopback(3000, fetchHandler);
+  if (port !== 3000) {
+    console.log(`Port 3000 in use; using ${port}.`);
+  }
+  // Advertise `localhost` (not `127.0.0.1`) so the app origin matches the host
+  // the platform hardcodes in its loopback callback. We bind both loopback
+  // families above so `localhost` reaches us whichever one it resolves to.
+  console.log(`Vellum web interface: http://localhost:${port}${SPA_BASE}`);
 
   const shutdown = (): void => {
-    server.stop();
+    for (const server of servers) server.stop();
     process.exit(0);
   };
   process.on("SIGINT", shutdown);
@@ -834,6 +959,14 @@ async function runViteDevServer(
     viteFlagVars[`VITE_${envName}`] = value;
   }
 
+  // Auto-pick a free port (Vite uses strictPort) so a running `vel up` stack
+  // on :3000 doesn't wedge dev. The loopback callback port follows
+  // window.location.port, so a non-3000 port propagates automatically.
+  const port = await findFreeDualLoopbackPort(3000);
+  if (port !== 3000) {
+    console.log(`Port 3000 in use; using ${port}.`);
+  }
+
   const child = spawn("bun", ["run", "dev"], {
     cwd: webSourceDir,
     stdio: "inherit",
@@ -846,7 +979,7 @@ async function runViteDevServer(
       API_PROXY_TARGET: platformUrl,
       VELLUM_WEB_URL: getWebUrl(),
       VELLUM_PLATFORM_URL: platformUrl,
-      PORT: "3000",
+      PORT: String(port),
     },
   });
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -54,6 +54,8 @@ import {
   getPlatformUrl,
   getWebUrl,
   readPlatformToken,
+  savePlatformToken,
+  clearPlatformToken,
 } from "../lib/platform-client";
 import { tuiLog } from "../lib/tui-log";
 import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
@@ -392,6 +394,20 @@ const HATCH_PATTERN = /^(?:\/assistant)?\/__local\/hatch$/;
 const RETIRE_PATTERN = /^(?:\/assistant)?\/__local\/retire$/;
 const GUARDIAN_TOKEN_PATTERN =
   /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
+const PLATFORM_SESSION_PATTERN =
+  /^(?:\/assistant)?\/__local\/platform-session$/;
+
+// The loopback platform session token. Persisted via the same store the CLI
+// uses (so `vellum client` restarts and CLI logins stay in sync), cached here
+// to keep it off the per-request proxy path. Set only after the SPA validates
+// the loopback `state`, so an unsolicited /callback can't fixate a session.
+let platformSessionToken: string | null | undefined;
+function currentPlatformToken(): string | null {
+  if (platformSessionToken === undefined) {
+    platformSessionToken = readPlatformToken();
+  }
+  return platformSessionToken;
+}
 
 function getEnvRecord(): Record<string, string> {
   const result: Record<string, string> = {};
@@ -421,6 +437,7 @@ async function handleLocalEndpoints(
     HATCH_PATTERN.test(pathname) ||
     RETIRE_PATTERN.test(pathname) ||
     GUARDIAN_TOKEN_PATTERN.test(pathname) ||
+    PLATFORM_SESSION_PATTERN.test(pathname) ||
     parseGatewayUrl(pathname).match;
 
   if (!isLocalRoute) return null;
@@ -436,6 +453,33 @@ async function handleLocalEndpoints(
     !originIsAllowed(req.headers.get("origin") ?? undefined)
   ) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Platform session: the SPA hands over the loopback token here (after it has
+  // validated the `state` nonce) so the proxy below can authenticate to the
+  // platform. The browser never holds a session cookie.
+  if (PLATFORM_SESSION_PATTERN.test(pathname)) {
+    if (req.method === "DELETE") {
+      clearPlatformToken();
+      platformSessionToken = null;
+      return Response.json({ ok: true });
+    }
+    if (req.method === "POST") {
+      const body = (await req.json().catch(() => null)) as {
+        token?: unknown;
+      } | null;
+      const token = body?.token;
+      if (typeof token !== "string" || !/^[A-Za-z0-9]+$/.test(token)) {
+        return Response.json(
+          { ok: false, error: "Invalid token" },
+          { status: 400 },
+        );
+      }
+      savePlatformToken(token);
+      platformSessionToken = token;
+      return Response.json({ ok: true });
+    }
+    return new Response(null, { status: 405 });
   }
 
   // Lockfile
@@ -761,22 +805,6 @@ async function findFreeDualLoopbackPort(preferred: number): Promise<number> {
   return preferred;
 }
 
-/**
- * Drop `Set-Cookie` headers for the Django session cookie from a proxied
- * upstream response so the loopback-managed session cookie stays authoritative
- * (the platform must not clobber the cookie the `/callback` handler installed).
- */
-function stripSessionSetCookies(headers: Headers): void {
-  const setCookies = headers.getSetCookie?.() ?? [];
-  if (setCookies.length === 0) return;
-  headers.delete("set-cookie");
-  for (const cookie of setCookies) {
-    if (!/^\s*(sessionid|__Secure-sessionid)=/i.test(cookie)) {
-      headers.append("set-cookie", cookie);
-    }
-  }
-}
-
 async function runWebInterface(
   flagEnvVars: Record<string, string>,
   parsedFlagOverrides: Record<string, boolean | string>,
@@ -827,25 +855,10 @@ async function runWebInterface(
     }
 
     // Loopback auth: the platform redirects here after login with
-    // ?state=...&session_token=... — install the session cookie server-side
-    // (a server Set-Cookie overwrites an HttpOnly squatter that the SPA's
-    // document.cookie write cannot) and forward into the SPA.
+    // ?state=...&session_token=... — forward into the SPA, which validates the
+    // `state` nonce before registering the token via /__local/platform-session.
     if (pathname === "/callback") {
-      const headers = new Headers({
-        Location: `/account/platform-callback${url.search}`,
-      });
-      const token = url.searchParams.get("session_token");
-      if (token && /^[A-Za-z0-9]+$/.test(token)) {
-        // Loopback http:// → no Secure; SameSite=Lax survives the cross-site
-        // login redirect. The proxy below mirrors sessionid →
-        // __Secure-sessionid when forwarding upstream, so the single cookie
-        // is sufficient locally.
-        headers.append(
-          "Set-Cookie",
-          `sessionid=${token}; Path=/; SameSite=Lax; Max-Age=1209600`,
-        );
-      }
-      return new Response(null, { status: 302, headers });
+      return Response.redirect(`/account/platform-callback${url.search}`, 302);
     }
 
     // Expose environment config to the SPA.
@@ -871,14 +884,10 @@ async function runWebInterface(
       headers.delete("Origin");
       headers.delete("Referer");
 
-      // Forward the session token — the loopback flow stores it in
-      // the browser cookie jar for localhost, but the platform backend
-      // expects it on its own domain. Set both the Cookie (for Django
-      // session middleware / allauth) and X-Session-Token (for DRF
-      // views that accept header-based auth).
-      const sessionToken = /sessionid=([^;]+)/.exec(
-        req.headers.get("Cookie") ?? "",
-      )?.[1];
+      // Authenticate with the loopback session token the SPA registered. The
+      // platform expects it both as the Django session cookie and as
+      // X-Session-Token (for DRF views that accept header-based auth).
+      const sessionToken = currentPlatformToken();
       if (sessionToken) {
         headers.set(
           "Cookie",
@@ -898,8 +907,6 @@ async function runWebInterface(
         });
         const resHeaders = new Headers(proxyRes.headers);
         resHeaders.delete("transfer-encoding");
-        // Keep the loopback-managed session cookie authoritative.
-        stripSessionSetCookies(resHeaders);
         return new Response(proxyRes.body, {
           status: proxyRes.status,
           statusText: proxyRes.statusText,

--- a/clients/web/src/domains/account/pages/platform-loopback-page.tsx
+++ b/clients/web/src/domains/account/pages/platform-loopback-page.tsx
@@ -3,8 +3,8 @@ import { useSearchParams, useNavigate } from "react-router";
 
 import { listAssistants } from "@/assistant/api";
 import { syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
+import { registerLocalPlatformSession } from "@/runtime/local-mode-host";
 import { setMenuPlatformSession } from "@/runtime/menu";
-import { getSessionTokenFromCookies } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { routes } from "@/utils/routes";
@@ -21,10 +21,10 @@ const LOOPBACK_RETURN_TO_KEY = "vellum:loopback:returnTo";
  *      `returnTo=/accounts/cli/callback?port={localPort}&state={nonce}`
  *   2. After authentication, the platform redirects to
  *      `http://localhost:{port}/callback?state={nonce}&session_token={token}`
- *   3. The local web server installs the session cookie (server-side, so it
- *      overrides any stale HttpOnly squatter) and redirects `/callback` → here
- *   4. This page validates the state, confirms the cookie, checks for existing
- *      assistants, and navigates accordingly
+ *   3. The local web server redirects `/callback` → this SPA page
+ *   4. This page validates the state, registers the token with the local
+ *      server (which authenticates its platform proxy with it — no browser
+ *      cookie), checks for existing assistants, and navigates accordingly
  */
 export function PlatformLoopbackPage() {
   const [searchParams] = useSearchParams();
@@ -56,22 +56,20 @@ export function PlatformLoopbackPage() {
       return;
     }
 
-    // The local web server already installed this cookie server-side on the
-    // `/callback` redirect (which can overwrite an HttpOnly squatter). Re-write
-    // it as a fallback, then verify it actually took — a stale HttpOnly
-    // `sessionid` left by the local platform would silently block both writes.
-    document.cookie = `sessionid=${sessionToken}; path=/; samesite=lax; max-age=1209600`;
-    if (getSessionTokenFromCookies() !== sessionToken) {
-      setError(
-        "Login failed: a stale 'sessionid' cookie from the local platform is " +
-          "blocking the session. Clear site data for this site (DevTools → " +
-          "Application → Clear storage) and try again.",
-      );
-      return;
-    }
-
     void (async () => {
-      // Re-run session init now that the cookie is set — this moves
+      // Hand the validated token to the local web server; its proxy uses it to
+      // authenticate to the platform. No browser session cookie is involved, so
+      // a stale HttpOnly `sessionid` from the local platform can't block login.
+      const registered = await registerLocalPlatformSession(sessionToken);
+      if (!registered) {
+        setError(
+          "Login failed: couldn't reach the local Vellum server to store the " +
+            "session. Please try again.",
+        );
+        return;
+      }
+
+      // Re-run session init now that the proxy is authenticated — this moves
       // sessionStatus to "authenticated" so the auth middleware lets
       // navigation through.
       await useAuthStore.getState().initSession();

--- a/clients/web/src/domains/account/pages/platform-loopback-page.tsx
+++ b/clients/web/src/domains/account/pages/platform-loopback-page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams, useNavigate } from "react-router";
 import { listAssistants } from "@/assistant/api";
 import { syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
 import { setMenuPlatformSession } from "@/runtime/menu";
+import { getSessionTokenFromCookies } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { routes } from "@/utils/routes";
@@ -19,10 +20,11 @@ const LOOPBACK_RETURN_TO_KEY = "vellum:loopback:returnTo";
  *      and navigates to the platform login with
  *      `returnTo=/accounts/cli/callback?port={localPort}&state={nonce}`
  *   2. After authentication, the platform redirects to
- *      `http://127.0.0.1:{port}/callback?state={nonce}&session_token={token}`
- *   3. The local web server redirects `/callback` → this SPA page
- *   4. This page validates the state, installs the session cookie,
- *      checks for existing assistants, and navigates accordingly
+ *      `http://localhost:{port}/callback?state={nonce}&session_token={token}`
+ *   3. The local web server installs the session cookie (server-side, so it
+ *      overrides any stale HttpOnly squatter) and redirects `/callback` → here
+ *   4. This page validates the state, confirms the cookie, checks for existing
+ *      assistants, and navigates accordingly
  */
 export function PlatformLoopbackPage() {
   const [searchParams] = useSearchParams();
@@ -33,7 +35,8 @@ export function PlatformLoopbackPage() {
     const state = searchParams.get("state");
     const sessionToken = searchParams.get("session_token");
     const expectedState = sessionStorage.getItem(LOOPBACK_STATE_KEY);
-    const returnTo = sessionStorage.getItem(LOOPBACK_RETURN_TO_KEY) || routes.assistant;
+    const returnTo =
+      sessionStorage.getItem(LOOPBACK_RETURN_TO_KEY) || routes.assistant;
 
     sessionStorage.removeItem(LOOPBACK_STATE_KEY);
     sessionStorage.removeItem(LOOPBACK_RETURN_TO_KEY);
@@ -53,7 +56,19 @@ export function PlatformLoopbackPage() {
       return;
     }
 
+    // The local web server already installed this cookie server-side on the
+    // `/callback` redirect (which can overwrite an HttpOnly squatter). Re-write
+    // it as a fallback, then verify it actually took — a stale HttpOnly
+    // `sessionid` left by the local platform would silently block both writes.
     document.cookie = `sessionid=${sessionToken}; path=/; samesite=lax; max-age=1209600`;
+    if (getSessionTokenFromCookies() !== sessionToken) {
+      setError(
+        "Login failed: a stale 'sessionid' cookie from the local platform is " +
+          "blocking the session. Clear site data for this site (DevTools → " +
+          "Application → Clear storage) and try again.",
+      );
+      return;
+    }
 
     void (async () => {
       // Re-run session init now that the cookie is set — this moves

--- a/clients/web/src/lib/auth/loopback-auth.ts
+++ b/clients/web/src/lib/auth/loopback-auth.ts
@@ -3,10 +3,10 @@
  *
  * Mirrors the CLI's `vellum login` browser flow: navigates to the
  * platform's login page, which authenticates via WorkOS and redirects
- * back to `http://127.0.0.1:{port}/callback?state=...&session_token=...`.
- * The local web server forwards `/callback` to the SPA's
- * `PlatformLoopbackPage` which validates the state and installs the
- * session cookie.
+ * back to `http://localhost:{port}/callback?state=...&session_token=...`.
+ * The local web server installs the session cookie server-side on the
+ * `/callback` redirect and forwards it to the SPA's `PlatformLoopbackPage`,
+ * which validates the state and confirms the session.
  */
 
 const FALLBACK_WEB_URL = "https://www.vellum.ai";
@@ -19,7 +19,8 @@ interface VellumConfig {
 }
 
 function getLocalConfig(): { webUrl: string } {
-  const injected = (window as unknown as { __VELLUM_CONFIG__?: VellumConfig }).__VELLUM_CONFIG__;
+  const injected = (window as unknown as { __VELLUM_CONFIG__?: VellumConfig })
+    .__VELLUM_CONFIG__;
   if (injected?.webUrl) return { webUrl: injected.webUrl };
   return { webUrl: FALLBACK_WEB_URL };
 }

--- a/clients/web/src/lib/auth/loopback-auth.ts
+++ b/clients/web/src/lib/auth/loopback-auth.ts
@@ -4,9 +4,9 @@
  * Mirrors the CLI's `vellum login` browser flow: navigates to the
  * platform's login page, which authenticates via WorkOS and redirects
  * back to `http://localhost:{port}/callback?state=...&session_token=...`.
- * The local web server installs the session cookie server-side on the
- * `/callback` redirect and forwards it to the SPA's `PlatformLoopbackPage`,
- * which validates the state and confirms the session.
+ * The local web server forwards `/callback` to the SPA's `PlatformLoopbackPage`,
+ * which validates the state and registers the token with the local server so
+ * its platform proxy can authenticate — no browser session cookie is used.
  */
 
 const FALLBACK_WEB_URL = "https://www.vellum.ai";

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -407,7 +407,11 @@ export async function getLocalAssistantStatusHost(
     .json()
     .catch(() => null)) as LocalAssistantStatusResult | null;
   return (
-    parsed ?? { ok: false, status: res.status, error: LOCAL_HOST_UNAVAILABLE_ERROR }
+    parsed ?? {
+      ok: false,
+      status: res.status,
+      error: LOCAL_HOST_UNAVAILABLE_ERROR,
+    }
   );
 }
 
@@ -442,4 +446,33 @@ export async function fetchGuardianTokenHost(
   }
   const { accessToken } = (await res.json()) as { accessToken: string };
   return accessToken;
+}
+
+/**
+ * Hand the loopback platform session token to the local web server so its proxy
+ * can authenticate to the platform. Called by the loopback callback page only
+ * after it validates the `state` nonce, so the token is never trusted from an
+ * unsolicited redirect. The browser never stores a session cookie.
+ */
+export async function registerLocalPlatformSession(
+  token: string,
+): Promise<boolean> {
+  const res = await postLocalCommand<{ ok: boolean }>(
+    "/assistant/__local/platform-session",
+    { token },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
+  return res.ok;
+}
+
+/**
+ * Clear the loopback platform session token on logout. Best-effort.
+ */
+export async function clearLocalPlatformSession(): Promise<void> {
+  if (!isLocalModeHostAvailable()) return;
+  try {
+    await fetch("/assistant/__local/platform-session", { method: "DELETE" });
+  } catch {
+    // best-effort — the server is going away or already cleared.
+  }
 }

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -76,6 +76,7 @@ import {
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
 import { subscribe } from "@/lib/event-bus";
 import { isElectron } from "@/runtime/is-electron";
+import { clearLocalPlatformSession } from "@/runtime/local-mode-host";
 import {
   isNativePlatform,
   isOAuthFlowInFlight,
@@ -310,7 +311,9 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         // opted-in user whose acceptance lives only in the per-device cache
         // isn't left with Sentry disabled. The live-session requirement still
         // applies via sentry-control's composed gate.
-        setDiagnosticsReportingGate(store.shareDiagnostics && diagnosticsCurrent);
+        setDiagnosticsReportingGate(
+          store.shareDiagnostics && diagnosticsCurrent,
+        );
         if (deviceConsent.tos && deviceConsent.privacy) {
           tos = true;
           privacy = true;
@@ -342,7 +345,10 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       store.setAnalyticsConsentCurrent(analyticsCurrent);
       store.setDiagnosticsConsentCurrent(diagnosticsCurrent);
       persistConsentForUser(nextUserId, tos, privacy);
-      persistToggleConsent(nextUserId, { analyticsCurrent, diagnosticsCurrent });
+      persistToggleConsent(nextUserId, {
+        analyticsCurrent,
+        diagnosticsCurrent,
+      });
       syncOrganizationState(nextUserId);
       return;
     } catch {
@@ -861,9 +867,9 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     } finally {
       // Clean up session token in the main process.
       if (isElectron()) await window.vellum?.auth?.signOut?.();
-      if (isLocalMode()) {
-        document.cookie =
-          "sessionid=; path=/; samesite=lax; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+      // Web loopback: drop the token the local server's proxy authenticates with.
+      if (isLocalMode() && !isElectron()) {
+        await clearLocalPlatformSession();
       }
       void deleteBiometricToken();
       clearOrganization();

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -41,6 +41,21 @@ export function getDevPlatformToken(): string | null {
   return devPlatformToken;
 }
 
+/**
+ * Whether a proxied request is same-origin SPA traffic that may carry the
+ * platform credential. A cross-site page must not be able to use the dev proxy
+ * as a confused deputy. Mirrors the Bun server's check.
+ */
+export function isSameOriginProxyRequest(req: http.IncomingMessage): boolean {
+  const origin = Array.isArray(req.headers.origin)
+    ? req.headers.origin[0]
+    : req.headers.origin;
+  if (!originIsAllowed(origin)) return false;
+  const site = req.headers["sec-fetch-site"];
+  const siteValue = Array.isArray(site) ? site[0] : site;
+  return !siteValue || siteValue === "same-origin" || siteValue === "none";
+}
+
 export function localModePlugin(env: Record<string, string>): Plugin {
   const config = resolveLocalConfigFromEnv(env);
   const baseDir = path.resolve(import.meta.dirname, "..", "..");

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -82,9 +82,17 @@ function rejectUnlessLocalEndpointRequest(
   res: http.ServerResponse,
 ): boolean {
   const peer = req.socket.remoteAddress ?? "";
-  const host = Array.isArray(req.headers.host) ? req.headers.host[0] : req.headers.host;
-  const origin = Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin;
-  if (!isLoopbackAddr(peer) || !headerHostIsLoopback(host) || !originIsAllowed(origin)) {
+  const host = Array.isArray(req.headers.host)
+    ? req.headers.host[0]
+    : req.headers.host;
+  const origin = Array.isArray(req.headers.origin)
+    ? req.headers.origin[0]
+    : req.headers.origin;
+  if (
+    !isLoopbackAddr(peer) ||
+    !headerHostIsLoopback(host) ||
+    !originIsAllowed(origin)
+  ) {
     res.statusCode = 403;
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify({ error: "Forbidden" }));
@@ -97,7 +105,20 @@ function loopbackCallbackMiddleware(): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (req.url?.startsWith("/callback")) {
       const qs = req.url.slice("/callback".length);
-      res.writeHead(302, { Location: `/account/platform-callback${qs}` });
+      const headers: Record<string, string> = {
+        Location: `/account/platform-callback${qs}`,
+      };
+      // Install the session cookie server-side: a server Set-Cookie overwrites
+      // a stale HttpOnly `sessionid` squatter (e.g. left by the local platform)
+      // that the SPA's document.cookie write cannot touch.
+      const token = new URLSearchParams(qs.replace(/^\?/, "")).get(
+        "session_token",
+      );
+      if (token && /^[A-Za-z0-9]+$/.test(token)) {
+        headers["Set-Cookie"] =
+          `sessionid=${token}; Path=/; SameSite=Lax; Max-Age=1209600`;
+      }
+      res.writeHead(302, headers);
       res.end();
       return;
     }
@@ -254,22 +275,27 @@ function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
         return;
       }
 
-      runHatch(invocation, species, remote ? { remote } : undefined).then((result) => {
-        res.statusCode = result.ok ? 200 : result.status;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify(
-            result.ok
-              ? { ok: true, assistantId: result.assistantId }
-              : { ok: false, error: result.error },
-          ),
-        );
-      });
+      runHatch(invocation, species, remote ? { remote } : undefined).then(
+        (result) => {
+          res.statusCode = result.ok ? 200 : result.status;
+          res.setHeader("Content-Type", "application/json");
+          res.end(
+            JSON.stringify(
+              result.ok
+                ? { ok: true, assistantId: result.assistantId }
+                : { ok: false, error: result.error },
+            ),
+          );
+        },
+      );
     });
   };
 }
 
-function retireMiddleware(baseDir: string, lockfilePaths: string[]): Connect.NextHandleFunction {
+function retireMiddleware(
+  baseDir: string,
+  lockfilePaths: string[],
+): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (
       req.url !== "/assistant/__local/retire" &&
@@ -313,7 +339,12 @@ function retireMiddleware(baseDir: string, lockfilePaths: string[]): Connect.Nex
       if (!isActiveAssistant(lockfilePaths, assistantId)) {
         res.statusCode = 403;
         res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ ok: false, error: "Can only retire the active local assistant" }));
+        res.end(
+          JSON.stringify({
+            ok: false,
+            error: "Can only retire the active local assistant",
+          }),
+        );
         return;
       }
 

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -29,6 +29,17 @@ const GUARDIAN_TOKEN_PATTERN =
   /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
 const LOCAL_STATUS_PATTERN = /^(?:\/assistant)?\/__local\/status\/([^/]+)$/;
 const LOCAL_UPGRADE_PATTERN = /^(?:\/assistant)?\/__local\/upgrade$/;
+const PLATFORM_SESSION_PATTERN =
+  /^(?:\/assistant)?\/__local\/platform-session$/;
+
+// In-memory loopback platform session token for the dev server. The proxy
+// (vite.config.ts) and the middleware below run in the same Node process, so
+// this module singleton bridges them. Dev-only and session-scoped; the
+// installed CLI persists the token via its own store.
+let devPlatformToken: string | null = null;
+export function getDevPlatformToken(): string | null {
+  return devPlatformToken;
+}
 
 export function localModePlugin(env: Record<string, string>): Plugin {
   const config = resolveLocalConfigFromEnv(env);
@@ -49,6 +60,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
     },
     configureServer(server) {
       server.middlewares.use(loopbackCallbackMiddleware());
+      server.middlewares.use(platformSessionMiddleware());
       server.middlewares.use(
         configMiddleware(config.webUrl, config.platformUrl),
       );
@@ -105,24 +117,56 @@ function loopbackCallbackMiddleware(): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (req.url?.startsWith("/callback")) {
       const qs = req.url.slice("/callback".length);
-      const headers: Record<string, string> = {
-        Location: `/account/platform-callback${qs}`,
-      };
-      // Install the session cookie server-side: a server Set-Cookie overwrites
-      // a stale HttpOnly `sessionid` squatter (e.g. left by the local platform)
-      // that the SPA's document.cookie write cannot touch.
-      const token = new URLSearchParams(qs.replace(/^\?/, "")).get(
-        "session_token",
-      );
-      if (token && /^[A-Za-z0-9]+$/.test(token)) {
-        headers["Set-Cookie"] =
-          `sessionid=${token}; Path=/; SameSite=Lax; Max-Age=1209600`;
-      }
-      res.writeHead(302, headers);
+      res.writeHead(302, { Location: `/account/platform-callback${qs}` });
       res.end();
       return;
     }
     next();
+  };
+}
+
+// Receives the loopback platform session token from the SPA (after it has
+// validated the `state` nonce) and holds it for the proxy. Mirrors the Bun
+// server's /__local/platform-session endpoint.
+function platformSessionMiddleware(): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    const path = (req.url ?? "").split("?")[0];
+    if (!PLATFORM_SESSION_PATTERN.test(path)) return next();
+    if (rejectUnlessLocalEndpointRequest(req, res)) return;
+
+    if (req.method === "DELETE") {
+      devPlatformToken = null;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      let token: unknown;
+      try {
+        token = (
+          JSON.parse(Buffer.concat(chunks).toString()) as { token?: unknown }
+        ).token;
+      } catch {
+        token = undefined;
+      }
+      if (typeof token !== "string" || !/^[A-Za-z0-9]+$/.test(token)) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: false, error: "Invalid token" }));
+        return;
+      }
+      devPlatformToken = token;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: true }));
+    });
   };
 }
 

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -20,8 +20,8 @@ function isPlatformMode(raw: string | undefined): boolean {
 
 /**
  * Proxy configure hook (local mode) that authenticates upstream requests with
- * the loopback platform session token the SPA registered — as both the Django
- * session cookie and `X-Session-Token`. No browser cookie is involved.
+ * the loopback platform session token the SPA registered, as the Django session
+ * cookie. No browser cookie is involved.
  */
 function injectPlatformToken(proxy: {
   on: (event: string, cb: (...args: unknown[]) => void) => void;
@@ -34,7 +34,6 @@ function injectPlatformToken(proxy: {
         "Cookie",
         `sessionid=${token}; __Secure-sessionid=${token}`,
       );
-      proxyReq.setHeader("X-Session-Token", token);
     }
   });
 }

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -5,7 +5,11 @@ import { rmSync } from "node:fs";
 import type http from "node:http";
 import path from "node:path";
 import { defineConfig, loadEnv } from "vite";
-import { localModePlugin, getDevPlatformToken } from "./vite-plugin-local-mode";
+import {
+  localModePlugin,
+  getDevPlatformToken,
+  isSameOriginProxyRequest,
+} from "./vite-plugin-local-mode";
 
 const DESIGN_LIBRARY_SRC = path.resolve(
   import.meta.dirname,
@@ -28,6 +32,8 @@ function injectPlatformToken(proxy: {
 }): void {
   proxy.on("proxyReq", (...args: unknown[]) => {
     const proxyReq = args[0] as http.ClientRequest;
+    const req = args[1] as http.IncomingMessage;
+    if (!isSameOriginProxyRequest(req)) return;
     const token = getDevPlatformToken();
     if (token) {
       proxyReq.setHeader(

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -26,16 +26,48 @@ function isPlatformMode(raw: string | undefined): boolean {
  *
  * Only used in local mode — platform mode proxies without rewriting.
  */
-function forwardSessionCookie(proxy: { on: (event: string, cb: (...args: unknown[]) => void) => void }): void {
+function forwardSessionCookie(proxy: {
+  on: (event: string, cb: (...args: unknown[]) => void) => void;
+}): void {
   proxy.on("proxyReq", (...args: unknown[]) => {
     const proxyReq = args[0] as http.ClientRequest;
     const req = args[1] as http.IncomingMessage;
     const cookie = req.headers.cookie ?? "";
     const match = /sessionid=([^;]+)/.exec(cookie);
     if (match?.[1]) {
-      proxyReq.setHeader("Cookie", `sessionid=${match[1]}; __Secure-sessionid=${match[1]}`);
+      proxyReq.setHeader(
+        "Cookie",
+        `sessionid=${match[1]}; __Secure-sessionid=${match[1]}`,
+      );
     }
   });
+}
+
+/**
+ * Drop the platform's own `sessionid`/`__Secure-sessionid` `Set-Cookie` from
+ * proxied responses so it can't clobber the loopback-managed session cookie.
+ * Local mode only — in platform mode those cookies are first-party and must
+ * pass through.
+ */
+function stripUpstreamSessionCookie(proxy: {
+  on: (event: string, cb: (...args: unknown[]) => void) => void;
+}): void {
+  proxy.on("proxyRes", (...args: unknown[]) => {
+    const proxyRes = args[0] as http.IncomingMessage;
+    const setCookie = proxyRes.headers["set-cookie"];
+    if (Array.isArray(setCookie)) {
+      proxyRes.headers["set-cookie"] = setCookie.filter(
+        (cookie) => !/^\s*(sessionid|__Secure-sessionid)=/i.test(cookie),
+      );
+    }
+  });
+}
+
+function configureLocalApiProxy(proxy: {
+  on: (event: string, cb: (...args: unknown[]) => void) => void;
+}): void {
+  forwardSessionCookie(proxy);
+  stripUpstreamSessionCookie(proxy);
 }
 
 // Reference: https://vite.dev/config/#using-environment-variables-in-config
@@ -46,17 +78,22 @@ export default defineConfig(({ mode }) => {
   // Server-only proxy targets — never embedded in the client bundle.
   // Reference: https://vite.dev/config/server-options#server-proxy
   const apiProxyTarget = env.API_PROXY_TARGET || "http://localhost:8000";
-  const gatewayProxyTarget = env.GATEWAY_PROXY_TARGET || "http://localhost:7830";
+  const gatewayProxyTarget =
+    env.GATEWAY_PROXY_TARGET || "http://localhost:7830";
 
   // Only enable Sentry source map upload for deploy builds.
   // Reference: https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/uploading/vite/
   const sentryUploadEnabled = env.SENTRY_UPLOAD_SOURCE_MAPS === "true";
   if (sentryUploadEnabled && !env.SENTRY_AUTH_TOKEN) {
-    throw new Error("SENTRY_AUTH_TOKEN is required to upload Sentry source maps.");
+    throw new Error(
+      "SENTRY_AUTH_TOKEN is required to upload Sentry source maps.",
+    );
   }
   if (sentryUploadEnabled) {
     if (!env.VITE_APP_VERSION) {
-      throw new Error("VITE_APP_VERSION is required to upload Sentry source maps.");
+      throw new Error(
+        "VITE_APP_VERSION is required to upload Sentry source maps.",
+      );
     }
   }
 
@@ -129,14 +166,29 @@ export default defineConfig(({ mode }) => {
         allow: [import.meta.dirname, DESIGN_LIBRARY_SRC],
       },
       proxy: {
-        ...(isPlatformMode(env.VITE_PLATFORM_MODE) ? {
-          "/v1": { target: apiProxyTarget, changeOrigin: true },
-          "/_allauth": { target: apiProxyTarget, changeOrigin: true },
-        } : {
-          "/v1": { target: apiProxyTarget, changeOrigin: true, configure: forwardSessionCookie },
-          "/_allauth": { target: apiProxyTarget, changeOrigin: true, configure: forwardSessionCookie },
-        }),
-        "/accounts": { target: apiProxyTarget, changeOrigin: true },
+        ...(isPlatformMode(env.VITE_PLATFORM_MODE)
+          ? {
+              "/v1": { target: apiProxyTarget, changeOrigin: true },
+              "/_allauth": { target: apiProxyTarget, changeOrigin: true },
+              "/accounts": { target: apiProxyTarget, changeOrigin: true },
+            }
+          : {
+              "/v1": {
+                target: apiProxyTarget,
+                changeOrigin: true,
+                configure: configureLocalApiProxy,
+              },
+              "/_allauth": {
+                target: apiProxyTarget,
+                changeOrigin: true,
+                configure: configureLocalApiProxy,
+              },
+              "/accounts": {
+                target: apiProxyTarget,
+                changeOrigin: true,
+                configure: stripUpstreamSessionCookie,
+              },
+            }),
         "/auth": { target: gatewayProxyTarget, changeOrigin: true },
       },
     },

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -5,7 +5,7 @@ import { rmSync } from "node:fs";
 import type http from "node:http";
 import path from "node:path";
 import { defineConfig, loadEnv } from "vite";
-import { localModePlugin } from "./vite-plugin-local-mode";
+import { localModePlugin, getDevPlatformToken } from "./vite-plugin-local-mode";
 
 const DESIGN_LIBRARY_SRC = path.resolve(
   import.meta.dirname,
@@ -19,55 +19,24 @@ function isPlatformMode(raw: string | undefined): boolean {
 }
 
 /**
- * Proxy configure hook that rewrites the localhost `sessionid` cookie
- * into both `sessionid` and `__Secure-sessionid` so the platform's
- * Django session middleware recognises it regardless of which cookie
- * name is configured (dev vs production).
- *
- * Only used in local mode — platform mode proxies without rewriting.
+ * Proxy configure hook (local mode) that authenticates upstream requests with
+ * the loopback platform session token the SPA registered — as both the Django
+ * session cookie and `X-Session-Token`. No browser cookie is involved.
  */
-function forwardSessionCookie(proxy: {
+function injectPlatformToken(proxy: {
   on: (event: string, cb: (...args: unknown[]) => void) => void;
 }): void {
   proxy.on("proxyReq", (...args: unknown[]) => {
     const proxyReq = args[0] as http.ClientRequest;
-    const req = args[1] as http.IncomingMessage;
-    const cookie = req.headers.cookie ?? "";
-    const match = /sessionid=([^;]+)/.exec(cookie);
-    if (match?.[1]) {
+    const token = getDevPlatformToken();
+    if (token) {
       proxyReq.setHeader(
         "Cookie",
-        `sessionid=${match[1]}; __Secure-sessionid=${match[1]}`,
+        `sessionid=${token}; __Secure-sessionid=${token}`,
       );
+      proxyReq.setHeader("X-Session-Token", token);
     }
   });
-}
-
-/**
- * Drop the platform's own `sessionid`/`__Secure-sessionid` `Set-Cookie` from
- * proxied responses so it can't clobber the loopback-managed session cookie.
- * Local mode only — in platform mode those cookies are first-party and must
- * pass through.
- */
-function stripUpstreamSessionCookie(proxy: {
-  on: (event: string, cb: (...args: unknown[]) => void) => void;
-}): void {
-  proxy.on("proxyRes", (...args: unknown[]) => {
-    const proxyRes = args[0] as http.IncomingMessage;
-    const setCookie = proxyRes.headers["set-cookie"];
-    if (Array.isArray(setCookie)) {
-      proxyRes.headers["set-cookie"] = setCookie.filter(
-        (cookie) => !/^\s*(sessionid|__Secure-sessionid)=/i.test(cookie),
-      );
-    }
-  });
-}
-
-function configureLocalApiProxy(proxy: {
-  on: (event: string, cb: (...args: unknown[]) => void) => void;
-}): void {
-  forwardSessionCookie(proxy);
-  stripUpstreamSessionCookie(proxy);
 }
 
 // Reference: https://vite.dev/config/#using-environment-variables-in-config
@@ -176,17 +145,17 @@ export default defineConfig(({ mode }) => {
               "/v1": {
                 target: apiProxyTarget,
                 changeOrigin: true,
-                configure: configureLocalApiProxy,
+                configure: injectPlatformToken,
               },
               "/_allauth": {
                 target: apiProxyTarget,
                 changeOrigin: true,
-                configure: configureLocalApiProxy,
+                configure: injectPlatformToken,
               },
               "/accounts": {
                 target: apiProxyTarget,
                 changeOrigin: true,
-                configure: stripUpstreamSessionCookie,
+                configure: injectPlatformToken,
               },
             }),
         "/auth": { target: gatewayProxyTarget, changeOrigin: true },


### PR DESCRIPTION
## Summary

`vellum client --interface web` served the assistant on `127.0.0.1` while the platform's loopback login callback hardcodes `localhost`. Browsers treat those as different origins (and `localhost` resolves to IPv6 `::1` first on macOS), so when the local platform stack (`vel up`) was also running, login broke in three distinct ways: a 404, a "state mismatch", and cloud assistants stuck disabled ("Requires Account"). This makes web login robust to all three, even with `vel up` running.

**Own the canonical origin (fixes the 404 + sessionStorage state mismatch)**
- Bind the local web server on **both** `127.0.0.1` and `::1`, and advertise `http://localhost:PORT`, so login starts on the same origin the platform's hardcoded `localhost` callback returns to.
- **Auto-pick a free port** when `:3000` is taken (a port counts only if both loopback families bind); the loopback callback port follows `window.location.port`, so it propagates automatically.

**Proxy holds the session token instead of a browser cookie (fixes session fixation + the HttpOnly-squatter / cookie-origin fragility)**
- `/callback` now just forwards to the SPA — it sets nothing.
- The SPA validates the `state` nonce, then hands the token to a **loopback-guarded `/__local/platform-session`** endpoint; the local proxy authenticates to the platform with it. The browser never holds a session cookie.
- The token is only ever trusted **after** the SPA's state check, closing the session-fixation hole flagged in review. The Bun server persists it via the existing platform-token store (so `vellum client` restarts and CLI logins stay in sync); the Vite dev server holds it in memory.
- Logout clears it via `DELETE /__local/platform-session`.

Touches `cli/src/commands/client.ts`, `clients/web/{vite.config.ts,vite-plugin-local-mode.ts}`, and the SPA loopback page / auth store / local-mode host.

## Original prompt

While debugging a live session (Linear **ATL-890**), we root-caused three cascading `vellum client --interface web` login failures — all stemming from the assistant serving on `127.0.0.1` while the platform's loopback callback hardcodes `localhost`, colliding with a locally-running `vel up` stack. The ask was for the in-repo code changes that prevent this class of failure from recurring. During review, the original approach (manual server-side `Set-Cookie`) was flagged for a session-fixation risk and reworked into a proxy-held, state-gated token handoff that removes browser cookie manipulation entirely.
