### PR TITLE
feat(assistant): add trust-verdict → TrustContext/ResolvedMember mappers

### DIFF
--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -15,8 +15,8 @@ describe("trustContextFromVerdict", () => {
   test("guardian verdict maps trust + guardian fields and is byte-identical to toTrustContext", () => {
     const verdict = {
       trustClass: "guardian",
-      canonicalSenderId: "+15551234567",
-      guardianExternalUserId: "+15551234567",
+      canonicalSenderId: "+15550100",
+      guardianExternalUserId: "+15550100",
       guardianDeliveryChatId: "chat-9",
       guardianPrincipalId: "vellum-principal-abc",
       memberDisplayName: "Alice",
@@ -30,8 +30,8 @@ describe("trustContextFromVerdict", () => {
     });
 
     expect(result.trustClass).toBe("guardian");
-    expect(result.requesterExternalUserId).toBe("+15551234567");
-    expect(result.guardianExternalUserId).toBe("+15551234567");
+    expect(result.requesterExternalUserId).toBe("+15550100");
+    expect(result.guardianExternalUserId).toBe("+15550100");
     expect(result.guardianChatId).toBe("chat-9");
     expect(result.guardianPrincipalId).toBe("vellum-principal-abc");
     // memberDisplayName wins over sender display name.
@@ -39,9 +39,9 @@ describe("trustContextFromVerdict", () => {
     expect(result.requesterIdentifier).toBe("@alice");
 
     const equivalent: ActorTrustContext = {
-      canonicalSenderId: "+15551234567",
+      canonicalSenderId: "+15550100",
       guardianBindingMatch: {
-        guardianExternalUserId: "+15551234567",
+        guardianExternalUserId: "+15550100",
         guardianDeliveryChatId: "chat-9",
       },
       guardianPrincipalId: "vellum-principal-abc",
@@ -63,7 +63,7 @@ describe("trustContextFromVerdict", () => {
   test("identifier falls back to canonicalSenderId when no username", () => {
     const verdict = {
       trustClass: "trusted_contact",
-      canonicalSenderId: "+15550009999",
+      canonicalSenderId: "+15550101",
       memberDisplayName: "Bob",
     } satisfies TrustVerdict;
 
@@ -72,7 +72,7 @@ describe("trustContextFromVerdict", () => {
       conversationExternalId: CONV,
     });
 
-    expect(result.requesterIdentifier).toBe("+15550009999");
+    expect(result.requesterIdentifier).toBe("+15550101");
     // No memberDisplayName/sender override -> memberDisplayName used.
     expect(result.requesterDisplayName).toBe("Bob");
   });
@@ -176,6 +176,30 @@ describe("resolvedMemberFromVerdict", () => {
     const verdict = {
       trustClass: "unknown",
       canonicalSenderId: "u-2",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict missing status returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-4",
+      contactId: "contact-4",
+      channelId: "channel-4",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict missing policy returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-5",
+      contactId: "contact-5",
+      channelId: "channel-5",
+      status: "active",
     } satisfies TrustVerdict;
 
     expect(resolvedMemberFromVerdict(verdict)).toBeNull();

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import type { ActorTrustContext } from "../actor-trust-resolver.js";
+import { toTrustContext } from "../actor-trust-resolver.js";
+import {
+  resolvedMemberFromVerdict,
+  trustContextFromVerdict,
+} from "../trust-verdict-consumer.js";
+
+const CONV = "conv-123";
+
+describe("trustContextFromVerdict", () => {
+  test("guardian verdict maps trust + guardian fields and is byte-identical to toTrustContext", () => {
+    const verdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "+15551234567",
+      guardianExternalUserId: "+15551234567",
+      guardianDeliveryChatId: "chat-9",
+      guardianPrincipalId: "vellum-principal-abc",
+      memberDisplayName: "Alice",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "phone",
+      conversationExternalId: CONV,
+      actorUsername: "alice",
+      actorDisplayName: "Alice Sender",
+    });
+
+    expect(result.trustClass).toBe("guardian");
+    expect(result.requesterExternalUserId).toBe("+15551234567");
+    expect(result.guardianExternalUserId).toBe("+15551234567");
+    expect(result.guardianChatId).toBe("chat-9");
+    expect(result.guardianPrincipalId).toBe("vellum-principal-abc");
+    // memberDisplayName wins over sender display name.
+    expect(result.requesterDisplayName).toBe("Alice");
+    expect(result.requesterIdentifier).toBe("@alice");
+
+    const equivalent: ActorTrustContext = {
+      canonicalSenderId: "+15551234567",
+      guardianBindingMatch: {
+        guardianExternalUserId: "+15551234567",
+        guardianDeliveryChatId: "chat-9",
+      },
+      guardianPrincipalId: "vellum-principal-abc",
+      memberRecord: null,
+      trustClass: "guardian",
+      actorMetadata: {
+        identifier: "@alice",
+        displayName: "Alice",
+        senderDisplayName: "Alice Sender",
+        memberDisplayName: "Alice",
+        username: "alice",
+        channel: "phone",
+        trustStatus: "guardian",
+      },
+    };
+    expect(result).toEqual(toTrustContext(equivalent, CONV));
+  });
+
+  test("identifier falls back to canonicalSenderId when no username", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15550009999",
+      memberDisplayName: "Bob",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "phone",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterIdentifier).toBe("+15550009999");
+    // No memberDisplayName/sender override -> memberDisplayName used.
+    expect(result.requesterDisplayName).toBe("Bob");
+  });
+
+  test("displayName falls back to actorDisplayName when no memberDisplayName", () => {
+    const verdict = {
+      trustClass: "unverified_contact",
+      canonicalSenderId: "u-1",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+      actorUsername: "carol",
+      actorDisplayName: "Carol Display",
+    });
+
+    expect(result.trustClass).toBe("unverified_contact");
+    expect(result.requesterDisplayName).toBe("Carol Display");
+    expect(result.requesterIdentifier).toBe("@carol");
+  });
+
+  test("maps trustClass through and leaves guardian fields undefined when absent", () => {
+    for (const trustClass of [
+      "trusted_contact",
+      "unverified_contact",
+      "unknown",
+    ] as const) {
+      const verdict = {
+        trustClass,
+        canonicalSenderId: "u-x",
+      } satisfies TrustVerdict;
+
+      const result = trustContextFromVerdict(verdict, {
+        sourceChannel: "slack",
+        conversationExternalId: CONV,
+      });
+
+      expect(result.trustClass).toBe(trustClass);
+      expect(result.guardianExternalUserId).toBeUndefined();
+      expect(result.guardianPrincipalId).toBeUndefined();
+      // Non-guardian without binding -> no guardian chat id.
+      expect(result.guardianChatId).toBeUndefined();
+    }
+  });
+});
+
+describe("resolvedMemberFromVerdict", () => {
+  test("member verdict surfaces channel ACL/identity, info fields null", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "active",
+      policy: "allow",
+      externalChatId: "chat-1",
+      verifiedAt: 1700000000,
+      verifiedVia: "code",
+      memberDisplayName: "Dora",
+    } satisfies TrustVerdict;
+
+    const member = resolvedMemberFromVerdict(verdict);
+    expect(member).not.toBeNull();
+    expect(member!.channel.id).toBe("channel-1");
+    expect(member!.channel.status).toBe("active");
+    expect(member!.channel.policy).toBe("allow");
+    expect(member!.channel.verifiedAt).toBe(1700000000);
+    expect(member!.channel.verifiedVia).toBe("code");
+    expect(member!.channel.externalChatId).toBe("chat-1");
+
+    expect(member!.contact.id).toBe("contact-1");
+    expect(member!.contact.displayName).toBe("Dora");
+    expect(member!.contact.role).toBe("contact");
+    // INFO fields must be null/default placeholders.
+    expect(member!.contact.notes).toBeNull();
+    expect(member!.contact.userFile).toBeNull();
+    expect(member!.contact.interactionCount).toBe(0);
+    expect(member!.contact.lastInteraction).toBeNull();
+  });
+
+  test("guardian member verdict maps role guardian + principalId", () => {
+    const verdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "u-g",
+      contactId: "contact-g",
+      channelId: "channel-g",
+      guardianPrincipalId: "vellum-principal-g",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const member = resolvedMemberFromVerdict(verdict);
+    expect(member!.contact.role).toBe("guardian");
+    expect(member!.contact.principalId).toBe("vellum-principal-g");
+  });
+
+  test("memberless verdict (no contactId) returns null", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-2",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("blocked/revoked verdict surfaces channel.status verbatim", () => {
+    for (const status of ["blocked", "revoked"] as const) {
+      const verdict = {
+        trustClass: "unknown",
+        canonicalSenderId: "u-3",
+        contactId: "contact-3",
+        channelId: "channel-3",
+        status,
+        policy: "deny",
+      } satisfies TrustVerdict;
+
+      const member = resolvedMemberFromVerdict(verdict);
+      expect(member!.channel.status).toBe(status);
+      expect(member!.channel.policy).toBe("deny");
+    }
+  });
+});

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -205,6 +205,48 @@ describe("resolvedMemberFromVerdict", () => {
     expect(resolvedMemberFromVerdict(verdict)).toBeNull();
   });
 
+  test("member verdict with unknown policy returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-6",
+      contactId: "contact-6",
+      channelId: "channel-6",
+      status: "active",
+      policy: "bogus",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict with unknown status returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-7",
+      contactId: "contact-7",
+      channelId: "channel-7",
+      status: "quarantined",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict with valid known status+policy returns a member", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-8",
+      contactId: "contact-8",
+      channelId: "channel-8",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const member = resolvedMemberFromVerdict(verdict);
+    expect(member).not.toBeNull();
+    expect(member!.channel.status).toBe("active");
+    expect(member!.channel.policy).toBe("allow");
+  });
+
   test("blocked/revoked verdict surfaces channel.status verbatim", () => {
     for (const status of ["blocked", "revoked"] as const) {
       const verdict = {

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -13,7 +13,12 @@
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
-import type { ContactChannel, ContactWithChannels } from "../contacts/types.js";
+import type {
+  ChannelPolicy,
+  ChannelStatus,
+  ContactChannel,
+  ContactWithChannels,
+} from "../contacts/types.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ActorTrustContext } from "./actor-trust-resolver.js";
 import { toTrustContext } from "./actor-trust-resolver.js";
@@ -70,6 +75,28 @@ export function trustContextFromVerdict(
   return toTrustContext(actorTrustContext, input.conversationExternalId);
 }
 
+// Allowed ACL enum values, kept in sync with the ContactChannel union types.
+const CHANNEL_STATUS_VALUES: readonly ChannelStatus[] = [
+  "active",
+  "pending",
+  "revoked",
+  "blocked",
+  "unverified",
+];
+const CHANNEL_POLICY_VALUES: readonly ChannelPolicy[] = [
+  "allow",
+  "deny",
+  "escalate",
+];
+
+function isChannelStatus(value: string): value is ChannelStatus {
+  return (CHANNEL_STATUS_VALUES as readonly string[]).includes(value);
+}
+
+function isChannelPolicy(value: string): value is ChannelPolicy {
+  return (CHANNEL_POLICY_VALUES as readonly string[]).includes(value);
+}
+
 /**
  * Build a synthetic {@link ResolvedMember} from a gateway verdict.
  *
@@ -80,10 +107,14 @@ export function resolvedMemberFromVerdict(
   verdict: TrustVerdict,
 ): ResolvedMember | null {
   if (!verdict.contactId || !verdict.channelId) return null;
-  // Member verdict requires status+policy, else null (fail-closed): a
-  // partial/mixed-version verdict must not synthesize an active/allow channel
+  // Member verdict requires valid known status+policy enums, else null
+  // (fail-closed): a partial/mixed-version verdict (absent OR
+  // present-but-unknown ACL value) must not synthesize an active/allow channel
   // that would skip ingress ACL gates.
   if (!verdict.status || !verdict.policy) return null;
+  if (!isChannelStatus(verdict.status) || !isChannelPolicy(verdict.policy)) {
+    return null;
+  }
 
   const channel: ContactChannel = {
     id: verdict.channelId,
@@ -92,8 +123,8 @@ export function resolvedMemberFromVerdict(
     address: verdict.address ?? "",
     isPrimary: false,
     externalChatId: verdict.externalChatId ?? null,
-    status: verdict.status as ContactChannel["status"],
-    policy: verdict.policy as ContactChannel["policy"],
+    status: verdict.status,
+    policy: verdict.policy,
     verifiedAt: verdict.verifiedAt ?? null,
     verifiedVia: verdict.verifiedVia ?? null,
     inviteId: null,

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -1,0 +1,121 @@
+/**
+ * Consume a gateway-stamped {@link TrustVerdict} into the daemon's local
+ * trust shapes.
+ *
+ * The gateway resolves a per-actor verdict from its ACL DB and stamps it onto
+ * inbound `sourceMetadata`. These pure mappers turn that verdict into the same
+ * {@link TrustContext} / {@link ResolvedMember} the local resolver would have
+ * produced — ACL + identity only. INFO fields (notes, userFile, contactType,
+ * interactionCount) are never carried on the wire; the consumer re-joins them
+ * locally by contactId.
+ */
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import type { ChannelId } from "../channels/types.js";
+import type { ContactChannel, ContactWithChannels } from "../contacts/types.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type { ActorTrustContext } from "./actor-trust-resolver.js";
+import { toTrustContext } from "./actor-trust-resolver.js";
+import type { ResolvedMember } from "./routes/inbound-stages/acl-enforcement.js";
+
+export interface TrustVerdictTransport {
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+  actorUsername?: string;
+  actorDisplayName?: string;
+}
+
+/**
+ * Build a {@link TrustContext} from a gateway verdict + transport identity.
+ *
+ * Reassembles an {@link ActorTrustContext} (mirroring `resolveActorTrust`) and
+ * routes it through {@link toTrustContext}, so the output is byte-identical to
+ * the local resolution path.
+ */
+export function trustContextFromVerdict(
+  verdict: TrustVerdict,
+  input: TrustVerdictTransport,
+): TrustContext {
+  const canonicalSenderId = verdict.canonicalSenderId;
+  const memberDisplayName = verdict.memberDisplayName;
+  const senderDisplayName = input.actorDisplayName;
+  const username = input.actorUsername;
+  const identifier = username
+    ? `@${username}`
+    : (canonicalSenderId ?? undefined);
+
+  const actorTrustContext: ActorTrustContext = {
+    canonicalSenderId,
+    guardianBindingMatch: verdict.guardianExternalUserId
+      ? {
+          guardianExternalUserId: verdict.guardianExternalUserId,
+          guardianDeliveryChatId: verdict.guardianDeliveryChatId ?? null,
+        }
+      : null,
+    guardianPrincipalId: verdict.guardianPrincipalId,
+    memberRecord: null,
+    trustClass: verdict.trustClass,
+    actorMetadata: {
+      identifier,
+      displayName: memberDisplayName ?? senderDisplayName,
+      senderDisplayName,
+      memberDisplayName,
+      username,
+      channel: input.sourceChannel,
+      trustStatus: verdict.trustClass,
+    },
+  };
+
+  return toTrustContext(actorTrustContext, input.conversationExternalId);
+}
+
+/**
+ * Build a synthetic {@link ResolvedMember} from a gateway verdict.
+ *
+ * ACL + identity only; info fields are placeholders, re-joined locally by
+ * contactId. Returns null for memberless verdicts.
+ */
+export function resolvedMemberFromVerdict(
+  verdict: TrustVerdict,
+): ResolvedMember | null {
+  if (!verdict.contactId || !verdict.channelId) return null;
+
+  const channel: ContactChannel = {
+    id: verdict.channelId,
+    contactId: verdict.contactId,
+    type: verdict.type ?? "",
+    address: verdict.address ?? "",
+    isPrimary: false,
+    externalChatId: verdict.externalChatId ?? null,
+    status: (verdict.status ?? "active") as ContactChannel["status"],
+    policy: (verdict.policy ?? "allow") as ContactChannel["policy"],
+    verifiedAt: verdict.verifiedAt ?? null,
+    verifiedVia: verdict.verifiedVia ?? null,
+    inviteId: null,
+    revokedReason: null,
+    blockedReason: null,
+    lastSeenAt: null,
+    interactionCount: 0,
+    lastInteraction: null,
+    updatedAt: null,
+    createdAt: 0,
+  };
+
+  const contact: ContactWithChannels = {
+    id: verdict.contactId,
+    displayName: verdict.memberDisplayName ?? "",
+    notes: null,
+    lastInteraction: null,
+    interactionCount: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    role: verdict.trustClass === "guardian" ? "guardian" : "contact",
+    contactType: "human",
+    principalId: verdict.guardianPrincipalId ?? null,
+    userFile: null,
+    channels: [channel],
+  };
+
+  return { contact, channel };
+}

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -80,6 +80,10 @@ export function resolvedMemberFromVerdict(
   verdict: TrustVerdict,
 ): ResolvedMember | null {
   if (!verdict.contactId || !verdict.channelId) return null;
+  // Member verdict requires status+policy, else null (fail-closed): a
+  // partial/mixed-version verdict must not synthesize an active/allow channel
+  // that would skip ingress ACL gates.
+  if (!verdict.status || !verdict.policy) return null;
 
   const channel: ContactChannel = {
     id: verdict.channelId,
@@ -88,8 +92,8 @@ export function resolvedMemberFromVerdict(
     address: verdict.address ?? "",
     isPrimary: false,
     externalChatId: verdict.externalChatId ?? null,
-    status: (verdict.status ?? "active") as ContactChannel["status"],
-    policy: (verdict.policy ?? "allow") as ContactChannel["policy"],
+    status: verdict.status as ContactChannel["status"],
+    policy: verdict.policy as ContactChannel["policy"],
     verifiedAt: verdict.verifiedAt ?? null,
     verifiedVia: verdict.verifiedVia ?? null,
     inviteId: null,


### PR DESCRIPTION
## Summary
- Add `trust-verdict-consumer.ts`: pure `trustContextFromVerdict` (reuses `toTrustContext` for byte-identical output) and `resolvedMemberFromVerdict` (ACL + identity from the verdict; INFO fields left null for local join).
- Additive only — no wiring into the inbound pipeline yet.

Part of plan: daemon-consumes-trust-verdict.md (PR 1 of 4)