### PR TITLE
fix(browser): scope browser_execute host-bridge routing to the caller's actor

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1550,9 +1550,7 @@ export class Conversation {
 
   ensureHostProxiesForTurn(
     sourceInterface: import("../channels/types.js").InterfaceId | undefined,
-    sourceActorPrincipalId = this.currentTurnSourceActorPrincipalId ??
-      this.currentTurnAuthContext?.actorPrincipalId ??
-      this.authContext?.actorPrincipalId,
+    sourceActorPrincipalId = this.getTurnActorPrincipalId(),
   ): void {
     if (
       shouldAttachHostProxyForCapability(
@@ -1845,6 +1843,21 @@ export class Conversation {
 
   getAuthContext(): AuthContext | undefined {
     return this.authContext;
+  }
+
+  /**
+   * The actor principal that owns the current turn, for host-proxy routing.
+   * Prefers the in-flight turn's actor over the conversation's resting
+   * authContext so a /v1/messages turn (which sets only
+   * `currentTurnSourceActorPrincipalId`/`currentTurnAuthContext`) scopes
+   * correctly. Returns `undefined` when no actor identity is known.
+   */
+  getTurnActorPrincipalId(): string | undefined {
+    return (
+      this.currentTurnSourceActorPrincipalId ??
+      this.currentTurnAuthContext?.actorPrincipalId ??
+      this.authContext?.actorPrincipalId
+    );
   }
 
   setVoiceCallControlPrompt(prompt: string | null): void {

--- a/assistant/src/ipc/__tests__/browser-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/browser-ipc.test.ts
@@ -31,7 +31,7 @@ let mockOperationCalls: Array<{
 let mockConversation: {
   trustContext?: { trustClass: string };
   transportInterface?: string;
-  authContext?: { actorPrincipalId?: string };
+  getTurnActorPrincipalId?: () => string | undefined;
 } | null = null;
 
 let mockFindConversationCalls: string[] = [];
@@ -199,6 +199,7 @@ describe("browser_execute route", () => {
     mockConversation = {
       trustContext: { trustClass: "trusted" },
       transportInterface: "chrome-extension",
+      getTurnActorPrincipalId: () => undefined,
     };
 
     await callHandler({
@@ -234,7 +235,7 @@ describe("browser_execute route", () => {
     mockConversation = {
       trustContext: { trustClass: "trusted" },
       transportInterface: "macos",
-      authContext: { actorPrincipalId: "conversation-actor" },
+      getTurnActorPrincipalId: () => "conversation-actor",
     };
 
     await callHandler({
@@ -255,7 +256,7 @@ describe("browser_execute route", () => {
     mockConversation = {
       trustContext: { trustClass: "trusted" },
       transportInterface: "macos",
-      authContext: { actorPrincipalId: "conversation-actor" },
+      getTurnActorPrincipalId: () => "conversation-actor",
     };
 
     await callHandler(

--- a/assistant/src/ipc/__tests__/browser-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/browser-ipc.test.ts
@@ -251,6 +251,29 @@ describe("browser_execute route", () => {
     });
   });
 
+  test("prefers live conversation actor over the request header", async () => {
+    mockConversation = {
+      trustContext: { trustClass: "trusted" },
+      transportInterface: "macos",
+      authContext: { actorPrincipalId: "conversation-actor" },
+    };
+
+    await callHandler(
+      {
+        operation: "status",
+        input: {},
+        sessionId: "unused",
+        conversationId: "conv-live-actor",
+      },
+      { "x-vellum-actor-principal-id": "header-actor" },
+    );
+
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0].sourceActorPrincipalId).toBe(
+      "conversation-actor",
+    );
+  });
+
   test("does not call findConversation when no conversationId provided", async () => {
     await callHandler({
       operation: "snapshot",

--- a/assistant/src/ipc/__tests__/browser-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/browser-ipc.test.ts
@@ -24,12 +24,14 @@ let mockOperationCalls: Array<{
   conversationId: string;
   trustClass?: string;
   transportInterface?: string;
+  sourceActorPrincipalId?: string;
 }> = [];
 
 /** When set, findConversation returns a fake conversation object. */
 let mockConversation: {
   trustContext?: { trustClass: string };
   transportInterface?: string;
+  authContext?: { actorPrincipalId?: string };
 } | null = null;
 
 let mockFindConversationCalls: string[] = [];
@@ -42,6 +44,7 @@ mock.module("../../browser/operations.js", () => ({
       conversationId: string;
       trustClass?: string;
       transportInterface?: string;
+      sourceActorPrincipalId?: string;
     },
   ) => {
     mockOperationCalls.push({
@@ -50,6 +53,7 @@ mock.module("../../browser/operations.js", () => ({
       conversationId: context.conversationId,
       trustClass: context.trustClass,
       transportInterface: context.transportInterface,
+      sourceActorPrincipalId: context.sourceActorPrincipalId,
     });
     return mockOperationResult;
   },
@@ -71,8 +75,16 @@ const browserExecuteHandler = ROUTES.find(
 )!.handler;
 
 /** Call the handler with the RouteHandlerArgs shape. */
-function callHandler(body: Record<string, unknown>) {
-  return browserExecuteHandler({ body, pathParams: {}, queryParams: {} });
+function callHandler(
+  body: Record<string, unknown>,
+  headers?: Record<string, string>,
+) {
+  return browserExecuteHandler({
+    body,
+    headers,
+    pathParams: {},
+    queryParams: {},
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -201,6 +213,41 @@ describe("browser_execute route", () => {
       conversationId: "conv-live-456",
       trustClass: "trusted",
       transportInterface: "chrome-extension",
+    });
+  });
+
+  test("threads actor principal header into browser tool context", async () => {
+    await callHandler(
+      {
+        operation: "status",
+        input: {},
+        sessionId: "actor-session",
+      },
+      { "x-vellum-actor-principal-id": "actor-123" },
+    );
+
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0].sourceActorPrincipalId).toBe("actor-123");
+  });
+
+  test("falls back to live conversation actor when no actor header exists", async () => {
+    mockConversation = {
+      trustContext: { trustClass: "trusted" },
+      transportInterface: "macos",
+      authContext: { actorPrincipalId: "conversation-actor" },
+    };
+
+    await callHandler({
+      operation: "status",
+      input: {},
+      sessionId: "unused",
+      conversationId: "conv-live-actor",
+    });
+
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0]).toMatchObject({
+      conversationId: "conv-live-actor",
+      sourceActorPrincipalId: "conversation-actor",
     });
   });
 

--- a/assistant/src/runtime/routes/browser-routes.ts
+++ b/assistant/src/runtime/routes/browser-routes.ts
@@ -84,16 +84,16 @@ async function handleBrowserExecute({
     : browserCliConversationKey(sessionId);
 
   // Actor principal lets host-browser routing enforce same-actor ownership.
-  // A live conversation's authContext owns the turn (e.g. a nested-bash browser
-  // call inherits the conversation's actor), so it wins over the request header
-  // — which over IPC may carry a synthetic local-guardian id injected for
-  // header-less local callers. Resolve through the local-guardian translation
-  // so the value matches the actorPrincipalId host_browser clients register
-  // with (dev-bypass otherwise mismatches).
+  // A live conversation's turn actor owns the request (e.g. a nested-bash
+  // browser call inherits the conversation's actor), so it wins over the
+  // request header — which over IPC may carry a synthetic local-guardian id
+  // injected for header-less local callers. Resolve through the local-guardian
+  // translation so the value matches the actorPrincipalId host_browser clients
+  // register with (dev-bypass otherwise mismatches).
   const headerActor =
     headers["x-vellum-actor-principal-id"]?.trim() || undefined;
   const sourceActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-    conversation?.authContext?.actorPrincipalId ?? headerActor,
+    conversation?.getTurnActorPrincipalId() ?? headerActor,
   );
 
   const result = await executeBrowserOperation(

--- a/assistant/src/runtime/routes/browser-routes.ts
+++ b/assistant/src/runtime/routes/browser-routes.ts
@@ -84,12 +84,16 @@ async function handleBrowserExecute({
     : browserCliConversationKey(sessionId);
 
   // Actor principal lets host-browser routing enforce same-actor ownership.
-  // Resolve through the local-guardian translation so the value matches the
-  // actorPrincipalId host_browser clients register with (dev-bypass otherwise
-  // mismatches). Falls back to the conversation actor for nested-bash callers.
+  // A live conversation's authContext owns the turn (e.g. a nested-bash browser
+  // call inherits the conversation's actor), so it wins over the request header
+  // — which over IPC may carry a synthetic local-guardian id injected for
+  // header-less local callers. Resolve through the local-guardian translation
+  // so the value matches the actorPrincipalId host_browser clients register
+  // with (dev-bypass otherwise mismatches).
+  const headerActor =
+    headers["x-vellum-actor-principal-id"]?.trim() || undefined;
   const sourceActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-    headers["x-vellum-actor-principal-id"]?.trim() ||
-      conversation?.authContext?.actorPrincipalId,
+    conversation?.authContext?.actorPrincipalId ?? headerActor,
   );
 
   const result = await executeBrowserOperation(

--- a/assistant/src/runtime/routes/browser-routes.ts
+++ b/assistant/src/runtime/routes/browser-routes.ts
@@ -19,6 +19,7 @@ import {
 import { findConversation } from "../../daemon/conversation-registry.js";
 import type { ContentBlock } from "../../providers/types.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Param validation ─────────────────────────────────────────────────
@@ -64,7 +65,10 @@ function extractScreenshots(
 
 // ── Handler ──────────────────────────────────────────────────────────
 
-async function handleBrowserExecute({ body = {} }: RouteHandlerArgs) {
+async function handleBrowserExecute({
+  body = {},
+  headers = {},
+}: RouteHandlerArgs) {
   const { operation, input, sessionId, conversationId } =
     BrowserExecuteParams.parse(body);
 
@@ -79,6 +83,15 @@ async function handleBrowserExecute({ body = {} }: RouteHandlerArgs) {
     ? conversationId!
     : browserCliConversationKey(sessionId);
 
+  // Actor principal lets host-browser routing enforce same-actor ownership.
+  // Resolve through the local-guardian translation so the value matches the
+  // actorPrincipalId host_browser clients register with (dev-bypass otherwise
+  // mismatches). Falls back to the conversation actor for nested-bash callers.
+  const sourceActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+    headers["x-vellum-actor-principal-id"]?.trim() ||
+      conversation?.authContext?.actorPrincipalId,
+  );
+
   const result = await executeBrowserOperation(
     operation as BrowserOperation,
     input,
@@ -87,6 +100,7 @@ async function handleBrowserExecute({ body = {} }: RouteHandlerArgs) {
       conversationId: resolvedConversationId,
       trustClass: conversation?.trustContext?.trustClass ?? "unknown",
       transportInterface: conversation?.transportInterface,
+      sourceActorPrincipalId,
     },
   );
 


### PR DESCRIPTION
## Summary
- `browser_execute` built its `ToolContext` without `sourceActorPrincipalId`, so the new host-bridge auto candidate (`cdp-client/factory.ts`) and `HostBrowserProxy` fell back to legacy single-user routing — any `host_browser` client was accepted, `candidates[0]` was returned, and the same-actor enforcement block was skipped. In a multi-actor cloud daemon this let a caller's CDP commands be dispatched to **another actor's** connected macOS desktop bridge, which then executes raw CDP against that user's local Chrome.
- Thread the caller's actor principal into the tool context: from the `x-vellum-actor-principal-id` header (injected by both the HTTP adapter and the IPC server), falling back to the live conversation's `authContext.actorPrincipalId` for nested-bash callers. This re-enables the existing same-actor guard in `HostBrowserProxy`.
- Resolve the value through `resolveActorPrincipalIdForLocalGuardian(...)` — matching every sibling host-proxy route (host-bash, host-cu, host-browser result, host-file, host-app-control, host-transfer). Using the raw header instead would, under `DISABLE_HTTP_AUTH=true` (dev-bypass), leave the actor as `"dev-bypass"` while SSE clients register with the resolved guardian id, wrongly rejecting the user's own host-bridge.
- Added regression tests covering header-based and conversation-fallback actor threading.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/6b274851529c819193aa6a789b5444c3

## Original prompt
Triage of a Codex security finding ("Host-bridge browser calls can bypass actor scoping", rated high). The vulnerability was confirmed still present: `browser_execute` omits `sourceActorPrincipalId`, disabling `HostBrowserProxy`'s same-actor enforcement on the host-bridge path. The Codex-proposed patch was correct in approach but used the raw header value; this PR adopts the fix while wrapping the value through `resolveActorPrincipalIdForLocalGuardian` to match the codebase convention and avoid breaking the legitimate same-actor path in dev-bypass mode.