### PR TITLE
feat(assistant): acl-enforcement reads trust verdict; fail-closed when absent

### DIFF
--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -302,6 +302,12 @@ describe("Verification control messages are deterministic (guard)", () => {
           replyCallbackUrl: "http://localhost/callback",
           sourceMetadata: {
             commandIntent: { type: "start", payload: `gv_${bootstrapToken}` },
+            // Gateway stamps a stranger verdict for this not-yet-bound user;
+            // the bootstrap intercept still fires for a present stranger.
+            trustVerdict: {
+              trustClass: "unknown",
+              canonicalSenderId: "user-bootstrap-123",
+            },
           },
         }),
       });
@@ -367,6 +373,18 @@ describe("Verification control messages are deterministic (guard)", () => {
         actorDisplayName: blockedIdentity.displayName,
         sourceMetadata: {
           commandIntent: { type: "start", payload: `gv_${bootstrapToken}` },
+          // Gateway stamps the member verdict surfacing the blocked status; the
+          // ACL hard-deny fires before the bootstrap intercept.
+          trustVerdict: {
+            trustClass: "unknown",
+            canonicalSenderId: blockedIdentity.externalUserId,
+            contactId: "contact-blocked-bootstrap",
+            channelId: "channel-blocked-bootstrap",
+            type: blockedIdentity.sourceChannel,
+            address: blockedIdentity.externalUserId,
+            status: blockedIdentity.status,
+            policy: blockedIdentity.policy,
+          },
         },
       }),
     });

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -61,6 +61,12 @@ mock.module("../../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => undefined,
 }));
 
+import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
+
+import {
+  findContactChannel,
+  findGuardianForChannel,
+} from "../../contacts/contact-store.js";
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
@@ -112,7 +118,99 @@ export async function handleChannelInbound(
   _approvalConversationGenerator?: ApprovalConversationGenerator,
 ): Promise<Response> {
   const body = await req.json();
+  stampTrustVerdict(body);
   return wrapHandler(() => _handleChannelInbound({ body }));
+}
+
+/**
+ * Mirror the gateway: stamp a per-actor {@link TrustVerdict} onto inbound
+ * `sourceMetadata` from the local contact store, so the daemon's ACL stage
+ * (which now reads the verdict and fail-closed-denies when it is absent) sees
+ * the same verdict the gateway would resolve in production.
+ *
+ * Skipped when a test already supplies `trustVerdict` (or sets `sourceMetadata`
+ * to null) so absent-verdict / explicit-verdict tests keep their setup.
+ */
+function stampTrustVerdict(body: Record<string, unknown>): void {
+  const meta = body.sourceMetadata as Record<string, unknown> | undefined;
+  if (meta && "trustVerdict" in meta) return;
+
+  const channelType = String(body.sourceChannel ?? "");
+  const actorExternalId =
+    typeof body.actorExternalId === "string" ? body.actorExternalId : undefined;
+  const externalChatId =
+    typeof body.conversationExternalId === "string"
+      ? body.conversationExternalId
+      : undefined;
+  if (!channelType) return;
+
+  const verdict = resolveLocalTrustVerdict({
+    channelType,
+    actorExternalId,
+    externalChatId,
+  });
+  body.sourceMetadata = { ...(meta ?? {}), trustVerdict: verdict };
+}
+
+/** Local mirror of the gateway resolver, reading the daemon contact store. */
+function resolveLocalTrustVerdict(input: {
+  channelType: string;
+  actorExternalId?: string;
+  externalChatId?: string;
+}): TrustVerdict {
+  const canonicalSenderId = input.actorExternalId ?? null;
+
+  const member = input.actorExternalId
+    ? findContactChannel({
+        channelType: input.channelType,
+        address: input.actorExternalId,
+        externalChatId: input.externalChatId,
+      })
+    : null;
+  const guardian = findGuardianForChannel(input.channelType);
+
+  const isGuardian =
+    !!guardian &&
+    !!canonicalSenderId &&
+    guardian.channel.address.toLowerCase() === canonicalSenderId.toLowerCase();
+
+  let trustClass: TrustClass;
+  if (isGuardian) {
+    trustClass = "guardian";
+  } else if (member) {
+    const status = member.channel.status;
+    if (status === "active") trustClass = "trusted_contact";
+    else if (status === "unverified" || status === "pending")
+      trustClass = "unverified_contact";
+    else trustClass = "unknown";
+  } else {
+    trustClass = "unknown";
+  }
+
+  const verdict: TrustVerdict = { trustClass, canonicalSenderId };
+
+  if (guardian) {
+    verdict.guardianExternalUserId = guardian.channel.address;
+    verdict.guardianDeliveryChatId = guardian.channel.externalChatId;
+    if (guardian.contact.principalId)
+      verdict.guardianPrincipalId = guardian.contact.principalId;
+    verdict.guardianDisplayName = guardian.contact.displayName;
+  }
+
+  if (member) {
+    verdict.contactId = member.channel.contactId;
+    verdict.channelId = member.channel.id;
+    verdict.type = member.channel.type;
+    verdict.address = member.channel.address;
+    verdict.externalChatId = member.channel.externalChatId;
+    verdict.status = member.channel.status;
+    verdict.policy = member.channel.policy;
+    verdict.verifiedAt = member.channel.verifiedAt;
+    verdict.verifiedVia = member.channel.verifiedVia;
+    verdict.memberDisplayName = member.contact.displayName;
+  }
+
+  return verdict;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -153,7 +153,7 @@ function stampTrustVerdict(body: Record<string, unknown>): void {
 }
 
 /** Local mirror of the gateway resolver, reading the daemon contact store. */
-function resolveLocalTrustVerdict(input: {
+export function resolveLocalTrustVerdict(input: {
   channelType: string;
   actorExternalId?: string;
   externalChatId?: string;

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -45,6 +45,7 @@ mock.module("../daemon/approval-generators.js", () => ({
 }));
 
 import { upsertContact } from "../contacts/contact-store.js";
+import { resolveLocalTrustVerdict } from "./helpers/channel-test-adapter.js";
 import {
   linkAttachmentToMessage,
   uploadAttachment,
@@ -266,6 +267,13 @@ describe("WhatsApp channel ingress attachment resolution", () => {
   function makeInboundBody(
     overrides: Record<string, unknown> = {},
   ): Record<string, unknown> {
+    // Mirror the gateway: stamp a trust verdict from the local contact store so
+    // the daemon's fail-closed ACL stage admits the request to attachment logic.
+    const trustVerdict = resolveLocalTrustVerdict({
+      channelType: "whatsapp",
+      actorExternalId: WHATSAPP_USER_ID,
+      externalChatId: "whatsapp-chat-1",
+    });
     return {
       sourceChannel: "whatsapp",
       interface: "whatsapp",
@@ -274,6 +282,7 @@ describe("WhatsApp channel ingress attachment resolution", () => {
       externalMessageId: `wa-msg-${Date.now()}-${Math.random()}`,
       content: "Check these attachments",
       replyCallbackUrl: "https://gateway.test/deliver",
+      sourceMetadata: { trustVerdict },
       ...overrides,
     };
   }

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -45,7 +45,6 @@ mock.module("../daemon/approval-generators.js", () => ({
 }));
 
 import { upsertContact } from "../contacts/contact-store.js";
-import { resolveLocalTrustVerdict } from "./helpers/channel-test-adapter.js";
 import {
   linkAttachmentToMessage,
   uploadAttachment,
@@ -59,6 +58,7 @@ import { resetTestTables } from "../memory/raw-query.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
+import { resolveLocalTrustVerdict } from "./helpers/channel-test-adapter.js";
 
 await initializeDb();
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for `enforceIngressAcl` consuming the gateway trust verdict.
+ *
+ * Drives the stage directly with a `sourceMetadata.trustVerdict` and mocks the
+ * leaf I/O (contact store, gateway delivery, guardian notification, invite
+ * transport) so the ACL decision logic is exercised in isolation.
+ *
+ * Covers: verdict-sourced member resolution, fail-closed deny on an ABSENT
+ * verdict, hard-denies for blocked/revoked/policy, and the non-member invite
+ * intercept still firing for a present stranger verdict.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SourceMetadata, TrustVerdict } from "@vellumai/gateway-client";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Track contact-store reads to prove findContactChannel is NOT used on the
+// verdict path. findGuardianForChannel is still called by resolveGuardianLabel.
+const findContactChannelCalls: unknown[] = [];
+mock.module("../../../contacts/contact-store.js", () => ({
+  findContactChannel: (params: unknown) => {
+    findContactChannelCalls.push(params);
+    return null;
+  },
+  findGuardianForChannel: () => null,
+}));
+
+const deliverReplyCalls: Array<{ url: string; payload: unknown }> = [];
+mock.module("../../gateway-client.js", () => ({
+  deliverChannelReply: async (url: string, payload: unknown) => {
+    deliverReplyCalls.push({ url, payload });
+  },
+}));
+
+const accessRequestCalls: unknown[] = [];
+mock.module("../../access-request-helper.js", () => ({
+  notifyGuardianOfAccessRequest: (params: unknown) => {
+    accessRequestCalls.push(params);
+    return { notified: true };
+  },
+}));
+
+// Invite transport: by default no adapter (no token). Per-test override below.
+let inviteTokenForTest: string | undefined;
+mock.module("../../channel-invite-transport.js", () => ({
+  getInviteAdapterRegistry: () => ({
+    get: () => ({
+      extractInboundToken: () => inviteTokenForTest,
+    }),
+  }),
+}));
+
+// Invite redemption: default to a successful redeem so the token intercept
+// short-circuits with an earlyResponse.
+mock.module("../../invite-redemption-service.js", () => ({
+  redeemInvite: async () => ({ ok: true, type: "redeemed", memberId: "m-1" }),
+  redeemInviteByCode: async () => ({
+    ok: true,
+    type: "redeemed",
+    memberId: "m-1",
+  }),
+}));
+
+mock.module("../../invite-redemption-templates.js", () => ({
+  getInviteRedemptionReply: () => "redeemed reply",
+}));
+
+mock.module("../../../memory/delivery-crud.js", () => ({
+  recordInbound: () => ({ duplicate: false, eventId: "evt-1" }),
+  deleteInbound: () => {},
+}));
+
+mock.module("../../../memory/delivery-status.js", () => ({
+  markProcessed: () => {},
+}));
+
+import type { AclEnforcementParams } from "./acl-enforcement.js";
+import { enforceIngressAcl } from "./acl-enforcement.js";
+
+function makeParams(
+  overrides: Partial<AclEnforcementParams> = {},
+): AclEnforcementParams {
+  return {
+    canonicalSenderId: "sender-1",
+    hasSenderIdentityClaim: true,
+    rawSenderId: "sender-1",
+    sourceChannel: "telegram",
+    conversationExternalId: "chat-1",
+    canonicalAssistantId: "assistant-1",
+    trimmedContent: "hello",
+    sourceMetadata: undefined,
+    actorDisplayName: "Sender One",
+    actorUsername: "sender_one",
+    replyCallbackUrl: "http://localhost/deliver",
+    assistantId: "assistant-1",
+    externalMessageId: "msg-1",
+    ...overrides,
+  };
+}
+
+function memberVerdict(overrides: Partial<TrustVerdict> = {}): TrustVerdict {
+  return {
+    trustClass: "trusted_contact",
+    canonicalSenderId: "sender-1",
+    contactId: "contact-1",
+    channelId: "channel-1",
+    type: "telegram",
+    address: "sender-1",
+    status: "active",
+    policy: "allow",
+    memberDisplayName: "Sender One",
+    ...overrides,
+  };
+}
+
+function withVerdict(verdict: TrustVerdict): SourceMetadata {
+  return { trustVerdict: verdict } as SourceMetadata;
+}
+
+beforeEach(() => {
+  findContactChannelCalls.length = 0;
+  deliverReplyCalls.length = 0;
+  accessRequestCalls.length = 0;
+  inviteTokenForTest = undefined;
+});
+
+afterEach(() => {
+  inviteTokenForTest = undefined;
+});
+
+describe("enforceIngressAcl — verdict-sourced member resolution", () => {
+  test("active trusted verdict is admitted (resolvedMember threaded, no deny)", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({ sourceMetadata: withVerdict(memberVerdict()) }),
+    );
+
+    expect(result.earlyResponse).toBeUndefined();
+    expect(result.resolvedMember).not.toBeNull();
+    expect(result.resolvedMember!.channel.status).toBe("active");
+    expect(result.resolvedMember!.channel.policy).toBe("allow");
+    // Member came from the verdict, never the local contact store.
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+
+  test("guardian verdict is admitted purely from the verdict (empty contact store)", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(
+          memberVerdict({ trustClass: "guardian", guardianPrincipalId: "p-1" }),
+        ),
+      }),
+    );
+
+    expect(result.earlyResponse).toBeUndefined();
+    expect(result.resolvedMember!.contact.role).toBe("guardian");
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+});
+
+describe("enforceIngressAcl — hard denies from the verdict status/policy", () => {
+  test("blocked verdict → member_blocked deny", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ status: "blocked" })),
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("member_blocked");
+    // Blocked members do not trigger a guardian notification.
+    expect(accessRequestCalls.length).toBe(0);
+  });
+
+  test("revoked verdict → member_revoked deny (even under strangers)", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ status: "revoked" })),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("member_revoked");
+  });
+
+  test("policy deny verdict → policy_deny", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ policy: "deny" })),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("policy_deny");
+  });
+});
+
+describe("enforceIngressAcl — present stranger verdict flows through intercepts", () => {
+  test("present unknown/no-member verdict + invite token redeems via intercept", async () => {
+    inviteTokenForTest = "iv_token123";
+    const strangerVerdict: TrustVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "stranger-1",
+    };
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        sourceMetadata: withVerdict(strangerVerdict),
+      }),
+    );
+
+    // The invite token intercept fired — NOT a fail-closed deny.
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.inviteRedemption).toBe("redeemed");
+    expect(result.resolvedMember).toBeNull();
+  });
+});
+
+describe("enforceIngressAcl — fail-closed on absent verdict", () => {
+  test("absent trustVerdict → not_a_member deny even under strangers", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        // sourceMetadata present but WITHOUT trustVerdict.
+        sourceMetadata: {} as SourceMetadata,
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+    // Fail-closed deny short-circuits BEFORE any intercept or onboarding.
+    expect(deliverReplyCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+
+  test("no sourceMetadata at all → not_a_member deny", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({ sourceMetadata: undefined }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -183,7 +183,7 @@ export async function enforceIngressAcl(
 
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member intercepts.
-  let resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
+  const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
 
   // /start gv_<token> bootstrap commands must also bypass ACL — the user
   // hasn't been verified yet and needs to complete the bootstrap handshake.

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -7,10 +7,7 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
-import {
-  findContactChannel,
-  findGuardianForChannel,
-} from "../../../contacts/contact-store.js";
+import { findGuardianForChannel } from "../../../contacts/contact-store.js";
 import type {
   ChannelStatus,
   ContactChannel,
@@ -41,6 +38,7 @@ import {
   redeemInviteByCode,
 } from "../../invite-redemption-service.js";
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
+import { resolvedMemberFromVerdict } from "../../trust-verdict-consumer.js";
 
 const log = getLogger("runtime-http");
 
@@ -164,7 +162,28 @@ export async function enforceIngressAcl(
   // Slack message timestamp for permalink construction.
   const messageTs = sourceMetadata?.messageId ?? undefined;
 
-  let resolvedMember: ResolvedMember | null = null;
+  // Absent verdict = gateway could not vouch for this actor → fail-closed deny.
+  // A PRESENT verdict with no member (stranger) still flows through the
+  // intercepts below; only a missing verdict short-circuits here.
+  const verdict = sourceMetadata?.trustVerdict;
+  if (verdict == null) {
+    log.info(
+      { sourceChannel, externalUserId: canonicalSenderId },
+      "Ingress ACL: absent trust verdict, denying fail-closed",
+    );
+    return {
+      resolvedMember: null,
+      earlyResponse: {
+        accepted: true,
+        denied: true,
+        reason: "not_a_member",
+      },
+    };
+  }
+
+  // Member resolved from the gateway verdict (ACL + identity only); null for a
+  // stranger verdict, which falls through to the non-member intercepts.
+  let resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
 
   // /start gv_<token> bootstrap commands must also bypass ACL — the user
   // hasn't been verified yet and needs to complete the bootstrap handshake.
@@ -181,23 +200,6 @@ export async function enforceIngressAcl(
   });
 
   if (canonicalSenderId || hasSenderIdentityClaim) {
-    // Only perform member lookup when we have a usable canonical ID.
-    // Whitespace-only senders (hasSenderIdentityClaim=true but
-    // canonicalSenderId=null) skip the lookup and fall into the deny path.
-    if (canonicalSenderId) {
-      const contactResult = findContactChannel({
-        channelType: sourceChannel,
-        address: canonicalSenderId,
-        externalChatId: conversationExternalId,
-      });
-      resolvedMember = contactResult
-        ? {
-            contact: contactResult.contact,
-            channel: contactResult.channel,
-          }
-        : null;
-    }
-
     if (!resolvedMember) {
       let denyNonMember = true;
 


### PR DESCRIPTION
## Summary
- `enforceIngressAcl` resolves the inbound member from `sourceMetadata.trustVerdict` via `resolvedMemberFromVerdict` instead of the local contact store.
- Fail-closed: an ABSENT verdict (gateway fail-soft) denies with `not_a_member` before any intercept; a present stranger verdict (`trustClass:unknown`, no member) still flows through invite/bootstrap/verification intercepts.
- blocked/revoked/policy hard-denies preserved, now from the verdict's status/policy.

Part of plan: daemon-consumes-trust-verdict.md (PR 2 of 4)