### PR TITLE
feat(assistant): build inbound TrustContext from the gateway verdict

### DIFF
--- a/assistant/src/__tests__/inbound-trust-verdict.test.ts
+++ b/assistant/src/__tests__/inbound-trust-verdict.test.ts
@@ -1,9 +1,8 @@
 /**
- * Tests that the inbound text path builds `trustCtx` from the gateway-stamped
- * `sourceMetadata.trustVerdict` (via `trustContextFromVerdict`) instead of the
- * local `resolveTrustContext`. Admission decisions for a given trust class +
- * floor must match pre-cutover behavior, and the Slack requester timezone must
- * still attach to the resulting context.
+ * The inbound text path builds `trustCtx` from the gateway-stamped
+ * `sourceMetadata.trustVerdict` via `trustContextFromVerdict`. Admission follows
+ * the trust class + floor, and the Slack requester timezone attaches to the
+ * resulting context.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 

--- a/assistant/src/__tests__/inbound-trust-verdict.test.ts
+++ b/assistant/src/__tests__/inbound-trust-verdict.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests that the inbound text path builds `trustCtx` from the gateway-stamped
+ * `sourceMetadata.trustVerdict` (via `trustContextFromVerdict`) instead of the
+ * local `resolveTrustContext`. Admission decisions for a given trust class +
+ * floor must match pre-cutover behavior, and the Slack requester timezone must
+ * still attach to the resulting context.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Enable the channel-trust-floors flag so the admission-policy stage runs.
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => key === "channel-trust-floors",
+}));
+
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async () => {},
+}));
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import type { TrustContext } from "../daemon/trust-context.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { messages } from "../memory/schema.js";
+import {
+  handleChannelInbound,
+  setAdapterProcessMessage,
+} from "./helpers/channel-test-adapter.js";
+
+await initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM canonical_guardian_requests");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+}
+
+/** Capture the `trustContext` the handler dispatches to the agent loop. */
+function captureTrustContextProcessor(captured: { ctx?: TrustContext }) {
+  return async (
+    conversationId: string,
+    _content: string,
+    options?: Record<string, unknown>,
+  ) => {
+    captured.ctx = options?.trustContext as TrustContext | undefined;
+    const messageId = `msg-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+    getDb()
+      .insert(messages)
+      .values({
+        id: messageId,
+        conversationId,
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "hello" }]),
+        createdAt: Date.now(),
+      })
+      .run();
+    return { messageId };
+  };
+}
+
+function makeInboundRequest(
+  sourceMetadata: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+): Request {
+  return new Request("http://localhost/channels/inbound", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gateway-Origin": "test-token",
+    },
+    body: JSON.stringify({
+      sourceChannel: "telegram",
+      interface: "telegram",
+      conversationExternalId: "chat-123",
+      externalMessageId: `msg-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`,
+      content: "hello",
+      actorExternalId: "user-1",
+      replyCallbackUrl: "https://gateway.test/deliver/telegram",
+      sourceMetadata,
+      ...overrides,
+    }),
+  });
+}
+
+/** A full member verdict (ACL passes) for the given trust class. */
+function memberVerdict(
+  trustClass: TrustVerdict["trustClass"],
+  overrides: Partial<TrustVerdict> = {},
+): TrustVerdict {
+  return {
+    trustClass,
+    canonicalSenderId: "user-1",
+    contactId: "contact-1",
+    channelId: "channel-1",
+    type: "telegram",
+    address: "user-1",
+    externalChatId: "chat-123",
+    status: "active",
+    policy: "allow",
+    memberDisplayName: "Member One",
+    ...overrides,
+  } satisfies TrustVerdict;
+}
+
+describe("inbound trust verdict → TrustContext", () => {
+  beforeEach(() => {
+    resetTables();
+    setAdapterProcessMessage(undefined);
+  });
+
+  test("guardian verdict admits with guardian-class trustCtx and guardian fields", async () => {
+    const verdict = memberVerdict("guardian", {
+      guardianExternalUserId: "user-1",
+      guardianDeliveryChatId: "guardian-chat-1",
+      guardianPrincipalId: "vellum-principal-1",
+    });
+
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: verdict,
+        admissionPolicy: "trusted_contacts",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(captured.ctx?.trustClass).toBe("guardian");
+    expect(captured.ctx?.guardianExternalUserId).toBe("user-1");
+    expect(captured.ctx?.guardianChatId).toBe("guardian-chat-1");
+    expect(captured.ctx?.guardianPrincipalId).toBe("vellum-principal-1");
+  });
+
+  test("trusted_contact admitted under a trusted_contacts floor", async () => {
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: memberVerdict("trusted_contact"),
+        admissionPolicy: "trusted_contacts",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(captured.ctx?.trustClass).toBe("trusted_contact");
+  });
+
+  test("trusted_contact denied under a guardian_only floor", async () => {
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: memberVerdict("trusted_contact"),
+        admissionPolicy: "guardian_only",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBe(true);
+    expect(body.reason).toBe("admission_policy_guardian_only");
+  });
+
+  test("present unknown (stranger) verdict admitted under a strangers floor", async () => {
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: {
+          trustClass: "unknown",
+          canonicalSenderId: "user-1",
+        } satisfies TrustVerdict,
+        admissionPolicy: "strangers",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(captured.ctx?.trustClass).toBe("unknown");
+  });
+
+  test("present unknown (stranger) verdict denied under a trusted_contacts floor", async () => {
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: {
+          trustClass: "unknown",
+          canonicalSenderId: "user-1",
+        } satisfies TrustVerdict,
+        admissionPolicy: "trusted_contacts",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBe(true);
+    expect(body.reason).toBe("not_a_member");
+  });
+
+  test("slack requester timezone is attached to the verdict-sourced trustCtx", async () => {
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest(
+        {
+          trustVerdict: memberVerdict("trusted_contact", {
+            type: "slack",
+            externalChatId: "slack-chan-1",
+          }),
+          admissionPolicy: "trusted_contacts",
+          timezone: "America/New_York",
+          timezoneLabel: "ET",
+          timezoneOffsetSeconds: -18000,
+        },
+        {
+          sourceChannel: "slack",
+          interface: "slack",
+          conversationExternalId: "slack-chan-1",
+          replyCallbackUrl: "https://gateway.test/deliver/slack",
+        },
+      ),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(captured.ctx?.trustClass).toBe("trusted_contact");
+    expect(captured.ctx?.requesterTimezone).toBe("America/New_York");
+    expect(captured.ctx?.requesterTimezoneLabel).toBe("ET");
+    expect(captured.ctx?.requesterTimezoneOffsetSeconds).toBe(-18000);
+  });
+});

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -92,7 +92,7 @@ import { truncate } from "../../util/truncate.js";
 import { notifyGuardianOfAccessRequest } from "../access-request-helper.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { deliverChannelReply } from "../gateway-client.js";
-import { resolveTrustContext } from "../trust-context-resolver.js";
+import { trustContextFromVerdict } from "../trust-verdict-consumer.js";
 import { canonicalChannelAssistantId } from "./channel-route-shared.js";
 import { BadRequestError } from "./errors.js";
 import { handleApprovalInterception } from "./guardian-approval-interception.js";
@@ -717,17 +717,24 @@ export async function handleChannelInbound({
   }
 
   // ── Actor role resolution ──
-  // Uses shared channel-agnostic resolution so all ingress paths classify
-  // guardian vs non-guardian actors the same way.
+  // Built from the gateway-stamped trust verdict (ACL + identity). An absent
+  // verdict is already hard-denied upstream in enforceIngressAcl; the synthetic
+  // unknown ctx here only guards non-ACL metadata use on that unreachable path.
+  const inboundVerdict = sourceMetadata?.trustVerdict;
   const trustCtx: TrustContext = attachSlackRequesterTimezone(
-    resolveTrustContext({
-      assistantId: canonicalAssistantId,
-      sourceChannel,
-      conversationExternalId,
-      actorExternalId: rawSenderId,
-      actorUsername: body.actorUsername,
-      actorDisplayName: body.actorDisplayName,
-    }),
+    inboundVerdict
+      ? trustContextFromVerdict(inboundVerdict, {
+          sourceChannel,
+          conversationExternalId,
+          actorUsername: body.actorUsername,
+          actorDisplayName: body.actorDisplayName,
+        })
+      : {
+          sourceChannel,
+          trustClass: "unknown",
+          requesterExternalUserId: canonicalSenderId ?? undefined,
+          requesterChatId: conversationExternalId,
+        },
     slackActorTimezone,
   );
 


### PR DESCRIPTION
## Summary
- The inbound text path builds `trustCtx` from `sourceMetadata.trustVerdict` via `trustContextFromVerdict` (PR 1 mapper) instead of `resolveTrustContext`; `attachSlackRequesterTimezone` wrapper preserved.
- Absent verdict is already hard-denied upstream in `enforceIngressAcl` (PR 2); the synthetic unknown ctx here only guards non-ACL metadata use.
- Pure `enforceAdmissionPolicy` auto-converts (reads verdict-sourced `trustClass`). VOICE path untouched.

Part of plan: daemon-consumes-trust-verdict.md (PR 3 of 4)