### PR TITLE
feat(assistant): turn-context + persona read trust from verdict-derived context

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -33,6 +33,40 @@ mock.module("../config/loader.js", () => ({
   },
 }));
 
+// `resolveTurnInboundActorContext` reads INFO (contact notes / interaction
+// count) via a local contactId join. Stub the join so the actor-context tests
+// can stage it without standing up the contacts schema.
+const realContactStoreForAssemblyTest =
+  await import("../contacts/contact-store.js");
+let contactInfoById: Record<
+  string,
+  { notes: string | null; interactionCount: number; userFile: string | null }
+> = {};
+mock.module("../contacts/contact-store.js", () => ({
+  ...realContactStoreForAssemblyTest,
+  findContactInfoById: (contactId: string) =>
+    contactInfoById[contactId] ?? null,
+}));
+
+// `resolveTurnInboundActorContext` must NOT re-resolve ACL via the actor-trust
+// resolver on the fresh-inbound path. Track calls so the tests can assert it
+// is never invoked.
+const realActorTrustResolverForAssemblyTest = await import(
+  "../runtime/actor-trust-resolver.js"
+);
+let resolveActorTrustCalls = 0;
+mock.module("../runtime/actor-trust-resolver.js", () => ({
+  ...realActorTrustResolverForAssemblyTest,
+  resolveActorTrust: (
+    ...args: Parameters<
+      typeof realActorTrustResolverForAssemblyTest.resolveActorTrust
+    >
+  ) => {
+    resolveActorTrustCalls += 1;
+    return realActorTrustResolverForAssemblyTest.resolveActorTrust(...args);
+  },
+}));
+
 // PKB search is mocked so the reminder-hints tests can assert behavior
 // without standing up Qdrant. The mock returns whatever is staged in
 // `pkbSearchResults` / `pkbSearchThrows` for the enclosing test.
@@ -1476,6 +1510,11 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveTurnInboundActorContext", () => {
+  beforeEach(() => {
+    contactInfoById = {};
+    resolveActorTrustCalls = 0;
+  });
+
   /**
    * No trust context means there is no inbound actor to ground the turn on, so
    * the actor section is suppressed.
@@ -1483,7 +1522,7 @@ describe("resolveTurnInboundActorContext", () => {
   test("returns null when there is no trust context", () => {
     // GIVEN a turn with no trust context
     // WHEN the inbound actor context is resolved
-    const actorContext = resolveTurnInboundActorContext(undefined, "asst-1");
+    const actorContext = resolveTurnInboundActorContext(undefined);
 
     // THEN there is no actor context to inject
     expect(actorContext).toBeNull();
@@ -1494,8 +1533,7 @@ describe("resolveTurnInboundActorContext", () => {
    * only renders actor fields for non-guardian actors.
    */
   test("returns null on guardian turns", () => {
-    // GIVEN a guardian trust context (no requester chat id, so the direct
-    // projection branch is taken)
+    // GIVEN a guardian trust context
     const trustContext: TrustContext = {
       sourceChannel: "vellum",
       trustClass: "guardian",
@@ -1503,40 +1541,79 @@ describe("resolveTurnInboundActorContext", () => {
     };
 
     // WHEN the inbound actor context is resolved
-    const actorContext = resolveTurnInboundActorContext(trustContext, "asst-1");
+    const actorContext = resolveTurnInboundActorContext(trustContext);
 
     // THEN the actor section is suppressed for the owner
     expect(actorContext).toBeNull();
   });
 
   /**
-   * A non-guardian trust context without the identity fields needed for the
-   * unified actor-trust lookup is projected directly into the actor context.
+   * ACL fields (trust class, member status/policy, guardian identity) project
+   * from the verdict-derived trust context — without re-resolving via the
+   * actor-trust resolver.
    */
-  test("projects a non-guardian trust context directly", () => {
-    // GIVEN a trusted-contact trust context lacking requester chat/user ids
+  test("projects ACL from the verdict-derived trust context", () => {
+    // GIVEN a trusted-contact trust context carrying verdict-derived ACL fields
     const trustContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
       requesterIdentifier: "@bob_handle",
       requesterDisplayName: "Bob",
       requesterSenderDisplayName: "Bobby",
+      requesterExternalUserId: "tg-123",
+      requesterChatId: "chat-1",
+      memberStatus: "active",
+      memberPolicy: "allow",
     };
 
     // WHEN the inbound actor context is resolved
-    const actorContext = resolveTurnInboundActorContext(trustContext, "asst-1");
+    const actorContext = resolveTurnInboundActorContext(trustContext);
 
-    // THEN the trust context is projected into the model-facing actor context
+    // THEN ACL is projected from the context and no ACL re-read happened
     expect(actorContext).toEqual({
       sourceChannel: "telegram",
-      canonicalActorIdentity: null,
+      canonicalActorIdentity: "tg-123",
       actorIdentifier: "@bob_handle",
       actorDisplayName: "Bob",
       actorSenderDisplayName: "Bobby",
       actorMemberDisplayName: undefined,
       trustClass: "trusted_contact",
       guardianIdentity: undefined,
+      memberStatus: "active",
+      memberPolicy: "allow",
     });
+    expect(resolveActorTrustCalls).toBe(0);
+  });
+
+  /**
+   * INFO fields (contact notes, interaction count) are joined locally by the
+   * verdict-stamped contact ID, not re-resolved through the ACL store.
+   */
+  test("populates INFO via the local contactId join", () => {
+    // GIVEN a contact whose INFO is available by id
+    contactInfoById["contact-42"] = {
+      notes: "prefers async updates",
+      interactionCount: 7,
+      userFile: "bob.md",
+    };
+    const trustContext: TrustContext = {
+      sourceChannel: "telegram",
+      trustClass: "trusted_contact",
+      requesterExternalUserId: "tg-123",
+      requesterChatId: "chat-1",
+      requesterContactId: "contact-42",
+      memberStatus: "active",
+      memberPolicy: "allow",
+    };
+
+    // WHEN the inbound actor context is resolved
+    const actorContext = resolveTurnInboundActorContext(trustContext);
+
+    // THEN INFO comes from the local join and ACL stays verdict-derived
+    expect(actorContext?.contactNotes).toBe("prefers async updates");
+    expect(actorContext?.contactInteractionCount).toBe(7);
+    expect(actorContext?.memberStatus).toBe("active");
+    expect(resolveActorTrustCalls).toBe(0);
   });
 });
 

--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -40,6 +40,7 @@ let mockAnyGuardian: {
   contact: { userFile: string | null };
   channels: Record<string, unknown>[];
 } | null = null;
+let mockContactsByAddress: Record<string, { userFile: string | null }> = {};
 
 // ── Mock modules (must precede imports from the module under test) ──
 
@@ -48,7 +49,8 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../contacts/contact-store.js", () => ({
-  findContactByAddress: () => null,
+  findContactByAddress: (channelType: string, address: string) =>
+    mockContactsByAddress[`${channelType}:${address}`] ?? null,
   findGuardianForChannel: (channelType: string) =>
     channelType === "vellum" ? mockVellumGuardian : null,
   listGuardianChannels: () => mockAnyGuardian,
@@ -83,6 +85,7 @@ beforeEach(() => {
   mockWorkspaceDir = mkdtempSync(join(testRoot, "ws-"));
   mockVellumGuardian = null;
   mockAnyGuardian = null;
+  mockContactsByAddress = {};
 });
 
 afterEach(() => {
@@ -282,5 +285,40 @@ describe("resolveUserSlug (guardian trust, no requester identity)", () => {
     } as TrustContext;
 
     expect(resolveUserSlug(trustContext)).toBeNull();
+  });
+
+  test("guardian identity from the verdict keys the guardian user-file info read", () => {
+    // The verdict-bound guardian is looked up by its address, not by the
+    // most-recently-verified channel guardian, so a different channel guardian
+    // does not shadow the verdict's binding.
+    mockVellumGuardian = {
+      contact: { userFile: "wrong-guardian.md" },
+      channel: {},
+    };
+    mockContactsByAddress["telegram:guardian-tg"] = {
+      userFile: "alice.md",
+    };
+
+    const trustContext = {
+      sourceChannel: "telegram",
+      trustClass: "guardian",
+      guardianExternalUserId: "guardian-tg",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
+  });
+
+  test("falls back to the channel guardian when the verdict carries no guardian identity", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "alice.md" },
+      channel: {},
+    };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
   });
 });

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -184,6 +184,29 @@ export function getContact(id: string): ContactWithChannels | null {
 /** @deprecated Use {@link getContact} directly. */
 export const getContactInternal = getContact;
 
+/** INFO-only contact fields, joined locally by contact ID. */
+export interface ContactInfo {
+  notes: string | null;
+  interactionCount: number;
+  userFile: string | null;
+}
+
+/**
+ * Look up a contact's INFO fields (notes, interaction count, user file) by ID.
+ *
+ * Carries no ACL state (status/policy/verification) — those are owned by the
+ * gateway-stamped trust verdict. Returns null when the contact does not exist.
+ */
+export function findContactInfoById(contactId: string): ContactInfo | null {
+  const contact = getContact(contactId);
+  if (!contact) return null;
+  return {
+    notes: contact.notes,
+    interactionCount: contact.interactionCount,
+    userFile: contact.userFile,
+  };
+}
+
 /**
  * Look up a single contact channel by its primary key.
  * Returns the parsed channel row, or null if it does not exist.

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -791,10 +791,7 @@ export async function runAgentLoopImpl(
     // the post-compaction hook re-emits this same value during in-loop recovery
     // instead of re-resolving against contact/member registry state that may
     // have drifted mid-turn.
-    const actorContext = resolveTurnInboundActorContext(
-      ctx.trustContext,
-      ctx.assistantId,
-    );
+    const actorContext = resolveTurnInboundActorContext(ctx.trustContext);
     ctx.currentTurnInboundActorContext = actorContext;
 
     // Surface long gaps between user messages so the model can acknowledge

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -13,6 +13,7 @@ import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite, LLMConfig } from "../config/schemas/llm.js";
+import { findContactInfoById } from "../contacts/contact-store.js";
 import {
   NOW_SCRATCHPAD_STRIP_PREFIXES,
   stripSpotlightInjections,
@@ -60,14 +61,8 @@ import type {
   TurnContext,
 } from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
-import {
-  type ActorTrustContext,
-  resolveActorTrust,
-  type TrustClass,
-} from "../runtime/actor-trust-resolver.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
-import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
@@ -156,32 +151,8 @@ export function inboundActorContextFromTrustContext(
     actorMemberDisplayName: ctx.requesterMemberDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianExternalUserId,
-  };
-}
-
-/**
- * Construct an InboundActorContext from an ActorTrustContext (the new
- * unified trust resolver output from M1).
- */
-export function inboundActorContextFromTrust(
-  ctx: ActorTrustContext,
-): InboundActorContext {
-  return {
-    sourceChannel: ctx.actorMetadata.channel,
-    canonicalActorIdentity: ctx.canonicalSenderId,
-    actorIdentifier: ctx.actorMetadata.identifier,
-    actorDisplayName: ctx.actorMetadata.displayName,
-    actorSenderDisplayName: ctx.actorMetadata.senderDisplayName,
-    actorMemberDisplayName: ctx.actorMetadata.memberDisplayName,
-    trustClass: ctx.trustClass,
-    guardianIdentity: ctx.guardianBindingMatch?.guardianExternalUserId,
-    memberStatus: ctx.memberRecord
-      ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)
-      : undefined,
-    memberPolicy: ctx.memberRecord?.channel.policy ?? undefined,
-    contactNotes: ctx.memberRecord?.contact.notes ?? undefined,
-    contactInteractionCount:
-      ctx.memberRecord?.contact.interactionCount ?? undefined,
+    memberStatus: ctx.memberStatus,
+    memberPolicy: ctx.memberPolicy,
   };
 }
 
@@ -190,33 +161,30 @@ export function inboundActorContextFromTrust(
  * conversation's trust context, for the unified `<turn_context>` actor section.
  *
  * Returns `null` when there is no trust context and on guardian (owner) turns —
- * the actor section is suppressed for the owner. When the trust context carries
- * enough identity to look up member status / policy and the guardian binding,
- * the unified actor-trust resolver is preferred; otherwise the context is
- * projected directly. Derives purely from the passed trust context, so callers
+ * the actor section is suppressed for the owner. ACL fields (trust class,
+ * member status/policy, guardian binding) come from the verdict-derived trust
+ * context; INFO fields (contact notes, interaction count) are joined locally by
+ * contact ID. Derives purely from the passed trust context, so callers
  * self-resolve it from the live conversation rather than threading it.
  */
 export function resolveTurnInboundActorContext(
   trustContext: TrustContext | undefined,
-  assistantId: string | undefined,
 ): InboundActorContext | null {
   if (!trustContext) {
     return null;
   }
-  let resolved: InboundActorContext;
-  if (trustContext.requesterExternalUserId && trustContext.requesterChatId) {
-    const actorTrust = resolveActorTrust({
-      assistantId: assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-      sourceChannel: trustContext.sourceChannel,
-      conversationExternalId: trustContext.requesterChatId,
-      actorExternalId: trustContext.requesterExternalUserId,
-      actorDisplayName: trustContext.requesterSenderDisplayName,
-    });
-    resolved = inboundActorContextFromTrust(actorTrust);
-  } else {
-    resolved = inboundActorContextFromTrustContext(trustContext);
+  const resolved = inboundActorContextFromTrustContext(trustContext);
+  if (resolved.trustClass === "guardian") {
+    return null;
   }
-  return resolved.trustClass === "guardian" ? null : resolved;
+  if (trustContext.requesterContactId) {
+    const info = findContactInfoById(trustContext.requesterContactId);
+    if (info) {
+      resolved.contactNotes = info.notes ?? undefined;
+      resolved.contactInteractionCount = info.interactionCount;
+    }
+  }
+  return resolved;
 }
 
 /**

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -38,6 +38,12 @@ export interface TrustContext {
   requesterExternalUserId?: string;
   /** Chat/conversation ID the requester is interacting through. */
   requesterChatId?: string;
+  /** Contact ID of the requester's member record, for local info joins. */
+  requesterContactId?: string;
+  /** API-facing member status of the requester's channel (ACL). */
+  memberStatus?: string;
+  /** Channel policy of the requester's channel (ACL). */
+  memberPolicy?: string;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -278,7 +278,6 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     resolveTrustClass(conversation?.trustContext) === "guardian";
   const actorContext = resolveTurnInboundActorContext(
     conversation?.trustContext,
-    conversation?.assistantId,
   );
 
   // v2 graph retrieval is the deprecated path: `shouldRunV2Retrieval` skips it

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -69,6 +69,29 @@ function readPersonaFile(filePath: string): string | null {
 // ── User filename resolution ──────────────────────────────────────
 
 /**
+ * Resolve the guardian's persona `userFile` (INFO) for a guardian-trust turn.
+ *
+ * The guardian identity comes from the verdict-derived trust context
+ * (`guardianExternalUserId`): the info read is keyed on that address so it
+ * matches the gateway's guardian binding. When the context carries no guardian
+ * address (desktop / native turns), fall back to the channel's guardian
+ * contact. Returns `"guardian.md"` when the resolved guardian has no userFile.
+ */
+function resolveGuardianUserFile(trustContext: TrustContext): string | null {
+  if (trustContext.guardianExternalUserId) {
+    const guardianContact = findContactByAddress(
+      trustContext.sourceChannel,
+      trustContext.guardianExternalUserId,
+    );
+    if (guardianContact) {
+      return guardianContact.userFile ?? "guardian.md";
+    }
+  }
+  const guardian = findGuardianForChannel(trustContext.sourceChannel);
+  return guardian ? (guardian.contact.userFile ?? "guardian.md") : null;
+}
+
+/**
  * Resolve the raw userFile filename for the current actor's contact.
  * Returns the validated filename (e.g. "alice.md") or null.
  */
@@ -97,22 +120,17 @@ function resolveUserFilename(
       } else if (trustContext.trustClass === "guardian") {
         // Managed desktop: the JWT principal ID used as requesterExternalUserId
         // may differ from the contact channel's address (they are separate
-        // identity concepts). Fall back to the channel-type guardian.
-        const guardian = findGuardianForChannel(trustContext.sourceChannel);
-        if (guardian) {
-          filename = guardian.contact.userFile ?? "guardian.md";
-        }
+        // identity concepts). Read the guardian's user file keyed by the
+        // verdict-bound guardian identity.
+        filename = resolveGuardianUserFile(trustContext);
       }
     } else if (trustContext.trustClass === "guardian") {
       // Guardian-trust turn carrying no requester identity — background and
       // scheduled turns (heartbeat, scheduled pulses) run under the guardian
       // trust class but have no per-actor address to look up. Resolve the
-      // channel's guardian user file so they load the same persona as a
-      // foreground guardian turn instead of falling back to users/default.md.
-      const guardian = findGuardianForChannel(trustContext.sourceChannel);
-      if (guardian) {
-        filename = guardian.contact.userFile ?? "guardian.md";
-      }
+      // guardian's user file so they load the same persona as a foreground
+      // guardian turn instead of falling back to users/default.md.
+      filename = resolveGuardianUserFile(trustContext);
     }
   } catch (err) {
     // Contacts table may be absent — happens during early bootstrap

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -95,6 +95,45 @@ describe("trustContextFromVerdict", () => {
     expect(result.requesterIdentifier).toBe("@carol");
   });
 
+  test("member verdict stamps ACL member fields + contact id onto the context", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "unverified",
+      policy: "escalate",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterContactId).toBe("contact-1");
+    // "unverified" maps to the API-facing "pending" member status.
+    expect(result.memberStatus).toBe("pending");
+    expect(result.memberPolicy).toBe("escalate");
+  });
+
+  test("memberless verdict leaves ACL member fields undefined", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-2",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterContactId).toBeUndefined();
+    expect(result.memberStatus).toBeUndefined();
+    expect(result.memberPolicy).toBeUndefined();
+  });
+
   test("maps trustClass through and leaves guardian fields undefined when absent", () => {
     for (const trustClass of [
       "trusted_contact",

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -22,7 +22,10 @@ import type {
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ActorTrustContext } from "./actor-trust-resolver.js";
 import { toTrustContext } from "./actor-trust-resolver.js";
-import type { ResolvedMember } from "./routes/inbound-stages/acl-enforcement.js";
+import {
+  channelStatusToMemberStatus,
+  type ResolvedMember,
+} from "./routes/inbound-stages/acl-enforcement.js";
 
 export interface TrustVerdictTransport {
   sourceChannel: ChannelId;
@@ -72,7 +75,22 @@ export function trustContextFromVerdict(
     },
   };
 
-  return toTrustContext(actorTrustContext, input.conversationExternalId);
+  const context = toTrustContext(
+    actorTrustContext,
+    input.conversationExternalId,
+  );
+
+  // Stamp the verdict's ACL member fields onto the context so downstream turn
+  // assembly reads member status/policy from the verdict rather than a local
+  // re-resolution. The contact ID anchors the local info-only join.
+  const member = resolvedMemberFromVerdict(verdict);
+  if (member) {
+    context.requesterContactId = member.contact.id;
+    context.memberStatus = channelStatusToMemberStatus(member.channel.status);
+    context.memberPolicy = member.channel.policy;
+  }
+
+  return context;
 }
 
 // Allowed ACL enum values, kept in sync with the ContactChannel union types.


### PR DESCRIPTION
## Summary
- `resolveTurnInboundActorContext` builds `InboundActorContext` from the verdict-derived `TrustContext` (ACL) + a local `contactId` info join (INFO), dropping the `resolveActorTrust` ACL re-read on the fresh-inbound path.
- `persona-resolver` keeps the requester/guardian `userFile` (INFO) reads local; guardian identity comes from the verdict-derived context.
- VOICE path + the shared trust resolvers are untouched (Combo 10 removes them).

Part of plan: daemon-consumes-trust-verdict.md (PR 4 of 4)