### PR TITLE
refactor(assistant): drop unread userFile from ContactInfo

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -40,7 +40,7 @@ const realContactStoreForAssemblyTest =
   await import("../contacts/contact-store.js");
 let contactInfoById: Record<
   string,
-  { notes: string | null; interactionCount: number; userFile: string | null }
+  { notes: string | null; interactionCount: number }
 > = {};
 mock.module("../contacts/contact-store.js", () => ({
   ...realContactStoreForAssemblyTest,
@@ -1594,7 +1594,6 @@ describe("resolveTurnInboundActorContext", () => {
     contactInfoById["contact-42"] = {
       notes: "prefers async updates",
       interactionCount: 7,
-      userFile: "bob.md",
     };
     const trustContext: TrustContext = {
       sourceChannel: "telegram",

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -188,11 +188,10 @@ export const getContactInternal = getContact;
 export interface ContactInfo {
   notes: string | null;
   interactionCount: number;
-  userFile: string | null;
 }
 
 /**
- * Look up a contact's INFO fields (notes, interaction count, user file) by ID.
+ * Look up a contact's INFO fields (notes, interaction count) by ID.
  *
  * Carries no ACL state (status/policy/verification) — those are owned by the
  * gateway-stamped trust verdict. Returns null when the contact does not exist.
@@ -203,7 +202,6 @@ export function findContactInfoById(contactId: string): ContactInfo | null {
   return {
     notes: contact.notes,
     interactionCount: contact.interactionCount,
-    userFile: contact.userFile,
   };
 }
 


### PR DESCRIPTION
## Summary
- `findContactInfoById` returned `userFile` but no consumer reads it (persona resolves userFile via its own local lookup); drop it from `ContactInfo` and the local INFO join.

Self-review slop fix for plan: daemon-consumes-trust-verdict.md