### PR TITLE
Combo 9 — Daemon CONSUMES the gateway trust verdict on TEXT inbound + fail-closed

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -40,7 +40,7 @@ const realContactStoreForAssemblyTest =
   await import("../contacts/contact-store.js");
 let contactInfoById: Record<
   string,
-  { notes: string | null; interactionCount: number; userFile: string | null }
+  { notes: string | null; interactionCount: number }
 > = {};
 mock.module("../contacts/contact-store.js", () => ({
   ...realContactStoreForAssemblyTest,
@@ -1594,7 +1594,6 @@ describe("resolveTurnInboundActorContext", () => {
     contactInfoById["contact-42"] = {
       notes: "prefers async updates",
       interactionCount: 7,
-      userFile: "bob.md",
     };
     const trustContext: TrustContext = {
       sourceChannel: "telegram",

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -33,6 +33,40 @@ mock.module("../config/loader.js", () => ({
   },
 }));
 
+// `resolveTurnInboundActorContext` reads INFO (contact notes / interaction
+// count) via a local contactId join. Stub the join so the actor-context tests
+// can stage it without standing up the contacts schema.
+const realContactStoreForAssemblyTest =
+  await import("../contacts/contact-store.js");
+let contactInfoById: Record<
+  string,
+  { notes: string | null; interactionCount: number; userFile: string | null }
+> = {};
+mock.module("../contacts/contact-store.js", () => ({
+  ...realContactStoreForAssemblyTest,
+  findContactInfoById: (contactId: string) =>
+    contactInfoById[contactId] ?? null,
+}));
+
+// `resolveTurnInboundActorContext` must NOT re-resolve ACL via the actor-trust
+// resolver on the fresh-inbound path. Track calls so the tests can assert it
+// is never invoked.
+const realActorTrustResolverForAssemblyTest = await import(
+  "../runtime/actor-trust-resolver.js"
+);
+let resolveActorTrustCalls = 0;
+mock.module("../runtime/actor-trust-resolver.js", () => ({
+  ...realActorTrustResolverForAssemblyTest,
+  resolveActorTrust: (
+    ...args: Parameters<
+      typeof realActorTrustResolverForAssemblyTest.resolveActorTrust
+    >
+  ) => {
+    resolveActorTrustCalls += 1;
+    return realActorTrustResolverForAssemblyTest.resolveActorTrust(...args);
+  },
+}));
+
 // PKB search is mocked so the reminder-hints tests can assert behavior
 // without standing up Qdrant. The mock returns whatever is staged in
 // `pkbSearchResults` / `pkbSearchThrows` for the enclosing test.
@@ -1476,6 +1510,11 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveTurnInboundActorContext", () => {
+  beforeEach(() => {
+    contactInfoById = {};
+    resolveActorTrustCalls = 0;
+  });
+
   /**
    * No trust context means there is no inbound actor to ground the turn on, so
    * the actor section is suppressed.
@@ -1483,7 +1522,7 @@ describe("resolveTurnInboundActorContext", () => {
   test("returns null when there is no trust context", () => {
     // GIVEN a turn with no trust context
     // WHEN the inbound actor context is resolved
-    const actorContext = resolveTurnInboundActorContext(undefined, "asst-1");
+    const actorContext = resolveTurnInboundActorContext(undefined);
 
     // THEN there is no actor context to inject
     expect(actorContext).toBeNull();
@@ -1494,8 +1533,7 @@ describe("resolveTurnInboundActorContext", () => {
    * only renders actor fields for non-guardian actors.
    */
   test("returns null on guardian turns", () => {
-    // GIVEN a guardian trust context (no requester chat id, so the direct
-    // projection branch is taken)
+    // GIVEN a guardian trust context
     const trustContext: TrustContext = {
       sourceChannel: "vellum",
       trustClass: "guardian",
@@ -1503,40 +1541,79 @@ describe("resolveTurnInboundActorContext", () => {
     };
 
     // WHEN the inbound actor context is resolved
-    const actorContext = resolveTurnInboundActorContext(trustContext, "asst-1");
+    const actorContext = resolveTurnInboundActorContext(trustContext);
 
     // THEN the actor section is suppressed for the owner
     expect(actorContext).toBeNull();
   });
 
   /**
-   * A non-guardian trust context without the identity fields needed for the
-   * unified actor-trust lookup is projected directly into the actor context.
+   * ACL fields (trust class, member status/policy, guardian identity) project
+   * from the verdict-derived trust context — without re-resolving via the
+   * actor-trust resolver.
    */
-  test("projects a non-guardian trust context directly", () => {
-    // GIVEN a trusted-contact trust context lacking requester chat/user ids
+  test("projects ACL from the verdict-derived trust context", () => {
+    // GIVEN a trusted-contact trust context carrying verdict-derived ACL fields
     const trustContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
       requesterIdentifier: "@bob_handle",
       requesterDisplayName: "Bob",
       requesterSenderDisplayName: "Bobby",
+      requesterExternalUserId: "tg-123",
+      requesterChatId: "chat-1",
+      memberStatus: "active",
+      memberPolicy: "allow",
     };
 
     // WHEN the inbound actor context is resolved
-    const actorContext = resolveTurnInboundActorContext(trustContext, "asst-1");
+    const actorContext = resolveTurnInboundActorContext(trustContext);
 
-    // THEN the trust context is projected into the model-facing actor context
+    // THEN ACL is projected from the context and no ACL re-read happened
     expect(actorContext).toEqual({
       sourceChannel: "telegram",
-      canonicalActorIdentity: null,
+      canonicalActorIdentity: "tg-123",
       actorIdentifier: "@bob_handle",
       actorDisplayName: "Bob",
       actorSenderDisplayName: "Bobby",
       actorMemberDisplayName: undefined,
       trustClass: "trusted_contact",
       guardianIdentity: undefined,
+      memberStatus: "active",
+      memberPolicy: "allow",
     });
+    expect(resolveActorTrustCalls).toBe(0);
+  });
+
+  /**
+   * INFO fields (contact notes, interaction count) are joined locally by the
+   * verdict-stamped contact ID, not re-resolved through the ACL store.
+   */
+  test("populates INFO via the local contactId join", () => {
+    // GIVEN a contact whose INFO is available by id
+    contactInfoById["contact-42"] = {
+      notes: "prefers async updates",
+      interactionCount: 7,
+      userFile: "bob.md",
+    };
+    const trustContext: TrustContext = {
+      sourceChannel: "telegram",
+      trustClass: "trusted_contact",
+      requesterExternalUserId: "tg-123",
+      requesterChatId: "chat-1",
+      requesterContactId: "contact-42",
+      memberStatus: "active",
+      memberPolicy: "allow",
+    };
+
+    // WHEN the inbound actor context is resolved
+    const actorContext = resolveTurnInboundActorContext(trustContext);
+
+    // THEN INFO comes from the local join and ACL stays verdict-derived
+    expect(actorContext?.contactNotes).toBe("prefers async updates");
+    expect(actorContext?.contactInteractionCount).toBe(7);
+    expect(actorContext?.memberStatus).toBe("active");
+    expect(resolveActorTrustCalls).toBe(0);
   });
 });
 

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -302,6 +302,12 @@ describe("Verification control messages are deterministic (guard)", () => {
           replyCallbackUrl: "http://localhost/callback",
           sourceMetadata: {
             commandIntent: { type: "start", payload: `gv_${bootstrapToken}` },
+            // Gateway stamps a stranger verdict for this not-yet-bound user;
+            // the bootstrap intercept still fires for a present stranger.
+            trustVerdict: {
+              trustClass: "unknown",
+              canonicalSenderId: "user-bootstrap-123",
+            },
           },
         }),
       });
@@ -367,6 +373,18 @@ describe("Verification control messages are deterministic (guard)", () => {
         actorDisplayName: blockedIdentity.displayName,
         sourceMetadata: {
           commandIntent: { type: "start", payload: `gv_${bootstrapToken}` },
+          // Gateway stamps the member verdict surfacing the blocked status; the
+          // ACL hard-deny fires before the bootstrap intercept.
+          trustVerdict: {
+            trustClass: "unknown",
+            canonicalSenderId: blockedIdentity.externalUserId,
+            contactId: "contact-blocked-bootstrap",
+            channelId: "channel-blocked-bootstrap",
+            type: blockedIdentity.sourceChannel,
+            address: blockedIdentity.externalUserId,
+            status: blockedIdentity.status,
+            policy: blockedIdentity.policy,
+          },
         },
       }),
     });

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -61,6 +61,12 @@ mock.module("../../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => undefined,
 }));
 
+import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
+
+import {
+  findContactChannel,
+  findGuardianForChannel,
+} from "../../contacts/contact-store.js";
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
@@ -112,7 +118,99 @@ export async function handleChannelInbound(
   _approvalConversationGenerator?: ApprovalConversationGenerator,
 ): Promise<Response> {
   const body = await req.json();
+  stampTrustVerdict(body);
   return wrapHandler(() => _handleChannelInbound({ body }));
+}
+
+/**
+ * Mirror the gateway: stamp a per-actor {@link TrustVerdict} onto inbound
+ * `sourceMetadata` from the local contact store, so the daemon's ACL stage
+ * (which now reads the verdict and fail-closed-denies when it is absent) sees
+ * the same verdict the gateway would resolve in production.
+ *
+ * Skipped when a test already supplies `trustVerdict` (or sets `sourceMetadata`
+ * to null) so absent-verdict / explicit-verdict tests keep their setup.
+ */
+function stampTrustVerdict(body: Record<string, unknown>): void {
+  const meta = body.sourceMetadata as Record<string, unknown> | undefined;
+  if (meta && "trustVerdict" in meta) return;
+
+  const channelType = String(body.sourceChannel ?? "");
+  const actorExternalId =
+    typeof body.actorExternalId === "string" ? body.actorExternalId : undefined;
+  const externalChatId =
+    typeof body.conversationExternalId === "string"
+      ? body.conversationExternalId
+      : undefined;
+  if (!channelType) return;
+
+  const verdict = resolveLocalTrustVerdict({
+    channelType,
+    actorExternalId,
+    externalChatId,
+  });
+  body.sourceMetadata = { ...(meta ?? {}), trustVerdict: verdict };
+}
+
+/** Local mirror of the gateway resolver, reading the daemon contact store. */
+export function resolveLocalTrustVerdict(input: {
+  channelType: string;
+  actorExternalId?: string;
+  externalChatId?: string;
+}): TrustVerdict {
+  const canonicalSenderId = input.actorExternalId ?? null;
+
+  const member = input.actorExternalId
+    ? findContactChannel({
+        channelType: input.channelType,
+        address: input.actorExternalId,
+        externalChatId: input.externalChatId,
+      })
+    : null;
+  const guardian = findGuardianForChannel(input.channelType);
+
+  const isGuardian =
+    !!guardian &&
+    !!canonicalSenderId &&
+    guardian.channel.address.toLowerCase() === canonicalSenderId.toLowerCase();
+
+  let trustClass: TrustClass;
+  if (isGuardian) {
+    trustClass = "guardian";
+  } else if (member) {
+    const status = member.channel.status;
+    if (status === "active") trustClass = "trusted_contact";
+    else if (status === "unverified" || status === "pending")
+      trustClass = "unverified_contact";
+    else trustClass = "unknown";
+  } else {
+    trustClass = "unknown";
+  }
+
+  const verdict: TrustVerdict = { trustClass, canonicalSenderId };
+
+  if (guardian) {
+    verdict.guardianExternalUserId = guardian.channel.address;
+    verdict.guardianDeliveryChatId = guardian.channel.externalChatId;
+    if (guardian.contact.principalId)
+      verdict.guardianPrincipalId = guardian.contact.principalId;
+    verdict.guardianDisplayName = guardian.contact.displayName;
+  }
+
+  if (member) {
+    verdict.contactId = member.channel.contactId;
+    verdict.channelId = member.channel.id;
+    verdict.type = member.channel.type;
+    verdict.address = member.channel.address;
+    verdict.externalChatId = member.channel.externalChatId;
+    verdict.status = member.channel.status;
+    verdict.policy = member.channel.policy;
+    verdict.verifiedAt = member.channel.verifiedAt;
+    verdict.verifiedVia = member.channel.verifiedVia;
+    verdict.memberDisplayName = member.contact.displayName;
+  }
+
+  return verdict;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/inbound-trust-verdict.test.ts
+++ b/assistant/src/__tests__/inbound-trust-verdict.test.ts
@@ -1,0 +1,254 @@
+/**
+ * The inbound text path builds `trustCtx` from the gateway-stamped
+ * `sourceMetadata.trustVerdict` via `trustContextFromVerdict`. Admission follows
+ * the trust class + floor, and the Slack requester timezone attaches to the
+ * resulting context.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Enable the channel-trust-floors flag so the admission-policy stage runs.
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => key === "channel-trust-floors",
+}));
+
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async () => {},
+}));
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import type { TrustContext } from "../daemon/trust-context.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { messages } from "../memory/schema.js";
+import {
+  handleChannelInbound,
+  setAdapterProcessMessage,
+} from "./helpers/channel-test-adapter.js";
+
+await initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM canonical_guardian_requests");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+}
+
+/** Capture the `trustContext` the handler dispatches to the agent loop. */
+function captureTrustContextProcessor(captured: { ctx?: TrustContext }) {
+  return async (
+    conversationId: string,
+    _content: string,
+    options?: Record<string, unknown>,
+  ) => {
+    captured.ctx = options?.trustContext as TrustContext | undefined;
+    const messageId = `msg-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+    getDb()
+      .insert(messages)
+      .values({
+        id: messageId,
+        conversationId,
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "hello" }]),
+        createdAt: Date.now(),
+      })
+      .run();
+    return { messageId };
+  };
+}
+
+function makeInboundRequest(
+  sourceMetadata: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+): Request {
+  return new Request("http://localhost/channels/inbound", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gateway-Origin": "test-token",
+    },
+    body: JSON.stringify({
+      sourceChannel: "telegram",
+      interface: "telegram",
+      conversationExternalId: "chat-123",
+      externalMessageId: `msg-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`,
+      content: "hello",
+      actorExternalId: "user-1",
+      replyCallbackUrl: "https://gateway.test/deliver/telegram",
+      sourceMetadata,
+      ...overrides,
+    }),
+  });
+}
+
+/** A full member verdict (ACL passes) for the given trust class. */
+function memberVerdict(
+  trustClass: TrustVerdict["trustClass"],
+  overrides: Partial<TrustVerdict> = {},
+): TrustVerdict {
+  return {
+    trustClass,
+    canonicalSenderId: "user-1",
+    contactId: "contact-1",
+    channelId: "channel-1",
+    type: "telegram",
+    address: "user-1",
+    externalChatId: "chat-123",
+    status: "active",
+    policy: "allow",
+    memberDisplayName: "Member One",
+    ...overrides,
+  } satisfies TrustVerdict;
+}
+
+describe("inbound trust verdict → TrustContext", () => {
+  beforeEach(() => {
+    resetTables();
+    setAdapterProcessMessage(undefined);
+  });
+
+  test("guardian verdict admits with guardian-class trustCtx and guardian fields", async () => {
+    const verdict = memberVerdict("guardian", {
+      guardianExternalUserId: "user-1",
+      guardianDeliveryChatId: "guardian-chat-1",
+      guardianPrincipalId: "vellum-principal-1",
+    });
+
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: verdict,
+        admissionPolicy: "trusted_contacts",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(captured.ctx?.trustClass).toBe("guardian");
+    expect(captured.ctx?.guardianExternalUserId).toBe("user-1");
+    expect(captured.ctx?.guardianChatId).toBe("guardian-chat-1");
+    expect(captured.ctx?.guardianPrincipalId).toBe("vellum-principal-1");
+  });
+
+  test("trusted_contact admitted under a trusted_contacts floor", async () => {
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: memberVerdict("trusted_contact"),
+        admissionPolicy: "trusted_contacts",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(captured.ctx?.trustClass).toBe("trusted_contact");
+  });
+
+  test("trusted_contact denied under a guardian_only floor", async () => {
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: memberVerdict("trusted_contact"),
+        admissionPolicy: "guardian_only",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBe(true);
+    expect(body.reason).toBe("admission_policy_guardian_only");
+  });
+
+  test("present unknown (stranger) verdict admitted under a strangers floor", async () => {
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: {
+          trustClass: "unknown",
+          canonicalSenderId: "user-1",
+        } satisfies TrustVerdict,
+        admissionPolicy: "strangers",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(captured.ctx?.trustClass).toBe("unknown");
+  });
+
+  test("present unknown (stranger) verdict denied under a trusted_contacts floor", async () => {
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        trustVerdict: {
+          trustClass: "unknown",
+          canonicalSenderId: "user-1",
+        } satisfies TrustVerdict,
+        admissionPolicy: "trusted_contacts",
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBe(true);
+    expect(body.reason).toBe("not_a_member");
+  });
+
+  test("slack requester timezone is attached to the verdict-sourced trustCtx", async () => {
+    const captured: { ctx?: TrustContext } = {};
+    setAdapterProcessMessage(captureTrustContextProcessor(captured));
+    const res = await handleChannelInbound(
+      makeInboundRequest(
+        {
+          trustVerdict: memberVerdict("trusted_contact", {
+            type: "slack",
+            externalChatId: "slack-chan-1",
+          }),
+          admissionPolicy: "trusted_contacts",
+          timezone: "America/New_York",
+          timezoneLabel: "ET",
+          timezoneOffsetSeconds: -18000,
+        },
+        {
+          sourceChannel: "slack",
+          interface: "slack",
+          conversationExternalId: "slack-chan-1",
+          replyCallbackUrl: "https://gateway.test/deliver/slack",
+        },
+      ),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(captured.ctx?.trustClass).toBe("trusted_contact");
+    expect(captured.ctx?.requesterTimezone).toBe("America/New_York");
+    expect(captured.ctx?.requesterTimezoneLabel).toBe("ET");
+    expect(captured.ctx?.requesterTimezoneOffsetSeconds).toBe(-18000);
+  });
+});

--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -40,6 +40,7 @@ let mockAnyGuardian: {
   contact: { userFile: string | null };
   channels: Record<string, unknown>[];
 } | null = null;
+let mockContactsByAddress: Record<string, { userFile: string | null }> = {};
 
 // ── Mock modules (must precede imports from the module under test) ──
 
@@ -48,7 +49,8 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../contacts/contact-store.js", () => ({
-  findContactByAddress: () => null,
+  findContactByAddress: (channelType: string, address: string) =>
+    mockContactsByAddress[`${channelType}:${address}`] ?? null,
   findGuardianForChannel: (channelType: string) =>
     channelType === "vellum" ? mockVellumGuardian : null,
   listGuardianChannels: () => mockAnyGuardian,
@@ -83,6 +85,7 @@ beforeEach(() => {
   mockWorkspaceDir = mkdtempSync(join(testRoot, "ws-"));
   mockVellumGuardian = null;
   mockAnyGuardian = null;
+  mockContactsByAddress = {};
 });
 
 afterEach(() => {
@@ -282,5 +285,40 @@ describe("resolveUserSlug (guardian trust, no requester identity)", () => {
     } as TrustContext;
 
     expect(resolveUserSlug(trustContext)).toBeNull();
+  });
+
+  test("guardian identity from the verdict keys the guardian user-file info read", () => {
+    // The verdict-bound guardian is looked up by its address, not by the
+    // most-recently-verified channel guardian, so a different channel guardian
+    // does not shadow the verdict's binding.
+    mockVellumGuardian = {
+      contact: { userFile: "wrong-guardian.md" },
+      channel: {},
+    };
+    mockContactsByAddress["telegram:guardian-tg"] = {
+      userFile: "alice.md",
+    };
+
+    const trustContext = {
+      sourceChannel: "telegram",
+      trustClass: "guardian",
+      guardianExternalUserId: "guardian-tg",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
+  });
+
+  test("falls back to the channel guardian when the verdict carries no guardian identity", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "alice.md" },
+      channel: {},
+    };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
   });
 });

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -58,6 +58,7 @@ import { resetTestTables } from "../memory/raw-query.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
+import { resolveLocalTrustVerdict } from "./helpers/channel-test-adapter.js";
 
 await initializeDb();
 
@@ -266,6 +267,13 @@ describe("WhatsApp channel ingress attachment resolution", () => {
   function makeInboundBody(
     overrides: Record<string, unknown> = {},
   ): Record<string, unknown> {
+    // Mirror the gateway: stamp a trust verdict from the local contact store so
+    // the daemon's fail-closed ACL stage admits the request to attachment logic.
+    const trustVerdict = resolveLocalTrustVerdict({
+      channelType: "whatsapp",
+      actorExternalId: WHATSAPP_USER_ID,
+      externalChatId: "whatsapp-chat-1",
+    });
     return {
       sourceChannel: "whatsapp",
       interface: "whatsapp",
@@ -274,6 +282,7 @@ describe("WhatsApp channel ingress attachment resolution", () => {
       externalMessageId: `wa-msg-${Date.now()}-${Math.random()}`,
       content: "Check these attachments",
       replyCallbackUrl: "https://gateway.test/deliver",
+      sourceMetadata: { trustVerdict },
       ...overrides,
     };
   }

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -184,6 +184,29 @@ export function getContact(id: string): ContactWithChannels | null {
 /** @deprecated Use {@link getContact} directly. */
 export const getContactInternal = getContact;
 
+/** INFO-only contact fields, joined locally by contact ID. */
+export interface ContactInfo {
+  notes: string | null;
+  interactionCount: number;
+  userFile: string | null;
+}
+
+/**
+ * Look up a contact's INFO fields (notes, interaction count, user file) by ID.
+ *
+ * Carries no ACL state (status/policy/verification) — those are owned by the
+ * gateway-stamped trust verdict. Returns null when the contact does not exist.
+ */
+export function findContactInfoById(contactId: string): ContactInfo | null {
+  const contact = getContact(contactId);
+  if (!contact) return null;
+  return {
+    notes: contact.notes,
+    interactionCount: contact.interactionCount,
+    userFile: contact.userFile,
+  };
+}
+
 /**
  * Look up a single contact channel by its primary key.
  * Returns the parsed channel row, or null if it does not exist.

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -188,11 +188,10 @@ export const getContactInternal = getContact;
 export interface ContactInfo {
   notes: string | null;
   interactionCount: number;
-  userFile: string | null;
 }
 
 /**
- * Look up a contact's INFO fields (notes, interaction count, user file) by ID.
+ * Look up a contact's INFO fields (notes, interaction count) by ID.
  *
  * Carries no ACL state (status/policy/verification) — those are owned by the
  * gateway-stamped trust verdict. Returns null when the contact does not exist.
@@ -203,7 +202,6 @@ export function findContactInfoById(contactId: string): ContactInfo | null {
   return {
     notes: contact.notes,
     interactionCount: contact.interactionCount,
-    userFile: contact.userFile,
   };
 }
 

--- a/assistant/src/contacts/member-status.ts
+++ b/assistant/src/contacts/member-status.ts
@@ -1,0 +1,9 @@
+import type { ChannelStatus } from "./types.js";
+
+/** Map ChannelStatus to the API-facing member status (excludes "unverified"). */
+export function channelStatusToMemberStatus(
+  status: ChannelStatus,
+): Exclude<ChannelStatus, "unverified"> {
+  if (status === "unverified") return "pending";
+  return status;
+}

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -791,10 +791,7 @@ export async function runAgentLoopImpl(
     // the post-compaction hook re-emits this same value during in-loop recovery
     // instead of re-resolving against contact/member registry state that may
     // have drifted mid-turn.
-    const actorContext = resolveTurnInboundActorContext(
-      ctx.trustContext,
-      ctx.assistantId,
-    );
+    const actorContext = resolveTurnInboundActorContext(ctx.trustContext);
     ctx.currentTurnInboundActorContext = actorContext;
 
     // Surface long gaps between user messages so the model can acknowledge

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -13,6 +13,7 @@ import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite, LLMConfig } from "../config/schemas/llm.js";
+import { findContactInfoById } from "../contacts/contact-store.js";
 import {
   NOW_SCRATCHPAD_STRIP_PREFIXES,
   stripSpotlightInjections,
@@ -60,14 +61,8 @@ import type {
   TurnContext,
 } from "../plugins/types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
-import {
-  type ActorTrustContext,
-  resolveActorTrust,
-  type TrustClass,
-} from "../runtime/actor-trust-resolver.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
-import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
@@ -156,32 +151,8 @@ export function inboundActorContextFromTrustContext(
     actorMemberDisplayName: ctx.requesterMemberDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianExternalUserId,
-  };
-}
-
-/**
- * Construct an InboundActorContext from an ActorTrustContext (the new
- * unified trust resolver output from M1).
- */
-export function inboundActorContextFromTrust(
-  ctx: ActorTrustContext,
-): InboundActorContext {
-  return {
-    sourceChannel: ctx.actorMetadata.channel,
-    canonicalActorIdentity: ctx.canonicalSenderId,
-    actorIdentifier: ctx.actorMetadata.identifier,
-    actorDisplayName: ctx.actorMetadata.displayName,
-    actorSenderDisplayName: ctx.actorMetadata.senderDisplayName,
-    actorMemberDisplayName: ctx.actorMetadata.memberDisplayName,
-    trustClass: ctx.trustClass,
-    guardianIdentity: ctx.guardianBindingMatch?.guardianExternalUserId,
-    memberStatus: ctx.memberRecord
-      ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)
-      : undefined,
-    memberPolicy: ctx.memberRecord?.channel.policy ?? undefined,
-    contactNotes: ctx.memberRecord?.contact.notes ?? undefined,
-    contactInteractionCount:
-      ctx.memberRecord?.contact.interactionCount ?? undefined,
+    memberStatus: ctx.memberStatus,
+    memberPolicy: ctx.memberPolicy,
   };
 }
 
@@ -190,33 +161,30 @@ export function inboundActorContextFromTrust(
  * conversation's trust context, for the unified `<turn_context>` actor section.
  *
  * Returns `null` when there is no trust context and on guardian (owner) turns —
- * the actor section is suppressed for the owner. When the trust context carries
- * enough identity to look up member status / policy and the guardian binding,
- * the unified actor-trust resolver is preferred; otherwise the context is
- * projected directly. Derives purely from the passed trust context, so callers
+ * the actor section is suppressed for the owner. ACL fields (trust class,
+ * member status/policy, guardian binding) come from the verdict-derived trust
+ * context; INFO fields (contact notes, interaction count) are joined locally by
+ * contact ID. Derives purely from the passed trust context, so callers
  * self-resolve it from the live conversation rather than threading it.
  */
 export function resolveTurnInboundActorContext(
   trustContext: TrustContext | undefined,
-  assistantId: string | undefined,
 ): InboundActorContext | null {
   if (!trustContext) {
     return null;
   }
-  let resolved: InboundActorContext;
-  if (trustContext.requesterExternalUserId && trustContext.requesterChatId) {
-    const actorTrust = resolveActorTrust({
-      assistantId: assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-      sourceChannel: trustContext.sourceChannel,
-      conversationExternalId: trustContext.requesterChatId,
-      actorExternalId: trustContext.requesterExternalUserId,
-      actorDisplayName: trustContext.requesterSenderDisplayName,
-    });
-    resolved = inboundActorContextFromTrust(actorTrust);
-  } else {
-    resolved = inboundActorContextFromTrustContext(trustContext);
+  const resolved = inboundActorContextFromTrustContext(trustContext);
+  if (resolved.trustClass === "guardian") {
+    return null;
   }
-  return resolved.trustClass === "guardian" ? null : resolved;
+  if (trustContext.requesterContactId) {
+    const info = findContactInfoById(trustContext.requesterContactId);
+    if (info) {
+      resolved.contactNotes = info.notes ?? undefined;
+      resolved.contactInteractionCount = info.interactionCount;
+    }
+  }
+  return resolved;
 }
 
 /**

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -38,6 +38,12 @@ export interface TrustContext {
   requesterExternalUserId?: string;
   /** Chat/conversation ID the requester is interacting through. */
   requesterChatId?: string;
+  /** Contact ID of the requester's member record, for local info joins. */
+  requesterContactId?: string;
+  /** API-facing member status of the requester's channel (ACL). */
+  memberStatus?: string;
+  /** Channel policy of the requester's channel (ACL). */
+  memberPolicy?: string;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -278,7 +278,6 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     resolveTrustClass(conversation?.trustContext) === "guardian";
   const actorContext = resolveTurnInboundActorContext(
     conversation?.trustContext,
-    conversation?.assistantId,
   );
 
   // v2 graph retrieval is the deprecated path: `shouldRunV2Retrieval` skips it

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -69,6 +69,29 @@ function readPersonaFile(filePath: string): string | null {
 // ── User filename resolution ──────────────────────────────────────
 
 /**
+ * Resolve the guardian's persona `userFile` (INFO) for a guardian-trust turn.
+ *
+ * The guardian identity comes from the verdict-derived trust context
+ * (`guardianExternalUserId`): the info read is keyed on that address so it
+ * matches the gateway's guardian binding. When the context carries no guardian
+ * address (desktop / native turns), fall back to the channel's guardian
+ * contact. Returns `"guardian.md"` when the resolved guardian has no userFile.
+ */
+function resolveGuardianUserFile(trustContext: TrustContext): string | null {
+  if (trustContext.guardianExternalUserId) {
+    const guardianContact = findContactByAddress(
+      trustContext.sourceChannel,
+      trustContext.guardianExternalUserId,
+    );
+    if (guardianContact) {
+      return guardianContact.userFile ?? "guardian.md";
+    }
+  }
+  const guardian = findGuardianForChannel(trustContext.sourceChannel);
+  return guardian ? (guardian.contact.userFile ?? "guardian.md") : null;
+}
+
+/**
  * Resolve the raw userFile filename for the current actor's contact.
  * Returns the validated filename (e.g. "alice.md") or null.
  */
@@ -97,22 +120,17 @@ function resolveUserFilename(
       } else if (trustContext.trustClass === "guardian") {
         // Managed desktop: the JWT principal ID used as requesterExternalUserId
         // may differ from the contact channel's address (they are separate
-        // identity concepts). Fall back to the channel-type guardian.
-        const guardian = findGuardianForChannel(trustContext.sourceChannel);
-        if (guardian) {
-          filename = guardian.contact.userFile ?? "guardian.md";
-        }
+        // identity concepts). Read the guardian's user file keyed by the
+        // verdict-bound guardian identity.
+        filename = resolveGuardianUserFile(trustContext);
       }
     } else if (trustContext.trustClass === "guardian") {
       // Guardian-trust turn carrying no requester identity — background and
       // scheduled turns (heartbeat, scheduled pulses) run under the guardian
       // trust class but have no per-actor address to look up. Resolve the
-      // channel's guardian user file so they load the same persona as a
-      // foreground guardian turn instead of falling back to users/default.md.
-      const guardian = findGuardianForChannel(trustContext.sourceChannel);
-      if (guardian) {
-        filename = guardian.contact.userFile ?? "guardian.md";
-      }
+      // guardian's user file so they load the same persona as a foreground
+      // guardian turn instead of falling back to users/default.md.
+      filename = resolveGuardianUserFile(trustContext);
     }
   } catch (err) {
     // Contacts table may be absent — happens during early bootstrap

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
+import type {
+  ContactChannel,
+  ContactWithChannels,
+} from "../../contacts/types.js";
 import type { ActorTrustContext } from "../actor-trust-resolver.js";
 import { toTrustContext } from "../actor-trust-resolver.js";
 import {
@@ -156,6 +160,114 @@ describe("trustContextFromVerdict", () => {
       // Non-guardian without binding -> no guardian chat id.
       expect(result.guardianChatId).toBeUndefined();
     }
+  });
+});
+
+describe("toTrustContext member grounding", () => {
+  function memberChannel(
+    overrides: Partial<ContactChannel> = {},
+  ): ContactChannel {
+    return {
+      id: "channel-1",
+      contactId: "contact-1",
+      type: "phone",
+      address: "+15550100",
+      isPrimary: true,
+      externalChatId: null,
+      status: "unverified",
+      policy: "escalate",
+      verifiedAt: null,
+      verifiedVia: null,
+      inviteId: null,
+      revokedReason: null,
+      blockedReason: null,
+      lastSeenAt: null,
+      interactionCount: 0,
+      lastInteraction: null,
+      updatedAt: null,
+      createdAt: 0,
+      ...overrides,
+    };
+  }
+
+  function memberContact(): ContactWithChannels {
+    return {
+      id: "contact-1",
+      displayName: "Frank",
+      notes: null,
+      lastInteraction: null,
+      interactionCount: 0,
+      createdAt: 0,
+      updatedAt: 0,
+      role: "contact",
+      contactType: "human",
+      principalId: null,
+      userFile: null,
+      channels: [memberChannel()],
+    };
+  }
+
+  function ctxWithMember(
+    channel: ContactChannel,
+  ): ActorTrustContext {
+    return {
+      canonicalSenderId: "+15550100",
+      guardianBindingMatch: null,
+      guardianPrincipalId: undefined,
+      memberRecord: { contact: memberContact(), channel },
+      trustClass: "trusted_contact",
+      actorMetadata: {
+        identifier: "+15550100",
+        displayName: "Frank",
+        senderDisplayName: "Frank",
+        memberDisplayName: "Frank",
+        username: undefined,
+        channel: "phone",
+        trustStatus: "trusted_contact",
+      },
+    };
+  }
+
+  test("populates member fields from memberRecord (voice path)", () => {
+    const context = toTrustContext(ctxWithMember(memberChannel()), CONV);
+    expect(context.requesterContactId).toBe("contact-1");
+    // "unverified" maps to the API-facing "pending" member status.
+    expect(context.memberStatus).toBe("pending");
+    expect(context.memberPolicy).toBe("escalate");
+  });
+
+  test("passes through active status + allow policy", () => {
+    const context = toTrustContext(
+      ctxWithMember(memberChannel({ status: "active", policy: "allow" })),
+      CONV,
+    );
+    expect(context.memberStatus).toBe("active");
+    expect(context.memberPolicy).toBe("allow");
+  });
+
+  test("leaves member fields undefined when memberRecord is null", () => {
+    const context = toTrustContext(
+      {
+        canonicalSenderId: "u-2",
+        guardianBindingMatch: null,
+        guardianPrincipalId: undefined,
+        memberRecord: null,
+        trustClass: "unknown",
+        actorMetadata: {
+          identifier: "u-2",
+          displayName: undefined,
+          senderDisplayName: undefined,
+          memberDisplayName: undefined,
+          username: undefined,
+          channel: "slack",
+          trustStatus: "unknown",
+        },
+      },
+      CONV,
+    );
+    expect(context.requesterContactId).toBeUndefined();
+    expect(context.memberStatus).toBeUndefined();
+    expect(context.memberPolicy).toBeUndefined();
   });
 });
 

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -95,6 +95,45 @@ describe("trustContextFromVerdict", () => {
     expect(result.requesterIdentifier).toBe("@carol");
   });
 
+  test("member verdict stamps ACL member fields + contact id onto the context", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "unverified",
+      policy: "escalate",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterContactId).toBe("contact-1");
+    // "unverified" maps to the API-facing "pending" member status.
+    expect(result.memberStatus).toBe("pending");
+    expect(result.memberPolicy).toBe("escalate");
+  });
+
+  test("memberless verdict leaves ACL member fields undefined", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-2",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterContactId).toBeUndefined();
+    expect(result.memberStatus).toBeUndefined();
+    expect(result.memberPolicy).toBeUndefined();
+  });
+
   test("maps trustClass through and leaves guardian fields undefined when absent", () => {
     for (const trustClass of [
       "trusted_contact",

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import type { ActorTrustContext } from "../actor-trust-resolver.js";
+import { toTrustContext } from "../actor-trust-resolver.js";
+import {
+  resolvedMemberFromVerdict,
+  trustContextFromVerdict,
+} from "../trust-verdict-consumer.js";
+
+const CONV = "conv-123";
+
+describe("trustContextFromVerdict", () => {
+  test("guardian verdict maps trust + guardian fields and is byte-identical to toTrustContext", () => {
+    const verdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "+15550100",
+      guardianExternalUserId: "+15550100",
+      guardianDeliveryChatId: "chat-9",
+      guardianPrincipalId: "vellum-principal-abc",
+      memberDisplayName: "Alice",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "phone",
+      conversationExternalId: CONV,
+      actorUsername: "alice",
+      actorDisplayName: "Alice Sender",
+    });
+
+    expect(result.trustClass).toBe("guardian");
+    expect(result.requesterExternalUserId).toBe("+15550100");
+    expect(result.guardianExternalUserId).toBe("+15550100");
+    expect(result.guardianChatId).toBe("chat-9");
+    expect(result.guardianPrincipalId).toBe("vellum-principal-abc");
+    // memberDisplayName wins over sender display name.
+    expect(result.requesterDisplayName).toBe("Alice");
+    expect(result.requesterIdentifier).toBe("@alice");
+
+    const equivalent: ActorTrustContext = {
+      canonicalSenderId: "+15550100",
+      guardianBindingMatch: {
+        guardianExternalUserId: "+15550100",
+        guardianDeliveryChatId: "chat-9",
+      },
+      guardianPrincipalId: "vellum-principal-abc",
+      memberRecord: null,
+      trustClass: "guardian",
+      actorMetadata: {
+        identifier: "@alice",
+        displayName: "Alice",
+        senderDisplayName: "Alice Sender",
+        memberDisplayName: "Alice",
+        username: "alice",
+        channel: "phone",
+        trustStatus: "guardian",
+      },
+    };
+    expect(result).toEqual(toTrustContext(equivalent, CONV));
+  });
+
+  test("identifier falls back to canonicalSenderId when no username", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15550101",
+      memberDisplayName: "Bob",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "phone",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterIdentifier).toBe("+15550101");
+    // No memberDisplayName/sender override -> memberDisplayName used.
+    expect(result.requesterDisplayName).toBe("Bob");
+  });
+
+  test("displayName falls back to actorDisplayName when no memberDisplayName", () => {
+    const verdict = {
+      trustClass: "unverified_contact",
+      canonicalSenderId: "u-1",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+      actorUsername: "carol",
+      actorDisplayName: "Carol Display",
+    });
+
+    expect(result.trustClass).toBe("unverified_contact");
+    expect(result.requesterDisplayName).toBe("Carol Display");
+    expect(result.requesterIdentifier).toBe("@carol");
+  });
+
+  test("maps trustClass through and leaves guardian fields undefined when absent", () => {
+    for (const trustClass of [
+      "trusted_contact",
+      "unverified_contact",
+      "unknown",
+    ] as const) {
+      const verdict = {
+        trustClass,
+        canonicalSenderId: "u-x",
+      } satisfies TrustVerdict;
+
+      const result = trustContextFromVerdict(verdict, {
+        sourceChannel: "slack",
+        conversationExternalId: CONV,
+      });
+
+      expect(result.trustClass).toBe(trustClass);
+      expect(result.guardianExternalUserId).toBeUndefined();
+      expect(result.guardianPrincipalId).toBeUndefined();
+      // Non-guardian without binding -> no guardian chat id.
+      expect(result.guardianChatId).toBeUndefined();
+    }
+  });
+});
+
+describe("resolvedMemberFromVerdict", () => {
+  test("member verdict surfaces channel ACL/identity, info fields null", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "active",
+      policy: "allow",
+      externalChatId: "chat-1",
+      verifiedAt: 1700000000,
+      verifiedVia: "code",
+      memberDisplayName: "Dora",
+    } satisfies TrustVerdict;
+
+    const member = resolvedMemberFromVerdict(verdict);
+    expect(member).not.toBeNull();
+    expect(member!.channel.id).toBe("channel-1");
+    expect(member!.channel.status).toBe("active");
+    expect(member!.channel.policy).toBe("allow");
+    expect(member!.channel.verifiedAt).toBe(1700000000);
+    expect(member!.channel.verifiedVia).toBe("code");
+    expect(member!.channel.externalChatId).toBe("chat-1");
+
+    expect(member!.contact.id).toBe("contact-1");
+    expect(member!.contact.displayName).toBe("Dora");
+    expect(member!.contact.role).toBe("contact");
+    // INFO fields must be null/default placeholders.
+    expect(member!.contact.notes).toBeNull();
+    expect(member!.contact.userFile).toBeNull();
+    expect(member!.contact.interactionCount).toBe(0);
+    expect(member!.contact.lastInteraction).toBeNull();
+  });
+
+  test("guardian member verdict maps role guardian + principalId", () => {
+    const verdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "u-g",
+      contactId: "contact-g",
+      channelId: "channel-g",
+      guardianPrincipalId: "vellum-principal-g",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const member = resolvedMemberFromVerdict(verdict);
+    expect(member!.contact.role).toBe("guardian");
+    expect(member!.contact.principalId).toBe("vellum-principal-g");
+  });
+
+  test("memberless verdict (no contactId) returns null", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-2",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict missing status returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-4",
+      contactId: "contact-4",
+      channelId: "channel-4",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict missing policy returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-5",
+      contactId: "contact-5",
+      channelId: "channel-5",
+      status: "active",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict with unknown policy returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-6",
+      contactId: "contact-6",
+      channelId: "channel-6",
+      status: "active",
+      policy: "bogus",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict with unknown status returns null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-7",
+      contactId: "contact-7",
+      channelId: "channel-7",
+      status: "quarantined",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
+  });
+
+  test("member verdict with valid known status+policy returns a member", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-8",
+      contactId: "contact-8",
+      channelId: "channel-8",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const member = resolvedMemberFromVerdict(verdict);
+    expect(member).not.toBeNull();
+    expect(member!.channel.status).toBe("active");
+    expect(member!.channel.policy).toBe("allow");
+  });
+
+  test("blocked/revoked verdict surfaces channel.status verbatim", () => {
+    for (const status of ["blocked", "revoked"] as const) {
+      const verdict = {
+        trustClass: "unknown",
+        canonicalSenderId: "u-3",
+        contactId: "contact-3",
+        channelId: "channel-3",
+        status,
+        policy: "deny",
+      } satisfies TrustVerdict;
+
+      const member = resolvedMemberFromVerdict(verdict);
+      expect(member!.channel.status).toBe(status);
+      expect(member!.channel.policy).toBe("deny");
+    }
+  });
+});

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -21,6 +21,7 @@ import {
   findContactByAddress,
   findGuardianForChannel,
 } from "../contacts/contact-store.js";
+import { channelStatusToMemberStatus } from "../contacts/member-status.js";
 import type { ContactChannel, ContactWithChannels } from "../contacts/types.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
@@ -322,5 +323,12 @@ export function toTrustContext(
     requesterMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
     requesterChatId: conversationExternalId,
+    // Member grounding from a real memberRecord (voice path); the verdict path
+    // (memberRecord=null) stamps these from the verdict instead.
+    requesterContactId: ctx.memberRecord?.contact.id,
+    memberStatus: ctx.memberRecord
+      ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)
+      : undefined,
+    memberPolicy: ctx.memberRecord?.channel.policy,
   };
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -24,6 +24,7 @@ import {
 } from "../../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
+import { channelStatusToMemberStatus } from "../../contacts/member-status.js";
 import {
   createApprovalConversationGenerator,
   createApprovalCopyGenerator,
@@ -96,10 +97,7 @@ import { trustContextFromVerdict } from "../trust-verdict-consumer.js";
 import { canonicalChannelAssistantId } from "./channel-route-shared.js";
 import { BadRequestError } from "./errors.js";
 import { handleApprovalInterception } from "./guardian-approval-interception.js";
-import {
-  channelStatusToMemberStatus,
-  enforceIngressAcl,
-} from "./inbound-stages/acl-enforcement.js";
+import { enforceIngressAcl } from "./inbound-stages/acl-enforcement.js";
 import { enforceAdmissionPolicy } from "./inbound-stages/admission-policy.js";
 import { processChannelMessageInBackground } from "./inbound-stages/background-dispatch.js";
 import { handleBootstrapIntercept } from "./inbound-stages/bootstrap-intercept.js";

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -92,7 +92,7 @@ import { truncate } from "../../util/truncate.js";
 import { notifyGuardianOfAccessRequest } from "../access-request-helper.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { deliverChannelReply } from "../gateway-client.js";
-import { resolveTrustContext } from "../trust-context-resolver.js";
+import { trustContextFromVerdict } from "../trust-verdict-consumer.js";
 import { canonicalChannelAssistantId } from "./channel-route-shared.js";
 import { BadRequestError } from "./errors.js";
 import { handleApprovalInterception } from "./guardian-approval-interception.js";
@@ -717,17 +717,24 @@ export async function handleChannelInbound({
   }
 
   // ── Actor role resolution ──
-  // Uses shared channel-agnostic resolution so all ingress paths classify
-  // guardian vs non-guardian actors the same way.
+  // Built from the gateway-stamped trust verdict (ACL + identity). An absent
+  // verdict is already hard-denied upstream in enforceIngressAcl; the synthetic
+  // unknown ctx here only guards non-ACL metadata use on that unreachable path.
+  const inboundVerdict = sourceMetadata?.trustVerdict;
   const trustCtx: TrustContext = attachSlackRequesterTimezone(
-    resolveTrustContext({
-      assistantId: canonicalAssistantId,
-      sourceChannel,
-      conversationExternalId,
-      actorExternalId: rawSenderId,
-      actorUsername: body.actorUsername,
-      actorDisplayName: body.actorDisplayName,
-    }),
+    inboundVerdict
+      ? trustContextFromVerdict(inboundVerdict, {
+          sourceChannel,
+          conversationExternalId,
+          actorUsername: body.actorUsername,
+          actorDisplayName: body.actorDisplayName,
+        })
+      : {
+          sourceChannel,
+          trustClass: "unknown",
+          requesterExternalUserId: canonicalSenderId ?? undefined,
+          requesterChatId: conversationExternalId,
+        },
     slackActorTimezone,
   );
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for `enforceIngressAcl` consuming the gateway trust verdict.
+ *
+ * Drives the stage directly with a `sourceMetadata.trustVerdict` and mocks the
+ * leaf I/O (contact store, gateway delivery, guardian notification, invite
+ * transport) so the ACL decision logic is exercised in isolation.
+ *
+ * Covers: verdict-sourced member resolution, fail-closed deny on an ABSENT
+ * verdict, hard-denies for blocked/revoked/policy, and the non-member invite
+ * intercept still firing for a present stranger verdict.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SourceMetadata, TrustVerdict } from "@vellumai/gateway-client";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Track contact-store reads to prove findContactChannel is NOT used on the
+// verdict path. findGuardianForChannel is still called by resolveGuardianLabel.
+const findContactChannelCalls: unknown[] = [];
+mock.module("../../../contacts/contact-store.js", () => ({
+  findContactChannel: (params: unknown) => {
+    findContactChannelCalls.push(params);
+    return null;
+  },
+  findGuardianForChannel: () => null,
+}));
+
+const deliverReplyCalls: Array<{ url: string; payload: unknown }> = [];
+mock.module("../../gateway-client.js", () => ({
+  deliverChannelReply: async (url: string, payload: unknown) => {
+    deliverReplyCalls.push({ url, payload });
+  },
+}));
+
+const accessRequestCalls: unknown[] = [];
+mock.module("../../access-request-helper.js", () => ({
+  notifyGuardianOfAccessRequest: (params: unknown) => {
+    accessRequestCalls.push(params);
+    return { notified: true };
+  },
+}));
+
+// Invite transport: by default no adapter (no token). Per-test override below.
+let inviteTokenForTest: string | undefined;
+mock.module("../../channel-invite-transport.js", () => ({
+  getInviteAdapterRegistry: () => ({
+    get: () => ({
+      extractInboundToken: () => inviteTokenForTest,
+    }),
+  }),
+}));
+
+// Invite redemption: default to a successful redeem so the token intercept
+// short-circuits with an earlyResponse.
+mock.module("../../invite-redemption-service.js", () => ({
+  redeemInvite: async () => ({ ok: true, type: "redeemed", memberId: "m-1" }),
+  redeemInviteByCode: async () => ({
+    ok: true,
+    type: "redeemed",
+    memberId: "m-1",
+  }),
+}));
+
+mock.module("../../invite-redemption-templates.js", () => ({
+  getInviteRedemptionReply: () => "redeemed reply",
+}));
+
+mock.module("../../../memory/delivery-crud.js", () => ({
+  recordInbound: () => ({ duplicate: false, eventId: "evt-1" }),
+  deleteInbound: () => {},
+}));
+
+mock.module("../../../memory/delivery-status.js", () => ({
+  markProcessed: () => {},
+}));
+
+import type { AclEnforcementParams } from "./acl-enforcement.js";
+import { enforceIngressAcl } from "./acl-enforcement.js";
+
+function makeParams(
+  overrides: Partial<AclEnforcementParams> = {},
+): AclEnforcementParams {
+  return {
+    canonicalSenderId: "sender-1",
+    hasSenderIdentityClaim: true,
+    rawSenderId: "sender-1",
+    sourceChannel: "telegram",
+    conversationExternalId: "chat-1",
+    canonicalAssistantId: "assistant-1",
+    trimmedContent: "hello",
+    sourceMetadata: undefined,
+    actorDisplayName: "Sender One",
+    actorUsername: "sender_one",
+    replyCallbackUrl: "http://localhost/deliver",
+    assistantId: "assistant-1",
+    externalMessageId: "msg-1",
+    ...overrides,
+  };
+}
+
+function memberVerdict(overrides: Partial<TrustVerdict> = {}): TrustVerdict {
+  return {
+    trustClass: "trusted_contact",
+    canonicalSenderId: "sender-1",
+    contactId: "contact-1",
+    channelId: "channel-1",
+    type: "telegram",
+    address: "sender-1",
+    status: "active",
+    policy: "allow",
+    memberDisplayName: "Sender One",
+    ...overrides,
+  };
+}
+
+function withVerdict(verdict: TrustVerdict): SourceMetadata {
+  return { trustVerdict: verdict } as SourceMetadata;
+}
+
+beforeEach(() => {
+  findContactChannelCalls.length = 0;
+  deliverReplyCalls.length = 0;
+  accessRequestCalls.length = 0;
+  inviteTokenForTest = undefined;
+});
+
+afterEach(() => {
+  inviteTokenForTest = undefined;
+});
+
+describe("enforceIngressAcl — verdict-sourced member resolution", () => {
+  test("active trusted verdict is admitted (resolvedMember threaded, no deny)", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({ sourceMetadata: withVerdict(memberVerdict()) }),
+    );
+
+    expect(result.earlyResponse).toBeUndefined();
+    expect(result.resolvedMember).not.toBeNull();
+    expect(result.resolvedMember!.channel.status).toBe("active");
+    expect(result.resolvedMember!.channel.policy).toBe("allow");
+    // Member came from the verdict, never the local contact store.
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+
+  test("guardian verdict is admitted purely from the verdict (empty contact store)", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(
+          memberVerdict({ trustClass: "guardian", guardianPrincipalId: "p-1" }),
+        ),
+      }),
+    );
+
+    expect(result.earlyResponse).toBeUndefined();
+    expect(result.resolvedMember!.contact.role).toBe("guardian");
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+});
+
+describe("enforceIngressAcl — hard denies from the verdict status/policy", () => {
+  test("blocked verdict → member_blocked deny", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ status: "blocked" })),
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("member_blocked");
+    // Blocked members do not trigger a guardian notification.
+    expect(accessRequestCalls.length).toBe(0);
+  });
+
+  test("revoked verdict → member_revoked deny (even under strangers)", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ status: "revoked" })),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("member_revoked");
+  });
+
+  test("policy deny verdict → policy_deny", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ policy: "deny" })),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("policy_deny");
+  });
+});
+
+describe("enforceIngressAcl — present stranger verdict flows through intercepts", () => {
+  test("present unknown/no-member verdict + invite token redeems via intercept", async () => {
+    inviteTokenForTest = "iv_token123";
+    const strangerVerdict: TrustVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "stranger-1",
+    };
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        sourceMetadata: withVerdict(strangerVerdict),
+      }),
+    );
+
+    // The invite token intercept fired — NOT a fail-closed deny.
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.inviteRedemption).toBe("redeemed");
+    expect(result.resolvedMember).toBeNull();
+  });
+});
+
+describe("enforceIngressAcl — fail-closed on absent verdict", () => {
+  test("absent trustVerdict → not_a_member deny even under strangers", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        // sourceMetadata present but WITHOUT trustVerdict.
+        sourceMetadata: {} as SourceMetadata,
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+    // Fail-closed deny short-circuits BEFORE any intercept or onboarding.
+    expect(deliverReplyCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+
+  test("no sourceMetadata at all → not_a_member deny", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({ sourceMetadata: undefined }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -248,3 +248,38 @@ describe("enforceIngressAcl — fail-closed on absent verdict", () => {
     expect(result.resolvedMember).toBeNull();
   });
 });
+
+describe("enforceIngressAcl — fail-closed on malformed member verdict", () => {
+  test("member identity + unknown policy → not_a_member deny even under strangers", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(
+          memberVerdict({ policy: "bogus" as TrustVerdict["policy"] }),
+        ),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    // Carries contactId/channelId but no resolvable member → fail closed,
+    // NOT admitted as a stranger by the floor.
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+    expect(deliverReplyCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+  });
+
+  test("member identity + missing status → not_a_member deny even under strangers", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(
+          memberVerdict({ status: undefined as unknown as TrustVerdict["status"] }),
+        ),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -8,8 +8,8 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
 import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
 import type {
-  ChannelStatus,
   ContactChannel,
   ContactWithChannels,
 } from "../../../contacts/types.js";
@@ -120,14 +120,6 @@ export interface AclResult {
   isValidatedBootstrap?: boolean;
 }
 
-/** Map ChannelStatus to the API-facing member status (excludes "unverified"). */
-export function channelStatusToMemberStatus(
-  status: ChannelStatus,
-): Exclude<ChannelStatus, "unverified"> {
-  if (status === "unverified") return "pending";
-  return status;
-}
-
 /**
  * Enforce ingress ACL rules: member lookup, non-member/inactive denial,
  * policy enforcement (allow/deny/escalate bypass), invite token intercepts,
@@ -184,6 +176,23 @@ export async function enforceIngressAcl(
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member intercepts.
   const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
+
+  // A verdict carrying member identity but no resolvable member
+  // (malformed/unknown ACL) fails closed, not treated as a stranger.
+  if (!resolvedMember && (verdict.contactId || verdict.channelId)) {
+    log.info(
+      { sourceChannel, externalUserId: canonicalSenderId },
+      "Ingress ACL: member verdict with unresolvable ACL, denying fail-closed",
+    );
+    return {
+      resolvedMember: null,
+      earlyResponse: {
+        accepted: true,
+        denied: true,
+        reason: "not_a_member",
+      },
+    };
+  }
 
   // /start gv_<token> bootstrap commands must also bypass ACL — the user
   // hasn't been verified yet and needs to complete the bootstrap handshake.

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -7,10 +7,7 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
-import {
-  findContactChannel,
-  findGuardianForChannel,
-} from "../../../contacts/contact-store.js";
+import { findGuardianForChannel } from "../../../contacts/contact-store.js";
 import type {
   ChannelStatus,
   ContactChannel,
@@ -41,6 +38,7 @@ import {
   redeemInviteByCode,
 } from "../../invite-redemption-service.js";
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
+import { resolvedMemberFromVerdict } from "../../trust-verdict-consumer.js";
 
 const log = getLogger("runtime-http");
 
@@ -164,7 +162,28 @@ export async function enforceIngressAcl(
   // Slack message timestamp for permalink construction.
   const messageTs = sourceMetadata?.messageId ?? undefined;
 
-  let resolvedMember: ResolvedMember | null = null;
+  // Absent verdict = gateway could not vouch for this actor → fail-closed deny.
+  // A PRESENT verdict with no member (stranger) still flows through the
+  // intercepts below; only a missing verdict short-circuits here.
+  const verdict = sourceMetadata?.trustVerdict;
+  if (verdict == null) {
+    log.info(
+      { sourceChannel, externalUserId: canonicalSenderId },
+      "Ingress ACL: absent trust verdict, denying fail-closed",
+    );
+    return {
+      resolvedMember: null,
+      earlyResponse: {
+        accepted: true,
+        denied: true,
+        reason: "not_a_member",
+      },
+    };
+  }
+
+  // Member resolved from the gateway verdict (ACL + identity only); null for a
+  // stranger verdict, which falls through to the non-member intercepts.
+  const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
 
   // /start gv_<token> bootstrap commands must also bypass ACL — the user
   // hasn't been verified yet and needs to complete the bootstrap handshake.
@@ -181,23 +200,6 @@ export async function enforceIngressAcl(
   });
 
   if (canonicalSenderId || hasSenderIdentityClaim) {
-    // Only perform member lookup when we have a usable canonical ID.
-    // Whitespace-only senders (hasSenderIdentityClaim=true but
-    // canonicalSenderId=null) skip the lookup and fall into the deny path.
-    if (canonicalSenderId) {
-      const contactResult = findContactChannel({
-        channelType: sourceChannel,
-        address: canonicalSenderId,
-        externalChatId: conversationExternalId,
-      });
-      resolvedMember = contactResult
-        ? {
-            contact: contactResult.contact,
-            channel: contactResult.channel,
-          }
-        : null;
-    }
-
     if (!resolvedMember) {
       let denyNonMember = true;
 

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -22,7 +22,10 @@ import type {
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ActorTrustContext } from "./actor-trust-resolver.js";
 import { toTrustContext } from "./actor-trust-resolver.js";
-import type { ResolvedMember } from "./routes/inbound-stages/acl-enforcement.js";
+import {
+  channelStatusToMemberStatus,
+  type ResolvedMember,
+} from "./routes/inbound-stages/acl-enforcement.js";
 
 export interface TrustVerdictTransport {
   sourceChannel: ChannelId;
@@ -72,7 +75,22 @@ export function trustContextFromVerdict(
     },
   };
 
-  return toTrustContext(actorTrustContext, input.conversationExternalId);
+  const context = toTrustContext(
+    actorTrustContext,
+    input.conversationExternalId,
+  );
+
+  // Stamp the verdict's ACL member fields onto the context so downstream turn
+  // assembly reads member status/policy from the verdict rather than a local
+  // re-resolution. The contact ID anchors the local info-only join.
+  const member = resolvedMemberFromVerdict(verdict);
+  if (member) {
+    context.requesterContactId = member.contact.id;
+    context.memberStatus = channelStatusToMemberStatus(member.channel.status);
+    context.memberPolicy = member.channel.policy;
+  }
+
+  return context;
 }
 
 // Allowed ACL enum values, kept in sync with the ContactChannel union types.

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -13,6 +13,7 @@
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
+import { channelStatusToMemberStatus } from "../contacts/member-status.js";
 import type {
   ChannelPolicy,
   ChannelStatus,
@@ -22,10 +23,7 @@ import type {
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ActorTrustContext } from "./actor-trust-resolver.js";
 import { toTrustContext } from "./actor-trust-resolver.js";
-import {
-  channelStatusToMemberStatus,
-  type ResolvedMember,
-} from "./routes/inbound-stages/acl-enforcement.js";
+import type { ResolvedMember } from "./routes/inbound-stages/acl-enforcement.js";
 
 export interface TrustVerdictTransport {
   sourceChannel: ChannelId;

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -1,0 +1,156 @@
+/**
+ * Consume a gateway-stamped {@link TrustVerdict} into the daemon's local
+ * trust shapes.
+ *
+ * The gateway resolves a per-actor verdict from its ACL DB and stamps it onto
+ * inbound `sourceMetadata`. These pure mappers turn that verdict into the same
+ * {@link TrustContext} / {@link ResolvedMember} the local resolver would have
+ * produced — ACL + identity only. INFO fields (notes, userFile, contactType,
+ * interactionCount) are never carried on the wire; the consumer re-joins them
+ * locally by contactId.
+ */
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import type { ChannelId } from "../channels/types.js";
+import type {
+  ChannelPolicy,
+  ChannelStatus,
+  ContactChannel,
+  ContactWithChannels,
+} from "../contacts/types.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type { ActorTrustContext } from "./actor-trust-resolver.js";
+import { toTrustContext } from "./actor-trust-resolver.js";
+import type { ResolvedMember } from "./routes/inbound-stages/acl-enforcement.js";
+
+export interface TrustVerdictTransport {
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+  actorUsername?: string;
+  actorDisplayName?: string;
+}
+
+/**
+ * Build a {@link TrustContext} from a gateway verdict + transport identity.
+ *
+ * Reassembles an {@link ActorTrustContext} (mirroring `resolveActorTrust`) and
+ * routes it through {@link toTrustContext}, so the output is byte-identical to
+ * the local resolution path.
+ */
+export function trustContextFromVerdict(
+  verdict: TrustVerdict,
+  input: TrustVerdictTransport,
+): TrustContext {
+  const canonicalSenderId = verdict.canonicalSenderId;
+  const memberDisplayName = verdict.memberDisplayName;
+  const senderDisplayName = input.actorDisplayName;
+  const username = input.actorUsername;
+  const identifier = username
+    ? `@${username}`
+    : (canonicalSenderId ?? undefined);
+
+  const actorTrustContext: ActorTrustContext = {
+    canonicalSenderId,
+    guardianBindingMatch: verdict.guardianExternalUserId
+      ? {
+          guardianExternalUserId: verdict.guardianExternalUserId,
+          guardianDeliveryChatId: verdict.guardianDeliveryChatId ?? null,
+        }
+      : null,
+    guardianPrincipalId: verdict.guardianPrincipalId,
+    memberRecord: null,
+    trustClass: verdict.trustClass,
+    actorMetadata: {
+      identifier,
+      displayName: memberDisplayName ?? senderDisplayName,
+      senderDisplayName,
+      memberDisplayName,
+      username,
+      channel: input.sourceChannel,
+      trustStatus: verdict.trustClass,
+    },
+  };
+
+  return toTrustContext(actorTrustContext, input.conversationExternalId);
+}
+
+// Allowed ACL enum values, kept in sync with the ContactChannel union types.
+const CHANNEL_STATUS_VALUES: readonly ChannelStatus[] = [
+  "active",
+  "pending",
+  "revoked",
+  "blocked",
+  "unverified",
+];
+const CHANNEL_POLICY_VALUES: readonly ChannelPolicy[] = [
+  "allow",
+  "deny",
+  "escalate",
+];
+
+function isChannelStatus(value: string): value is ChannelStatus {
+  return (CHANNEL_STATUS_VALUES as readonly string[]).includes(value);
+}
+
+function isChannelPolicy(value: string): value is ChannelPolicy {
+  return (CHANNEL_POLICY_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Build a synthetic {@link ResolvedMember} from a gateway verdict.
+ *
+ * ACL + identity only; info fields are placeholders, re-joined locally by
+ * contactId. Returns null for memberless verdicts.
+ */
+export function resolvedMemberFromVerdict(
+  verdict: TrustVerdict,
+): ResolvedMember | null {
+  if (!verdict.contactId || !verdict.channelId) return null;
+  // Member verdict requires valid known status+policy enums, else null
+  // (fail-closed): a partial/mixed-version verdict (absent OR
+  // present-but-unknown ACL value) must not synthesize an active/allow channel
+  // that would skip ingress ACL gates.
+  if (!verdict.status || !verdict.policy) return null;
+  if (!isChannelStatus(verdict.status) || !isChannelPolicy(verdict.policy)) {
+    return null;
+  }
+
+  const channel: ContactChannel = {
+    id: verdict.channelId,
+    contactId: verdict.contactId,
+    type: verdict.type ?? "",
+    address: verdict.address ?? "",
+    isPrimary: false,
+    externalChatId: verdict.externalChatId ?? null,
+    status: verdict.status,
+    policy: verdict.policy,
+    verifiedAt: verdict.verifiedAt ?? null,
+    verifiedVia: verdict.verifiedVia ?? null,
+    inviteId: null,
+    revokedReason: null,
+    blockedReason: null,
+    lastSeenAt: null,
+    interactionCount: 0,
+    lastInteraction: null,
+    updatedAt: null,
+    createdAt: 0,
+  };
+
+  const contact: ContactWithChannels = {
+    id: verdict.contactId,
+    displayName: verdict.memberDisplayName ?? "",
+    notes: null,
+    lastInteraction: null,
+    interactionCount: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    role: verdict.trustClass === "guardian" ? "guardian" : "contact",
+    contactType: "human",
+    principalId: verdict.guardianPrincipalId ?? null,
+    userFile: null,
+    channels: [channel],
+  };
+
+  return { contact, channel };
+}


### PR DESCRIPTION
## Summary
The daemon's **text inbound** path now consumes the gateway-stamped `sourceMetadata.trustVerdict` (Combo 8) for ACL instead of resolving trust locally, and **fail-closes** (denies) when the verdict is absent. ACL fields (trustClass, guardian binding, channel status/policy/verifiedAt/verifiedVia, principalId) come from the verdict; INFO fields (notes/interactionCount/userFile) stay local, joined by `contactId`. First behavior change in the contacts-ACL gateway-source-of-truth migration. **No feature flag** — deploy-safety is at the feature-branch level. VOICE stays on local resolution (Combo 10).

**Fail-closed framing:** the gateway stamps a verdict for *every* normal text inbound, including unknown strangers (`trustClass:"unknown"`, no member fields — invite/bootstrap/verification intercepts still apply). An **absent** verdict means the gateway resolver failed soft → fail-closed `not_a_member` deny.

## PRs merged into this feature branch
- #35726 — verdict→`TrustContext`/`ResolvedMember` mappers (pure; reuses `toTrustContext` for byte-identical output; rejects partial/invalid status·policy enums → fail-closed)
- #35728 — `acl-enforcement` sources the member from the verdict; absent verdict denies before intercepts; blocked/revoked/policy hard-denies preserved
- #35729 — inbound `TrustContext` cutover (`resolveTrustContext` no longer called on the text path; slack timezone preserved)
- #35730 — turn-context + persona read ACL from the verdict-derived context, INFO from a local `contactId` join
- #35731 — self-review cleanup: drop unread `userFile` from the `ContactInfo` join

## Self-review result
4 fresh-eyes passes (plan faithfulness, repo integration, slop/reuse, external feedback). PASS after remediation. Notable findings triaged:
- **externalChatId member-match** — the gateway resolver matches members by `(type,address)` only, dropping the old `findContactChannel` externalChatId fallback; under fail-closed, chat-keyed channels with no user-level address are denied. **Accepted as intended** (address-only canonical identity is the migration's end state; externalChatId-only members are legacy).
- **Producer fail-soft vs consumer fail-closed** — a transient gateway ACL-DB error omits the stamp, which now denies (including the guardian). This is the deliberate fail-closed tradeoff; noted as an operational consideration (possible future hardening: retry / explicit `resolution_failed` sentinel).
- Dead `userFile` field removed (#35731).

## Out of scope (Combo 10+)
VOICE path (`relay-setup-router.ts`, `relay-server.ts`), `notifications/destination-resolver.ts`, and deleting `resolveActorTrust`/`resolveTrustContext`/`toTrustContext` (still used by voice + rehydration).

Part of plan: daemon-consumes-trust-verdict.md