### PR TITLE
fix(tools): give ask_question an execution-timeout budget above its prompt wait

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -166,7 +166,11 @@ mock.module("../tools/shared/filesystem/path-policy.js", () => ({
 }));
 
 import { PermissionPrompter } from "../permissions/prompter.js";
-import { isSideEffectTool, ToolExecutor } from "../tools/executor.js";
+import {
+  computePerToolTimeoutMs,
+  isSideEffectTool,
+  ToolExecutor,
+} from "../tools/executor.js";
 import type { ToolContext } from "../tools/types.js";
 
 function makeContext(overrides?: Partial<ToolContext>): ToolContext {
@@ -1291,5 +1295,32 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
         pattern: "action:rm",
       },
     ]);
+  });
+});
+
+describe("computePerToolTimeoutMs ask_question budget", () => {
+  // Regression guard: ask_question blocks on user input inside execute() via
+  // QuestionPrompter, which waits up to permissionTimeoutSec. The executor's
+  // generic toolExecutionTimeoutSec wrapper must give ask_question a budget
+  // strictly larger than that prompt timeout — otherwise the wrapper fires
+  // first and orphans the still-pending prompt behind the confusing "may
+  // still be running in the background" error. These assertions fail if the
+  // special case is removed and ask_question falls back to the generic budget.
+  test("execution-timeout budget exceeds the prompt's own permissionTimeoutSec", () => {
+    const { permissionTimeoutSec } = mockConfig.timeouts;
+    const askQuestionBudgetMs = computePerToolTimeoutMs("ask_question", {});
+
+    expect(askQuestionBudgetMs).toBeGreaterThan(permissionTimeoutSec * 1000);
+    expect(askQuestionBudgetMs).toBe((permissionTimeoutSec + 5) * 1000);
+  });
+
+  test("the generic budget that would otherwise apply is shorter than the prompt timeout", () => {
+    const { permissionTimeoutSec } = mockConfig.timeouts;
+    const genericBudgetMs = computePerToolTimeoutMs("some_other_tool", {});
+
+    // This is the collision the ask_question special case fixes: the generic
+    // execution-timeout budget is shorter than the prompter's own wait, so
+    // without the special case the wrapper trips first.
+    expect(genericBudgetMs).toBeLessThan(permissionTimeoutSec * 1000);
   });
 });

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -525,13 +525,21 @@ export { isSideEffectTool } from "./side-effects.js";
  *
  * Shell tools (`bash`, `host_bash`) manage their own timeouts with SIGKILL
  * on expiry. We add a 5s buffer so the shell's own deadline fires first and
- * handles cleanup before the executor wrapper trips. Non-shell tools use
- * the generic `toolExecutionTimeoutSec` configuration value.
+ * handles cleanup before the executor wrapper trips.
+ *
+ * `ask_question` blocks on user input inside `execute()` via `QuestionPrompter`,
+ * which waits up to `permissionTimeoutSec`. We give the wrapper the same 5s
+ * buffer over that deadline so the prompter's own timeout fires first and
+ * returns its clean "User did not respond within timeout" result — otherwise
+ * the shorter generic budget trips first, orphaning the still-pending prompt
+ * behind the confusing "may still be running in the background" error.
+ *
+ * All other tools use the generic `toolExecutionTimeoutSec` configuration value.
  *
  * Consumed by `executeInternal` via `executeWithTimeout`, which is the
  * sole enforcer of the per-tool budget.
  */
-function computePerToolTimeoutMs(
+export function computePerToolTimeoutMs(
   name: string,
   input: Record<string, unknown>,
 ): number {
@@ -546,6 +554,10 @@ function computePerToolTimeoutMs(
       Math.min(requestedSec, shellMaxTimeoutSec),
     );
     return (shellTimeoutSec + 5) * 1000;
+  }
+  if (name === "ask_question") {
+    const { permissionTimeoutSec } = getConfig().timeouts;
+    return (permissionTimeoutSec + 5) * 1000;
   }
   const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
   return safeTimeoutMs(rawTimeoutSec);


### PR DESCRIPTION
## Summary

- `computePerToolTimeoutMs` only special-cased `bash`/`host_bash`; every other tool inherited the flat `toolExecutionTimeoutSec` (default 120s). `ask_question` blocks on user input inside `execute()` via `QuestionPrompter`, which waits up to `permissionTimeoutSec` (default 300s), so the 120s wrapper always tripped first — surfacing `Tool "ask_question" timed out after 120s … may still be running in the background` and orphaning the still-pending prompt whenever a user took longer than two minutes to answer.
- Add an `ask_question` case to `computePerToolTimeoutMs` returning `(permissionTimeoutSec + 5) * 1000`, mirroring the existing shell `+5s` buffer so the prompter's own deadline fires first and returns its clean `User did not respond within timeout` result.
- Add regression tests asserting the `ask_question` wrapper budget exceeds `permissionTimeoutSec` (and that the generic budget it would otherwise inherit is shorter), so the two timeouts can't silently drift back into collision.

## Original prompt

A user saw `Tool "ask_question" timed out after 120s … Consider increasing timeouts.toolExecutionTimeoutSec` errors in their logs and asked why. The cause is a collision between two independent timeouts: the executor's generic 120s `toolExecutionTimeoutSec` wrapper and the `ask_question` tool's own 300s `permissionTimeoutSec` wait for a user response. The fix sizes the wrapper budget for `ask_question` above its prompt timeout so users who take longer than two minutes to answer aren't cut off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)