### PR TITLE
fix(assistant): fail-closed on malformed member verdicts; restore voice member grounding

### DIFF
--- a/assistant/src/contacts/member-status.ts
+++ b/assistant/src/contacts/member-status.ts
@@ -1,0 +1,9 @@
+import type { ChannelStatus } from "./types.js";
+
+/** Map ChannelStatus to the API-facing member status (excludes "unverified"). */
+export function channelStatusToMemberStatus(
+  status: ChannelStatus,
+): Exclude<ChannelStatus, "unverified"> {
+  if (status === "unverified") return "pending";
+  return status;
+}

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
+import type {
+  ContactChannel,
+  ContactWithChannels,
+} from "../../contacts/types.js";
 import type { ActorTrustContext } from "../actor-trust-resolver.js";
 import { toTrustContext } from "../actor-trust-resolver.js";
 import {
@@ -156,6 +160,114 @@ describe("trustContextFromVerdict", () => {
       // Non-guardian without binding -> no guardian chat id.
       expect(result.guardianChatId).toBeUndefined();
     }
+  });
+});
+
+describe("toTrustContext member grounding", () => {
+  function memberChannel(
+    overrides: Partial<ContactChannel> = {},
+  ): ContactChannel {
+    return {
+      id: "channel-1",
+      contactId: "contact-1",
+      type: "phone",
+      address: "+15550100",
+      isPrimary: true,
+      externalChatId: null,
+      status: "unverified",
+      policy: "escalate",
+      verifiedAt: null,
+      verifiedVia: null,
+      inviteId: null,
+      revokedReason: null,
+      blockedReason: null,
+      lastSeenAt: null,
+      interactionCount: 0,
+      lastInteraction: null,
+      updatedAt: null,
+      createdAt: 0,
+      ...overrides,
+    };
+  }
+
+  function memberContact(): ContactWithChannels {
+    return {
+      id: "contact-1",
+      displayName: "Frank",
+      notes: null,
+      lastInteraction: null,
+      interactionCount: 0,
+      createdAt: 0,
+      updatedAt: 0,
+      role: "contact",
+      contactType: "human",
+      principalId: null,
+      userFile: null,
+      channels: [memberChannel()],
+    };
+  }
+
+  function ctxWithMember(
+    channel: ContactChannel,
+  ): ActorTrustContext {
+    return {
+      canonicalSenderId: "+15550100",
+      guardianBindingMatch: null,
+      guardianPrincipalId: undefined,
+      memberRecord: { contact: memberContact(), channel },
+      trustClass: "trusted_contact",
+      actorMetadata: {
+        identifier: "+15550100",
+        displayName: "Frank",
+        senderDisplayName: "Frank",
+        memberDisplayName: "Frank",
+        username: undefined,
+        channel: "phone",
+        trustStatus: "trusted_contact",
+      },
+    };
+  }
+
+  test("populates member fields from memberRecord (voice path)", () => {
+    const context = toTrustContext(ctxWithMember(memberChannel()), CONV);
+    expect(context.requesterContactId).toBe("contact-1");
+    // "unverified" maps to the API-facing "pending" member status.
+    expect(context.memberStatus).toBe("pending");
+    expect(context.memberPolicy).toBe("escalate");
+  });
+
+  test("passes through active status + allow policy", () => {
+    const context = toTrustContext(
+      ctxWithMember(memberChannel({ status: "active", policy: "allow" })),
+      CONV,
+    );
+    expect(context.memberStatus).toBe("active");
+    expect(context.memberPolicy).toBe("allow");
+  });
+
+  test("leaves member fields undefined when memberRecord is null", () => {
+    const context = toTrustContext(
+      {
+        canonicalSenderId: "u-2",
+        guardianBindingMatch: null,
+        guardianPrincipalId: undefined,
+        memberRecord: null,
+        trustClass: "unknown",
+        actorMetadata: {
+          identifier: "u-2",
+          displayName: undefined,
+          senderDisplayName: undefined,
+          memberDisplayName: undefined,
+          username: undefined,
+          channel: "slack",
+          trustStatus: "unknown",
+        },
+      },
+      CONV,
+    );
+    expect(context.requesterContactId).toBeUndefined();
+    expect(context.memberStatus).toBeUndefined();
+    expect(context.memberPolicy).toBeUndefined();
   });
 });
 

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -21,6 +21,7 @@ import {
   findContactByAddress,
   findGuardianForChannel,
 } from "../contacts/contact-store.js";
+import { channelStatusToMemberStatus } from "../contacts/member-status.js";
 import type { ContactChannel, ContactWithChannels } from "../contacts/types.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
@@ -322,5 +323,12 @@ export function toTrustContext(
     requesterMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
     requesterChatId: conversationExternalId,
+    // Member grounding from a real memberRecord (voice path); the verdict path
+    // (memberRecord=null) stamps these from the verdict instead.
+    requesterContactId: ctx.memberRecord?.contact.id,
+    memberStatus: ctx.memberRecord
+      ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)
+      : undefined,
+    memberPolicy: ctx.memberRecord?.channel.policy,
   };
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -24,6 +24,7 @@ import {
 } from "../../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
+import { channelStatusToMemberStatus } from "../../contacts/member-status.js";
 import {
   createApprovalConversationGenerator,
   createApprovalCopyGenerator,
@@ -96,10 +97,7 @@ import { trustContextFromVerdict } from "../trust-verdict-consumer.js";
 import { canonicalChannelAssistantId } from "./channel-route-shared.js";
 import { BadRequestError } from "./errors.js";
 import { handleApprovalInterception } from "./guardian-approval-interception.js";
-import {
-  channelStatusToMemberStatus,
-  enforceIngressAcl,
-} from "./inbound-stages/acl-enforcement.js";
+import { enforceIngressAcl } from "./inbound-stages/acl-enforcement.js";
 import { enforceAdmissionPolicy } from "./inbound-stages/admission-policy.js";
 import { processChannelMessageInBackground } from "./inbound-stages/background-dispatch.js";
 import { handleBootstrapIntercept } from "./inbound-stages/bootstrap-intercept.js";

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -248,3 +248,38 @@ describe("enforceIngressAcl — fail-closed on absent verdict", () => {
     expect(result.resolvedMember).toBeNull();
   });
 });
+
+describe("enforceIngressAcl — fail-closed on malformed member verdict", () => {
+  test("member identity + unknown policy → not_a_member deny even under strangers", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(
+          memberVerdict({ policy: "bogus" as TrustVerdict["policy"] }),
+        ),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    // Carries contactId/channelId but no resolvable member → fail closed,
+    // NOT admitted as a stranger by the floor.
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+    expect(deliverReplyCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+  });
+
+  test("member identity + missing status → not_a_member deny even under strangers", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(
+          memberVerdict({ status: undefined as unknown as TrustVerdict["status"] }),
+        ),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -8,8 +8,8 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
 import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
 import type {
-  ChannelStatus,
   ContactChannel,
   ContactWithChannels,
 } from "../../../contacts/types.js";
@@ -120,14 +120,6 @@ export interface AclResult {
   isValidatedBootstrap?: boolean;
 }
 
-/** Map ChannelStatus to the API-facing member status (excludes "unverified"). */
-export function channelStatusToMemberStatus(
-  status: ChannelStatus,
-): Exclude<ChannelStatus, "unverified"> {
-  if (status === "unverified") return "pending";
-  return status;
-}
-
 /**
  * Enforce ingress ACL rules: member lookup, non-member/inactive denial,
  * policy enforcement (allow/deny/escalate bypass), invite token intercepts,
@@ -184,6 +176,23 @@ export async function enforceIngressAcl(
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member intercepts.
   const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
+
+  // A verdict carrying member identity but no resolvable member
+  // (malformed/unknown ACL) fails closed, not treated as a stranger.
+  if (!resolvedMember && (verdict.contactId || verdict.channelId)) {
+    log.info(
+      { sourceChannel, externalUserId: canonicalSenderId },
+      "Ingress ACL: member verdict with unresolvable ACL, denying fail-closed",
+    );
+    return {
+      resolvedMember: null,
+      earlyResponse: {
+        accepted: true,
+        denied: true,
+        reason: "not_a_member",
+      },
+    };
+  }
 
   // /start gv_<token> bootstrap commands must also bypass ACL — the user
   // hasn't been verified yet and needs to complete the bootstrap handshake.

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -13,6 +13,7 @@
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
+import { channelStatusToMemberStatus } from "../contacts/member-status.js";
 import type {
   ChannelPolicy,
   ChannelStatus,
@@ -22,10 +23,7 @@ import type {
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ActorTrustContext } from "./actor-trust-resolver.js";
 import { toTrustContext } from "./actor-trust-resolver.js";
-import {
-  channelStatusToMemberStatus,
-  type ResolvedMember,
-} from "./routes/inbound-stages/acl-enforcement.js";
+import type { ResolvedMember } from "./routes/inbound-stages/acl-enforcement.js";
 
 export interface TrustVerdictTransport {
   sourceChannel: ChannelId;


### PR DESCRIPTION
## Summary
- **acl-enforcement:** a verdict carrying member identity (`contactId`/`channelId`) but malformed/unknown `status`·`policy` now fail-closes (`not_a_member`) instead of being treated as a stranger and admitted under a `strangers` floor.
- **toTrustContext:** populates `requesterContactId`/`memberStatus`/`memberPolicy` from `memberRecord`, restoring `<turn_context>` member grounding for VOICE turns (which build their context via `toTrustContext`). `channelStatusToMemberStatus` relocated to a neutral `contacts/member-status.ts` to avoid an import cycle.

Addresses Codex P2s on #35732.