### PR TITLE
fix(ask_question): make the prompt timeout liveness-driven, not a 5-min wall clock

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -120,6 +120,7 @@ describe("AssistantConfigSchema", () => {
       shellDefaultTimeoutSec: 120,
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
+      questionResponseTimeoutSec: 1800,
       toolExecutionTimeoutSec: 120,
       providerStreamTimeoutSec: 1800,
       backgroundTurnTimeoutSec: 1800,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1705,6 +1705,10 @@ describe("session-agent-loop", () => {
       expect(ctx.abortController).toBeNull();
       expect(ctx.currentRequestId).toBeUndefined();
       expect(ctx.commandIntent).toBeUndefined();
+      // Turn-scoped interactivity is stamped during the run and must be cleared
+      // so paths that bypass this loop (e.g. opportunity wakes) don't inherit a
+      // stale value instead of falling back to live client state.
+      expect(ctx.currentTurnIsNonInteractive).toBeUndefined();
     });
 
     test("clears state and surfaces a processing error when the provider call fails", async () => {

--- a/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
@@ -321,3 +321,50 @@ describe("createToolExecutor attribution threading", () => {
     expect(calls[0].context.attribution).toBeNull();
   });
 });
+
+describe("createToolExecutor isInteractive threading", () => {
+  test("uses the resolved turn-level interactivity over live client state", async () => {
+    // A scheduled/background turn (currentTurnIsNonInteractive=true) must read
+    // as non-interactive even when a client is attached (hasNoClient=false), so
+    // ask_question short-circuits instead of parking on the response backstop.
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeCtx({ currentTurnIsNonInteractive: true, hasNoClient: false }),
+    );
+
+    await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(calls[0].context.isInteractive).toBe(false);
+  });
+
+  test("reflects an interactive turn as interactive", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeCtx({ currentTurnIsNonInteractive: false }),
+    );
+
+    await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(calls[0].context.isInteractive).toBe(true);
+  });
+
+  test("falls back to live client state when no turn value is set", async () => {
+    // No in-flight turn resolution (e.g. tool execution outside runAgentLoop):
+    // derive interactivity from whether a client is connected.
+    const noClient = makeCapturingExecutor();
+    await makeToolFn(
+      noClient.executor,
+      makeCtx({ currentTurnIsNonInteractive: undefined, hasNoClient: true }),
+    )("file_read", { path: "/tmp/a" });
+    expect(noClient.calls[0].context.isInteractive).toBe(false);
+
+    const withClient = makeCapturingExecutor();
+    await makeToolFn(
+      withClient.executor,
+      makeCtx({ currentTurnIsNonInteractive: undefined, hasNoClient: false }),
+    )("file_read", { path: "/tmp/a" });
+    expect(withClient.calls[0].context.isInteractive).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
+++ b/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
@@ -155,7 +155,7 @@ describe("pendingInteractions.resolve emits interaction_resolved", () => {
 });
 
 describe("removeByConversation emits interaction_resolved per entry", () => {
-  test("emits superseded for every non-host interaction in the conversation", () => {
+  test("emits superseded for every confirmation/secret interaction in the conversation", () => {
     pendingInteractions.register("conf-1", {
       conversationId: "conv-x",
       kind: "confirmation",
@@ -182,13 +182,16 @@ describe("removeByConversation emits interaction_resolved per entry", () => {
     const events = publishedMessages.filter(
       (m) => m.type === "interaction_resolved",
     ) as Extract<ServerMessage, { type: "interaction_resolved" }>[];
-    expect(events).toHaveLength(3);
+    expect(events).toHaveLength(2);
     expect(events.every((e) => e.state === "superseded")).toBe(true);
     const requestIds = new Set(events.map((e) => e.requestId));
-    expect(requestIds).toEqual(new Set(["conf-1", "secret-1", "question-1"]));
+    expect(requestIds).toEqual(new Set(["conf-1", "secret-1"]));
 
-    // host_bash entries survive auto-deny — no event for them.
+    // host_bash and question entries both survive auto-deny — no event for
+    // either. host proxies are settled by their result POST; questions by the
+    // enqueue steer's turn abort (see removeByConversation's skip list).
     expect(pendingInteractions.get("host-bash-1")).toBeDefined();
+    expect(pendingInteractions.get("question-1")).toBeDefined();
     // Unrelated conversation is untouched.
     expect(pendingInteractions.get("conf-other")).toBeDefined();
   });

--- a/assistant/src/__tests__/steer-on-enqueue-question.test.ts
+++ b/assistant/src/__tests__/steer-on-enqueue-question.test.ts
@@ -16,7 +16,10 @@ import {
   deleteConversation,
   setConversation,
 } from "../daemon/conversation-registry.js";
-import { steerOnEnqueuedMessageIfQuestionParked } from "../daemon/handlers/conversations.js";
+import {
+  steerOnEnqueuedMessageIfQuestionParked,
+  supersedePendingInteractionsOnEnqueue,
+} from "../daemon/handlers/conversations.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 interface ParkedTurn {
@@ -43,6 +46,7 @@ function registerParkedTurn(id: string): ParkedTurn {
         abortCount += 1;
       },
     },
+    hasAnyPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
   };
   setConversation(id, fake as unknown as Conversation);
@@ -128,6 +132,19 @@ describe("steerOnEnqueuedMessageIfQuestionParked", () => {
 
     expect(steered).toBe(false);
     expect(conv.abortCount()).toBe(0);
+  });
+
+  test("supersedePendingInteractionsOnEnqueue steers a parked question", () => {
+    // The centralized routine is invoked by both the HTTP send handler and the
+    // CLI signal path. With no pending confirmation it steers a parked question
+    // — the behavior the CLI signal path previously lacked.
+    const conv = registerParkedTurn(QUESTION_CONV);
+    registerInteraction(QUESTION_CONV, "question");
+
+    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
+
+    expect(conv.abortCount()).toBe(1);
+    expect(conv.fake.pendingSteerRepair).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/steer-on-enqueue-question.test.ts
+++ b/assistant/src/__tests__/steer-on-enqueue-question.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Enqueue-steer contract: when a chat message is enqueued while an
+ * `ask_question` prompt is open for the same conversation, the user has chosen
+ * to move on rather than answer it. `steerOnEnqueuedMessageIfQuestionParked`
+ * steers to that message — aborting the parked turn (which settles the open
+ * question via its turn-abort signal) and draining the message — instead of
+ * stranding it behind a prompt no one will answer.
+ *
+ * Only `kind: "question"` interactions trigger the steer; pending confirmations
+ * are handled separately by the enqueue path's auto-deny.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { steerOnEnqueuedMessageIfQuestionParked } from "../daemon/handlers/conversations.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+
+interface ParkedTurn {
+  abortCount: () => number;
+  fake: { pendingSteerRepair: boolean };
+}
+
+/**
+ * Register a fake conversation whose in-flight turn is parked. The fake exposes
+ * just the surface `steerToMessage` touches: a processing flag, a queue whose
+ * head can be promoted, an abort controller that records aborts, and the
+ * confirmation-deny hook.
+ */
+function registerParkedTurn(id: string): ParkedTurn {
+  let abortCount = 0;
+  const fake = {
+    isProcessing: () => true,
+    queue: {
+      promoteToHead: (requestId: string) => ({ requestId }),
+    },
+    pendingSteerRepair: false,
+    abortController: {
+      abort: () => {
+        abortCount += 1;
+      },
+    },
+    denyAllPendingConfirmations: () => {},
+  };
+  setConversation(id, fake as unknown as Conversation);
+  return { abortCount: () => abortCount, fake };
+}
+
+const registeredRequestIds: string[] = [];
+function registerInteraction(
+  conversationId: string,
+  kind: "question" | "confirmation",
+): void {
+  const requestId = `pending-${kind}-${conversationId}`;
+  pendingInteractions.register(requestId, { conversationId, kind });
+  registeredRequestIds.push(requestId);
+}
+
+const QUESTION_CONV = "steer-enqueue-question";
+const CONFIRMATION_CONV = "steer-enqueue-confirmation";
+const NONE_CONV = "steer-enqueue-none";
+
+describe("steerOnEnqueuedMessageIfQuestionParked", () => {
+  afterEach(() => {
+    for (const id of registeredRequestIds) {
+      pendingInteractions.resolve(id, "cancelled");
+    }
+    registeredRequestIds.length = 0;
+    deleteConversation(QUESTION_CONV);
+    deleteConversation(CONFIRMATION_CONV);
+    deleteConversation(NONE_CONV);
+  });
+
+  test("steers to the enqueued message when an ask_question is parked", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    registerInteraction(QUESTION_CONV, "question");
+
+    const steered = steerOnEnqueuedMessageIfQuestionParked(
+      QUESTION_CONV,
+      "msg-1",
+    );
+
+    // The parked turn is aborted (which settles the open question) and marked
+    // for tool-result repair so the drain path can pick up the new message.
+    expect(steered).toBe(true);
+    expect(conv.abortCount()).toBe(1);
+    expect(conv.fake.pendingSteerRepair).toBe(true);
+  });
+
+  test("does not steer for a pending confirmation (not a question)", () => {
+    const conv = registerParkedTurn(CONFIRMATION_CONV);
+    registerInteraction(CONFIRMATION_CONV, "confirmation");
+
+    const steered = steerOnEnqueuedMessageIfQuestionParked(
+      CONFIRMATION_CONV,
+      "msg-1",
+    );
+
+    expect(steered).toBe(false);
+    expect(conv.abortCount()).toBe(0);
+  });
+
+  test("does not steer when no prompt is parked", () => {
+    const conv = registerParkedTurn(NONE_CONV);
+
+    const steered = steerOnEnqueuedMessageIfQuestionParked(NONE_CONV, "msg-1");
+
+    expect(steered).toBe(false);
+    expect(conv.abortCount()).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/steer-on-enqueue-question.test.ts
+++ b/assistant/src/__tests__/steer-on-enqueue-question.test.ts
@@ -130,3 +130,35 @@ describe("steerOnEnqueuedMessageIfQuestionParked", () => {
     expect(conv.abortCount()).toBe(0);
   });
 });
+
+describe("removeByConversation preserves question interactions", () => {
+  // The enqueue path's confirmation auto-deny calls removeByConversation before
+  // the steer runs. Questions must survive it — they are settled instead by the
+  // steer's turn abort — or, when an ask_question and a confirmation are pending
+  // concurrently, the queued message would strand behind a question whose entry
+  // was cleared (and whose Promise was never settled) before the steer fired.
+  const CONV = "remove-by-conv-preserve-question";
+  const ids: string[] = [];
+  function register(kind: "question" | "confirmation"): void {
+    const requestId = `rbc-${kind}`;
+    pendingInteractions.register(requestId, { conversationId: CONV, kind });
+    ids.push(requestId);
+  }
+
+  afterEach(() => {
+    for (const id of ids) pendingInteractions.resolve(id, "cancelled");
+    ids.length = 0;
+  });
+
+  test("removes confirmations but leaves questions registered", () => {
+    register("confirmation");
+    register("question");
+
+    pendingInteractions.removeByConversation(CONV);
+
+    const remaining = pendingInteractions
+      .getByConversation(CONV)
+      .map((interaction) => interaction.kind);
+    expect(remaining).toEqual(["question"]);
+  });
+});

--- a/assistant/src/__tests__/steer-on-enqueue-question.test.ts
+++ b/assistant/src/__tests__/steer-on-enqueue-question.test.ts
@@ -90,6 +90,24 @@ describe("steerOnEnqueuedMessageIfQuestionParked", () => {
     expect(conv.fake.pendingSteerRepair).toBe(true);
   });
 
+  test("steers for a parked question even when a confirmation is also pending", () => {
+    // A single model response can open an ask_question and a confirmation
+    // concurrently (tools run via Promise.all), so both interactions can be
+    // registered at once. The steer must still fire for the question — the
+    // enqueue path runs it before the confirmation auto-deny clears entries.
+    const conv = registerParkedTurn(QUESTION_CONV);
+    registerInteraction(QUESTION_CONV, "confirmation");
+    registerInteraction(QUESTION_CONV, "question");
+
+    const steered = steerOnEnqueuedMessageIfQuestionParked(
+      QUESTION_CONV,
+      "msg-1",
+    );
+
+    expect(steered).toBe(true);
+    expect(conv.abortCount()).toBe(1);
+  });
+
   test("does not steer for a pending confirmation (not a question)", () => {
     const conv = registerParkedTurn(CONFIRMATION_CONV);
     registerInteraction(CONFIRMATION_CONV, "confirmation");

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -17,6 +17,7 @@ const mockConfig = {
     shellDefaultTimeoutSec: 120,
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
+    questionResponseTimeoutSec: 1800,
   },
   sandbox: {
     enabled: false,
@@ -1300,27 +1301,31 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
 
 describe("computePerToolTimeoutMs ask_question budget", () => {
   // Regression guard: ask_question blocks on user input inside execute() via
-  // QuestionPrompter, which waits up to permissionTimeoutSec. The executor's
-  // generic toolExecutionTimeoutSec wrapper must give ask_question a budget
-  // strictly larger than that prompt timeout — otherwise the wrapper fires
-  // first and orphans the still-pending prompt behind the confusing "may
+  // QuestionPrompter, which waits up to questionResponseTimeoutSec. The
+  // executor's generic toolExecutionTimeoutSec wrapper must give ask_question a
+  // budget strictly larger than that prompt timeout — otherwise the wrapper
+  // fires first and orphans the still-pending prompt behind the confusing "may
   // still be running in the background" error. These assertions fail if the
-  // special case is removed and ask_question falls back to the generic budget.
-  test("execution-timeout budget exceeds the prompt's own permissionTimeoutSec", () => {
-    const { permissionTimeoutSec } = mockConfig.timeouts;
+  // special case is removed and ask_question falls back to the generic budget,
+  // or if the executor budget and the prompter timeout drift onto different
+  // config knobs.
+  test("execution-timeout budget exceeds the prompt's own questionResponseTimeoutSec", () => {
+    const { questionResponseTimeoutSec } = mockConfig.timeouts;
     const askQuestionBudgetMs = computePerToolTimeoutMs("ask_question", {});
 
-    expect(askQuestionBudgetMs).toBeGreaterThan(permissionTimeoutSec * 1000);
-    expect(askQuestionBudgetMs).toBe((permissionTimeoutSec + 5) * 1000);
+    expect(askQuestionBudgetMs).toBeGreaterThan(
+      questionResponseTimeoutSec * 1000,
+    );
+    expect(askQuestionBudgetMs).toBe((questionResponseTimeoutSec + 5) * 1000);
   });
 
   test("the generic budget that would otherwise apply is shorter than the prompt timeout", () => {
-    const { permissionTimeoutSec } = mockConfig.timeouts;
+    const { questionResponseTimeoutSec } = mockConfig.timeouts;
     const genericBudgetMs = computePerToolTimeoutMs("some_other_tool", {});
 
     // This is the collision the ask_question special case fixes: the generic
     // execution-timeout budget is shorter than the prompter's own wait, so
     // without the special case the wrapper trips first.
-    expect(genericBudgetMs).toBeLessThan(permissionTimeoutSec * 1000);
+    expect(genericBudgetMs).toBeLessThan(questionResponseTimeoutSec * 1000);
   });
 });

--- a/assistant/src/config/schemas/timeouts.ts
+++ b/assistant/src/config/schemas/timeouts.ts
@@ -28,6 +28,14 @@ export const TimeoutConfigSchema = z
       .describe(
         "How long to wait for user permission approval before timing out (seconds)",
       ),
+    questionResponseTimeoutSec: z
+      .number({ error: "timeouts.questionResponseTimeoutSec must be a number" })
+      .finite("timeouts.questionResponseTimeoutSec must be finite")
+      .positive("timeouts.questionResponseTimeoutSec must be a positive number")
+      .default(1800)
+      .describe(
+        "Backstop timeout for an unanswered ask_question prompt (seconds). The primary way an interactive user dismisses a prompt is by moving on — enqueuing another message supersedes it — so this only bounds a prompt left open with no response and no follow-up message.",
+      ),
     toolExecutionTimeoutSec: z
       .number({ error: "timeouts.toolExecutionTimeoutSec must be a number" })
       .finite("timeouts.toolExecutionTimeoutSec must be finite")

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -480,6 +480,11 @@ export async function runAgentLoopImpl(
   // resolved once here and threaded into every re-injection — including the
   // post-compaction hook — rather than re-read per assembly call.
   const isNonInteractive = !isInteractiveResolved;
+  // Expose the resolved turn-level interactivity to tool execution so tools
+  // (e.g. ask_question) see whether a human is present to answer, rather than
+  // re-deriving it from live client state that misclassifies a scheduled turn
+  // running on a client-attached conversation.
+  ctx.currentTurnIsNonInteractive = isNonInteractive;
   const diskPressureDecision = classifyDiskPressureTurnPolicy(
     getDiskPressureStatus(),
     {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1523,6 +1523,10 @@ export async function runAgentLoopImpl(
     ctx.diskPressureCleanupModeActive = false;
     ctx.preactivatedSkillIds = undefined;
     ctx.currentTurnOverrideProfile = undefined;
+    // Turn-scoped interactivity. Clear it so paths that bypass this loop (e.g.
+    // opportunity wakes calling `agentLoop.run` directly) don't inherit a stale
+    // value and instead fall back to live client state in the tool context.
+    ctx.currentTurnIsNonInteractive = undefined;
     // Channel command intents (e.g. Telegram /start) are single-turn metadata.
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -238,7 +238,10 @@ export function createToolExecutor(
           });
         }
       },
-      isInteractive: !ctx.hasNoClient && !ctx.headlessLock,
+      isInteractive:
+        ctx.currentTurnIsNonInteractive !== undefined
+          ? !ctx.currentTurnIsNonInteractive
+          : !ctx.hasNoClient && !ctx.headlessLock,
       proxyToolResolver: (
         toolName: string,
         proxyInput: Record<string, unknown>,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -376,6 +376,7 @@ export class Conversation {
    */
   wakePersonaOverride?: SystemPromptPersonaOverride;
   /** @internal */ currentTurnOverrideProfile?: string;
+  /** @internal */ currentTurnIsNonInteractive?: boolean;
   /** @internal */ authContext?: AuthContext;
   /** @internal */ currentTurnAuthContext?: AuthContext;
   /** @internal */ currentTurnSourceActorPrincipalId?: string;

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -5,6 +5,7 @@ import { clearAll, getConversation } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import { resolveCapabilities } from "../../runtime/capabilities.js";
+import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { createAbortReason } from "../../util/abort-reasons.js";
 import { UserError } from "../../util/errors.js";
@@ -387,6 +388,32 @@ export function steerToMessage(
   conversation.denyAllPendingConfirmations();
 
   return { steered: true };
+}
+
+/**
+ * Supersede an open `ask_question` prompt when a new chat message is enqueued
+ * for the same conversation.
+ *
+ * A queued message while a clarification question is open means the user chose
+ * to move on rather than answer it. Steering to that message aborts the parked
+ * turn — which settles the open question via its turn-abort signal — repairs
+ * the dangling `tool_use`, and drains the message, instead of stranding it
+ * behind a prompt no one is going to answer. Only `ask_question` prompts
+ * (`kind: "question"`) trigger this; pending confirmations are handled
+ * separately by the enqueue path's auto-deny.
+ *
+ * Returns `true` when a parked question was found and a steer was issued.
+ */
+export function steerOnEnqueuedMessageIfQuestionParked(
+  conversationId: string,
+  enqueuedRequestId: string,
+): boolean {
+  const hasParkedQuestion = pendingInteractions
+    .getByConversation(conversationId)
+    .some((interaction) => interaction.kind === "question");
+  if (!hasParkedQuestion) return false;
+  steerToMessage(conversationId, enqueuedRequestId);
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 
 import { peekAcpSessionManager } from "../../acp/index.js";
+import { resolveCanonicalGuardianRequest } from "../../memory/canonical-guardian-store.js";
 import { clearAll, getConversation } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
@@ -414,6 +415,55 @@ export function steerOnEnqueuedMessageIfQuestionParked(
   if (!hasParkedQuestion) return false;
   steerToMessage(conversationId, enqueuedRequestId);
   return true;
+}
+
+/**
+ * Supersede interactions left pending by an in-flight turn when a new message
+ * is enqueued for a busy conversation. Centralized so every ingress path (the
+ * HTTP send handler and the CLI signal path) gets identical handling:
+ *
+ *  1. Auto-deny pending confirmations — notify the client and sync the
+ *     canonical guardian record *before* clearing the prompter-owned
+ *     confirmations, so a later guardian reply can't match a stale "pending"
+ *     record and fail with `pending_interaction_not_found`.
+ *  2. Supersede a parked ask_question by steering to the enqueued message.
+ *
+ * Order matters: the steer aborts the turn, which denies the prompter's
+ * confirmations as a side effect, so the canonical/notification sync must run
+ * first. `removeByConversation` preserves `question` entries, so the parked
+ * question is still registered for the steer even after the confirmation sweep.
+ */
+export function supersedePendingInteractionsOnEnqueue(
+  conversationId: string,
+  enqueuedRequestId: string,
+): void {
+  const conversation = findConversation(conversationId);
+  if (!conversation) return;
+
+  if (conversation.hasAnyPendingConfirmation()) {
+    for (const interaction of pendingInteractions.getByConversation(
+      conversationId,
+    )) {
+      if (interaction.kind === "confirmation") {
+        // sendToClient (wired to the SSE hub) delivers the denial to clients.
+        conversation.emitConfirmationStateChanged({
+          conversationId,
+          requestId: interaction.requestId,
+          state: "denied" as const,
+          source: "auto_deny" as const,
+        });
+        // Sync the canonical guardian record so stale "pending" rows aren't
+        // matched by later guardian reply routing.
+        resolveCanonicalGuardianRequest(interaction.requestId, "pending", {
+          status: "denied",
+        });
+      }
+    }
+    conversation.denyAllPendingConfirmations();
+    pendingInteractions.removeByConversation(conversationId);
+  }
+
+  steerOnEnqueuedMessageIfQuestionParked(conversationId, enqueuedRequestId);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -124,4 +124,13 @@ export interface ToolSetupContext extends SurfaceConversationContext {
    * return `undefined` for the in-flight (background) subagent.
    */
   currentTurnOverrideProfile?: string;
+  /**
+   * Whether the current turn has no human present to answer clarification
+   * prompts. Resolved once per turn by the agent loop — honoring an explicit
+   * per-run `isInteractive` option (e.g. scheduled/background turns) over the
+   * live client state — so tool execution sees turn-level interactivity rather
+   * than re-deriving it from `hasNoClient`/`headlessLock`, which would read a
+   * scheduled turn running on a client-attached conversation as interactive.
+   */
+  currentTurnIsNonInteractive?: boolean;
 }

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -9,7 +9,7 @@ import type {
 
 // Use a tiny timeout so the setTimeout branch fires quickly in tests
 const mockConfig = {
-  timeouts: { permissionTimeoutSec: 0.05 },
+  timeouts: { questionResponseTimeoutSec: 0.05 },
 };
 // Preserve every other export from the real config/loader so other
 // tests in the same `bun test` run (which share module-level mocks)

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -156,9 +156,12 @@ export interface QuestionBatchMetadata {
  * the whole batch to `/v1/question-response` when the user is done — no
  * per-question accumulator, no partial state machine.
  *
- * Timeout reuses `getConfig().timeouts.permissionTimeoutSec` (default 5 min) —
- * questions are user-prompts in the same UX family as permission prompts and
- * secret prompts, so they share the same idle-timeout knob.
+ * The idle timeout is a backstop (`getConfig().timeouts.questionResponseTimeoutSec`,
+ * default 30 min), not the primary way a prompt is dismissed. An interactive
+ * user who moves on instead of answering enqueues another message, which
+ * supersedes the open prompt at the enqueue handler (see conversation-routes.ts);
+ * a non-interactive turn resolves immediately at the tool. The backstop only
+ * fires when a prompt is left open with no response and no follow-up message.
  */
 export class QuestionPrompter {
   async prompt(params: QuestionPromptParams): Promise<QuestionPromptResult> {
@@ -199,7 +202,7 @@ export class QuestionPrompter {
     const requestId = uuid();
 
     return new Promise<QuestionPromptResult>((resolve, reject) => {
-      const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
+      const timeoutMs = getConfig().timeouts.questionResponseTimeoutSec * 1000;
 
       // Closure-scoped idempotency guard. Every resolution path (timeout,
       // abort, route resolution via `rpcResolve`/`rpcReject`) routes through

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -229,6 +229,15 @@ export function getByConversation(
  * /v1/host-browser-result, /v1/host-app-control-result, or
  * /v1/host-transfer-result after completing the operation, get a 404, and the
  * proxy timer would fire with a spurious timeout error.
+ *
+ * `question` interactions are also skipped: a new message supersedes an open
+ * ask_question by steering to it (see the enqueue path in
+ * conversation-routes.ts), which aborts the parked turn and settles the
+ * question via its abort signal. Clearing the entry here instead would drop it
+ * without settling the prompt's Promise (questions carry no `rpcResolve`
+ * fallback like secrets do) and would strip the steer of the entry it needs to
+ * fire — which can co-occur with a confirmation, since one model response can
+ * open both tools concurrently.
  */
 export function removeByConversation(
   conversationId: string,
@@ -244,7 +253,8 @@ export function removeByConversation(
       interaction.kind !== "host_browser" &&
       interaction.kind !== "host_app_control" &&
       interaction.kind !== "host_transfer" &&
-      interaction.kind !== "acp_confirmation"
+      interaction.kind !== "acp_confirmation" &&
+      interaction.kind !== "question"
     ) {
       // resolve() clears the stored timer and detaches abort listeners.
       resolve(requestId, state);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -50,7 +50,7 @@ import {
   getCannedFirstGreeting,
   isWakeUpGreeting,
 } from "../../daemon/first-greeting.js";
-import { steerOnEnqueuedMessageIfQuestionParked } from "../../daemon/handlers/conversations.js";
+import { supersedePendingInteractionsOnEnqueue } from "../../daemon/handlers/conversations.js";
 import {
   collectAttachmentRefs,
   type HistoryAttachmentRef,
@@ -1818,38 +1818,11 @@ export async function handleSendMessage(
     // the client showing "Failed to send" for a message the daemon will
     // process from the queue.
     try {
-      if (conversation.hasAnyPendingConfirmation()) {
-        // Emit authoritative denial state for each pending request.
-        // sendToClient (wired to the SSE hub) delivers these to the client.
-        for (const interaction of pendingInteractions.getByConversation(
-          mapping.conversationId,
-        )) {
-          if (interaction.kind === "confirmation") {
-            conversation.emitConfirmationStateChanged({
-              conversationId: mapping.conversationId,
-              requestId: interaction.requestId,
-              state: "denied" as const,
-              source: "auto_deny" as const,
-            });
-            // Sync canonical guardian request status so stale "pending" DB
-            // records don't get matched by later guardian reply routing.
-            resolveCanonicalGuardianRequest(interaction.requestId, "pending", {
-              status: "denied",
-            });
-          }
-        }
-        conversation.denyAllPendingConfirmations();
-        pendingInteractions.removeByConversation(mapping.conversationId);
-      }
-
-      // A queued chat message while a clarification question is open means the
-      // user chose to move on rather than answer it; steer to it instead of
-      // stranding it behind a prompt no one will answer. This runs after the
-      // confirmation auto-deny: removeByConversation() preserves `question`
-      // entries (one model response can open an ask_question and a confirmation
-      // concurrently via Promise.all), so the parked question is still
-      // registered here for the steer to abort and drain.
-      steerOnEnqueuedMessageIfQuestionParked(mapping.conversationId, requestId);
+      // Supersede interactions left pending by the in-flight turn: auto-deny
+      // confirmations (with canonical/client sync) and steer to the enqueued
+      // message if an ask_question is parked. Centralized so the CLI signal
+      // path (signals/user-message.ts) gets identical handling.
+      supersedePendingInteractionsOnEnqueue(mapping.conversationId, requestId);
 
       // Expire any orphaned canonical requests that survived without a
       // matching in-memory pending interaction (e.g. prompter timeouts).

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1818,6 +1818,17 @@ export async function handleSendMessage(
     // the client showing "Failed to send" for a message the daemon will
     // process from the queue.
     try {
+      // A queued chat message while a clarification question is open means the
+      // user chose to move on rather than answer it; steer to it instead of
+      // stranding it behind a prompt no one will answer. This must run before
+      // the confirmation auto-deny below: a single model response can open an
+      // ask_question and a confirmation concurrently (tools run via Promise.all),
+      // and removeByConversation() would otherwise clear the question entry
+      // before the steer fires, leaving the queued message stuck behind an
+      // unresolved question. Steering aborts the parked turn synchronously,
+      // which settles the question via its turn-abort signal.
+      steerOnEnqueuedMessageIfQuestionParked(mapping.conversationId, requestId);
+
       if (conversation.hasAnyPendingConfirmation()) {
         // Emit authoritative denial state for each pending request.
         // sendToClient (wired to the SSE hub) delivers these to the client.
@@ -1841,13 +1852,6 @@ export async function handleSendMessage(
         conversation.denyAllPendingConfirmations();
         pendingInteractions.removeByConversation(mapping.conversationId);
       }
-
-      // A queued chat message while a clarification question is open means the
-      // user chose to move on rather than answer it; steer to it instead of
-      // stranding it behind a prompt no one will answer. A turn parks on at most
-      // one interactive tool, so this and the confirmation auto-deny above are
-      // mutually exclusive in practice.
-      steerOnEnqueuedMessageIfQuestionParked(mapping.conversationId, requestId);
 
       // Expire any orphaned canonical requests that survived without a
       // matching in-memory pending interaction (e.g. prompter timeouts).

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1818,17 +1818,6 @@ export async function handleSendMessage(
     // the client showing "Failed to send" for a message the daemon will
     // process from the queue.
     try {
-      // A queued chat message while a clarification question is open means the
-      // user chose to move on rather than answer it; steer to it instead of
-      // stranding it behind a prompt no one will answer. This must run before
-      // the confirmation auto-deny below: a single model response can open an
-      // ask_question and a confirmation concurrently (tools run via Promise.all),
-      // and removeByConversation() would otherwise clear the question entry
-      // before the steer fires, leaving the queued message stuck behind an
-      // unresolved question. Steering aborts the parked turn synchronously,
-      // which settles the question via its turn-abort signal.
-      steerOnEnqueuedMessageIfQuestionParked(mapping.conversationId, requestId);
-
       if (conversation.hasAnyPendingConfirmation()) {
         // Emit authoritative denial state for each pending request.
         // sendToClient (wired to the SSE hub) delivers these to the client.
@@ -1852,6 +1841,15 @@ export async function handleSendMessage(
         conversation.denyAllPendingConfirmations();
         pendingInteractions.removeByConversation(mapping.conversationId);
       }
+
+      // A queued chat message while a clarification question is open means the
+      // user chose to move on rather than answer it; steer to it instead of
+      // stranding it behind a prompt no one will answer. This runs after the
+      // confirmation auto-deny: removeByConversation() preserves `question`
+      // entries (one model response can open an ask_question and a confirmation
+      // concurrently via Promise.all), so the parked question is still
+      // registered here for the steer to abort and drain.
+      steerOnEnqueuedMessageIfQuestionParked(mapping.conversationId, requestId);
 
       // Expire any orphaned canonical requests that survived without a
       // matching in-memory pending interaction (e.g. prompter timeouts).

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -50,6 +50,7 @@ import {
   getCannedFirstGreeting,
   isWakeUpGreeting,
 } from "../../daemon/first-greeting.js";
+import { steerOnEnqueuedMessageIfQuestionParked } from "../../daemon/handlers/conversations.js";
 import {
   collectAttachmentRefs,
   type HistoryAttachmentRef,
@@ -946,25 +947,28 @@ export function handleListMessages({
         .filter((block) => block.type !== "text" || block.text.length > 0);
     }
 
-  // Ensure every hydrated attachment has a corresponding content block.
-  // renderHistoryContent inlines attachment blocks only when it has
-  // file-block refs with matching DB rows; directives (assistant-authored
-  // <vellum-attachment/> tags) don't leave a file block after stripping,
-  // so their attachments end up in the flat `attachments` array but not in
-  // `contentBlocks`. Append any that are missing so the canonical
-  // projection is complete.
-  const existingAttachmentIds = new Set(
-    contentBlocks
-      .filter((b): b is Extract<ConversationContentBlock, { type: "attachment" }> => b.type === "attachment")
-      .map((b) => b.attachment.id),
-  );
-  for (const att of msgAttachments) {
-    if (!existingAttachmentIds.has(att.id)) {
-      contentBlocks.push({ type: "attachment", attachment: att });
+    // Ensure every hydrated attachment has a corresponding content block.
+    // renderHistoryContent inlines attachment blocks only when it has
+    // file-block refs with matching DB rows; directives (assistant-authored
+    // <vellum-attachment/> tags) don't leave a file block after stripping,
+    // so their attachments end up in the flat `attachments` array but not in
+    // `contentBlocks`. Append any that are missing so the canonical
+    // projection is complete.
+    const existingAttachmentIds = new Set(
+      contentBlocks
+        .filter(
+          (b): b is Extract<ConversationContentBlock, { type: "attachment" }> =>
+            b.type === "attachment",
+        )
+        .map((b) => b.attachment.id),
+    );
+    for (const att of msgAttachments) {
+      if (!existingAttachmentIds.has(att.id)) {
+        contentBlocks.push({ type: "attachment", attachment: att });
+      }
     }
-  }
 
-  const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
+    const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
 
     // Use sentAt (actual event time) for the display timestamp when available,
     // falling back to createdAt (persistence time). Clients use this display
@@ -1837,6 +1841,13 @@ export async function handleSendMessage(
         conversation.denyAllPendingConfirmations();
         pendingInteractions.removeByConversation(mapping.conversationId);
       }
+
+      // A queued chat message while a clarification question is open means the
+      // user chose to move on rather than answer it; steer to it instead of
+      // stranding it behind a prompt no one will answer. A turn parks on at most
+      // one interactive tool, so this and the confirmation auto-deny above are
+      // mutually exclusive in practice.
+      steerOnEnqueuedMessageIfQuestionParked(mapping.conversationId, requestId);
 
       // Expire any orphaned canonical requests that survived without a
       // matching in-memory pending interaction (e.g. prompter timeouts).

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -15,6 +15,7 @@ import { readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
+import { supersedePendingInteractionsOnEnqueue } from "../daemon/handlers/conversations.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
 import {
   processMessageInBackground,
@@ -131,6 +132,12 @@ async function dispatchUserMessage(params: {
         assistantMessageInterface: resolvedInterface,
       },
     });
+    if (!result.rejected) {
+      // Mirror the HTTP send path: a follow-up enqueued while the turn is busy
+      // auto-denies pending confirmations and supersedes a parked ask_question
+      // so it isn't stranded behind the prompt until the response backstop.
+      supersedePendingInteractionsOnEnqueue(conversationId, requestId);
+    }
     return { accepted: !result.rejected };
   }
 

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -136,7 +136,16 @@ async function dispatchUserMessage(params: {
       // Mirror the HTTP send path: a follow-up enqueued while the turn is busy
       // auto-denies pending confirmations and supersedes a parked ask_question
       // so it isn't stranded behind the prompt until the response backstop.
-      supersedePendingInteractionsOnEnqueue(conversationId, requestId);
+      // Best-effort — the message is already queued, so a cleanup failure must
+      // not surface as an error that makes the CLI retry and enqueue a duplicate.
+      try {
+        supersedePendingInteractionsOnEnqueue(conversationId, requestId);
+      } catch (err) {
+        log.warn(
+          { err, conversationId },
+          "Post-enqueue supersession failed — queued message unaffected",
+        );
+      }
     }
     return { accepted: !result.rejected };
   }

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -206,6 +206,35 @@ describe("AskQuestionTool.execute", () => {
     expect(result.content).toBe("Question aborted");
   });
 
+  test("short-circuits without prompting when no interactive user is present", async () => {
+    setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
+
+    const result = await askQuestionTool.execute(
+      validInput,
+      makeContext({ isInteractive: false }),
+    );
+
+    // The prompter must never be invoked — there is no one to answer, so the
+    // turn proceeds with defaults instead of parking on the response backstop.
+    expect(calls).toHaveLength(0);
+    expect(result.isError).toBe(false);
+    expect(result.content.toLowerCase()).toContain("no interactive user");
+  });
+
+  test("still prompts when isInteractive is true or unset", async () => {
+    setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
+
+    // The short-circuit keys off an explicit `false`, not a missing flag, so an
+    // interactive turn (or one that never set the flag) still prompts.
+    await askQuestionTool.execute(
+      validInput,
+      makeContext({ isInteractive: true }),
+    );
+    await askQuestionTool.execute(validInput, makeContext());
+
+    expect(calls).toHaveLength(2);
+  });
+
   test("rejects a question with fewer than 2 options", async () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
     const result = await askQuestionTool.execute(

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -182,6 +182,19 @@ export const askQuestionTool = {
 
     const questions: SingleQuestion[] = parsed.data.questions;
 
+    // No interactive user is present to answer (scheduled/headless/background
+    // turn). Don't park the turn on a prompt no one can resolve — proceed with
+    // defaults immediately. Non-interactive turns are already instructed not to
+    // ask (NON_INTERACTIVE_CONTEXT_BLOCK); this is the backstop for when the
+    // model asks anyway, so it doesn't wait out the full response timeout.
+    if (context.isInteractive === false) {
+      return {
+        content:
+          "No interactive user is present to answer; proceeding with reasonable defaults.",
+        isError: false,
+      };
+    }
+
     const prompter = new QuestionPrompter();
     const result = await prompter.prompt({
       conversationId: context.conversationId,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -528,8 +528,8 @@ export { isSideEffectTool } from "./side-effects.js";
  * handles cleanup before the executor wrapper trips.
  *
  * `ask_question` blocks on user input inside `execute()` via `QuestionPrompter`,
- * which waits up to `permissionTimeoutSec`. We give the wrapper the same 5s
- * buffer over that deadline so the prompter's own timeout fires first and
+ * which waits up to `questionResponseTimeoutSec`. We give the wrapper the same
+ * 5s buffer over that deadline so the prompter's own timeout fires first and
  * returns its clean "User did not respond within timeout" result — otherwise
  * the shorter generic budget trips first, orphaning the still-pending prompt
  * behind the confusing "may still be running in the background" error.
@@ -556,8 +556,8 @@ export function computePerToolTimeoutMs(
     return (shellTimeoutSec + 5) * 1000;
   }
   if (name === "ask_question") {
-    const { permissionTimeoutSec } = getConfig().timeouts;
-    return (permissionTimeoutSec + 5) * 1000;
+    const { questionResponseTimeoutSec } = getConfig().timeouts;
+    return (questionResponseTimeoutSec + 5) * 1000;
   }
   const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
   return safeTimeoutMs(rawTimeoutSec);


### PR DESCRIPTION
## Summary

Reworks `ask_question`'s lifetime so it is driven by liveness/lifecycle signals (turn-abort, client presence, the conversation queue) rather than a fixed 5-minute wall-clock idle timer that fired regardless of whether anyone was still there to answer.

- **Non-interactive short-circuit** (`ask-question-tool.ts`): when `context.isInteractive === false` (scheduled/headless/background turn), return immediately with defaults instead of parking on a prompt no one can answer. These turns are already told not to ask (`NON_INTERACTIVE_CONTEXT_BLOCK`); this backstops the model asking anyway so it does not wait out the timeout.
- **Enqueue supersession** (`conversation-routes.ts` + `handlers/conversations.ts`): a chat message enqueued while a question is open means the user moved on. `steerOnEnqueuedMessageIfQuestionParked` steers to that message — aborting the parked turn (which settles the open question via its shared turn-abort signal), repairing the dangling `tool_use`, and draining the message — instead of stranding it behind a prompt no one will answer. Reuses the existing, tested `steerToMessage` machinery.
- **Decoupled long backstop** (`timeouts.ts`, `question-prompter.ts`, `executor.ts`): the wall-clock timeout moves off `permissionTimeoutSec` (5 min) onto a new `questionResponseTimeoutSec` (default 30 min), now purely a backstop for a prompt left open with no response *and* no follow-up message. The executor's per-tool budget for `ask_question` tracks the same knob so it cannot drift back into the collision fixed in #35733.

## Why

A parked `ask_question` blocks the conversation queue: a new message queues behind it (`conversation-messaging.ts`) and only drains when the turn completes — it does not auto-abort the parked turn. The old 5-minute timer was simultaneously too short for an interactive user who stepped away (it truncated the card's rehydrate-on-reconnect window) and too long for a non-interactive turn or a user who had already moved on. Keying the lifetime off the signals that actually mean "no one is answering" fixes both ends.

## Testing

- `ask-question-tool.test.ts`: non-interactive short-circuit issues no prompt; still prompts when interactive/unset.
- `steer-on-enqueue-question.test.ts`: an enqueue steers (aborts + flags repair) for a parked question, and does **not** for a confirmation or when nothing is parked.
- `tool-executor.test.ts`, `question-prompter.test.ts`, `config-schema.test.ts`: updated for the new config knob; the executor regression guard now asserts the budget tracks `questionResponseTimeoutSec`.
- All five files pass in isolation; `tsc` clean for changed files (remaining errors are pre-existing `@slack/types` / `gateway-client` cross-package noise). CI skipped per request.

## Original prompt

Follow-up to #35733. The user asked whether `ask_question` should have a timeout at all or sit open forever. Investigation showed a parked prompt blocks the conversation queue, the old 5-minute timer was the wrong instrument, and the enqueue + abort signals already encode "the user moved on." This PR makes the prompt's lifetime liveness-driven. Opened for review, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)