### PR TITLE
feat(gateway-client): add optional resolutionFailed signal to TrustVerdict

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3973,6 +3973,8 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        resolutionFailed:
+                          type: boolean
                         guardianExternalUserId:
                           type: string
                         guardianDeliveryChatId:

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -43,6 +43,23 @@ describe("TrustVerdictSchema", () => {
     expect(TrustVerdictSchema.parse(minimal)).toEqual(minimal);
   });
 
+  test("parses a verdict carrying resolutionFailed", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: null,
+      resolutionFailed: true,
+    } satisfies TrustVerdict;
+    expect(TrustVerdictSchema.parse(verdict)).toEqual(verdict);
+  });
+
+  test("leaves resolutionFailed undefined when absent", () => {
+    const parsed = TrustVerdictSchema.parse({
+      trustClass: "unknown",
+      canonicalSenderId: null,
+    });
+    expect(parsed.resolutionFailed).toBeUndefined();
+  });
+
   test("rejects an invalid trustClass", () => {
     expect(() =>
       TrustVerdictSchema.parse({

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -42,6 +42,11 @@ export const TrustVerdictSchema = z.object({
   trustClass: TrustClassSchema,
   canonicalSenderId: z.string().nullable(),
 
+  // Present+true ⇒ gateway attempted resolution but failed (DB error);
+  // consumer treats it as "could not vouch", distinct from a real `unknown`
+  // stranger.
+  resolutionFailed: z.boolean().optional(),
+
   // Guardian binding — present only when a guardian binding matches.
   guardianExternalUserId: z.string().optional(),
   guardianDeliveryChatId: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary
- Add optional `resolutionFailed` boolean to `TrustVerdictSchema`: a gateway resolver failure is distinguishable from a real stranger / absent verdict.
- Regenerate `assistant/openapi.yaml` (TrustVerdict flows into SourceMetadata). Additive, non-breaking.

Part of plan: voice-consumes-trust-verdict.md (PR 1 of 7)