### PR TITLE
fix(assistant): test trust-verdict mirror matches gateway address-only matching

### DIFF
--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -138,16 +138,11 @@ function stampTrustVerdict(body: Record<string, unknown>): void {
   const channelType = String(body.sourceChannel ?? "");
   const actorExternalId =
     typeof body.actorExternalId === "string" ? body.actorExternalId : undefined;
-  const externalChatId =
-    typeof body.conversationExternalId === "string"
-      ? body.conversationExternalId
-      : undefined;
   if (!channelType) return;
 
   const verdict = resolveLocalTrustVerdict({
     channelType,
     actorExternalId,
-    externalChatId,
   });
   body.sourceMetadata = { ...(meta ?? {}), trustVerdict: verdict };
 }
@@ -156,15 +151,14 @@ function stampTrustVerdict(body: Record<string, unknown>): void {
 export function resolveLocalTrustVerdict(input: {
   channelType: string;
   actorExternalId?: string;
-  externalChatId?: string;
 }): TrustVerdict {
   const canonicalSenderId = input.actorExternalId ?? null;
 
+  // Match the gateway's address-only member resolution (no externalChatId).
   const member = input.actorExternalId
     ? findContactChannel({
         channelType: input.channelType,
         address: input.actorExternalId,
-        externalChatId: input.externalChatId,
       })
     : null;
   const guardian = findGuardianForChannel(input.channelType);

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -272,7 +272,6 @@ describe("WhatsApp channel ingress attachment resolution", () => {
     const trustVerdict = resolveLocalTrustVerdict({
       channelType: "whatsapp",
       actorExternalId: WHATSAPP_USER_ID,
-      externalChatId: "whatsapp-chat-1",
     });
     return {
       sourceChannel: "whatsapp",


### PR DESCRIPTION
## Summary
- `resolveLocalTrustVerdict` (test adapter) resolves inbound members by address/actorExternalId only, mirroring the production gateway resolver; drops the externalChatId member fallback so tests can't admit a path production can't produce.
- Addresses the open #35732 review P2.

Part of plan: voice-consumes-trust-verdict.md (PR 7 of 7)