### PR TITLE
feat(assistant): acl-enforcement treats resolutionFailed verdict as observable fail-closed

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -249,6 +249,47 @@ describe("enforceIngressAcl — fail-closed on absent verdict", () => {
   });
 });
 
+describe("enforceIngressAcl — fail-closed on resolutionFailed verdict", () => {
+  test("resolutionFailed verdict → not_a_member deny, does not flow to intercepts", async () => {
+    inviteTokenForTest = "iv_token123";
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "sender-1",
+          resolutionFailed: true,
+        }),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+    // Distinct from a stranger: no invite redemption, onboarding, or
+    // guardian notification fires.
+    expect(result.earlyResponse!.inviteRedemption).toBeUndefined();
+    expect(deliverReplyCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+
+  test("real unknown stranger (no resolutionFailed) still redeems via intercept", async () => {
+    inviteTokenForTest = "iv_token123";
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "sender-1",
+        }),
+      }),
+    );
+
+    expect(result.earlyResponse!.inviteRedemption).toBe("redeemed");
+    expect(result.resolvedMember).toBeNull();
+  });
+});
+
 describe("enforceIngressAcl — fail-closed on malformed member verdict", () => {
   test("member identity + unknown policy → not_a_member deny even under strangers", async () => {
     const result = await enforceIngressAcl(

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -173,6 +173,24 @@ export async function enforceIngressAcl(
     };
   }
 
+  // Gateway attempted resolution but failed (DB error) → fail-closed deny,
+  // distinct from an absent verdict and from a real stranger. TEXT does not
+  // fall back to local ACL reads; the sender can retry.
+  if (verdict.resolutionFailed === true) {
+    log.warn(
+      { sourceChannel, externalUserId: canonicalSenderId },
+      "Ingress ACL: gateway trust resolution failed, denying fail-closed",
+    );
+    return {
+      resolvedMember: null,
+      earlyResponse: {
+        accepted: true,
+        denied: true,
+        reason: "not_a_member",
+      },
+    };
+  }
+
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member intercepts.
   const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);


### PR DESCRIPTION
## Summary
- A present verdict with `resolutionFailed: true` (gateway resolver error) fail-closes with a distinct structured log, separate from the absent-verdict deny and from real strangers (which still flow through intercepts).

Part of plan: voice-consumes-trust-verdict.md (PR 4 of 7)