### PR TITLE
feat(gateway): stamp resolutionFailed sentinel verdict on resolver error

### DIFF
--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -5,7 +5,8 @@
  *    actor's gateway-DB ACL (guardian / trusted_contact / unknown).
  *  - The `admissionPolicy` floor stamp coexists unchanged with the new verdict.
  *  - The verification-code intercept short-circuits — no forward, no stamp.
- *  - A resolver failure omits the stamp and still forwards (fail-soft).
+ *  - A resolver failure stamps a `resolutionFailed` sentinel and still forwards
+ *    (fail-soft).
  *
  * Module mocks isolate the test from the live runtime client. The
  * verification intercept is mocked per-test so the default path forwards.
@@ -244,13 +245,15 @@ describe("handle-inbound trust verdict stamping", () => {
     expect(verdict.memberDisplayName).toBe("Trusted Member");
   });
 
-  test("unknown actor (no rows) → trustVerdict 'unknown', canonicalSenderId set", async () => {
+  test("unknown actor (no rows) → trustVerdict 'unknown', canonicalSenderId set, not resolutionFailed", async () => {
     await handleInbound(makeConfig(), makeEvent(), ROUTING);
 
     const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
     expect(verdict.trustClass).toBe("unknown");
     expect(verdict.canonicalSenderId).toBe("U_USER_1");
     expect(verdict.contactId).toBeUndefined();
+    // A real stranger is NOT flagged as a resolver failure.
+    expect(verdict.resolutionFailed).toBeUndefined();
   });
 
   test("admissionPolicy stamp present and unchanged alongside the new trustVerdict", async () => {
@@ -278,7 +281,7 @@ describe("handle-inbound trust verdict stamping", () => {
     expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
   });
 
-  test("resolver throw → inbound still forwards, trustVerdict absent (fail-soft)", async () => {
+  test("resolver throw → inbound forwards with a resolutionFailed sentinel (fail-soft)", async () => {
     // Drop the gateway DB connection so resolveTrustVerdict's getGatewayDb()
     // throws. The admission cache is in-memory and unaffected, so its floor
     // stamp still flows.
@@ -288,7 +291,11 @@ describe("handle-inbound trust verdict stamping", () => {
 
     expect(result.forwarded).toBe(true);
     expect(forwardToRuntimeMock).toHaveBeenCalledTimes(1);
-    expect(runtimePayloads[0]!.sourceMetadata!.trustVerdict).toBeUndefined();
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.resolutionFailed).toBe(true);
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.canonicalSenderId).toBe("U_USER_1");
+    expect(verdict.contactId).toBeUndefined();
     // The floor stamp still flows even when verdict resolution fails.
     expect(runtimePayloads[0]!.sourceMetadata!.admissionPolicy).toBe(
       "trusted_contacts",

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -166,9 +166,17 @@ export async function handleInbound(
       actorExternalId: event.actor.actorExternalId,
     });
   } catch (err) {
-    // Producer fails soft — resolution never breaks ingress. trustVerdict
-    // stays undefined so the stamp is omitted; the consumer owns deny policy.
-    log.warn({ err }, "trust verdict resolution failed; omitting stamp");
+    // Producer fails soft — resolution never breaks ingress. Stamp a sentinel
+    // so the consumer can tell a resolver failure from a real stranger.
+    log.warn({ err }, "trust verdict resolution failed; stamping sentinel");
+    trustVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: canonicalizeInboundIdentity(
+        event.sourceChannel,
+        event.actor.actorExternalId,
+      ),
+      resolutionFailed: true,
+    };
   }
 
   try {

--- a/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
@@ -132,7 +132,7 @@ describe("resolve_inbound_trust route", () => {
     );
   });
 
-  test("unknown actor → unknown verdict matching the resolver", async () => {
+  test("unknown actor → unknown verdict matching the resolver, not resolutionFailed", async () => {
     const params = { channelType: CHANNEL, actorExternalId: "U_STRANGER" };
     const result = (await route.handler(params)) as { verdict: unknown };
     const expected = await resolveTrustVerdict(params);
@@ -141,5 +141,28 @@ describe("resolve_inbound_trust route", () => {
     expect((result.verdict as { trustClass: string }).trustClass).toBe(
       "unknown",
     );
+    // A real stranger is NOT flagged as a resolver failure.
+    expect(
+      (result.verdict as { resolutionFailed?: boolean }).resolutionFailed,
+    ).toBeUndefined();
+  });
+
+  test("resolver throw → resolutionFailed sentinel verdict", async () => {
+    // Drop the gateway DB connection so resolveTrustVerdict's getGatewayDb()
+    // throws.
+    resetGatewayDb();
+
+    const params = { channelType: CHANNEL, actorExternalId: "U_STRANGER" };
+    const result = (await route.handler(params)) as {
+      verdict: {
+        trustClass: string;
+        canonicalSenderId: string | null;
+        resolutionFailed?: boolean;
+      };
+    };
+
+    expect(result.verdict.resolutionFailed).toBe(true);
+    expect(result.verdict.trustClass).toBe("unknown");
+    expect(result.verdict.canonicalSenderId).toBe("U_STRANGER");
   });
 });

--- a/gateway/src/ipc/trust-verdict-handlers.ts
+++ b/gateway/src/ipc/trust-verdict-handlers.ts
@@ -11,6 +11,7 @@
 import { ResolveInboundTrustRequestSchema } from "@vellumai/gateway-client";
 
 import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
+import { canonicalizeInboundIdentity } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
 
 export const trustVerdictRoutes: IpcRoute[] = [
@@ -19,7 +20,24 @@ export const trustVerdictRoutes: IpcRoute[] = [
     schema: ResolveInboundTrustRequestSchema,
     handler: async (params?: Record<string, unknown>) => {
       const input = ResolveInboundTrustRequestSchema.parse(params);
-      return { verdict: await resolveTrustVerdict(input) };
+      try {
+        return { verdict: await resolveTrustVerdict(input) };
+      } catch {
+        // Sentinel lets the daemon distinguish a resolver failure from a real
+        // stranger.
+        return {
+          verdict: {
+            trustClass: "unknown",
+            canonicalSenderId: input.actorExternalId
+              ? canonicalizeInboundIdentity(
+                  input.channelType,
+                  input.actorExternalId,
+                )
+              : null,
+            resolutionFailed: true,
+          },
+        };
+      }
     },
   },
 ];


### PR DESCRIPTION
## Summary
- On a trust-verdict resolver error, the gateway now stamps (text) / returns (resolve_inbound_trust IPC) a `resolutionFailed: true` sentinel verdict instead of omitting the stamp, so the daemon can distinguish a resolver failure from a real stranger / absent verdict.
- `resolveTrustVerdict` unchanged; sentinel built only in the callers' catch blocks.

Part of plan: voice-consumes-trust-verdict.md (PR 3 of 7)