### PR TITLE
feat(assistant): voice call setup resolves caller trust from the gateway verdict

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -176,6 +176,15 @@ mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: mockGetChannelAdmissionPolicy,
 }));
 
+// Mock the inbound trust reader. handleStart awaits this and threads the
+// verdict into routeSetup so the media-stream transport enforces the same
+// gateway ACL as ConversationRelay. Tests override mockInboundVerdict.
+let mockInboundVerdict: unknown = null;
+const mockGetInboundTrustVerdict = jest.fn(async () => mockInboundVerdict);
+mock.module("../calls/inbound-trust-reader.js", () => ({
+  getInboundTrustVerdict: mockGetInboundTrustVerdict,
+}));
+
 // Mock the actor trust resolver (used by handleStart to derive trust context)
 mock.module("../runtime/actor-trust-resolver.js", () => ({
   toTrustContext: jest.fn(() => ({
@@ -356,6 +365,8 @@ beforeEach(() => {
   mockGetChannelAdmissionPolicy.mockClear();
   mockAdmissionPolicy = null;
   mockAdmissionGate = null;
+  mockGetInboundTrustVerdict.mockClear();
+  mockInboundVerdict = null;
   // Reset routeSetup to default normal_call
   mockRouteSetupResult = {
     outcome: { action: "normal_call" as const, isInbound: true },
@@ -1533,6 +1544,115 @@ describe("media-stream setup outcome scenarios", () => {
       expect(registerCallController).not.toHaveBeenCalled();
       expect(mockStartInitialGreeting).not.toHaveBeenCalled();
       expect(speakSystemPrompt).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Gateway trust verdict ──────────────────────────────────────────
+  // handleStart fetches getInboundTrustVerdict for the inbound caller and
+  // threads it into routeSetup, so the media-stream transport enforces the
+  // same gateway ACL as ConversationRelay. routeSetup itself decides
+  // verdict-vs-local; these tests assert the verdict is fetched and passed.
+
+  describe("gateway trust verdict", () => {
+    test("fetches the inbound caller's verdict and threads it into routeSetup", async () => {
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155550000",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "verified",
+        policy: "allow",
+        resolutionFailed: false,
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-verdict-thread-1", {
+        id: "call-verdict-thread-1",
+        conversationId: "conv-verdict-thread-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-verdict-thread-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Verdict fetched for the inbound caller (from number) on the phone channel.
+      expect(mockGetInboundTrustVerdict).toHaveBeenCalledWith({
+        channelType: "phone",
+        actorExternalId: "+14155550000",
+      });
+      // Verdict threaded into routeSetup.
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ verdict: mockInboundVerdict }),
+      );
+    });
+
+    test("a blocked/denied member verdict is enforced (deny) on the media-stream transport", async () => {
+      // The real router returns `deny` for a member verdict whose ACL is
+      // blocked/revoked/deny; the mock reflects that outcome here.
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155550000",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "blocked",
+        policy: "deny",
+        resolutionFailed: false,
+      };
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message:
+            "This number is not authorized to reach the assistant right now.",
+          logReason: "Inbound voice ACL: member blocked",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155550000",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-verdict-deny-1", {
+        id: "call-verdict-deny-1",
+        conversationId: "conv-verdict-deny-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-verdict-deny-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Verdict was passed into routeSetup, which denied the caller.
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ verdict: mockInboundVerdict }),
+      );
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "This number is not authorized to reach the assistant right now.",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-verdict-deny-1",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
     });
   });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -109,6 +109,18 @@ mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: async () => mockAdmissionPolicy,
 }));
 
+// Mock the inbound trust reader used by the media-stream preflight. Captures
+// its args so tests can assert the inbound caller's verdict is fetched, and
+// returns mockInboundVerdict which is threaded into the preflight routeSetup.
+let mockInboundVerdict: unknown = null;
+let lastInboundVerdictArgs: Record<string, unknown> | null = null;
+mock.module("../calls/inbound-trust-reader.js", () => ({
+  getInboundTrustVerdict: async (args: Record<string, unknown>) => {
+    lastInboundVerdictArgs = args;
+    return mockInboundVerdict;
+  },
+}));
+
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://gateway.internal:7830",
@@ -470,6 +482,8 @@ describe("twilio webhook routes", () => {
     // Reset admission policy + captured routeSetup context between tests
     mockAdmissionPolicy = null;
     lastRouteSetupCtx = null;
+    mockInboundVerdict = null;
+    lastInboundVerdictArgs = null;
     // Reset routeSetup mock to default normal_call
     mockRouteSetupResult = {
       outcome: { action: "normal_call", isInbound: true },
@@ -1267,6 +1281,81 @@ describe("twilio webhook routes", () => {
       // classification matches the real stream-start enforcement.
       expect(lastRouteSetupCtx).not.toBeNull();
       expect(lastRouteSetupCtx?.admissionPolicy).toBe("guardian_only");
+    });
+
+    test("media-stream inbound: fetches the caller's verdict (From) and threads it into the preflight routeSetup", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155551234",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "verified",
+        policy: "allow",
+        resolutionFailed: false,
+      };
+
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_ms_verdict_inbound_1",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      // Inbound: verdict fetched for the caller (From) on the phone channel.
+      expect(lastInboundVerdictArgs).toEqual({
+        channelType: "phone",
+        actorExternalId: "+14155551234",
+      });
+      // Verdict threaded into the preflight routeSetup.
+      expect(lastRouteSetupCtx?.verdict).toEqual(mockInboundVerdict);
+    });
+
+    test("media-stream inbound: a blocked/denied member verdict is classified deny in the preflight", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155551234",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "blocked",
+        policy: "deny",
+        resolutionFailed: false,
+      };
+      // The real router returns `deny` for a blocked member verdict; the mock
+      // reflects that outcome. deny is supported on media-stream, so the
+      // preflight still emits Stream TwiML (denial spoken at stream start).
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message:
+            "This number is not authorized to reach the assistant right now.",
+          logReason: "Inbound voice ACL: member blocked",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_ms_verdict_deny_1",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      // Verdict was threaded into routeSetup, which denied the caller.
+      expect(lastRouteSetupCtx?.verdict).toEqual(mockInboundVerdict);
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
     });
 
     test("media-stream: floor-denied caller classified deny still produces Stream TwiML (deny handled at stream level)", async () => {

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -462,3 +462,74 @@ describe("routeSetup — caller-trust source", () => {
     expect(outcome.action).toBe("deny");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Verdict-path ACL: blocked / revoked / deny enforced from the verdict-derived
+// memberRecord (no local fallback). Guards the P1 where a verdict member with
+// no memberRecord bypassed these gates.
+// ---------------------------------------------------------------------------
+
+describe("routeSetup — verdict path enforces member ACL", () => {
+  test("blocked member via verdict is denied (not normal_call) under permissive floor", () => {
+    verdictTrust = makeTrust("unknown", { status: "blocked" });
+    const { outcome } = route("strangers", makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("revoked member via verdict is denied under permissive floor", () => {
+    verdictTrust = makeTrust("unknown", { status: "revoked" });
+    const { outcome } = route("strangers", makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("policy deny member via verdict is denied (not normal_call)", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "deny",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("policy escalate member via verdict is denied (live call can't await approval)", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "escalate",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("trusted/active member via verdict still admits to normal_call", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "allow",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("normal_call");
+  });
+
+  test("guardian via verdict still admits to normal_call", () => {
+    verdictTrust = makeTrust("guardian", {
+      status: "active",
+      role: "guardian",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("normal_call");
+  });
+});

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -15,7 +15,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
+import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 
 import type {
   ChannelPolicy,
@@ -38,10 +38,19 @@ mock.module("../../config/loader.js", () => ({
   getConfig: () => ({ calls: { verification: { enabled: false } } }),
 }));
 
-// Controllable resolved trust context.
+// Controllable resolved trust context. `resolveActorTrust` is a tracked mock
+// so the verdict-source tests can assert the local fallback fires (or not).
 let nextTrust: ActorTrustContext;
+const resolveActorTrustMock = mock(() => nextTrust);
 mock.module("../../runtime/actor-trust-resolver.js", () => ({
-  resolveActorTrust: () => nextTrust,
+  resolveActorTrust: resolveActorTrustMock,
+}));
+
+// Controllable verdict-derived trust context.
+let verdictTrust: ActorTrustContext;
+const actorTrustContextFromVerdictMock = mock(() => verdictTrust);
+mock.module("../../runtime/trust-verdict-consumer.js", () => ({
+  actorTrustContextFromVerdict: actorTrustContextFromVerdictMock,
 }));
 
 // Controllable pending verification challenge.
@@ -151,13 +160,17 @@ function makeTrust(
   };
 }
 
-function route(admissionPolicy?: AdmissionPolicy | null) {
+function route(
+  admissionPolicy?: AdmissionPolicy | null,
+  verdict?: TrustVerdict | null,
+) {
   return routeSetup({
     callSessionId: "cs_1",
     session: null, // inbound
     from: "+12025550142",
     to: "+12025550199",
     admissionPolicy,
+    verdict,
   });
 }
 
@@ -165,6 +178,8 @@ beforeEach(() => {
   pendingChallenge = null;
   activeInvites = [];
   boundContact = null;
+  resolveActorTrustMock.mockClear();
+  actorTrustContextFromVerdictMock.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -372,5 +387,78 @@ describe("routeSetup — floor bypasses", () => {
     pendingChallenge = { id: "vs_1" };
     const { outcome } = route("no_one");
     expect(outcome.action).toBe("verification");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caller-trust source: gateway verdict first, local fallback
+// ---------------------------------------------------------------------------
+
+function makeVerdict(overrides: Partial<TrustVerdict> = {}): TrustVerdict {
+  return {
+    trustClass: "guardian",
+    canonicalSenderId: "+12025550142",
+    ...overrides,
+  };
+}
+
+describe("routeSetup — caller-trust source", () => {
+  test("present verdict builds trust via actorTrustContextFromVerdict (no local resolve)", () => {
+    verdictTrust = makeTrust("guardian", {
+      status: "active",
+      role: "guardian",
+    });
+    const { resolved, outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("guardian");
+    expect(outcome.action).toBe("normal_call");
+  });
+
+  test("resolutionFailed verdict falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("guardian", { status: "active", role: "guardian" });
+    const { resolved } = route(null, makeVerdict({ resolutionFailed: true }));
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("guardian");
+  });
+
+  test("null verdict falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    const { resolved } = route(null, null);
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
+  });
+
+  test("absent verdict falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("guardian", { status: "active", role: "guardian" });
+    route(null);
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+  });
+
+  test("admission floor still applies on the verdict path (guardian_only denies trusted_contact)", () => {
+    verdictTrust = makeTrust("trusted_contact", { status: "active" });
+    const { outcome } = route("guardian_only", makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("admission floor still applies on the fallback path (guardian_only denies trusted_contact)", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    const { outcome } = route(
+      "guardian_only",
+      makeVerdict({ resolutionFailed: true }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("deny");
   });
 });

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -49,8 +49,31 @@ mock.module("../../runtime/actor-trust-resolver.js", () => ({
 // Controllable verdict-derived trust context.
 let verdictTrust: ActorTrustContext;
 const actorTrustContextFromVerdictMock = mock(() => verdictTrust);
+// Mirror the real fail-closed contract: a verdict claiming a member resolves
+// only with valid known status+policy enums; otherwise null (memberless or
+// malformed/mixed-version).
+const CHANNEL_STATUS_VALUES = [
+  "active",
+  "pending",
+  "revoked",
+  "blocked",
+  "unverified",
+];
+const CHANNEL_POLICY_VALUES = ["allow", "deny", "escalate"];
+const resolvedMemberFromVerdictMock = mock((verdict: TrustVerdict) => {
+  if (!verdict.contactId || !verdict.channelId) return null;
+  if (!verdict.status || !verdict.policy) return null;
+  if (
+    !CHANNEL_STATUS_VALUES.includes(verdict.status) ||
+    !CHANNEL_POLICY_VALUES.includes(verdict.policy)
+  ) {
+    return null;
+  }
+  return { contact: {}, channel: {} };
+});
 mock.module("../../runtime/trust-verdict-consumer.js", () => ({
   actorTrustContextFromVerdict: actorTrustContextFromVerdictMock,
+  resolvedMemberFromVerdict: resolvedMemberFromVerdictMock,
 }));
 
 // Controllable pending verification challenge.
@@ -180,6 +203,7 @@ beforeEach(() => {
   boundContact = null;
   resolveActorTrustMock.mockClear();
   actorTrustContextFromVerdictMock.mockClear();
+  resolvedMemberFromVerdictMock.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -530,6 +554,96 @@ describe("routeSetup — verdict path enforces member ACL", () => {
     const { outcome } = route(null, makeVerdict());
 
     expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("normal_call");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unresolvable member verdict → local fallback (never trust an un-ACL-checkable
+// member). A verdict claiming a member (contactId/channelId) whose ACL can't be
+// reassembled (missing/unknown status·policy) must take the local resolveActorTrust
+// path so the member is ACL-checked locally, not trusted by trustClass.
+// ---------------------------------------------------------------------------
+
+describe("routeSetup — unresolvable member verdict falls back to local", () => {
+  test("member identity with missing status falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    const { resolved } = route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        policy: "allow",
+        // status absent → unresolvable
+      }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
+  });
+
+  test("member identity with unknown status falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        status: "bogus",
+        policy: "allow",
+      }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+  });
+
+  test("member identity with unknown policy falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        status: "active",
+        policy: "bogus",
+      }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+  });
+
+  test("real stranger verdict (no member identity) still takes the verdict path", () => {
+    verdictTrust = makeTrust("unknown");
+    route(null, makeVerdict({ trustClass: "unknown" }));
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+  });
+
+  test("valid member verdict (good status+policy) still takes the verdict path", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "allow",
+    });
+    const { outcome } = route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        status: "active",
+        policy: "allow",
+      }),
+    );
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("normal_call");
   });
 });

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -52,6 +52,7 @@ import {
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
+import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import { MediaStreamOutput } from "./media-stream-output.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type { MediaStreamStartEvent } from "./media-stream-protocol.js";
@@ -391,6 +392,28 @@ export class MediaStreamCallSession {
       return;
     }
 
+    // Verdict-first caller trust so this transport enforces the same gateway
+    // ACL as ConversationRelay. routeSetup uses it when present and not
+    // resolutionFailed, else falls back to local resolution. The reader returns
+    // null on failure, keeping the local path on a gateway blip.
+    const isInbound = session?.initiatedFromConversationId == null;
+    const otherPartyNumber = isInbound ? from : to;
+    const verdict = await getInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    });
+
+    // The verdict read above yields the event loop; abort if the session was
+    // disposed meanwhile, matching the admission-read guard above.
+    if (this.disposed) {
+      log.info(
+        { callSessionId: this.callSessionId },
+        "Media-stream session disposed during verdict read — aborting setup",
+      );
+      this.setupRouting = false;
+      return;
+    }
+
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,
       session: session ?? null,
@@ -398,6 +421,7 @@ export class MediaStreamCallSession {
       to,
       customParameters: event.start.customParameters,
       admissionPolicy,
+      verdict,
     });
 
     log.info(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -8,7 +8,7 @@
 
 import { randomInt } from "node:crypto";
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
+import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import {
@@ -50,6 +50,7 @@ import {
 import { ConversationRelayTransport } from "./call-transport.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
+import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import {
   classifyWaitUtterance,
   emitAccessRequestCallbackHandoff,
@@ -585,8 +586,18 @@ export class RelayConnection {
     // open to `null` by contract, so a transport hiccup admits the caller.
     const admissionPolicy = await getChannelAdmissionPolicy("phone");
 
+    // Verdict-first caller trust. routeSetup uses it when present and not
+    // resolutionFailed, else falls back to local resolution. The reader
+    // returns null on failure, so a gateway blip keeps the local path.
+    const isInbound = session?.initiatedFromConversationId == null;
+    const otherPartyNumber = isInbound ? msg.from : msg.to;
+    const verdict = await getInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    });
+
     try {
-      await this.routeSetupOutcome(msg, session, admissionPolicy);
+      await this.routeSetupOutcome(msg, session, admissionPolicy, verdict);
     } catch (err) {
       // Never leave the connection stranded in "setting_up": a setup that
       // throws before reaching a terminal outcome would otherwise drop every
@@ -615,6 +626,7 @@ export class RelayConnection {
     msg: RelaySetupMessage,
     session: ReturnType<typeof getCallSession>,
     admissionPolicy: AdmissionPolicy | null,
+    verdict: TrustVerdict | null,
   ): Promise<void> {
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,
@@ -623,6 +635,7 @@ export class RelayConnection {
       to: msg.to,
       customParameters: msg.customParameters,
       admissionPolicy,
+      verdict,
     });
 
     const initialTrustContext = toTrustContext(

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -6,7 +6,7 @@
  * next — without performing any side effects itself.
  */
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
+import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 
 import { getConfig } from "../config/loader.js";
 import { getContact } from "../contacts/contact-store.js";
@@ -21,6 +21,7 @@ import {
   type AdmissionPolicyResult,
   enforceAdmissionPolicy,
 } from "../runtime/routes/inbound-stages/admission-policy.js";
+import { actorTrustContextFromVerdict } from "../runtime/trust-verdict-consumer.js";
 import { getLogger } from "../util/logger.js";
 import type { CallSession } from "./types.js";
 
@@ -40,6 +41,12 @@ interface SetupContext {
    * preserving all pre-admission behavior.
    */
   admissionPolicy?: AdmissionPolicy | null;
+  /**
+   * Gateway-stamped caller trust verdict. When present and not
+   * `resolutionFailed`, the caller's trust is built from it; otherwise the
+   * router falls back to local resolution.
+   */
+  verdict?: TrustVerdict | null;
 }
 
 // ── Setup outcomes ───────────────────────────────────────────────────
@@ -112,12 +119,23 @@ export function routeSetup(ctx: SetupContext): {
   const isInbound = ctx.session?.initiatedFromConversationId == null;
   const otherPartyNumber = isInbound ? ctx.from : ctx.to;
 
-  const actorTrust = resolveActorTrust({
-    assistantId,
-    sourceChannel: "phone",
-    conversationExternalId: otherPartyNumber,
-    actorExternalId: otherPartyNumber || undefined,
-  });
+  // Verdict-first: build caller trust from the gateway verdict when present.
+  // Voice falls back to local resolution on a missing/failed verdict so a
+  // gateway blip does not drop a known guardian's call — the deliberate
+  // difference from the fail-closed text path.
+  const actorTrust =
+    ctx.verdict && !ctx.verdict.resolutionFailed
+      ? actorTrustContextFromVerdict(ctx.verdict, {
+          sourceChannel: "phone",
+          conversationExternalId: otherPartyNumber,
+          actorDisplayName: undefined,
+        })
+      : resolveActorTrust({
+          assistantId,
+          sourceChannel: "phone",
+          conversationExternalId: otherPartyNumber,
+          actorExternalId: otherPartyNumber || undefined,
+        });
 
   const resolved: SetupResolved = {
     assistantId,

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -21,7 +21,10 @@ import {
   type AdmissionPolicyResult,
   enforceAdmissionPolicy,
 } from "../runtime/routes/inbound-stages/admission-policy.js";
-import { actorTrustContextFromVerdict } from "../runtime/trust-verdict-consumer.js";
+import {
+  actorTrustContextFromVerdict,
+  resolvedMemberFromVerdict,
+} from "../runtime/trust-verdict-consumer.js";
 import { getLogger } from "../util/logger.js";
 import type { CallSession } from "./types.js";
 
@@ -123,8 +126,19 @@ export function routeSetup(ctx: SetupContext): {
   // Voice falls back to local resolution on a missing/failed verdict so a
   // gateway blip does not drop a known guardian's call — the deliberate
   // difference from the fail-closed text path.
+  //
+  // A verdict that claims a member (contactId/channelId) but whose ACL can't be
+  // reassembled (malformed/mixed-version status·policy) also falls back to local
+  // resolution, so voice never trusts a member it cannot ACL-check. A real
+  // stranger verdict (no member identity) still takes the verdict path —
+  // memberRecord null is correct there.
+  const hasMemberIdentity = !!(
+    ctx.verdict?.contactId || ctx.verdict?.channelId
+  );
+  const memberUnresolvable =
+    hasMemberIdentity && resolvedMemberFromVerdict(ctx.verdict!) === null;
   const actorTrust =
-    ctx.verdict && !ctx.verdict.resolutionFailed
+    ctx.verdict && !ctx.verdict.resolutionFailed && !memberUnresolvable
       ? actorTrustContextFromVerdict(ctx.verdict, {
           sourceChannel: "phone",
           conversationExternalId: otherPartyNumber,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -55,6 +55,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
+import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
@@ -484,12 +485,24 @@ async function buildVoiceWebhookTwiml(
   // admits the caller.
   const admissionPolicy = await getChannelAdmissionPolicy("phone");
 
+  // Verdict-first caller trust so this preflight matches handleSetup's ACL.
+  // routeSetup uses it when present and not resolutionFailed, else falls back
+  // to local resolution. The reader returns null on failure, keeping the
+  // local path on a gateway blip.
+  const isInbound = sessionContext?.direction !== "outbound";
+  const otherPartyNumber = isInbound ? from : to;
+  const verdict = await getInboundTrustVerdict({
+    channelType: "phone",
+    actorExternalId: otherPartyNumber || undefined,
+  });
+
   const { outcome } = routeSetup({
     callSessionId,
     session: session ?? null,
     from,
     to,
     admissionPolicy,
+    verdict,
   });
 
   // The media-stream transport supports normal_call and deny (which speaks

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -265,6 +265,62 @@ describe("actorTrustContextFromVerdict", () => {
     expect(ctx.actorMetadata.displayName).toBeUndefined();
   });
 
+  test("member verdict populates memberRecord from the verdict (voice ACL)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "blocked",
+      policy: "deny",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.memberRecord).not.toBeNull();
+    expect(ctx.memberRecord!.contact.id).toBe("contact-1");
+    expect(ctx.memberRecord!.channel.id).toBe("channel-1");
+    expect(ctx.memberRecord!.channel.status).toBe("blocked");
+    expect(ctx.memberRecord!.channel.policy).toBe("deny");
+  });
+
+  test("stranger verdict (no contactId/channelId) leaves memberRecord null", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-9",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.memberRecord).toBeNull();
+  });
+
+  test("malformed member verdict (unknown status) leaves memberRecord null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-10",
+      contactId: "contact-10",
+      channelId: "channel-10",
+      status: "quarantined",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.memberRecord).toBeNull();
+  });
+
   test("trustContextFromVerdict equals member stamp applied to toTrustContext(actorTrustContextFromVerdict)", () => {
     const verdict = {
       trustClass: "trusted_contact",

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -323,8 +323,8 @@ export function toTrustContext(
     requesterMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
     requesterChatId: conversationExternalId,
-    // Member grounding from a real memberRecord (voice path); the verdict path
-    // (memberRecord=null) stamps these from the verdict instead.
+    // Member grounding from the resolved memberRecord (voice + verdict paths
+    // both populate it).
     requesterContactId: ctx.memberRecord?.contact.id,
     memberStatus: ctx.memberRecord
       ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -61,7 +61,12 @@ export function actorTrustContextFromVerdict(
         }
       : null,
     guardianPrincipalId: verdict.guardianPrincipalId,
-    memberRecord: null,
+    // Populate from the verdict so the voice path's ACL gates (which read
+    // actorTrust.memberRecord.channel status/policy) enforce blocked/revoked/
+    // deny/escalate. Null for memberless verdicts. Text path is unaffected:
+    // toTrustContext derives the same member fields trustContextFromVerdict
+    // already stamps.
+    memberRecord: resolvedMemberFromVerdict(verdict),
     trustClass: verdict.trustClass,
     actorMetadata: {
       identifier,


### PR DESCRIPTION
## Summary
- Voice setup fetches the gateway trust verdict (`getInboundTrustVerdict`) and builds the caller's ActorTrustContext via `actorTrustContextFromVerdict`; falls back to local `resolveActorTrust` only on a resolutionFailed/absent verdict so a gateway blip never drops a known guardian's call.
- Admission floor + routing + controller flow unchanged. Voice guardian-delivery/routing reads untouched (deferred).

Part of plan: voice-consumes-trust-verdict.md (PR 5 of 7)