### PR TITLE
feat(assistant): voice mid-call verification re-resolves trust from the gateway verdict

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -163,6 +163,34 @@ mock.module("../calls/channel-admission-reader.js", () => ({
   },
 }));
 
+// ── Inbound trust verdict reader mock ───────────────────────────────
+//
+// Mid-call re-resolution (post verification/activation) prefers the gateway
+// verdict via getInboundTrustVerdict, falling back to local resolution on a
+// missing/failed/unusable verdict. Tests drive the verdict through
+// `mockMidCallVerdict`; null (the default) exercises the local fallback. As
+// with the admission reader, delegate to the real module for sibling files
+// that load later in the same worker.
+let mockMidCallVerdict:
+  | import("@vellumai/gateway-client").TrustVerdict
+  | null = null;
+const realInboundTrustReaderModule = {
+  ...(await import("../calls/inbound-trust-reader.js")),
+};
+let inboundTrustMockActive = false;
+mock.module("../calls/inbound-trust-reader.js", () => ({
+  ...realInboundTrustReaderModule,
+  getInboundTrustVerdict: async (input: {
+    channelType: import("../channels/types.js").ChannelId;
+    actorExternalId?: string;
+  }) => {
+    if (!inboundTrustMockActive) {
+      return realInboundTrustReaderModule.getInboundTrustVerdict(input);
+    }
+    return mockMidCallVerdict;
+  },
+}));
+
 // ── TTS provider mocks (for call-speech-output) ─────────────────────
 
 let mockTtsProviderId: string = "elevenlabs";
@@ -308,10 +336,12 @@ await initializeDb();
 // sibling files that load later in the same worker.
 beforeAll(() => {
   admissionMockActive = true;
+  inboundTrustMockActive = true;
 });
 
 afterAll(() => {
   admissionMockActive = false;
+  inboundTrustMockActive = false;
   resetDbForTesting();
 });
 
@@ -479,6 +509,7 @@ describe("relay-server", () => {
     mockAssistantName = "Vellum";
     mockAdmissionPolicy = null;
     mockAdmissionGate = null;
+    mockMidCallVerdict = null;
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
     mockConfig.calls.verification.maxAttempts = 3;
@@ -5439,5 +5470,159 @@ describe("relay-server", () => {
 
       relay.destroy();
     });
+  });
+
+  // ── Mid-call trust re-resolution from the gateway verdict ───────────
+  //
+  // After a verification/activation success the relay re-resolves caller trust.
+  // It prefers the gateway verdict (authoritative right after the gateway
+  // updated the binding) and falls back to local resolution on a missing/
+  // failed/unusable verdict so a blip never drops the call.
+
+  function readControllerTrustClass(relay: RelayConnection): string | undefined {
+    return (
+      relay.getController() as unknown as {
+        trustContext?: { trustClass?: string };
+      }
+    )?.trustContext?.trustClass;
+  }
+
+  test("inbound guardian verification: re-resolves trust from the gateway verdict", async () => {
+    ensureConversation("conv-midcall-verdict-guardian");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-guardian",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // The gateway verdict upgrades the caller to guardian post-verification.
+    mockMidCallVerdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "+15559999999",
+      guardianExternalUserId: "+15559999999",
+      guardianPrincipalId: "+15559999999",
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, verified guardian!"]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_guardian",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    // Controller trust reflects the gateway verdict's upgraded class.
+    expect(readControllerTrustClass(relay)).toBe("guardian");
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: resolutionFailed verdict falls back to local resolution without dropping the call", async () => {
+    ensureConversation("conv-midcall-verdict-failed");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-failed",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // A failed verdict must fall back to local resolution — the call stays up.
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: null,
+      resolutionFailed: true,
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, how can I help you?"]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_failed",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Fail-soft: verification still completes and the call connects.
+    expect(relay.isVerificationSessionActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(readControllerTrustClass(relay)).toBeDefined();
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: member-claiming but unusable verdict falls back to local resolution", async () => {
+    ensureConversation("conv-midcall-verdict-unusable");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-unusable",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // Claims a member (contactId/channelId) but the ACL can't be reassembled
+    // (missing status/policy) — mirrors the setup path's unusable condition.
+    mockMidCallVerdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_unusable",
+      channelId: "ch_unusable",
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_unusable",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Fail-soft: unusable verdict does not drop the call; local fallback fires.
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(readControllerTrustClass(relay)).toBeDefined();
+
+    relay.destroy();
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -5713,7 +5713,7 @@ describe("relay-server", () => {
     )?.trustContext?.memberStatus;
   }
 
-  test("inbound guardian verification: memberful blocked verdict is denied mid-call (spoken denial + teardown, not continued)", async () => {
+  test("inbound guardian verification: memberful blocked unknown verdict is honored (verdict path enforces blocked status)", async () => {
     ensureConversation("conv-midcall-verdict-blocked");
     const session = createCallSession({
       conversationId: "conv-midcall-verdict-blocked",
@@ -5728,7 +5728,7 @@ describe("relay-server", () => {
       createMockProviderResponse(["Hello there."]),
     );
 
-    const { ws, relay } = createMockWs(session.id);
+    const { relay } = createMockWs(session.id);
 
     // Setup resolves locally (no verdict) so the pending guardian challenge
     // drives verification rather than denying at the door.
@@ -5742,9 +5742,9 @@ describe("relay-server", () => {
     );
 
     // The gateway classifies a blocked member as trustClass "unknown" but still
-    // carries contactId/channelId and the deny ACL. On mid-call re-resolution
-    // this hard-deny verdict must route to the existing denial/disconnect path —
-    // NOT continue to connected/greeting.
+    // carries contactId/channelId and the deny ACL. This memberful unknown must
+    // take the verdict path on mid-call re-resolution so its blocked status is
+    // enforced — not fall back to local, which could miss a stale block.
     mockMidCallVerdict = {
       trustClass: "unknown",
       canonicalSenderId: "+15559999999",
@@ -5759,26 +5759,15 @@ describe("relay-server", () => {
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    // Denied + torn down, not connected.
-    expect(relay.getConnectionState()).toBe("disconnecting");
-    expect(getCallSession(session.id)!.status).toBe("failed");
-
-    const denyEvents = getCallEvents(session.id).filter(
-      (e) => e.eventType === "inbound_acl_denied",
-    );
-    expect(denyEvents.length).toBeGreaterThan(0);
-
-    const textMessages = ws.sentMessages
-      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
-      .filter((m) => m.type === "text");
-    expect(
-      textMessages.some((m) => (m.token ?? "").includes("not authorized")),
-    ).toBe(true);
+    expect(relay.getConnectionState()).toBe("connected");
+    // Verdict path consumed the memberful unknown verdict; blocked status lands.
+    expect(trustVerdictMapperUsed).toBe(true);
+    expect(readControllerMemberStatus(relay)).toBe("blocked");
 
     relay.destroy();
   });
 
-  test("inbound guardian verification: memberful revoked verdict is denied mid-call (spoken denial + teardown, not continued)", async () => {
+  test("inbound guardian verification: memberful revoked unknown verdict is honored (verdict path enforces revoked status)", async () => {
     ensureConversation("conv-midcall-verdict-revoked");
     const session = createCallSession({
       conversationId: "conv-midcall-verdict-revoked",
@@ -5793,7 +5782,7 @@ describe("relay-server", () => {
       createMockProviderResponse(["Hello there."]),
     );
 
-    const { ws, relay } = createMockWs(session.id);
+    const { relay } = createMockWs(session.id);
 
     await relay.handleMessage(
       JSON.stringify({
@@ -5818,81 +5807,9 @@ describe("relay-server", () => {
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    expect(relay.getConnectionState()).toBe("disconnecting");
-    expect(getCallSession(session.id)!.status).toBe("failed");
-    expect(
-      getCallEvents(session.id).filter(
-        (e) => e.eventType === "inbound_acl_denied",
-      ).length,
-    ).toBeGreaterThan(0);
-
-    const textMessages = ws.sentMessages
-      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
-      .filter((m) => m.type === "text");
-    expect(
-      textMessages.some((m) => (m.token ?? "").includes("not authorized")),
-    ).toBe(true);
-
-    relay.destroy();
-  });
-
-  test("inbound guardian verification: memberful policy-escalate verdict is denied mid-call (not continued)", async () => {
-    ensureConversation("conv-midcall-verdict-escalate");
-    const session = createCallSession({
-      conversationId: "conv-midcall-verdict-escalate",
-      provider: "twilio",
-      fromNumber: "+15559999999",
-      toNumber: "+15551111111",
-    });
-
-    const secret = createPendingVoiceGuardianChallenge();
-
-    mockSendMessage.mockImplementation(
-      createMockProviderResponse(["Hello there."]),
-    );
-
-    const { ws, relay } = createMockWs(session.id);
-
-    await relay.handleMessage(
-      JSON.stringify({
-        type: "setup",
-        callSid: "CA_midcall_verdict_escalate",
-        from: "+15559999999",
-        to: "+15551111111",
-      }),
-    );
-
-    // Active member whose channel requires guardian approval (escalate). Live
-    // calls can't await approval, so the setup path denies escalate — mid-call
-    // must too.
-    mockMidCallVerdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "+15559999999",
-      contactId: "ct_escalate",
-      channelId: "ch_escalate",
-      status: "active",
-      policy: "escalate",
-    };
-
-    for (const digit of secret) {
-      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(relay.getConnectionState()).toBe("disconnecting");
-    expect(getCallSession(session.id)!.status).toBe("failed");
-    expect(
-      getCallEvents(session.id).filter(
-        (e) => e.eventType === "inbound_acl_denied",
-      ).length,
-    ).toBeGreaterThan(0);
-
-    const textMessages = ws.sentMessages
-      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
-      .filter((m) => m.type === "text");
-    expect(
-      textMessages.some((m) => (m.token ?? "").includes("guardian approval")),
-    ).toBe(true);
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(trustVerdictMapperUsed).toBe(true);
+    expect(readControllerMemberStatus(relay)).toBe("revoked");
 
     relay.destroy();
   });
@@ -5981,129 +5898,6 @@ describe("relay-server", () => {
     expect(readControllerTrustClass(relay)).toBe("guardian");
     expect(trustClassAtTurn.length).toBeGreaterThan(0);
     expect(trustClassAtTurn.every((c) => c === "guardian")).toBe(true);
-
-    relay.destroy();
-  });
-
-  test("inbound guardian verification: memberful active/allow verdict admits and lands member status", async () => {
-    ensureConversation("conv-midcall-verdict-active");
-    const session = createCallSession({
-      conversationId: "conv-midcall-verdict-active",
-      provider: "twilio",
-      fromNumber: "+15559999999",
-      toNumber: "+15551111111",
-    });
-
-    const secret = createPendingVoiceGuardianChallenge();
-
-    mockSendMessage.mockImplementation(
-      createMockProviderResponse(["Hello there."]),
-    );
-
-    const { relay } = createMockWs(session.id);
-
-    await relay.handleMessage(
-      JSON.stringify({
-        type: "setup",
-        callSid: "CA_midcall_verdict_active",
-        from: "+15559999999",
-        to: "+15551111111",
-      }),
-    );
-
-    // A normal verified member (active/allow) must still be admitted mid-call.
-    mockMidCallVerdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "+15559999999",
-      contactId: "ct_active",
-      channelId: "ch_active",
-      status: "active",
-      policy: "allow",
-    };
-
-    for (const digit of secret) {
-      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(relay.getConnectionState()).toBe("connected");
-    expect(trustVerdictMapperUsed).toBe(true);
-    expect(readControllerMemberStatus(relay)).toBe("active");
-
-    relay.destroy();
-  });
-
-  test("a prompt buffered during re-resolution is NOT replayed as a turn when the verdict denies the caller", async () => {
-    ensureConversation("conv-midcall-deny-buffer");
-    const session = createCallSession({
-      conversationId: "conv-midcall-deny-buffer",
-      provider: "twilio",
-      fromNumber: "+15559999999",
-      toNumber: "+15551111111",
-    });
-
-    const secret = createPendingVoiceGuardianChallenge();
-
-    let turnsFired = 0;
-    mockSendMessage.mockImplementation((...args: unknown[]) => {
-      turnsFired += 1;
-      return createMockProviderResponse(["Should not run."])(
-        ...(args as Parameters<ReturnType<typeof createMockProviderResponse>>),
-      );
-    });
-
-    const { relay } = createMockWs(session.id);
-
-    await relay.handleMessage(
-      JSON.stringify({
-        type: "setup",
-        callSid: "CA_midcall_deny_buffer",
-        from: "+15559999999",
-        to: "+15551111111",
-      }),
-    );
-
-    // Slow, denying verdict so a prompt can land in the re-resolution await.
-    mockMidCallVerdict = {
-      trustClass: "unknown",
-      canonicalSenderId: "+15559999999",
-      contactId: "ct_deny_buffer",
-      channelId: "ch_deny_buffer",
-      status: "blocked",
-      policy: "deny",
-    };
-    let releaseVerdict!: () => void;
-    mockMidCallVerdictGate = new Promise<void>((resolve) => {
-      releaseVerdict = resolve;
-    });
-
-    const digits = secret.split("");
-    for (const digit of digits.slice(0, -1)) {
-      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
-    }
-    const verificationDone = relay.handleMessage(
-      JSON.stringify({ type: "dtmf", digit: digits[digits.length - 1] }),
-    );
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    // Prompt arrives mid-await: buffered while trust re-resolves.
-    await relay.handleMessage(
-      JSON.stringify({
-        type: "prompt",
-        voicePrompt: "Let me in.",
-        lang: "en-US",
-        last: true,
-      }),
-    );
-
-    // Release the denying verdict; the call is torn down and the buffered prompt
-    // must be discarded, not replayed as a turn.
-    releaseVerdict();
-    await verificationDone;
-    await new Promise((resolve) => setTimeout(resolve, 20));
-
-    expect(relay.getConnectionState()).toBe("disconnecting");
-    expect(turnsFired).toBe(0);
 
     relay.destroy();
   });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -174,6 +174,10 @@ mock.module("../calls/channel-admission-reader.js", () => ({
 let mockMidCallVerdict:
   | import("@vellumai/gateway-client").TrustVerdict
   | null = null;
+// When set, the mid-call verdict reader blocks on this gate before returning,
+// simulating a slow gateway round-trip so a test can drive a prompt into the
+// re-resolution await window.
+let mockMidCallVerdictGate: Promise<void> | null = null;
 const realInboundTrustReaderModule = {
   ...(await import("../calls/inbound-trust-reader.js")),
 };
@@ -187,6 +191,7 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
     if (!inboundTrustMockActive) {
       return realInboundTrustReaderModule.getInboundTrustVerdict(input);
     }
+    if (mockMidCallVerdictGate) await mockMidCallVerdictGate;
     return mockMidCallVerdict;
   },
 }));
@@ -530,6 +535,7 @@ describe("relay-server", () => {
     mockAdmissionPolicy = null;
     mockAdmissionGate = null;
     mockMidCallVerdict = null;
+    mockMidCallVerdictGate = null;
     trustVerdictMapperUsed = false;
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
@@ -5693,6 +5699,205 @@ describe("relay-server", () => {
     // consumed as authoritative.
     expect(trustVerdictMapperUsed).toBe(false);
     expect(readControllerTrustClass(relay)).toBeDefined();
+
+    relay.destroy();
+  });
+
+  function readControllerMemberStatus(
+    relay: RelayConnection,
+  ): string | undefined {
+    return (
+      relay.getController() as unknown as {
+        trustContext?: { memberStatus?: string };
+      }
+    )?.trustContext?.memberStatus;
+  }
+
+  test("inbound guardian verification: memberful blocked unknown verdict is honored (verdict path enforces blocked status)", async () => {
+    ensureConversation("conv-midcall-verdict-blocked");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-blocked",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    // Setup resolves locally (no verdict) so the pending guardian challenge
+    // drives verification rather than denying at the door.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_blocked",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    // The gateway classifies a blocked member as trustClass "unknown" but still
+    // carries contactId/channelId and the deny ACL. This memberful unknown must
+    // take the verdict path on mid-call re-resolution so its blocked status is
+    // enforced — not fall back to local, which could miss a stale block.
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_blocked",
+      channelId: "ch_blocked",
+      status: "blocked",
+      policy: "deny",
+    };
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    // Verdict path consumed the memberful unknown verdict; blocked status lands.
+    expect(trustVerdictMapperUsed).toBe(true);
+    expect(readControllerMemberStatus(relay)).toBe("blocked");
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: memberful revoked unknown verdict is honored (verdict path enforces revoked status)", async () => {
+    ensureConversation("conv-midcall-verdict-revoked");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-revoked",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_revoked",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_revoked",
+      channelId: "ch_revoked",
+      status: "revoked",
+      policy: "deny",
+    };
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(trustVerdictMapperUsed).toBe(true);
+    expect(readControllerMemberStatus(relay)).toBe("revoked");
+
+    relay.destroy();
+  });
+
+  test("a prompt arriving during the mid-call re-resolution await is deferred and runs under the upgraded trust", async () => {
+    ensureConversation("conv-midcall-race");
+    const session = createCallSession({
+      conversationId: "conv-midcall-race",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // Capture the controller's trust class at the moment a turn actually fires,
+    // so we can prove the deferred prompt did not run under the stale context.
+    const trustClassAtTurn: Array<string | undefined> = [];
+    mockSendMessage.mockImplementation((...args: unknown[]) => {
+      trustClassAtTurn.push(readControllerTrustClass(relay));
+      return createMockProviderResponse(["Hello, verified guardian!"])(
+        ...(args as Parameters<ReturnType<typeof createMockProviderResponse>>),
+      );
+    });
+
+    const { relay } = createMockWs(session.id);
+
+    // Setup resolves locally (no verdict) so the pending challenge drives
+    // verification; the gated guardian verdict is armed only for the mid-call
+    // re-resolution below.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_race",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    // The gateway verdict upgrades the caller to guardian, but the round-trip is
+    // slow — gate it so a prompt can land in the re-resolution await window.
+    mockMidCallVerdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "+15559999999",
+      guardianExternalUserId: "+15559999999",
+      guardianPrincipalId: "+15559999999",
+    };
+    let releaseVerdict!: () => void;
+    mockMidCallVerdictGate = new Promise<void>((resolve) => {
+      releaseVerdict = resolve;
+    });
+
+    // Enter the gated re-resolution: the final DTMF digit triggers
+    // handleVerificationCodeResult, which awaits the slow verdict.
+    const digits = secret.split("");
+    for (const digit of digits.slice(0, -1)) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    const verificationDone = relay.handleMessage(
+      JSON.stringify({ type: "dtmf", digit: digits[digits.length - 1] }),
+    );
+    // Let the verdict await begin (connectionState is now "connected", guard set).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(relay.getConnectionState()).toBe("connected");
+    // Trust is still stale (verdict gated) — caller is not yet guardian.
+    expect(readControllerTrustClass(relay)).not.toBe("guardian");
+
+    // Prompt arrives mid-await: it must be deferred, not processed under stale trust.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "Are my appointments confirmed?",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    // No turn yet — the prompt was buffered, not run under the stale context.
+    expect(trustClassAtTurn).toHaveLength(0);
+
+    // Release the verdict; re-resolution installs the upgraded context, then the
+    // deferred prompt is flushed and its turn runs under guardian trust.
+    releaseVerdict();
+    await verificationDone;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(readControllerTrustClass(relay)).toBe("guardian");
+    expect(trustClassAtTurn.length).toBeGreaterThan(0);
+    expect(trustClassAtTurn.every((c) => c === "guardian")).toBe(true);
 
     relay.destroy();
   });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -191,6 +191,26 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
   },
 }));
 
+// ── Trust verdict consumer spy ──────────────────────────────────────
+//
+// Tracks whether the verdict mapper produced the final mid-call context, so a
+// test can assert the local resolver was used instead (verdict not consumed).
+let trustVerdictMapperUsed = false;
+const realTrustVerdictConsumerModule = {
+  ...(await import("../runtime/trust-verdict-consumer.js")),
+};
+mock.module("../runtime/trust-verdict-consumer.js", () => ({
+  ...realTrustVerdictConsumerModule,
+  trustContextFromVerdict: (
+    ...args: Parameters<
+      typeof realTrustVerdictConsumerModule.trustContextFromVerdict
+    >
+  ) => {
+    trustVerdictMapperUsed = true;
+    return realTrustVerdictConsumerModule.trustContextFromVerdict(...args);
+  },
+}));
+
 // ── TTS provider mocks (for call-speech-output) ─────────────────────
 
 let mockTtsProviderId: string = "elevenlabs";
@@ -510,6 +530,7 @@ describe("relay-server", () => {
     mockAdmissionPolicy = null;
     mockAdmissionGate = null;
     mockMidCallVerdict = null;
+    trustVerdictMapperUsed = false;
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
     mockConfig.calls.verification.maxAttempts = 3;
@@ -5621,6 +5642,56 @@ describe("relay-server", () => {
 
     // Fail-soft: unusable verdict does not drop the call; local fallback fires.
     expect(relay.getConnectionState()).toBe("connected");
+    expect(readControllerTrustClass(relay)).toBeDefined();
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: memberless unknown verdict falls back to local resolution (just-activated invitee not downgraded)", async () => {
+    ensureConversation("conv-midcall-verdict-unknown");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-unknown",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // Invite redemption writes the channel assistant-side, so right after
+    // activation the gateway has no member and returns a memberless unknown
+    // verdict. Mid-call re-resolution must treat it as a stale gateway view
+    // and fall back to local resolution (which has the fresh channel) rather
+    // than downgrade the just-activated invitee to unknown.
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "+15559999999",
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_unknown",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    // Local resolver produced the final context; the unknown verdict was not
+    // consumed as authoritative.
+    expect(trustVerdictMapperUsed).toBe(false);
     expect(readControllerTrustClass(relay)).toBeDefined();
 
     relay.destroy();

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -5713,7 +5713,7 @@ describe("relay-server", () => {
     )?.trustContext?.memberStatus;
   }
 
-  test("inbound guardian verification: memberful blocked unknown verdict is honored (verdict path enforces blocked status)", async () => {
+  test("inbound guardian verification: memberful blocked verdict is denied mid-call (spoken denial + teardown, not continued)", async () => {
     ensureConversation("conv-midcall-verdict-blocked");
     const session = createCallSession({
       conversationId: "conv-midcall-verdict-blocked",
@@ -5728,7 +5728,7 @@ describe("relay-server", () => {
       createMockProviderResponse(["Hello there."]),
     );
 
-    const { relay } = createMockWs(session.id);
+    const { ws, relay } = createMockWs(session.id);
 
     // Setup resolves locally (no verdict) so the pending guardian challenge
     // drives verification rather than denying at the door.
@@ -5742,9 +5742,9 @@ describe("relay-server", () => {
     );
 
     // The gateway classifies a blocked member as trustClass "unknown" but still
-    // carries contactId/channelId and the deny ACL. This memberful unknown must
-    // take the verdict path on mid-call re-resolution so its blocked status is
-    // enforced — not fall back to local, which could miss a stale block.
+    // carries contactId/channelId and the deny ACL. On mid-call re-resolution
+    // this hard-deny verdict must route to the existing denial/disconnect path —
+    // NOT continue to connected/greeting.
     mockMidCallVerdict = {
       trustClass: "unknown",
       canonicalSenderId: "+15559999999",
@@ -5759,15 +5759,26 @@ describe("relay-server", () => {
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    expect(relay.getConnectionState()).toBe("connected");
-    // Verdict path consumed the memberful unknown verdict; blocked status lands.
-    expect(trustVerdictMapperUsed).toBe(true);
-    expect(readControllerMemberStatus(relay)).toBe("blocked");
+    // Denied + torn down, not connected.
+    expect(relay.getConnectionState()).toBe("disconnecting");
+    expect(getCallSession(session.id)!.status).toBe("failed");
+
+    const denyEvents = getCallEvents(session.id).filter(
+      (e) => e.eventType === "inbound_acl_denied",
+    );
+    expect(denyEvents.length).toBeGreaterThan(0);
+
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("not authorized")),
+    ).toBe(true);
 
     relay.destroy();
   });
 
-  test("inbound guardian verification: memberful revoked unknown verdict is honored (verdict path enforces revoked status)", async () => {
+  test("inbound guardian verification: memberful revoked verdict is denied mid-call (spoken denial + teardown, not continued)", async () => {
     ensureConversation("conv-midcall-verdict-revoked");
     const session = createCallSession({
       conversationId: "conv-midcall-verdict-revoked",
@@ -5782,7 +5793,7 @@ describe("relay-server", () => {
       createMockProviderResponse(["Hello there."]),
     );
 
-    const { relay } = createMockWs(session.id);
+    const { ws, relay } = createMockWs(session.id);
 
     await relay.handleMessage(
       JSON.stringify({
@@ -5807,9 +5818,81 @@ describe("relay-server", () => {
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    expect(relay.getConnectionState()).toBe("connected");
-    expect(trustVerdictMapperUsed).toBe(true);
-    expect(readControllerMemberStatus(relay)).toBe("revoked");
+    expect(relay.getConnectionState()).toBe("disconnecting");
+    expect(getCallSession(session.id)!.status).toBe("failed");
+    expect(
+      getCallEvents(session.id).filter(
+        (e) => e.eventType === "inbound_acl_denied",
+      ).length,
+    ).toBeGreaterThan(0);
+
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("not authorized")),
+    ).toBe(true);
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: memberful policy-escalate verdict is denied mid-call (not continued)", async () => {
+    ensureConversation("conv-midcall-verdict-escalate");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-escalate",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_escalate",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    // Active member whose channel requires guardian approval (escalate). Live
+    // calls can't await approval, so the setup path denies escalate — mid-call
+    // must too.
+    mockMidCallVerdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_escalate",
+      channelId: "ch_escalate",
+      status: "active",
+      policy: "escalate",
+    };
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("disconnecting");
+    expect(getCallSession(session.id)!.status).toBe("failed");
+    expect(
+      getCallEvents(session.id).filter(
+        (e) => e.eventType === "inbound_acl_denied",
+      ).length,
+    ).toBeGreaterThan(0);
+
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("guardian approval")),
+    ).toBe(true);
 
     relay.destroy();
   });
@@ -5898,6 +5981,129 @@ describe("relay-server", () => {
     expect(readControllerTrustClass(relay)).toBe("guardian");
     expect(trustClassAtTurn.length).toBeGreaterThan(0);
     expect(trustClassAtTurn.every((c) => c === "guardian")).toBe(true);
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: memberful active/allow verdict admits and lands member status", async () => {
+    ensureConversation("conv-midcall-verdict-active");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-active",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_active",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    // A normal verified member (active/allow) must still be admitted mid-call.
+    mockMidCallVerdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_active",
+      channelId: "ch_active",
+      status: "active",
+      policy: "allow",
+    };
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(trustVerdictMapperUsed).toBe(true);
+    expect(readControllerMemberStatus(relay)).toBe("active");
+
+    relay.destroy();
+  });
+
+  test("a prompt buffered during re-resolution is NOT replayed as a turn when the verdict denies the caller", async () => {
+    ensureConversation("conv-midcall-deny-buffer");
+    const session = createCallSession({
+      conversationId: "conv-midcall-deny-buffer",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    let turnsFired = 0;
+    mockSendMessage.mockImplementation((...args: unknown[]) => {
+      turnsFired += 1;
+      return createMockProviderResponse(["Should not run."])(
+        ...(args as Parameters<ReturnType<typeof createMockProviderResponse>>),
+      );
+    });
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_deny_buffer",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    // Slow, denying verdict so a prompt can land in the re-resolution await.
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_deny_buffer",
+      channelId: "ch_deny_buffer",
+      status: "blocked",
+      policy: "deny",
+    };
+    let releaseVerdict!: () => void;
+    mockMidCallVerdictGate = new Promise<void>((resolve) => {
+      releaseVerdict = resolve;
+    });
+
+    const digits = secret.split("");
+    for (const digit of digits.slice(0, -1)) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    const verificationDone = relay.handleMessage(
+      JSON.stringify({ type: "dtmf", digit: digits[digits.length - 1] }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Prompt arrives mid-await: buffered while trust re-resolves.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "Let me in.",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+
+    // Release the denying verdict; the call is torn down and the buffered prompt
+    // must be discarded, not replayed as a turn.
+    releaseVerdict();
+    await verificationDone;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(relay.getConnectionState()).toBe("disconnecting");
+    expect(turnsFired).toBe(0);
 
     relay.destroy();
   });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -17,6 +17,7 @@ import {
 } from "../contacts/contact-store.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { TrustContext } from "../daemon/trust-context.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { addMessage } from "../memory/conversation-crud.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
@@ -26,6 +27,10 @@ import {
   resolveActorTrust,
   toTrustContext,
 } from "../runtime/actor-trust-resolver.js";
+import {
+  resolvedMemberFromVerdict,
+  trustContextFromVerdict,
+} from "../runtime/trust-verdict-consumer.js";
 import {
   composeVerificationVoice,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
@@ -885,13 +890,53 @@ export class RelayConnection {
   }
 
   /**
+   * Re-resolve caller trust after a mid-call verification/activation. Prefers
+   * the gateway verdict (authoritative right after the gateway updated the
+   * binding); falls back to local resolution on a missing/failed/unusable
+   * verdict so a blip never drops the call. Mirrors the setup path's
+   * verdict-first-with-fallback condition.
+   */
+  private async resolveMidCallTrustContext(
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<TrustContext> {
+    const verdict = await getInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: fromNumber,
+    });
+
+    const hasMemberIdentity = !!(verdict?.contactId || verdict?.channelId);
+    const memberUnresolvable =
+      hasMemberIdentity && resolvedMemberFromVerdict(verdict!) === null;
+    const usable =
+      verdict && !verdict.resolutionFailed && !memberUnresolvable;
+
+    if (usable) {
+      return trustContextFromVerdict(verdict, {
+        sourceChannel: "phone",
+        conversationExternalId: fromNumber,
+      });
+    }
+
+    return toTrustContext(
+      resolveActorTrust({
+        assistantId,
+        sourceChannel: "phone",
+        conversationExternalId: fromNumber,
+        actorExternalId: fromNumber,
+      }),
+      fromNumber,
+    );
+  }
+
+  /**
    * Shared post-activation handoff for all trusted-contact success paths
    * (access-request approval, invite redemption, verification code).
    * Activates the caller, updates guardian context, delivers deterministic
    * transition copy, and marks the next utterance as opening-ack so the
    * LLM continues naturally.
    */
-  private continueCallAfterTrustedContactActivation(params: {
+  private async continueCallAfterTrustedContactActivation(params: {
     assistantId: string;
     fromNumber: string;
     activationReason?:
@@ -906,21 +951,16 @@ export class RelayConnection {
      * address.
      */
     inviteeName?: string | null;
-  }): void {
+  }): Promise<void> {
     const { assistantId, fromNumber } = params;
 
     // Contact activation is handled by the gateway — the assistant no
     // longer writes contact/channel records on inbound voice calls.
 
-    const updatedTrust = resolveActorTrust({
-      assistantId,
-      sourceChannel: "phone",
-      conversationExternalId: fromNumber,
-      actorExternalId: fromNumber,
-    });
-
     if (this.controller) {
-      this.controller.setTrustContext(toTrustContext(updatedTrust, fromNumber));
+      this.controller.setTrustContext(
+        await this.resolveMidCallTrustContext(assistantId, fromNumber),
+      );
     }
 
     this.connectionState = "connected";
@@ -1104,14 +1144,8 @@ export class RelayConnection {
 
         // Update trust context on the controller so the LLM knows this is the guardian
         if (this.controller) {
-          const verifiedActorTrust = resolveActorTrust({
-            assistantId,
-            sourceChannel: "phone",
-            conversationExternalId: fromNumber,
-            actorExternalId: fromNumber,
-          });
           this.controller.setTrustContext(
-            toTrustContext(verifiedActorTrust, fromNumber),
+            await this.resolveMidCallTrustContext(assistantId, fromNumber),
           );
         }
 
@@ -1129,7 +1163,7 @@ export class RelayConnection {
             );
         }
       } else if (result.verificationType === "trusted_contact") {
-        this.continueCallAfterTrustedContactActivation({
+        await this.continueCallAfterTrustedContactActivation({
           assistantId,
           fromNumber,
           activationReason: "trusted_contact_verified",
@@ -1138,14 +1172,8 @@ export class RelayConnection {
         // Inbound guardian verification: binding already handled above,
         // proceed to normal call flow.
         if (this.controller) {
-          const verifiedActorTrust = resolveActorTrust({
-            assistantId,
-            sourceChannel: "phone",
-            conversationExternalId: fromNumber,
-            actorExternalId: fromNumber,
-          });
           this.controller.setTrustContext(
-            toTrustContext(verifiedActorTrust, fromNumber),
+            await this.resolveMidCallTrustContext(assistantId, fromNumber),
           );
           this.startNormalCallFlow(this.controller, true);
         }
@@ -1423,7 +1451,7 @@ export class RelayConnection {
       }
 
       if (request.status === "approved") {
-        this.handleAccessRequestApproved();
+        void this.handleAccessRequestApproved();
       } else if (request.status === "denied") {
         void this.handleAccessRequestDenied();
       }
@@ -1475,7 +1503,7 @@ export class RelayConnection {
    * Handle an approved access request: activate the caller as a trusted
    * contact, update runtime context, and continue with normal call flow.
    */
-  private handleAccessRequestApproved(): void {
+  private async handleAccessRequestApproved(): Promise<void> {
     this.clearAccessRequestWait();
 
     const assistantId = this.accessRequestAssistantId!;
@@ -1493,7 +1521,7 @@ export class RelayConnection {
       "Access request approved — caller activated and continuing call",
     );
 
-    this.continueCallAfterTrustedContactActivation({
+    await this.continueCallAfterTrustedContactActivation({
       assistantId,
       fromNumber,
       activationReason: "access_approved",
@@ -1701,7 +1729,7 @@ export class RelayConnection {
         "Voice invite redemption succeeded",
       );
 
-      this.continueCallAfterTrustedContactActivation({
+      await this.continueCallAfterTrustedContactActivation({
         assistantId: this.inviteRedemptionAssistantId,
         fromNumber: this.inviteRedemptionFromNumber,
         activationReason: "invite_redeemed",

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -267,6 +267,12 @@ export class RelayConnection {
   private callbackOptIn = false;
   private callbackHandoffNotified = false;
 
+  // True while mid-call trust is being re-resolved (async). handlePrompt defers
+  // prompts to trustReResolvePending so a verified caller can't start a turn
+  // under the stale pre-verification trust context during the await window.
+  private trustReResolving = false;
+  private trustReResolvePending: RelayPromptMessage[] = [];
+
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
     this.callSessionId = callSessionId;
@@ -908,16 +914,20 @@ export class RelayConnection {
     const hasMemberIdentity = !!(verdict?.contactId || verdict?.channelId);
     const memberUnresolvable =
       hasMemberIdentity && resolvedMemberFromVerdict(verdict!) === null;
-    // Post-activation re-resolution falls back to local on an unknown/memberless
-    // verdict: the caller was just activated, and invite redemption writes the
-    // channel assistant-side, so the gateway may not see the member yet — local
-    // resolution has it. (Setup path treats unknown as a real stranger; here it
-    // means a stale gateway view.)
+    // Only a MEMBERLESS unknown verdict is treated as a stale gateway view and
+    // falls back to local: the caller was just activated, and invite redemption
+    // writes the channel assistant-side, so the gateway may not see the member
+    // yet — local resolution has it. A MEMBERFUL unknown verdict (blocked/revoked
+    // member, carrying contactId/channelId) is honored so its deny ACL is
+    // enforced; falling back could lose the gateway's member status if local
+    // state is stale.
+    const memberlessUnknown =
+      verdict?.trustClass === "unknown" && !hasMemberIdentity;
     const usable =
       verdict &&
       !verdict.resolutionFailed &&
       !memberUnresolvable &&
-      verdict.trustClass !== "unknown";
+      !memberlessUnknown;
 
     if (usable) {
       return trustContextFromVerdict(verdict, {
@@ -935,6 +945,46 @@ export class RelayConnection {
       }),
       fromNumber,
     );
+  }
+
+  /**
+   * Re-resolve mid-call trust and install it on the controller, deferring any
+   * prompt that arrives during the async window. Guards the gap between
+   * connectionState flipping to "connected" and the upgraded context landing so
+   * a verified caller never starts a turn under the stale pre-verification
+   * trust. Clears the guard in a finally and flushes buffered prompts under the
+   * new context, so an IPC error can't wedge the call.
+   */
+  private async reResolveAndApplyTrustContext(
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<void> {
+    if (!this.controller) return;
+    this.trustReResolving = true;
+    try {
+      const context = await this.resolveMidCallTrustContext(
+        assistantId,
+        fromNumber,
+      );
+      this.controller.setTrustContext(context);
+    } finally {
+      this.trustReResolving = false;
+      this.flushDeferredPrompts();
+    }
+  }
+
+  /**
+   * Replay prompts buffered while trust was re-resolving. Runs after the
+   * upgraded context is installed so deferred utterances are answered under the
+   * correct trust.
+   */
+  private flushDeferredPrompts(): void {
+    if (this.trustReResolvePending.length === 0) return;
+    const pending = this.trustReResolvePending;
+    this.trustReResolvePending = [];
+    for (const msg of pending) {
+      void this.handlePrompt(msg);
+    }
   }
 
   /**
@@ -966,9 +1016,7 @@ export class RelayConnection {
     // longer writes contact/channel records on inbound voice calls.
 
     if (this.controller) {
-      this.controller.setTrustContext(
-        await this.resolveMidCallTrustContext(assistantId, fromNumber),
-      );
+      await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
     }
 
     this.connectionState = "connected";
@@ -1152,9 +1200,7 @@ export class RelayConnection {
 
         // Update trust context on the controller so the LLM knows this is the guardian
         if (this.controller) {
-          this.controller.setTrustContext(
-            await this.resolveMidCallTrustContext(assistantId, fromNumber),
-          );
+          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
         }
 
         // Mark session as in-progress and transition to guardian conversation
@@ -1180,9 +1226,7 @@ export class RelayConnection {
         // Inbound guardian verification: binding already handled above,
         // proceed to normal call flow.
         if (this.controller) {
-          this.controller.setTrustContext(
-            await this.resolveMidCallTrustContext(assistantId, fromNumber),
-          );
+          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
           this.startNormalCallFlow(this.controller, true);
         }
       }
@@ -1963,6 +2007,15 @@ export class RelayConnection {
 
   private async handlePrompt(msg: RelayPromptMessage): Promise<void> {
     if (this.connectionState === "disconnecting") {
+      return;
+    }
+
+    // Defer (don't drop) prompts while trust is being re-resolved mid-call so a
+    // verified caller's first utterance runs under the upgraded context, not the
+    // stale pre-verification one. flushDeferredPrompts replays them in order
+    // once the new context lands.
+    if (this.trustReResolving) {
+      this.trustReResolvePending.push(msg);
       return;
     }
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -908,8 +908,16 @@ export class RelayConnection {
     const hasMemberIdentity = !!(verdict?.contactId || verdict?.channelId);
     const memberUnresolvable =
       hasMemberIdentity && resolvedMemberFromVerdict(verdict!) === null;
+    // Post-activation re-resolution falls back to local on an unknown/memberless
+    // verdict: the caller was just activated, and invite redemption writes the
+    // channel assistant-side, so the gateway may not see the member yet — local
+    // resolution has it. (Setup path treats unknown as a real stranger; here it
+    // means a stale gateway view.)
     const usable =
-      verdict && !verdict.resolutionFailed && !memberUnresolvable;
+      verdict &&
+      !verdict.resolutionFailed &&
+      !memberUnresolvable &&
+      verdict.trustClass !== "unknown";
 
     if (usable) {
       return trustContextFromVerdict(verdict, {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -26,10 +26,7 @@ import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.
 import {
   resolveActorTrust,
   toTrustContext,
-  type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
-import type { ResolvedMember } from "../runtime/routes/inbound-stages/acl-enforcement.js";
-import { enforceAdmissionPolicy } from "../runtime/routes/inbound-stages/admission-policy.js";
 import {
   resolvedMemberFromVerdict,
   trustContextFromVerdict,
@@ -64,7 +61,7 @@ import {
   emitAccessRequestCallbackHandoff,
   scheduleNextHeartbeat,
 } from "./relay-access-wait.js";
-import { routeSetup } from "./relay-setup-router.js";
+import { routeSetup, type SetupResolved } from "./relay-setup-router.js";
 import {
   attemptInviteCodeRedemption,
   attemptVerificationCode,
@@ -89,74 +86,6 @@ function firstToken(name: string | null | undefined): string | null {
   const trimmed = name.trim();
   if (!trimmed) return null;
   return trimmed.split(/\s+/)[0] ?? null;
-}
-
-/** Mid-call re-resolved trust: the context plus the member/class it enforces. */
-interface MidCallTrust {
-  context: TrustContext;
-  member: ResolvedMember | null;
-  trustClass: TrustClass;
-}
-
-/**
- * Hard-deny check for a mid-call re-resolved verdict, mirroring the setup
- * path's member deny criteria EXACTLY (`relay-setup-router.routeSetup`):
- * blocked/revoked status and the admission floor via `enforceAdmissionPolicy`,
- * plus member `policy: "deny"`/`"escalate"` (live calls can't await guardian
- * approval). Returns the spoken-denial copy + log reason for `denyInboundCall`,
- * or `null` to admit. Messages match the corresponding setup deny branches.
- */
-function midCallTrustDeny(
-  member: ResolvedMember | null,
-  trustClass: TrustClass,
-  admissionPolicy: AdmissionPolicy | null,
-): { message: string; logReason: string } | null {
-  const channel = member?.channel;
-
-  if (channel?.policy === "deny") {
-    return {
-      message: "This number is not authorized to use this assistant.",
-      logReason: "Inbound voice ACL: member policy deny",
-    };
-  }
-  if (channel?.policy === "escalate") {
-    return {
-      message:
-        "This number requires guardian approval for calls. Please have the account guardian update your permissions.",
-      logReason:
-        "Inbound voice ACL: member policy escalate — voice calls cannot await guardian approval",
-    };
-  }
-
-  if (admissionPolicy != null) {
-    const floor = enforceAdmissionPolicy({
-      sourceChannel: "phone",
-      trustClass,
-      memberStatus: channel?.status,
-      policy: admissionPolicy,
-    });
-    if (!floor.admitted) {
-      const blockedOrRevoked =
-        floor.reason === "member_blocked" || floor.reason === "member_revoked";
-      return {
-        message: blockedOrRevoked
-          ? "This number is not authorized to use this assistant."
-          : "This number is not authorized to reach the assistant right now.",
-        logReason: blockedOrRevoked
-          ? `Inbound voice ACL: caller ${channel?.status}`
-          : `Inbound voice admission floor: ${floor.effectivePolicy}`,
-      };
-    }
-  } else if (channel?.status === "blocked" || channel?.status === "revoked") {
-    // No admission floor configured: still hard-deny blocked/revoked, matching
-    // the setup blocked-caller branch (which denies independent of the floor).
-    return {
-      message: "This number is not authorized to use this assistant.",
-      logReason: `Inbound voice ACL: caller ${channel.status}`,
-    };
-  }
-
-  return null;
 }
 
 // ── ConversationRelay message types ──────────────────────────────────
@@ -749,14 +678,7 @@ export class RelayConnection {
         await this.startVerification(session, outcome.verificationConfig);
         return;
       case "deny":
-        await this.denyInboundCall(
-          msg.from,
-          {
-            trustClass: resolved.actorTrust.trustClass,
-            member: resolved.actorTrust.memberRecord,
-          },
-          outcome,
-        );
+        await this.denyInboundCall(msg.from, resolved, outcome);
         return;
       case "invite_redemption":
         this.startInviteRedemption(
@@ -875,14 +797,14 @@ export class RelayConnection {
   /** Deny an inbound call with a TTS message and schedule disconnect. */
   private async denyInboundCall(
     from: string,
-    denied: { trustClass: TrustClass; member: ResolvedMember | null },
+    resolved: SetupResolved,
     outcome: { message: string; logReason: string },
   ): Promise<void> {
     recordCallEvent(this.callSessionId, "inbound_acl_denied", {
       from,
-      trustClass: denied.trustClass,
-      channelId: denied.member?.channel.id,
-      memberPolicy: denied.member?.channel.policy,
+      trustClass: resolved.actorTrust.trustClass,
+      channelId: resolved.actorTrust.memberRecord?.channel.id,
+      memberPolicy: resolved.actorTrust.memberRecord?.channel.policy,
     });
     this.connectionState = "disconnecting";
     updateCallSession(this.callSessionId, {
@@ -983,7 +905,7 @@ export class RelayConnection {
   private async resolveMidCallTrustContext(
     assistantId: string,
     fromNumber: string,
-  ): Promise<MidCallTrust> {
+  ): Promise<TrustContext> {
     const verdict = await getInboundTrustVerdict({
       channelType: "phone",
       actorExternalId: fromNumber,
@@ -1008,27 +930,21 @@ export class RelayConnection {
       !memberlessUnknown;
 
     if (usable) {
-      return {
-        context: trustContextFromVerdict(verdict, {
-          sourceChannel: "phone",
-          conversationExternalId: fromNumber,
-        }),
-        member: resolvedMemberFromVerdict(verdict),
-        trustClass: verdict.trustClass,
-      };
+      return trustContextFromVerdict(verdict, {
+        sourceChannel: "phone",
+        conversationExternalId: fromNumber,
+      });
     }
 
-    const actorTrust = resolveActorTrust({
-      assistantId,
-      sourceChannel: "phone",
-      conversationExternalId: fromNumber,
-      actorExternalId: fromNumber,
-    });
-    return {
-      context: toTrustContext(actorTrust, fromNumber),
-      member: actorTrust.memberRecord,
-      trustClass: actorTrust.trustClass,
-    };
+    return toTrustContext(
+      resolveActorTrust({
+        assistantId,
+        sourceChannel: "phone",
+        conversationExternalId: fromNumber,
+        actorExternalId: fromNumber,
+      }),
+      fromNumber,
+    );
   }
 
   /**
@@ -1036,46 +952,24 @@ export class RelayConnection {
    * prompt that arrives during the async window. Guards the gap between
    * connectionState flipping to "connected" and the upgraded context landing so
    * a verified caller never starts a turn under the stale pre-verification
-   * trust. Clears the guard in a finally so an IPC error can't wedge the call.
-   *
-   * Returns `true` when the re-resolved verdict is a hard deny (blocked/revoked
-   * status or deny/escalate policy): the caller is torn down via the same
-   * denial path as setup and MUST NOT proceed to connected/greeting. On admit
-   * (or fail-soft fallback) returns `false`; the caller flushes buffered prompts
-   * AFTER the connected transition so a deferred utterance runs as the first
-   * real turn under the upgraded trust.
+   * trust. Clears the guard in a finally and flushes buffered prompts under the
+   * new context, so an IPC error can't wedge the call.
    */
   private async reResolveAndApplyTrustContext(
     assistantId: string,
     fromNumber: string,
-  ): Promise<boolean> {
-    if (!this.controller) return false;
+  ): Promise<void> {
+    if (!this.controller) return;
     this.trustReResolving = true;
     try {
-      const { context, member, trustClass } =
-        await this.resolveMidCallTrustContext(assistantId, fromNumber);
-
-      const admissionPolicy = await getChannelAdmissionPolicy("phone");
-      const deny = midCallTrustDeny(member, trustClass, admissionPolicy);
-      if (deny) {
-        this.trustReResolvePending = [];
-        await this.denyInboundCall(fromNumber, { trustClass, member }, deny);
-        return true;
-      }
-
-      this.controller.setTrustContext(context);
-      return false;
-    } catch (err) {
-      // Fail soft: a re-resolution error must not wedge the call. Keep the
-      // controller's existing (setup-time) trust and let the caller proceed to
-      // connected + flush, consistent with the verdict-first fallback.
-      log.error(
-        { err, callSessionId: this.callSessionId },
-        "Mid-call trust re-resolution failed — keeping existing trust",
+      const context = await this.resolveMidCallTrustContext(
+        assistantId,
+        fromNumber,
       );
-      return false;
+      this.controller.setTrustContext(context);
     } finally {
       this.trustReResolving = false;
+      this.flushDeferredPrompts();
     }
   }
 
@@ -1122,21 +1016,11 @@ export class RelayConnection {
     // longer writes contact/channel records on inbound voice calls.
 
     if (this.controller) {
-      const denied = await this.reResolveAndApplyTrustContext(
-        assistantId,
-        fromNumber,
-      );
-      // Re-resolution surfaced a blocked/revoked/policy-deny verdict: the call
-      // is torn down by denyInboundCall — don't continue to connected/greeting.
-      if (denied) return;
+      await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
     }
 
     this.connectionState = "connected";
     updateCallSession(this.callSessionId, { status: "in_progress" });
-    // Flush AFTER connected so a prompt buffered during re-resolution runs as
-    // the caller's first real turn under the upgraded trust, not as wait-state
-    // chatter swallowed while still verification_pending.
-    this.flushDeferredPrompts();
 
     const guardianLabel = this.resolveGuardianLabel();
     let handoffText: string;
@@ -1316,20 +1200,12 @@ export class RelayConnection {
 
         // Update trust context on the controller so the LLM knows this is the guardian
         if (this.controller) {
-          const denied = await this.reResolveAndApplyTrustContext(
-            assistantId,
-            fromNumber,
-          );
-          // Blocked/revoked/policy-deny verdict: torn down — don't greet.
-          if (denied) return;
+          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
         }
 
         // Mark session as in-progress and transition to guardian conversation
-        // with verification context so the LLM greets naturally. Connected was
-        // already set above; flush buffered prompts now so a deferred utterance
-        // runs as the first real turn under the upgraded trust.
+        // with verification context so the LLM greets naturally.
         updateCallSession(this.callSessionId, { status: "in_progress" });
-        this.flushDeferredPrompts();
         if (this.controller) {
           this.controller
             .startPostVerificationGreeting()
@@ -1350,15 +1226,7 @@ export class RelayConnection {
         // Inbound guardian verification: binding already handled above,
         // proceed to normal call flow.
         if (this.controller) {
-          const denied = await this.reResolveAndApplyTrustContext(
-            assistantId,
-            fromNumber,
-          );
-          // Blocked/revoked/policy-deny verdict: torn down — don't start flow.
-          if (denied) return;
-          // Connected was already set above; flush buffered prompts so a
-          // deferred utterance runs as the first real turn under upgraded trust.
-          this.flushDeferredPrompts();
+          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
           this.startNormalCallFlow(this.controller, true);
         }
       }

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -26,7 +26,10 @@ import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.
 import {
   resolveActorTrust,
   toTrustContext,
+  type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
+import type { ResolvedMember } from "../runtime/routes/inbound-stages/acl-enforcement.js";
+import { enforceAdmissionPolicy } from "../runtime/routes/inbound-stages/admission-policy.js";
 import {
   resolvedMemberFromVerdict,
   trustContextFromVerdict,
@@ -61,7 +64,7 @@ import {
   emitAccessRequestCallbackHandoff,
   scheduleNextHeartbeat,
 } from "./relay-access-wait.js";
-import { routeSetup, type SetupResolved } from "./relay-setup-router.js";
+import { routeSetup } from "./relay-setup-router.js";
 import {
   attemptInviteCodeRedemption,
   attemptVerificationCode,
@@ -86,6 +89,74 @@ function firstToken(name: string | null | undefined): string | null {
   const trimmed = name.trim();
   if (!trimmed) return null;
   return trimmed.split(/\s+/)[0] ?? null;
+}
+
+/** Mid-call re-resolved trust: the context plus the member/class it enforces. */
+interface MidCallTrust {
+  context: TrustContext;
+  member: ResolvedMember | null;
+  trustClass: TrustClass;
+}
+
+/**
+ * Hard-deny check for a mid-call re-resolved verdict, mirroring the setup
+ * path's member deny criteria EXACTLY (`relay-setup-router.routeSetup`):
+ * blocked/revoked status and the admission floor via `enforceAdmissionPolicy`,
+ * plus member `policy: "deny"`/`"escalate"` (live calls can't await guardian
+ * approval). Returns the spoken-denial copy + log reason for `denyInboundCall`,
+ * or `null` to admit. Messages match the corresponding setup deny branches.
+ */
+function midCallTrustDeny(
+  member: ResolvedMember | null,
+  trustClass: TrustClass,
+  admissionPolicy: AdmissionPolicy | null,
+): { message: string; logReason: string } | null {
+  const channel = member?.channel;
+
+  if (channel?.policy === "deny") {
+    return {
+      message: "This number is not authorized to use this assistant.",
+      logReason: "Inbound voice ACL: member policy deny",
+    };
+  }
+  if (channel?.policy === "escalate") {
+    return {
+      message:
+        "This number requires guardian approval for calls. Please have the account guardian update your permissions.",
+      logReason:
+        "Inbound voice ACL: member policy escalate — voice calls cannot await guardian approval",
+    };
+  }
+
+  if (admissionPolicy != null) {
+    const floor = enforceAdmissionPolicy({
+      sourceChannel: "phone",
+      trustClass,
+      memberStatus: channel?.status,
+      policy: admissionPolicy,
+    });
+    if (!floor.admitted) {
+      const blockedOrRevoked =
+        floor.reason === "member_blocked" || floor.reason === "member_revoked";
+      return {
+        message: blockedOrRevoked
+          ? "This number is not authorized to use this assistant."
+          : "This number is not authorized to reach the assistant right now.",
+        logReason: blockedOrRevoked
+          ? `Inbound voice ACL: caller ${channel?.status}`
+          : `Inbound voice admission floor: ${floor.effectivePolicy}`,
+      };
+    }
+  } else if (channel?.status === "blocked" || channel?.status === "revoked") {
+    // No admission floor configured: still hard-deny blocked/revoked, matching
+    // the setup blocked-caller branch (which denies independent of the floor).
+    return {
+      message: "This number is not authorized to use this assistant.",
+      logReason: `Inbound voice ACL: caller ${channel.status}`,
+    };
+  }
+
+  return null;
 }
 
 // ── ConversationRelay message types ──────────────────────────────────
@@ -678,7 +749,14 @@ export class RelayConnection {
         await this.startVerification(session, outcome.verificationConfig);
         return;
       case "deny":
-        await this.denyInboundCall(msg.from, resolved, outcome);
+        await this.denyInboundCall(
+          msg.from,
+          {
+            trustClass: resolved.actorTrust.trustClass,
+            member: resolved.actorTrust.memberRecord,
+          },
+          outcome,
+        );
         return;
       case "invite_redemption":
         this.startInviteRedemption(
@@ -797,14 +875,14 @@ export class RelayConnection {
   /** Deny an inbound call with a TTS message and schedule disconnect. */
   private async denyInboundCall(
     from: string,
-    resolved: SetupResolved,
+    denied: { trustClass: TrustClass; member: ResolvedMember | null },
     outcome: { message: string; logReason: string },
   ): Promise<void> {
     recordCallEvent(this.callSessionId, "inbound_acl_denied", {
       from,
-      trustClass: resolved.actorTrust.trustClass,
-      channelId: resolved.actorTrust.memberRecord?.channel.id,
-      memberPolicy: resolved.actorTrust.memberRecord?.channel.policy,
+      trustClass: denied.trustClass,
+      channelId: denied.member?.channel.id,
+      memberPolicy: denied.member?.channel.policy,
     });
     this.connectionState = "disconnecting";
     updateCallSession(this.callSessionId, {
@@ -905,7 +983,7 @@ export class RelayConnection {
   private async resolveMidCallTrustContext(
     assistantId: string,
     fromNumber: string,
-  ): Promise<TrustContext> {
+  ): Promise<MidCallTrust> {
     const verdict = await getInboundTrustVerdict({
       channelType: "phone",
       actorExternalId: fromNumber,
@@ -930,21 +1008,27 @@ export class RelayConnection {
       !memberlessUnknown;
 
     if (usable) {
-      return trustContextFromVerdict(verdict, {
-        sourceChannel: "phone",
-        conversationExternalId: fromNumber,
-      });
+      return {
+        context: trustContextFromVerdict(verdict, {
+          sourceChannel: "phone",
+          conversationExternalId: fromNumber,
+        }),
+        member: resolvedMemberFromVerdict(verdict),
+        trustClass: verdict.trustClass,
+      };
     }
 
-    return toTrustContext(
-      resolveActorTrust({
-        assistantId,
-        sourceChannel: "phone",
-        conversationExternalId: fromNumber,
-        actorExternalId: fromNumber,
-      }),
-      fromNumber,
-    );
+    const actorTrust = resolveActorTrust({
+      assistantId,
+      sourceChannel: "phone",
+      conversationExternalId: fromNumber,
+      actorExternalId: fromNumber,
+    });
+    return {
+      context: toTrustContext(actorTrust, fromNumber),
+      member: actorTrust.memberRecord,
+      trustClass: actorTrust.trustClass,
+    };
   }
 
   /**
@@ -952,24 +1036,46 @@ export class RelayConnection {
    * prompt that arrives during the async window. Guards the gap between
    * connectionState flipping to "connected" and the upgraded context landing so
    * a verified caller never starts a turn under the stale pre-verification
-   * trust. Clears the guard in a finally and flushes buffered prompts under the
-   * new context, so an IPC error can't wedge the call.
+   * trust. Clears the guard in a finally so an IPC error can't wedge the call.
+   *
+   * Returns `true` when the re-resolved verdict is a hard deny (blocked/revoked
+   * status or deny/escalate policy): the caller is torn down via the same
+   * denial path as setup and MUST NOT proceed to connected/greeting. On admit
+   * (or fail-soft fallback) returns `false`; the caller flushes buffered prompts
+   * AFTER the connected transition so a deferred utterance runs as the first
+   * real turn under the upgraded trust.
    */
   private async reResolveAndApplyTrustContext(
     assistantId: string,
     fromNumber: string,
-  ): Promise<void> {
-    if (!this.controller) return;
+  ): Promise<boolean> {
+    if (!this.controller) return false;
     this.trustReResolving = true;
     try {
-      const context = await this.resolveMidCallTrustContext(
-        assistantId,
-        fromNumber,
-      );
+      const { context, member, trustClass } =
+        await this.resolveMidCallTrustContext(assistantId, fromNumber);
+
+      const admissionPolicy = await getChannelAdmissionPolicy("phone");
+      const deny = midCallTrustDeny(member, trustClass, admissionPolicy);
+      if (deny) {
+        this.trustReResolvePending = [];
+        await this.denyInboundCall(fromNumber, { trustClass, member }, deny);
+        return true;
+      }
+
       this.controller.setTrustContext(context);
+      return false;
+    } catch (err) {
+      // Fail soft: a re-resolution error must not wedge the call. Keep the
+      // controller's existing (setup-time) trust and let the caller proceed to
+      // connected + flush, consistent with the verdict-first fallback.
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Mid-call trust re-resolution failed — keeping existing trust",
+      );
+      return false;
     } finally {
       this.trustReResolving = false;
-      this.flushDeferredPrompts();
     }
   }
 
@@ -1016,11 +1122,21 @@ export class RelayConnection {
     // longer writes contact/channel records on inbound voice calls.
 
     if (this.controller) {
-      await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
+      const denied = await this.reResolveAndApplyTrustContext(
+        assistantId,
+        fromNumber,
+      );
+      // Re-resolution surfaced a blocked/revoked/policy-deny verdict: the call
+      // is torn down by denyInboundCall — don't continue to connected/greeting.
+      if (denied) return;
     }
 
     this.connectionState = "connected";
     updateCallSession(this.callSessionId, { status: "in_progress" });
+    // Flush AFTER connected so a prompt buffered during re-resolution runs as
+    // the caller's first real turn under the upgraded trust, not as wait-state
+    // chatter swallowed while still verification_pending.
+    this.flushDeferredPrompts();
 
     const guardianLabel = this.resolveGuardianLabel();
     let handoffText: string;
@@ -1200,12 +1316,20 @@ export class RelayConnection {
 
         // Update trust context on the controller so the LLM knows this is the guardian
         if (this.controller) {
-          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
+          const denied = await this.reResolveAndApplyTrustContext(
+            assistantId,
+            fromNumber,
+          );
+          // Blocked/revoked/policy-deny verdict: torn down — don't greet.
+          if (denied) return;
         }
 
         // Mark session as in-progress and transition to guardian conversation
-        // with verification context so the LLM greets naturally.
+        // with verification context so the LLM greets naturally. Connected was
+        // already set above; flush buffered prompts now so a deferred utterance
+        // runs as the first real turn under the upgraded trust.
         updateCallSession(this.callSessionId, { status: "in_progress" });
+        this.flushDeferredPrompts();
         if (this.controller) {
           this.controller
             .startPostVerificationGreeting()
@@ -1226,7 +1350,15 @@ export class RelayConnection {
         // Inbound guardian verification: binding already handled above,
         // proceed to normal call flow.
         if (this.controller) {
-          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
+          const denied = await this.reResolveAndApplyTrustContext(
+            assistantId,
+            fromNumber,
+          );
+          // Blocked/revoked/policy-deny verdict: torn down — don't start flow.
+          if (denied) return;
+          // Connected was already set above; flush buffered prompts so a
+          // deferred utterance runs as the first real turn under upgraded trust.
+          this.flushDeferredPrompts();
           this.startNormalCallFlow(this.controller, true);
         }
       }


### PR DESCRIPTION
## Summary
- The three mid-call re-resolution sites (trusted-contact activation, outbound + inbound guardian verification) now re-resolve caller trust from the gateway verdict via a shared verdict-first helper, falling back to local resolution on a missing/failed/unusable verdict. The verdict is authoritative right after the gateway updates the binding.

Part of plan: voice-consumes-trust-verdict.md (PR 6 of 7)