### PR TITLE
fix(plugins): scope the empty-response nudge to user-facing turns

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -2327,6 +2327,7 @@ describe("AgentLoop", () => {
       messages: [userMessage],
       onEvent: collectEvents(events),
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      callSite: "mainAgent",
     });
 
     // Provider should be called 3 times: initial, empty response, retry
@@ -2410,6 +2411,7 @@ describe("AgentLoop", () => {
       messages: [userMessage],
       onEvent: collectEvents(events),
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      callSite: "mainAgent",
     });
 
     // Provider called exactly 2 times: initial [text+tool_use], then empty.
@@ -2477,6 +2479,7 @@ describe("AgentLoop", () => {
       messages: [userMessage],
       onEvent: collectEvents(events),
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      callSite: "mainAgent",
     });
 
     // Provider called 3 times: initial, empty, retry (also empty)

--- a/assistant/src/__tests__/empty-response-hook.test.ts
+++ b/assistant/src/__tests__/empty-response-hook.test.ts
@@ -326,6 +326,48 @@ describe("empty-response post-model-call hook — default decisions", () => {
     expect(ctx.decision).toBe("stop");
     expect(ctx.messages).toEqual([priorToolUseTurn]);
   });
+
+  // ─── Call-site gating ──────────────────────────────────────────────────────
+
+  test("empty turn after tools on a non-mainAgent call site → stop, no nudge", async () => {
+    // GIVEN an empty-after-tools turn that would nudge on the user-facing reply,
+    // but the call site is a background one (a memory retrospective). There is
+    // no user awaiting a summary, so the re-query nudge must not fire.
+    const ctx = makeCtx({
+      callSite: "memoryRetrospective",
+      messages: [priorToolUseTurn],
+      content: [],
+    });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN the turn ends silently — no nudge appended, no re-query.
+    expect(ctx.decision).toBe("stop");
+    expect(ctx.messages).toEqual([priorToolUseTurn]);
+  });
+
+  test("refusal on a non-mainAgent call site is still rewritten to the fallback", async () => {
+    // GIVEN a refusal with no visible text on a background call site. The
+    // call-site gate scopes only the re-query nudge; the refusal-rewrite is a
+    // user-facing terminal fallback for any consumer that reads the final text,
+    // so it stays ungated.
+    const ctx = makeCtx({
+      callSite: "memoryRetrospective",
+      messages: [],
+      content: [],
+      stopReason: "refusal",
+    });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN the empty refusal is still rewritten to the user-facing fallback.
+    expect(ctx.decision).toBe("stop");
+    expect(ctx.content).toEqual([
+      { type: "text", text: REFUSAL_FALLBACK_TEXT },
+    ]);
+  });
 });
 
 // ─── One-shot retry bound ────────────────────────────────────────────────────

--- a/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
@@ -16,10 +16,12 @@
  *    at least one prior assistant turn this run, and no earlier turn this run
  *    already delivered visible text. The hook re-queries the model with
  *    `NUDGE_TEXT` (a tool trail exists to summarize, so a retry can recover a
- *    real answer). The retry is bounded to one pass per run by a one-shot
- *    per-conversation mark this hook sets; the sibling `stop` hook (see
- *    `./stop.ts`) clears it when the turn terminates, so the next run nudges
- *    afresh.
+ *    real answer). Main-agent turns only: background, subagent, and compaction
+ *    calls have no user awaiting a summary, so per the post-model-call contract
+ *    the nudge self-gates on {@link PostModelCallContext.callSite}. The retry is
+ *    bounded to one pass per run by a one-shot per-conversation mark this hook
+ *    sets; the sibling `stop` hook (see `./stop.ts`) clears it when the turn
+ *    terminates, so the next run nudges afresh.
  *
  * Every other case leaves the decision at `"stop"` (the model said its piece,
  * or there is nothing to act on).
@@ -146,6 +148,13 @@ const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
     !priorAssistantHadVisibleText;
 
   if (isEmptyTurnAfterTools) {
+    // Only the user-facing reply gets the re-query nudge. Background, subagent,
+    // and compaction calls have no user awaiting a summary, and the
+    // post-model-call contract requires self-gating on call site to avoid
+    // re-querying them. The refusal-rewrite above is a user-facing terminal
+    // fallback, not a re-query, so it stays ungated.
+    if (ctx.callSite !== "mainAgent") return;
+
     // Re-query once to recover a real answer. The one-shot per-conversation
     // mark makes the hook self-limiting: a second empty turn this run finds the
     // mark already set and lets the turn end rather than nudging again.


### PR DESCRIPTION
## Summary

- The `empty-response` plugin injected a `<system_notice>` nudge and re-queried the model whenever a turn ended empty after tool use — on **every** call site, including background turns like memory retrospectives that have no user awaiting a response.
- Gate the nudge on `ctx.callSite === "mainAgent"`, matching the sibling `surface-completion-nudge` and `max-tokens-continue` hooks and the `PostModelCallContext` contract (`plugin-api/types.ts`), which mandates self-gating on call site to avoid re-querying background/subagent/compaction calls. `empty-response` was the lone holdout.
- The refusal-rewrite branch (a user-facing terminal fallback, not a re-query) stays ungated. Added unit tests for the gate and the still-ungated refusal path, and tagged the three nudge-driven integration tests with `callSite: "mainAgent"`.

## Original prompt

A memory-retrospective background turn surfaced a `<system_notice>` reading "Your previous response was empty. You must respond to the user with a summary of what you found or did…" and then produced a summary. Background turns like memory retrospectives don't need a user-facing response, so that nudge shouldn't fire for them — it's noise and an extra LLM call. Fix: scope the empty-response nudge to the user-facing main-agent turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)