### PR TITLE
refactor(gateway): shared resolutionFailed sentinel factory + canonical id normalization

### DIFF
--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -301,4 +301,22 @@ describe("handle-inbound trust verdict stamping", () => {
       "trusted_contacts",
     );
   });
+
+  test("resolver throw with whitespace-only actor id → sentinel canonicalSenderId is null", async () => {
+    resetGatewayDb();
+
+    await handleInbound(
+      makeConfig(),
+      makeEvent({
+        actor: { actorExternalId: "   ", displayName: "Blank", username: "" },
+      }),
+      ROUTING,
+    );
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.resolutionFailed).toBe(true);
+    expect(verdict.trustClass).toBe("unknown");
+    // Matches a real resolve: whitespace-only id normalizes to absent.
+    expect(verdict.canonicalSenderId).toBeNull();
+  });
 });

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,5 +1,9 @@
 import { existsSync } from "node:fs";
-import type { SourceMetadata, TrustVerdict } from "@vellumai/gateway-client";
+import {
+  makeResolutionFailedVerdict,
+  type SourceMetadata,
+  type TrustVerdict,
+} from "@vellumai/gateway-client";
 import type { GatewayConfig } from "../config.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
@@ -7,7 +11,10 @@ import { ContactStore } from "../db/contact-store.js";
 import { getLogger } from "../logger.js";
 import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
 import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
-import { canonicalizeInboundIdentity } from "../verification/identity.js";
+import {
+  canonicalizeInboundIdentity,
+  canonicalSenderIdFor,
+} from "../verification/identity.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
 import {
@@ -169,14 +176,9 @@ export async function handleInbound(
     // Producer fails soft — resolution never breaks ingress. Stamp a sentinel
     // so the consumer can tell a resolver failure from a real stranger.
     log.warn({ err }, "trust verdict resolution failed; stamping sentinel");
-    trustVerdict = {
-      trustClass: "unknown",
-      canonicalSenderId: canonicalizeInboundIdentity(
-        event.sourceChannel,
-        event.actor.actorExternalId,
-      ),
-      resolutionFailed: true,
-    };
+    trustVerdict = makeResolutionFailedVerdict(
+      canonicalSenderIdFor(event.sourceChannel, event.actor.actorExternalId),
+    );
   }
 
   try {

--- a/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
@@ -165,4 +165,22 @@ describe("resolve_inbound_trust route", () => {
     expect(result.verdict.trustClass).toBe("unknown");
     expect(result.verdict.canonicalSenderId).toBe("U_STRANGER");
   });
+
+  test("resolver throw with whitespace-only actor id → sentinel canonicalSenderId is null", async () => {
+    resetGatewayDb();
+
+    const params = { channelType: CHANNEL, actorExternalId: "   " };
+    const result = (await route.handler(params)) as {
+      verdict: {
+        trustClass: string;
+        canonicalSenderId: string | null;
+        resolutionFailed?: boolean;
+      };
+    };
+
+    expect(result.verdict.resolutionFailed).toBe(true);
+    expect(result.verdict.trustClass).toBe("unknown");
+    // Matches a real resolve: whitespace-only id normalizes to absent.
+    expect(result.verdict.canonicalSenderId).toBeNull();
+  });
 });

--- a/gateway/src/ipc/trust-verdict-handlers.ts
+++ b/gateway/src/ipc/trust-verdict-handlers.ts
@@ -8,10 +8,13 @@
  * per-actor and must not share that cache or widen that response.
  */
 
-import { ResolveInboundTrustRequestSchema } from "@vellumai/gateway-client";
+import {
+  makeResolutionFailedVerdict,
+  ResolveInboundTrustRequestSchema,
+} from "@vellumai/gateway-client";
 
 import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
-import { canonicalizeInboundIdentity } from "../verification/identity.js";
+import { canonicalSenderIdFor } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
 
 export const trustVerdictRoutes: IpcRoute[] = [
@@ -26,16 +29,9 @@ export const trustVerdictRoutes: IpcRoute[] = [
         // Sentinel lets the daemon distinguish a resolver failure from a real
         // stranger.
         return {
-          verdict: {
-            trustClass: "unknown",
-            canonicalSenderId: input.actorExternalId
-              ? canonicalizeInboundIdentity(
-                  input.channelType,
-                  input.actorExternalId,
-                )
-              : null,
-            resolutionFailed: true,
-          },
+          verdict: makeResolutionFailedVerdict(
+            canonicalSenderIdFor(input.channelType, input.actorExternalId),
+          ),
         };
       }
     },

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -19,7 +19,7 @@ import {
   contacts as gwContacts,
   contactChannels as gwContactChannels,
 } from "../db/schema.js";
-import { canonicalizeInboundIdentity } from "../verification/identity.js";
+import { canonicalSenderIdFor } from "../verification/identity.js";
 
 export interface ResolveTrustVerdictInput {
   channelType: string;
@@ -39,15 +39,10 @@ export async function resolveTrustVerdict(
 ): Promise<TrustVerdict> {
   const db = getGatewayDb();
 
-  const rawActorId =
-    typeof input.actorExternalId === "string" &&
-    input.actorExternalId.trim().length > 0
-      ? input.actorExternalId.trim()
-      : undefined;
-
-  const canonicalSenderId = rawActorId
-    ? canonicalizeInboundIdentity(input.channelType, rawActorId)
-    : null;
+  const canonicalSenderId = canonicalSenderIdFor(
+    input.channelType,
+    input.actorExternalId,
+  );
 
   // --- Guardian-for-channel binding (independent of THIS actor) ---
   const guardianRow = db

--- a/gateway/src/verification/identity.ts
+++ b/gateway/src/verification/identity.ts
@@ -67,3 +67,16 @@ export function canonicalizeInboundIdentity(
 
   return trimmed;
 }
+
+/**
+ * Canonical sender id for a possibly-absent inbound actor id. Treats a missing
+ * or whitespace-only id as absent (null) before canonicalizing, so trust
+ * resolution and its failure sentinels share one normalization.
+ */
+export function canonicalSenderIdFor(
+  channel: string,
+  actorExternalId?: string,
+): string | null {
+  const trimmed = actorExternalId?.trim();
+  return trimmed ? canonicalizeInboundIdentity(channel, trimmed) : null;
+}

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from "bun:test";
 
 import { SourceMetadataSchema } from "../inbound-contract.js";
 import {
+  makeResolutionFailedVerdict,
   TrustVerdictSchema,
   type TrustVerdict,
 } from "../trust-verdict-contract.js";
@@ -58,6 +59,19 @@ describe("TrustVerdictSchema", () => {
       canonicalSenderId: null,
     });
     expect(parsed.resolutionFailed).toBeUndefined();
+  });
+
+  test("makeResolutionFailedVerdict builds an unknown sentinel", () => {
+    expect(makeResolutionFailedVerdict("+15555550100")).toEqual({
+      trustClass: "unknown",
+      canonicalSenderId: "+15555550100",
+      resolutionFailed: true,
+    });
+    expect(makeResolutionFailedVerdict(null)).toEqual({
+      trustClass: "unknown",
+      canonicalSenderId: null,
+      resolutionFailed: true,
+    });
   });
 
   test("rejects an invalid trustClass", () => {

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -73,6 +73,7 @@ export type { AdmissionPolicy } from "./admission-policy-contract.js";
 
 // Trust verdict contract (gateway → daemon) — Zod schemas + derived types
 export {
+  makeResolutionFailedVerdict,
   ResolveInboundTrustRequestSchema,
   TRUST_CLASS_VALUES,
   TrustClassSchema,

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -69,6 +69,18 @@ export const TrustVerdictSchema = z.object({
 export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;
 
 /**
+ * Sentinel for a gateway resolver failure; consumers treat it as
+ * could-not-vouch (distinct from a real `unknown` stranger). Takes the
+ * already-canonicalized sender id so this module stays free of the gateway's
+ * canonicalization util.
+ */
+export function makeResolutionFailedVerdict(
+  canonicalSenderId: string | null,
+): TrustVerdict {
+  return { trustClass: "unknown", canonicalSenderId, resolutionFailed: true };
+}
+
+/**
  * IPC request for `resolve_inbound_trust`. Per-actor identity keys the
  * gateway resolver needs to classify the inbound sender. The response reuses
  * {@link TrustVerdictSchema}.


### PR DESCRIPTION
## Summary
- Add `makeResolutionFailedVerdict` factory; both gateway catch blocks (text stamp + resolve_inbound_trust IPC) use it.
- Sentinel `canonicalSenderId` now applies the resolver's trim/empty normalization, so a whitespace-only actor id yields null (matching a real resolve).

Self-review remediation for plan: voice-consumes-trust-verdict.md