### PR TITLE
fix(assistant): mid-call prompt flush ordering + verdict-helper dedup

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -180,9 +180,16 @@ mock.module("../calls/channel-admission-reader.js", () => ({
 // verdict into routeSetup so the media-stream transport enforces the same
 // gateway ACL as ConversationRelay. Tests override mockInboundVerdict.
 let mockInboundVerdict: unknown = null;
-const mockGetInboundTrustVerdict = jest.fn(async () => mockInboundVerdict);
+const mockGetInboundTrustVerdict = jest.fn(
+  async (_args?: Record<string, unknown>) => mockInboundVerdict,
+);
 mock.module("../calls/inbound-trust-reader.js", () => ({
   getInboundTrustVerdict: mockGetInboundTrustVerdict,
+  getPhoneCallerVerdict: (otherPartyNumber: string | undefined) =>
+    mockGetInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    }),
 }));
 
 // Mock the actor trust resolver (used by handleStart to derive trust context)

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -5901,4 +5901,160 @@ describe("relay-server", () => {
 
     relay.destroy();
   });
+
+  test("invite redemption: a prompt buffered during re-resolution runs as a real turn after activation (not dropped)", async () => {
+    ensureConversation("conv-midcall-invite-flush");
+    const session = createCallSession({
+      conversationId: "conv-midcall-invite-flush",
+      provider: "twilio",
+      fromNumber: "+15558887777",
+      toNumber: "+15551111111",
+    });
+
+    const code = generateVoiceCode(6);
+    createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact("Alice"),
+      maxUses: 1,
+      expectedExternalUserId: "+15558887777",
+      voiceCodeHash: hashVoiceCode(code),
+      voiceCodeDigits: 6,
+    });
+
+    const turnCountBefore = mockSendMessage.mock.calls.length;
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Sure, here you go."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_invite_flush",
+        from: "+15558887777",
+        to: "+15551111111",
+      }),
+    );
+    expect(relay.getConnectionState()).toBe("verification_pending");
+
+    // Gate the mid-call verdict so the prompt lands inside the re-resolution
+    // await, after activation flips connectionState to "connected".
+    let releaseVerdict!: () => void;
+    mockMidCallVerdictGate = new Promise<void>((resolve) => {
+      releaseVerdict = resolve;
+    });
+
+    const digits = code.split("");
+    for (const digit of digits.slice(0, -1)) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    const redemptionDone = relay.handleMessage(
+      JSON.stringify({ type: "dtmf", digit: digits[digits.length - 1] }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Activation already reached the terminal state before re-resolution.
+    expect(relay.getConnectionState()).toBe("connected");
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "What's on my calendar today?",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    // Buffered, not yet run (verdict gated).
+    expect(mockSendMessage.mock.calls.length).toBe(turnCountBefore);
+
+    releaseVerdict();
+    await redemptionDone;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Flushed onto the real-turn path: the prompt produced an LLM turn rather
+    // than being dropped by the verification-pending branch.
+    expect(mockSendMessage.mock.calls.length).toBeGreaterThan(turnCountBefore);
+
+    relay.destroy();
+  });
+
+  test("access-request approval: a prompt buffered during re-resolution runs as a real turn (not misrouted to wait-state)", async () => {
+    ensureConversation("conv-midcall-access-flush");
+    const session = createCallSession({
+      conversationId: "conv-midcall-access-flush",
+      provider: "twilio",
+      fromNumber: "+15557770003",
+      toNumber: "+15551111111",
+    });
+
+    const turnCountBefore = mockSendMessage.mock.calls.length;
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Sure, here you go."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_access_flush",
+        from: "+15557770003",
+        to: "+15551111111",
+      }),
+    );
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "Bob Smith",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    expect(relay.getConnectionState()).toBe("awaiting_guardian_decision");
+
+    // Gate the mid-call verdict so the prompt lands inside the re-resolution
+    // await triggered by the approval poll.
+    let releaseVerdict!: () => void;
+    mockMidCallVerdictGate = new Promise<void>((resolve) => {
+      releaseVerdict = resolve;
+    });
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "+15557770003",
+      sourceChannel: "phone",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
+    resolveCanonicalGuardianRequest(pending[0].id, "pending", {
+      status: "approved",
+      answerText: undefined,
+      decidedByExternalUserId: undefined,
+    });
+
+    // Let the poll detect approval and enter the gated re-resolution.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(relay.getConnectionState()).toBe("connected");
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "What's on my calendar today?",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    // Buffered, not yet run (verdict gated).
+    expect(mockSendMessage.mock.calls.length).toBe(turnCountBefore);
+
+    releaseVerdict();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Flushed onto the real-turn path rather than the awaiting-guardian-decision
+    // wait-state classifier: the prompt produced an LLM turn.
+    expect(mockSendMessage.mock.calls.length).toBeGreaterThan(turnCountBefore);
+
+    relay.destroy();
+  });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -119,6 +119,13 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
     lastInboundVerdictArgs = args;
     return mockInboundVerdict;
   },
+  getPhoneCallerVerdict: async (otherPartyNumber: string | undefined) => {
+    lastInboundVerdictArgs = {
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    };
+    return mockInboundVerdict;
+  },
 }));
 
 mock.module("../config/env.js", () => ({

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -60,20 +60,21 @@ const CHANNEL_STATUS_VALUES = [
   "unverified",
 ];
 const CHANNEL_POLICY_VALUES = ["allow", "deny", "escalate"];
-const resolvedMemberFromVerdictMock = mock((verdict: TrustVerdict) => {
-  if (!verdict.contactId || !verdict.channelId) return null;
-  if (!verdict.status || !verdict.policy) return null;
-  if (
-    !CHANNEL_STATUS_VALUES.includes(verdict.status) ||
-    !CHANNEL_POLICY_VALUES.includes(verdict.policy)
-  ) {
-    return null;
-  }
-  return { contact: {}, channel: {} };
-});
+function resolvesMember(verdict: TrustVerdict): boolean {
+  if (!verdict.contactId || !verdict.channelId) return false;
+  if (!verdict.status || !verdict.policy) return false;
+  return (
+    CHANNEL_STATUS_VALUES.includes(verdict.status) &&
+    CHANNEL_POLICY_VALUES.includes(verdict.policy)
+  );
+}
+const verdictMemberUnresolvableMock = mock(
+  (verdict: TrustVerdict) =>
+    !!(verdict.contactId || verdict.channelId) && !resolvesMember(verdict),
+);
 mock.module("../../runtime/trust-verdict-consumer.js", () => ({
   actorTrustContextFromVerdict: actorTrustContextFromVerdictMock,
-  resolvedMemberFromVerdict: resolvedMemberFromVerdictMock,
+  verdictMemberUnresolvable: verdictMemberUnresolvableMock,
 }));
 
 // Controllable pending verification challenge.
@@ -203,7 +204,7 @@ beforeEach(() => {
   boundContact = null;
   resolveActorTrustMock.mockClear();
   actorTrustContextFromVerdictMock.mockClear();
-  resolvedMemberFromVerdictMock.mockClear();
+  verdictMemberUnresolvableMock.mockClear();
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -10,7 +10,10 @@
  * fail-closed); this reader only reports the verdict or `null`.
  */
 
-import { type TrustVerdict, TrustVerdictSchema } from "@vellumai/gateway-client";
+import {
+  type TrustVerdict,
+  TrustVerdictSchema,
+} from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
 import { ipcCall } from "../ipc/gateway-client.js";
@@ -37,4 +40,17 @@ export async function getInboundTrustVerdict(input: {
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the verdict for a phone caller by their external number. Callers
+ * compute `otherPartyNumber` from their own transport-specific direction.
+ */
+export function getPhoneCallerVerdict(
+  otherPartyNumber: string | undefined,
+): Promise<TrustVerdict | null> {
+  return getInboundTrustVerdict({
+    channelType: "phone",
+    actorExternalId: otherPartyNumber || undefined,
+  });
 }

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -52,7 +52,7 @@ import {
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
-import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
+import { getPhoneCallerVerdict } from "./inbound-trust-reader.js";
 import { MediaStreamOutput } from "./media-stream-output.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type { MediaStreamStartEvent } from "./media-stream-protocol.js";
@@ -398,10 +398,7 @@ export class MediaStreamCallSession {
     // null on failure, keeping the local path on a gateway blip.
     const isInbound = session?.initiatedFromConversationId == null;
     const otherPartyNumber = isInbound ? from : to;
-    const verdict = await getInboundTrustVerdict({
-      channelType: "phone",
-      actorExternalId: otherPartyNumber || undefined,
-    });
+    const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
     // The verdict read above yields the event loop; abort if the session was
     // disposed meanwhile, matching the admission-read guard above.

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -28,8 +28,9 @@ import {
   toTrustContext,
 } from "../runtime/actor-trust-resolver.js";
 import {
-  resolvedMemberFromVerdict,
   trustContextFromVerdict,
+  verdictHasMemberIdentity,
+  verdictMemberUnresolvable,
 } from "../runtime/trust-verdict-consumer.js";
 import {
   composeVerificationVoice,
@@ -55,7 +56,10 @@ import {
 import { ConversationRelayTransport } from "./call-transport.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
-import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
+import {
+  getInboundTrustVerdict,
+  getPhoneCallerVerdict,
+} from "./inbound-trust-reader.js";
 import {
   classifyWaitUtterance,
   emitAccessRequestCallbackHandoff,
@@ -602,10 +606,7 @@ export class RelayConnection {
     // returns null on failure, so a gateway blip keeps the local path.
     const isInbound = session?.initiatedFromConversationId == null;
     const otherPartyNumber = isInbound ? msg.from : msg.to;
-    const verdict = await getInboundTrustVerdict({
-      channelType: "phone",
-      actorExternalId: otherPartyNumber || undefined,
-    });
+    const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
     try {
       await this.routeSetupOutcome(msg, session, admissionPolicy, verdict);
@@ -911,9 +912,6 @@ export class RelayConnection {
       actorExternalId: fromNumber,
     });
 
-    const hasMemberIdentity = !!(verdict?.contactId || verdict?.channelId);
-    const memberUnresolvable =
-      hasMemberIdentity && resolvedMemberFromVerdict(verdict!) === null;
     // Only a MEMBERLESS unknown verdict is treated as a stale gateway view and
     // falls back to local: the caller was just activated, and invite redemption
     // writes the channel assistant-side, so the gateway may not see the member
@@ -922,11 +920,11 @@ export class RelayConnection {
     // enforced; falling back could lose the gateway's member status if local
     // state is stale.
     const memberlessUnknown =
-      verdict?.trustClass === "unknown" && !hasMemberIdentity;
+      verdict?.trustClass === "unknown" && !verdictHasMemberIdentity(verdict);
     const usable =
       verdict &&
       !verdict.resolutionFailed &&
-      !memberUnresolvable &&
+      !verdictMemberUnresolvable(verdict) &&
       !memberlessUnknown;
 
     if (usable) {
@@ -1015,12 +1013,18 @@ export class RelayConnection {
     // Contact activation is handled by the gateway — the assistant no
     // longer writes contact/channel records on inbound voice calls.
 
+    // Reach connected and clear wait/verification flags before re-resolving
+    // trust, so a prompt buffered during re-resolution flushes onto the
+    // real-turn path, not the verification/wait branches.
+    this.connectionState = "connected";
+    this.verificationSessionActive = false;
+    this.inviteRedemptionActive = false;
+    this.accessRequestWaitActive = false;
+    updateCallSession(this.callSessionId, { status: "in_progress" });
+
     if (this.controller) {
       await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
     }
-
-    this.connectionState = "connected";
-    updateCallSession(this.callSessionId, { status: "in_progress" });
 
     const guardianLabel = this.resolveGuardianLabel();
     let handoffText: string;

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -23,7 +23,7 @@ import {
 } from "../runtime/routes/inbound-stages/admission-policy.js";
 import {
   actorTrustContextFromVerdict,
-  resolvedMemberFromVerdict,
+  verdictMemberUnresolvable,
 } from "../runtime/trust-verdict-consumer.js";
 import { getLogger } from "../util/logger.js";
 import type { CallSession } from "./types.js";
@@ -132,24 +132,22 @@ export function routeSetup(ctx: SetupContext): {
   // resolution, so voice never trusts a member it cannot ACL-check. A real
   // stranger verdict (no member identity) still takes the verdict path —
   // memberRecord null is correct there.
-  const hasMemberIdentity = !!(
-    ctx.verdict?.contactId || ctx.verdict?.channelId
-  );
-  const memberUnresolvable =
-    hasMemberIdentity && resolvedMemberFromVerdict(ctx.verdict!) === null;
-  const actorTrust =
-    ctx.verdict && !ctx.verdict.resolutionFailed && !memberUnresolvable
-      ? actorTrustContextFromVerdict(ctx.verdict, {
-          sourceChannel: "phone",
-          conversationExternalId: otherPartyNumber,
-          actorDisplayName: undefined,
-        })
-      : resolveActorTrust({
-          assistantId,
-          sourceChannel: "phone",
-          conversationExternalId: otherPartyNumber,
-          actorExternalId: otherPartyNumber || undefined,
-        });
+  const usable =
+    ctx.verdict &&
+    !ctx.verdict.resolutionFailed &&
+    !verdictMemberUnresolvable(ctx.verdict);
+  const actorTrust = usable
+    ? actorTrustContextFromVerdict(ctx.verdict!, {
+        sourceChannel: "phone",
+        conversationExternalId: otherPartyNumber,
+        actorDisplayName: undefined,
+      })
+    : resolveActorTrust({
+        assistantId,
+        sourceChannel: "phone",
+        conversationExternalId: otherPartyNumber,
+        actorExternalId: otherPartyNumber || undefined,
+      });
 
   const resolved: SetupResolved = {
     assistantId,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -55,7 +55,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
-import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
+import { getPhoneCallerVerdict } from "./inbound-trust-reader.js";
 import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
@@ -491,10 +491,7 @@ async function buildVoiceWebhookTwiml(
   // local path on a gateway blip.
   const isInbound = sessionContext?.direction !== "outbound";
   const otherPartyNumber = isInbound ? from : to;
-  const verdict = await getInboundTrustVerdict({
-    channelType: "phone",
-    actorExternalId: otherPartyNumber || undefined,
-  });
+  const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
   const { outcome } = routeSetup({
     callSessionId,

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -13,6 +13,8 @@ import {
   actorTrustContextFromVerdict,
   resolvedMemberFromVerdict,
   trustContextFromVerdict,
+  verdictHasMemberIdentity,
+  verdictMemberUnresolvable,
 } from "../trust-verdict-consumer.js";
 
 const CONV = "conv-123";
@@ -398,9 +400,7 @@ describe("toTrustContext member grounding", () => {
     };
   }
 
-  function ctxWithMember(
-    channel: ContactChannel,
-  ): ActorTrustContext {
+  function ctxWithMember(channel: ContactChannel): ActorTrustContext {
     return {
       canonicalSenderId: "+15550100",
       guardianBindingMatch: null,
@@ -604,5 +604,67 @@ describe("resolvedMemberFromVerdict", () => {
       expect(member!.channel.status).toBe(status);
       expect(member!.channel.policy).toBe("deny");
     }
+  });
+});
+
+describe("verdict predicates", () => {
+  test("verdictHasMemberIdentity is true with contactId or channelId", () => {
+    expect(
+      verdictHasMemberIdentity({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+        contactId: "contact-1",
+      } satisfies TrustVerdict),
+    ).toBe(true);
+    expect(
+      verdictHasMemberIdentity({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+        channelId: "channel-1",
+      } satisfies TrustVerdict),
+    ).toBe(true);
+  });
+
+  test("verdictHasMemberIdentity is false for a memberless verdict", () => {
+    expect(
+      verdictHasMemberIdentity({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+      } satisfies TrustVerdict),
+    ).toBe(false);
+  });
+
+  test("verdictMemberUnresolvable is true when member identity present but ACL unsynthesizable", () => {
+    expect(
+      verdictMemberUnresolvable({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-1",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toBe(true);
+  });
+
+  test("verdictMemberUnresolvable is false for a usable member verdict", () => {
+    expect(
+      verdictMemberUnresolvable({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-1",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "active",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toBe(false);
+  });
+
+  test("verdictMemberUnresolvable is false for a memberless verdict", () => {
+    expect(
+      verdictMemberUnresolvable({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+      } satisfies TrustVerdict),
+    ).toBe(false);
   });
 });

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -109,6 +109,26 @@ export function trustContextFromVerdict(
   return context;
 }
 
+/**
+ * True when the verdict carries a member identity (contactId or channelId),
+ * regardless of whether that member resolves to a usable {@link ResolvedMember}.
+ */
+export function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
+  return !!(verdict.contactId || verdict.channelId);
+}
+
+/**
+ * True when the verdict claims a member identity but that member can't be
+ * synthesized (partial/mixed-version verdict). Such a verdict is unusable —
+ * callers fall back to local resolution.
+ */
+export function verdictMemberUnresolvable(verdict: TrustVerdict): boolean {
+  return (
+    verdictHasMemberIdentity(verdict) &&
+    resolvedMemberFromVerdict(verdict) === null
+  );
+}
+
 // Allowed ACL enum values, kept in sync with the ContactChannel union types.
 const CHANNEL_STATUS_VALUES: readonly ChannelStatus[] = [
   "active",


### PR DESCRIPTION
## Summary
- Flush mid-call buffered prompts only after the call reaches `connected` so a verified caller's first utterance is answered (was dropped on invite-redemption / misrouted on access-request).
- Share `verdictHasMemberIdentity`/`verdictMemberUnresolvable` between setup + mid-call; add `getPhoneCallerVerdict` to de-dup the prefetch block. No behavior change beyond the flush fix.

Self-review remediation for plan: voice-consumes-trust-verdict.md