### PR TITLE
Combo 10 — Voice CONSUMES the gateway trust verdict + fail-soft/fail-closed reconciliation

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3973,6 +3973,8 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        resolutionFailed:
+                          type: boolean
                         guardianExternalUserId:
                           type: string
                         guardianDeliveryChatId:

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -138,16 +138,11 @@ function stampTrustVerdict(body: Record<string, unknown>): void {
   const channelType = String(body.sourceChannel ?? "");
   const actorExternalId =
     typeof body.actorExternalId === "string" ? body.actorExternalId : undefined;
-  const externalChatId =
-    typeof body.conversationExternalId === "string"
-      ? body.conversationExternalId
-      : undefined;
   if (!channelType) return;
 
   const verdict = resolveLocalTrustVerdict({
     channelType,
     actorExternalId,
-    externalChatId,
   });
   body.sourceMetadata = { ...(meta ?? {}), trustVerdict: verdict };
 }
@@ -156,15 +151,14 @@ function stampTrustVerdict(body: Record<string, unknown>): void {
 export function resolveLocalTrustVerdict(input: {
   channelType: string;
   actorExternalId?: string;
-  externalChatId?: string;
 }): TrustVerdict {
   const canonicalSenderId = input.actorExternalId ?? null;
 
+  // Match the gateway's address-only member resolution (no externalChatId).
   const member = input.actorExternalId
     ? findContactChannel({
         channelType: input.channelType,
         address: input.actorExternalId,
-        externalChatId: input.externalChatId,
       })
     : null;
   const guardian = findGuardianForChannel(input.channelType);

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -180,9 +180,16 @@ mock.module("../calls/channel-admission-reader.js", () => ({
 // verdict into routeSetup so the media-stream transport enforces the same
 // gateway ACL as ConversationRelay. Tests override mockInboundVerdict.
 let mockInboundVerdict: unknown = null;
-const mockGetInboundTrustVerdict = jest.fn(async () => mockInboundVerdict);
+const mockGetInboundTrustVerdict = jest.fn(
+  async (_args?: Record<string, unknown>) => mockInboundVerdict,
+);
 mock.module("../calls/inbound-trust-reader.js", () => ({
   getInboundTrustVerdict: mockGetInboundTrustVerdict,
+  getPhoneCallerVerdict: (otherPartyNumber: string | undefined) =>
+    mockGetInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    }),
 }));
 
 // Mock the actor trust resolver (used by handleStart to derive trust context)

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -176,6 +176,15 @@ mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: mockGetChannelAdmissionPolicy,
 }));
 
+// Mock the inbound trust reader. handleStart awaits this and threads the
+// verdict into routeSetup so the media-stream transport enforces the same
+// gateway ACL as ConversationRelay. Tests override mockInboundVerdict.
+let mockInboundVerdict: unknown = null;
+const mockGetInboundTrustVerdict = jest.fn(async () => mockInboundVerdict);
+mock.module("../calls/inbound-trust-reader.js", () => ({
+  getInboundTrustVerdict: mockGetInboundTrustVerdict,
+}));
+
 // Mock the actor trust resolver (used by handleStart to derive trust context)
 mock.module("../runtime/actor-trust-resolver.js", () => ({
   toTrustContext: jest.fn(() => ({
@@ -356,6 +365,8 @@ beforeEach(() => {
   mockGetChannelAdmissionPolicy.mockClear();
   mockAdmissionPolicy = null;
   mockAdmissionGate = null;
+  mockGetInboundTrustVerdict.mockClear();
+  mockInboundVerdict = null;
   // Reset routeSetup to default normal_call
   mockRouteSetupResult = {
     outcome: { action: "normal_call" as const, isInbound: true },
@@ -1533,6 +1544,115 @@ describe("media-stream setup outcome scenarios", () => {
       expect(registerCallController).not.toHaveBeenCalled();
       expect(mockStartInitialGreeting).not.toHaveBeenCalled();
       expect(speakSystemPrompt).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Gateway trust verdict ──────────────────────────────────────────
+  // handleStart fetches getInboundTrustVerdict for the inbound caller and
+  // threads it into routeSetup, so the media-stream transport enforces the
+  // same gateway ACL as ConversationRelay. routeSetup itself decides
+  // verdict-vs-local; these tests assert the verdict is fetched and passed.
+
+  describe("gateway trust verdict", () => {
+    test("fetches the inbound caller's verdict and threads it into routeSetup", async () => {
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155550000",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "verified",
+        policy: "allow",
+        resolutionFailed: false,
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-verdict-thread-1", {
+        id: "call-verdict-thread-1",
+        conversationId: "conv-verdict-thread-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-verdict-thread-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Verdict fetched for the inbound caller (from number) on the phone channel.
+      expect(mockGetInboundTrustVerdict).toHaveBeenCalledWith({
+        channelType: "phone",
+        actorExternalId: "+14155550000",
+      });
+      // Verdict threaded into routeSetup.
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ verdict: mockInboundVerdict }),
+      );
+    });
+
+    test("a blocked/denied member verdict is enforced (deny) on the media-stream transport", async () => {
+      // The real router returns `deny` for a member verdict whose ACL is
+      // blocked/revoked/deny; the mock reflects that outcome here.
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155550000",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "blocked",
+        policy: "deny",
+        resolutionFailed: false,
+      };
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message:
+            "This number is not authorized to reach the assistant right now.",
+          logReason: "Inbound voice ACL: member blocked",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155550000",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-verdict-deny-1", {
+        id: "call-verdict-deny-1",
+        conversationId: "conv-verdict-deny-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-verdict-deny-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Verdict was passed into routeSetup, which denied the caller.
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ verdict: mockInboundVerdict }),
+      );
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "This number is not authorized to reach the assistant right now.",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-verdict-deny-1",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
     });
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -163,6 +163,59 @@ mock.module("../calls/channel-admission-reader.js", () => ({
   },
 }));
 
+// ── Inbound trust verdict reader mock ───────────────────────────────
+//
+// Mid-call re-resolution (post verification/activation) prefers the gateway
+// verdict via getInboundTrustVerdict, falling back to local resolution on a
+// missing/failed/unusable verdict. Tests drive the verdict through
+// `mockMidCallVerdict`; null (the default) exercises the local fallback. As
+// with the admission reader, delegate to the real module for sibling files
+// that load later in the same worker.
+let mockMidCallVerdict:
+  | import("@vellumai/gateway-client").TrustVerdict
+  | null = null;
+// When set, the mid-call verdict reader blocks on this gate before returning,
+// simulating a slow gateway round-trip so a test can drive a prompt into the
+// re-resolution await window.
+let mockMidCallVerdictGate: Promise<void> | null = null;
+const realInboundTrustReaderModule = {
+  ...(await import("../calls/inbound-trust-reader.js")),
+};
+let inboundTrustMockActive = false;
+mock.module("../calls/inbound-trust-reader.js", () => ({
+  ...realInboundTrustReaderModule,
+  getInboundTrustVerdict: async (input: {
+    channelType: import("../channels/types.js").ChannelId;
+    actorExternalId?: string;
+  }) => {
+    if (!inboundTrustMockActive) {
+      return realInboundTrustReaderModule.getInboundTrustVerdict(input);
+    }
+    if (mockMidCallVerdictGate) await mockMidCallVerdictGate;
+    return mockMidCallVerdict;
+  },
+}));
+
+// ── Trust verdict consumer spy ──────────────────────────────────────
+//
+// Tracks whether the verdict mapper produced the final mid-call context, so a
+// test can assert the local resolver was used instead (verdict not consumed).
+let trustVerdictMapperUsed = false;
+const realTrustVerdictConsumerModule = {
+  ...(await import("../runtime/trust-verdict-consumer.js")),
+};
+mock.module("../runtime/trust-verdict-consumer.js", () => ({
+  ...realTrustVerdictConsumerModule,
+  trustContextFromVerdict: (
+    ...args: Parameters<
+      typeof realTrustVerdictConsumerModule.trustContextFromVerdict
+    >
+  ) => {
+    trustVerdictMapperUsed = true;
+    return realTrustVerdictConsumerModule.trustContextFromVerdict(...args);
+  },
+}));
+
 // ── TTS provider mocks (for call-speech-output) ─────────────────────
 
 let mockTtsProviderId: string = "elevenlabs";
@@ -308,10 +361,12 @@ await initializeDb();
 // sibling files that load later in the same worker.
 beforeAll(() => {
   admissionMockActive = true;
+  inboundTrustMockActive = true;
 });
 
 afterAll(() => {
   admissionMockActive = false;
+  inboundTrustMockActive = false;
   resetDbForTesting();
 });
 
@@ -479,6 +534,9 @@ describe("relay-server", () => {
     mockAssistantName = "Vellum";
     mockAdmissionPolicy = null;
     mockAdmissionGate = null;
+    mockMidCallVerdict = null;
+    mockMidCallVerdictGate = null;
+    trustVerdictMapperUsed = false;
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
     mockConfig.calls.verification.maxAttempts = 3;
@@ -5439,5 +5497,408 @@ describe("relay-server", () => {
 
       relay.destroy();
     });
+  });
+
+  // ── Mid-call trust re-resolution from the gateway verdict ───────────
+  //
+  // After a verification/activation success the relay re-resolves caller trust.
+  // It prefers the gateway verdict (authoritative right after the gateway
+  // updated the binding) and falls back to local resolution on a missing/
+  // failed/unusable verdict so a blip never drops the call.
+
+  function readControllerTrustClass(relay: RelayConnection): string | undefined {
+    return (
+      relay.getController() as unknown as {
+        trustContext?: { trustClass?: string };
+      }
+    )?.trustContext?.trustClass;
+  }
+
+  test("inbound guardian verification: re-resolves trust from the gateway verdict", async () => {
+    ensureConversation("conv-midcall-verdict-guardian");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-guardian",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // The gateway verdict upgrades the caller to guardian post-verification.
+    mockMidCallVerdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "+15559999999",
+      guardianExternalUserId: "+15559999999",
+      guardianPrincipalId: "+15559999999",
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, verified guardian!"]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_guardian",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    // Controller trust reflects the gateway verdict's upgraded class.
+    expect(readControllerTrustClass(relay)).toBe("guardian");
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: resolutionFailed verdict falls back to local resolution without dropping the call", async () => {
+    ensureConversation("conv-midcall-verdict-failed");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-failed",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // A failed verdict must fall back to local resolution — the call stays up.
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: null,
+      resolutionFailed: true,
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, how can I help you?"]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_failed",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Fail-soft: verification still completes and the call connects.
+    expect(relay.isVerificationSessionActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(readControllerTrustClass(relay)).toBeDefined();
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: member-claiming but unusable verdict falls back to local resolution", async () => {
+    ensureConversation("conv-midcall-verdict-unusable");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-unusable",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // Claims a member (contactId/channelId) but the ACL can't be reassembled
+    // (missing status/policy) — mirrors the setup path's unusable condition.
+    mockMidCallVerdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_unusable",
+      channelId: "ch_unusable",
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_unusable",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Fail-soft: unusable verdict does not drop the call; local fallback fires.
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(readControllerTrustClass(relay)).toBeDefined();
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: memberless unknown verdict falls back to local resolution (just-activated invitee not downgraded)", async () => {
+    ensureConversation("conv-midcall-verdict-unknown");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-unknown",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // Invite redemption writes the channel assistant-side, so right after
+    // activation the gateway has no member and returns a memberless unknown
+    // verdict. Mid-call re-resolution must treat it as a stale gateway view
+    // and fall back to local resolution (which has the fresh channel) rather
+    // than downgrade the just-activated invitee to unknown.
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "+15559999999",
+    };
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_unknown",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    // Local resolver produced the final context; the unknown verdict was not
+    // consumed as authoritative.
+    expect(trustVerdictMapperUsed).toBe(false);
+    expect(readControllerTrustClass(relay)).toBeDefined();
+
+    relay.destroy();
+  });
+
+  function readControllerMemberStatus(
+    relay: RelayConnection,
+  ): string | undefined {
+    return (
+      relay.getController() as unknown as {
+        trustContext?: { memberStatus?: string };
+      }
+    )?.trustContext?.memberStatus;
+  }
+
+  test("inbound guardian verification: memberful blocked unknown verdict is honored (verdict path enforces blocked status)", async () => {
+    ensureConversation("conv-midcall-verdict-blocked");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-blocked",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    // Setup resolves locally (no verdict) so the pending guardian challenge
+    // drives verification rather than denying at the door.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_blocked",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    // The gateway classifies a blocked member as trustClass "unknown" but still
+    // carries contactId/channelId and the deny ACL. This memberful unknown must
+    // take the verdict path on mid-call re-resolution so its blocked status is
+    // enforced — not fall back to local, which could miss a stale block.
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_blocked",
+      channelId: "ch_blocked",
+      status: "blocked",
+      policy: "deny",
+    };
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    // Verdict path consumed the memberful unknown verdict; blocked status lands.
+    expect(trustVerdictMapperUsed).toBe(true);
+    expect(readControllerMemberStatus(relay)).toBe("blocked");
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification: memberful revoked unknown verdict is honored (verdict path enforces revoked status)", async () => {
+    ensureConversation("conv-midcall-verdict-revoked");
+    const session = createCallSession({
+      conversationId: "conv-midcall-verdict-revoked",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello there."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_verdict_revoked",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    mockMidCallVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "+15559999999",
+      contactId: "ct_revoked",
+      channelId: "ch_revoked",
+      status: "revoked",
+      policy: "deny",
+    };
+
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(relay.getConnectionState()).toBe("connected");
+    expect(trustVerdictMapperUsed).toBe(true);
+    expect(readControllerMemberStatus(relay)).toBe("revoked");
+
+    relay.destroy();
+  });
+
+  test("a prompt arriving during the mid-call re-resolution await is deferred and runs under the upgraded trust", async () => {
+    ensureConversation("conv-midcall-race");
+    const session = createCallSession({
+      conversationId: "conv-midcall-race",
+      provider: "twilio",
+      fromNumber: "+15559999999",
+      toNumber: "+15551111111",
+    });
+
+    const secret = createPendingVoiceGuardianChallenge();
+
+    // Capture the controller's trust class at the moment a turn actually fires,
+    // so we can prove the deferred prompt did not run under the stale context.
+    const trustClassAtTurn: Array<string | undefined> = [];
+    mockSendMessage.mockImplementation((...args: unknown[]) => {
+      trustClassAtTurn.push(readControllerTrustClass(relay));
+      return createMockProviderResponse(["Hello, verified guardian!"])(
+        ...(args as Parameters<ReturnType<typeof createMockProviderResponse>>),
+      );
+    });
+
+    const { relay } = createMockWs(session.id);
+
+    // Setup resolves locally (no verdict) so the pending challenge drives
+    // verification; the gated guardian verdict is armed only for the mid-call
+    // re-resolution below.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_race",
+        from: "+15559999999",
+        to: "+15551111111",
+      }),
+    );
+
+    // The gateway verdict upgrades the caller to guardian, but the round-trip is
+    // slow — gate it so a prompt can land in the re-resolution await window.
+    mockMidCallVerdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "+15559999999",
+      guardianExternalUserId: "+15559999999",
+      guardianPrincipalId: "+15559999999",
+    };
+    let releaseVerdict!: () => void;
+    mockMidCallVerdictGate = new Promise<void>((resolve) => {
+      releaseVerdict = resolve;
+    });
+
+    // Enter the gated re-resolution: the final DTMF digit triggers
+    // handleVerificationCodeResult, which awaits the slow verdict.
+    const digits = secret.split("");
+    for (const digit of digits.slice(0, -1)) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    const verificationDone = relay.handleMessage(
+      JSON.stringify({ type: "dtmf", digit: digits[digits.length - 1] }),
+    );
+    // Let the verdict await begin (connectionState is now "connected", guard set).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(relay.getConnectionState()).toBe("connected");
+    // Trust is still stale (verdict gated) — caller is not yet guardian.
+    expect(readControllerTrustClass(relay)).not.toBe("guardian");
+
+    // Prompt arrives mid-await: it must be deferred, not processed under stale trust.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "Are my appointments confirmed?",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    // No turn yet — the prompt was buffered, not run under the stale context.
+    expect(trustClassAtTurn).toHaveLength(0);
+
+    // Release the verdict; re-resolution installs the upgraded context, then the
+    // deferred prompt is flushed and its turn runs under guardian trust.
+    releaseVerdict();
+    await verificationDone;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(readControllerTrustClass(relay)).toBe("guardian");
+    expect(trustClassAtTurn.length).toBeGreaterThan(0);
+    expect(trustClassAtTurn.every((c) => c === "guardian")).toBe(true);
+
+    relay.destroy();
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -5901,4 +5901,160 @@ describe("relay-server", () => {
 
     relay.destroy();
   });
+
+  test("invite redemption: a prompt buffered during re-resolution runs as a real turn after activation (not dropped)", async () => {
+    ensureConversation("conv-midcall-invite-flush");
+    const session = createCallSession({
+      conversationId: "conv-midcall-invite-flush",
+      provider: "twilio",
+      fromNumber: "+15558887777",
+      toNumber: "+15551111111",
+    });
+
+    const code = generateVoiceCode(6);
+    createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact("Alice"),
+      maxUses: 1,
+      expectedExternalUserId: "+15558887777",
+      voiceCodeHash: hashVoiceCode(code),
+      voiceCodeDigits: 6,
+    });
+
+    const turnCountBefore = mockSendMessage.mock.calls.length;
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Sure, here you go."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_invite_flush",
+        from: "+15558887777",
+        to: "+15551111111",
+      }),
+    );
+    expect(relay.getConnectionState()).toBe("verification_pending");
+
+    // Gate the mid-call verdict so the prompt lands inside the re-resolution
+    // await, after activation flips connectionState to "connected".
+    let releaseVerdict!: () => void;
+    mockMidCallVerdictGate = new Promise<void>((resolve) => {
+      releaseVerdict = resolve;
+    });
+
+    const digits = code.split("");
+    for (const digit of digits.slice(0, -1)) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    const redemptionDone = relay.handleMessage(
+      JSON.stringify({ type: "dtmf", digit: digits[digits.length - 1] }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Activation already reached the terminal state before re-resolution.
+    expect(relay.getConnectionState()).toBe("connected");
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "What's on my calendar today?",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    // Buffered, not yet run (verdict gated).
+    expect(mockSendMessage.mock.calls.length).toBe(turnCountBefore);
+
+    releaseVerdict();
+    await redemptionDone;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Flushed onto the real-turn path: the prompt produced an LLM turn rather
+    // than being dropped by the verification-pending branch.
+    expect(mockSendMessage.mock.calls.length).toBeGreaterThan(turnCountBefore);
+
+    relay.destroy();
+  });
+
+  test("access-request approval: a prompt buffered during re-resolution runs as a real turn (not misrouted to wait-state)", async () => {
+    ensureConversation("conv-midcall-access-flush");
+    const session = createCallSession({
+      conversationId: "conv-midcall-access-flush",
+      provider: "twilio",
+      fromNumber: "+15557770003",
+      toNumber: "+15551111111",
+    });
+
+    const turnCountBefore = mockSendMessage.mock.calls.length;
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Sure, here you go."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_midcall_access_flush",
+        from: "+15557770003",
+        to: "+15551111111",
+      }),
+    );
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "Bob Smith",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    expect(relay.getConnectionState()).toBe("awaiting_guardian_decision");
+
+    // Gate the mid-call verdict so the prompt lands inside the re-resolution
+    // await triggered by the approval poll.
+    let releaseVerdict!: () => void;
+    mockMidCallVerdictGate = new Promise<void>((resolve) => {
+      releaseVerdict = resolve;
+    });
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "+15557770003",
+      sourceChannel: "phone",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
+    resolveCanonicalGuardianRequest(pending[0].id, "pending", {
+      status: "approved",
+      answerText: undefined,
+      decidedByExternalUserId: undefined,
+    });
+
+    // Let the poll detect approval and enter the gated re-resolution.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(relay.getConnectionState()).toBe("connected");
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "What's on my calendar today?",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+    // Buffered, not yet run (verdict gated).
+    expect(mockSendMessage.mock.calls.length).toBe(turnCountBefore);
+
+    releaseVerdict();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Flushed onto the real-turn path rather than the awaiting-guardian-decision
+    // wait-state classifier: the prompt produced an LLM turn.
+    expect(mockSendMessage.mock.calls.length).toBeGreaterThan(turnCountBefore);
+
+    relay.destroy();
+  });
 });

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -272,7 +272,6 @@ describe("WhatsApp channel ingress attachment resolution", () => {
     const trustVerdict = resolveLocalTrustVerdict({
       channelType: "whatsapp",
       actorExternalId: WHATSAPP_USER_ID,
-      externalChatId: "whatsapp-chat-1",
     });
     return {
       sourceChannel: "whatsapp",

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -109,6 +109,18 @@ mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: async () => mockAdmissionPolicy,
 }));
 
+// Mock the inbound trust reader used by the media-stream preflight. Captures
+// its args so tests can assert the inbound caller's verdict is fetched, and
+// returns mockInboundVerdict which is threaded into the preflight routeSetup.
+let mockInboundVerdict: unknown = null;
+let lastInboundVerdictArgs: Record<string, unknown> | null = null;
+mock.module("../calls/inbound-trust-reader.js", () => ({
+  getInboundTrustVerdict: async (args: Record<string, unknown>) => {
+    lastInboundVerdictArgs = args;
+    return mockInboundVerdict;
+  },
+}));
+
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://gateway.internal:7830",
@@ -470,6 +482,8 @@ describe("twilio webhook routes", () => {
     // Reset admission policy + captured routeSetup context between tests
     mockAdmissionPolicy = null;
     lastRouteSetupCtx = null;
+    mockInboundVerdict = null;
+    lastInboundVerdictArgs = null;
     // Reset routeSetup mock to default normal_call
     mockRouteSetupResult = {
       outcome: { action: "normal_call", isInbound: true },
@@ -1267,6 +1281,81 @@ describe("twilio webhook routes", () => {
       // classification matches the real stream-start enforcement.
       expect(lastRouteSetupCtx).not.toBeNull();
       expect(lastRouteSetupCtx?.admissionPolicy).toBe("guardian_only");
+    });
+
+    test("media-stream inbound: fetches the caller's verdict (From) and threads it into the preflight routeSetup", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155551234",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "verified",
+        policy: "allow",
+        resolutionFailed: false,
+      };
+
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_ms_verdict_inbound_1",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      // Inbound: verdict fetched for the caller (From) on the phone channel.
+      expect(lastInboundVerdictArgs).toEqual({
+        channelType: "phone",
+        actorExternalId: "+14155551234",
+      });
+      // Verdict threaded into the preflight routeSetup.
+      expect(lastRouteSetupCtx?.verdict).toEqual(mockInboundVerdict);
+    });
+
+    test("media-stream inbound: a blocked/denied member verdict is classified deny in the preflight", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockInboundVerdict = {
+        channelType: "phone",
+        actorExternalId: "+14155551234",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "blocked",
+        policy: "deny",
+        resolutionFailed: false,
+      };
+      // The real router returns `deny` for a blocked member verdict; the mock
+      // reflects that outcome. deny is supported on media-stream, so the
+      // preflight still emits Stream TwiML (denial spoken at stream start).
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message:
+            "This number is not authorized to reach the assistant right now.",
+          logReason: "Inbound voice ACL: member blocked",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_ms_verdict_deny_1",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      // Verdict was threaded into routeSetup, which denied the caller.
+      expect(lastRouteSetupCtx?.verdict).toEqual(mockInboundVerdict);
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
     });
 
     test("media-stream: floor-denied caller classified deny still produces Stream TwiML (deny handled at stream level)", async () => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -119,6 +119,13 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
     lastInboundVerdictArgs = args;
     return mockInboundVerdict;
   },
+  getPhoneCallerVerdict: async (otherPartyNumber: string | undefined) => {
+    lastInboundVerdictArgs = {
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    };
+    return mockInboundVerdict;
+  },
 }));
 
 mock.module("../config/env.js", () => ({

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -40,41 +40,19 @@ mock.module("../../config/loader.js", () => ({
 
 // Controllable resolved trust context. `resolveActorTrust` is a tracked mock
 // so the verdict-source tests can assert the local fallback fires (or not).
+// The verdict path uses the REAL, pure `actorTrustContextFromVerdict` /
+// `verdictMemberUnresolvable` — no module mock — so this file leaks nothing
+// into sibling test files sharing the bun process.
 let nextTrust: ActorTrustContext;
 const resolveActorTrustMock = mock(() => nextTrust);
-mock.module("../../runtime/actor-trust-resolver.js", () => ({
-  resolveActorTrust: resolveActorTrustMock,
-}));
-
-// Controllable verdict-derived trust context.
-let verdictTrust: ActorTrustContext;
-const actorTrustContextFromVerdictMock = mock(() => verdictTrust);
-// Mirror the real fail-closed contract: a verdict claiming a member resolves
-// only with valid known status+policy enums; otherwise null (memberless or
-// malformed/mixed-version).
-const CHANNEL_STATUS_VALUES = [
-  "active",
-  "pending",
-  "revoked",
-  "blocked",
-  "unverified",
-];
-const CHANNEL_POLICY_VALUES = ["allow", "deny", "escalate"];
-function resolvesMember(verdict: TrustVerdict): boolean {
-  if (!verdict.contactId || !verdict.channelId) return false;
-  if (!verdict.status || !verdict.policy) return false;
-  return (
-    CHANNEL_STATUS_VALUES.includes(verdict.status) &&
-    CHANNEL_POLICY_VALUES.includes(verdict.policy)
-  );
-}
-const verdictMemberUnresolvableMock = mock(
-  (verdict: TrustVerdict) =>
-    !!(verdict.contactId || verdict.channelId) && !resolvesMember(verdict),
+// Override only `resolveActorTrust`; the real `trust-verdict-consumer` imports
+// `toTrustContext` from this module, so the rest must pass through untouched.
+const actorTrustResolverModule = await import(
+  "../../runtime/actor-trust-resolver.js"
 );
-mock.module("../../runtime/trust-verdict-consumer.js", () => ({
-  actorTrustContextFromVerdict: actorTrustContextFromVerdictMock,
-  verdictMemberUnresolvable: verdictMemberUnresolvableMock,
+mock.module("../../runtime/actor-trust-resolver.js", () => ({
+  ...actorTrustResolverModule,
+  resolveActorTrust: resolveActorTrustMock,
 }));
 
 // Controllable pending verification challenge.
@@ -203,8 +181,6 @@ beforeEach(() => {
   activeInvites = [];
   boundContact = null;
   resolveActorTrustMock.mockClear();
-  actorTrustContextFromVerdictMock.mockClear();
-  verdictMemberUnresolvableMock.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -427,15 +403,31 @@ function makeVerdict(overrides: Partial<TrustVerdict> = {}): TrustVerdict {
   };
 }
 
-describe("routeSetup — caller-trust source", () => {
-  test("present verdict builds trust via actorTrustContextFromVerdict (no local resolve)", () => {
-    verdictTrust = makeTrust("guardian", {
-      status: "active",
-      role: "guardian",
-    });
-    const { resolved, outcome } = route(null, makeVerdict());
+// A verdict carrying a fully-resolvable member ACL (contactId/channelId + valid
+// known status·policy enums). The REAL `resolvedMemberFromVerdict` synthesizes
+// a memberRecord from these, so the verdict path enforces blocked/revoked/deny.
+function makeMemberVerdict(
+  trustClass: TrustVerdict["trustClass"],
+  channel: { status: string; policy?: string },
+  overrides: Partial<TrustVerdict> = {},
+): TrustVerdict {
+  return makeVerdict({
+    trustClass,
+    contactId: "ct_1",
+    channelId: "ch_1",
+    status: channel.status,
+    policy: channel.policy ?? "allow",
+    ...overrides,
+  });
+}
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+describe("routeSetup — caller-trust source", () => {
+  test("present verdict builds trust from the verdict (no local resolve)", () => {
+    const { resolved, outcome } = route(
+      null,
+      makeMemberVerdict("guardian", { status: "active" }),
+    );
+
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(resolved.actorTrust.trustClass).toBe("guardian");
     expect(outcome.action).toBe("normal_call");
@@ -446,7 +438,6 @@ describe("routeSetup — caller-trust source", () => {
     const { resolved } = route(null, makeVerdict({ resolutionFailed: true }));
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
-    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
     expect(resolved.actorTrust.trustClass).toBe("guardian");
   });
 
@@ -455,7 +446,6 @@ describe("routeSetup — caller-trust source", () => {
     const { resolved } = route(null, null);
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
-    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
     expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
   });
 
@@ -464,14 +454,14 @@ describe("routeSetup — caller-trust source", () => {
     route(null);
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
-    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
   });
 
   test("admission floor still applies on the verdict path (guardian_only denies trusted_contact)", () => {
-    verdictTrust = makeTrust("trusted_contact", { status: "active" });
-    const { outcome } = route("guardian_only", makeVerdict());
+    const { outcome } = route(
+      "guardian_only",
+      makeMemberVerdict("trusted_contact", { status: "active" }),
+    );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("deny");
   });
@@ -496,65 +486,71 @@ describe("routeSetup — caller-trust source", () => {
 
 describe("routeSetup — verdict path enforces member ACL", () => {
   test("blocked member via verdict is denied (not normal_call) under permissive floor", () => {
-    verdictTrust = makeTrust("unknown", { status: "blocked" });
-    const { outcome } = route("strangers", makeVerdict());
+    const { outcome } = route(
+      "strangers",
+      makeMemberVerdict("unknown", { status: "blocked" }),
+    );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("deny");
   });
 
   test("revoked member via verdict is denied under permissive floor", () => {
-    verdictTrust = makeTrust("unknown", { status: "revoked" });
-    const { outcome } = route("strangers", makeVerdict());
+    const { outcome } = route(
+      "strangers",
+      makeMemberVerdict("unknown", { status: "revoked" }),
+    );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("deny");
   });
 
   test("policy deny member via verdict is denied (not normal_call)", () => {
-    verdictTrust = makeTrust("trusted_contact", {
-      status: "active",
-      policy: "deny",
-    });
-    const { outcome } = route(null, makeVerdict());
+    const { outcome } = route(
+      null,
+      makeMemberVerdict("trusted_contact", {
+        status: "active",
+        policy: "deny",
+      }),
+    );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("deny");
   });
 
   test("policy escalate member via verdict is denied (live call can't await approval)", () => {
-    verdictTrust = makeTrust("trusted_contact", {
-      status: "active",
-      policy: "escalate",
-    });
-    const { outcome } = route(null, makeVerdict());
+    const { outcome } = route(
+      null,
+      makeMemberVerdict("trusted_contact", {
+        status: "active",
+        policy: "escalate",
+      }),
+    );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("deny");
   });
 
   test("trusted/active member via verdict still admits to normal_call", () => {
-    verdictTrust = makeTrust("trusted_contact", {
-      status: "active",
-      policy: "allow",
-    });
-    const { outcome } = route(null, makeVerdict());
+    const { outcome } = route(
+      null,
+      makeMemberVerdict("trusted_contact", {
+        status: "active",
+        policy: "allow",
+      }),
+    );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("normal_call");
   });
 
   test("guardian via verdict still admits to normal_call", () => {
-    verdictTrust = makeTrust("guardian", {
-      status: "active",
-      role: "guardian",
-    });
-    const { outcome } = route(null, makeVerdict());
+    const { outcome } = route(
+      null,
+      makeMemberVerdict("guardian", { status: "active" }),
+    );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("normal_call");
   });
 });
@@ -581,7 +577,6 @@ describe("routeSetup — unresolvable member verdict falls back to local", () =>
     );
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
-    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
     expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
   });
 
@@ -599,7 +594,6 @@ describe("routeSetup — unresolvable member verdict falls back to local", () =>
     );
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
-    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
   });
 
   test("member identity with unknown policy falls back to local resolveActorTrust", () => {
@@ -616,34 +610,24 @@ describe("routeSetup — unresolvable member verdict falls back to local", () =>
     );
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
-    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
   });
 
   test("real stranger verdict (no member identity) still takes the verdict path", () => {
-    verdictTrust = makeTrust("unknown");
-    route(null, makeVerdict({ trustClass: "unknown" }));
+    const { resolved } = route(null, makeVerdict({ trustClass: "unknown" }));
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("unknown");
   });
 
   test("valid member verdict (good status+policy) still takes the verdict path", () => {
-    verdictTrust = makeTrust("trusted_contact", {
-      status: "active",
-      policy: "allow",
-    });
     const { outcome } = route(
       null,
-      makeVerdict({
-        trustClass: "trusted_contact",
-        contactId: "ct_1",
-        channelId: "ch_1",
+      makeMemberVerdict("trusted_contact", {
         status: "active",
         policy: "allow",
       }),
     );
 
-    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(outcome.action).toBe("normal_call");
   });

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -15,7 +15,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
+import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 
 import type {
   ChannelPolicy,
@@ -38,10 +38,42 @@ mock.module("../../config/loader.js", () => ({
   getConfig: () => ({ calls: { verification: { enabled: false } } }),
 }));
 
-// Controllable resolved trust context.
+// Controllable resolved trust context. `resolveActorTrust` is a tracked mock
+// so the verdict-source tests can assert the local fallback fires (or not).
 let nextTrust: ActorTrustContext;
+const resolveActorTrustMock = mock(() => nextTrust);
 mock.module("../../runtime/actor-trust-resolver.js", () => ({
-  resolveActorTrust: () => nextTrust,
+  resolveActorTrust: resolveActorTrustMock,
+}));
+
+// Controllable verdict-derived trust context.
+let verdictTrust: ActorTrustContext;
+const actorTrustContextFromVerdictMock = mock(() => verdictTrust);
+// Mirror the real fail-closed contract: a verdict claiming a member resolves
+// only with valid known status+policy enums; otherwise null (memberless or
+// malformed/mixed-version).
+const CHANNEL_STATUS_VALUES = [
+  "active",
+  "pending",
+  "revoked",
+  "blocked",
+  "unverified",
+];
+const CHANNEL_POLICY_VALUES = ["allow", "deny", "escalate"];
+const resolvedMemberFromVerdictMock = mock((verdict: TrustVerdict) => {
+  if (!verdict.contactId || !verdict.channelId) return null;
+  if (!verdict.status || !verdict.policy) return null;
+  if (
+    !CHANNEL_STATUS_VALUES.includes(verdict.status) ||
+    !CHANNEL_POLICY_VALUES.includes(verdict.policy)
+  ) {
+    return null;
+  }
+  return { contact: {}, channel: {} };
+});
+mock.module("../../runtime/trust-verdict-consumer.js", () => ({
+  actorTrustContextFromVerdict: actorTrustContextFromVerdictMock,
+  resolvedMemberFromVerdict: resolvedMemberFromVerdictMock,
 }));
 
 // Controllable pending verification challenge.
@@ -151,13 +183,17 @@ function makeTrust(
   };
 }
 
-function route(admissionPolicy?: AdmissionPolicy | null) {
+function route(
+  admissionPolicy?: AdmissionPolicy | null,
+  verdict?: TrustVerdict | null,
+) {
   return routeSetup({
     callSessionId: "cs_1",
     session: null, // inbound
     from: "+12025550142",
     to: "+12025550199",
     admissionPolicy,
+    verdict,
   });
 }
 
@@ -165,6 +201,9 @@ beforeEach(() => {
   pendingChallenge = null;
   activeInvites = [];
   boundContact = null;
+  resolveActorTrustMock.mockClear();
+  actorTrustContextFromVerdictMock.mockClear();
+  resolvedMemberFromVerdictMock.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -372,5 +411,239 @@ describe("routeSetup — floor bypasses", () => {
     pendingChallenge = { id: "vs_1" };
     const { outcome } = route("no_one");
     expect(outcome.action).toBe("verification");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caller-trust source: gateway verdict first, local fallback
+// ---------------------------------------------------------------------------
+
+function makeVerdict(overrides: Partial<TrustVerdict> = {}): TrustVerdict {
+  return {
+    trustClass: "guardian",
+    canonicalSenderId: "+12025550142",
+    ...overrides,
+  };
+}
+
+describe("routeSetup — caller-trust source", () => {
+  test("present verdict builds trust via actorTrustContextFromVerdict (no local resolve)", () => {
+    verdictTrust = makeTrust("guardian", {
+      status: "active",
+      role: "guardian",
+    });
+    const { resolved, outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("guardian");
+    expect(outcome.action).toBe("normal_call");
+  });
+
+  test("resolutionFailed verdict falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("guardian", { status: "active", role: "guardian" });
+    const { resolved } = route(null, makeVerdict({ resolutionFailed: true }));
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("guardian");
+  });
+
+  test("null verdict falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    const { resolved } = route(null, null);
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
+  });
+
+  test("absent verdict falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("guardian", { status: "active", role: "guardian" });
+    route(null);
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+  });
+
+  test("admission floor still applies on the verdict path (guardian_only denies trusted_contact)", () => {
+    verdictTrust = makeTrust("trusted_contact", { status: "active" });
+    const { outcome } = route("guardian_only", makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("admission floor still applies on the fallback path (guardian_only denies trusted_contact)", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    const { outcome } = route(
+      "guardian_only",
+      makeVerdict({ resolutionFailed: true }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("deny");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verdict-path ACL: blocked / revoked / deny enforced from the verdict-derived
+// memberRecord (no local fallback). Guards the P1 where a verdict member with
+// no memberRecord bypassed these gates.
+// ---------------------------------------------------------------------------
+
+describe("routeSetup — verdict path enforces member ACL", () => {
+  test("blocked member via verdict is denied (not normal_call) under permissive floor", () => {
+    verdictTrust = makeTrust("unknown", { status: "blocked" });
+    const { outcome } = route("strangers", makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("revoked member via verdict is denied under permissive floor", () => {
+    verdictTrust = makeTrust("unknown", { status: "revoked" });
+    const { outcome } = route("strangers", makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("policy deny member via verdict is denied (not normal_call)", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "deny",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("policy escalate member via verdict is denied (live call can't await approval)", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "escalate",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("trusted/active member via verdict still admits to normal_call", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "allow",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("normal_call");
+  });
+
+  test("guardian via verdict still admits to normal_call", () => {
+    verdictTrust = makeTrust("guardian", {
+      status: "active",
+      role: "guardian",
+    });
+    const { outcome } = route(null, makeVerdict());
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(outcome.action).toBe("normal_call");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unresolvable member verdict → local fallback (never trust an un-ACL-checkable
+// member). A verdict claiming a member (contactId/channelId) whose ACL can't be
+// reassembled (missing/unknown status·policy) must take the local resolveActorTrust
+// path so the member is ACL-checked locally, not trusted by trustClass.
+// ---------------------------------------------------------------------------
+
+describe("routeSetup — unresolvable member verdict falls back to local", () => {
+  test("member identity with missing status falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    const { resolved } = route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        policy: "allow",
+        // status absent → unresolvable
+      }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+    expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
+  });
+
+  test("member identity with unknown status falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        status: "bogus",
+        policy: "allow",
+      }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+  });
+
+  test("member identity with unknown policy falls back to local resolveActorTrust", () => {
+    nextTrust = makeTrust("trusted_contact", { status: "active" });
+    route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        status: "active",
+        policy: "bogus",
+      }),
+    );
+
+    expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
+    expect(actorTrustContextFromVerdictMock).not.toHaveBeenCalled();
+  });
+
+  test("real stranger verdict (no member identity) still takes the verdict path", () => {
+    verdictTrust = makeTrust("unknown");
+    route(null, makeVerdict({ trustClass: "unknown" }));
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+  });
+
+  test("valid member verdict (good status+policy) still takes the verdict path", () => {
+    verdictTrust = makeTrust("trusted_contact", {
+      status: "active",
+      policy: "allow",
+    });
+    const { outcome } = route(
+      null,
+      makeVerdict({
+        trustClass: "trusted_contact",
+        contactId: "ct_1",
+        channelId: "ch_1",
+        status: "active",
+        policy: "allow",
+      }),
+    );
+
+    expect(actorTrustContextFromVerdictMock).toHaveBeenCalledTimes(1);
+    expect(resolveActorTrustMock).not.toHaveBeenCalled();
+    expect(outcome.action).toBe("normal_call");
   });
 });

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -60,20 +60,21 @@ const CHANNEL_STATUS_VALUES = [
   "unverified",
 ];
 const CHANNEL_POLICY_VALUES = ["allow", "deny", "escalate"];
-const resolvedMemberFromVerdictMock = mock((verdict: TrustVerdict) => {
-  if (!verdict.contactId || !verdict.channelId) return null;
-  if (!verdict.status || !verdict.policy) return null;
-  if (
-    !CHANNEL_STATUS_VALUES.includes(verdict.status) ||
-    !CHANNEL_POLICY_VALUES.includes(verdict.policy)
-  ) {
-    return null;
-  }
-  return { contact: {}, channel: {} };
-});
+function resolvesMember(verdict: TrustVerdict): boolean {
+  if (!verdict.contactId || !verdict.channelId) return false;
+  if (!verdict.status || !verdict.policy) return false;
+  return (
+    CHANNEL_STATUS_VALUES.includes(verdict.status) &&
+    CHANNEL_POLICY_VALUES.includes(verdict.policy)
+  );
+}
+const verdictMemberUnresolvableMock = mock(
+  (verdict: TrustVerdict) =>
+    !!(verdict.contactId || verdict.channelId) && !resolvesMember(verdict),
+);
 mock.module("../../runtime/trust-verdict-consumer.js", () => ({
   actorTrustContextFromVerdict: actorTrustContextFromVerdictMock,
-  resolvedMemberFromVerdict: resolvedMemberFromVerdictMock,
+  verdictMemberUnresolvable: verdictMemberUnresolvableMock,
 }));
 
 // Controllable pending verification challenge.
@@ -203,7 +204,7 @@ beforeEach(() => {
   boundContact = null;
   resolveActorTrustMock.mockClear();
   actorTrustContextFromVerdictMock.mockClear();
-  resolvedMemberFromVerdictMock.mockClear();
+  verdictMemberUnresolvableMock.mockClear();
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -10,7 +10,10 @@
  * fail-closed); this reader only reports the verdict or `null`.
  */
 
-import { type TrustVerdict, TrustVerdictSchema } from "@vellumai/gateway-client";
+import {
+  type TrustVerdict,
+  TrustVerdictSchema,
+} from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
 import { ipcCall } from "../ipc/gateway-client.js";
@@ -37,4 +40,17 @@ export async function getInboundTrustVerdict(input: {
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the verdict for a phone caller by their external number. Callers
+ * compute `otherPartyNumber` from their own transport-specific direction.
+ */
+export function getPhoneCallerVerdict(
+  otherPartyNumber: string | undefined,
+): Promise<TrustVerdict | null> {
+  return getInboundTrustVerdict({
+    channelType: "phone",
+    actorExternalId: otherPartyNumber || undefined,
+  });
 }

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -52,7 +52,7 @@ import {
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
-import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
+import { getPhoneCallerVerdict } from "./inbound-trust-reader.js";
 import { MediaStreamOutput } from "./media-stream-output.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type { MediaStreamStartEvent } from "./media-stream-protocol.js";
@@ -398,10 +398,7 @@ export class MediaStreamCallSession {
     // null on failure, keeping the local path on a gateway blip.
     const isInbound = session?.initiatedFromConversationId == null;
     const otherPartyNumber = isInbound ? from : to;
-    const verdict = await getInboundTrustVerdict({
-      channelType: "phone",
-      actorExternalId: otherPartyNumber || undefined,
-    });
+    const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
     // The verdict read above yields the event loop; abort if the session was
     // disposed meanwhile, matching the admission-read guard above.

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -52,6 +52,7 @@ import {
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
+import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import { MediaStreamOutput } from "./media-stream-output.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type { MediaStreamStartEvent } from "./media-stream-protocol.js";
@@ -391,6 +392,28 @@ export class MediaStreamCallSession {
       return;
     }
 
+    // Verdict-first caller trust so this transport enforces the same gateway
+    // ACL as ConversationRelay. routeSetup uses it when present and not
+    // resolutionFailed, else falls back to local resolution. The reader returns
+    // null on failure, keeping the local path on a gateway blip.
+    const isInbound = session?.initiatedFromConversationId == null;
+    const otherPartyNumber = isInbound ? from : to;
+    const verdict = await getInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    });
+
+    // The verdict read above yields the event loop; abort if the session was
+    // disposed meanwhile, matching the admission-read guard above.
+    if (this.disposed) {
+      log.info(
+        { callSessionId: this.callSessionId },
+        "Media-stream session disposed during verdict read — aborting setup",
+      );
+      this.setupRouting = false;
+      return;
+    }
+
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,
       session: session ?? null,
@@ -398,6 +421,7 @@ export class MediaStreamCallSession {
       to,
       customParameters: event.start.customParameters,
       admissionPolicy,
+      verdict,
     });
 
     log.info(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -17,6 +17,7 @@ import {
 } from "../contacts/contact-store.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { TrustContext } from "../daemon/trust-context.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { addMessage } from "../memory/conversation-crud.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
@@ -26,6 +27,10 @@ import {
   resolveActorTrust,
   toTrustContext,
 } from "../runtime/actor-trust-resolver.js";
+import {
+  resolvedMemberFromVerdict,
+  trustContextFromVerdict,
+} from "../runtime/trust-verdict-consumer.js";
 import {
   composeVerificationVoice,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
@@ -261,6 +266,12 @@ export class RelayConnection {
   private callbackOfferMade = false;
   private callbackOptIn = false;
   private callbackHandoffNotified = false;
+
+  // True while mid-call trust is being re-resolved (async). handlePrompt defers
+  // prompts to trustReResolvePending so a verified caller can't start a turn
+  // under the stale pre-verification trust context during the await window.
+  private trustReResolving = false;
+  private trustReResolvePending: RelayPromptMessage[] = [];
 
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
@@ -885,13 +896,105 @@ export class RelayConnection {
   }
 
   /**
+   * Re-resolve caller trust after a mid-call verification/activation. Prefers
+   * the gateway verdict (authoritative right after the gateway updated the
+   * binding); falls back to local resolution on a missing/failed/unusable
+   * verdict so a blip never drops the call. Mirrors the setup path's
+   * verdict-first-with-fallback condition.
+   */
+  private async resolveMidCallTrustContext(
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<TrustContext> {
+    const verdict = await getInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: fromNumber,
+    });
+
+    const hasMemberIdentity = !!(verdict?.contactId || verdict?.channelId);
+    const memberUnresolvable =
+      hasMemberIdentity && resolvedMemberFromVerdict(verdict!) === null;
+    // Only a MEMBERLESS unknown verdict is treated as a stale gateway view and
+    // falls back to local: the caller was just activated, and invite redemption
+    // writes the channel assistant-side, so the gateway may not see the member
+    // yet — local resolution has it. A MEMBERFUL unknown verdict (blocked/revoked
+    // member, carrying contactId/channelId) is honored so its deny ACL is
+    // enforced; falling back could lose the gateway's member status if local
+    // state is stale.
+    const memberlessUnknown =
+      verdict?.trustClass === "unknown" && !hasMemberIdentity;
+    const usable =
+      verdict &&
+      !verdict.resolutionFailed &&
+      !memberUnresolvable &&
+      !memberlessUnknown;
+
+    if (usable) {
+      return trustContextFromVerdict(verdict, {
+        sourceChannel: "phone",
+        conversationExternalId: fromNumber,
+      });
+    }
+
+    return toTrustContext(
+      resolveActorTrust({
+        assistantId,
+        sourceChannel: "phone",
+        conversationExternalId: fromNumber,
+        actorExternalId: fromNumber,
+      }),
+      fromNumber,
+    );
+  }
+
+  /**
+   * Re-resolve mid-call trust and install it on the controller, deferring any
+   * prompt that arrives during the async window. Guards the gap between
+   * connectionState flipping to "connected" and the upgraded context landing so
+   * a verified caller never starts a turn under the stale pre-verification
+   * trust. Clears the guard in a finally and flushes buffered prompts under the
+   * new context, so an IPC error can't wedge the call.
+   */
+  private async reResolveAndApplyTrustContext(
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<void> {
+    if (!this.controller) return;
+    this.trustReResolving = true;
+    try {
+      const context = await this.resolveMidCallTrustContext(
+        assistantId,
+        fromNumber,
+      );
+      this.controller.setTrustContext(context);
+    } finally {
+      this.trustReResolving = false;
+      this.flushDeferredPrompts();
+    }
+  }
+
+  /**
+   * Replay prompts buffered while trust was re-resolving. Runs after the
+   * upgraded context is installed so deferred utterances are answered under the
+   * correct trust.
+   */
+  private flushDeferredPrompts(): void {
+    if (this.trustReResolvePending.length === 0) return;
+    const pending = this.trustReResolvePending;
+    this.trustReResolvePending = [];
+    for (const msg of pending) {
+      void this.handlePrompt(msg);
+    }
+  }
+
+  /**
    * Shared post-activation handoff for all trusted-contact success paths
    * (access-request approval, invite redemption, verification code).
    * Activates the caller, updates guardian context, delivers deterministic
    * transition copy, and marks the next utterance as opening-ack so the
    * LLM continues naturally.
    */
-  private continueCallAfterTrustedContactActivation(params: {
+  private async continueCallAfterTrustedContactActivation(params: {
     assistantId: string;
     fromNumber: string;
     activationReason?:
@@ -906,21 +1009,14 @@ export class RelayConnection {
      * address.
      */
     inviteeName?: string | null;
-  }): void {
+  }): Promise<void> {
     const { assistantId, fromNumber } = params;
 
     // Contact activation is handled by the gateway — the assistant no
     // longer writes contact/channel records on inbound voice calls.
 
-    const updatedTrust = resolveActorTrust({
-      assistantId,
-      sourceChannel: "phone",
-      conversationExternalId: fromNumber,
-      actorExternalId: fromNumber,
-    });
-
     if (this.controller) {
-      this.controller.setTrustContext(toTrustContext(updatedTrust, fromNumber));
+      await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
     }
 
     this.connectionState = "connected";
@@ -1104,15 +1200,7 @@ export class RelayConnection {
 
         // Update trust context on the controller so the LLM knows this is the guardian
         if (this.controller) {
-          const verifiedActorTrust = resolveActorTrust({
-            assistantId,
-            sourceChannel: "phone",
-            conversationExternalId: fromNumber,
-            actorExternalId: fromNumber,
-          });
-          this.controller.setTrustContext(
-            toTrustContext(verifiedActorTrust, fromNumber),
-          );
+          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
         }
 
         // Mark session as in-progress and transition to guardian conversation
@@ -1129,7 +1217,7 @@ export class RelayConnection {
             );
         }
       } else if (result.verificationType === "trusted_contact") {
-        this.continueCallAfterTrustedContactActivation({
+        await this.continueCallAfterTrustedContactActivation({
           assistantId,
           fromNumber,
           activationReason: "trusted_contact_verified",
@@ -1138,15 +1226,7 @@ export class RelayConnection {
         // Inbound guardian verification: binding already handled above,
         // proceed to normal call flow.
         if (this.controller) {
-          const verifiedActorTrust = resolveActorTrust({
-            assistantId,
-            sourceChannel: "phone",
-            conversationExternalId: fromNumber,
-            actorExternalId: fromNumber,
-          });
-          this.controller.setTrustContext(
-            toTrustContext(verifiedActorTrust, fromNumber),
-          );
+          await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
           this.startNormalCallFlow(this.controller, true);
         }
       }
@@ -1423,7 +1503,7 @@ export class RelayConnection {
       }
 
       if (request.status === "approved") {
-        this.handleAccessRequestApproved();
+        void this.handleAccessRequestApproved();
       } else if (request.status === "denied") {
         void this.handleAccessRequestDenied();
       }
@@ -1475,7 +1555,7 @@ export class RelayConnection {
    * Handle an approved access request: activate the caller as a trusted
    * contact, update runtime context, and continue with normal call flow.
    */
-  private handleAccessRequestApproved(): void {
+  private async handleAccessRequestApproved(): Promise<void> {
     this.clearAccessRequestWait();
 
     const assistantId = this.accessRequestAssistantId!;
@@ -1493,7 +1573,7 @@ export class RelayConnection {
       "Access request approved — caller activated and continuing call",
     );
 
-    this.continueCallAfterTrustedContactActivation({
+    await this.continueCallAfterTrustedContactActivation({
       assistantId,
       fromNumber,
       activationReason: "access_approved",
@@ -1701,7 +1781,7 @@ export class RelayConnection {
         "Voice invite redemption succeeded",
       );
 
-      this.continueCallAfterTrustedContactActivation({
+      await this.continueCallAfterTrustedContactActivation({
         assistantId: this.inviteRedemptionAssistantId,
         fromNumber: this.inviteRedemptionFromNumber,
         activationReason: "invite_redeemed",
@@ -1927,6 +2007,15 @@ export class RelayConnection {
 
   private async handlePrompt(msg: RelayPromptMessage): Promise<void> {
     if (this.connectionState === "disconnecting") {
+      return;
+    }
+
+    // Defer (don't drop) prompts while trust is being re-resolved mid-call so a
+    // verified caller's first utterance runs under the upgraded context, not the
+    // stale pre-verification one. flushDeferredPrompts replays them in order
+    // once the new context lands.
+    if (this.trustReResolving) {
+      this.trustReResolvePending.push(msg);
       return;
     }
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -8,7 +8,7 @@
 
 import { randomInt } from "node:crypto";
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
+import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import {
@@ -50,6 +50,7 @@ import {
 import { ConversationRelayTransport } from "./call-transport.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
+import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import {
   classifyWaitUtterance,
   emitAccessRequestCallbackHandoff,
@@ -585,8 +586,18 @@ export class RelayConnection {
     // open to `null` by contract, so a transport hiccup admits the caller.
     const admissionPolicy = await getChannelAdmissionPolicy("phone");
 
+    // Verdict-first caller trust. routeSetup uses it when present and not
+    // resolutionFailed, else falls back to local resolution. The reader
+    // returns null on failure, so a gateway blip keeps the local path.
+    const isInbound = session?.initiatedFromConversationId == null;
+    const otherPartyNumber = isInbound ? msg.from : msg.to;
+    const verdict = await getInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    });
+
     try {
-      await this.routeSetupOutcome(msg, session, admissionPolicy);
+      await this.routeSetupOutcome(msg, session, admissionPolicy, verdict);
     } catch (err) {
       // Never leave the connection stranded in "setting_up": a setup that
       // throws before reaching a terminal outcome would otherwise drop every
@@ -615,6 +626,7 @@ export class RelayConnection {
     msg: RelaySetupMessage,
     session: ReturnType<typeof getCallSession>,
     admissionPolicy: AdmissionPolicy | null,
+    verdict: TrustVerdict | null,
   ): Promise<void> {
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,
@@ -623,6 +635,7 @@ export class RelayConnection {
       to: msg.to,
       customParameters: msg.customParameters,
       admissionPolicy,
+      verdict,
     });
 
     const initialTrustContext = toTrustContext(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -28,8 +28,9 @@ import {
   toTrustContext,
 } from "../runtime/actor-trust-resolver.js";
 import {
-  resolvedMemberFromVerdict,
   trustContextFromVerdict,
+  verdictHasMemberIdentity,
+  verdictMemberUnresolvable,
 } from "../runtime/trust-verdict-consumer.js";
 import {
   composeVerificationVoice,
@@ -55,7 +56,10 @@ import {
 import { ConversationRelayTransport } from "./call-transport.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
-import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
+import {
+  getInboundTrustVerdict,
+  getPhoneCallerVerdict,
+} from "./inbound-trust-reader.js";
 import {
   classifyWaitUtterance,
   emitAccessRequestCallbackHandoff,
@@ -602,10 +606,7 @@ export class RelayConnection {
     // returns null on failure, so a gateway blip keeps the local path.
     const isInbound = session?.initiatedFromConversationId == null;
     const otherPartyNumber = isInbound ? msg.from : msg.to;
-    const verdict = await getInboundTrustVerdict({
-      channelType: "phone",
-      actorExternalId: otherPartyNumber || undefined,
-    });
+    const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
     try {
       await this.routeSetupOutcome(msg, session, admissionPolicy, verdict);
@@ -911,9 +912,6 @@ export class RelayConnection {
       actorExternalId: fromNumber,
     });
 
-    const hasMemberIdentity = !!(verdict?.contactId || verdict?.channelId);
-    const memberUnresolvable =
-      hasMemberIdentity && resolvedMemberFromVerdict(verdict!) === null;
     // Only a MEMBERLESS unknown verdict is treated as a stale gateway view and
     // falls back to local: the caller was just activated, and invite redemption
     // writes the channel assistant-side, so the gateway may not see the member
@@ -922,11 +920,11 @@ export class RelayConnection {
     // enforced; falling back could lose the gateway's member status if local
     // state is stale.
     const memberlessUnknown =
-      verdict?.trustClass === "unknown" && !hasMemberIdentity;
+      verdict?.trustClass === "unknown" && !verdictHasMemberIdentity(verdict);
     const usable =
       verdict &&
       !verdict.resolutionFailed &&
-      !memberUnresolvable &&
+      !verdictMemberUnresolvable(verdict) &&
       !memberlessUnknown;
 
     if (usable) {
@@ -1015,12 +1013,18 @@ export class RelayConnection {
     // Contact activation is handled by the gateway — the assistant no
     // longer writes contact/channel records on inbound voice calls.
 
+    // Reach connected and clear wait/verification flags before re-resolving
+    // trust, so a prompt buffered during re-resolution flushes onto the
+    // real-turn path, not the verification/wait branches.
+    this.connectionState = "connected";
+    this.verificationSessionActive = false;
+    this.inviteRedemptionActive = false;
+    this.accessRequestWaitActive = false;
+    updateCallSession(this.callSessionId, { status: "in_progress" });
+
     if (this.controller) {
       await this.reResolveAndApplyTrustContext(assistantId, fromNumber);
     }
-
-    this.connectionState = "connected";
-    updateCallSession(this.callSessionId, { status: "in_progress" });
 
     const guardianLabel = this.resolveGuardianLabel();
     let handoffText: string;

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -23,7 +23,7 @@ import {
 } from "../runtime/routes/inbound-stages/admission-policy.js";
 import {
   actorTrustContextFromVerdict,
-  resolvedMemberFromVerdict,
+  verdictMemberUnresolvable,
 } from "../runtime/trust-verdict-consumer.js";
 import { getLogger } from "../util/logger.js";
 import type { CallSession } from "./types.js";
@@ -132,24 +132,22 @@ export function routeSetup(ctx: SetupContext): {
   // resolution, so voice never trusts a member it cannot ACL-check. A real
   // stranger verdict (no member identity) still takes the verdict path —
   // memberRecord null is correct there.
-  const hasMemberIdentity = !!(
-    ctx.verdict?.contactId || ctx.verdict?.channelId
-  );
-  const memberUnresolvable =
-    hasMemberIdentity && resolvedMemberFromVerdict(ctx.verdict!) === null;
-  const actorTrust =
-    ctx.verdict && !ctx.verdict.resolutionFailed && !memberUnresolvable
-      ? actorTrustContextFromVerdict(ctx.verdict, {
-          sourceChannel: "phone",
-          conversationExternalId: otherPartyNumber,
-          actorDisplayName: undefined,
-        })
-      : resolveActorTrust({
-          assistantId,
-          sourceChannel: "phone",
-          conversationExternalId: otherPartyNumber,
-          actorExternalId: otherPartyNumber || undefined,
-        });
+  const usable =
+    ctx.verdict &&
+    !ctx.verdict.resolutionFailed &&
+    !verdictMemberUnresolvable(ctx.verdict);
+  const actorTrust = usable
+    ? actorTrustContextFromVerdict(ctx.verdict!, {
+        sourceChannel: "phone",
+        conversationExternalId: otherPartyNumber,
+        actorDisplayName: undefined,
+      })
+    : resolveActorTrust({
+        assistantId,
+        sourceChannel: "phone",
+        conversationExternalId: otherPartyNumber,
+        actorExternalId: otherPartyNumber || undefined,
+      });
 
   const resolved: SetupResolved = {
     assistantId,

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -6,7 +6,7 @@
  * next — without performing any side effects itself.
  */
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
+import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 
 import { getConfig } from "../config/loader.js";
 import { getContact } from "../contacts/contact-store.js";
@@ -21,6 +21,10 @@ import {
   type AdmissionPolicyResult,
   enforceAdmissionPolicy,
 } from "../runtime/routes/inbound-stages/admission-policy.js";
+import {
+  actorTrustContextFromVerdict,
+  resolvedMemberFromVerdict,
+} from "../runtime/trust-verdict-consumer.js";
 import { getLogger } from "../util/logger.js";
 import type { CallSession } from "./types.js";
 
@@ -40,6 +44,12 @@ interface SetupContext {
    * preserving all pre-admission behavior.
    */
   admissionPolicy?: AdmissionPolicy | null;
+  /**
+   * Gateway-stamped caller trust verdict. When present and not
+   * `resolutionFailed`, the caller's trust is built from it; otherwise the
+   * router falls back to local resolution.
+   */
+  verdict?: TrustVerdict | null;
 }
 
 // ── Setup outcomes ───────────────────────────────────────────────────
@@ -112,12 +122,34 @@ export function routeSetup(ctx: SetupContext): {
   const isInbound = ctx.session?.initiatedFromConversationId == null;
   const otherPartyNumber = isInbound ? ctx.from : ctx.to;
 
-  const actorTrust = resolveActorTrust({
-    assistantId,
-    sourceChannel: "phone",
-    conversationExternalId: otherPartyNumber,
-    actorExternalId: otherPartyNumber || undefined,
-  });
+  // Verdict-first: build caller trust from the gateway verdict when present.
+  // Voice falls back to local resolution on a missing/failed verdict so a
+  // gateway blip does not drop a known guardian's call — the deliberate
+  // difference from the fail-closed text path.
+  //
+  // A verdict that claims a member (contactId/channelId) but whose ACL can't be
+  // reassembled (malformed/mixed-version status·policy) also falls back to local
+  // resolution, so voice never trusts a member it cannot ACL-check. A real
+  // stranger verdict (no member identity) still takes the verdict path —
+  // memberRecord null is correct there.
+  const hasMemberIdentity = !!(
+    ctx.verdict?.contactId || ctx.verdict?.channelId
+  );
+  const memberUnresolvable =
+    hasMemberIdentity && resolvedMemberFromVerdict(ctx.verdict!) === null;
+  const actorTrust =
+    ctx.verdict && !ctx.verdict.resolutionFailed && !memberUnresolvable
+      ? actorTrustContextFromVerdict(ctx.verdict, {
+          sourceChannel: "phone",
+          conversationExternalId: otherPartyNumber,
+          actorDisplayName: undefined,
+        })
+      : resolveActorTrust({
+          assistantId,
+          sourceChannel: "phone",
+          conversationExternalId: otherPartyNumber,
+          actorExternalId: otherPartyNumber || undefined,
+        });
 
   const resolved: SetupResolved = {
     assistantId,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -55,6 +55,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
+import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
@@ -484,12 +485,24 @@ async function buildVoiceWebhookTwiml(
   // admits the caller.
   const admissionPolicy = await getChannelAdmissionPolicy("phone");
 
+  // Verdict-first caller trust so this preflight matches handleSetup's ACL.
+  // routeSetup uses it when present and not resolutionFailed, else falls back
+  // to local resolution. The reader returns null on failure, keeping the
+  // local path on a gateway blip.
+  const isInbound = sessionContext?.direction !== "outbound";
+  const otherPartyNumber = isInbound ? from : to;
+  const verdict = await getInboundTrustVerdict({
+    channelType: "phone",
+    actorExternalId: otherPartyNumber || undefined,
+  });
+
   const { outcome } = routeSetup({
     callSessionId,
     session: session ?? null,
     from,
     to,
     admissionPolicy,
+    verdict,
   });
 
   // The media-stream transport supports normal_call and deny (which speaks

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -55,7 +55,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
-import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
+import { getPhoneCallerVerdict } from "./inbound-trust-reader.js";
 import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
@@ -491,10 +491,7 @@ async function buildVoiceWebhookTwiml(
   // local path on a gateway blip.
   const isInbound = sessionContext?.direction !== "outbound";
   const otherPartyNumber = isInbound ? from : to;
-  const verdict = await getInboundTrustVerdict({
-    channelType: "phone",
-    actorExternalId: otherPartyNumber || undefined,
-  });
+  const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
   const { outcome } = routeSetup({
     callSessionId,

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -13,6 +13,8 @@ import {
   actorTrustContextFromVerdict,
   resolvedMemberFromVerdict,
   trustContextFromVerdict,
+  verdictHasMemberIdentity,
+  verdictMemberUnresolvable,
 } from "../trust-verdict-consumer.js";
 
 const CONV = "conv-123";
@@ -398,9 +400,7 @@ describe("toTrustContext member grounding", () => {
     };
   }
 
-  function ctxWithMember(
-    channel: ContactChannel,
-  ): ActorTrustContext {
+  function ctxWithMember(channel: ContactChannel): ActorTrustContext {
     return {
       canonicalSenderId: "+15550100",
       guardianBindingMatch: null,
@@ -604,5 +604,67 @@ describe("resolvedMemberFromVerdict", () => {
       expect(member!.channel.status).toBe(status);
       expect(member!.channel.policy).toBe("deny");
     }
+  });
+});
+
+describe("verdict predicates", () => {
+  test("verdictHasMemberIdentity is true with contactId or channelId", () => {
+    expect(
+      verdictHasMemberIdentity({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+        contactId: "contact-1",
+      } satisfies TrustVerdict),
+    ).toBe(true);
+    expect(
+      verdictHasMemberIdentity({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+        channelId: "channel-1",
+      } satisfies TrustVerdict),
+    ).toBe(true);
+  });
+
+  test("verdictHasMemberIdentity is false for a memberless verdict", () => {
+    expect(
+      verdictHasMemberIdentity({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+      } satisfies TrustVerdict),
+    ).toBe(false);
+  });
+
+  test("verdictMemberUnresolvable is true when member identity present but ACL unsynthesizable", () => {
+    expect(
+      verdictMemberUnresolvable({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-1",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toBe(true);
+  });
+
+  test("verdictMemberUnresolvable is false for a usable member verdict", () => {
+    expect(
+      verdictMemberUnresolvable({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-1",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        status: "active",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toBe(false);
+  });
+
+  test("verdictMemberUnresolvable is false for a memberless verdict", () => {
+    expect(
+      verdictMemberUnresolvable({
+        trustClass: "unknown",
+        canonicalSenderId: "u-1",
+      } satisfies TrustVerdict),
+    ).toBe(false);
   });
 });

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -265,6 +265,62 @@ describe("actorTrustContextFromVerdict", () => {
     expect(ctx.actorMetadata.displayName).toBeUndefined();
   });
 
+  test("member verdict populates memberRecord from the verdict (voice ACL)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "blocked",
+      policy: "deny",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.memberRecord).not.toBeNull();
+    expect(ctx.memberRecord!.contact.id).toBe("contact-1");
+    expect(ctx.memberRecord!.channel.id).toBe("channel-1");
+    expect(ctx.memberRecord!.channel.status).toBe("blocked");
+    expect(ctx.memberRecord!.channel.policy).toBe("deny");
+  });
+
+  test("stranger verdict (no contactId/channelId) leaves memberRecord null", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-9",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.memberRecord).toBeNull();
+  });
+
+  test("malformed member verdict (unknown status) leaves memberRecord null (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-10",
+      contactId: "contact-10",
+      channelId: "channel-10",
+      status: "quarantined",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.memberRecord).toBeNull();
+  });
+
   test("trustContextFromVerdict equals member stamp applied to toTrustContext(actorTrustContextFromVerdict)", () => {
     const verdict = {
       trustClass: "trusted_contact",

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
+import { channelStatusToMemberStatus } from "../../contacts/member-status.js";
 import type {
   ContactChannel,
   ContactWithChannels,
@@ -9,6 +10,7 @@ import type {
 import type { ActorTrustContext } from "../actor-trust-resolver.js";
 import { toTrustContext } from "../actor-trust-resolver.js";
 import {
+  actorTrustContextFromVerdict,
   resolvedMemberFromVerdict,
   trustContextFromVerdict,
 } from "../trust-verdict-consumer.js";
@@ -160,6 +162,139 @@ describe("trustContextFromVerdict", () => {
       // Non-guardian without binding -> no guardian chat id.
       expect(result.guardianChatId).toBeUndefined();
     }
+  });
+});
+
+describe("actorTrustContextFromVerdict", () => {
+  test("maps guardian verdict fields", () => {
+    const verdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "+15550100",
+      guardianExternalUserId: "+15550100",
+      guardianDeliveryChatId: "chat-9",
+      guardianPrincipalId: "vellum-principal-abc",
+      memberDisplayName: "Alice",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "phone",
+      conversationExternalId: CONV,
+      actorUsername: "alice",
+      actorDisplayName: "Alice Sender",
+    });
+
+    expect(ctx).toEqual({
+      canonicalSenderId: "+15550100",
+      guardianBindingMatch: {
+        guardianExternalUserId: "+15550100",
+        guardianDeliveryChatId: "chat-9",
+      },
+      guardianPrincipalId: "vellum-principal-abc",
+      memberRecord: null,
+      trustClass: "guardian",
+      actorMetadata: {
+        identifier: "@alice",
+        displayName: "Alice",
+        senderDisplayName: "Alice Sender",
+        memberDisplayName: "Alice",
+        username: "alice",
+        channel: "phone",
+        trustStatus: "guardian",
+      },
+    });
+  });
+
+  test("guardianBindingMatch is null without guardianExternalUserId", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15550101",
+      memberDisplayName: "Bob",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "phone",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.guardianBindingMatch).toBeNull();
+    expect(ctx.trustClass).toBe("trusted_contact");
+    // identifier falls back to canonicalSenderId when no username.
+    expect(ctx.actorMetadata.identifier).toBe("+15550101");
+    // displayName uses memberDisplayName when present.
+    expect(ctx.actorMetadata.displayName).toBe("Bob");
+    expect(ctx.actorMetadata.channel).toBe("phone");
+    expect(ctx.memberRecord).toBeNull();
+  });
+
+  test("displayName falls back to actorDisplayName; identifier uses @username", () => {
+    const verdict = {
+      trustClass: "unverified_contact",
+      canonicalSenderId: "u-1",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+      actorUsername: "carol",
+      actorDisplayName: "Carol Display",
+    });
+
+    expect(ctx.trustClass).toBe("unverified_contact");
+    expect(ctx.actorMetadata.identifier).toBe("@carol");
+    expect(ctx.actorMetadata.displayName).toBe("Carol Display");
+    expect(ctx.actorMetadata.memberDisplayName).toBeUndefined();
+    expect(ctx.actorMetadata.trustStatus).toBe("unverified_contact");
+  });
+
+  test("maps unknown verdict with no identity overrides", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-2",
+    } satisfies TrustVerdict;
+
+    const ctx = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(ctx.trustClass).toBe("unknown");
+    expect(ctx.guardianBindingMatch).toBeNull();
+    expect(ctx.guardianPrincipalId).toBeUndefined();
+    expect(ctx.memberRecord).toBeNull();
+    expect(ctx.actorMetadata.identifier).toBe("u-2");
+    expect(ctx.actorMetadata.displayName).toBeUndefined();
+  });
+
+  test("trustContextFromVerdict equals member stamp applied to toTrustContext(actorTrustContextFromVerdict)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "unverified",
+      policy: "escalate",
+      memberDisplayName: "Dora",
+    } satisfies TrustVerdict;
+    const input = {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+      actorUsername: "dora",
+      actorDisplayName: "Dora Display",
+    } as const;
+
+    const expected = toTrustContext(
+      actorTrustContextFromVerdict(verdict, input),
+      input.conversationExternalId,
+    );
+    const member = resolvedMemberFromVerdict(verdict);
+    expect(member).not.toBeNull();
+    expected.requesterContactId = member!.contact.id;
+    expected.memberStatus = channelStatusToMemberStatus(member!.channel.status);
+    expected.memberPolicy = member!.channel.policy;
+
+    expect(trustContextFromVerdict(verdict, input)).toEqual(expected);
   });
 });
 

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -323,8 +323,8 @@ export function toTrustContext(
     requesterMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
     requesterChatId: conversationExternalId,
-    // Member grounding from a real memberRecord (voice path); the verdict path
-    // (memberRecord=null) stamps these from the verdict instead.
+    // Member grounding from the resolved memberRecord (voice + verdict paths
+    // both populate it).
     requesterContactId: ctx.memberRecord?.contact.id,
     memberStatus: ctx.memberRecord
       ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -249,6 +249,47 @@ describe("enforceIngressAcl — fail-closed on absent verdict", () => {
   });
 });
 
+describe("enforceIngressAcl — fail-closed on resolutionFailed verdict", () => {
+  test("resolutionFailed verdict → not_a_member deny, does not flow to intercepts", async () => {
+    inviteTokenForTest = "iv_token123";
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "sender-1",
+          resolutionFailed: true,
+        }),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+    // Distinct from a stranger: no invite redemption, onboarding, or
+    // guardian notification fires.
+    expect(result.earlyResponse!.inviteRedemption).toBeUndefined();
+    expect(deliverReplyCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+    expect(findContactChannelCalls.length).toBe(0);
+  });
+
+  test("real unknown stranger (no resolutionFailed) still redeems via intercept", async () => {
+    inviteTokenForTest = "iv_token123";
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "sender-1",
+        }),
+      }),
+    );
+
+    expect(result.earlyResponse!.inviteRedemption).toBe("redeemed");
+    expect(result.resolvedMember).toBeNull();
+  });
+});
+
 describe("enforceIngressAcl — fail-closed on malformed member verdict", () => {
   test("member identity + unknown policy → not_a_member deny even under strangers", async () => {
     const result = await enforceIngressAcl(

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -173,6 +173,24 @@ export async function enforceIngressAcl(
     };
   }
 
+  // Gateway attempted resolution but failed (DB error) → fail-closed deny,
+  // distinct from an absent verdict and from a real stranger. TEXT does not
+  // fall back to local ACL reads; the sender can retry.
+  if (verdict.resolutionFailed === true) {
+    log.warn(
+      { sourceChannel, externalUserId: canonicalSenderId },
+      "Ingress ACL: gateway trust resolution failed, denying fail-closed",
+    );
+    return {
+      resolvedMember: null,
+      earlyResponse: {
+        accepted: true,
+        denied: true,
+        reason: "not_a_member",
+      },
+    };
+  }
+
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member intercepts.
   const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -109,6 +109,26 @@ export function trustContextFromVerdict(
   return context;
 }
 
+/**
+ * True when the verdict carries a member identity (contactId or channelId),
+ * regardless of whether that member resolves to a usable {@link ResolvedMember}.
+ */
+export function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
+  return !!(verdict.contactId || verdict.channelId);
+}
+
+/**
+ * True when the verdict claims a member identity but that member can't be
+ * synthesized (partial/mixed-version verdict). Such a verdict is unusable —
+ * callers fall back to local resolution.
+ */
+export function verdictMemberUnresolvable(verdict: TrustVerdict): boolean {
+  return (
+    verdictHasMemberIdentity(verdict) &&
+    resolvedMemberFromVerdict(verdict) === null
+  );
+}
+
 // Allowed ACL enum values, kept in sync with the ContactChannel union types.
 const CHANNEL_STATUS_VALUES: readonly ChannelStatus[] = [
   "active",

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -33,16 +33,17 @@ export interface TrustVerdictTransport {
 }
 
 /**
- * Build a {@link TrustContext} from a gateway verdict + transport identity.
+ * Reassemble an {@link ActorTrustContext} from a gateway verdict + transport
+ * identity (mirroring `resolveActorTrust`), without any local DB/IPC reads.
  *
- * Reassembles an {@link ActorTrustContext} (mirroring `resolveActorTrust`) and
- * routes it through {@link toTrustContext}, so the output is byte-identical to
- * the local resolution path.
+ * Pure: the voice path consumes this directly for routing on
+ * `actorTrust.trustClass`; {@link trustContextFromVerdict} routes it through
+ * {@link toTrustContext}.
  */
-export function trustContextFromVerdict(
+export function actorTrustContextFromVerdict(
   verdict: TrustVerdict,
   input: TrustVerdictTransport,
-): TrustContext {
+): ActorTrustContext {
   const canonicalSenderId = verdict.canonicalSenderId;
   const memberDisplayName = verdict.memberDisplayName;
   const senderDisplayName = input.actorDisplayName;
@@ -51,7 +52,7 @@ export function trustContextFromVerdict(
     ? `@${username}`
     : (canonicalSenderId ?? undefined);
 
-  const actorTrustContext: ActorTrustContext = {
+  return {
     canonicalSenderId,
     guardianBindingMatch: verdict.guardianExternalUserId
       ? {
@@ -72,9 +73,21 @@ export function trustContextFromVerdict(
       trustStatus: verdict.trustClass,
     },
   };
+}
 
+/**
+ * Build a {@link TrustContext} from a gateway verdict + transport identity.
+ *
+ * Reassembles an {@link ActorTrustContext} (mirroring `resolveActorTrust`) and
+ * routes it through {@link toTrustContext}, so the output is byte-identical to
+ * the local resolution path.
+ */
+export function trustContextFromVerdict(
+  verdict: TrustVerdict,
+  input: TrustVerdictTransport,
+): TrustContext {
   const context = toTrustContext(
-    actorTrustContext,
+    actorTrustContextFromVerdict(verdict, input),
     input.conversationExternalId,
   );
 

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -61,7 +61,12 @@ export function actorTrustContextFromVerdict(
         }
       : null,
     guardianPrincipalId: verdict.guardianPrincipalId,
-    memberRecord: null,
+    // Populate from the verdict so the voice path's ACL gates (which read
+    // actorTrust.memberRecord.channel status/policy) enforce blocked/revoked/
+    // deny/escalate. Null for memberless verdicts. Text path is unaffected:
+    // toTrustContext derives the same member fields trustContextFromVerdict
+    // already stamps.
+    memberRecord: resolvedMemberFromVerdict(verdict),
     trustClass: verdict.trustClass,
     actorMetadata: {
       identifier,

--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -301,4 +301,22 @@ describe("handle-inbound trust verdict stamping", () => {
       "trusted_contacts",
     );
   });
+
+  test("resolver throw with whitespace-only actor id → sentinel canonicalSenderId is null", async () => {
+    resetGatewayDb();
+
+    await handleInbound(
+      makeConfig(),
+      makeEvent({
+        actor: { actorExternalId: "   ", displayName: "Blank", username: "" },
+      }),
+      ROUTING,
+    );
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.resolutionFailed).toBe(true);
+    expect(verdict.trustClass).toBe("unknown");
+    // Matches a real resolve: whitespace-only id normalizes to absent.
+    expect(verdict.canonicalSenderId).toBeNull();
+  });
 });

--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -5,7 +5,8 @@
  *    actor's gateway-DB ACL (guardian / trusted_contact / unknown).
  *  - The `admissionPolicy` floor stamp coexists unchanged with the new verdict.
  *  - The verification-code intercept short-circuits — no forward, no stamp.
- *  - A resolver failure omits the stamp and still forwards (fail-soft).
+ *  - A resolver failure stamps a `resolutionFailed` sentinel and still forwards
+ *    (fail-soft).
  *
  * Module mocks isolate the test from the live runtime client. The
  * verification intercept is mocked per-test so the default path forwards.
@@ -244,13 +245,15 @@ describe("handle-inbound trust verdict stamping", () => {
     expect(verdict.memberDisplayName).toBe("Trusted Member");
   });
 
-  test("unknown actor (no rows) → trustVerdict 'unknown', canonicalSenderId set", async () => {
+  test("unknown actor (no rows) → trustVerdict 'unknown', canonicalSenderId set, not resolutionFailed", async () => {
     await handleInbound(makeConfig(), makeEvent(), ROUTING);
 
     const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
     expect(verdict.trustClass).toBe("unknown");
     expect(verdict.canonicalSenderId).toBe("U_USER_1");
     expect(verdict.contactId).toBeUndefined();
+    // A real stranger is NOT flagged as a resolver failure.
+    expect(verdict.resolutionFailed).toBeUndefined();
   });
 
   test("admissionPolicy stamp present and unchanged alongside the new trustVerdict", async () => {
@@ -278,7 +281,7 @@ describe("handle-inbound trust verdict stamping", () => {
     expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
   });
 
-  test("resolver throw → inbound still forwards, trustVerdict absent (fail-soft)", async () => {
+  test("resolver throw → inbound forwards with a resolutionFailed sentinel (fail-soft)", async () => {
     // Drop the gateway DB connection so resolveTrustVerdict's getGatewayDb()
     // throws. The admission cache is in-memory and unaffected, so its floor
     // stamp still flows.
@@ -288,7 +291,11 @@ describe("handle-inbound trust verdict stamping", () => {
 
     expect(result.forwarded).toBe(true);
     expect(forwardToRuntimeMock).toHaveBeenCalledTimes(1);
-    expect(runtimePayloads[0]!.sourceMetadata!.trustVerdict).toBeUndefined();
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.resolutionFailed).toBe(true);
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.canonicalSenderId).toBe("U_USER_1");
+    expect(verdict.contactId).toBeUndefined();
     // The floor stamp still flows even when verdict resolution fails.
     expect(runtimePayloads[0]!.sourceMetadata!.admissionPolicy).toBe(
       "trusted_contacts",

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,5 +1,9 @@
 import { existsSync } from "node:fs";
-import type { SourceMetadata, TrustVerdict } from "@vellumai/gateway-client";
+import {
+  makeResolutionFailedVerdict,
+  type SourceMetadata,
+  type TrustVerdict,
+} from "@vellumai/gateway-client";
 import type { GatewayConfig } from "../config.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
@@ -7,7 +11,10 @@ import { ContactStore } from "../db/contact-store.js";
 import { getLogger } from "../logger.js";
 import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
 import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
-import { canonicalizeInboundIdentity } from "../verification/identity.js";
+import {
+  canonicalizeInboundIdentity,
+  canonicalSenderIdFor,
+} from "../verification/identity.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
 import {
@@ -169,14 +176,9 @@ export async function handleInbound(
     // Producer fails soft — resolution never breaks ingress. Stamp a sentinel
     // so the consumer can tell a resolver failure from a real stranger.
     log.warn({ err }, "trust verdict resolution failed; stamping sentinel");
-    trustVerdict = {
-      trustClass: "unknown",
-      canonicalSenderId: canonicalizeInboundIdentity(
-        event.sourceChannel,
-        event.actor.actorExternalId,
-      ),
-      resolutionFailed: true,
-    };
+    trustVerdict = makeResolutionFailedVerdict(
+      canonicalSenderIdFor(event.sourceChannel, event.actor.actorExternalId),
+    );
   }
 
   try {

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -166,9 +166,17 @@ export async function handleInbound(
       actorExternalId: event.actor.actorExternalId,
     });
   } catch (err) {
-    // Producer fails soft — resolution never breaks ingress. trustVerdict
-    // stays undefined so the stamp is omitted; the consumer owns deny policy.
-    log.warn({ err }, "trust verdict resolution failed; omitting stamp");
+    // Producer fails soft — resolution never breaks ingress. Stamp a sentinel
+    // so the consumer can tell a resolver failure from a real stranger.
+    log.warn({ err }, "trust verdict resolution failed; stamping sentinel");
+    trustVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: canonicalizeInboundIdentity(
+        event.sourceChannel,
+        event.actor.actorExternalId,
+      ),
+      resolutionFailed: true,
+    };
   }
 
   try {

--- a/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
@@ -165,4 +165,22 @@ describe("resolve_inbound_trust route", () => {
     expect(result.verdict.trustClass).toBe("unknown");
     expect(result.verdict.canonicalSenderId).toBe("U_STRANGER");
   });
+
+  test("resolver throw with whitespace-only actor id → sentinel canonicalSenderId is null", async () => {
+    resetGatewayDb();
+
+    const params = { channelType: CHANNEL, actorExternalId: "   " };
+    const result = (await route.handler(params)) as {
+      verdict: {
+        trustClass: string;
+        canonicalSenderId: string | null;
+        resolutionFailed?: boolean;
+      };
+    };
+
+    expect(result.verdict.resolutionFailed).toBe(true);
+    expect(result.verdict.trustClass).toBe("unknown");
+    // Matches a real resolve: whitespace-only id normalizes to absent.
+    expect(result.verdict.canonicalSenderId).toBeNull();
+  });
 });

--- a/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
@@ -132,7 +132,7 @@ describe("resolve_inbound_trust route", () => {
     );
   });
 
-  test("unknown actor → unknown verdict matching the resolver", async () => {
+  test("unknown actor → unknown verdict matching the resolver, not resolutionFailed", async () => {
     const params = { channelType: CHANNEL, actorExternalId: "U_STRANGER" };
     const result = (await route.handler(params)) as { verdict: unknown };
     const expected = await resolveTrustVerdict(params);
@@ -141,5 +141,28 @@ describe("resolve_inbound_trust route", () => {
     expect((result.verdict as { trustClass: string }).trustClass).toBe(
       "unknown",
     );
+    // A real stranger is NOT flagged as a resolver failure.
+    expect(
+      (result.verdict as { resolutionFailed?: boolean }).resolutionFailed,
+    ).toBeUndefined();
+  });
+
+  test("resolver throw → resolutionFailed sentinel verdict", async () => {
+    // Drop the gateway DB connection so resolveTrustVerdict's getGatewayDb()
+    // throws.
+    resetGatewayDb();
+
+    const params = { channelType: CHANNEL, actorExternalId: "U_STRANGER" };
+    const result = (await route.handler(params)) as {
+      verdict: {
+        trustClass: string;
+        canonicalSenderId: string | null;
+        resolutionFailed?: boolean;
+      };
+    };
+
+    expect(result.verdict.resolutionFailed).toBe(true);
+    expect(result.verdict.trustClass).toBe("unknown");
+    expect(result.verdict.canonicalSenderId).toBe("U_STRANGER");
   });
 });

--- a/gateway/src/ipc/trust-verdict-handlers.ts
+++ b/gateway/src/ipc/trust-verdict-handlers.ts
@@ -11,6 +11,7 @@
 import { ResolveInboundTrustRequestSchema } from "@vellumai/gateway-client";
 
 import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
+import { canonicalizeInboundIdentity } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
 
 export const trustVerdictRoutes: IpcRoute[] = [
@@ -19,7 +20,24 @@ export const trustVerdictRoutes: IpcRoute[] = [
     schema: ResolveInboundTrustRequestSchema,
     handler: async (params?: Record<string, unknown>) => {
       const input = ResolveInboundTrustRequestSchema.parse(params);
-      return { verdict: await resolveTrustVerdict(input) };
+      try {
+        return { verdict: await resolveTrustVerdict(input) };
+      } catch {
+        // Sentinel lets the daemon distinguish a resolver failure from a real
+        // stranger.
+        return {
+          verdict: {
+            trustClass: "unknown",
+            canonicalSenderId: input.actorExternalId
+              ? canonicalizeInboundIdentity(
+                  input.channelType,
+                  input.actorExternalId,
+                )
+              : null,
+            resolutionFailed: true,
+          },
+        };
+      }
     },
   },
 ];

--- a/gateway/src/ipc/trust-verdict-handlers.ts
+++ b/gateway/src/ipc/trust-verdict-handlers.ts
@@ -8,10 +8,13 @@
  * per-actor and must not share that cache or widen that response.
  */
 
-import { ResolveInboundTrustRequestSchema } from "@vellumai/gateway-client";
+import {
+  makeResolutionFailedVerdict,
+  ResolveInboundTrustRequestSchema,
+} from "@vellumai/gateway-client";
 
 import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
-import { canonicalizeInboundIdentity } from "../verification/identity.js";
+import { canonicalSenderIdFor } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
 
 export const trustVerdictRoutes: IpcRoute[] = [
@@ -26,16 +29,9 @@ export const trustVerdictRoutes: IpcRoute[] = [
         // Sentinel lets the daemon distinguish a resolver failure from a real
         // stranger.
         return {
-          verdict: {
-            trustClass: "unknown",
-            canonicalSenderId: input.actorExternalId
-              ? canonicalizeInboundIdentity(
-                  input.channelType,
-                  input.actorExternalId,
-                )
-              : null,
-            resolutionFailed: true,
-          },
+          verdict: makeResolutionFailedVerdict(
+            canonicalSenderIdFor(input.channelType, input.actorExternalId),
+          ),
         };
       }
     },

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -19,7 +19,7 @@ import {
   contacts as gwContacts,
   contactChannels as gwContactChannels,
 } from "../db/schema.js";
-import { canonicalizeInboundIdentity } from "../verification/identity.js";
+import { canonicalSenderIdFor } from "../verification/identity.js";
 
 export interface ResolveTrustVerdictInput {
   channelType: string;
@@ -39,15 +39,10 @@ export async function resolveTrustVerdict(
 ): Promise<TrustVerdict> {
   const db = getGatewayDb();
 
-  const rawActorId =
-    typeof input.actorExternalId === "string" &&
-    input.actorExternalId.trim().length > 0
-      ? input.actorExternalId.trim()
-      : undefined;
-
-  const canonicalSenderId = rawActorId
-    ? canonicalizeInboundIdentity(input.channelType, rawActorId)
-    : null;
+  const canonicalSenderId = canonicalSenderIdFor(
+    input.channelType,
+    input.actorExternalId,
+  );
 
   // --- Guardian-for-channel binding (independent of THIS actor) ---
   const guardianRow = db

--- a/gateway/src/verification/identity.ts
+++ b/gateway/src/verification/identity.ts
@@ -67,3 +67,16 @@ export function canonicalizeInboundIdentity(
 
   return trimmed;
 }
+
+/**
+ * Canonical sender id for a possibly-absent inbound actor id. Treats a missing
+ * or whitespace-only id as absent (null) before canonicalizing, so trust
+ * resolution and its failure sentinels share one normalization.
+ */
+export function canonicalSenderIdFor(
+  channel: string,
+  actorExternalId?: string,
+): string | null {
+  const trimmed = actorExternalId?.trim();
+  return trimmed ? canonicalizeInboundIdentity(channel, trimmed) : null;
+}

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -43,6 +43,23 @@ describe("TrustVerdictSchema", () => {
     expect(TrustVerdictSchema.parse(minimal)).toEqual(minimal);
   });
 
+  test("parses a verdict carrying resolutionFailed", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: null,
+      resolutionFailed: true,
+    } satisfies TrustVerdict;
+    expect(TrustVerdictSchema.parse(verdict)).toEqual(verdict);
+  });
+
+  test("leaves resolutionFailed undefined when absent", () => {
+    const parsed = TrustVerdictSchema.parse({
+      trustClass: "unknown",
+      canonicalSenderId: null,
+    });
+    expect(parsed.resolutionFailed).toBeUndefined();
+  });
+
   test("rejects an invalid trustClass", () => {
     expect(() =>
       TrustVerdictSchema.parse({

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from "bun:test";
 
 import { SourceMetadataSchema } from "../inbound-contract.js";
 import {
+  makeResolutionFailedVerdict,
   TrustVerdictSchema,
   type TrustVerdict,
 } from "../trust-verdict-contract.js";
@@ -58,6 +59,19 @@ describe("TrustVerdictSchema", () => {
       canonicalSenderId: null,
     });
     expect(parsed.resolutionFailed).toBeUndefined();
+  });
+
+  test("makeResolutionFailedVerdict builds an unknown sentinel", () => {
+    expect(makeResolutionFailedVerdict("+15555550100")).toEqual({
+      trustClass: "unknown",
+      canonicalSenderId: "+15555550100",
+      resolutionFailed: true,
+    });
+    expect(makeResolutionFailedVerdict(null)).toEqual({
+      trustClass: "unknown",
+      canonicalSenderId: null,
+      resolutionFailed: true,
+    });
   });
 
   test("rejects an invalid trustClass", () => {

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -73,6 +73,7 @@ export type { AdmissionPolicy } from "./admission-policy-contract.js";
 
 // Trust verdict contract (gateway → daemon) — Zod schemas + derived types
 export {
+  makeResolutionFailedVerdict,
   ResolveInboundTrustRequestSchema,
   TRUST_CLASS_VALUES,
   TrustClassSchema,

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -69,6 +69,18 @@ export const TrustVerdictSchema = z.object({
 export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;
 
 /**
+ * Sentinel for a gateway resolver failure; consumers treat it as
+ * could-not-vouch (distinct from a real `unknown` stranger). Takes the
+ * already-canonicalized sender id so this module stays free of the gateway's
+ * canonicalization util.
+ */
+export function makeResolutionFailedVerdict(
+  canonicalSenderId: string | null,
+): TrustVerdict {
+  return { trustClass: "unknown", canonicalSenderId, resolutionFailed: true };
+}
+
+/**
  * IPC request for `resolve_inbound_trust`. Per-actor identity keys the
  * gateway resolver needs to classify the inbound sender. The response reuses
  * {@link TrustVerdictSchema}.

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -42,6 +42,11 @@ export const TrustVerdictSchema = z.object({
   trustClass: TrustClassSchema,
   canonicalSenderId: z.string().nullable(),
 
+  // Present+true ⇒ gateway attempted resolution but failed (DB error);
+  // consumer treats it as "could not vouch", distinct from a real `unknown`
+  // stranger.
+  resolutionFailed: z.boolean().optional(),
+
   // Guardian binding — present only when a guardian binding matches.
   guardianExternalUserId: z.string().optional(),
   guardianDeliveryChatId: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary
The **voice** call path now consumes the gateway-stamped `sourceMetadata`/`resolve_inbound_trust` `TrustVerdict` for caller trust instead of resolving locally — the symmetric counterpart to Combo 9 (text). Adds a **fail-soft/fail-closed reconciliation**: a gateway resolver error now stamps an explicit `resolutionFailed` sentinel verdict so callers can distinguish a resolver failure from a real stranger / absent verdict. **Text** stays fail-closed (denies the sentinel, observably); **voice** fails soft (falls back to local resolution on the sentinel) so a transient gateway blip never drops a known guardian's call.

## What changed
- **Contract:** optional `resolutionFailed` on `TrustVerdict` (+ `assistant/openapi.yaml` regen); shared `makeResolutionFailedVerdict` factory.
- **Gateway:** on a resolver error, the text stamp path and the `resolve_inbound_trust` IPC return a `resolutionFailed` sentinel (sharing the resolver's canonical-id normalization) instead of omitting the stamp.
- **Text (`acl-enforcement`):** denies a `resolutionFailed` verdict fail-closed with a distinct log — separate from absent-verdict and from real strangers (intercepts intact).
- **Voice setup** (`relay-server` handleSetup, `routeSetup`, + `twilio-routes` / `media-stream-server` callsites): fetches the verdict, builds the caller's trust via `actorTrustContextFromVerdict` (now populating `memberRecord` so **blocked/revoked/deny/escalate are enforced at setup**), and falls back to local resolution on `resolutionFailed`/absent/unresolvable-member.
- **Voice mid-call** (3 verification/activation re-resolution sites): refresh the verdict-derived trust context (verdict-first, local fallback on resolutionFailed/unresolvable/memberless-unknown), with prompts buffered during the async re-resolve and flushed after the connected transition.
- **Test mirror:** `resolveLocalTrustVerdict` is address-only, matching the gateway resolver.

## Scope decision (owner)
Mid-call **admission enforcement** (disconnecting a caller who becomes blocked/revoked *while a verification flow is open*) is **deferred** to a focused follow-up — it entangles with voice choreography (invite-floor bypass, opening-ack/handoff sequencing). Mid-call re-resolution here is an **informational** trust-context refresh and never disconnects (matches pre-Combo-10 behavior). Admission is still enforced at call **setup** (the common case). Also deferred (unchanged from the plan): deleting `resolveActorTrust`/`resolveTrustContext`/`toTrustContext` (~40 non-voice callers), `notifications/destination-resolver.ts`, and voice guardian-delivery/routing reads.

## Self-review
4 fresh-eyes passes → PASS after one remediation round (2 fix PRs: #35748 mid-call flush-ordering bug + verdict-helper dedup; #35746 gateway sentinel factory + canonical-id normalization). A focused re-review of the remediation delta confirmed behavior-preserving.

## PRs merged into this feature branch
- #35738 resolutionFailed contract field · #35737 actorTrustContextFromVerdict · #35739 test mirror address-only
- #35741 gateway sentinel · #35740 text consumer · #35742 voice setup · #35744 voice mid-call (scoped)
- #35748, #35746 self-review fixes

Part of plan: voice-consumes-trust-verdict.md