### PR TITLE
Bump git-workflow plugin pin to v0.3.0

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -106,9 +106,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/git-workflow",
-        "ref": "205c245d5e66d02f98f1de5e889b66b30b6ee470"
+        "ref": "6a8a8df108615c3fdae2bb5c512c2b6632047dd6"
       },
-      "description": "Git workflow tools and multi-perspective code review: branch management, PR creation/review/merge, diffs, logs, changelog generation, and parallel subagent code review with confidence scoring.",
+      "description": "Git workflow tools and multi-perspective code review: branch management, push, stash, PR creation/review/merge/checkout, diffs, logs, changelog generation, and parallel subagent code review with confidence scoring.",
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/git-workflow",
       "license": "MIT"


### PR DESCRIPTION
## What

Re-pins the `git-workflow` marketplace entry in `plugins/marketplace.json` from the **0.2.0** commit (`205c245`) to **v0.3.0** (`6a8a8df`), and refreshes its description.

## Why

The marketplace pins each plugin to an immutable commit SHA (tags/branches are rejected by `plugin-marketplace.ts`). The `git-workflow` repo was updated to `0.3.0` and a release was cut, but the catalog kept advertising `0.2.0` because its pin still pointed at `205c245`. Updating the plugin repo can't move the catalog — only re-pinning here can.

## What's in v0.3.0

- **3 new tools:** `git_push` (safe `--force-with-lease`), `git_stash`, `pr_checkout` (12 → 15 tools)
- **New `post-tool-use` hook** nudging on commits/pushes to the default branch
- **Bug fixes:** `pr_review_gather` git-blame now emits real line ranges (was always `L0-0`); removed dead imports; real `RiskLevel` enum so the plugin type-checks
- **Tests + CI** (test + typecheck), repo guards, parallelized review-gather

Plugin release: https://github.com/vellum-ai/git-workflow/releases/tag/v0.3.0

## After merge

`assistant plugins upgrade git-workflow` (or reinstall) materializes `0.3.0`, and the marketplace card shows 15 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)