### PR TITLE
feat(onboarding): surface marketplace plugins as research suggestions

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -350,9 +350,16 @@ export function ResearchOnboardingRoute() {
           <SuggestionsStep
             suggestions={research.suggestions}
             loading={researchLoading}
-            onSuggestionClick={(prompt) =>
-              enterAssistant(formValues, faceValues, prompt)
-            }
+            onSuggestionClick={async (suggestion) => {
+              // For a plugin-backed suggestion, wait out the background install
+              // so the new chat can discover the plugin's skills (else it
+              // silently degrades to a generic prompt). Usually instant — the
+              // install kicked off while the user reviewed the results.
+              if (suggestion.plugin) {
+                await research.awaitPluginInstall(suggestion.plugin);
+              }
+              enterAssistant(formValues, faceValues, suggestion.prompt);
+            }}
             onBack={() => goBackTo("results")}
             onForward={onForward}
           />

--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the research prompt's capability injection.
+ *
+ * The capabilities block is what makes the assistant aware of marketplace
+ * plugins (e.g. marketing-expert) during onboarding research. These pin that it
+ * only appears when a catalog is passed (back-compat for the route's fallback
+ * kickoff), stays compact under a growing catalog, and instructs the model to
+ * tag a suggestion with a plugin name.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildResearchPrompt,
+  type AvailableCapability,
+} from "@/domains/onboarding/research-prompt";
+
+const SUBJECT = {
+  firstName: "Ada",
+  lastName: "Lovelace",
+  occupation: "Technical founder",
+  hobby: "chess",
+};
+
+describe("buildResearchPrompt — capabilities", () => {
+  test("omits the capabilities block when no catalog is passed", () => {
+    const prompt = buildResearchPrompt(SUBJECT);
+    expect(prompt).not.toContain("Capabilities you can offer");
+    expect(prompt).not.toContain('"plugin"');
+  });
+
+  test("injects passed capabilities and the plugin-tag instruction", () => {
+    const caps: AvailableCapability[] = [
+      { name: "marketing-expert", description: "Full-stack marketing." },
+      { name: "admin-copilot", description: "Proactive chief-of-staff." },
+    ];
+    const prompt = buildResearchPrompt(SUBJECT, caps);
+
+    expect(prompt).toContain("Capabilities you can offer");
+    expect(prompt).toContain("- marketing-expert — Full-stack marketing.");
+    expect(prompt).toContain("- admin-copilot — Proactive chief-of-staff.");
+    expect(prompt).toContain('"plugin"');
+  });
+
+  test("caps the injected list so a large catalog can't bloat the prompt", () => {
+    const caps: AvailableCapability[] = Array.from({ length: 30 }, (_, i) => ({
+      name: `plugin-${i}`,
+      description: `Capability number ${i}.`,
+    }));
+    const prompt = buildResearchPrompt(SUBJECT, caps);
+
+    const listed = caps.filter((c) => prompt.includes(`- ${c.name} —`)).length;
+    expect(listed).toBe(12);
+  });
+});

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -57,9 +57,9 @@ function renderCapabilitiesBlock(capabilities: AvailableCapability[]): string {
 Capabilities you can offer me. Each is a specialized skillset you can invoke on my behalf via your skills — not generic chat:
 ${lines}
 
-If one of these capabilities genuinely fits my situation, make AT LEAST ONE of your suggestions invoke it, and set that suggestion's "plugin" field to the capability's exact name (e.g. "marketing-expert"). The "prompt" for that suggestion must be phrased as concrete work that capability would do (e.g. "Draft positioning and a competitive teardown for my product"), so clicking it actually puts the skillset to work.
+If one of these capabilities genuinely fits my situation, make AT LEAST ONE of your suggestions invoke it, and set that suggestion's "plugin" field to the capability's exact name from the list above. The "suggestion" and "prompt" must describe the concrete work that capability would do for ME — grounded in what you researched (my actual product, stack, market, and the rivals/tools by name) — so clicking it puts the skillset to work on my real situation, not a generic version.
 Match on my IMPLIED needs, not just my stated role — use everything you researched. A technical founder very likely needs marketing-expert and admin-copilot help even though they never said "marketing" or "operations"; a solo builder shipping product still benefits from go-to-market help. Infer the capabilities that would genuinely move the needle for someone in my situation. It's fine for more than one suggestion to carry a "plugin". A suggestion with no fitting capability simply omits "plugin".
-Shape of a capability-backed suggestion: { "suggestion": "I'll sharpen your positioning and run a competitive teardown", "prompt": "Sharpen my product's positioning and run a competitive teardown of my top rivals", "plugin": "marketing-expert" }
+A capability-backed suggestion is shaped like the others plus a "plugin" key: { "suggestion": "<offer in your voice>", "prompt": "<the request in my voice>", "plugin": "<exact name from the list above>" }. The angle-bracketed parts are PLACEHOLDERS — replace them with specifics about me. Do NOT copy this example wording into a real suggestion.
 `;
 }
 

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -27,17 +27,52 @@ export interface ResearchSubject {
   hobby?: string;
 }
 
-export function buildResearchPrompt({
-  firstName,
-  lastName,
-  occupation,
-  hobby,
-}: ResearchSubject): string {
+/**
+ * A specialized capability (marketplace plugin) the assistant can offer to
+ * invoke on the user's behalf. `name` is the install name (e.g.
+ * "marketing-expert"); `description` is a one-line summary. The runner compacts
+ * the live catalog into these before injecting them so the prompt never bloats.
+ */
+export interface AvailableCapability {
+  name: string;
+  description: string;
+}
+
+/** Cap on injected capabilities so a growing marketplace can't bloat the turn. */
+const MAX_INJECTED_CAPABILITIES = 12;
+
+/**
+ * Render the "capabilities you can offer" block. Compact by construction: one
+ * short line per capability (`- name — description`), capped. Returns "" when
+ * nothing was passed so the prompt is byte-for-byte unchanged for callers that
+ * don't inject a catalog (e.g. the route's fallback kickoff message).
+ */
+function renderCapabilitiesBlock(capabilities: AvailableCapability[]): string {
+  const lines = capabilities
+    .slice(0, MAX_INJECTED_CAPABILITIES)
+    .map((c) => `- ${c.name} — ${c.description}`)
+    .join("\n");
+  if (!lines) return "";
+  return `
+Capabilities you can offer me. Each is a specialized skillset you can invoke on my behalf via your skills — not generic chat:
+${lines}
+
+If one of these capabilities genuinely fits my situation, make AT LEAST ONE of your suggestions invoke it, and set that suggestion's "plugin" field to the capability's exact name (e.g. "marketing-expert"). The "prompt" for that suggestion must be phrased as concrete work that capability would do (e.g. "Draft positioning and a competitive teardown for my product"), so clicking it actually puts the skillset to work.
+Match on my IMPLIED needs, not just my stated role — use everything you researched. A technical founder very likely needs marketing-expert and admin-copilot help even though they never said "marketing" or "operations"; a solo builder shipping product still benefits from go-to-market help. Infer the capabilities that would genuinely move the needle for someone in my situation. It's fine for more than one suggestion to carry a "plugin". A suggestion with no fitting capability simply omits "plugin".
+Shape of a capability-backed suggestion: { "suggestion": "I'll sharpen your positioning and run a competitive teardown", "prompt": "Sharpen my product's positioning and run a competitive teardown of my top rivals", "plugin": "marketing-expert" }
+`;
+}
+
+export function buildResearchPrompt(
+  { firstName, lastName, occupation, hobby }: ResearchSubject,
+  availableCapabilities: AvailableCapability[] = [],
+): string {
   const fullName = [firstName.trim(), lastName.trim()]
     .filter(Boolean)
     .join(" ");
   const role = occupation.trim();
   const hobbyText = hobby?.trim() ?? "";
+  const capabilitiesBlock = renderCapabilitiesBlock(availableCapabilities);
 
   const identity =
     [
@@ -77,5 +112,6 @@ Role (occupation-driven). Anchor on their day-to-day function (SWE, PM, designer
 Life admin (always present). Target the home and personal side. Anchor on the app builder or scheduled monitor capability. The opening should be a flexible conversation opener ("Tell me what admin eats your week" / "Tell me how your household runs and..."). The menu of items should be tuned to occupation when relevant (medical: rotations / CME / expense; founder: tax deadlines / subscriptions / finances; family-heavy: groceries / school pickup / meal planning; default: meal planning / errands / recurring bills). Specific artifact per item ("weekly grocery list", "live view of subscriptions").
 Each suggestion should be spoken in your voice, offering a service. First-person "I" in the suggestion refers to you, regardless of your name. Core sentence pattern: "I'll [verb] [specific artifact]" or "Connect me to [integration] and I'll [verb] [artifact]." An intake question can lead ("Tell me about your next trip. I'll build a training plan") as long as the offer is preserved. Suggestions render as clickable; clicking indicates the user wants to proceed. Refinement happens in follow-up conversation, not through the click itself.
 Use what you learned about me during research to make each suggestion feel specific to my stack, role, and industry, not generic LLM-assistant stuff. Avoid "summarize" or "draft a post" as standalone suggestions. Favor the surprising, specific capabilities (apps, monitors, doc editor, integrations).
+${capabilitiesBlock}
 Don't include anything sensitive or private. If you found very little, lean on "guessing" claims and broadly useful suggestions for my role. Output ONLY the JSON object. No code fence, no extra text.`;
 }

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the catalog filter that decides which plugins onboarding surfaces.
+ *
+ * The hard rule: only Vellum-hosted (first-party, reviewed) plugins are ever
+ * offered or installed during onboarding — never third-party/external
+ * marketplace repos — minus a couple of Vellum-owned infra/meta plugins.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { selectRecommendableCapabilities } from "@/domains/onboarding/research-runner";
+
+type Match = Parameters<typeof selectRecommendableCapabilities>[0][number];
+
+function match(
+  name: string,
+  repo: string,
+  description?: string,
+): Match {
+  return {
+    name,
+    path: `github:${repo}@abc123`,
+    ...(description ? { description } : {}),
+    source: { kind: "github", repo, ref: "abc123" },
+  };
+}
+
+describe("selectRecommendableCapabilities", () => {
+  test("keeps vellum-hosted plugins and drops external-owner ones", () => {
+    const { capabilities, validNames } = selectRecommendableCapabilities([
+      match("marketing-expert", "vellum-ai/marketing-expert", "Full-stack marketing."),
+      match("admin-copilot", "vellum-ai/admin-copilot", "Chief-of-staff."),
+      match("caveman", "JuliusBrussee/caveman", "Compression mode."),
+      match("dynamic-notch", "AnitaKirkovska/dynamic-notch", "Notch UI."),
+      match("ai-hero-engineer-kit", "marinatrajk/ai-hero-engineer-kit", "Eng skills."),
+    ]);
+
+    expect([...validNames].sort()).toEqual(["admin-copilot", "marketing-expert"]);
+    expect(capabilities.map((c) => c.name).sort()).toEqual([
+      "admin-copilot",
+      "marketing-expert",
+    ]);
+  });
+
+  test("drops vellum-hosted infra/meta plugins (simple-memory, level-up)", () => {
+    const { validNames } = selectRecommendableCapabilities([
+      match("simple-memory", "vellum-ai/simple-memory", "Reference memory."),
+      match("level-up", "vellum-ai/level-up", "Self-edit diff card."),
+      match("git-workflow", "vellum-ai/git-workflow", "Git tools."),
+    ]);
+
+    expect([...validNames]).toEqual(["git-workflow"]);
+  });
+
+  test("drops entries missing a description", () => {
+    const { validNames } = selectRecommendableCapabilities([
+      match("marketing-expert", "vellum-ai/marketing-expert"),
+    ]);
+
+    expect(validNames.size).toBe(0);
+  });
+
+  test("compacts descriptions to one short clause", () => {
+    const long =
+      "Acts as a full-stack marketing expert for any business. " +
+      "Includes positioning, demand planning, launches, content, brand voice, SEO, and competitive teardown playbooks.";
+    const { capabilities } = selectRecommendableCapabilities([
+      match("marketing-expert", "vellum-ai/marketing-expert", long),
+    ]);
+
+    expect(capabilities[0]?.description).toBe(
+      "Acts as a full-stack marketing expert for any business.",
+    );
+  });
+});

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -31,6 +31,7 @@ import {
 import type {
   MessagesGetResponses,
   MessagesPostData,
+  PluginsSearchGetResponses,
 } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import {
@@ -38,6 +39,7 @@ import {
   type AvailableCapability,
   type ResearchSubject,
 } from "@/domains/onboarding/research-prompt";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {
   parseResearchResultStreaming,
   type ResearchFact,
@@ -55,20 +57,31 @@ const MAX_POLL_MS = 120_000;
 const STABLE_READS_TO_SETTLE = 2;
 
 /**
- * Marketplace plugins that are infrastructure/meta rather than a capability the
- * assistant would ever offer a new user as a suggestion (compression modes,
- * model routers, reference/memory samples, UI shells). Filtered out of the
- * catalog before injection so the prompt only ever lists recommendable
- * skillsets. Anything NOT on this list — including future persona plugins like a
- * developer/PM kit — flows through automatically.
+ * Org that owns first-party, reviewed Vellum plugins. Onboarding only ever
+ * surfaces and installs plugins from this owner — never third-party/external
+ * marketplace repos — so a new user is never offered (or silently handed)
+ * community code during onboarding.
  */
-const NON_RECOMMENDABLE_PLUGINS = new Set<string>([
-  "caveman",
-  "model-router",
-  "simple-memory",
-  "dynamic-notch",
-  "level-up",
-]);
+const VELLUM_PLUGIN_OWNER = "vellum-ai";
+
+/**
+ * Vellum-hosted plugins that are still infrastructure/meta rather than a
+ * capability worth offering a new user (a reference memory sample, the
+ * self-edit diff card). Dropped on top of the owner filter. Anything else owned
+ * by Vellum — including future persona plugins like a developer/PM kit — flows
+ * through automatically.
+ */
+const NON_RECOMMENDABLE_PLUGINS = new Set<string>(["simple-memory", "level-up"]);
+
+type CatalogMatch = NonNullable<
+  PluginsSearchGetResponses[200]["matches"]
+>[number];
+
+export interface RecommendableCapabilities {
+  capabilities: AvailableCapability[];
+  /** Valid install names, used to gate background installs against hallucination. */
+  validNames: Set<string>;
+}
 
 /** Keep injected descriptions to one short clause so the prompt stays compact. */
 function compactDescription(raw: string): string {
@@ -78,33 +91,54 @@ function compactDescription(raw: string): string {
     : firstSentence;
 }
 
+/** Owner segment of an `owner/repo` locator, or "" when unparseable. */
+function repoOwner(repo: string | undefined): string {
+  return repo?.split("/")[0]?.trim() ?? "";
+}
+
+/**
+ * Narrow the marketplace catalog to the capabilities onboarding will surface:
+ * Vellum-hosted (first-party, reviewed) plugins only, minus the meta/infra
+ * ones, each compacted to one short line. Pure so it's unit-testable without
+ * mocking the catalog fetch.
+ */
+export function selectRecommendableCapabilities(
+  matches: CatalogMatch[],
+): RecommendableCapabilities {
+  const capabilities: AvailableCapability[] = [];
+  const validNames = new Set<string>();
+  for (const m of matches) {
+    const name = m.name?.trim();
+    const description = m.description?.trim();
+    if (!name || !description) continue;
+    if (repoOwner(m.source?.repo) !== VELLUM_PLUGIN_OWNER) continue;
+    if (NON_RECOMMENDABLE_PLUGINS.has(name)) continue;
+    validNames.add(name);
+    capabilities.push({ name, description: compactDescription(description) });
+  }
+  return { capabilities, validNames };
+}
+
+const EMPTY_CAPABILITIES: RecommendableCapabilities = {
+  capabilities: [],
+  validNames: new Set<string>(),
+};
+
 /**
  * Pull the live marketplace catalog and compact it into the capability list the
  * research prompt advertises. Best-effort: any failure yields an empty list, in
  * which case the prompt simply omits the capabilities block (unchanged from the
- * pre-plugin behavior). Returns the recommendable entries plus the set of valid
- * install names, used to gate background installs against model hallucination.
+ * pre-plugin behavior).
  */
 async function fetchAvailableCapabilities(
   assistantId: string,
-): Promise<{ capabilities: AvailableCapability[]; validNames: Set<string> }> {
+): Promise<RecommendableCapabilities> {
   try {
     const res = await pluginsSearchGet({
       path: { assistant_id: assistantId },
       throwOnError: false,
     });
-    const matches = res.data?.matches ?? [];
-    const capabilities: AvailableCapability[] = [];
-    const validNames = new Set<string>();
-    for (const m of matches) {
-      const name = m.name?.trim();
-      const description = m.description?.trim();
-      if (!name || !description) continue;
-      if (NON_RECOMMENDABLE_PLUGINS.has(name)) continue;
-      validNames.add(name);
-      capabilities.push({ name, description: compactDescription(description) });
-    }
-    return { capabilities, validNames };
+    return selectRecommendableCapabilities(res.data?.matches ?? []);
   } catch (err) {
     captureError(err, { context: "research_onboarding_catalog" });
     return { capabilities: [], validNames: new Set<string>() };
@@ -158,12 +192,46 @@ export interface UseResearchRunner extends ResearchRunnerState {
    * stale poll loop so the results reflect the corrected subject.
    */
   start: (options: StartResearchOptions) => void;
+  /**
+   * Await the background install of a plugin a suggestion is tagged with, so the
+   * click doesn't open the chat before `<workspace>/plugins/<name>` exists —
+   * otherwise the plugin's skills aren't discoverable in the new conversation
+   * and the suggestion silently degrades to a generic prompt. Resolves
+   * immediately when nothing is pending for that name.
+   */
+  awaitPluginInstall: (name: string) => Promise<void>;
 }
 
 type GetMessage = MessagesGetResponses[200]["messages"][number];
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Bounded wait (ms) for the assistant flag store to hydrate before gating on it. */
+const FLAG_HYDRATE_TIMEOUT_MS = 8000;
+
+/**
+ * Whether the experimental external-plugin surface is enabled for this
+ * assistant. Plugin install/load lives behind the `external-plugins` rollout
+ * gate (assistant flag store key `externalPlugins`), so onboarding must not
+ * surface or materialize plugins when it's off — otherwise we'd bypass the gate
+ * and expose/install marketplace plugins to an unentitled workspace. Waits
+ * (bounded) for the flag store to hydrate so a cold load doesn't read the
+ * default-off value as a hard "no"; an un-hydrated timeout is treated as off.
+ */
+async function awaitExternalPluginsEnabled(
+  isStale: () => boolean,
+): Promise<boolean> {
+  const deadline = Date.now() + FLAG_HYDRATE_TIMEOUT_MS;
+  while (
+    !useAssistantFeatureFlagStore.getState().hasHydrated &&
+    Date.now() < deadline
+  ) {
+    await sleep(250);
+    if (isStale()) return false;
+  }
+  return useAssistantFeatureFlagStore.getState().externalPlugins === true;
+}
 
 /** Latest assistant reply text from a messages list (text blocks, then legacy flat content). */
 function latestAssistantText(messages: GetMessage[]): string {
@@ -195,6 +263,10 @@ export function useResearchRunner(): UseResearchRunner {
   // an identical resubmit is a no-op but an edited one restarts.
   const runIdRef = useRef(0);
   const subjectKeyRef = useRef<string | null>(null);
+  // Background plugin installs keyed by name, so the suggestion click can await
+  // the matching install before opening the chat (see `awaitPluginInstall`).
+  // Promises stay resolved in the map, so awaiting a settled one is instant.
+  const installPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
 
   const start = useCallback(
     ({ awaitAssistantId, subject, conversationTitle }: StartResearchOptions) => {
@@ -204,6 +276,8 @@ export function useResearchRunner(): UseResearchRunner {
       const runId = runIdRef.current + 1;
       runIdRef.current = runId;
       const isStale = () => runIdRef.current !== runId;
+      // Fresh run — drop installs tracked for a superseded subject.
+      installPromisesRef.current.clear();
       setState({ status: "running", claims: [], suggestions: [] });
 
       void (async () => {
@@ -213,9 +287,14 @@ export function useResearchRunner(): UseResearchRunner {
 
           // Advertise the live marketplace catalog to the research turn so it can
           // tag a suggestion with a plugin whose skills the prompt would trigger.
+          // Only when the external-plugin surface is enabled for this assistant;
+          // otherwise run plain research with no plugin injection or install.
           // Best-effort: an empty list just omits the capabilities block.
-          const { capabilities, validNames } =
-            await fetchAvailableCapabilities(assistantId);
+          const pluginsEnabled = await awaitExternalPluginsEnabled(isStale);
+          if (isStale()) return;
+          const { capabilities, validNames } = pluginsEnabled
+            ? await fetchAvailableCapabilities(assistantId)
+            : EMPTY_CAPABILITIES;
           if (isStale()) return;
 
           const conversation = await conversationsPost({
@@ -266,11 +345,12 @@ export function useResearchRunner(): UseResearchRunner {
           const deadline = Date.now() + MAX_POLL_MS;
           let lastText = "";
           let stableReads = 0;
-          // Plugins we've already kicked off an install for — installs fire the
-          // moment a tagged suggestion first streams in (overlapping the user's
-          // results-review screens) so the plugin is materialized before the
-          // click opens the chat. Idempotent, so racing the same name is fine.
-          const installing = new Set<string>();
+          // Installs fire the moment a tagged suggestion first streams in
+          // (overlapping the user's results-review screens) so the plugin is
+          // materialized before the click opens the chat. Tracked by promise so
+          // the click can await a still-running one. Idempotent, so racing the
+          // same name is fine.
+          const installs = installPromisesRef.current;
           while (Date.now() < deadline) {
             await sleep(POLL_INTERVAL_MS);
             if (isStale()) return;
@@ -288,13 +368,11 @@ export function useResearchRunner(): UseResearchRunner {
               for (const s of suggestions) {
                 // Gate on the fetched catalog so a hallucinated name never hits
                 // the install route; skip ones already in flight.
-                if (
-                  s.plugin &&
-                  validNames.has(s.plugin) &&
-                  !installing.has(s.plugin)
-                ) {
-                  installing.add(s.plugin);
-                  void installCapabilityBestEffort(assistantId, s.plugin);
+                if (s.plugin && validNames.has(s.plugin) && !installs.has(s.plugin)) {
+                  installs.set(
+                    s.plugin,
+                    installCapabilityBestEffort(assistantId, s.plugin),
+                  );
                 }
               }
               stableReads = text === lastText ? stableReads + 1 : 0;
@@ -315,5 +393,13 @@ export function useResearchRunner(): UseResearchRunner {
     [],
   );
 
-  return { ...state, start };
+  const awaitPluginInstall = useCallback(
+    async (name: string): Promise<void> => {
+      const pending = installPromisesRef.current.get(name);
+      if (pending) await pending;
+    },
+    [],
+  );
+
+  return { ...state, start, awaitPluginInstall };
 }

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -25,6 +25,8 @@ import {
   conversationsPost,
   messagesGet,
   messagesPost,
+  pluginsInstallPost,
+  pluginsSearchGet,
 } from "@/generated/daemon/sdk.gen";
 import type {
   MessagesGetResponses,
@@ -33,6 +35,7 @@ import type {
 import { captureError } from "@/lib/sentry/capture-error";
 import {
   buildResearchPrompt,
+  type AvailableCapability,
   type ResearchSubject,
 } from "@/domains/onboarding/research-prompt";
 import {
@@ -50,6 +53,86 @@ const MAX_POLL_MS = 120_000;
  * persists the assistant message incrementally or only on completion.
  */
 const STABLE_READS_TO_SETTLE = 2;
+
+/**
+ * Marketplace plugins that are infrastructure/meta rather than a capability the
+ * assistant would ever offer a new user as a suggestion (compression modes,
+ * model routers, reference/memory samples, UI shells). Filtered out of the
+ * catalog before injection so the prompt only ever lists recommendable
+ * skillsets. Anything NOT on this list — including future persona plugins like a
+ * developer/PM kit — flows through automatically.
+ */
+const NON_RECOMMENDABLE_PLUGINS = new Set<string>([
+  "caveman",
+  "model-router",
+  "simple-memory",
+  "dynamic-notch",
+  "level-up",
+]);
+
+/** Keep injected descriptions to one short clause so the prompt stays compact. */
+function compactDescription(raw: string): string {
+  const firstSentence = raw.trim().split(/(?<=\.)\s/)[0]?.trim() ?? raw.trim();
+  return firstSentence.length > 100
+    ? `${firstSentence.slice(0, 97).trimEnd()}…`
+    : firstSentence;
+}
+
+/**
+ * Pull the live marketplace catalog and compact it into the capability list the
+ * research prompt advertises. Best-effort: any failure yields an empty list, in
+ * which case the prompt simply omits the capabilities block (unchanged from the
+ * pre-plugin behavior). Returns the recommendable entries plus the set of valid
+ * install names, used to gate background installs against model hallucination.
+ */
+async function fetchAvailableCapabilities(
+  assistantId: string,
+): Promise<{ capabilities: AvailableCapability[]; validNames: Set<string> }> {
+  try {
+    const res = await pluginsSearchGet({
+      path: { assistant_id: assistantId },
+      throwOnError: false,
+    });
+    const matches = res.data?.matches ?? [];
+    const capabilities: AvailableCapability[] = [];
+    const validNames = new Set<string>();
+    for (const m of matches) {
+      const name = m.name?.trim();
+      const description = m.description?.trim();
+      if (!name || !description) continue;
+      if (NON_RECOMMENDABLE_PLUGINS.has(name)) continue;
+      validNames.add(name);
+      capabilities.push({ name, description: compactDescription(description) });
+    }
+    return { capabilities, validNames };
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_catalog" });
+    return { capabilities: [], validNames: new Set<string>() };
+  }
+}
+
+/**
+ * Materialize a matched plugin under the assistant's workspace so the fresh
+ * conversation the suggestion click opens can discover its skills (plugin-
+ * resident skills load per-conversation from disk — no restart needed; the
+ * plugin's hooks/persona would need a later restart, but the skills carry the
+ * value). Best-effort and idempotent: an already-installed plugin returns 409,
+ * which we ignore.
+ */
+async function installCapabilityBestEffort(
+  assistantId: string,
+  name: string,
+): Promise<void> {
+  try {
+    await pluginsInstallPost({
+      path: { assistant_id: assistantId },
+      body: { name },
+      throwOnError: false,
+    });
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_install" });
+  }
+}
 
 export type ResearchStatus = "idle" | "running" | "done" | "error";
 
@@ -128,6 +211,13 @@ export function useResearchRunner(): UseResearchRunner {
           const assistantId = await awaitAssistantId();
           if (isStale()) return;
 
+          // Advertise the live marketplace catalog to the research turn so it can
+          // tag a suggestion with a plugin whose skills the prompt would trigger.
+          // Best-effort: an empty list just omits the capabilities block.
+          const { capabilities, validNames } =
+            await fetchAvailableCapabilities(assistantId);
+          if (isStale()) return;
+
           const conversation = await conversationsPost({
             path: { assistant_id: assistantId },
             body: {
@@ -145,7 +235,7 @@ export function useResearchRunner(): UseResearchRunner {
 
           const body: MessagesPostData["body"] = {
             conversationId,
-            content: buildResearchPrompt(subject),
+            content: buildResearchPrompt(subject, capabilities),
             sourceChannel: "vellum",
             interface: "vellum",
             clientMessageId: crypto.randomUUID(),
@@ -176,6 +266,11 @@ export function useResearchRunner(): UseResearchRunner {
           const deadline = Date.now() + MAX_POLL_MS;
           let lastText = "";
           let stableReads = 0;
+          // Plugins we've already kicked off an install for — installs fire the
+          // moment a tagged suggestion first streams in (overlapping the user's
+          // results-review screens) so the plugin is materialized before the
+          // click opens the chat. Idempotent, so racing the same name is fine.
+          const installing = new Set<string>();
           while (Date.now() < deadline) {
             await sleep(POLL_INTERVAL_MS);
             if (isStale()) return;
@@ -190,6 +285,18 @@ export function useResearchRunner(): UseResearchRunner {
             if (text) {
               const { claims, suggestions } = parseResearchResultStreaming(text);
               setState({ status: "running", claims, suggestions });
+              for (const s of suggestions) {
+                // Gate on the fetched catalog so a hallucinated name never hits
+                // the install route; skip ones already in flight.
+                if (
+                  s.plugin &&
+                  validNames.has(s.plugin) &&
+                  !installing.has(s.plugin)
+                ) {
+                  installing.add(s.plugin);
+                  void installCapabilityBestEffort(assistantId, s.plugin);
+                }
+              }
               stableReads = text === lastText ? stableReads + 1 : 0;
               lastText = text;
               if (stableReads >= STABLE_READS_TO_SETTLE) break;

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -350,8 +350,11 @@ export function SuggestionsStep({
   suggestions: ResearchSuggestion[];
   /** True while the research turn is still streaming. */
   loading: boolean;
-  /** Sends the user-voiced prompt for the clicked suggestion. */
-  onSuggestionClick: (prompt: string) => void;
+  /**
+   * Opens the chat on the clicked suggestion. Receives the whole suggestion so
+   * the caller can await any tagged plugin's install before navigating.
+   */
+  onSuggestionClick: (suggestion: ResearchSuggestion) => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
@@ -389,7 +392,7 @@ export function SuggestionsStep({
             <motion.button
               key={`${i}-${s.suggestion}`}
               type="button"
-              onClick={() => onSuggestionClick(s.prompt)}
+              onClick={() => onSuggestionClick(s)}
               initial={reduce ? false : { opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }}

--- a/clients/web/src/utils/research-facts.test.ts
+++ b/clients/web/src/utils/research-facts.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Contract tests for the research-fact parser's plugin tagging.
+ *
+ * The research-onboarding flow lets the assistant tag a suggestion with the
+ * marketplace plugin (`plugin`) whose skills its prompt should trigger; the
+ * runner background-installs any tagged plugin. These tests pin that the
+ * optional `plugin` field round-trips, stays absent for ordinary suggestions,
+ * and survives the streaming-tolerant extraction unchanged.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseResearchResultStreaming } from "@/utils/research-facts";
+
+describe("parseResearchResultStreaming — plugin tagging", () => {
+  test("parses the optional plugin field on a suggestion", () => {
+    const text = JSON.stringify({
+      claims: [],
+      suggestions: [
+        {
+          suggestion: "I'll sharpen your positioning and run a teardown",
+          prompt: "Sharpen my positioning and run a competitive teardown",
+          plugin: "marketing-expert",
+        },
+      ],
+    });
+
+    const { suggestions } = parseResearchResultStreaming(text);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.plugin).toBe("marketing-expert");
+  });
+
+  test("leaves plugin undefined for an ordinary suggestion", () => {
+    const text = JSON.stringify({
+      claims: [],
+      suggestions: [
+        { suggestion: "I'll plan your trip", prompt: "Plan my trip" },
+      ],
+    });
+
+    const { suggestions } = parseResearchResultStreaming(text);
+
+    expect(suggestions[0]).toBeDefined();
+    expect(suggestions[0]?.plugin).toBeUndefined();
+  });
+
+  test("trims plugin whitespace and drops blank tags", () => {
+    const text = JSON.stringify({
+      suggestions: [
+        { suggestion: "a", prompt: "a", plugin: "  admin-copilot  " },
+        { suggestion: "b", prompt: "b", plugin: "   " },
+      ],
+    });
+
+    const { suggestions } = parseResearchResultStreaming(text);
+
+    expect(suggestions[0]?.plugin).toBe("admin-copilot");
+    expect(suggestions[1]?.plugin).toBeUndefined();
+  });
+
+  test("surfaces a tagged suggestion mid-stream before the array closes", () => {
+    // Unterminated payload: suggestions array still open, trailing object
+    // half-written. The first, complete object must still surface with its tag.
+    const partial =
+      '{ "claims": [], "suggestions": [ ' +
+      '{ "suggestion": "I\'ll run GTM", "prompt": "Run my GTM", "plugin": "marketing-expert" }, ' +
+      '{ "suggestion": "half';
+
+    const { suggestions } = parseResearchResultStreaming(partial);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.plugin).toBe("marketing-expert");
+  });
+});

--- a/clients/web/src/utils/research-facts.ts
+++ b/clients/web/src/utils/research-facts.ts
@@ -51,6 +51,16 @@ export interface ResearchSuggestion {
    * talking to itself.
    */
   prompt: string;
+  /**
+   * Optional marketplace plugin (install name, e.g. "marketing-expert") whose
+   * skills this suggestion's prompt is designed to trigger. Set by the model
+   * when it matches a capability from the injected catalog to the user's
+   * situation. The runner background-installs any tagged plugin so its skills
+   * are discoverable in the fresh conversation the click opens (plugin-resident
+   * skills load per-conversation from disk — no daemon restart needed). Absent
+   * for ordinary suggestions.
+   */
+  plugin?: string;
 }
 
 /** Bare registrable domain from a URL (www stripped), or null if unparseable. */
@@ -145,7 +155,12 @@ function toSuggestion(entry: unknown): ResearchSuggestion | null {
     typeof rawPrompt === "string" && rawPrompt.trim()
       ? rawPrompt.trim()
       : suggestion.trim();
-  return { suggestion: suggestion.trim(), prompt };
+  const rawPlugin = (entry as { plugin?: unknown }).plugin;
+  const plugin =
+    typeof rawPlugin === "string" && rawPlugin.trim()
+      ? rawPlugin.trim()
+      : undefined;
+  return { suggestion: suggestion.trim(), prompt, ...(plugin ? { plugin } : {}) };
 }
 
 /** Body after a `"key": [` opening, or null if that array isn't present yet. */


### PR DESCRIPTION
## What

Makes the research-onboarding flow **aware of marketplace plugins** (e.g. `marketing-expert`, `admin-copilot`) and have the assistant generate at least one suggestion whose prompt actually triggers a relevant plugin's skills — driven by the user's role, whether they stated it or it was inferred during research.

## Why

A new user signing up should be met with suggestions that put real, role-specific capabilities to work. Today the research turn has zero knowledge that these plugins exist, and marketplace plugins aren't installed by default — so even a perfectly-phrased suggestion wouldn't trigger anything.

## How

**1. Awareness** — the runner fetches the **live marketplace catalog** (`pluginsSearchGet`), filters a small denylist of infra/meta plugins, compacts each to one short line, caps the list at 12, and injects it into the research prompt. New persona plugins (e.g. a future dev/PM kit) flow through automatically — no code change.

**2. Matching** — the model matches freely from the injected catalog, with an explicit *"infer latent need, not just stated role"* rule (a technical founder → `marketing-expert` + `admin-copilot`, even if they never said "marketing"). It tags the matching suggestion with `"plugin": "<name>"`.

**3. Activation** — as tagged suggestions stream in, the runner **background-installs** each matched plugin (`pluginsInstallPost`) — gated on the fetched catalog (no hallucinated names), best-effort, idempotent, non-blocking. Installs fire while the user is still on the claims/results screens.

### Activation nuance
Plugin **install** needs a daemon restart to load hooks/persona/tools — but plugin-resident **skills are discovered fresh per-conversation from disk** (no restart). The suggestion click opens a *new* conversation, so the matched plugin's skills are immediately discoverable and `skill_load`-able there. The skills are the substance, so the prompt genuinely triggers the plugin.

## Changes
- `utils/research-facts.ts` — optional `plugin` tag on `ResearchSuggestion` + streaming-tolerant parse (back-compatible).
- `domains/onboarding/research-prompt.ts` — conditional, compact, capped capability block + infer-latent-need rule + plugin-tag instruction. Prompt unchanged when no catalog passed.
- `domains/onboarding/research-runner.ts` — catalog fetch/compact/denylist, injection, gated background install.
- Tests: parser tag (parse/absent/trim/mid-stream) + prompt compaction/conditional-inject (7 tests).

## Verification
- `bun run typecheck` ✅ · `eslint` ✅ · cross-domain import audit ✅ · 7 new tests pass ✅

## Follow-up to verify in a hatched env
The web token needs `settings.write` for `POST …/plugins/install`. It's best-effort, so a denial won't break onboarding — but if installs silently 403, that policy is where to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)