### PR TITLE
perf(usage): pre-aggregate series/daily usage reads in SQL

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -779,6 +779,31 @@ describe("getUsageDayBuckets", () => {
     expect(buckets[0].totalEstimatedCostUsd).toBeCloseTo(0.05);
     expect(buckets[0].eventCount).toBe(2);
   });
+
+  test("collapses many events within a sub-bucket span without losing totals", () => {
+    // The read path pre-aggregates events into 15-minute UTC buckets in SQL
+    // before local-time bucketing. Many events inside one such window must
+    // still sum exactly, and events split across the 15-minute boundary but
+    // within the same local day must land in the same day bucket.
+    const windowStart = utcMs(2025, 3, 1, 10); // 10:00:00 UTC
+    for (let i = 0; i < 50; i++) {
+      // Spread across ~16 minutes so the events straddle a 15-minute boundary.
+      insertEventAt(windowStart + i * 20_000, {
+        inputTokens: 2,
+        outputTokens: 1,
+      });
+    }
+
+    const buckets = getUsageDayBuckets({
+      from: utcMs(2025, 3, 1),
+      to: utcMs(2025, 3, 2),
+    });
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].date).toBe("2025-03-01");
+    expect(buckets[0].totalInputTokens).toBe(100);
+    expect(buckets[0].totalOutputTokens).toBe(50);
+    expect(buckets[0].eventCount).toBe(50);
+  });
 });
 
 describe("getUsageDayBuckets — timezone-aware", () => {

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -525,7 +525,32 @@ export function getUsageTotals(
   };
 }
 
-/** Fetch raw events in a time range for in-memory bucketing. */
+/**
+ * Width of the SQL pre-aggregation bucket used by the time-series read paths,
+ * in milliseconds. The series/daily endpoints bucket events into local-day or
+ * local-hour buckets in JavaScript (SQLite's `strftime` is UTC-only and can't
+ * honor an IANA timezone). To avoid materializing one JS object per usage event
+ * — which on a 90-day window can mean hundreds of thousands of rows on the
+ * daemon's main thread — we first roll events up in SQL into fixed UTC buckets,
+ * then feed those far-fewer rows into the same JS bucketing logic.
+ *
+ * 15 minutes is the finest quantum every real-world IANA UTC offset divides
+ * into (whole-hour offsets, plus the :30 and :45 zones like Asia/Kolkata and
+ * Asia/Kathmandu). Because every local-day and local-hour boundary therefore
+ * lands on a 15-minute UTC boundary, no pre-aggregation bucket can straddle a
+ * local bucket boundary — so rolling up to 15-minute UTC buckets and then
+ * re-bucketing in local time is exactly equal to bucketing each raw event.
+ * DST fall-back hours stay distinct because their instants fall in different
+ * 15-minute UTC buckets (and the JS layer disambiguates them by UTC offset).
+ */
+const USAGE_PREAGG_BUCKET_MS = 15 * 60 * 1000;
+
+/**
+ * Fetch usage rows for a time range, pre-aggregated into {@link
+ * USAGE_PREAGG_BUCKET_MS} UTC buckets, for in-memory local-time bucketing. Each
+ * returned row's `created_at` is its UTC bucket start, which the JS bucketing
+ * maps to the same local bucket every raw event in that window would map to.
+ */
 function fetchRawBucketRows(
   range: UsageTimeRange,
   filter?: UsageAggregationFilter,
@@ -534,13 +559,14 @@ function fetchRawBucketRows(
   return rawAll<UsageEventBucketRow>(
     /*sql*/ `
     SELECT
-      created_at,
-      input_tokens,
-      output_tokens,
-      estimated_cost_usd,
-      llm_call_count
+      (created_at / ${USAGE_PREAGG_BUCKET_MS}) * ${USAGE_PREAGG_BUCKET_MS} AS created_at,
+      COALESCE(SUM(input_tokens), 0)                AS input_tokens,
+      COALESCE(SUM(output_tokens), 0)               AS output_tokens,
+      SUM(estimated_cost_usd)                       AS estimated_cost_usd,
+      SUM(COALESCE(llm_call_count, 1))              AS llm_call_count
     FROM llm_usage_events
     WHERE ${where.sql}
+    GROUP BY (created_at / ${USAGE_PREAGG_BUCKET_MS})
     ORDER BY created_at ASC
     `,
     ...where.params,
@@ -829,17 +855,18 @@ export function getUsageGroupedSeries(
         WHERE ${where.sql}
       )
       SELECT
-        schedule_usage.created_at,
-        schedule_usage.input_tokens,
-        schedule_usage.output_tokens,
-        schedule_usage.estimated_cost_usd,
-        schedule_usage.llm_call_count,
-        schedule_usage.group_key,
-        schedule_group_jobs.name AS group_label
+        (schedule_usage.created_at / ${USAGE_PREAGG_BUCKET_MS}) * ${USAGE_PREAGG_BUCKET_MS} AS created_at,
+        COALESCE(SUM(schedule_usage.input_tokens), 0)            AS input_tokens,
+        COALESCE(SUM(schedule_usage.output_tokens), 0)           AS output_tokens,
+        SUM(schedule_usage.estimated_cost_usd)                   AS estimated_cost_usd,
+        SUM(COALESCE(schedule_usage.llm_call_count, 1))          AS llm_call_count,
+        schedule_usage.group_key                                 AS group_key,
+        MAX(schedule_group_jobs.name)                            AS group_label
       FROM schedule_usage
       LEFT JOIN cron_jobs schedule_group_jobs
         ON schedule_group_jobs.id = schedule_usage.group_key
-      ORDER BY schedule_usage.created_at ASC
+      GROUP BY (schedule_usage.created_at / ${USAGE_PREAGG_BUCKET_MS}), schedule_usage.group_key
+      ORDER BY created_at ASC
       `,
       ...groupKeySubquery.params,
       ...where.params,
@@ -850,15 +877,16 @@ export function getUsageGroupedSeries(
     rows = rawAll<UsageGroupedBucketRow>(
       /*sql*/ `
       SELECT
-        e.created_at,
-        e.input_tokens,
-        e.output_tokens,
-        e.estimated_cost_usd,
-        e.llm_call_count,
+        (e.created_at / ${USAGE_PREAGG_BUCKET_MS}) * ${USAGE_PREAGG_BUCKET_MS} AS created_at,
+        COALESCE(SUM(e.input_tokens), 0)             AS input_tokens,
+        COALESCE(SUM(e.output_tokens), 0)            AS output_tokens,
+        SUM(e.estimated_cost_usd)                    AS estimated_cost_usd,
+        SUM(COALESCE(e.llm_call_count, 1))           AS llm_call_count,
         e.${column} AS group_key
       FROM llm_usage_events e
       WHERE ${where.sql}
-      ORDER BY e.created_at ASC
+      GROUP BY (e.created_at / ${USAGE_PREAGG_BUCKET_MS}), e.${column}
+      ORDER BY created_at ASC
       `,
       ...where.params,
     );


### PR DESCRIPTION
## Why

When you open `/assistants/logs/usage` and switch the range to **90 days** (or **All time**), the assistant can become unresponsive — it looks like it "goes to sleep." The root cause isn't memory exhaustion so much as **main-thread (event-loop) starvation**.

The toggle just widens the query window and fires four daemon endpoints. Two of them split very differently by cost:

- **totals** and **breakdown** aggregate in SQL (`SUM ... GROUP BY`) → cheap, bounded by group count.
- **series** (the chart) and **daily** did `SELECT <per-event columns> ... ORDER BY created_at` with **no aggregation** — one row per LLM usage event — then bucketed them in JavaScript (`fetchRawBucketRows` / `bucketGroupedUsageEvents`).

`bun:sqlite`'s `.all()` is synchronous, so a 90-day window on a busy assistant materializes hundreds of thousands of rows and runs an O(events) bucketing loop **synchronously on the event loop**, calling `bucketEvents([row], …)` — which constructs a fresh `Intl.DateTimeFormat` — once per row. During that burst the daemon can't service SSE, health checks, or queued messages.

## What

Roll events up in SQL into fixed **15-minute UTC buckets** (per group, for the grouped series) before feeding them into the **existing** timezone-aware JS bucketing — which is unchanged.

15 minutes is the finest quantum every real-world IANA UTC offset divides into (whole-hour offsets plus the `:30`/`:45` zones like `Asia/Kolkata` and `Asia/Kathmandu`). Because every local-day and local-hour boundary therefore lands on a 15-minute UTC boundary, no pre-aggregation bucket can straddle a local bucket boundary — so re-bucketing the rolled-up rows in local time is **exactly equal** to bucketing each raw event, including DST fall-back disambiguation (the two duplicated local hours fall in different 15-minute UTC buckets).

A 90-day daily window now crosses at most ~8.6k buckets per group into JS instead of every event.

## Scope

- `fetchRawBucketRows` (powers `usage/daily` + the daily/series fallback)
- `getUsageGroupedSeries` (both the per-dimension and schedule-attribution branches)
- `totals`/`breakdown` were already SQL-aggregated — untouched.

## Testing

- Existing DB-level suites that exercise the now-pre-aggregated path all pass, including the correctness-critical cases: fractional offset (`Asia/Kolkata`, daily + hourly) and DST spring-forward / fall-back (`America/Los_Angeles`, `America/New_York`).
- Added a regression test asserting many events within a sub-15-minute span (straddling a 15-minute boundary) collapse with exact summed totals and correct `eventCount`.
- `bun test` on the usage suites: green. `tsc --noEmit` and eslint on the changed files: clean.

## Follow-ups (not in this PR)

The quick constant-factor wins discussed alongside this — caching the per-`tz` `Intl.DateTimeFormat` instead of constructing one per row, and avoiding the per-row `bucketEvents([row], …)` call — are still worth doing as a smaller follow-up. This PR is the durable structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MdkVAY11kB8MY28kWRWks

---
_Generated by [Claude Code](https://claude.ai/code/session_012MdkVAY11kB8MY28kWRWks)_