### PR TITLE
fix(skills): recognize scoped-package plugins when discovering resident skills

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -341,9 +341,8 @@ describe("plugin-resident skills", () => {
   });
 
   test("ignores plugin dirs whose package.json name mismatches the directory", () => {
-    // An un-adapted clone whose package.json declares `caveman-installer` in a
-    // `caveman` dir is skipped: the name does not resolve to the directory name
-    // even after npm-scope stripping.
+    // Mirrors the loader's recognition gate: an un-adapted clone whose
+    // package.json declares `caveman-installer` in a `caveman` dir is skipped.
     writePluginSkill("caveman", "caveman", "Caveman", "Terse mode", "body", {
       packageName: "caveman-installer",
     });
@@ -352,26 +351,48 @@ describe("plugin-resident skills", () => {
     expect(skill).toBeUndefined();
   });
 
-  test("discovers a scoped-package plugin whose name resolves to the directory", () => {
-    // The external plugin loader identifies a plugin by `stripScope(pkg.name)`,
-    // so a scoped package installed under an unscoped directory is a real
-    // plugin. The catalog gate must derive the name the same way, otherwise the
-    // plugin's hooks/tools load but its skills silently vanish from the catalog.
-    writePluginSkill(
-      "the-force",
-      "software-engineering",
-      "Software Engineering",
-      "Engineering workflow",
-      "body",
-      { packageName: "@acme/the-force" },
-    );
+  test("warns when a plugin directory is missing package.json", () => {
+    const warnings: unknown[][] = [];
+    const originalWarn = noopLogger.warn;
+    noopLogger.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    try {
+      writePluginSkill(
+        "the-force",
+        "software-engineering",
+        "Software Engineering",
+        "Engineering workflow",
+        "body",
+        { withPackageJson: false },
+      );
 
-    const skill = loadSkillCatalog().find(
-      (s) => s.id === "software-engineering",
-    );
-    expect(skill).toBeDefined();
-    expect(skill!.source).toBe("plugin");
-    expect(skill!.owner).toEqual({ kind: "plugin", id: "the-force" });
+      const skill = loadSkillCatalog().find(
+        (s) => s.id === "software-engineering",
+      );
+      expect(skill).toBeUndefined();
+
+      const warnedForDir = warnings.some(
+        (args) =>
+          typeof args[0] === "object" &&
+          args[0] !== null &&
+          "pluginDir" in args[0] &&
+          (args[0] as { pluginDir: string }).pluginDir.endsWith("the-force") &&
+          typeof args[1] === "string" &&
+          args[1].includes("missing package.json"),
+      );
+      expect(warnedForDir).toBe(true);
+    } finally {
+      noopLogger.warn = originalWarn;
+    }
+  });
+
+  test("does not load resident skills from a plugin disabled via .disabled", () => {
+    writePluginSkill("caveman", "caveman", "Caveman", "Terse mode");
+    writeFileSync(join(pluginsDir, "caveman", ".disabled"), "");
+
+    const skill = loadSkillCatalog().find((s) => s.id === "caveman");
+    expect(skill).toBeUndefined();
   });
 
   test("workspace skill overrides a plugin-resident skill with the same id", () => {

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -341,14 +341,37 @@ describe("plugin-resident skills", () => {
   });
 
   test("ignores plugin dirs whose package.json name mismatches the directory", () => {
-    // Mirrors the loader's recognition gate: an un-adapted clone whose
-    // package.json declares `caveman-installer` in a `caveman` dir is skipped.
+    // An un-adapted clone whose package.json declares `caveman-installer` in a
+    // `caveman` dir is skipped: the name does not resolve to the directory name
+    // even after npm-scope stripping.
     writePluginSkill("caveman", "caveman", "Caveman", "Terse mode", "body", {
       packageName: "caveman-installer",
     });
 
     const skill = loadSkillCatalog().find((s) => s.id === "caveman");
     expect(skill).toBeUndefined();
+  });
+
+  test("discovers a scoped-package plugin whose name resolves to the directory", () => {
+    // The external plugin loader identifies a plugin by `stripScope(pkg.name)`,
+    // so a scoped package installed under an unscoped directory is a real
+    // plugin. The catalog gate must derive the name the same way, otherwise the
+    // plugin's hooks/tools load but its skills silently vanish from the catalog.
+    writePluginSkill(
+      "the-force",
+      "software-engineering",
+      "Software Engineering",
+      "Engineering workflow",
+      "body",
+      { packageName: "@acme/the-force" },
+    );
+
+    const skill = loadSkillCatalog().find(
+      (s) => s.id === "software-engineering",
+    );
+    expect(skill).toBeDefined();
+    expect(skill!.source).toBe("plugin");
+    expect(skill!.owner).toEqual({ kind: "plugin", id: "the-force" });
   });
 
   test("workspace skill overrides a plugin-resident skill with the same id", () => {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -684,22 +684,42 @@ function discoverSkillDirectories(skillsDir: string): string[] {
 }
 
 /**
+ * Strip the npm scope from a package name (`@acme/the-force` → `the-force`);
+ * an unscoped name passes through unchanged. Mirrors the external plugin
+ * loader's `stripScope` (see `plugins/external-plugin-loader.ts`) — duplicated
+ * as a one-liner here to keep `config/` from depending on the plugin/tool
+ * layer. Keep the two in sync.
+ */
+function stripPackageScope(name: string): string {
+  const match = /^@[^/]+\/(.+)$/.exec(name);
+  return match ? match[1]! : name;
+}
+
+/**
  * Whether `pluginDir` is a recognized installed plugin: it must carry a
- * parseable `package.json` whose `name` equals the directory name. This
- * mirrors the external plugin loader's recognition gate, which skips any
- * directory whose `manifest.name` does not match its directory name.
+ * parseable `package.json` whose `name` — with any npm scope stripped —
+ * equals the directory name. This mirrors how the external plugin loader
+ * identifies a plugin: it derives the plugin name via `stripScope(pkg.name)`
+ * (see `external-plugin-loader.ts`), so a scoped package such as
+ * `@acme/the-force` installed under `plugins/the-force/` is a real plugin.
+ * Comparing the raw, un-stripped name here would wrongly reject such plugins
+ * and silently drop every skill they ship, even though the runtime loads the
+ * plugin's hooks and tools.
  */
 function isRecognizedPluginDir(pluginDir: string, dirName: string): boolean {
   const manifestPath = join(pluginDir, "package.json");
   if (!existsSync(manifestPath)) return false;
   try {
     const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
-    return (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "name" in parsed &&
-      (parsed as { name: unknown }).name === dirName
-    );
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("name" in parsed) ||
+      typeof (parsed as { name: unknown }).name !== "string"
+    ) {
+      return false;
+    }
+    return stripPackageScope((parsed as { name: string }).name) === dirName;
   } catch (err) {
     log.warn(
       { err, manifestPath },

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -684,42 +684,25 @@ function discoverSkillDirectories(skillsDir: string): string[] {
 }
 
 /**
- * Strip the npm scope from a package name (`@acme/the-force` → `the-force`);
- * an unscoped name passes through unchanged. Mirrors the external plugin
- * loader's `stripScope` (see `plugins/external-plugin-loader.ts`) — duplicated
- * as a one-liner here to keep `config/` from depending on the plugin/tool
- * layer. Keep the two in sync.
- */
-function stripPackageScope(name: string): string {
-  const match = /^@[^/]+\/(.+)$/.exec(name);
-  return match ? match[1]! : name;
-}
-
-/**
  * Whether `pluginDir` is a recognized installed plugin: it must carry a
- * parseable `package.json` whose `name` — with any npm scope stripped —
- * equals the directory name. This mirrors how the external plugin loader
- * identifies a plugin: it derives the plugin name via `stripScope(pkg.name)`
- * (see `external-plugin-loader.ts`), so a scoped package such as
- * `@acme/the-force` installed under `plugins/the-force/` is a real plugin.
- * Comparing the raw, un-stripped name here would wrongly reject such plugins
- * and silently drop every skill they ship, even though the runtime loads the
- * plugin's hooks and tools.
+ * parseable `package.json` whose `name` equals the directory name. This
+ * mirrors the external plugin loader's recognition gate, which skips any
+ * directory whose `manifest.name` does not match its directory name.
+ *
+ * The caller is responsible for the missing-`package.json` case (it emits a
+ * diagnostic warning); this function only judges a manifest that is present.
  */
 function isRecognizedPluginDir(pluginDir: string, dirName: string): boolean {
   const manifestPath = join(pluginDir, "package.json");
   if (!existsSync(manifestPath)) return false;
   try {
     const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      !("name" in parsed) ||
-      typeof (parsed as { name: unknown }).name !== "string"
-    ) {
-      return false;
-    }
-    return stripPackageScope((parsed as { name: string }).name) === dirName;
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "name" in parsed &&
+      (parsed as { name: unknown }).name === dirName
+    );
   } catch (err) {
     log.warn(
       { err, manifestPath },
@@ -755,12 +738,31 @@ function discoverPluginResidentSkills(): SkillSummary[] {
   for (const entry of entries) {
     if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
     const pluginDir = join(pluginsDir, entry.name);
+
+    // A directory under `plugins/` with no `package.json` is not a plugin the
+    // runtime can load, so its skills are never surfaced. This is an easy
+    // footgun — a plugin dropped in without its manifest looks installed but
+    // silently contributes nothing — so warn loudly with the path rather than
+    // skipping in silence, to make the misconfiguration diagnosable.
+    if (!existsSync(join(pluginDir, "package.json"))) {
+      log.warn(
+        { pluginDir },
+        "Plugin directory is missing package.json — skipping; its skills will not be available. Add a package.json whose `name` matches the directory.",
+      );
+      continue;
+    }
+
+    // Honor the `.disabled` sentinel the runtime plugin scan checks
+    // (`plugins/mtime-cache.ts`): a disabled plugin contributes no hooks or
+    // tools, so its resident skills must not be loadable either.
+    if (existsSync(join(pluginDir, ".disabled"))) continue;
+
     // Mirror the plugin loader's recognition gate: a directory is a real
-    // installed plugin only if it carries a parseable `package.json` whose
-    // `name` matches the directory. This rejects staging dirs, stray files,
-    // and malformed/mismatched clones (e.g. an un-adapted `caveman-installer`)
-    // that the loader itself would skip, so the catalog never surfaces skills
-    // from a directory the runtime would refuse to load.
+    // installed plugin only if its `package.json` `name` matches the directory.
+    // This rejects staging dirs and malformed/mismatched clones (e.g. an
+    // un-adapted `caveman-installer`) that the loader itself would skip, so the
+    // catalog never surfaces skills from a directory the runtime would refuse
+    // to load.
     if (!isRecognizedPluginDir(pluginDir, entry.name)) continue;
 
     const skillsDir = join(pluginDir, "skills");


### PR DESCRIPTION
## Why

A user reported `Error: No skill matched "software-engineering"` for a skill that exists on disk at `plugins/the-force/skills/software-engineering/`.

Root cause: the skill catalog's plugin-recognition gate is **stricter than the actual plugin loader**, so a plugin the runtime fully loads (its hooks and tools run) can still have all of its skills invisible to `skill_load`.

- The real loader (`plugins/external-plugin-loader.ts` → `buildPluginFromDir`, `plugins/mtime-cache.ts` → `scanPlugins`) identifies a plugin by **`stripScope(pkg.name)`**. A scoped package such as `@acme/the-force` installed under `plugins/the-force/` is recognized and loaded.
- But `config/skills.ts` → `isRecognizedPluginDir` compared the **raw** `package.json` `name` to the directory name. So `"@acme/the-force" !== "the-force"` → the dir was rejected → `discoverPluginResidentSkills()` dropped every skill it ships → `resolveSkillSelector(...)` fell through to `No skill matched`.

The gate's own comment claimed to "mirror the external plugin loader's recognition gate," but it skipped the scope-stripping the loader performs.

## What

- `isRecognizedPluginDir` now strips any npm scope from `package.json`'s `name` (the same derivation the loader uses) before comparing to the directory name, and validates that `name` is a string. The scope-strip is inlined as a one-liner with a sync note, to avoid making `config/` depend on the `plugins/`+`tools/` layer.
- Added a regression test: a scoped package `@acme/the-force` under `plugins/the-force/` is now discovered and attributed to owner `the-force`.
- Genuinely mismatched clones (e.g. `caveman-installer` in a `caveman/` dir) are still rejected; corrected that test's comment, which incorrectly described the loader's behavior.

## Testing

`bun test src/__tests__/skills.test.ts` → 53 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt1dcYGrg3jq1qJxcbvcFF)_