### PR TITLE
image-fallback: caption tool-returned images and tighten the caption text

### DIFF
--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
+  ContentBlock,
   ImageContent,
   Message,
   ModelProfileInfo,
+  PostToolUseContext,
+  ToolResultContent,
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
@@ -27,20 +30,24 @@ const fakeProvider = {
 // Mock @vellumai/plugin-api — only the runtime handles the plugin imports.
 // `extractAllText` stays real (imported from the relative path, not plugin-api).
 mock.module("@vellumai/plugin-api", () => ({
-  doesSupportVision: (profile: ModelProfileInfo) => visionProfiles.has(profile.key),
+  doesSupportVision: (profile: ModelProfileInfo) =>
+    visionProfiles.has(profile.key),
   getModelProfiles: () => mockProfiles,
   getConfiguredProvider: async () => (providerResolves ? fakeProvider : null),
 }));
 
 // Mock the image-persist module to avoid filesystem side effects in tests.
-let mockPersistPath: string | null = "/workspace/data/attachments/mock-hash.png";
+let mockPersistPath: string | null =
+  "/workspace/data/attachments/mock-hash.png";
 mock.module("../src/image-persist.js", () => ({
   persistImage: () => mockPersistPath,
 }));
 
 // ─── Imports (after mocks are registered) ───────────────────────────────────
 
-const userPromptSubmit = (await import("../hooks/user-prompt-submit.js")).default;
+const userPromptSubmit = (await import("../hooks/user-prompt-submit.js"))
+  .default;
+const postToolUse = (await import("../hooks/post-tool-use.js")).default;
 const { findVisionProfile } = await import("../src/vision-caption.js");
 const { resetCaptionCacheForTests } = await import("../src/caption-cache.js");
 
@@ -101,6 +108,30 @@ function makeCtx(
   } as unknown as UserPromptSubmitContext;
 }
 
+function toolResult(contentBlocks?: ContentBlock[]): ToolResultContent {
+  return {
+    type: "tool_result",
+    tool_use_id: "tu1",
+    content: "Took a screenshot.",
+    ...(contentBlocks ? { contentBlocks } : {}),
+  };
+}
+
+function makeToolCtx(
+  overrides: Partial<PostToolUseContext> = {},
+): PostToolUseContext {
+  return {
+    conversationId: "c1",
+    toolResponse: toolResult(),
+    messages: [],
+    additionalContext: null,
+    model: "text-only-model",
+    maxInputTokens: 100_000,
+    logger,
+    ...overrides,
+  } as unknown as PostToolUseContext;
+}
+
 // ─── Setup ──────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -133,9 +164,9 @@ describe("image-fallback user-prompt-submit hook", () => {
     const ctx = makeCtx({ latestMessages: messages, isNonInteractive: true });
     await userPromptSubmit(ctx);
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
-    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toContain(
-      "[Image:",
-    );
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("[Image auto-described");
   });
 
   test("replaces image blocks with captions when active model is text-only", async () => {
@@ -143,27 +174,27 @@ describe("image-fallback user-prompt-submit hook", () => {
     const ctx = makeCtx({ latestMessages: messages });
     await userPromptSubmit(ctx);
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
-    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toContain(
-      "[Image: A red chart showing Q3 revenue.]",
+    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toBe(
+      "[Image auto-described for text-only model: A red chart showing Q3 revenue.]",
     );
   });
 
-  test("references the saved image path in the caption text", async () => {
+  test("caption states the model can't view images and the text is derived", async () => {
     const messages = [imageMsg("img1")];
     const ctx = makeCtx({ latestMessages: messages });
     await userPromptSubmit(ctx);
     const text = (ctx.latestMessages[0].content[0] as { text: string }).text;
-    expect(text).toContain("(saved to /workspace/data/attachments/");
+    expect(text).toContain("text-only model");
+    expect(text).toContain("auto-described");
   });
 
-  test("works without a saved path when persist fails", async () => {
-    mockPersistPath = null;
+  test("does not embed the saved image path in the caption text", async () => {
     const messages = [imageMsg("img1")];
     const ctx = makeCtx({ latestMessages: messages });
     await userPromptSubmit(ctx);
     const text = (ctx.latestMessages[0].content[0] as { text: string }).text;
-    expect(text).toContain("[Image: A red chart showing Q3 revenue.]");
-    expect(text).not.toContain("(saved to");
+    expect(text).not.toContain("saved to");
+    expect(text).not.toContain("/workspace/data/attachments/");
   });
 
   test("preserves non-image blocks and captions only images", async () => {
@@ -183,9 +214,9 @@ describe("image-fallback user-prompt-submit hook", () => {
       "Look at this:",
     );
     expect(ctx.latestMessages[0].content[1].type).toBe("text");
-    expect((ctx.latestMessages[0].content[1] as { text: string }).text).toContain(
-      "[Image:",
-    );
+    expect(
+      (ctx.latestMessages[0].content[1] as { text: string }).text,
+    ).toContain("[Image auto-described");
     expect((ctx.latestMessages[0].content[2] as { text: string }).text).toBe(
       "What do you see?",
     );
@@ -197,9 +228,9 @@ describe("image-fallback user-prompt-submit hook", () => {
     const ctx = makeCtx({ latestMessages: messages });
     await userPromptSubmit(ctx);
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
-    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toContain(
-      "no vision-capable model",
-    );
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("no vision-capable model");
   });
 
   test("uses fail-open placeholder when provider resolution returns null", async () => {
@@ -208,9 +239,9 @@ describe("image-fallback user-prompt-submit hook", () => {
     const ctx = makeCtx({ latestMessages: messages });
     await userPromptSubmit(ctx);
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
-    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toContain(
-      "captioning failed",
-    );
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("auto-description failed");
   });
 
   test("caches captions — second call with same image does not invoke provider", async () => {
@@ -244,7 +275,8 @@ describe("image-fallback user-prompt-submit hook", () => {
     mock.module("@vellumai/plugin-api", () => ({
       doesSupportVision: (p: ModelProfileInfo) => visionProfiles.has(p.key),
       getModelProfiles: () => mockProfiles,
-      getConfiguredProvider: async () => (providerResolves ? fakeProvider : null),
+      getConfiguredProvider: async () =>
+        providerResolves ? fakeProvider : null,
     }));
   });
 
@@ -260,13 +292,13 @@ describe("image-fallback user-prompt-submit hook", () => {
     const ctx = makeCtx({ latestMessages: messages });
     await userPromptSubmit(ctx);
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
-    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toContain(
-      "[Image:",
-    );
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("[Image auto-described");
     expect(ctx.latestMessages[2].content[0].type).toBe("text");
-    expect((ctx.latestMessages[2].content[0] as { text: string }).text).toContain(
-      "[Image:",
-    );
+    expect(
+      (ctx.latestMessages[2].content[0] as { text: string }).text,
+    ).toContain("[Image auto-described");
     expect((ctx.latestMessages[2].content[1] as { text: string }).text).toBe(
       "both?",
     );
@@ -298,5 +330,72 @@ describe("findVisionProfile", () => {
   test("returns null when no profiles support vision", () => {
     visionProfiles = new Set<string>();
     expect(findVisionProfile()).toBeNull();
+  });
+});
+
+describe("image-fallback post-tool-use hook", () => {
+  test("captions image blocks nested in a tool result for a text-only model", async () => {
+    const ctx = makeToolCtx({
+      toolResponse: toolResult([imageBlock("shot1")]),
+    });
+    await postToolUse(ctx);
+    const block = ctx.toolResponse.contentBlocks![0];
+    expect(block.type).toBe("text");
+    expect((block as { text: string }).text).toBe(
+      "[Image auto-described for text-only model: A red chart showing Q3 revenue.]",
+    );
+  });
+
+  test("is a no-op when the active model supports vision", async () => {
+    visionProfiles = new Set(["text-only"]); // active profile supports vision
+    const ctx = makeToolCtx({
+      toolResponse: toolResult([imageBlock("shot1")]),
+    });
+    await postToolUse(ctx);
+    expect(ctx.toolResponse.contentBlocks![0].type).toBe("image");
+  });
+
+  test("is a no-op when the tool result has no contentBlocks", async () => {
+    const ctx = makeToolCtx({ toolResponse: toolResult() });
+    await postToolUse(ctx);
+    expect(ctx.toolResponse.contentBlocks).toBeUndefined();
+  });
+
+  test("preserves non-image contentBlocks and captions only images", async () => {
+    const ctx = makeToolCtx({
+      toolResponse: toolResult([
+        { type: "text", text: "page title" },
+        imageBlock("shot1"),
+      ]),
+    });
+    await postToolUse(ctx);
+    const blocks = ctx.toolResponse.contentBlocks!;
+    expect((blocks[0] as { text: string }).text).toBe("page title");
+    expect(blocks[1].type).toBe("text");
+    expect((blocks[1] as { text: string }).text).toContain(
+      "[Image auto-described",
+    );
+  });
+
+  test("uses fail-open placeholder when no vision profile is configured", async () => {
+    visionProfiles = new Set<string>(); // no vision profiles
+    const ctx = makeToolCtx({
+      toolResponse: toolResult([imageBlock("shot1")]),
+    });
+    await postToolUse(ctx);
+    const block = ctx.toolResponse.contentBlocks![0];
+    expect(block.type).toBe("text");
+    expect((block as { text: string }).text).toContain(
+      "no vision-capable model",
+    );
+  });
+
+  test("does not embed the saved image path in the caption text", async () => {
+    const ctx = makeToolCtx({
+      toolResponse: toolResult([imageBlock("shot1")]),
+    });
+    await postToolUse(ctx);
+    const text = (ctx.toolResponse.contentBlocks![0] as { text: string }).text;
+    expect(text).not.toContain("saved to");
   });
 });

--- a/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
@@ -1,0 +1,58 @@
+/**
+ * Default `post-tool-use` hook: when the active model is text-only, captions
+ * the image blocks a tool returns (e.g. a `browser_screenshot`) and
+ * substitutes the caption as a text block so the result stays sendable to a
+ * provider that would otherwise reject the raw image.
+ *
+ * Tool images arrive nested in `toolResponse.contentBlocks` (the rich-content
+ * companion to the tool result's text `content`), so the hook scans there
+ * rather than the top-level message content the `user-prompt-submit` hook
+ * handles. Both share {@link captionImageBlocks}.
+ *
+ * The active model is resolved from the workspace's active profile — the
+ * post-tool-use context carries the running model, and the active profile is
+ * what the loop is executing this turn. If that profile supports vision, the
+ * hook is a no-op and the image reaches the model untouched.
+ */
+
+import {
+  doesSupportVision,
+  getModelProfiles,
+  type PluginHookFn,
+  type PostToolUseContext,
+} from "@vellumai/plugin-api";
+
+import { captionImageBlocks } from "../src/caption-blocks.js";
+import { findVisionProfile } from "../src/vision-caption.js";
+
+const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+  const blocks = ctx.toolResponse.contentBlocks;
+  if (blocks == null || blocks.length === 0) return;
+
+  // If the active model already supports vision, leave the image in place.
+  const activeProfile = getModelProfiles().find((p) => p.isActive);
+  if (activeProfile == null) return;
+  if (doesSupportVision(activeProfile)) return;
+
+  // Find a vision-capable profile for captioning.
+  const visionProfileKey = findVisionProfile();
+
+  const imageCount = await captionImageBlocks(
+    blocks,
+    visionProfileKey,
+    ctx.logger,
+  );
+
+  if (imageCount > 0) {
+    ctx.logger.info(
+      {
+        plugin: "image-fallback",
+        toolUseId: ctx.toolResponse.tool_use_id,
+        imageCount,
+      },
+      "Replaced tool-result image blocks with text captions for text-only model",
+    );
+  }
+};
+
+export default postToolUse;

--- a/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
@@ -13,29 +13,23 @@
  * 2. Finds a vision-capable profile for captioning via `findVisionProfile`.
  *    If none exists, images are replaced with a fail-open placeholder so the
  *    model at least knows an image was present.
- * 3. Persists each image to the workspace attachments directory (content-hash
- *    deduped) so the original image is accessible to future vision-capable
- *    turns or subagents.
- * 4. Captions each `ImageContent` block through the `vision` call site (with
- *    an in-memory content-hash cache to avoid re-captioning across turns), and
- *    replaces the block with `[Image: <caption>] (saved to <path>)`.
+ * 3. Replaces each `ImageContent` block with a `[Image …]` text caption via
+ *    {@link captionImageBlocks} (which also persists the original and caches
+ *    captions across turns).
  *
- * Fail-open is the dominant error mode: a captioning failure leaves a
- * placeholder text block (with the saved image path) rather than the raw
- * image (which would cause a provider rejection on a text-only model) or
- * dropping the image entirely (which would lose information).
+ * The companion `post-tool-use` hook applies the same substitution to images a
+ * tool returns (e.g. a browser screenshot).
  */
 
 import {
   doesSupportVision,
   getModelProfiles,
-  type ImageContent,
   type PluginHookFn,
   type UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
-import { persistImage } from "../src/image-persist.js";
-import { captionImage, findVisionProfile } from "../src/vision-caption.js";
+import { captionImageBlocks } from "../src/caption-blocks.js";
+import { findVisionProfile } from "../src/vision-caption.js";
 
 const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
   // Resolve the active profile from modelProfileKey, falling back to the
@@ -57,39 +51,11 @@ const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
   // Scan all messages for image blocks and replace them with captions.
   let imageCount = 0;
   for (const message of ctx.latestMessages) {
-    for (let i = 0; i < message.content.length; i++) {
-      const block = message.content[i];
-      if (block.type !== "image") continue;
-
-      imageCount++;
-      const image = block as ImageContent;
-
-      // Persist the image to the workspace so it's accessible to future
-      // vision-capable turns or subagents.
-      const savedPath = persistImage(
-        image.source.data,
-        image.source.media_type,
-      );
-
-      if (visionProfileKey != null) {
-        const caption = await captionImage(image, visionProfileKey, ctx.logger);
-        const pathSuffix = savedPath != null ? ` (saved to ${savedPath})` : "";
-        message.content[i] = {
-          type: "text",
-          text:
-            caption != null
-              ? `[Image: ${caption}]${pathSuffix}`
-              : `[Image: captioning failed — unable to describe]${pathSuffix}`,
-        };
-      } else {
-        // No vision profile configured at all — fail-open placeholder.
-        const pathSuffix = savedPath != null ? ` (saved to ${savedPath})` : "";
-        message.content[i] = {
-          type: "text",
-          text: `[Image: no vision-capable model configured to describe this image]${pathSuffix}`,
-        };
-      }
-    }
+    imageCount += await captionImageBlocks(
+      message.content,
+      visionProfileKey,
+      ctx.logger,
+    );
   }
 
   if (imageCount > 0) {

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared image→text substitution for the image-fallback plugin's hooks.
+ *
+ * Two hooks replace `image` content blocks with a text caption when the active
+ * model can't process images: `user-prompt-submit` handles user-attached
+ * images, and `post-tool-use` handles images a tool returns (e.g. a browser
+ * screenshot). This module holds the per-block substitution they share —
+ * persist the original image to a known location, caption it via a
+ * vision-capable profile, and swap in a `[Image …]` text block.
+ *
+ * The caption text states up front that the active model can't view images and
+ * the image was auto-described to text, so the model treats the block as a
+ * derived description rather than a verbatim transcript.
+ *
+ * Fail-open is the dominant error mode: a captioning failure leaves a
+ * placeholder text block rather than the raw image (which a text-only provider
+ * would reject) or nothing (which would lose information).
+ */
+
+import type {
+  ContentBlock,
+  ImageContent,
+  PluginLogger,
+} from "@vellumai/plugin-api";
+
+import { persistImage } from "./image-persist.js";
+import { captionImage } from "./vision-caption.js";
+
+/**
+ * Replace every `image` block in `blocks` (in place) with a text caption so a
+ * text-only model can still reason about the image's content. Returns the
+ * number of image blocks replaced.
+ *
+ * @param blocks            Content-block array to scan and mutate in place.
+ * @param visionProfileKey  Key of a vision-capable profile for captioning, or
+ *                          `null` when none is configured (fail-open
+ *                          placeholder).
+ * @param logger            Turn-scoped logger for attribution.
+ */
+export async function captionImageBlocks(
+  blocks: ContentBlock[],
+  visionProfileKey: string | null,
+  logger: PluginLogger,
+): Promise<number> {
+  let imageCount = 0;
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (block.type !== "image") continue;
+
+    imageCount++;
+    const image = block as ImageContent;
+
+    // Persist the original to a known, content-hash-deduped location so it
+    // survives the text substitution and stays findable on disk.
+    persistImage(image.source.data, image.source.media_type);
+
+    if (visionProfileKey != null) {
+      const caption = await captionImage(image, visionProfileKey, logger);
+      blocks[i] = {
+        type: "text",
+        text:
+          caption != null
+            ? `[Image auto-described for text-only model: ${caption}]`
+            : `[Image: auto-description failed (text-only model)]`,
+      };
+    } else {
+      // No vision profile configured at all — fail-open placeholder.
+      blocks[i] = {
+        type: "text",
+        text: `[Image: no vision-capable model configured to describe it]`,
+      };
+    }
+  }
+
+  return imageCount;
+}

--- a/assistant/src/plugins/defaults/image-fallback/src/image-persist.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/image-persist.ts
@@ -2,10 +2,10 @@
  * Persist image data to the workspace attachments directory.
  *
  * When the active model is text-only, the image-fallback plugin captions the
- * image and substitutes a text block. Saving the raw image to disk and
- * referencing the path in the caption text means a future turn with a
- * vision-capable model (or a subagent) could still access the original image
- * via file_read, and the user can find the image at a known location.
+ * image and substitutes a text block. Saving the raw image to a known,
+ * content-hash-deduped location means the original survives the text
+ * substitution and stays findable on disk for the user (or a subagent with a
+ * vision-capable model that reads it via file_read).
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
@@ -36,10 +36,7 @@ function extensionForMediaType(mediaType: string): string {
  * Save an image's base64 data to the attachments dir if not already present.
  * Returns the absolute file path, or `null` when the write fails.
  */
-export function persistImage(
-  data: string,
-  mediaType: string,
-): string | null {
+export function persistImage(data: string, mediaType: string): string | null {
   try {
     mkdirSync(ATTACHMENTS_DIR, { recursive: true });
 

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -47,6 +47,7 @@ import historyRepairStop from "./history-repair/hooks/stop.js";
 import historyRepairUserPromptSubmit from "./history-repair/hooks/user-prompt-submit.js";
 import historyRepairPkg from "./history-repair/package.json" with { type: "json" };
 import { resetRepairStateStoreForTests } from "./history-repair/repair-state-store.js";
+import imageFallbackPostToolUse from "./image-fallback/hooks/post-tool-use.js";
 import imageFallbackUserPromptSubmit from "./image-fallback/hooks/user-prompt-submit.js";
 import imageFallbackPkg from "./image-fallback/package.json" with { type: "json" };
 import { resetCaptionCacheForTests } from "./image-fallback/src/caption-cache.js";
@@ -81,12 +82,14 @@ import toolResultTruncatePostToolUse from "./tool-result-truncate/hooks/post-too
 import toolResultTruncatePkg from "./tool-result-truncate/package.json" with { type: "json" };
 
 /**
- * `image-fallback` — a `user-prompt-submit` hook that captions image blocks via
- * a vision-capable profile when the active model is text-only, substituting the
- * caption as a `[Image: <caption>]` text block so the model can still reason
- * about the image's content. Self-gates on `isNonInteractive`; fail-open with a
- * placeholder when no vision profile is configured or captioning fails. An
- * in-memory content-hash cache avoids re-captioning the same image across turns.
+ * `image-fallback` — captions image blocks via a vision-capable profile when
+ * the active model is text-only, substituting the caption as an `[Image …]`
+ * text block so the model can still reason about the image's content. The
+ * `user-prompt-submit` hook handles user-attached images; the `post-tool-use`
+ * hook handles images a tool returns (e.g. a browser screenshot) nested in the
+ * tool result's `contentBlocks`. Fail-open with a placeholder when no vision
+ * profile is configured or captioning fails. An in-memory content-hash cache
+ * avoids re-captioning the same image across turns.
  */
 export const defaultImageFallbackPlugin: Plugin = {
   manifest: {
@@ -95,6 +98,7 @@ export const defaultImageFallbackPlugin: Plugin = {
   },
   hooks: {
     "user-prompt-submit": imageFallbackUserPromptSubmit,
+    "post-tool-use": imageFallbackPostToolUse,
   },
 };
 


### PR DESCRIPTION
## Why

The `image-fallback` default plugin lets a text-only model reason about images by captioning them through a vision-capable profile and substituting a text block. Until now it only ran as a `user-prompt-submit` hook, so it covered **user-attached** images but ignored images a **tool** returns mid-turn (e.g. a `browser_screenshot`). Those reach a text-only provider as raw `image` blocks and get rejected. This PR closes that gap and cleans up the caption text along the way.

## What changed

**1. Caption tool-returned images (`post-tool-use`)**
- New `post-tool-use` hook intercepts `image` blocks nested in a tool result's `contentBlocks` and swaps in a text caption — the same substitution `user-prompt-submit` already does for top-level message content.
- The active model is resolved from the workspace's active profile; if it supports vision the hook is a no-op and the image passes through untouched.
- Both hooks now share a single `captionImageBlocks` helper (`src/caption-blocks.ts`), so the persist + caption + fail-open logic lives in one place.

**2. Tighter, clearer caption text**
- The caption now states up front that the model can't view the image and the text is auto-derived: `[Image auto-described for text-only model: <caption>]`. This signals the model should treat the block as a description rather than a verbatim transcript, kept terse to spend few tokens.
- Fail-open placeholders follow the same shape (`auto-description failed (text-only model)`, `no vision-capable model configured to describe it`).

**3. Don't render the image source twice**
- Dropped the `(saved to <path>)` suffix from the caption. The image's location was being rendered twice — once here and once via the existing `[Attached image source: …]` annotation — so the annotation is now the single source-path reference. The image is still persisted to disk for findability; only the redundant caption text is gone.

## Testing
- Extended `image-fallback.test.ts`: updated the caption-text expectations, added a "does not embed the saved path" assertion, and added a full `post-tool-use` describe block (captions nested tool images, no-ops for vision models / empty `contentBlocks`, preserves non-image blocks, fail-open). 20/20 pass.
- `tsc --noEmit`, `eslint`, and `prettier --check` all clean on the touched files (also enforced by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzpX2VCi2pVTbybPhkkqY)_