### PR TITLE
[codex] Fix Together MiniMax app tool args

### DIFF
--- a/assistant/src/__tests__/app-builder-skill-instructions.test.ts
+++ b/assistant/src/__tests__/app-builder-skill-instructions.test.ts
@@ -17,6 +17,25 @@ async function readAllSkillMarkdown(): Promise<string> {
 }
 
 describe("app-builder skill instructions", () => {
+  test("lets app tools infer the active app before schema validation", async () => {
+    const manifest = JSON.parse(
+      await readFile(new URL("TOOLS.json", skillDir), "utf8"),
+    ) as {
+      tools: Array<{
+        name: string;
+        input_schema?: { required?: string[] };
+      }>;
+    };
+    const requiredFor = (name: string) =>
+      manifest.tools.find((tool) => tool.name === name)?.input_schema
+        ?.required ?? [];
+
+    expect(requiredFor("app_update")).not.toContain("app_id");
+    expect(requiredFor("app_refresh")).not.toContain("app_id");
+    expect(requiredFor("app_generate_icon")).not.toContain("app_id");
+    expect(requiredFor("app_delete")).toContain("app_id");
+  });
+
   test("uses non-CLI UI confirmation for optional profile switch", async () => {
     const skillText = await readFile(new URL("SKILL.md", skillDir), "utf8");
     const preflightStart = skillText.indexOf("### 0. Preflight");

--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -55,6 +55,7 @@ const mockStore = makeMockStore();
 
 mock.module("../memory/app-store.js", () => ({
   ...mockStore,
+  listAppsByConversation: () => [makeApp({ id: "active-app" })],
   getAppsDir: () => "/tmp/test-apps",
   getAppDirPath: (appId: string) => `/tmp/test-apps/${appId}`,
   resolveAppDir: (id: string) => ({
@@ -171,6 +172,15 @@ describe("app-builder skill tool scripts", () => {
       expect(parsed.refreshed).toBe(true);
       expect(parsed.appId).toBe("app-1");
     });
+
+    test("infers the active app when app_id is missing", async () => {
+      const result = await appRefreshScript.run({}, makeContext());
+
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.refreshed).toBe(true);
+      expect(parsed.appId).toBe("active-app");
+    });
   });
 
   // ---- app-update --------------------------------------------------------
@@ -190,6 +200,19 @@ describe("app-builder skill tool scripts", () => {
       expect(parsed.updated).toBe(true);
       expect(parsed.appId).toBe("app-1");
       expect(parsed.name).toBe("Renamed");
+    });
+
+    test("infers the active app when app_id is missing", async () => {
+      const result = await appUpdateScript.run(
+        { name: "Renamed Active App" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.updated).toBe(true);
+      expect(parsed.appId).toBe("active-app");
+      expect(parsed.name).toBe("Renamed Active App");
     });
   });
 });

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -111,6 +111,7 @@ import {
 } from "../providers/openai/chat-completions-provider.js";
 import { OpenAIProvider } from "../providers/openai/client.js";
 import { OpenRouterProvider } from "../providers/openrouter/client.js";
+import { TogetherProvider } from "../providers/together/client.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -282,6 +283,63 @@ describe("OpenAIChatCompletionsProvider extraction", () => {
 
     const ol = new OllamaProvider("llama3.2");
     expect(ol).toBeInstanceOf(OpenAIChatCompletionsProvider);
+  });
+
+  test("Together MiniMax round-trips object tool args as JSON strings", async () => {
+    fakeChunks = [
+      ...toolCallChunks([
+        {
+          id: "call-1",
+          name: "skill_execute",
+          args: JSON.stringify({
+            tool: "app_refresh",
+            input: JSON.stringify({ app_id: "app-1" }),
+            activity: "Compile app",
+          }),
+        },
+      ]),
+      usageChunk(10, 5),
+    ];
+
+    const provider = new TogetherProvider("tg-key", "MiniMaxAI/MiniMax-M3");
+    const response = await provider.sendMessage([userMsg("compile")], {
+      tools: [
+        {
+          name: "skill_execute",
+          description: "Execute a loaded skill tool",
+          input_schema: {
+            type: "object",
+            properties: {
+              tool: { type: "string" },
+              input: { type: "object" },
+              activity: { type: "string" },
+            },
+            required: ["tool", "input", "activity"],
+          },
+        },
+      ],
+    });
+
+    const sentTools = lastCreateParams!.tools as Array<{
+      function: {
+        parameters: { properties: Record<string, { type: string }> };
+      };
+    }>;
+    expect(sentTools[0].function.parameters.properties.input.type).toBe(
+      "string",
+    );
+    expect(response.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call-1",
+        name: "skill_execute",
+        input: {
+          tool: "app_refresh",
+          input: { app_id: "app-1" },
+          activity: "Compile app",
+        },
+      },
+    ]);
   });
 });
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -128,7 +128,7 @@
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'fix: correct totals', 'feat: add dark mode'). Used as the version history entry."
           }
         },
-        "required": ["app_id"]
+        "required": []
       },
       "executor": "tools/app-update.ts",
       "execution_target": "host"
@@ -172,7 +172,7 @@
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: add dark mode toggle', 'fix: form validation'). Used as the version history entry."
           }
         },
-        "required": ["app_id"]
+        "required": []
       },
       "executor": "tools/app-refresh.ts",
       "execution_target": "host"
@@ -198,7 +198,7 @@
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: generate app icon'). Used as the version history entry."
           }
         },
-        "required": ["app_id"]
+        "required": []
       },
       "executor": "tools/app-generate-icon.ts",
       "execution_target": "host"

--- a/assistant/src/providers/together/client.ts
+++ b/assistant/src/providers/together/client.ts
@@ -10,9 +10,7 @@ const DEFAULT_TOGETHER_BASE_URL = "https://api.together.ai/v1";
 
 /**
  * Together AI exposes an OpenAI-compatible endpoint. Used as the managed route
- * for MiniMax M3. Together serializes object-typed tool args correctly, so —
- * unlike {@link FireworksProvider} — no `coerceObjectArgsToJsonString`
- * workaround is needed.
+ * for MiniMax M3.
  */
 export class TogetherProvider extends OpenAIChatCompletionsProvider {
   constructor(
@@ -30,6 +28,9 @@ export class TogetherProvider extends OpenAIChatCompletionsProvider {
       // blocks and replays on multi-turn requests.
       assistantReasoningField: "reasoning_content",
       maxReasoningEffort: "high",
+      // MiniMax M3 can collapse object-typed function-call args to `{}` even
+      // on Together. Present those args as JSON strings and decode them back.
+      coerceObjectArgsToJsonString: /minimax/i.test(model),
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes the app-builder failure mode where Together-hosted MiniMax M3 collapses object-typed tool arguments to `{}`, causing app creation/update/refresh calls to silently lose nested payloads and then loop on `app_id is required` errors.

## Root Cause

A feedback bundle showed the Maru landing-page build produced valid app source files, but never reached compilation. The raw provider responses from Together `MiniMaxAI/MiniMax-M3` emitted `skill_execute` calls like `{ "tool": "app_refresh", "input": {} }` repeatedly. We already had an object-argument JSON-string workaround for MiniMax on Fireworks, but not for the Together route.

A second guardrail was also ineffective: `app_refresh` / `app_update` scripts can infer the active app from conversation context when `app_id` is missing, but their skill manifest still marked `app_id` as required, so schema validation rejected `{}` before the fallback ran.

## Changes

- Enable the existing object-argument JSON-string coercion for Together MiniMax models.
- Allow non-destructive app-builder tools (`app_update`, `app_refresh`, `app_generate_icon`) to reach their active-app fallback when `app_id` is omitted.
- Keep `app_delete` requiring an explicit `app_id`.
- Add regressions for Together MiniMax tool-arg round-tripping and app-builder active-app fallback behavior.

## Validation

- `cd assistant && bun test src/__tests__/openai-provider.test.ts src/__tests__/app-builder-skill-instructions.test.ts src/__tests__/app-builder-tool-scripts.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `git diff --check`
- Pre-push hook: assistant typecheck and lint passed
