### PR TITLE
feat(onboarding): rework pitch steps — eyes choreography, team, flat coin

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
@@ -1,23 +1,18 @@
 /**
- * A chunky, glossy gold credit coin rendered with real CSS 3D depth.
+ * A flat, glossy gold credit coin (no thickness), facing forward.
  *
  * SPIKE — research-onboarding flow.
  *
- * Built from a front face, a back face, and a stack of edge slices between them
- * — a solid cylinder with genuine thickness when tilted. The coin owns its
- * whole 3D context (one `perspective` → `preserve-3d` element carrying both the
- * resting tilt and the spin), so the front face and its embossed $ stay
- * coplanar with the coin. Pass `spinning` to make it tumble (e.g. on claim);
- * the caller can still wrap it in a plain 2D motion element for a flight path.
+ * A front + back face back-to-back, kept in a `preserve-3d` context only so the
+ * coin can still flip on claim. Pass `spinning` to make it tumble; the caller
+ * can wrap it in a plain 2D motion element for a flight path.
  */
 
 import { motion } from "motion/react";
 
 interface OnboardingCoinProps {
   size: number;
-  /** Coin thickness as a fraction of size. */
-  depthRatio?: number;
-  /** Resting tilt (degrees). */
+  /** Resting tilt (degrees) — face-forward by default. */
   tiltX?: number;
   tiltY?: number;
   /** Draw a soft cast shadow beneath the coin. */
@@ -26,8 +21,6 @@ interface OnboardingCoinProps {
   spinning?: boolean;
   className?: string;
 }
-
-const EDGE_SLICES = 24;
 
 /** One coin face — raised rim, even gold center, specular shine, embossed $. */
 function CoinFace({ idSuffix }: { idSuffix: string }) {
@@ -119,16 +112,12 @@ function CoinFace({ idSuffix }: { idSuffix: string }) {
 
 export function OnboardingCoin({
   size,
-  depthRatio = 0.22,
-  tiltX = 8,
-  tiltY = -22,
+  tiltX = 0,
+  tiltY = 0,
   shadow = true,
   spinning = false,
   className,
 }: OnboardingCoinProps) {
-  const depth = size * depthRatio;
-  const step = depth / (EDGE_SLICES - 1);
-
   return (
     <div style={{ position: "relative", width: size, height: size }}>
       {/* Soft cast shadow beneath the coin. */}
@@ -148,7 +137,7 @@ export function OnboardingCoin({
           }}
         />
       )}
-      {/* Single perspective for the whole coin so the face + $ stay coplanar. */}
+      {/* Perspective only so the coin can flip on claim; it sits flat otherwise. */}
       <div style={{ width: size, height: size, perspective: size * 10 }}>
         <motion.div
           className={className}
@@ -171,44 +160,24 @@ export function OnboardingCoin({
               : { duration: 0 }
           }
         >
-          {/* Edge slices form the coin's thickness; brighter toward the middle
-              of the stack so the rim reads as a rounded, specular edge. */}
-          {Array.from({ length: EDGE_SLICES }, (_, i) => {
-            const t = i / (EDGE_SLICES - 1);
-            const mid = 1 - Math.abs(t - 0.5) * 2; // 0 at faces, 1 at middle
-            const lightness = 44 + mid * 22;
-            return (
-              <div
-                key={i}
-                style={{
-                  position: "absolute",
-                  inset: 0,
-                  borderRadius: "50%",
-                  background: `linear-gradient(to bottom, hsl(45 92% ${Math.min(lightness + 10, 82)}%), hsl(42 90% ${lightness - 8}%))`,
-                  transform: `translateZ(${-depth / 2 + i * step}px)`,
-                }}
-              />
-            );
-          })}
-
-          {/* Front face */}
+          {/* Front + back faces, back-to-back (a hair apart to avoid z-fighting)
+              so the coin can still flip on claim. */}
           <div
             style={{
               position: "absolute",
               inset: 0,
               backfaceVisibility: "hidden",
-              transform: `translateZ(${depth / 2}px)`,
+              transform: "translateZ(0.5px)",
             }}
           >
             <CoinFace idSuffix="front" />
           </div>
-          {/* Back face (rotated so its $ reads correctly facing the viewer) */}
           <div
             style={{
               position: "absolute",
               inset: 0,
               backfaceVisibility: "hidden",
-              transform: `translateZ(${-depth / 2}px) rotateY(180deg)`,
+              transform: "translateZ(-0.5px) rotateY(180deg)",
             }}
           >
             <CoinFace idSuffix="back" />

--- a/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
@@ -52,6 +52,12 @@ export function OnboardingEdgeCharacters() {
   const size = edgeSize(w, h);
   const positions = useMemo(() => edgeSlots(w, h, size / 2), [w, h, size]);
 
+  // On mobile the form is full-width with left-aligned labels, so a left-edge
+  // avatar sits right behind them. Drop the mid-left slot there and keep the
+  // cast to the top, right, and bottom. (Slot 7 is the left-mid sprout.)
+  const isMobile = w < 640;
+  const HIDDEN_ON_MOBILE = new Set([7]);
+
   if (!components || characters.length === 0) return null;
 
   // Indices 1–9 sit at edge slots 0–8 (same mapping as the picker); index 0 is
@@ -64,6 +70,7 @@ export function OnboardingEdgeCharacters() {
       {characters.map((traits, i) => {
         if (i === 0) return null;
         const slot = i - 1;
+        if (isMobile && HIDDEN_ON_MOBILE.has(slot)) return null;
         const p = positions[slot];
         if (!p) return null;
         const rotation = SLOT_ROTATIONS[slot % SLOT_ROTATIONS.length] ?? 0;

--- a/clients/web/src/domains/onboarding/components/onboarding-motion-eyes.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-motion-eyes.tsx
@@ -1,0 +1,178 @@
+/**
+ * The assistant's eyes, peeking from the bottom edge, fully driven by the
+ * caller's motion values so a step can make them rise, grow, dash, blink, etc.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Geometry (size + resting center) mirrors `OnboardingPeekingEyes`, so a step
+ * that wants to choreograph the eyes can hide the backdrop's resting pair (via
+ * `showBottomEyes={false}`) and swap in these without a visible jump.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { motion, useTransform, type MotionValue } from "motion/react";
+
+import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+
+const EYE_TARGET_HEIGHT = 0.3;
+const EYE_MAX_WIDTH = 0.85;
+const EYE_REST_CUTOFF = 0.25;
+
+type BBox = { x: number; y: number; w: number; h: number };
+
+/** Tight bounding box of a single path's absolute coords. */
+function pathBBox(d: string): BBox {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  const nums =
+    d.match(/-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?/gi)?.map(Number) ?? [];
+  for (let i = 0; i + 1 < nums.length; i += 2) {
+    const x = nums[i]!;
+    const y = nums[i + 1]!;
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  }
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
+function unionBBox(boxes: BBox[]): BBox {
+  const minX = Math.min(...boxes.map((b) => b.x));
+  const minY = Math.min(...boxes.map((b) => b.y));
+  const maxX = Math.max(...boxes.map((b) => b.x + b.w));
+  const maxY = Math.max(...boxes.map((b) => b.y + b.h));
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
+function useViewport() {
+  const [size, setSize] = useState(() => ({
+    w: typeof window === "undefined" ? 1280 : window.innerWidth,
+    h: typeof window === "undefined" ? 800 : window.innerHeight,
+  }));
+  useEffect(() => {
+    const onResize = () =>
+      setSize({ w: window.innerWidth, h: window.innerHeight });
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return size;
+}
+
+export interface OnboardingEyeArt {
+  paths: { svgPath: string; color: string }[];
+  bbox: BBox;
+}
+
+export interface OnboardingEyes {
+  /** The chosen avatar's eye art, or null until components/character load. */
+  art: OnboardingEyeArt | null;
+  eyesW: number;
+  eyesH: number;
+  /** Resting vertical center: peeking from the bottom, ~25% cut off. */
+  restCy: number;
+  /** Horizontal center of the viewport. */
+  centerX: number;
+  w: number;
+  h: number;
+}
+
+/** Resolve the chosen avatar's eyes + the backdrop-matching geometry. */
+export function useOnboardingEyes(): OnboardingEyes {
+  const components = useBundledAvatarComponents();
+  const characters = useOnboardingAvatarPoolStore.use.characters();
+  const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
+  const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
+  const { w, h } = useViewport();
+
+  const art = useMemo<OnboardingEyeArt | null>(() => {
+    if (!components || !chosen) return null;
+    const def = components.eyeStyles.find((e) => e.id === chosen.eyeStyle);
+    if (!def) return null;
+    return {
+      paths: def.paths,
+      bbox: unionBBox(def.paths.map((p) => pathBBox(p.svgPath))),
+    };
+  }, [components, chosen]);
+
+  const eyesH = art
+    ? Math.min(
+        Math.min(w, h) * EYE_TARGET_HEIGHT,
+        (w * EYE_MAX_WIDTH * art.bbox.h) / art.bbox.w,
+      )
+    : 0;
+  const eyesW = art ? (eyesH * art.bbox.w) / art.bbox.h : 0;
+  const restCy = h - EYE_REST_CUTOFF * eyesH;
+
+  return { art, eyesW, eyesH, restCy, centerX: w / 2, w, h };
+}
+
+/**
+ * Render the eyes at a caller-driven center (`eyeCy` vertical, `centerX` + the
+ * optional `eyeX` offset horizontal) and `eyeScale`, with a `blinking` squish.
+ * Scaling is about the box center, so growing/shrinking keeps the eyes pinned.
+ */
+export function MotionEyes({
+  art,
+  eyesW,
+  eyesH,
+  centerX,
+  eyeCy,
+  eyeScale,
+  eyeX,
+  blinking,
+  className = "pointer-events-none absolute top-0 z-0",
+}: {
+  art: OnboardingEyeArt;
+  eyesW: number;
+  eyesH: number;
+  centerX: number;
+  eyeCy: MotionValue<number>;
+  eyeScale: MotionValue<number>;
+  /** Horizontal offset from center (px). Omit to stay centered. */
+  eyeX?: MotionValue<number>;
+  blinking: boolean;
+  className?: string;
+}) {
+  const top = useTransform(eyeCy, (v) => v - eyesH / 2);
+  const cx = art.bbox.x + art.bbox.w / 2;
+  const cy = art.bbox.y + art.bbox.h / 2;
+  return (
+    <motion.div
+      aria-hidden="true"
+      className={className}
+      style={{
+        left: centerX - eyesW / 2,
+        top: 0,
+        x: eyeX,
+        y: top,
+        width: eyesW,
+        height: eyesH,
+        scale: eyeScale,
+        transformOrigin: "center",
+      }}
+    >
+      <svg
+        viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
+        width={eyesW}
+        height={eyesH}
+        style={{ overflow: "visible", display: "block" }}
+      >
+        <g
+          style={{
+            transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+            transformOrigin: `${cx}px ${cy}px`,
+            transition: "transform 0.13s ease-in-out",
+          }}
+        >
+          {art.paths.map((p, i) => (
+            <path key={i} d={p.svgPath} fill={p.color} />
+          ))}
+        </g>
+      </svg>
+    </motion.div>
+  );
+}

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -43,6 +43,10 @@ function useViewport() {
  * `pos` returns the cut-off offsets (negative / percentage) so each character
  * is clipped by the viewport edge — the "peeking in" look.
  */
+// Revealed one-per-message during the looking-you-up carousel. Kept off the top
+// (the persistent team lives there) and spread evenly across the left, right,
+// and bottom edges. The first four — what the carousel reveals — are balanced
+// left / right / bottom-left / bottom-right.
 const PEEKERS: {
   bodyShape: string;
   eyeStyle: string;
@@ -50,23 +54,32 @@ const PEEKERS: {
   base: number;
   pos: (s: number) => Record<string, number | string>;
 }[] = [
-  { bodyShape: "blob", eyeStyle: "gentle", colorIdx: 0, base: 300, pos: (s) => ({ left: "6%", top: -s * 0.46 }) },
-  { bodyShape: "burst", eyeStyle: "quirky", colorIdx: 1, base: 260, pos: (s) => ({ right: "6%", top: -s * 0.46 }) },
-  { bodyShape: "urchin", eyeStyle: "curious", colorIdx: 2, base: 240, pos: (s) => ({ left: "42%", top: -s * 0.52 }) },
-  { bodyShape: "sprout", eyeStyle: "curious", colorIdx: 0, base: 230, pos: (s) => ({ left: -s * 0.34, top: "42%" }) },
-  { bodyShape: "flower", eyeStyle: "goofy", colorIdx: 1, base: 230, pos: (s) => ({ right: -s * 0.34, top: "54%" }) },
-  { bodyShape: "star", eyeStyle: "dazed", colorIdx: 2, base: 220, pos: (s) => ({ right: -s * 0.26, bottom: -s * 0.18 }) },
-  { bodyShape: "burst", eyeStyle: "angry", colorIdx: 0, base: 220, pos: (s) => ({ left: -s * 0.2, bottom: -s * 0.22 }) },
-  { bodyShape: "flower", eyeStyle: "quirky", colorIdx: 1, base: 250, pos: (s) => ({ left: "24%", top: -s * 0.5 }) },
+  { bodyShape: "sprout", eyeStyle: "curious", colorIdx: 0, base: 230, pos: (s) => ({ left: -s * 0.32, top: "40%" }) },
+  { bodyShape: "flower", eyeStyle: "goofy", colorIdx: 1, base: 230, pos: (s) => ({ right: -s * 0.32, top: "40%" }) },
+  { bodyShape: "star", eyeStyle: "dazed", colorIdx: 2, base: 240, pos: (s) => ({ left: "16%", bottom: -s * 0.42 }) },
+  { bodyShape: "burst", eyeStyle: "angry", colorIdx: 0, base: 240, pos: (s) => ({ right: "16%", bottom: -s * 0.42 }) },
+  { bodyShape: "blob", eyeStyle: "gentle", colorIdx: 1, base: 220, pos: (s) => ({ left: "42%", bottom: -s * 0.5 }) },
+  { bodyShape: "urchin", eyeStyle: "curious", colorIdx: 2, base: 220, pos: (s) => ({ left: -s * 0.28, bottom: "16%" }) },
+  { bodyShape: "burst", eyeStyle: "quirky", colorIdx: 0, base: 220, pos: (s) => ({ right: -s * 0.28, bottom: "16%" }) },
+  { bodyShape: "flower", eyeStyle: "quirky", colorIdx: 1, base: 230, pos: (s) => ({ left: "30%", bottom: -s * 0.4 }) },
 ];
 
 const DARK_SURFACE = "#17191C";
+
+/** The team that peeks in from the top, persisting once it forms. */
+const TOP_TEAM = [
+  { bodyShape: "blob", eyeStyle: "gentle" },
+  { bodyShape: "urchin", eyeStyle: "curious" },
+  { bodyShape: "star", eyeStyle: "goofy" },
+];
+const TOP_TEAM_SIZE = 290;
 
 export function OnboardingTonedBackdrop({
   peekLevel = 0,
   eyesBumpNonce = 0,
   darkBg = false,
   showBottomEyes = true,
+  showTopTeam = false,
 }: {
   /** How many edge characters to reveal — grows one per onboarding step. */
   peekLevel?: number;
@@ -76,6 +89,9 @@ export function OnboardingTonedBackdrop({
   darkBg?: boolean;
   /** Show the giant eyes peeking from the bottom (off once they've collapsed). */
   showBottomEyes?: boolean;
+  /** Show the little team peeking in from the top (forms on the "together"
+   *  step and persists through the rest of the flow). */
+  showTopTeam?: boolean;
 }) {
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
@@ -113,6 +129,51 @@ export function OnboardingTonedBackdrop({
       {/* The assistant's eyes peek up from the bottom (until they collapse into
           the small avatar at the calendar step). */}
       {showBottomEyes && <OnboardingPeekingEyes bumpNonce={eyesBumpNonce} />}
+
+      {/* The team peeks in from the top-right — three larger avatars, overlapping
+          and cut off by the top edge. Forms on "together" and stays put. */}
+      {showTopTeam && components && (
+        <div
+          className="pointer-events-none absolute right-0 z-[1] flex items-start"
+          style={{
+            top: -Math.round(TOP_TEAM_SIZE * peekScale) * 0.42,
+            right: -Math.round(TOP_TEAM_SIZE * peekScale) * 0.12,
+          }}
+        >
+          {TOP_TEAM.map((m, i) => {
+            const size = Math.round(TOP_TEAM_SIZE * peekScale);
+            return (
+              <motion.div
+                key={m.bodyShape}
+                style={{
+                  width: size,
+                  height: size,
+                  marginLeft: i === 0 ? 0 : -size * 0.34,
+                  zIndex: TOP_TEAM.length - i,
+                }}
+                initial={reduce ? false : { y: -36, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                transition={
+                  reduce
+                    ? { duration: 0 }
+                    : { type: "spring", stiffness: 300, damping: 18, delay: i * 0.1 }
+                }
+              >
+                <AnimatedAvatar
+                  components={components}
+                  traits={{
+                    bodyShape: m.bodyShape,
+                    eyeStyle: m.eyeStyle,
+                    color: peekColors[i] ?? "teal",
+                  }}
+                  size={size}
+                  breathe={false}
+                />
+              </motion.div>
+            );
+          })}
+        </div>
+      )}
 
       {/* The crowd peeks in around the edges — more reveal as steps progress. */}
       {components && (

--- a/clients/web/src/domains/onboarding/onboarding-tone.ts
+++ b/clients/web/src/domains/onboarding/onboarding-tone.ts
@@ -26,6 +26,12 @@ export interface OnboardingTone {
   isLight: boolean;
   /** Foreground color: black on light bg, white otherwise. */
   fg: string;
+  /**
+   * A deeper heading foreground: the background color itself, darkened. Shared
+   * by the "Hey {name}" greeting and the pitch setup line so they read as the
+   * same secondary tone.
+   */
+  fgDeep: string;
   /** Muted/secondary foreground at the matching tone. */
   fgMuted: string;
   /** A subtle hover/fill wash at the matching tone. */
@@ -46,6 +52,16 @@ function brightness(hex: string): number {
   return (r * 299 + g * 587 + b * 114) / 1000 / 255;
 }
 
+/** Multiply each channel of a #rrggbb hex by `factor` (clamped 0–255). */
+function darkenHex(hex: string, factor: number): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return hex;
+  const n = parseInt(m[1]!, 16);
+  const ch = (shift: number) =>
+    Math.max(0, Math.min(255, Math.round(((n >> shift) & 0xff) * factor)));
+  return `#${((1 << 24) | (ch(16) << 16) | (ch(8) << 8) | ch(0)).toString(16).slice(1)}`;
+}
+
 /** Build a tone object from a background hex. */
 export function toneForBg(bg: string): OnboardingTone {
   const isLight = brightness(bg) > 0.6;
@@ -53,6 +69,7 @@ export function toneForBg(bg: string): OnboardingTone {
     bg,
     isLight,
     fg: isLight ? FG_DARK : FG_LIGHT,
+    fgDeep: darkenHex(bg, 0.6),
     fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
     wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
   };

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -279,20 +279,30 @@ export function ResearchOnboardingRoute() {
     // eyes collapse into the small avatar beside the text. Extra edge
     // characters are revealed by the looking-you-up carousel (see edgeAvatars).
     const postCalendar = ["meeting", "looking", "results", "suggestions"].includes(step);
-    // The peeking crowd grows one per step (by position in the toned sequence),
-    // plus any extras the looking-you-up carousel reveals.
-    const peekLevel = tonedSteps.indexOf(step) + 1 + edgeAvatars;
+    // The edge crowd is gone from the pitch/setup steps — there it's just the
+    // top team and the eyes. The crowd builds up one character per message
+    // during the looking-you-up carousel, then stays on for the result steps.
+    const peekLevel = ["looking", "results", "suggestions"].includes(step)
+      ? edgeAvatars
+      : 0;
     return (
       <div data-theme="dark" className="relative h-full overflow-hidden">
         <OnboardingTonedBackdrop
           eyesBumpNonce={eyesBump}
           peekLevel={peekLevel}
           darkBg={postCalendar}
-          showBottomEyes={!postCalendar}
+          // The pitch steps choreograph their own eyes (rising to speak the
+          // line in, or acting out "smarter"/"faster"), so hide the backdrop's
+          // resting pair there to avoid doubling.
+          showBottomEyes={
+            !postCalendar && step !== "different" && step !== "together"
+          }
+          // The team forms on "together" and rides along for the rest of the flow.
+          showTopTeam={step !== "different"}
         />
         {step === "different" && (
           <PitchDifferentStep
-            onDone={() => goForwardTo("together")}
+            onContinue={() => goForwardTo("together")}
             onBack={() => goBackTo("intro")}
             onForward={onForward}
           />

--- a/clients/web/src/domains/onboarding/screens/integration-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/integration-step.tsx
@@ -1,25 +1,20 @@
 /**
- * "We're giving you 10 free credits" step content.
+ * "Want to connect your first integration?" step content.
  *
  * SPIKE — research-onboarding flow.
  *
- * Foreground only (the toned backdrop sits behind). Grants 10 free credits. The
- * coin itself is the action: clicking it drops the coin toward the eyes, the
- * eyes bump it up Mario-style, and it pops up and vanishes — then the flow
- * advances. If the user hasn't clicked after a few seconds, a little character
- * pops in with a "click it!" nudge. Not skippable.
+ * Foreground only (the toned backdrop sits behind). Offers 10 free credits. On
+ * Claim the coin drops toward the eyes, the eyes bump it up Mario-style, and it
+ * pops up and vanishes — then the flow advances. Skippable.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
+import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
-import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingCoin } from "@/domains/onboarding/components/onboarding-coin";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
-import { pickOverlayColors } from "@/domains/onboarding/onboarding-avatar-colors";
-import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
-import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 interface IntegrationStepProps {
   onClaim: () => void;
@@ -35,9 +30,6 @@ interface IntegrationStepProps {
 const DROP = 0.3;
 const TOTAL = 0.95;
 
-/** How long the user can sit on the coin before the "click it!" nudge appears. */
-const NUDGE_DELAY_MS = 5000;
-
 export function IntegrationStep({
   onClaim,
   onBumpEyes,
@@ -46,37 +38,11 @@ export function IntegrationStep({
 }: IntegrationStepProps) {
   const reduce = useReducedMotion();
   const tone = useOnboardingTone();
-  const components = useBundledAvatarComponents();
-  const characters = useOnboardingAvatarPoolStore.use.characters();
-  const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const [claiming, setClaiming] = useState(false);
-  const [showNudge, setShowNudge] = useState(false);
-
-  // A little character (in a contrasting overlay color) for the nudge.
-  const nudgeTraits = useMemo(() => {
-    const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
-    const color =
-      components && chosen
-        ? pickOverlayColors(
-            chosen.color,
-            components.colors.map((c) => c.id),
-            1,
-          )[0]
-        : undefined;
-    return { bodyShape: "blob", eyeStyle: "quirky", color: color ?? "yellow" };
-  }, [components, characters, selectedIndex]);
-
-  // Nudge the user if they haven't claimed after a beat.
-  useEffect(() => {
-    if (claiming) return;
-    const t = window.setTimeout(() => setShowNudge(true), NUDGE_DELAY_MS);
-    return () => window.clearTimeout(t);
-  }, [claiming]);
 
   function handleClaim() {
     if (claiming) return;
     setClaiming(true);
-    setShowNudge(false);
     if (reduce) {
       onClaim();
       return;
@@ -96,76 +62,61 @@ export function IntegrationStep({
 
       <div className="absolute left-1/2 top-[26%] flex -translate-x-1/2 flex-col items-center gap-3 px-6 text-center">
         <h1
-          className="max-w-[640px] text-[2.6rem] leading-tight"
+          className="text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}
         >
-          Here&rsquo;s 10 free credits to get started!
+          Want to connect your first integration?
         </h1>
+        <p className="text-[16px]" style={{ color: tone.fgMuted }}>
+          Here&rsquo;s 10 free credits to get you started.
+        </p>
 
-        {/* Coin — the click target. Drops to the eyes, gets bumped up, then
-            falls away (2D flight here) while the coin spins in its own 3D
-            context (`spinning`). */}
-        <div className="mt-10 flex flex-col items-center gap-4">
-          <div className="relative">
-            <motion.button
-              type="button"
-              onClick={handleClaim}
-              disabled={claiming}
-              aria-label="Claim your 10 free credits"
-              className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:cursor-default enabled:cursor-pointer"
-              animate={
-                claiming && !reduce
-                  ? {
-                      y: [0, dropY, apexY, fallY],
-                      scale: [1, 1, 1, 0.2],
-                      opacity: [1, 1, 1, 0],
-                    }
-                  : reduce
-                    ? {}
-                    : { y: [0, -9, 0] }
-              }
-              transition={
-                claiming
-                  ? {
-                      duration: TOTAL,
-                      // Fall into the eyes, get bumped up (decelerating like
-                      // gravity), then accelerate back down — a parabolic arc.
-                      times: [0, DROP / TOTAL, 0.62, 1],
-                      ease: ["easeIn", "easeOut", "easeIn"],
-                    }
-                  : { duration: 2.2, repeat: Infinity, ease: "easeInOut" }
-              }
-              onAnimationComplete={() => {
-                if (claiming) onClaim();
-              }}
-            >
-              <OnboardingCoin size={88} spinning={claiming && !reduce} />
-            </motion.button>
-
-            {/* "click it!" nudge — a little character that slides in from the
-                right with a speech bubble, shown only if they've lingered and
-                haven't claimed yet. */}
-            {showNudge && !claiming && (
-              <motion.div
-                className="pointer-events-none absolute left-full top-1/2 ml-20 flex -translate-y-1/2 flex-col items-center"
-                initial={reduce ? false : { opacity: 0, x: 120 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={
-                  reduce ? { duration: 0 } : { type: "spring", stiffness: 220, damping: 22 }
-                }
-              >
-                <div className="relative mb-1.5 whitespace-nowrap rounded-2xl bg-white px-3.5 py-1.5 text-[15px] font-medium text-[#1A1A1A] shadow-md">
-                  click it!
-                  {/* Tail pointing down to the character. */}
-                  <span className="absolute -bottom-1 left-1/2 h-3 w-3 -translate-x-1/2 rotate-45 bg-white" />
-                </div>
-                {components && (
-                  <AnimatedAvatar components={components} traits={nudgeTraits} size={76} />
-                )}
-              </motion.div>
-            )}
-          </div>
+        {/* Coin — drops to the eyes, gets bumped up, then falls away (2D flight
+            here) while the coin spins in its own 3D context (`spinning`). */}
+        <div className="mt-8 flex flex-col items-center gap-4">
+          <motion.div
+            animate={
+              claiming && !reduce
+                ? {
+                    y: [0, dropY, apexY, fallY],
+                    scale: [1, 1, 1, 0.2],
+                    opacity: [1, 1, 1, 0],
+                  }
+                : {}
+            }
+            transition={{
+              duration: TOTAL,
+              // Fall into the eyes, get bumped up (decelerating like gravity),
+              // then accelerate back down — a quick parabolic arc.
+              times: [0, DROP / TOTAL, 0.62, 1],
+              ease: ["easeIn", "easeOut", "easeIn"],
+            }}
+            onAnimationComplete={() => {
+              if (claiming) onClaim();
+            }}
+          >
+            <OnboardingCoin size={88} spinning={claiming && !reduce} />
+          </motion.div>
+          {!claiming && (
+            <p className="text-[20px] font-medium" style={{ color: tone.fg }}>10 cr.</p>
+          )}
         </div>
+
+        {/* Claim — hidden while the coin animates. */}
+        {!claiming && (
+          <button
+            type="button"
+            onClick={handleClaim}
+            className="mt-6 flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
+            style={{
+              backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
+              color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
+            }}
+          >
+            Claim
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -5,133 +5,211 @@
  * SPIKE — research-onboarding flow.
  *
  * Foreground only — they render over the shared `OnboardingTonedBackdrop`
- * (assistant color + bottom eyes), so they share the Introduction's look and
- * flow straight into the later toned steps.
+ * (assistant color + edge crowd). Both choreograph the assistant's bottom eyes
+ * themselves, so the route hides the backdrop's resting pair on these steps and
+ * each renders its own `MotionEyes`.
  *
- *   - PitchDifferentStep  streams one line like an AI typing, then auto-advances
- *   - PitchTogetherStep   the "the more we work together" payoff + bullets
+ *   - PitchDifferentStep  eyes rise to "speak" the pitch in, then settle
+ *   - PitchTogetherStep   a team forms; the eyes act out "smarter" and "faster"
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ArrowRight } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
+import {
+  animate,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useTransform,
+} from "motion/react";
 
+import {
+  MotionEyes,
+  useOnboardingEyes,
+} from "@/domains/onboarding/components/onboarding-motion-eyes";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 
-/** Reveal `text` one character at a time; returns the visible prefix. */
-function useTypewriter(
-  text: string,
-  { speed, enabled }: { speed: number; enabled: boolean },
-): string {
-  const [count, setCount] = useState(enabled ? 0 : text.length);
-
-  useEffect(() => {
-    if (!enabled) {
-      setCount(text.length);
-      return;
-    }
-    setCount(0);
-    let i = 0;
-    const id = setInterval(() => {
-      i += 1;
-      setCount(i);
-      if (i >= text.length) clearInterval(id);
-    }, speed);
-    return () => clearInterval(id);
-  }, [text, speed, enabled]);
-
-  return text.slice(0, count);
-}
-
-// The first half streams like an ordinary answering AI; the payoff shoots in to
-// break that rhythm — the motion itself is the "I'm different".
-const STREAM_LINE = "You’ve seen AI that answers.";
-const PUNCH_LINE = "I’m different...";
+const SETUP_LINE = "You’ve used AI that just answers questions";
+const PUNCH_LINE = "I’m different";
 
 /**
- * The setup line streams in (deliberately like every other AI), then "I'm
- * different..." shoots in to break the streaming rhythm. Holds a longer beat
- * once it lands before auto-advancing to the payoff.
+ * The assistant's eyes shoot straight up from the bottom (shrinking), speaking
+ * line 1 into view bottom→top along the rise. They fly straight back down to
+ * their resting peek with a small bounce, speaking "I'm different" in as they
+ * pass over it, then blink twice. A Continue button then appears.
  */
 export function PitchDifferentStep({
-  onDone,
+  onContinue,
   onBack,
   onForward,
 }: {
-  onDone: () => void;
+  onContinue: () => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
   const tone = useOnboardingTone();
   const reduce = useReducedMotion();
-  const shown = useTypewriter(STREAM_LINE, { speed: 55, enabled: !reduce });
-  const streamDone = shown.length >= STREAM_LINE.length;
-  const [punchLanded, setPunchLanded] = useState(false);
+  const { art, eyesW, eyesH, restCy, centerX, w, h } = useOnboardingEyes();
 
-  // Hold once the payoff has landed, then advance. With reduced motion there's
-  // no shoot-in to land, so start the hold as soon as the line is shown.
+  const line1Ref = useRef<HTMLSpanElement>(null);
+
+  // The eyes' vertical center + scale, and how much of each line they've spoken
+  // in (0→1). Line 1 reveals bottom→top as the eyes rise past it; line 2 reveals
+  // top→bottom as they bounce back down past it.
+  const eyeCy = useMotionValue(0);
+  const eyeScale = useMotionValue(1);
+  const reveal1 = useMotionValue(reduce ? 1 : 0);
+  const reveal2 = useMotionValue(reduce ? 1 : 0);
+
+  const [ready, setReady] = useState(false);
+  const [landed, setLanded] = useState(reduce);
+  const [blinking, setBlinking] = useState(false);
+
+  // Line 1 wipes in bottom→top (top clipped until the rising eyes pass it); line
+  // 2 wipes in top→bottom (bottom clipped until the descending eyes pass it).
+  const clip1 = useTransform(reveal1, (r) => `inset(${(1 - r) * 100}% 0 -35% 0)`);
+  const clip2 = useTransform(reveal2, (r) => `inset(-35% 0 ${(1 - r) * 100}% 0)`);
+
+  // Park the eyes at rest until the journey starts (and, for reduced motion,
+  // leave them there with the text already shown).
   useEffect(() => {
-    if (reduce) {
-      if (!streamDone) return;
-      const t = setTimeout(onDone, 2000);
-      return () => clearTimeout(t);
-    }
-    if (!punchLanded) return;
-    const t = setTimeout(onDone, 1400);
-    return () => clearTimeout(t);
-  }, [reduce, streamDone, punchLanded, onDone]);
+    eyeCy.set(restCy);
+    setReady(true);
+  }, [restCy, eyeCy]);
+
+  useEffect(() => {
+    if (reduce || !art) return;
+    const l1 = line1Ref.current;
+    if (!l1) return;
+    const r1 = l1.getBoundingClientRect();
+
+    const smallScale = 0.55; // up above the words
+    const aboveCy = r1.top - 22 - (eyesH * smallScale) / 2; // clear above line 1
+
+    eyeCy.set(restCy);
+    eyeScale.set(1);
+    reveal1.set(0);
+    reveal2.set(0);
+
+    const controls: ReturnType<typeof animate>[] = [];
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+    let cancelled = false;
+    const track = <T extends ReturnType<typeof animate>>(c: T): T => {
+      controls.push(c);
+      return c;
+    };
+    const wait = (ms: number) =>
+      new Promise<void>((res) => {
+        timeouts.push(setTimeout(res, ms));
+      });
+    const blink = async (hold = 120) => {
+      setBlinking(true);
+      await wait(hold);
+      if (!cancelled) setBlinking(false);
+    };
+
+    const run = async () => {
+      // Shoot straight up — fast and tight — painting line 1 in along the rise
+      // (reveal locked to the rise via matching duration/ease).
+      await Promise.all([
+        track(animate(eyeCy, aboveCy, { duration: 0.55, ease: "easeOut", delay: 0.2 })),
+        track(animate(eyeScale, smallScale, { duration: 0.55, ease: "easeOut", delay: 0.2 })),
+        track(animate(reveal1, 1, { duration: 0.55, ease: "easeOut", delay: 0.2 })),
+      ]);
+      if (cancelled) return;
+      // Drop back down with a little bounce, revealing "I'm different" — and bring
+      // Continue in right alongside it.
+      setLanded(true);
+      await Promise.all([
+        track(animate(eyeCy, restCy, { type: "spring", stiffness: 210, damping: 15 })),
+        track(animate(eyeScale, 1, { duration: 0.45, ease: "easeOut" })),
+        track(animate(reveal2, 1, { duration: 0.45, ease: "easeOut" })),
+      ]);
+      if (cancelled) return;
+      // Settle with a couple of blinks.
+      await blink();
+      await wait(140);
+      if (cancelled) return;
+      await blink();
+    };
+    void run();
+
+    return () => {
+      cancelled = true;
+      controls.forEach((c) => c.stop());
+      timeouts.forEach(clearTimeout);
+    };
+  }, [reduce, art, w, h, eyesH, restCy, eyeCy, eyeScale, reveal1, reveal2]);
 
   return (
-    <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
+    <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-[32%] w-full max-w-3xl -translate-x-1/2 px-6 text-center">
-        {/* Setup line — streamed, in a muted tone to read as the "ordinary" AI. */}
-        <h1
-          className="text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.1]"
-          style={{ fontFamily: "var(--font-serif)", color: tone.fgMuted }}
-        >
-          {shown}
-          {/* Blinking caret while the setup line is still streaming in. */}
-          {!streamDone && (
-            <span className="ml-1 inline-block animate-pulse" aria-hidden="true">
-              ▍
-            </span>
-          )}
-        </h1>
+      {/* The assistant's eyes — behind the text, so the words read as lifted into
+          view in front of them as the eyes rise. */}
+      {ready && art && (
+        <MotionEyes
+          art={art}
+          eyesW={eyesW}
+          eyesH={eyesH}
+          centerX={centerX}
+          eyeCy={eyeCy}
+          eyeScale={eyeScale}
+          blinking={blinking}
+        />
+      )}
 
-        {/* Payoff — shoots in with a spring once the stream finishes. */}
-        {streamDone && (
-          <motion.h1
-            className="mt-2 text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.1]"
-            style={{ fontFamily: "var(--font-serif)", color: tone.fg }}
-            initial={reduce ? false : { opacity: 0, x: 140, scale: 0.85 }}
-            animate={{ opacity: 1, x: 0, scale: 1 }}
-            transition={
-              reduce
-                ? { duration: 0 }
-                : { type: "spring", stiffness: 320, damping: 17, delay: 1.3 }
-            }
-            onAnimationComplete={() => setPunchLanded(true)}
+      <div className="absolute left-1/2 top-[32%] z-10 flex w-full max-w-3xl -translate-x-1/2 flex-col items-center gap-10 px-6 text-center">
+        <h1
+          className="text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.15]"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          {/* Setup line — the darker secondary tone, matching "Hey {name}". */}
+          <motion.span
+            ref={line1Ref}
+            className="block"
+            style={{ color: tone.fgDeep, clipPath: clip1 }}
+          >
+            {SETUP_LINE}
+          </motion.span>
+          {/* Payoff — the full-strength foreground, with extra space above it. */}
+          <motion.span
+            className="mt-8 block"
+            style={{ color: tone.fg, clipPath: clip2 }}
           >
             {PUNCH_LINE}
-          </motion.h1>
+          </motion.span>
+        </h1>
+
+        {/* Continue appears once the eyes have settled back down. */}
+        {landed && (
+          <motion.button
+            type="button"
+            onClick={onContinue}
+            className="flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] bg-black text-body-medium-default text-white transition-transform duration-150 active:scale-[0.97]"
+            initial={reduce ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={reduce ? { duration: 0 } : { duration: 0.4 }}
+          >
+            Continue
+            <ArrowRight className="h-4 w-4" />
+          </motion.button>
         )}
       </div>
     </div>
   );
 }
 
-const TOGETHER_BULLETS = [
-  "The smarter my instincts get",
-  "The faster I can take things off your plate",
-];
+const TOGETHER_HEADING = "The more we work together";
+const SMARTER_LINE = "The smarter I get";
+const FASTER_LINE = "The faster I can take things off your plate";
 
 /**
- * The payoff: the relationship compounds. Title settles in, the bullets stagger
- * up, then a Continue affordance appears to carry on into the setup steps.
+ * The payoff: the relationship compounds. The heading lands and a little team of
+ * avatars forms beneath it (and stays). Then the eyes act out each benefit — they
+ * swell to "get smarter", then dash side to side to show how "fast" things move.
  */
 export function PitchTogetherStep({
   onContinue,
@@ -145,59 +223,165 @@ export function PitchTogetherStep({
 }) {
   const tone = useOnboardingTone();
   const reduce = useReducedMotion();
+  const { art, eyesW, eyesH, restCy, centerX, w, h } = useOnboardingEyes();
+
+  const eyeCy = useMotionValue(0);
+  const eyeScale = useMotionValue(1);
+  const eyeX = useMotionValue(0);
+
+  const [ready, setReady] = useState(false);
+  const [blinking, setBlinking] = useState(false);
+  const [showSmarter, setShowSmarter] = useState(reduce);
+  const [showFaster, setShowFaster] = useState(reduce);
+  const [landed, setLanded] = useState(reduce);
+
+  // Park the eyes at rest (and short-circuit for reduced motion).
+  useEffect(() => {
+    eyeCy.set(restCy);
+    setReady(true);
+  }, [restCy, eyeCy]);
+
+  useEffect(() => {
+    if (reduce || !art) return;
+
+    eyeCy.set(restCy);
+    eyeScale.set(1);
+    eyeX.set(0);
+
+    const controls: ReturnType<typeof animate>[] = [];
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+    let cancelled = false;
+    const track = <T extends ReturnType<typeof animate>>(c: T): T => {
+      controls.push(c);
+      return c;
+    };
+    const wait = (ms: number) =>
+      new Promise<void>((res) => {
+        timeouts.push(setTimeout(res, ms));
+      });
+    const blink = async (hold = 120) => {
+      setBlinking(true);
+      await wait(hold);
+      if (!cancelled) setBlinking(false);
+    };
+
+    // A subtle side-to-side dart (kept small — was too much before).
+    const dash = Math.min(42, w * 0.026);
+
+    const run = async () => {
+      // Let the heading + team settle in (briefly).
+      await wait(550);
+      if (cancelled) return;
+
+      // "The smarter I get" — the eyes swell up a bit to get smarter, then ease
+      // back down.
+      setShowSmarter(true);
+      await wait(60);
+      if (cancelled) return;
+      await track(
+        animate(eyeScale, 1.9, { duration: 0.4, ease: [0.34, 1.3, 0.64, 1] }),
+      );
+      if (cancelled) return;
+      await blink(90);
+      await track(animate(eyeScale, 1, { duration: 0.32, ease: "easeInOut" }));
+      if (cancelled) return;
+      await wait(160);
+      if (cancelled) return;
+
+      // "The faster..." — a quick, subtle side-to-side dart to show speed.
+      setShowFaster(true);
+      await wait(60);
+      if (cancelled) return;
+      await track(
+        animate(eyeX, [0, dash, -dash, 0], {
+          duration: 0.42,
+          ease: "easeInOut",
+          times: [0, 0.33, 0.66, 1],
+        }),
+      );
+      if (cancelled) return;
+      await wait(120);
+      if (cancelled) return;
+      setLanded(true);
+    };
+    void run();
+
+    return () => {
+      cancelled = true;
+      controls.forEach((c) => c.stop());
+      timeouts.forEach(clearTimeout);
+    };
+  }, [reduce, art, w, h, restCy, eyeCy, eyeScale, eyeX]);
 
   return (
-    <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
+    <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-[24%] flex w-full max-w-4xl -translate-x-1/2 flex-col items-center gap-10 px-6 text-center">
+      {/* The assistant's eyes, peeking from the bottom — they act out each line. */}
+      {ready && art && (
+        <MotionEyes
+          art={art}
+          eyesW={eyesW}
+          eyesH={eyesH}
+          centerX={centerX}
+          eyeCy={eyeCy}
+          eyeScale={eyeScale}
+          eyeX={eyeX}
+          blinking={blinking}
+        />
+      )}
+
+      <div className="absolute left-1/2 top-[30%] z-10 flex w-full max-w-4xl -translate-x-1/2 flex-col items-center gap-8 px-6 text-center">
+        {/* Drops down from the top with the team — teamwork carrying the line in. */}
         <motion.h1
           className="whitespace-nowrap text-[clamp(2.25rem,5.5vw,4.25rem)] leading-[1.1]"
-          style={{ fontFamily: "var(--font-serif)" }}
-          initial={reduce ? false : { opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={reduce ? { duration: 0 } : { duration: 0.5 }}
-        >
-          The more we collaborate,
-        </motion.h1>
-
-        {/* Centered lines (matching the heading) so the list reads as
-            intentional regardless of length — and wraps cleanly on mobile. */}
-        <ul className="flex w-full flex-col gap-4 text-center">
-          {TOGETHER_BULLETS.map((bullet, i) => (
-            <motion.li
-              key={bullet}
-              className="text-[clamp(1.75rem,3.4vw,2.75rem)] leading-snug"
-              style={{ fontFamily: "var(--font-serif)" }}
-              initial={reduce ? false : { opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={
-                reduce ? { duration: 0 } : { duration: 0.5, delay: 0.5 + i * 0.55 }
-              }
-            >
-              <span aria-hidden="true" className="mr-3" style={{ color: tone.fgMuted }}>
-                •
-              </span>
-              {bullet}
-            </motion.li>
-          ))}
-        </ul>
-
-        <motion.button
-          type="button"
-          onClick={onContinue}
-          className="flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] bg-black text-body-medium-default text-white transition-transform duration-150 active:scale-[0.97]"
-          initial={reduce ? false : { opacity: 0, y: 8 }}
+          style={{ fontFamily: "var(--font-serif)", color: tone.fgDeep }}
+          initial={reduce ? false : { opacity: 0, y: -Math.round(h * 0.26) }}
           animate={{ opacity: 1, y: 0 }}
           transition={
             reduce
               ? { duration: 0 }
-              : { duration: 0.4, delay: 0.6 + TOGETHER_BULLETS.length * 0.55 }
+              : { type: "spring", stiffness: 130, damping: 17, delay: 0.1 }
           }
         >
-          Continue
-          <ArrowRight className="h-4 w-4" />
-        </motion.button>
+          {TOGETHER_HEADING}
+        </motion.h1>
+
+        {/* Two benefits, each acted out by the eyes as it appears. */}
+        <div className="flex flex-col gap-4">
+          <motion.p
+            className="text-[clamp(1.75rem,3.4vw,2.75rem)] leading-snug"
+            style={{ fontFamily: "var(--font-serif)" }}
+            initial={reduce ? false : { opacity: 0, y: 10 }}
+            animate={showSmarter ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+            transition={reduce ? { duration: 0 } : { duration: 0.3, ease: "easeOut" }}
+          >
+            {SMARTER_LINE}
+          </motion.p>
+          <motion.p
+            className="text-[clamp(1.75rem,3.4vw,2.75rem)] leading-snug"
+            style={{ fontFamily: "var(--font-serif)" }}
+            initial={reduce ? false : { opacity: 0, y: 10 }}
+            animate={showFaster ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+            transition={reduce ? { duration: 0 } : { duration: 0.3, ease: "easeOut" }}
+          >
+            {FASTER_LINE}
+          </motion.p>
+        </div>
+
+        {landed && (
+          <motion.button
+            type="button"
+            onClick={onContinue}
+            className="flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] bg-black text-body-medium-default text-white transition-transform duration-150 active:scale-[0.97]"
+            initial={reduce ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={reduce ? { duration: 0 } : { duration: 0.4 }}
+          >
+            Continue
+            <ArrowRight className="h-4 w-4" />
+          </motion.button>
+        )}
       </div>
     </div>
   );

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -31,16 +31,6 @@ interface IntroductionScreenProps {
   onForward?: () => void;
 }
 
-/** Multiply each channel of a #rrggbb hex by `factor` (clamped). */
-function darkenHex(hex: string, factor: number): string {
-  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
-  if (!m) return hex;
-  const n = parseInt(m[1]!, 16);
-  const ch = (shift: number) =>
-    Math.max(0, Math.min(255, Math.round(((n >> shift) & 0xff) * factor)));
-  return `#${((1 << 24) | (ch(16) << 16) | (ch(8) << 8) | ch(0)).toString(16).slice(1)}`;
-}
-
 /** The body grow starts from the picker's centered size / position. */
 const PICKER_SIZE = 200;
 const PICKER_CENTER_VH = 40;
@@ -97,8 +87,6 @@ export function IntroductionScreen({
       />
     );
   }
-
-  const headingDark = darkenHex(art.color, 0.6);
 
   // Body grows to cover the screen end to end, starting from the picker size.
   const coverSize = 1.25 * Math.max(w, h);
@@ -171,7 +159,7 @@ export function IntroductionScreen({
         >
           <span
             className="block text-[clamp(2.5rem,6vw,5rem)]"
-            style={{ color: headingDark }}
+            style={{ color: tone.fgDeep }}
           >
             {greeting}
           </span>


### PR DESCRIPTION
## Summary

Polishes the research-onboarding pitch/setup flow, driven by design iteration.

### "I'm different" step
- The assistant's eyes rise from the bottom and **speak the line into view** — "You've used AI that just answers questions" wipes in on the way up, "I'm different" on the bounce back down. Replaces the typewriter.
- **Continue button** instead of auto-advance, appearing alongside "I'm different". Extra spacing above the payoff.

### "The more we work together" step
- Heading **drops in from the top** with the team (teamwork).
- Eyes **act out** each benefit: "The smarter I get" (a swell) and "The faster I can take things off your plate" (a subtle side-to-side dart). Bullets removed.
- Copy cleaned up (commas removed, first letters capitalized).

### Persistent team + crowd
- A **3-avatar team peeks in from the top-right** and persists across the rest of the flow (lives in the shared toned backdrop).
- Edge crowd removed from the pitch/setup steps; the **one-per-message reveal** during the looking-you-up carousel is restored and spread across the sides/bottom (off the top, where the team sits).

### Tone
- Onboarding uses **two text tones only**; added a shared `fgDeep` to the tone system (the darker secondary used by the "Hey {name}" greeting) and pointed the introduction screen at it.

### Integration step
- Reverted to the "Want to connect your first integration?" copy + Claim button. **"10 cr." and the Claim button both hide on claim.**

### Coin
- Flat, forward-facing (3D depth removed); "$" unchanged from main.

### Internal
- New shared `MotionEyes` / `useOnboardingEyes` for the choreographed bottom eyes.

## Test plan
- `bunx tsc --noEmit`, `eslint`, and `vite build` all pass.
- Visually QA'd throughout iteration across the intro → different → together → integration → looking-you-up steps. Reduced-motion paths render content statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)