### PR TITLE
feat(gateway-client): add resolve_guardian_delivery IPC contract

### DIFF
--- a/packages/gateway-client/src/__tests__/guardian-delivery-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/guardian-delivery-contract.test.ts
@@ -30,6 +30,10 @@ describe("ResolveGuardianDeliveryRequestSchema", () => {
   test("parses with channelTypes omitted", () => {
     expect(ResolveGuardianDeliveryRequestSchema.parse({})).toEqual({});
   });
+
+  test("defaults to {} when params are undefined (no-param IPC call)", () => {
+    expect(ResolveGuardianDeliveryRequestSchema.parse(undefined)).toEqual({});
+  });
 });
 
 describe("GuardianDeliverySchema", () => {

--- a/packages/gateway-client/src/__tests__/guardian-delivery-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/guardian-delivery-contract.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the guardian binding + delivery pull contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  GuardianDeliverySchema,
+  ResolveGuardianDeliveryRequestSchema,
+  type GuardianDelivery,
+} from "../guardian-delivery-contract.js";
+
+const fullGuardian: GuardianDelivery = {
+  channelType: "imessage",
+  contactId: "c1",
+  principalId: "p1",
+  displayName: "Guardian Name",
+  address: "+15555550100",
+  externalChatId: "ext-chat-1",
+  status: "active",
+  verifiedAt: 1699999999,
+};
+
+describe("ResolveGuardianDeliveryRequestSchema", () => {
+  test("parses with channelTypes", () => {
+    const req = { channelTypes: ["imessage", "sms"] };
+    expect(ResolveGuardianDeliveryRequestSchema.parse(req)).toEqual(req);
+  });
+
+  test("parses with channelTypes omitted", () => {
+    expect(ResolveGuardianDeliveryRequestSchema.parse({})).toEqual({});
+  });
+});
+
+describe("GuardianDeliverySchema", () => {
+  test("round-trips a fully-populated row", () => {
+    expect(GuardianDeliverySchema.parse(fullGuardian)).toEqual(fullGuardian);
+  });
+
+  test("requires channelType", () => {
+    const { channelType: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("requires contactId", () => {
+    const { contactId: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("requires address", () => {
+    const { address: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("requires status", () => {
+    const { status: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("optional fields accept null", () => {
+    const row = {
+      channelType: "imessage",
+      contactId: "c1",
+      address: "+15555550100",
+      status: "active",
+      principalId: null,
+      displayName: null,
+      externalChatId: null,
+      verifiedAt: null,
+    } satisfies GuardianDelivery;
+    expect(GuardianDeliverySchema.parse(row)).toEqual(row);
+  });
+
+  test("optional fields accept undefined (omitted)", () => {
+    const row = {
+      channelType: "imessage",
+      contactId: "c1",
+      address: "+15555550100",
+      status: "active",
+    } satisfies GuardianDelivery;
+    const parsed = GuardianDeliverySchema.parse(row);
+    expect(parsed.principalId).toBeUndefined();
+    expect(parsed.displayName).toBeUndefined();
+    expect(parsed.externalChatId).toBeUndefined();
+    expect(parsed.verifiedAt).toBeUndefined();
+  });
+});

--- a/packages/gateway-client/src/guardian-delivery-contract.ts
+++ b/packages/gateway-client/src/guardian-delivery-contract.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared contract for the gateway-owned guardian binding + delivery pull.
+ *
+ * The gateway resolves the active guardian binding(s) and their per-channel
+ * delivery endpoints from its DB; the daemon pulls them via the
+ * `resolve_guardian_delivery` IPC route. INFO (notes / userFile) is NOT
+ * carried here — the daemon joins it locally by `contactId`.
+ */
+
+import { z } from "zod";
+
+/**
+ * IPC request for `resolve_guardian_delivery`. `channelTypes` is an optional
+ * filter; omitted ⇒ all active guardian channels.
+ */
+export const ResolveGuardianDeliveryRequestSchema = z.object({
+  channelTypes: z.array(z.string()).optional(),
+});
+
+export type ResolveGuardianDeliveryRequest = z.infer<
+  typeof ResolveGuardianDeliveryRequestSchema
+>;
+
+/**
+ * One active guardian binding + delivery endpoint for a single channel.
+ */
+export const GuardianDeliverySchema = z.object({
+  channelType: z.string(),
+  contactId: z.string(),
+  principalId: z.string().nullable().optional(),
+  displayName: z.string().nullable().optional(),
+  address: z.string(),
+  externalChatId: z.string().nullable().optional(),
+  status: z.string(),
+  verifiedAt: z.number().nullable().optional(),
+});
+
+export type GuardianDelivery = z.infer<typeof GuardianDeliverySchema>;
+
+export const ResolveGuardianDeliveryResponseSchema = z.object({
+  guardians: z.array(GuardianDeliverySchema),
+});
+
+export type ResolveGuardianDeliveryResponse = z.infer<
+  typeof ResolveGuardianDeliveryResponseSchema
+>;

--- a/packages/gateway-client/src/guardian-delivery-contract.ts
+++ b/packages/gateway-client/src/guardian-delivery-contract.ts
@@ -13,9 +13,11 @@ import { z } from "zod";
  * IPC request for `resolve_guardian_delivery`. `channelTypes` is an optional
  * filter; omitted ⇒ all active guardian channels.
  */
-export const ResolveGuardianDeliveryRequestSchema = z.object({
-  channelTypes: z.array(z.string()).optional(),
-});
+export const ResolveGuardianDeliveryRequestSchema = z
+  .object({
+    channelTypes: z.array(z.string()).optional(),
+  })
+  .default({});
 
 export type ResolveGuardianDeliveryRequest = z.infer<
   typeof ResolveGuardianDeliveryRequestSchema

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -85,3 +85,16 @@ export type {
   TrustClass,
   TrustVerdict,
 } from "./trust-verdict-contract.js";
+
+// Guardian delivery contract (daemon → gateway pull) — Zod schemas + derived types
+export {
+  GuardianDeliverySchema,
+  ResolveGuardianDeliveryRequestSchema,
+  ResolveGuardianDeliveryResponseSchema,
+} from "./guardian-delivery-contract.js";
+
+export type {
+  GuardianDelivery,
+  ResolveGuardianDeliveryRequest,
+  ResolveGuardianDeliveryResponse,
+} from "./guardian-delivery-contract.js";


### PR DESCRIPTION
## Summary
- Add `ResolveGuardianDeliveryRequestSchema`/`ResolveGuardianDeliveryResponseSchema`/`GuardianDelivery` to gateway-client: the contract for a gateway-owned guardian binding + delivery pull. Additive, IPC-only.

Part of plan: gateway-guardian-binding-pull.md (PR 1 of 10)