### PR TITLE
Surface failed LLM calls in the context inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -1827,4 +1827,109 @@ describe("normalizeLlmContextPayloads", () => {
       },
     ]);
   });
+
+  describe("provider error response payloads", () => {
+    test("extracts a structured error from a rejected call's response payload", () => {
+      const normalized = normalizeLlmContextPayloads({
+        createdAt: 1_742_400_000_000,
+        requestPayload: {
+          model: "accounts/fireworks/models/glm-5p2",
+          messages: [{ role: "user", content: "hello" }],
+        },
+        responsePayload: {
+          error: {
+            name: "ProviderError",
+            message:
+              "This model doesn't support image input. Remove the image or switch to a vision-capable model.",
+            code: "PROVIDER_ERROR",
+            provider: "fireworks",
+            statusCode: 400,
+          },
+        },
+      });
+
+      expect(normalized.error).toEqual({
+        name: "ProviderError",
+        message:
+          "This model doesn't support image input. Remove the image or switch to a vision-capable model.",
+        code: "PROVIDER_ERROR",
+        provider: "fireworks",
+        statusCode: 400,
+      });
+      // No response sections are produced for an error payload.
+      expect(normalized.responseSections).toBeUndefined();
+    });
+
+    test("preserves a normalized request alongside the error", () => {
+      const normalized = normalizeLlmContextPayloads({
+        createdAt: 1_742_400_000_000,
+        requestPayload: {
+          model: "gpt-4.1",
+          tool_choice: "auto",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        responsePayload: { error: { message: "boom" } },
+      });
+
+      expect(normalized.error).toEqual({ message: "boom" });
+      // The request side still normalizes so the Prompt tab keeps working.
+      expect(normalized.requestSections?.length).toBeGreaterThan(0);
+      expect(normalized.summary?.provider).toBe("openai");
+    });
+
+    test("carries statusCode 0 and retryAfterMs through", () => {
+      const normalized = normalizeLlmContextPayloads({
+        createdAt: 1_742_400_000_000,
+        requestPayload: null,
+        responsePayload: {
+          error: {
+            name: "ProviderError",
+            message: "rate limited",
+            provider: "anthropic",
+            statusCode: 0,
+            retryAfterMs: 1500,
+          },
+        },
+      });
+
+      expect(normalized.error).toEqual({
+        name: "ProviderError",
+        message: "rate limited",
+        provider: "anthropic",
+        statusCode: 0,
+        retryAfterMs: 1500,
+      });
+    });
+
+    test("does not treat a successful response with no error as failed", () => {
+      const normalized = normalizeLlmContextPayloads({
+        createdAt: 1_742_400_000_000,
+        requestPayload: {
+          model: "gpt-4.1",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        responsePayload: {
+          model: "gpt-4.1",
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { role: "assistant", content: "hello" },
+            },
+          ],
+        },
+      });
+
+      expect(normalized.error).toBeUndefined();
+    });
+
+    test("ignores an empty error object with no identifying fields", () => {
+      const normalized = normalizeLlmContextPayloads({
+        createdAt: 1_742_400_000_000,
+        requestPayload: null,
+        responsePayload: { error: {} },
+      });
+
+      expect(normalized.error).toBeUndefined();
+    });
+  });
 });

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -430,6 +430,8 @@ export {
   LlmContextResponseSchema,
 } from "./responses/llm-context-response.js";
 export {
+  type LLMCallError,
+  LLMCallErrorSchema,
   type LLMCallSummary,
   LLMCallSummarySchema,
   type LLMContextSection,

--- a/assistant/src/api/responses/llm-request-log-entry.ts
+++ b/assistant/src/api/responses/llm-request-log-entry.ts
@@ -68,6 +68,30 @@ export const LLMContextSectionSchema = z.object({
 export type LLMContextSection = z.infer<typeof LLMContextSectionSchema>;
 
 /**
+ * Structured provider/transport error recorded when an LLM call was
+ * rejected before producing a response. Mirrors the on-disk
+ * `responsePayload.error` shape written by
+ * `buildProviderErrorResponsePayload` — the inspector branches on the
+ * presence of this field to render a failed call distinctly (failure
+ * banner in the Response tab, $0.00 cost in the rail, etc.) instead of
+ * the generic "section rendering unavailable" fallback.
+ *
+ * Every field is optional because the serializer degrades a plain
+ * `Error` down to just `{ name, message }`; only the wrapper object is
+ * guaranteed.
+ */
+export const LLMCallErrorSchema = z.object({
+  name: z.string().nullish(),
+  message: z.string().nullish(),
+  code: z.string().nullish(),
+  provider: z.string().nullish(),
+  statusCode: z.number().nullish(),
+  retryAfterMs: z.number().nullish(),
+});
+
+export type LLMCallError = z.infer<typeof LLMCallErrorSchema>;
+
+/**
  * One LLM request log row.
  *
  * `callSite` is the logical call site that produced this row —
@@ -88,6 +112,7 @@ export const LLMRequestLogEntrySchema = z.object({
   responseSections: z.array(LLMContextSectionSchema).nullish(),
   agentLoopExitReason: z.string().nullish(),
   callSite: z.string().nullish(),
+  error: LLMCallErrorSchema.nullish(),
 });
 
 export type LLMRequestLogEntry = z.infer<typeof LLMRequestLogEntrySchema>;

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -40,10 +40,27 @@ export interface LlmContextSection {
   language?: string;
 }
 
+/**
+ * Structured error extracted from a rejected call's response payload.
+ * Mirrors the on-disk `responsePayload.error` shape produced by
+ * `buildProviderErrorResponsePayload`. Present only when the call failed
+ * before returning a response — consumers branch on its presence to
+ * render the call as failed.
+ */
+export interface LlmContextError {
+  name?: string;
+  message?: string;
+  code?: string;
+  provider?: string;
+  statusCode?: number;
+  retryAfterMs?: number;
+}
+
 export interface LlmContextNormalizationResult {
   summary?: LlmContextSummary;
   requestSections?: LlmContextSection[];
   responseSections?: LlmContextSection[];
+  error?: LlmContextError;
 }
 
 interface NormalizedPayloadCandidate {
@@ -54,6 +71,60 @@ interface NormalizedPayloadCandidate {
 }
 
 export function normalizeLlmContextPayloads(
+  input: LlmContextNormalizationInput,
+): LlmContextNormalizationResult {
+  const base = normalizeSuccessPayloads(input);
+  const error = normalizeProviderErrorPayload(input.responsePayload);
+  if (!error) {
+    return base;
+  }
+  // A rejected call has no response sections to render — only the request
+  // side normalized. Attach the structured error so the inspector can show
+  // a failure banner and treat the cost as $0.00 instead of silently
+  // falling back to "section rendering unavailable".
+  return { ...base, error };
+}
+
+/**
+ * Detect a provider/transport error stored in the response payload.
+ *
+ * Error rows are written as `{ error: { name, message, code?, provider?,
+ * statusCode?, retryAfterMs? } }` by `buildProviderErrorResponsePayload`.
+ * Successful provider responses never carry a top-level `error` object, so
+ * the presence of one (with at least one identifying field) is a reliable
+ * signal that the call failed.
+ */
+function normalizeProviderErrorPayload(
+  responsePayload: unknown,
+): LlmContextError | null {
+  const error = asRecord(asRecord(responsePayload)?.error);
+  if (!error) {
+    return null;
+  }
+
+  const name = asString(error.name);
+  const message = asString(error.message);
+  const code = asString(error.code);
+  // Require at least one identifying field so an unrelated `error` key on a
+  // success payload isn't misread as a provider failure.
+  if (name === undefined && message === undefined && code === undefined) {
+    return null;
+  }
+
+  const normalized: LlmContextError = {};
+  if (name !== undefined) normalized.name = name;
+  if (message !== undefined) normalized.message = message;
+  if (code !== undefined) normalized.code = code;
+  const provider = asString(error.provider);
+  if (provider !== undefined) normalized.provider = provider;
+  const statusCode = asNumber(error.statusCode);
+  if (statusCode !== undefined) normalized.statusCode = statusCode;
+  const retryAfterMs = asNumber(error.retryAfterMs);
+  if (retryAfterMs !== undefined) normalized.retryAfterMs = retryAfterMs;
+  return normalized;
+}
+
+function normalizeSuccessPayloads(
   input: LlmContextNormalizationInput,
 ): LlmContextNormalizationResult {
   const requestCandidates = [

--- a/clients/web/src/domains/chat/inspector/components/call-rail.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/call-rail.test.tsx
@@ -39,7 +39,9 @@ mock.module("react-router", () => ({
 // Imported AFTER the mock so the component picks up the stub.
 import { CallRail } from "./call-rail";
 
-function makeRealEntry(overrides: Partial<LLMRequestLogEntry> = {}): LLMRequestLogEntry {
+function makeRealEntry(
+  overrides: Partial<LLMRequestLogEntry> = {},
+): LLMRequestLogEntry {
   return {
     id: "call-real-1",
     createdAt: Date.parse("2026-05-26T13:30:00Z"),
@@ -143,6 +145,31 @@ describe("CallRail — synthetic vs real rows", () => {
     expect(html).toContain("Cost");
     expect(html).toContain("Unavailable");
     expect(html).not.toContain("var(--system-negative-strong)");
+  });
+});
+
+describe("CallRail — failed rows", () => {
+  test("flags a provider-rejected call with the warning palette, a Failed pill, and $0.00 cost", () => {
+    // GIVEN a real call the provider rejected (structured `error` present)
+    // WHEN the rail renders the row
+    const html = render([
+      makeRealEntry({
+        summary: { provider: "fireworks", model: "glm-5p2" },
+        error: {
+          name: "ProviderError",
+          message: "This model doesn't support image input.",
+          code: "PROVIDER_ERROR",
+          provider: "fireworks",
+          statusCode: 400,
+        },
+      }),
+    ]);
+    // THEN it carries the failure styling and a Failed pill
+    expect(html).toContain("var(--system-negative-strong)");
+    expect(html).toContain("Failed");
+    // AND the cost reads $0.00 rather than "Unavailable"
+    expect(html).toContain("$0.00");
+    expect(html).not.toContain("Unavailable");
   });
 });
 

--- a/clients/web/src/domains/chat/inspector/components/call-rail.tsx
+++ b/clients/web/src/domains/chat/inspector/components/call-rail.tsx
@@ -78,9 +78,7 @@ export function CallRail({
         <CallRow
           key={entry.id}
           entry={entry}
-          callNumber={
-            callNumbers?.get(entry.id) ?? logs.length - displayIndex
-          }
+          callNumber={callNumbers?.get(entry.id) ?? logs.length - displayIndex}
           isSelected={entry.id === selectedLogId}
           isLatest={displayIndex === 0}
           href={buildCallHref(entry.id)}
@@ -109,18 +107,25 @@ function CallRow({
   onSelect,
 }: CallRowProps): ReactNode {
   const isSynthetic = isSyntheticAgentErrorMessage(entry);
+  const isFailed = isFailedCall(entry);
   const isCompaction = isCompactionAgentCall(entry);
   const subtitle = buildCallSubtitle(entry) ?? "Unrecognized call";
-  const estimatedCost = formatCost(entry.summary?.estimatedCostUsd ?? null);
+  // A rejected call accrued no billable cost — show $0.00 rather than the
+  // "Unavailable" placeholder a missing cost would otherwise render.
+  const estimatedCost = isFailed
+    ? formatCost(0)
+    : formatCost(entry.summary?.estimatedCostUsd ?? null);
 
   // Synthetic rows (e.g. budget_yield_unrecovered) represent agent-loop
-  // error messages with no LLM call backing them. Render with a
-  // warning-tinted border + icon so a yielded turn is spottable in the
-  // rail at a glance, while still occupying a numbered call slot so the
-  // "Call N" framing stays consistent with the rest of the conversation.
+  // error messages with no LLM call backing them; failed rows are real
+  // calls the provider rejected. Both render with a warning-tinted border
+  // + icon so a problem turn is spottable in the rail at a glance, while
+  // still occupying a numbered call slot so the "Call N" framing stays
+  // consistent with the rest of the conversation.
+  const isWarning = isSynthetic || isFailed;
   const borderColor = isSelected
     ? "var(--border-active)"
-    : isSynthetic
+    : isWarning
       ? "var(--system-negative-strong)"
       : "var(--border-base)";
 
@@ -142,7 +147,7 @@ function CallRow({
           className="line-clamp-1 flex-1 text-body-medium-default"
           style={{ color: "var(--content-default)" }}
         >
-          {isSynthetic ? (
+          {isWarning ? (
             <span className="inline-flex items-center gap-1.5">
               <TriangleAlert
                 className="h-3.5 w-3.5"
@@ -155,6 +160,17 @@ function CallRow({
             <>Call {callNumber}</>
           )}
         </span>
+        {isFailed ? (
+          <span
+            className="rounded-[4px] px-1.5 py-0.5 text-label-default"
+            style={{
+              background: "var(--system-negative-weak)",
+              color: "var(--system-negative-strong)",
+            }}
+          >
+            Failed
+          </span>
+        ) : null}
         {isCompaction ? (
           <span
             className="rounded-[4px] px-1.5 py-0.5 text-label-default"
@@ -212,6 +228,14 @@ function CallRow({
 
 function isSyntheticAgentErrorMessage(entry: LLMRequestLogEntry): boolean {
   return entry.callSite === CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE;
+}
+
+/**
+ * A real LLM call the provider rejected before returning a response. The
+ * daemon records the failure as a structured `error` object on the entry.
+ */
+function isFailedCall(entry: LLMRequestLogEntry): boolean {
+  return entry.error != null;
 }
 
 /**

--- a/clients/web/src/domains/chat/inspector/components/llm-call-error-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/llm-call-error-card.tsx
@@ -1,0 +1,100 @@
+import { TriangleAlert } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { displayProvider } from "@/domains/chat/inspector/inspector-formatters";
+import type { LLMCallError } from "@vellumai/assistant-api";
+import { Card } from "@vellumai/design-library";
+
+/**
+ * Failure banner shared by the Overview and Response tabs. Rendered when a
+ * call's `error` field is populated — i.e. the provider rejected the
+ * request before producing a response. Surfaces the provider's message
+ * plus any structured metadata (type, provider, HTTP status, error code)
+ * so a failed call reads as a failure instead of an empty/normalized row.
+ */
+export function LlmCallErrorCard({
+  error,
+}: {
+  error: LLMCallError;
+}): ReactNode {
+  const message = error.message?.trim();
+  const chips = buildErrorChips(error);
+
+  return (
+    <Card>
+      <div className="flex items-center gap-2">
+        <TriangleAlert
+          size={14}
+          aria-hidden
+          style={{ color: "var(--system-negative-strong)" }}
+        />
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--system-negative-strong)" }}
+        >
+          Call failed
+        </span>
+      </div>
+      <p
+        className="mt-2 select-text whitespace-pre-wrap break-words text-body-medium-lighter"
+        style={{ color: "var(--content-default)" }}
+      >
+        {message && message.length > 0
+          ? message
+          : "The provider rejected this call and returned no response."}
+      </p>
+      {chips.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {chips.map((chip) => (
+            <ErrorChip key={chip.label} label={chip.label} value={chip.value} />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+interface ErrorChipModel {
+  label: string;
+  value: string;
+}
+
+function buildErrorChips(error: LLMCallError): ErrorChipModel[] {
+  const chips: ErrorChipModel[] = [];
+  const name = error.name?.trim();
+  if (name) {
+    chips.push({ label: "Type", value: name });
+  }
+  const provider = error.provider?.trim();
+  if (provider) {
+    chips.push({ label: "Provider", value: displayProvider(provider) });
+  }
+  if (
+    typeof error.statusCode === "number" &&
+    Number.isFinite(error.statusCode)
+  ) {
+    chips.push({ label: "Status", value: String(error.statusCode) });
+  }
+  const code = error.code?.trim();
+  if (code) {
+    chips.push({ label: "Code", value: code });
+  }
+  return chips;
+}
+
+function ErrorChip({ label, value }: ErrorChipModel): ReactNode {
+  return (
+    <span
+      className="inline-flex items-baseline gap-1 rounded px-2 py-0.5 text-label-default"
+      style={{
+        background: "var(--surface-overlay)",
+        color: "var(--content-secondary)",
+      }}
+    >
+      <span>{label}</span>
+      <span className="font-medium" style={{ color: "var(--content-default)" }}>
+        {value}
+      </span>
+    </span>
+  );
+}

--- a/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for the OverviewTab's handling of failed calls. A rejected call
+ * must read as a failure (banner + "Failed" status) and show a $0.00
+ * estimated cost rather than the "Unavailable" placeholder.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { LLMRequestLogEntry } from "@vellumai/assistant-api";
+
+import { OverviewTab } from "./overview-tab";
+
+function makeEntry(
+  overrides: Partial<LLMRequestLogEntry> = {},
+): LLMRequestLogEntry {
+  return {
+    id: "call-1",
+    createdAt: Date.parse("2026-06-23T09:48:07Z"),
+    requestPayload: null,
+    responsePayload: null,
+    callSite: "mainAgent",
+    ...overrides,
+  };
+}
+
+function render(entry: LLMRequestLogEntry): string {
+  return renderToStaticMarkup(<OverviewTab entry={entry} />);
+}
+
+describe("OverviewTab — failed calls", () => {
+  test("shows a failure banner, Failed status, and $0.00 cost when the summary normalized", () => {
+    const html = render(
+      makeEntry({
+        summary: {
+          provider: "fireworks",
+          model: "glm-5p2",
+          requestMessageCount: 3,
+          requestToolCount: 2,
+        },
+        error: {
+          name: "ProviderError",
+          message: "This model doesn't support image input.",
+          code: "PROVIDER_ERROR",
+          provider: "fireworks",
+          statusCode: 400,
+        },
+      }),
+    );
+
+    expect(html).toContain("Call failed");
+    expect(html).toContain("Failed");
+    expect(html).toContain("$0.00");
+    // The normalized metadata cards still render the request-side counts.
+    expect(html).toContain("Normalized metadata");
+  });
+
+  test("shows the failure banner even when the summary never normalized past the provider", () => {
+    const html = render(
+      makeEntry({
+        summary: { provider: "fireworks" },
+        error: { message: "boom", provider: "fireworks" },
+      }),
+    );
+
+    expect(html).toContain("Call failed");
+    // The provider-only summary fallback must not hijack a failed call.
+    expect(html).not.toContain("Normalized summary unavailable");
+  });
+});

--- a/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
@@ -1,18 +1,19 @@
 import { type ReactNode } from "react";
 
 import {
-    displayProvider,
-    displayText,
-    formatCacheTokens,
-    formatCost,
-    formatCount,
-    formattedCreatedAt,
-    isProviderOnlySummary,
-    summaryFallbackMessage,
+  displayProvider,
+  displayText,
+  formatCacheTokens,
+  formatCost,
+  formatCount,
+  formattedCreatedAt,
+  isProviderOnlySummary,
+  summaryFallbackMessage,
 } from "@/domains/chat/inspector/inspector-formatters";
+import { LlmCallErrorCard } from "@/domains/chat/inspector/components/llm-call-error-card";
 import type {
-    LLMCallSummary,
-    LLMRequestLogEntry,
+  LLMCallSummary,
+  LLMRequestLogEntry,
 } from "@vellumai/assistant-api";
 import { Card } from "@vellumai/design-library";
 
@@ -37,7 +38,16 @@ export function OverviewTab({
   conversationTotalEstimatedCostUsd,
 }: OverviewTabProps): ReactNode {
   const summary = entry.summary;
-  const showFallback = !summary || isProviderOnlySummary(summary);
+  const error = entry.error ?? null;
+  const hasError = error != null;
+  // A failed call gets a dedicated banner; only show the generic
+  // "summary unavailable" fallback when the call didn't fail.
+  const showFallback =
+    !hasError && (!summary || isProviderOnlySummary(summary));
+  // Skip the sea-of-"Unavailable" metadata cards on a failed call whose
+  // summary never normalized past the provider name — the failure banner
+  // already carries the useful signal.
+  const showSummaryCards = summary != null && !isProviderOnlySummary(summary);
   const conversationTotals = renderConversationTotalsCard(
     conversationTotalEstimatedCostUsd,
   );
@@ -59,20 +69,26 @@ export function OverviewTab({
   return (
     <div className="flex flex-col gap-4 p-4">
       {conversationTotals}
-      <MetadataCard
-        title="Normalized metadata"
-        subtitle="Provider, model, timestamps, and usage counts."
-        rows={buildIdentityRows(
-          summary,
-          entry.createdAt,
-          entry.agentLoopExitReason,
-        )}
-      />
-      <MetadataCard
-        title="Usage"
-        subtitle="Token and call counts normalized by the assistant route."
-        rows={buildUsageRows(summary)}
-      />
+      {hasError && <LlmCallErrorCard error={error} />}
+      {showSummaryCards && (
+        <>
+          <MetadataCard
+            title="Normalized metadata"
+            subtitle="Provider, model, timestamps, and usage counts."
+            rows={buildIdentityRows(
+              summary,
+              entry.createdAt,
+              entry.agentLoopExitReason,
+              hasError,
+            )}
+          />
+          <MetadataCard
+            title="Usage"
+            subtitle="Token and call counts normalized by the assistant route."
+            rows={buildUsageRows(summary, hasError)}
+          />
+        </>
+      )}
     </div>
   );
 }
@@ -104,6 +120,7 @@ function buildIdentityRows(
   summary: LLMCallSummary,
   createdAt: number | null | undefined,
   agentLoopExitReason: string | null | undefined,
+  hasError: boolean,
 ): MetadataRow[] {
   const rows: MetadataRow[] = [
     { label: "Provider", value: displayProvider(summary.provider ?? null) },
@@ -111,6 +128,9 @@ function buildIdentityRows(
     { label: "Created", value: formattedCreatedAt(createdAt) },
     { label: "Stop reason", value: displayText(summary.stopReason ?? null) },
   ];
+  if (hasError) {
+    rows.push({ label: "Status", value: "Failed" });
+  }
   if (agentLoopExitReason != null && agentLoopExitReason.trim().length > 0) {
     rows.push({
       label: "Loop exit reason",
@@ -120,7 +140,10 @@ function buildIdentityRows(
   return rows;
 }
 
-function buildUsageRows(summary: LLMCallSummary): MetadataRow[] {
+function buildUsageRows(
+  summary: LLMCallSummary,
+  hasError: boolean,
+): MetadataRow[] {
   const rows: MetadataRow[] = [
     { label: "Input tokens", value: formatCount(summary.inputTokens) },
     { label: "Output tokens", value: formatCount(summary.outputTokens) },
@@ -131,18 +154,23 @@ function buildUsageRows(summary: LLMCallSummary): MetadataRow[] {
         summary.cacheReadInputTokens,
       ),
     },
-    { label: "Estimated cost", value: formatCost(summary.estimatedCostUsd) },
+    // A rejected call billed nothing, so show an explicit $0.00 rather than
+    // the "Unavailable" placeholder a missing cost would otherwise render.
+    {
+      label: "Estimated cost",
+      value: hasError ? formatCost(0) : formatCost(summary.estimatedCostUsd),
+    },
     {
       label: "Request messages",
       value: formatCount(summary.requestMessageCount),
     },
     { label: "Tools available", value: formatCount(summary.requestToolCount) },
-    { label: "Tool calls", value: formatCount(summary.responseToolCallCount ?? 0) },
+    {
+      label: "Tool calls",
+      value: formatCount(summary.responseToolCallCount ?? 0),
+    },
   ];
-  if (
-    summary.durationMs != null &&
-    Number.isFinite(summary.durationMs)
-  ) {
+  if (summary.durationMs != null && Number.isFinite(summary.durationMs)) {
     rows.splice(4, 0, {
       label: "Duration",
       value: `${formatCount(Math.round(summary.durationMs))} ms`,

--- a/clients/web/src/domains/chat/inspector/components/tabs/response-tab.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/response-tab.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for the ResponseTab's handling of failed calls. A call the
+ * provider rejected carries a structured `error` and no response
+ * sections; the tab must surface a failure banner instead of the generic
+ * "Section rendering unavailable" fallback.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { LLMRequestLogEntry } from "@vellumai/assistant-api";
+
+import { ResponseTab } from "./response-tab";
+
+function makeEntry(
+  overrides: Partial<LLMRequestLogEntry> = {},
+): LLMRequestLogEntry {
+  return {
+    id: "call-1",
+    createdAt: Date.parse("2026-06-23T09:48:07Z"),
+    requestPayload: null,
+    responsePayload: null,
+    callSite: "mainAgent",
+    ...overrides,
+  };
+}
+
+function render(entry: LLMRequestLogEntry): string {
+  return renderToStaticMarkup(<ResponseTab entry={entry} />);
+}
+
+describe("ResponseTab — failed calls", () => {
+  test("renders the failure banner with the provider message and metadata", () => {
+    const html = render(
+      makeEntry({
+        summary: { provider: "fireworks", model: "glm-5p2" },
+        error: {
+          name: "ProviderError",
+          message:
+            "This model doesn't support image input. Remove the image or switch to a vision-capable model.",
+          code: "PROVIDER_ERROR",
+          provider: "fireworks",
+          statusCode: 400,
+        },
+      }),
+    );
+
+    expect(html).toContain("Call failed");
+    expect(html).toContain("support image input");
+    // Structured chips surface the provider, status, type and code.
+    expect(html).toContain("Fireworks");
+    expect(html).toContain("400");
+    expect(html).toContain("ProviderError");
+    expect(html).toContain("PROVIDER_ERROR");
+    // The generic fallback must not appear when the call failed.
+    expect(html).not.toContain("Section rendering unavailable");
+  });
+
+  test("falls back to a default message when the error has no message", () => {
+    const html = render(makeEntry({ error: { name: "ProviderError" } }));
+    expect(html).toContain("Call failed");
+    expect(html).toContain("rejected this call");
+    expect(html).not.toContain("Section rendering unavailable");
+  });
+
+  test("still shows the generic fallback for a non-error empty response", () => {
+    const html = render(makeEntry());
+    expect(html).toContain("Section rendering unavailable");
+    expect(html).not.toContain("Call failed");
+  });
+});

--- a/clients/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
@@ -2,11 +2,13 @@ import { Copy, FileCode } from "lucide-react";
 import { type ReactNode } from "react";
 
 import type {
-    LLMCallSummary,
-    LLMContextSection,
-    LLMRequestLogEntry,
+  LLMCallSummary,
+  LLMContextSection,
+  LLMRequestLogEntry,
 } from "@vellumai/assistant-api";
 import { Button, Card } from "@vellumai/design-library";
+
+import { LlmCallErrorCard } from "@/domains/chat/inspector/components/llm-call-error-card";
 
 interface ResponseTabProps {
   entry: LLMRequestLogEntry;
@@ -14,9 +16,12 @@ interface ResponseTabProps {
 
 /**
  * Response tab rendering a metadata card (stop reason + mode label)
- * followed by per-section cards keyed on presentation kind.
+ * followed by per-section cards keyed on presentation kind. When the call
+ * failed, a failure banner replaces the generic "section rendering
+ * unavailable" fallback so the rejected response reads as an error.
  */
 export function ResponseTab({ entry }: ResponseTabProps): ReactNode {
+  const error = entry.error ?? null;
   const sections = buildSectionModels(entry.responseSections ?? []);
   const stopReason = deriveStopReason(entry.summary);
   const modeLabel = deriveModeLabel(entry.summary, sections);
@@ -25,13 +30,18 @@ export function ResponseTab({ entry }: ResponseTabProps): ReactNode {
   if (!sections.length && !hasMetadata) {
     return (
       <div className="flex flex-col gap-4 p-4">
-        <FallbackCard message={null} />
+        {error ? (
+          <LlmCallErrorCard error={error} />
+        ) : (
+          <FallbackCard message={null} />
+        )}
       </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-4 p-4">
+      {error && <LlmCallErrorCard error={error} />}
       {hasMetadata && (
         <Card>
           <p
@@ -41,17 +51,17 @@ export function ResponseTab({ entry }: ResponseTabProps): ReactNode {
             Response metadata
           </p>
           <div className="mt-2 flex flex-wrap gap-2">
-            {stopReason && <MetadataChip label={`Stop reason: ${stopReason}`} />}
+            {stopReason && (
+              <MetadataChip label={`Stop reason: ${stopReason}`} />
+            )}
             {modeLabel && <MetadataChip label={modeLabel} />}
           </div>
         </Card>
       )}
 
-      {sections.length > 0 ? (
-        sections.map((s) => <ResponseSectionCard key={s.id} section={s} />)
-      ) : (
-        <FallbackCard message={null} />
-      )}
+      {sections.length > 0
+        ? sections.map((s) => <ResponseSectionCard key={s.id} section={s} />)
+        : !error && <FallbackCard message={null} />}
     </div>
   );
 }
@@ -189,9 +199,7 @@ function SectionHeader({
         iconOnly
         leftIcon={<Copy size={14} aria-hidden />}
         aria-label="Copy section content"
-        onClick={() =>
-          void navigator.clipboard.writeText(section.copyText)
-        }
+        onClick={() => void navigator.clipboard.writeText(section.copyText)}
       />
     </div>
   );
@@ -211,7 +219,12 @@ function MetadataChip({ label }: { label: string }): ReactNode {
   );
 }
 
-type PresentationKind = "assistantText" | "reasoning" | "toolCall" | "result" | "other";
+type PresentationKind =
+  | "assistantText"
+  | "reasoning"
+  | "toolCall"
+  | "result"
+  | "other";
 
 interface ResponseSectionModel {
   id: number;
@@ -247,7 +260,10 @@ function toPresentationKind(kind: string): PresentationKind {
   return "other";
 }
 
-function kindDisplayLabel(kind: string, presentationKind: PresentationKind): string {
+function kindDisplayLabel(
+  kind: string,
+  presentationKind: PresentationKind,
+): string {
   switch (presentationKind) {
     case "toolCall":
       return "Tool call";
@@ -276,7 +292,9 @@ function sectionBodyText(section: LLMContextSection): string | null {
   return null;
 }
 
-function buildSectionModels(sections: LLMContextSection[]): ResponseSectionModel[] {
+function buildSectionModels(
+  sections: LLMContextSection[],
+): ResponseSectionModel[] {
   return sections.map((section, index) => {
     const pKind = toPresentationKind(section.kind);
     const rawTitle = section.label?.trim() ?? "";
@@ -317,7 +335,8 @@ function deriveModeLabel(
     return "Tool-calling response";
   }
   if (!sections.length) return null;
-  if (sections.some((s) => s.kind === "toolCall")) return "Tool-calling response";
+  if (sections.some((s) => s.kind === "toolCall"))
+    return "Tool-calling response";
   const hasText = sections.some((s) => s.kind === "assistantText");
   const hasResult = sections.some((s) => s.kind === "result");
   if (hasText && !hasResult) return "Text-only response";


### PR DESCRIPTION
## Why

When a provider rejects an LLM call, the daemon records the failure as a `{ error: { name, message, code, provider, statusCode } }` response payload. None of the inspector's response normalizers match that shape, so a failed call rendered as if it were a normal, empty call:

- the call rail showed **"Cost Unavailable"**,
- the Response tab showed **"Section rendering unavailable"**, and
- nothing marked the call as failed.

(Reported against a Fireworks image-input rejection, but the fix is provider-agnostic.)

## What

Detect the stored error during normalization and expose it as a structured `error` field on the log entry, then branch on it across the inspector UI:

- **Normalization** (`llm-context-normalization.ts`): `normalizeProviderErrorPayload` extracts the structured error from the response payload (requiring at least one identifying field so an unrelated `error` key on a success payload isn't misread). The request side still normalizes, so the Prompt tab keeps working.
- **Wire contract** (`llm-request-log-entry.ts`): new `LLMCallErrorSchema` + `error` field on the entry.
- **Response tab**: renders a "Call failed" banner (shared `LlmCallErrorCard`) with the provider message and metadata chips (type, provider, HTTP status, code) instead of the generic fallback.
- **Overview tab**: shows the failure banner, a `Status: Failed` row, and a **$0.00** estimated cost.
- **Call rail**: flags the row with the warning palette + a "Failed" pill and shows **$0.00** instead of "Unavailable".

## Tests

- Daemon: new cases in `llm-context-normalization.test.ts` (error extraction, request preserved alongside error, `statusCode: 0`/`retryAfterMs`, success-not-misread, empty-error-ignored).
- Web: new `response-tab.test.tsx` and `overview-tab.test.tsx`, plus a failed-row case in `call-rail.test.tsx`.
- Full inspector web suite (141 tests) and assistant typecheck/lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdEZbfPDaEiMMWcLF7kDay

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdEZbfPDaEiMMWcLF7kDay)_