### PR TITLE
feat(gateway): resolve_guardian_delivery IPC reads guardian bindings from the gateway DB

### DIFF
--- a/gateway/src/__tests__/guardian-delivery-resolver.test.ts
+++ b/gateway/src/__tests__/guardian-delivery-resolver.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the gateway-side guardian binding + delivery resolver.
+ *
+ * Seeds the gateway ACL DB directly (contacts + contact_channels) and asserts
+ * that every active guardian channel is returned (with correct delivery
+ * fields), that non-active channels and non-guardian contacts are excluded,
+ * that the `channelTypes` filter narrows the result, and that the handler
+ * fails soft to [] when the resolver throws.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+await import("./test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../db/connection.js"
+);
+const { contacts: gwContacts, contactChannels: gwContactChannels } =
+  await import("../db/schema.js");
+const { resolveGuardianDelivery } = await import(
+  "../risk/guardian-delivery-resolver.js"
+);
+
+function insertContact(args: {
+  id: string;
+  displayName: string;
+  role?: string;
+  principalId?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: args.id,
+      displayName: args.displayName,
+      role: args.role ?? "contact",
+      principalId: args.principalId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  type: string;
+  address: string;
+  externalChatId?: string | null;
+  status?: string;
+  policy?: string;
+  verifiedAt?: number | null;
+  verifiedVia?: string | null;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: args.type,
+      address: args.address,
+      externalChatId: args.externalChatId ?? null,
+      status: args.status ?? "active",
+      policy: args.policy ?? "allow",
+      verifiedAt: args.verifiedAt ?? now,
+      verifiedVia: args.verifiedVia ?? "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  // initGatewayDb reconnects to the same on-disk DB, so clear any rows a prior
+  // test left behind (channels first — FK cascade from contacts).
+  getGatewayDb().delete(gwContactChannels).run();
+  getGatewayDb().delete(gwContacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("resolveGuardianDelivery", () => {
+  test("active phone + telegram guardian channels → both returned with fields", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-phone",
+      contactId: "c-guardian",
+      type: "phone",
+      address: "+15555550100",
+      externalChatId: null,
+      verifiedAt: 1000,
+    });
+    insertChannel({
+      id: "ch-telegram",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+      verifiedAt: 2000,
+    });
+
+    const result = resolveGuardianDelivery({});
+
+    expect(result).toHaveLength(2);
+    const byType = Object.fromEntries(result.map((g) => [g.channelType, g]));
+    expect(byType.phone).toMatchObject({
+      channelType: "phone",
+      contactId: "c-guardian",
+      principalId: "principal-1",
+      displayName: "The Guardian",
+      address: "+15555550100",
+      externalChatId: null,
+      status: "active",
+      verifiedAt: 1000,
+    });
+    expect(byType.telegram).toMatchObject({
+      channelType: "telegram",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+      verifiedAt: 2000,
+    });
+  });
+
+  test("revoked/blocked guardian channels are excluded", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+    });
+    insertChannel({
+      id: "ch-active",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_ACTIVE",
+      status: "active",
+    });
+    insertChannel({
+      id: "ch-revoked",
+      contactId: "c-guardian",
+      type: "phone",
+      address: "+15555550111",
+      status: "revoked",
+    });
+    insertChannel({
+      id: "ch-blocked",
+      contactId: "c-guardian",
+      type: "slack",
+      address: "U_BLOCKED",
+      status: "blocked",
+    });
+
+    const result = resolveGuardianDelivery({});
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.channelType).toBe("telegram");
+    expect(result[0]?.address).toBe("U_ACTIVE");
+  });
+
+  test("channelTypes filter narrows the result", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+    });
+    insertChannel({
+      id: "ch-phone",
+      contactId: "c-guardian",
+      type: "phone",
+      address: "+15555550100",
+    });
+    insertChannel({
+      id: "ch-telegram",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_GUARDIAN",
+    });
+
+    const result = resolveGuardianDelivery({ channelTypes: ["telegram"] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.channelType).toBe("telegram");
+  });
+
+  test("no guardian → empty array", () => {
+    insertContact({ id: "c-member", displayName: "Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      type: "telegram",
+      address: "U_MEMBER",
+    });
+
+    expect(resolveGuardianDelivery({})).toEqual([]);
+  });
+
+  test("non-guardian contact's active channel is NOT returned", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_GUARDIAN",
+    });
+    insertContact({ id: "c-member", displayName: "Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      type: "telegram",
+      address: "U_MEMBER",
+    });
+
+    const result = resolveGuardianDelivery({});
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.contactId).toBe("c-guardian");
+  });
+});
+
+describe("guardianDeliveryRoutes handler", () => {
+  test("resolver throw → handler returns { guardians: [] }", async () => {
+    mock.module("../risk/guardian-delivery-resolver.js", () => ({
+      resolveGuardianDelivery: () => {
+        throw new Error("boom");
+      },
+    }));
+    const { guardianDeliveryRoutes } = await import(
+      "../ipc/guardian-delivery-handlers.js"
+    );
+
+    const route = guardianDeliveryRoutes[0]!;
+    expect(await route.handler({})).toEqual({ guardians: [] });
+
+    mock.restore();
+  });
+});

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -191,6 +191,7 @@ import { inviteRoutes } from "./ipc/invite-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
 import { trustVerdictRoutes } from "./ipc/trust-verdict-handlers.js";
+import { guardianDeliveryRoutes } from "./ipc/guardian-delivery-handlers.js";
 import { createLogTailRoutes } from "./ipc/log-tail-handlers.js";
 import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
@@ -2468,6 +2469,7 @@ async function main() {
     ...thresholdRoutes,
     ...admissionPolicyRoutes,
     ...trustVerdictRoutes,
+    ...guardianDeliveryRoutes,
     ...riskClassificationRoutes,
     ...createLogTailRoutes(config),
     ...trustRulesRoutes,

--- a/gateway/src/ipc/guardian-delivery-handlers.ts
+++ b/gateway/src/ipc/guardian-delivery-handlers.ts
@@ -1,0 +1,29 @@
+/**
+ * IPC route definitions for gateway-owned guardian binding + delivery reads.
+ *
+ * Exposes `resolve_guardian_delivery` to the assistant daemon over the IPC
+ * socket: returns every active guardian binding + delivery endpoint from the
+ * gateway ACL DB.
+ */
+
+import { ResolveGuardianDeliveryRequestSchema } from "@vellumai/gateway-client";
+
+import { resolveGuardianDelivery } from "../risk/guardian-delivery-resolver.js";
+import type { IpcRoute } from "./server.js";
+
+export const guardianDeliveryRoutes: IpcRoute[] = [
+  {
+    method: "resolve_guardian_delivery",
+    schema: ResolveGuardianDeliveryRequestSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const input = ResolveGuardianDeliveryRequestSchema.parse(params);
+      try {
+        return { guardians: resolveGuardianDelivery(input) };
+      } catch {
+        // Fails soft to [] — guardian delivery is not an admission decision;
+        // the daemon owns fallback.
+        return { guardians: [] };
+      }
+    },
+  },
+];

--- a/gateway/src/risk/guardian-delivery-resolver.ts
+++ b/gateway/src/risk/guardian-delivery-resolver.ts
@@ -1,0 +1,58 @@
+/**
+ * Gateway-side guardian binding + delivery resolver.
+ *
+ * Reads ONLY the gateway ACL DB to return every active guardian channel and
+ * its delivery endpoint as a {@link GuardianDelivery}. Mirrors the guardian
+ * binding query in `trust-verdict-resolver.ts`, but returns ALL active
+ * guardian channels (not LIMIT 1), optionally filtered to `channelTypes`.
+ * Read-only — no writes, no assistant DB, no IPC.
+ */
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import { getGatewayDb } from "../db/connection.js";
+import {
+  contacts as gwContacts,
+  contactChannels as gwContactChannels,
+} from "../db/schema.js";
+
+export interface ResolveGuardianDeliveryInput {
+  channelTypes?: string[];
+}
+
+/**
+ * Resolve the active guardian binding(s) + delivery endpoints from the gateway
+ * ACL DB, optionally narrowed to `channelTypes`.
+ */
+export function resolveGuardianDelivery(
+  input: ResolveGuardianDeliveryInput,
+): GuardianDelivery[] {
+  const db = getGatewayDb();
+
+  const filters = [
+    eq(gwContacts.role, "guardian"),
+    eq(gwContactChannels.status, "active"),
+  ];
+  if (input.channelTypes && input.channelTypes.length > 0) {
+    filters.push(inArray(gwContactChannels.type, input.channelTypes));
+  }
+
+  // Projection matches GuardianDelivery exactly.
+  return db
+    .select({
+      channelType: gwContactChannels.type,
+      contactId: gwContactChannels.contactId,
+      principalId: gwContacts.principalId,
+      displayName: gwContacts.displayName,
+      address: gwContactChannels.address,
+      externalChatId: gwContactChannels.externalChatId,
+      status: gwContactChannels.status,
+      verifiedAt: gwContactChannels.verifiedAt,
+    })
+    .from(gwContacts)
+    .innerJoin(gwContactChannels, eq(gwContactChannels.contactId, gwContacts.id))
+    .where(and(...filters))
+    .orderBy(desc(gwContactChannels.verifiedAt))
+    .all();
+}


### PR DESCRIPTION
## Summary
- Add the `resolve_guardian_delivery` IPC + resolver: returns active guardian binding(s) + delivery endpoints from the gateway DB (mirrors the trust-verdict guardian query, returns all active channels). Fails soft to []. Registered in the gateway IPC server.

Part of plan: gateway-guardian-binding-pull.md (PR 2 of 10)