### PR TITLE
feat(assistant): add getGuardianDelivery daemon reader over the IPC

### DIFF
--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -170,6 +170,29 @@ describe("getGuardianDelivery", () => {
     ]);
   });
 
+  test("an invalidation DURING an in-flight fetch is not masked — the next call re-fetches", async () => {
+    let resolveIpc: ((value: unknown) => void) | undefined;
+    ipcHandlers.set(
+      METHOD,
+      () =>
+        new Promise((resolve) => {
+          resolveIpc = resolve;
+        }),
+    );
+
+    // Start a cold fetch, invalidate before it resolves, then resolve it.
+    const inFlight = getGuardianDelivery();
+    invalidateGuardianDeliveryCache();
+    resolveIpc?.({ guardians: [telegramGuardian] });
+    expect(await inFlight).toEqual([telegramGuardian]);
+
+    // The pre-invalidation result must NOT have been cached: the next read
+    // issues a fresh IPC rather than serving the now-stale value.
+    ipcHandlers.set(METHOD, () => ({ guardians: [emailGuardian] }));
+    expect(await getGuardianDelivery()).toEqual([emailGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
   test("a failure does NOT poison the cache — the next call retries", async () => {
     ipcHandlers.set(METHOD, () => undefined);
     expect(await getGuardianDelivery()).toBeNull();

--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the gateway-backed guardian delivery reader.
+ *
+ * Guardian binding is near-static, so the reader caches behind a minutes-scale
+ * TTL, clears event-driven on invalidation, and coalesces concurrent cold-cache
+ * reads single-flight. These tests pin the parse contract plus all three cache
+ * behaviors (TTL hit, invalidation, single-flight) and the failure-no-poison
+ * rule.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+// ── Controllable IPC mock ────────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+
+const ipcHandlers = new Map<string, IpcHandler>();
+const ipcCallLog: Array<{
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+}> = [];
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCallLog.push({ method, params, timeoutMs });
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+import { emitContactChange } from "../contact-events.js";
+import {
+  __resetGuardianDeliveryCacheForTest,
+  anyGuardian,
+  getGuardianDelivery,
+  guardianForChannel,
+  invalidateGuardianDeliveryCache,
+} from "../guardian-delivery-reader.js";
+
+const METHOD = "resolve_guardian_delivery";
+
+function countCalls(method: string): number {
+  return ipcCallLog.filter((c) => c.method === method).length;
+}
+
+const telegramGuardian: GuardianDelivery = {
+  channelType: "telegram",
+  contactId: "contact-123",
+  address: "@guardian",
+  status: "active",
+};
+
+const emailGuardian: GuardianDelivery = {
+  channelType: "email",
+  contactId: "contact-456",
+  address: "guardian@example.com",
+  status: "active",
+};
+
+describe("getGuardianDelivery", () => {
+  beforeEach(() => {
+    __resetGuardianDeliveryCacheForTest();
+    ipcHandlers.clear();
+    ipcCallLog.length = 0;
+  });
+
+  test("returns the parsed guardian list", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
+  });
+
+  test("bounds the IPC read with a short timeout", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+
+    await getGuardianDelivery();
+
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.timeoutMs).toBe(2_000);
+  });
+
+  test("returns null when IPC transport fails (undefined)", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await getGuardianDelivery()).toBeNull();
+  });
+
+  test("returns null when the IPC call throws", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("socket exploded");
+    });
+    expect(await getGuardianDelivery()).toBeNull();
+  });
+
+  test("returns null for a malformed response shape", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: "not-an-array" }));
+    expect(await getGuardianDelivery()).toBeNull();
+  });
+
+  test("two calls within the TTL issue only ONE IPC call (cache hit)", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    await getGuardianDelivery();
+
+    expect(countCalls(METHOD)).toBe(1);
+  });
+
+  test("caches per channelTypes filter key", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    await getGuardianDelivery({ channelTypes: ["telegram"] });
+
+    // Distinct keys ("ALL" vs "telegram") miss each other → two IPC calls.
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("invalidateGuardianDeliveryCache() forces the next call to re-fetch", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    invalidateGuardianDeliveryCache();
+    await getGuardianDelivery();
+
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("a contact-change event clears the cache", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    emitContactChange();
+    await getGuardianDelivery();
+
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("a burst of concurrent cold-cache calls issues only ONE IPC call (single-flight)", async () => {
+    let resolveIpc: ((value: unknown) => void) | undefined;
+    ipcHandlers.set(
+      METHOD,
+      () =>
+        new Promise((resolve) => {
+          resolveIpc = resolve;
+        }),
+    );
+
+    const burst = Promise.all([
+      getGuardianDelivery(),
+      getGuardianDelivery(),
+      getGuardianDelivery(),
+    ]);
+    resolveIpc?.({ guardians: [telegramGuardian] });
+    const results = await burst;
+
+    expect(countCalls(METHOD)).toBe(1);
+    expect(results).toEqual([
+      [telegramGuardian],
+      [telegramGuardian],
+      [telegramGuardian],
+    ]);
+  });
+
+  test("a failure does NOT poison the cache — the next call retries", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await getGuardianDelivery()).toBeNull();
+
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+});
+
+describe("selectors", () => {
+  test("guardianForChannel picks the first active match for the type", () => {
+    const inactive: GuardianDelivery = {
+      ...telegramGuardian,
+      contactId: "contact-999",
+      status: "revoked",
+    };
+    const list = [inactive, telegramGuardian, emailGuardian];
+
+    expect(guardianForChannel(list, "telegram")).toBe(telegramGuardian);
+    expect(guardianForChannel(list, "email")).toBe(emailGuardian);
+    expect(guardianForChannel(list, "phone")).toBeUndefined();
+  });
+
+  test("anyGuardian returns the first overall", () => {
+    expect(anyGuardian([emailGuardian, telegramGuardian])).toBe(emailGuardian);
+    expect(anyGuardian([])).toBeUndefined();
+  });
+});

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -1,0 +1,132 @@
+/**
+ * Gateway-backed guardian binding + delivery reader.
+ *
+ * Resolves the active guardian binding(s) and their per-channel delivery
+ * endpoints from the gateway via the `resolve_guardian_delivery` IPC route,
+ * validating the response against {@link ResolveGuardianDeliveryResponseSchema}.
+ *
+ * Guardian binding is near-static — it only changes on guardian onboarding /
+ * verification or revocation — yet this reader sits on many hot paths. To keep
+ * those paths off the IPC, results are cached behind a minutes-scale TTL,
+ * cleared event-driven via {@link invalidateGuardianDeliveryCache} (subscribed
+ * to contact mutations, and called explicitly by guardian-binding mutations),
+ * and coalesced single-flight so a cold cache storms the gateway at most once.
+ *
+ * Returns `null` on ANY failure (transport failure, malformed shape, timeout,
+ * or thrown error); failures are NOT cached, so a recovered gateway is retried
+ * on the next call.
+ */
+
+import {
+  type GuardianDelivery,
+  ResolveGuardianDeliveryResponseSchema,
+} from "@vellumai/gateway-client";
+
+import { ipcCall } from "../ipc/gateway-client.js";
+import { onContactChange } from "./contact-events.js";
+
+// Short IPC timeout so the read resolves promptly rather than stalling a hot
+// path on a gateway that accepts the socket but hangs.
+const GUARDIAN_DELIVERY_IPC_TIMEOUT_MS = 2_000;
+
+// Guardian binding is near-static, so a minutes-scale TTL is safe; freshness is
+// driven primarily by event-based invalidation, not by this backstop expiry.
+const GUARDIAN_DELIVERY_CACHE_TTL_MS = 300_000;
+
+interface CacheEntry {
+  guardians: GuardianDelivery[];
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inFlight = new Map<string, Promise<GuardianDelivery[] | null>>();
+
+function cacheKey(channelTypes?: string[]): string {
+  if (!channelTypes || channelTypes.length === 0) return "ALL";
+  return [...channelTypes].sort().join(",");
+}
+
+async function fetchGuardianDelivery(
+  input: { channelTypes?: string[] },
+): Promise<GuardianDelivery[] | null> {
+  try {
+    const result = await ipcCall(
+      "resolve_guardian_delivery",
+      input,
+      GUARDIAN_DELIVERY_IPC_TIMEOUT_MS,
+    );
+    if (!result) return null;
+
+    const parsed = ResolveGuardianDeliveryResponseSchema.safeParse(result);
+    return parsed.success ? parsed.data.guardians : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve active guardian deliveries, optionally filtered by channel type.
+ * Returns the cached list when fresh, otherwise fetches (single-flight) and
+ * caches on success. Returns `null` on failure without caching.
+ */
+export async function getGuardianDelivery(
+  input?: { channelTypes?: string[] },
+): Promise<GuardianDelivery[] | null> {
+  const key = cacheKey(input?.channelTypes);
+
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < GUARDIAN_DELIVERY_CACHE_TTL_MS) {
+    return cached.guardians;
+  }
+
+  const pending = inFlight.get(key);
+  if (pending) return pending;
+
+  const promise = fetchGuardianDelivery(input ?? {})
+    .then((guardians) => {
+      if (guardians) {
+        cache.set(key, { guardians, fetchedAt: Date.now() });
+      }
+      return guardians;
+    })
+    .finally(() => {
+      inFlight.delete(key);
+    });
+
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/**
+ * Clear ALL cached guardian deliveries. Called event-driven on contact
+ * mutations, and must also be called from guardian-binding mutation sites
+ * (gateway onboarding / verification / revocation) so the next read refetches.
+ */
+export function invalidateGuardianDeliveryCache(): void {
+  cache.clear();
+}
+
+onContactChange(invalidateGuardianDeliveryCache);
+
+/** First active guardian delivery for the given channel type, if any. */
+export function guardianForChannel(
+  list: GuardianDelivery[],
+  channelType: string,
+): GuardianDelivery | undefined {
+  return list.find(
+    (g) => g.channelType === channelType && g.status === "active",
+  );
+}
+
+/** First guardian delivery overall — the `listGuardianChannels` fallback. */
+export function anyGuardian(
+  list: GuardianDelivery[],
+): GuardianDelivery | undefined {
+  return list[0];
+}
+
+/** Test-only: reset cache + in-flight state for deterministic test runs. */
+export function __resetGuardianDeliveryCacheForTest(): void {
+  cache.clear();
+  inFlight.clear();
+}

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -41,6 +41,12 @@ interface CacheEntry {
 const cache = new Map<string, CacheEntry>();
 const inFlight = new Map<string, Promise<GuardianDelivery[] | null>>();
 
+// Bumped on every invalidation. A fetch captures the generation when it starts
+// and only writes its result to the cache if the generation is unchanged on
+// resolve, so an invalidation mid-flight can't repopulate a stale pre-change
+// result and mask a guardian-binding change.
+let cacheGeneration = 0;
+
 function cacheKey(channelTypes?: string[]): string {
   if (!channelTypes || channelTypes.length === 0) return "ALL";
   return [...channelTypes].sort().join(",");
@@ -82,9 +88,13 @@ export async function getGuardianDelivery(
   const pending = inFlight.get(key);
   if (pending) return pending;
 
+  const startGen = cacheGeneration;
   const promise = fetchGuardianDelivery(input ?? {})
     .then((guardians) => {
-      if (guardians) {
+      // Skip the write if an invalidation fired during the fetch: the result
+      // may predate the change. Return it to this caller (freshest it has) but
+      // leave the cache empty so the next call re-fetches.
+      if (guardians && cacheGeneration === startGen) {
         cache.set(key, { guardians, fetchedAt: Date.now() });
       }
       return guardians;
@@ -103,7 +113,9 @@ export async function getGuardianDelivery(
  * (gateway onboarding / verification / revocation) so the next read refetches.
  */
 export function invalidateGuardianDeliveryCache(): void {
+  cacheGeneration += 1;
   cache.clear();
+  inFlight.clear();
 }
 
 onContactChange(invalidateGuardianDeliveryCache);
@@ -129,4 +141,5 @@ export function anyGuardian(
 export function __resetGuardianDeliveryCacheForTest(): void {
   cache.clear();
   inFlight.clear();
+  cacheGeneration = 0;
 }


### PR DESCRIPTION
## Summary
- Add `getGuardianDelivery` reading the gateway guardian binding/delivery over IPC, with a 5-min TTL cache, event-driven `invalidateGuardianDeliveryCache()`, and single-flight coalescing so hot paths don't storm the IPC for near-static data.
- Plus `guardianForChannel`/`anyGuardian` selectors.

Part of plan: gateway-guardian-binding-pull.md (PR 3 of 10)