### PR TITLE
fix(consent): monotonic consent-version comparison to stop cross-client re-consent loop

### DIFF
--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -29,7 +29,7 @@ import { setDeviceBool } from "@/utils/device-settings";
 export interface ResolvedDiagnosticsConsent {
   /** The server's `share_diagnostics` value; `null` when unknown/absent. */
   shareDiagnostics: boolean | null;
-  /** Whether the server's accepted version equals `PRIVACY_CONSENT_VERSION`. */
+  /** Whether the server's accepted version is at least `DIAGNOSTICS_CONSENT_VERSION`. */
   diagnosticsVersionCurrent: boolean;
   /** Whether the server returned a real consent record (not API defaults). */
   hasServerRecord: boolean;

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -173,6 +173,60 @@ describe("resolveServerConsent", () => {
     expect(resolveServerConsent(undefined).diagnosticsCurrent).toBe(false);
   });
 
+  // Cross-client skew regression: all clients share one server consent record
+  // but bake "current" into each build, so a lagging build sees versions NEWER
+  // than its own constant. Currency is monotonic (`>=`), so a newer accepted
+  // version resolves current — the lagging client neither re-prompts nor writes
+  // its older version back, which is what broke the re-consent loop.
+  test("a version NEWER than this build's constant resolves current on every axis", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        tos_accepted_version: "2099-01-01",
+        privacy_policy_accepted_version: "2099-01-01",
+        ai_data_sharing_accepted_version: "2099-01-01",
+        share_analytics_accepted_version: "2099-01-01",
+        share_diagnostics_accepted_version: "2099-01-01",
+      }),
+    );
+    expect(r.tos).toBe(true);
+    expect(r.privacy).toBe(true);
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("privacy needs BOTH artifacts current — a single stale artifact is stale", () => {
+    // ai_data_sharing newer than the privacy version, but privacy_policy older.
+    expect(
+      resolveServerConsent(
+        makeConsent({
+          privacy_policy_accepted_version: "2020-01-01",
+          ai_data_sharing_accepted_version: "2099-01-01",
+        }),
+      ).privacy,
+    ).toBe(false);
+    // ...and the mirror case.
+    expect(
+      resolveServerConsent(
+        makeConsent({
+          privacy_policy_accepted_version: "2099-01-01",
+          ai_data_sharing_accepted_version: "2020-01-01",
+        }),
+      ).privacy,
+    ).toBe(false);
+  });
+
+  test("a version OLDER than this build's constant resolves stale", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        tos_accepted_version: "2020-01-01",
+        privacy_policy_accepted_version: "2020-01-01",
+        ai_data_sharing_accepted_version: "2020-01-01",
+      }),
+    );
+    expect(r.tos).toBe(false);
+    expect(r.privacy).toBe(false);
+  });
+
   test("keeps the existing value/tos/privacy fields", () => {
     const r = resolveServerConsent(makeConsent({ share_analytics: false }));
     expect(r.tos).toBe(true);

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -173,11 +173,8 @@ describe("resolveServerConsent", () => {
     expect(resolveServerConsent(undefined).diagnosticsCurrent).toBe(false);
   });
 
-  // Cross-client skew regression: all clients share one server consent record
-  // but bake "current" into each build, so a lagging build sees versions NEWER
-  // than its own constant. Currency is monotonic (`>=`), so a newer accepted
-  // version resolves current — the lagging client neither re-prompts nor writes
-  // its older version back, which is what broke the re-consent loop.
+  // A server version newer than this build's constant counts as current on
+  // every axis (currency is monotonic `>=`, not exact equality).
   test("a version NEWER than this build's constant resolves current on every axis", () => {
     const r = resolveServerConsent(
       makeConsent({

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -32,6 +32,11 @@ import { setDiagnosticsReportingGate } from "@/lib/consent/diagnostics-consent";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
+// Consent versions MUST stay zero-padded ISO dates (YYYY-MM-DD) so currency is
+// decided by a monotonic comparison (`resolveServerConsent` uses `>=`): an
+// accepted version at or newer than this build's constant counts as current. A
+// non-sortable scheme would break that and reintroduce the cross-client
+// re-consent loop.
 export const TOS_CONSENT_VERSION = "2026-06-08";
 export const PRIVACY_CONSENT_VERSION = "2026-06-22";
 
@@ -164,6 +169,25 @@ export function clearConsentForUser(userId: string | null): void {
 // Server consent resolution
 // ---------------------------------------------------------------------------
 
+/**
+ * Whether a server-recorded `accepted` version satisfies the `required` build
+ * version. Compares monotonically (`>=`) rather than for exact equality so a
+ * client never treats a version NEWER than its own build constant as stale.
+ *
+ * All clients share one server consent record but bake the "current" version
+ * into each build (the macOS app embeds a packaged web build; native iOS
+ * renders the same web screen), so builds drift. With exact equality a lagging
+ * build calls a newer client's acceptance stale, re-prompts, and writes its own
+ * older version back — a last-writer-wins downgrade that ping-pongs re-consent
+ * between clients. `>=` closes that loop: a lagging build accepts a newer
+ * version as current. Versions are zero-padded ISO dates, so the lexicographic
+ * comparison is chronological; `""` (never accepted) sorts below any real
+ * version and stays stale.
+ */
+function versionIsCurrent(accepted: string, required: string): boolean {
+  return accepted >= required;
+}
+
 export function resolveServerConsent(
   consent: UserConsent | null | undefined,
 ): {
@@ -205,14 +229,21 @@ export function resolveServerConsent(
   return {
     // The ToS checkbox covers only the Terms of Service. The privacy checkbox
     // covers both the Privacy Policy and the AI Data Sharing Policy, so it is
-    // current only when BOTH versions match.
-    tos: consent.tos_accepted_version === TOS_CONSENT_VERSION,
-    privacy: consent.privacy_policy_accepted_version === PRIVACY_CONSENT_VERSION
-      && consent.ai_data_sharing_accepted_version === PRIVACY_CONSENT_VERSION,
+    // current only when BOTH versions are at or past the current version.
+    tos: versionIsCurrent(consent.tos_accepted_version, TOS_CONSENT_VERSION),
+    privacy:
+      versionIsCurrent(consent.privacy_policy_accepted_version, PRIVACY_CONSENT_VERSION) &&
+      versionIsCurrent(consent.ai_data_sharing_accepted_version, PRIVACY_CONSENT_VERSION),
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
-    analyticsCurrent: consent.share_analytics_accepted_version === ANALYTICS_CONSENT_VERSION,
-    diagnosticsCurrent: consent.share_diagnostics_accepted_version === DIAGNOSTICS_CONSENT_VERSION,
+    analyticsCurrent: versionIsCurrent(
+      consent.share_analytics_accepted_version,
+      ANALYTICS_CONSENT_VERSION,
+    ),
+    diagnosticsCurrent: versionIsCurrent(
+      consent.share_diagnostics_accepted_version,
+      DIAGNOSTICS_CONSENT_VERSION,
+    ),
     hasServerRecord,
   };
 }

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -32,11 +32,9 @@ import { setDiagnosticsReportingGate } from "@/lib/consent/diagnostics-consent";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
-// Consent versions MUST stay zero-padded ISO dates (YYYY-MM-DD) so currency is
-// decided by a monotonic comparison (`resolveServerConsent` uses `>=`): an
-// accepted version at or newer than this build's constant counts as current. A
-// non-sortable scheme would break that and reintroduce the cross-client
-// re-consent loop.
+// Consent versions must be zero-padded ISO dates (YYYY-MM-DD): currency is a
+// monotonic comparison (`resolveServerConsent` uses `>=`), which requires a
+// lexicographically sortable, chronological format.
 export const TOS_CONSENT_VERSION = "2026-06-08";
 export const PRIVACY_CONSENT_VERSION = "2026-06-22";
 
@@ -171,18 +169,10 @@ export function clearConsentForUser(userId: string | null): void {
 
 /**
  * Whether a server-recorded `accepted` version satisfies the `required` build
- * version. Compares monotonically (`>=`) rather than for exact equality so a
- * client never treats a version NEWER than its own build constant as stale.
- *
- * All clients share one server consent record but bake the "current" version
- * into each build (the macOS app embeds a packaged web build; native iOS
- * renders the same web screen), so builds drift. With exact equality a lagging
- * build calls a newer client's acceptance stale, re-prompts, and writes its own
- * older version back — a last-writer-wins downgrade that ping-pongs re-consent
- * between clients. `>=` closes that loop: a lagging build accepts a newer
- * version as current. Versions are zero-padded ISO dates, so the lexicographic
- * comparison is chronological; `""` (never accepted) sorts below any real
- * version and stays stale.
+ * version. Monotonic (`>=`): a version at or newer than the build's constant is
+ * current, so a build never treats a newer client's acceptance as stale. `""`
+ * (never accepted) sorts below any real version and stays stale. Relies on the
+ * ISO-date version format (see the version constants above).
  */
 function versionIsCurrent(accepted: string, required: string): boolean {
   return accepted >= required;


### PR DESCRIPTION
## Summary
- Replace the exact-equality (`===`) checks in `resolveServerConsent` with a monotonic `versionIsCurrent(accepted, required)` helper (`accepted >= required`) for ToS, privacy (both privacy-policy and AI-data-sharing artifacts), analytics, and diagnostics. A server-recorded version at or newer than this build's constant now counts as current; `""` (never accepted) still sorts below any real version and stays stale.
- This stops the repeated re-consent loop: all clients share one server consent record but bake "current" into each build (the macOS app embeds a packaged web build; native iOS renders the same web screen). Under exact equality a lagging build treated a newer client's acceptance as stale, re-prompted, and wrote its own older version back — a last-writer-wins downgrade that ping-ponged between clients. Monotonic comparison closes the loop: a lagging build accepts a newer version as current, so it neither re-prompts nor downgrades.
- Document the ISO-date (`YYYY-MM-DD`) invariant the comparison depends on, and add skew regression tests (newer-than-build resolves current; older/empty resolve stale; privacy still requires BOTH artifacts current).

## Original prompt
Users reported being repeatedly re-prompted to accept "Updated terms" even after accepting (multiple reports after PR #35721 bumped the privacy consent version to 2026-06-22). Investigation confirmed the platform persists and round-trips the consent record correctly — the bug is that consent *currency* is decided client-side by exact-match against a version constant compiled into each build, while all clients share one server record with last-writer-wins, so a lagging client (e.g. an older packaged desktop build) downgrades the record and ping-pongs re-consent. This PR is the client-side half of a two-repo fix: make the comparison monotonic so a client never treats a newer accepted version as stale. The server-authoritative half (reject downgrade writes on PUT /v1/user/consent/) is tracked separately for the vellum-assistant-platform repo.