### PR TITLE
feat(onboarding): chip plugin-backed research suggestions

### DIFF
--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -25,7 +25,11 @@ import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
-import type { ResearchFact, ResearchSuggestion } from "@/utils/research-facts";
+import {
+  pluginDisplayName,
+  type ResearchFact,
+  type ResearchSuggestion,
+} from "@/utils/research-facts";
 
 function useViewportSize() {
   const [size, setSize] = useState(() => ({
@@ -404,7 +408,22 @@ export function SuggestionsStep({
               }}
             >
               <Sparkles className="h-4 w-4 shrink-0" style={{ color: tone.fgMuted }} />
-              <span>{s.suggestion}</span>
+              <div className="flex flex-col items-start gap-2">
+                <span>{s.suggestion}</span>
+                {s.plugin && (
+                  <span
+                    className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium leading-none"
+                    style={{
+                      backgroundColor: tone.isLight
+                        ? "rgba(0,0,0,0.08)"
+                        : "rgba(255,255,255,0.16)",
+                      color: tone.fgMuted,
+                    }}
+                  >
+                    {pluginDisplayName(s.plugin)}
+                  </span>
+                )}
+              </div>
             </motion.button>
           ))}
         </div>

--- a/clients/web/src/utils/research-facts.test.ts
+++ b/clients/web/src/utils/research-facts.test.ts
@@ -10,7 +10,10 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parseResearchResultStreaming } from "@/utils/research-facts";
+import {
+  parseResearchResultStreaming,
+  pluginDisplayName,
+} from "@/utils/research-facts";
 
 describe("parseResearchResultStreaming — plugin tagging", () => {
   test("parses the optional plugin field on a suggestion", () => {
@@ -71,5 +74,25 @@ describe("parseResearchResultStreaming — plugin tagging", () => {
 
     expect(suggestions).toHaveLength(1);
     expect(suggestions[0]?.plugin).toBe("marketing-expert");
+  });
+});
+
+describe("pluginDisplayName", () => {
+  test("title-cases a hyphenated install name", () => {
+    expect(pluginDisplayName("marketing-expert")).toBe("Marketing Expert");
+  });
+
+  test("handles underscores and extra whitespace", () => {
+    expect(pluginDisplayName("admin_copilot")).toBe("Admin Copilot");
+    expect(pluginDisplayName("  growth   coach ")).toBe("Growth Coach");
+  });
+
+  test("leaves a single word capitalized", () => {
+    expect(pluginDisplayName("recruiter")).toBe("Recruiter");
+  });
+
+  test("returns an empty string for blank input", () => {
+    expect(pluginDisplayName("   ")).toBe("");
+    expect(pluginDisplayName("")).toBe("");
   });
 });

--- a/clients/web/src/utils/research-facts.ts
+++ b/clients/web/src/utils/research-facts.ts
@@ -216,6 +216,20 @@ export function parseResearchResultStreaming(text: string): ResearchResult {
   return { claims, suggestions };
 }
 
+/**
+ * Prettify a marketplace plugin install name into a human display label for the
+ * suggestion-card chip — `"marketing-expert"` → `"Marketing Expert"`. Splits on
+ * hyphens/underscores/whitespace and title-cases each word. Returns an empty
+ * string for a blank/whitespace input so callers can skip rendering the chip.
+ */
+export function pluginDisplayName(plugin: string): string {
+  return plugin
+    .split(/[-_\s]+/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 interface ConfidenceBadge {
   label: string;
   tone: "positive" | "warning" | "neutral";


### PR DESCRIPTION
## What

Surfaces a prettified plugin name as a chip on each research-onboarding suggestion card when the suggestion is backed by a marketplace plugin (e.g. `marketing-expert` → "Marketing Expert"). This is the badge follow-up deferred from #35756 (the foundational data layer).

The data already flows: `suggestion.plugin` is parsed in `utils/research-facts.ts` and reaches `SuggestionsStep` via the rendered `items`. This PR is the presentational layer — Phase 1, a prettified-name chip. A richer catalog-driven badge (display-name + icon) is a possible Phase 2.

## Changes

- **`utils/research-facts.ts`** — new pure `pluginDisplayName()` helper: splits on hyphens/underscores/whitespace, title-cases each word, returns `""` for blank input.
- **`screens/research-result-steps.tsx`** — `SuggestionsStep` renders a tone-aware rounded chip below the suggestion text when `s.plugin` is set.
- **`utils/research-facts.test.ts`** — unit coverage for `pluginDisplayName` (hyphens, underscores, whitespace, single-word, blank).

## Checks

`bun test` (8 pass) · `bun run typecheck` · `bunx eslint` · `bun run audit:cross-domain:check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)