### PR TITLE
Regenerate OpenAPI spec for LLM call error field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8380,6 +8380,36 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        error:
+                          anyOf:
+                            - type: object
+                              properties:
+                                name:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                message:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                code:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                provider:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                statusCode:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                retryAfterMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                              additionalProperties: false
+                            - type: "null"
                       required:
                         - id
                         - createdAt
@@ -15280,6 +15310,36 @@ paths:
                     anyOf:
                       - type: string
                       - type: "null"
+                  error:
+                    anyOf:
+                      - type: object
+                        properties:
+                          name:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          message:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          code:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          provider:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          statusCode:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          retryAfterMs:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        additionalProperties: false
+                      - type: "null"
                 required:
                   - id
                   - createdAt
@@ -17706,6 +17766,36 @@ paths:
                         callSite:
                           anyOf:
                             - type: string
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: object
+                              properties:
+                                name:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                message:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                code:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                provider:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                statusCode:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                retryAfterMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                              additionalProperties: false
                             - type: "null"
                       required:
                         - id


### PR DESCRIPTION
## Why

PR #35765 ("Surface failed LLM calls in the context inspector") added the structured `error` field to the LLM request log entry response schema, but didn't regenerate the committed `assistant/openapi.yaml`. The `generate:openapi -- --check` CI gate (`pr-assistant.yaml` → `openapi-check`) therefore fails on `main`.

## What

Regenerate `assistant/openapi.yaml` so it includes the `error` object (`name`, `message`, `code`, `provider`, `statusCode`, `retryAfterMs`) on the llm-context response schemas. No code changes — spec only.

Verified locally with `bun run generate:openapi -- --check` → `openapi.yaml is up to date.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdEZbfPDaEiMMWcLF7kDay

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdEZbfPDaEiMMWcLF7kDay)_