### PR TITLE
feat(assistant): destination-resolver resolves guardian delivery from the gateway

### DIFF
--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -24,6 +24,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => null,
+}));
+
 // Mock destination-resolver to return a destination for every requested channel.
 // External channels (telegram, slack) include bindingContext.
 mock.module("../notifications/destination-resolver.js", () => ({

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -20,6 +20,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => null,
+}));
+
 // Mock destination-resolver for broadcaster tests
 mock.module("../notifications/destination-resolver.js", () => ({
   resolveDestinations: (channels: string[]) => {

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -27,6 +27,10 @@ mock.module("../copy-composer.js", () => ({
   composeFallbackCopy: () => composeFallbackReturn,
 }));
 
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => null,
+}));
+
 mock.module("../destination-resolver.js", () => ({
   resolveDestinations: (channels: string[]) => {
     const map = new Map<string, ChannelDestination>();

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -27,18 +27,22 @@ mock.module("../copy-composer.js", () => ({
   composeFallbackCopy: () => composeFallbackReturn,
 }));
 
+// Stub only getGuardianDelivery; keep the real selectors so this mock is
+// harmless if it leaks into destination-resolver.test.ts under a shared run.
+const realGuardianReader = await import(
+  "../../contacts/guardian-delivery-reader.js"
+);
 mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  ...realGuardianReader,
   getGuardianDelivery: async () => null,
 }));
 
-mock.module("../destination-resolver.js", () => ({
-  resolveDestinations: (channels: string[]) => {
-    const map = new Map<string, ChannelDestination>();
-    for (const ch of channels) {
-      map.set(ch, { channel: ch as ChannelDestination["channel"] });
-    }
-    return map;
-  },
+// Use the real destination-resolver (DB-free via the local-read stub below)
+// so this mock does not leak into destination-resolver.test.ts under a shared
+// bun-test invocation. With no guardian, the resolver still yields a vellum
+// destination, which is all these tests exercise.
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => null,
 }));
 
 mock.module("../conversation-pairing.js", () => ({

--- a/assistant/src/notifications/__tests__/destination-resolver.test.ts
+++ b/assistant/src/notifications/__tests__/destination-resolver.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Verifies resolveDestinations resolves guardian delivery endpoints from the
+ * gateway-provided guardian list, with shapes identical to the local read, and
+ * falls back to the local contacts read when the list is null.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Local fallback read; mocked so the null-list path is deterministic.
+let localGuardian:
+  | { contact: { principalId?: string }; channel: { address: string; externalChatId?: string } }
+  | null = null;
+
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (_channelType: string) => localGuardian,
+}));
+
+const { resolveDestinations } = await import("../destination-resolver.js");
+
+function guardian(
+  overrides: Partial<GuardianDelivery> & Pick<GuardianDelivery, "channelType" | "address">,
+): GuardianDelivery {
+  return {
+    contactId: "contact-1",
+    status: "active",
+    ...overrides,
+  } as GuardianDelivery;
+}
+
+describe("resolveDestinations — gateway guardian list", () => {
+  beforeEach(() => {
+    localGuardian = null;
+  });
+
+  test("vellum carries guardianPrincipalId from the gateway list", () => {
+    const list = [
+      guardian({ channelType: "vellum", address: "user@example.com", principalId: "prin-1" }),
+    ];
+    const result = resolveDestinations(["vellum"], list);
+    expect(result.get("vellum")).toEqual({
+      channel: "vellum",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+
+  test("platform carries guardianPrincipalId from the vellum guardian", () => {
+    const list = [
+      guardian({ channelType: "vellum", address: "user@example.com", principalId: "prin-1" }),
+    ];
+    const result = resolveDestinations(["platform"], list);
+    expect(result.get("platform")).toEqual({
+      channel: "platform",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+
+  test("telegram resolves endpoint and binding context", () => {
+    const list = [
+      guardian({
+        channelType: "telegram",
+        address: "tg-user",
+        externalChatId: "12345",
+      }),
+    ];
+    const result = resolveDestinations(["telegram"], list);
+    expect(result.get("telegram")).toEqual({
+      channel: "telegram",
+      endpoint: "12345",
+      metadata: { externalUserId: "tg-user" },
+      bindingContext: {
+        sourceChannel: "telegram",
+        externalChatId: "12345",
+        externalUserId: "tg-user",
+      },
+    });
+  });
+
+  test("telegram without externalChatId is omitted", () => {
+    const list = [guardian({ channelType: "telegram", address: "tg-user" })];
+    const result = resolveDestinations(["telegram"], list);
+    expect(result.has("telegram")).toBe(false);
+  });
+
+  test("slack resolves DM endpoint and binding context", () => {
+    const list = [
+      guardian({
+        channelType: "slack",
+        address: "slack-user",
+        externalChatId: "D123",
+      }),
+    ];
+    const result = resolveDestinations(["slack"], list);
+    expect(result.get("slack")).toEqual({
+      channel: "slack",
+      endpoint: "D123",
+      metadata: { externalUserId: "slack-user" },
+      bindingContext: {
+        sourceChannel: "slack",
+        externalChatId: "D123",
+        externalUserId: "slack-user",
+      },
+    });
+  });
+
+  test("slack non-DM channel is dropped", () => {
+    const list = [
+      guardian({
+        channelType: "slack",
+        address: "slack-user",
+        externalChatId: "C123",
+      }),
+    ];
+    const result = resolveDestinations(["slack"], list);
+    expect(result.has("slack")).toBe(false);
+  });
+
+  test("inactive guardian is ignored", () => {
+    const list = [
+      guardian({
+        channelType: "telegram",
+        address: "tg-user",
+        externalChatId: "12345",
+        status: "revoked",
+      }),
+    ];
+    const result = resolveDestinations(["telegram"], list);
+    expect(result.has("telegram")).toBe(false);
+  });
+});
+
+describe("resolveDestinations — null list falls back to local read", () => {
+  beforeEach(() => {
+    localGuardian = null;
+  });
+
+  test("telegram resolves from the local contacts read", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "tg-user", externalChatId: "12345" },
+    };
+    const result = resolveDestinations(["telegram"], null);
+    expect(result.get("telegram")).toEqual({
+      channel: "telegram",
+      endpoint: "12345",
+      metadata: { externalUserId: "tg-user" },
+      bindingContext: {
+        sourceChannel: "telegram",
+        externalChatId: "12345",
+        externalUserId: "tg-user",
+      },
+    });
+  });
+
+  test("slack DM resolves from the local contacts read", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "slack-user", externalChatId: "D123" },
+    };
+    const result = resolveDestinations(["slack"], null);
+    expect(result.get("slack")).toEqual({
+      channel: "slack",
+      endpoint: "D123",
+      metadata: { externalUserId: "slack-user" },
+      bindingContext: {
+        sourceChannel: "slack",
+        externalChatId: "D123",
+        externalUserId: "slack-user",
+      },
+    });
+  });
+
+  test("vellum carries principalId from the local contacts read", () => {
+    localGuardian = {
+      contact: { principalId: "prin-1" },
+      channel: { address: "user@example.com" },
+    };
+    const result = resolveDestinations(["vellum"], null);
+    expect(result.get("vellum")).toEqual({
+      channel: "vellum",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+});

--- a/assistant/src/notifications/__tests__/destination-resolver.test.ts
+++ b/assistant/src/notifications/__tests__/destination-resolver.test.ts
@@ -190,3 +190,67 @@ describe("resolveDestinations — null list falls back to local read", () => {
     });
   });
 });
+
+describe("resolveDestinations — gateway yields no channel match falls back to local", () => {
+  beforeEach(() => {
+    localGuardian = null;
+  });
+
+  test("empty gateway list falls back to local telegram binding", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "tg-user", externalChatId: "12345" },
+    };
+    const result = resolveDestinations(["telegram"], []);
+    expect(result.get("telegram")).toEqual({
+      channel: "telegram",
+      endpoint: "12345",
+      metadata: { externalUserId: "tg-user" },
+      bindingContext: {
+        sourceChannel: "telegram",
+        externalChatId: "12345",
+        externalUserId: "tg-user",
+      },
+    });
+  });
+
+  test("gateway list missing the channel falls back to local slack DM", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "slack-user", externalChatId: "D123" },
+    };
+    // Gateway returns a telegram guardian but no slack entry.
+    const list = [
+      guardian({ channelType: "telegram", address: "tg", externalChatId: "999" }),
+    ];
+    const result = resolveDestinations(["slack"], list);
+    expect(result.get("slack")).toEqual({
+      channel: "slack",
+      endpoint: "D123",
+      metadata: { externalUserId: "slack-user" },
+      bindingContext: {
+        sourceChannel: "slack",
+        externalChatId: "D123",
+        externalUserId: "slack-user",
+      },
+    });
+  });
+
+  test("empty gateway list falls back to local vellum principalId", () => {
+    localGuardian = {
+      contact: { principalId: "prin-1" },
+      channel: { address: "user@example.com" },
+    };
+    const result = resolveDestinations(["vellum"], []);
+    expect(result.get("vellum")).toEqual({
+      channel: "vellum",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+
+  test("empty gateway list with no local binding omits telegram", () => {
+    localGuardian = null;
+    const result = resolveDestinations(["telegram"], []);
+    expect(result.has("telegram")).toBe(false);
+  });
+});

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -11,6 +11,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
 import { getConversation } from "../memory/conversation-crud.js";
 import type { ApprovalUIMetadata } from "../runtime/channel-approval-types.js";
 import { getLogger } from "../util/logger.js";
@@ -171,7 +172,13 @@ export class NotificationBroadcaster {
     decision: NotificationDecision,
     options?: BroadcastDecisionOptions,
   ): Promise<NotificationDeliveryResult[]> {
-    const destinations = resolveDestinations(decision.selectedChannels);
+    // Pull the guardian list once so the resolver stays pure. A null list
+    // (gateway unreachable) falls back to the local contacts read.
+    const guardians = await getGuardianDelivery();
+    const destinations = resolveDestinations(
+      decision.selectedChannels,
+      guardians,
+    );
 
     // Ensure vellum is processed first so the notification_conversation_created
     // event fires immediately, before slower channel sends (e.g. Telegram 30s

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -30,17 +30,20 @@ interface ResolvedGuardian {
 }
 
 /**
- * Resolve the guardian delivery endpoint for a channel from the gateway list
- * when available, falling back to the local contacts read when the list is
- * null (gateway unreachable). The local read is removed in Combo 11.
+ * Resolve the guardian delivery endpoint for a channel: gateway list first,
+ * else the local contacts read. The local read is the transitional
+ * dual-written mirror and covers a transient gateway failure (null list) or a
+ * gateway list missing this channel, so a soft-failed gateway read does not
+ * drop a binding the local store still holds. Removed in Combo 11.
  */
 function resolveGuardian(
   guardians: GuardianDelivery[] | null,
   channelType: string,
 ): ResolvedGuardian | undefined {
-  if (guardians) {
-    const g = guardianForChannel(guardians, channelType);
-    if (!g) return undefined;
+  const g = guardians
+    ? guardianForChannel(guardians, channelType)
+    : undefined;
+  if (g) {
     return {
       principalId: g.principalId ?? undefined,
       address: g.address,
@@ -64,8 +67,9 @@ function resolveGuardian(
  * Returns a map keyed by `NotificationChannel`. Channels that cannot be
  * resolved (e.g. no Telegram binding configured) are omitted from the result.
  *
- * `guardians` is the gateway-resolved guardian list; pass `null` to fall back
- * to the local contacts read for this release.
+ * `guardians` is the gateway-resolved guardian list; per channel, a missing
+ * match (null list or no entry for the channel) falls back to the local
+ * contacts read for this release.
  */
 export function resolveDestinations(
   channels: readonly (ChannelId | NotificationChannel)[],

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -1,7 +1,7 @@
 /**
  * Resolves per-channel destination endpoints for notification delivery.
  *
- * Reads guardian delivery info from the contacts table.
+ * Reads guardian delivery info from the gateway-backed guardian list.
  *
  * - Vellum: no external endpoint needed — delivery goes through the event
  *   broadcast mechanism to connected desktop/mobile clients. The
@@ -11,13 +11,50 @@
  *   sourced from the guardian contact's channel record.
  */
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
 import { isNotificationDeliverable } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import { guardianForChannel } from "../contacts/guardian-delivery-reader.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDestination, NotificationChannel } from "./types.js";
 
 const log = getLogger("destination-resolver");
+
+/** Guardian delivery endpoint for a channel, flattened from either source. */
+interface ResolvedGuardian {
+  principalId?: string;
+  address: string;
+  externalChatId?: string;
+}
+
+/**
+ * Resolve the guardian delivery endpoint for a channel from the gateway list
+ * when available, falling back to the local contacts read when the list is
+ * null (gateway unreachable). The local read is removed in Combo 11.
+ */
+function resolveGuardian(
+  guardians: GuardianDelivery[] | null,
+  channelType: string,
+): ResolvedGuardian | undefined {
+  if (guardians) {
+    const g = guardianForChannel(guardians, channelType);
+    if (!g) return undefined;
+    return {
+      principalId: g.principalId ?? undefined,
+      address: g.address,
+      externalChatId: g.externalChatId ?? undefined,
+    };
+  }
+  const local = findGuardianForChannel(channelType);
+  if (!local) return undefined;
+  return {
+    principalId: local.contact.principalId ?? undefined,
+    address: local.channel.address,
+    externalChatId: local.channel.externalChatId ?? undefined,
+  };
+}
 
 /**
  * Resolve destination information for each requested channel.
@@ -26,9 +63,13 @@ const log = getLogger("destination-resolver");
  * the function skips non-deliverable channels via `isNotificationDeliverable`.
  * Returns a map keyed by `NotificationChannel`. Channels that cannot be
  * resolved (e.g. no Telegram binding configured) are omitted from the result.
+ *
+ * `guardians` is the gateway-resolved guardian list; pass `null` to fall back
+ * to the local contacts read for this release.
  */
 export function resolveDestinations(
   channels: readonly (ChannelId | NotificationChannel)[],
+  guardians: GuardianDelivery[] | null,
 ): Map<NotificationChannel, ChannelDestination> {
   const result = new Map<NotificationChannel, ChannelDestination>();
 
@@ -43,10 +84,10 @@ export function resolveDestinations(
         // Vellum delivery is local — no external endpoint required.
         // Include the guardianPrincipalId so the adapter can annotate
         // guardian-sensitive notifications for scoped delivery.
-        const guardianResult = findGuardianForChannel("vellum");
+        const guardian = resolveGuardian(guardians, "vellum");
         const metadata: Record<string, unknown> = {};
-        if (guardianResult) {
-          metadata.guardianPrincipalId = guardianResult.contact.principalId;
+        if (guardian?.principalId) {
+          metadata.guardianPrincipalId = guardian.principalId;
         }
         result.set("vellum", {
           channel: "vellum",
@@ -55,7 +96,7 @@ export function resolveDestinations(
         log.debug(
           {
             channel: "vellum",
-            source: "contacts",
+            source: "guardian-delivery",
             hasEndpoint: false,
           },
           "destination resolved",
@@ -63,52 +104,52 @@ export function resolveDestinations(
         break;
       }
       case "telegram": {
-        const guardianResult = findGuardianForChannel(channel);
-        if (guardianResult && guardianResult.channel.externalChatId) {
-          const externalChatId = guardianResult.channel.externalChatId;
+        const guardian = resolveGuardian(guardians, channel);
+        if (guardian?.externalChatId) {
+          const externalChatId = guardian.externalChatId;
           result.set(channel as NotificationChannel, {
             channel: channel as NotificationChannel,
             endpoint: externalChatId,
             metadata: {
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
             bindingContext: {
               sourceChannel: channel as NotificationChannel,
               externalChatId,
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
           });
         }
         log.debug(
           {
             channel,
-            source: "contacts",
-            hasEndpoint: !!guardianResult?.channel.externalChatId,
+            source: "guardian-delivery",
+            hasEndpoint: !!guardian?.externalChatId,
           },
           "destination resolved",
         );
         break;
       }
       case "slack": {
-        const guardianResult = findGuardianForChannel("slack");
-        const chatId = guardianResult?.channel.externalChatId;
+        const guardian = resolveGuardian(guardians, "slack");
+        const chatId = guardian?.externalChatId;
         // Slack bindings can originate from app_mention in shared channels.
         // Only route notifications to DM channels (IDs starting with "D")
         // to prevent leaking notifications into shared workspaces.
-        if (guardianResult && chatId && isSlackDmChannel(chatId)) {
+        if (guardian && chatId && isSlackDmChannel(chatId)) {
           result.set("slack", {
             channel: "slack",
             endpoint: chatId,
             metadata: {
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
             bindingContext: {
               sourceChannel: "slack",
               externalChatId: chatId,
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
           });
-        } else if (guardianResult && chatId) {
+        } else if (guardian && chatId) {
           log.warn(
             { channel: "slack", chatId },
             "skipping non-DM Slack channel for notification delivery",
@@ -117,7 +158,7 @@ export function resolveDestinations(
         log.debug(
           {
             channel: "slack",
-            source: "contacts",
+            source: "guardian-delivery",
             hasEndpoint: !!(chatId && isSlackDmChannel(chatId)),
           },
           "destination resolved",
@@ -128,11 +169,10 @@ export function resolveDestinations(
         // Platform delivery goes through the daemon's VellumPlatformClient —
         // no external binding needed. Include guardianPrincipalId so the
         // adapter can scope guardian-sensitive notifications.
-        const platformGuardian = findGuardianForChannel("vellum");
+        const platformGuardian = resolveGuardian(guardians, "vellum");
         const platformMeta: Record<string, unknown> = {};
-        if (platformGuardian) {
-          platformMeta.guardianPrincipalId =
-            platformGuardian.contact.principalId;
+        if (platformGuardian?.principalId) {
+          platformMeta.guardianPrincipalId = platformGuardian.principalId;
         }
         result.set("platform", {
           channel: "platform",
@@ -140,7 +180,7 @@ export function resolveDestinations(
             Object.keys(platformMeta).length > 0 ? platformMeta : undefined,
         });
         log.debug(
-          { channel: "platform", source: "contacts", hasEndpoint: false },
+          { channel: "platform", source: "guardian-delivery", hasEndpoint: false },
           "destination resolved",
         );
         break;


### PR DESCRIPTION
## Summary
- destination-resolver resolves guardian delivery endpoints from getGuardianDelivery() instead of findGuardianForChannel; slack DM guard preserved; local fallback on a null list.

Part of plan: gateway-guardian-binding-pull.md (PR 4 of 10)