### PR TITLE
feat(onboarding): three-line together step + consistent step layout

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -151,12 +151,12 @@ export function OnboardingTonedBackdrop({
                   marginLeft: i === 0 ? 0 : -size * 0.34,
                   zIndex: TOP_TEAM.length - i,
                 }}
-                initial={reduce ? false : { y: -36, opacity: 0 }}
+                initial={reduce ? false : { y: -140, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={
                   reduce
                     ? { duration: 0 }
-                    : { type: "spring", stiffness: 300, damping: 18, delay: i * 0.1 }
+                    : { type: "spring", stiffness: 200, damping: 18, delay: i * 0.1 }
                 }
               >
                 <AnimatedAvatar

--- a/clients/web/src/domains/onboarding/onboarding-step-layout.ts
+++ b/clients/web/src/domains/onboarding/onboarding-step-layout.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared centered content container for the onboarding step screens.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Keeps the heading + Continue at a consistent height and spacing across every
+ * step. Width is left to each step (append a `max-w-*`), since the copy differs.
+ */
+export const ONBOARDING_STEP_CONTENT =
+  "absolute left-1/2 top-[30%] z-10 flex w-full -translate-x-1/2 flex-col items-center gap-8 px-6 text-center";

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -17,7 +17,7 @@
  * then clicks "Continue" to drop into the full workspace on the same conversation.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -94,22 +94,28 @@ export function ResearchOnboardingRoute() {
   // (any Continue/Skip) clears it, browser-style.
   const [forwardStack, setForwardStack] = useState<ResearchStep[]>([]);
 
+  // Re-entering "together" replays its sequence, so the team should drop in
+  // again on the third line — hide it on the way in.
+  function navTo(next: ResearchStep) {
+    if (next === "together") setTeamRevealed(false);
+    setStep(next);
+  }
   // Forward (Continue/Skip): a fresh forward move invalidates the redo stack.
   function goForwardTo(next: ResearchStep) {
     setForwardStack([]);
-    setStep(next);
+    navTo(next);
   }
   // Back: remember where we were so the forward chevron can return there.
   function goBackTo(prev: ResearchStep) {
     setForwardStack((s) => [...s, step]);
-    setStep(prev);
+    navTo(prev);
   }
   // Redo: pop the most-recently-backed-from step.
   function goForward() {
     const next = forwardStack[forwardStack.length - 1];
     if (!next) return;
     setForwardStack((s) => s.slice(0, -1));
-    setStep(next);
+    navTo(next);
   }
   // Passed to the step screens' header; undefined hides the forward chevron.
   const onForward = forwardStack.length > 0 ? goForward : undefined;
@@ -122,6 +128,10 @@ export function ResearchOnboardingRoute() {
   // Extra edge characters revealed so far — grows as the looking-you-up
   // carousel advances, then stays for the results/suggestions steps.
   const [edgeAvatars, setEdgeAvatars] = useState(0);
+  // The top-right team is revealed on the "together" step's third line, then
+  // persists for the rest of the flow.
+  const [teamRevealed, setTeamRevealed] = useState(false);
+  const revealTeam = useCallback(() => setTeamRevealed(true), []);
 
   // Provision the assistant in the background the moment the user lands here,
   // so it's (usually) healthy by the time they finish the intro/pitch steps —
@@ -297,8 +307,15 @@ export function ResearchOnboardingRoute() {
           showBottomEyes={
             !postCalendar && step !== "different" && step !== "together"
           }
-          // The team forms on "together" and rides along for the rest of the flow.
-          showTopTeam={step !== "different"}
+          // On "together" the team is gated on the third-line reveal (so it
+          // replays on back); on every later step it's simply present.
+          showTopTeam={
+            step === "together"
+              ? teamRevealed
+              : ["integration", "letschat", "meeting", "looking", "results", "suggestions"].includes(
+                  step,
+                )
+          }
         />
         {step === "different" && (
           <PitchDifferentStep
@@ -312,6 +329,7 @@ export function ResearchOnboardingRoute() {
             onContinue={() => goForwardTo("integration")}
             onBack={() => goBackTo("different")}
             onForward={onForward}
+            onRevealTeam={revealTeam}
           />
         )}
         {step === "integration" && (

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -13,7 +13,7 @@
  *   - PitchTogetherStep   a team forms; the eyes act out "smarter" and "faster"
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import {
   animate,
@@ -23,12 +23,17 @@ import {
   useTransform,
 } from "motion/react";
 
+import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import {
   MotionEyes,
   useOnboardingEyes,
 } from "@/domains/onboarding/components/onboarding-motion-eyes";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import { pickOverlayColors } from "@/domains/onboarding/onboarding-avatar-colors";
+import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 const SETUP_LINE = "You’ve used AI that just answers questions";
 const PUNCH_LINE = "I’m different";
@@ -161,7 +166,7 @@ export function PitchDifferentStep({
         />
       )}
 
-      <div className="absolute left-1/2 top-[32%] z-10 flex w-full max-w-3xl -translate-x-1/2 flex-col items-center gap-10 px-6 text-center">
+      <div className={`${ONBOARDING_STEP_CONTENT} max-w-3xl`}>
         <h1
           className="text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.15]"
           style={{ fontFamily: "var(--font-serif)" }}
@@ -174,9 +179,9 @@ export function PitchDifferentStep({
           >
             {SETUP_LINE}
           </motion.span>
-          {/* Payoff — the full-strength foreground, with extra space above it. */}
+          {/* Payoff — the full-strength foreground. */}
           <motion.span
-            className="mt-8 block"
+            className="block"
             style={{ color: tone.fg, clipPath: clip2 }}
           >
             {PUNCH_LINE}
@@ -202,51 +207,77 @@ export function PitchDifferentStep({
   );
 }
 
-const TOGETHER_HEADING = "The more we work together";
+const HELP_LINE = "The more I help";
 const SMARTER_LINE = "The smarter I get";
-const FASTER_LINE = "The faster I can take things off your plate";
+const LESS_LINE = "The less you have to do";
 
 /**
- * The payoff: the relationship compounds. The heading lands and a little team of
- * avatars forms beneath it (and stays). Then the eyes act out each benefit — they
- * swell to "get smarter", then dash side to side to show how "fast" things move.
+ * The payoff: three benefits, each with its own beat —
+ *   - "The more I help"        a helper peeks down from the top-left, then back
+ *   - "The smarter I get"      the eyes swell to get smarter, then settle
+ *   - "The less you have to do" the team drops in from the top-right (and stays)
  */
 export function PitchTogetherStep({
   onContinue,
   onBack,
   onForward,
+  onRevealTeam,
 }: {
   onContinue: () => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /** Reveal the persistent top-right team (fires on the third line). */
+  onRevealTeam: () => void;
 }) {
   const tone = useOnboardingTone();
   const reduce = useReducedMotion();
+  const components = useBundledAvatarComponents();
+  const characters = useOnboardingAvatarPoolStore.use.characters();
+  const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
+  const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
   const { art, eyesW, eyesH, restCy, centerX, w, h } = useOnboardingEyes();
+
+  // A lone helper that peeks down from the top-left on the first line.
+  const helperColor = useMemo(() => {
+    if (!components || !chosen) return "orange";
+    return (
+      pickOverlayColors(chosen.color, components.colors.map((c) => c.id), 1)[0] ??
+      "orange"
+    );
+  }, [components, chosen]);
+  const helperSize = Math.min(220, Math.max(150, w * 0.16));
+  const helperHidden = -helperSize; // fully above the top edge
+  const helperPeek = -helperSize * 0.4; // ~40% cut off, peeking down
 
   const eyeCy = useMotionValue(0);
   const eyeScale = useMotionValue(1);
-  const eyeX = useMotionValue(0);
+  const helperY = useMotionValue(-220);
 
   const [ready, setReady] = useState(false);
   const [blinking, setBlinking] = useState(false);
-  const [showSmarter, setShowSmarter] = useState(reduce);
-  const [showFaster, setShowFaster] = useState(reduce);
+  const [show1, setShow1] = useState(reduce);
+  const [show2, setShow2] = useState(reduce);
+  const [show3, setShow3] = useState(reduce);
   const [landed, setLanded] = useState(reduce);
 
-  // Park the eyes at rest (and short-circuit for reduced motion).
+  // Park the eyes at rest.
   useEffect(() => {
     eyeCy.set(restCy);
     setReady(true);
   }, [restCy, eyeCy]);
+
+  // Reduced motion: show the team straight away.
+  useEffect(() => {
+    if (reduce) onRevealTeam();
+  }, [reduce, onRevealTeam]);
 
   useEffect(() => {
     if (reduce || !art) return;
 
     eyeCy.set(restCy);
     eyeScale.set(1);
-    eyeX.set(0);
+    helperY.set(helperHidden);
 
     const controls: ReturnType<typeof animate>[] = [];
     const timeouts: ReturnType<typeof setTimeout>[] = [];
@@ -265,17 +296,25 @@ export function PitchTogetherStep({
       if (!cancelled) setBlinking(false);
     };
 
-    // A subtle side-to-side dart (kept small — was too much before).
-    const dash = Math.min(42, w * 0.026);
-
     const run = async () => {
-      // Let the heading + team settle in (briefly).
-      await wait(550);
+      await wait(450);
       if (cancelled) return;
 
-      // "The smarter I get" — the eyes swell up a bit to get smarter, then ease
-      // back down.
-      setShowSmarter(true);
+      // "The more I help" — a helper peeks down from the top-left, then retracts.
+      setShow1(true);
+      await track(
+        animate(helperY, [helperHidden, helperPeek, helperPeek, helperHidden], {
+          duration: 1.5,
+          times: [0, 0.28, 0.62, 1],
+          ease: "easeInOut",
+        }),
+      );
+      if (cancelled) return;
+      await wait(120);
+      if (cancelled) return;
+
+      // "The smarter I get" — the eyes swell, then ease back down.
+      setShow2(true);
       await wait(60);
       if (cancelled) return;
       await track(
@@ -288,19 +327,10 @@ export function PitchTogetherStep({
       await wait(160);
       if (cancelled) return;
 
-      // "The faster..." — a quick, subtle side-to-side dart to show speed.
-      setShowFaster(true);
-      await wait(60);
-      if (cancelled) return;
-      await track(
-        animate(eyeX, [0, dash, -dash, 0], {
-          duration: 0.42,
-          ease: "easeInOut",
-          times: [0, 0.33, 0.66, 1],
-        }),
-      );
-      if (cancelled) return;
-      await wait(120);
+      // "The less you have to do" — the team drops in from the top-right.
+      setShow3(true);
+      onRevealTeam();
+      await wait(700);
       if (cancelled) return;
       setLanded(true);
     };
@@ -311,13 +341,31 @@ export function PitchTogetherStep({
       controls.forEach((c) => c.stop());
       timeouts.forEach(clearTimeout);
     };
-  }, [reduce, art, w, h, restCy, eyeCy, eyeScale, eyeX]);
+  }, [
+    reduce,
+    art,
+    w,
+    h,
+    restCy,
+    eyeCy,
+    eyeScale,
+    helperY,
+    helperHidden,
+    helperPeek,
+    onRevealTeam,
+  ]);
+
+  const lineClass = "text-[clamp(1.85rem,3.8vw,2.9rem)] leading-snug";
+  const lineStyle = { fontFamily: "var(--font-serif)" } as const;
+  const lineTransition = reduce
+    ? { duration: 0 }
+    : { duration: 0.3, ease: "easeOut" as const };
 
   return (
     <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      {/* The assistant's eyes, peeking from the bottom — they act out each line. */}
+      {/* The assistant's eyes, peeking from the bottom — they swell on "smarter". */}
       {ready && art && (
         <MotionEyes
           art={art}
@@ -326,46 +374,62 @@ export function PitchTogetherStep({
           centerX={centerX}
           eyeCy={eyeCy}
           eyeScale={eyeScale}
-          eyeX={eyeX}
           blinking={blinking}
         />
       )}
 
-      <div className="absolute left-1/2 top-[30%] z-10 flex w-full max-w-4xl -translate-x-1/2 flex-col items-center gap-8 px-6 text-center">
-        {/* Drops down from the top with the team — teamwork carrying the line in. */}
-        <motion.h1
-          className="whitespace-nowrap text-[clamp(2.25rem,5.5vw,4.25rem)] leading-[1.1]"
-          style={{ fontFamily: "var(--font-serif)", color: tone.fgDeep }}
-          initial={reduce ? false : { opacity: 0, y: -Math.round(h * 0.26) }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={
-            reduce
-              ? { duration: 0 }
-              : { type: "spring", stiffness: 130, damping: 17, delay: 0.1 }
-          }
+      {/* The helper that peeks down from the top-left on the first line. */}
+      {ready && !reduce && components && (
+        <motion.div
+          aria-hidden="true"
+          className="pointer-events-none absolute z-[1]"
+          style={{
+            left: Math.max(16, w * 0.05),
+            top: 0,
+            y: helperY,
+            width: helperSize,
+            height: helperSize,
+          }}
         >
-          {TOGETHER_HEADING}
-        </motion.h1>
+          <AnimatedAvatar
+            components={components}
+            traits={{ bodyShape: "blob", eyeStyle: "goofy", color: helperColor }}
+            size={helperSize}
+            breathe={false}
+          />
+        </motion.div>
+      )}
 
-        {/* Two benefits, each acted out by the eyes as it appears. */}
+      <div className={`${ONBOARDING_STEP_CONTENT} max-w-3xl`}>
+        {/* Three benefits, each revealed with its own beat. */}
         <div className="flex flex-col gap-4">
           <motion.p
-            className="text-[clamp(1.75rem,3.4vw,2.75rem)] leading-snug"
-            style={{ fontFamily: "var(--font-serif)" }}
+            className={lineClass}
+            style={lineStyle}
             initial={reduce ? false : { opacity: 0, y: 10 }}
-            animate={showSmarter ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.3, ease: "easeOut" }}
+            animate={show1 ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+            transition={lineTransition}
+          >
+            {HELP_LINE}
+          </motion.p>
+          {/* Middle line in the darker secondary tone (matches other screens). */}
+          <motion.p
+            className={lineClass}
+            style={{ ...lineStyle, color: tone.fgDeep }}
+            initial={reduce ? false : { opacity: 0, y: 10 }}
+            animate={show2 ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+            transition={lineTransition}
           >
             {SMARTER_LINE}
           </motion.p>
           <motion.p
-            className="text-[clamp(1.75rem,3.4vw,2.75rem)] leading-snug"
-            style={{ fontFamily: "var(--font-serif)" }}
+            className={lineClass}
+            style={lineStyle}
             initial={reduce ? false : { opacity: 0, y: 10 }}
-            animate={showFaster ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.3, ease: "easeOut" }}
+            animate={show3 ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+            transition={lineTransition}
           >
-            {FASTER_LINE}
+            {LESS_LINE}
           </motion.p>
         </div>
 

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
+import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
 import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboarding-peeking-eyes";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
@@ -145,7 +146,7 @@ export function IntroductionScreen({
       </motion.div>
 
       {/* Greeting + Continue, grouped so the button sits just under the text. */}
-      <div className="absolute left-1/2 top-[30%] z-10 flex -translate-x-1/2 flex-col items-center gap-8">
+      <div className={ONBOARDING_STEP_CONTENT}>
         <motion.h1
           className="text-center leading-[1.05]"
           style={{ fontFamily: "var(--font-serif)" }}

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -6,7 +6,7 @@
  * SPIKE — research-onboarding flow.
  *
  * Foreground only (the toned backdrop sits behind, so the assistant color, its
- * eyes, and the tone characters carry over). "Add to Google Calendar" runs the
+ * eyes, and the tone characters carry over). "Setup check-in" runs the
  * real managed Google Calendar OAuth (calendar.events + identity scopes only)
  * via `useGoogleCalendarConnect`; on a successful grant the parent route fires
  * the Day-2 check-in prompt (`scheduleCheckin`) and advances. "Skip for now"
@@ -64,10 +64,10 @@ export function LetsChatTomorrowStep({
           I&rsquo;ll also check in with you
         </h1>
         <p className="text-[16px]" style={{ color: tone.fgMuted }}>
-          I&rsquo;ll add a quick check-in to your calendar to follow up tomorrow.
+          Add a quick check-in to your calendar to follow up tomorrow.
         </p>
 
-        <div className="mt-6 flex w-[234px] flex-col items-center gap-3">
+        <div className="mt-6 flex w-[234px] flex-col items-center">
           <button
             type="button"
             onClick={handleConnect}
@@ -84,20 +84,22 @@ export function LetsChatTomorrowStep({
                 Waiting for authorization…
               </>
             ) : (
-              "Add to Google Calendar"
+              "Set it up"
             )}
-          </button>
-          <button
-            type="button"
-            onClick={onSkip}
-            disabled={oauthInProgress}
-            className="text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
-            style={{ color: tone.fgMuted }}
-          >
-            Skip for now
           </button>
         </div>
       </div>
+
+      {/* Skip sits down near the bottom, just above the peeking eyes. */}
+      <button
+        type="button"
+        onClick={onSkip}
+        disabled={oauthInProgress}
+        className="absolute bottom-[26%] left-1/2 -translate-x-1/2 text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
+        style={{ color: tone.fgMuted }}
+      >
+        Skip for now
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up onboarding polish (after #35762).

### "Together" step → three animated benefit lines
Replaces the heading + two-line layout with three lines, each with its own beat:
- **"The more I help"** — a helper avatar peeks down from the **top-left**, then retracts.
- **"The smarter I get"** — the bottom eyes **swell** (middle line rendered in the darker secondary tone, matching the other screens).
- **"The less you have to do"** — the **team drops in from the top-right** and persists for the rest of the flow.

The top-right team is now gated on that third-line reveal, so it **replays when you step back** into "together"; on every later step it's simply present.

### Consistent step layout
- New shared `ONBOARDING_STEP_CONTENT` container so the **intro**, **different**, and **together** steps sit at a consistent height and spacing.
- Removed the extra `mt-8` above "I'm different" so its two lines match the intro's rhythm.

### "Let's chat tomorrow"
- Copy → "Add a quick check-in to your calendar to follow up tomorrow."
- CTA → "Set it up".
- "Skip for now" moved down to just above the peeking eyes.

## Test plan
- `bunx tsc --noEmit`, `eslint`, and `vite build` all pass.
- Visually iterated across intro → different → together → integration → let's-chat. Reduced-motion shows content statically and reveals the team immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)