### PR TITLE
feat(assistant): notification connectivity + recipient notes use gateway guardian binding

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -19,13 +19,12 @@ mock.module("../channels/config.js", () => ({
   getDeliverableChannels: () => ["vellum", "telegram"],
 }));
 
-mock.module("../contacts/contact-store.js", () => ({
-  findGuardianForChannel: (_channelType: string, _assistantId: string) => null,
+// Guardian connectivity is resolved from the gateway pull. No active guardian
+// binding ⇒ binding-based channels (telegram) are not reported connected.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [],
+  guardianForChannel: () => undefined,
 }));
-
-// Note: stale mock for channel-guardian-store.js removed — the barrel was
-// deleted and none of the functions it mocked (getActiveBinding) existed in
-// the barrel.
 
 mock.module("../notifications/adapters/macos.js", () => ({
   VellumAdapter: class {

--- a/assistant/src/__tests__/notification-decision-recipient-context.test.ts
+++ b/assistant/src/__tests__/notification-decision-recipient-context.test.ts
@@ -36,16 +36,35 @@ mock.module("../prompts/system-prompt.js", () => ({
   buildCoreIdentityContext: () => null,
 }));
 
-// ── Guardian contact mock ────────────────────────────────────────────
+// ── Guardian binding + contact notes mocks ───────────────────────────
 
-let mockGuardianResult: {
-  contact: { notes: string | null };
-  channels: Record<string, unknown>[];
-} | null = null;
+// Guardian binding (ACL) is resolved via the gateway pull; notes (INFO) are
+// joined locally by contactId. Tests drive both via mutable slots.
+let guardianDeliveryFixture: Array<{ contactId: string }> = [];
+let contactInfoFixture: Record<string, { notes: string | null } | null> = {};
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => guardianDeliveryFixture,
+  anyGuardian: (list: Array<{ contactId: string }>) => list[0],
+}));
 
 mock.module("../contacts/contact-store.js", () => ({
-  listGuardianChannels: () => mockGuardianResult,
+  findContactInfoById: (contactId: string) =>
+    contactInfoFixture[contactId] ?? null,
 }));
+
+const GUARDIAN_CONTACT_ID = "guardian-contact-1";
+
+/** Bind a guardian with the given notes (or no guardian when notes is null). */
+function setGuardian(notes: string | null | undefined): void {
+  if (notes === undefined) {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+    return;
+  }
+  guardianDeliveryFixture = [{ contactId: GUARDIAN_CONTACT_ID }];
+  contactInfoFixture = { [GUARDIAN_CONTACT_ID]: { notes } };
+}
 
 // ── Provider mock with system prompt capture ──────────────────────────
 
@@ -134,15 +153,12 @@ describe("recipient context in notification decision engine", () => {
   beforeEach(() => {
     configuredProvider = null;
     extractedToolUse = null;
-    mockGuardianResult = null;
+    setGuardian(undefined);
     capturedSystemPrompt = undefined;
   });
 
   test("guardian contact notes appear in system prompt as <recipient-context>", async () => {
-    mockGuardianResult = {
-      contact: { notes: "Prefers formal tone. Address as Dr. Smith." },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("Prefers formal tone. Address as Dr. Smith.");
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -157,7 +173,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context is omitted when no guardian exists", async () => {
-    mockGuardianResult = null;
+    setGuardian(undefined);
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -169,10 +185,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context is omitted when guardian notes are null", async () => {
-    mockGuardianResult = {
-      contact: { notes: null },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian(null);
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -184,10 +197,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context is omitted when guardian notes are empty string", async () => {
-    mockGuardianResult = {
-      contact: { notes: "" },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("");
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -199,10 +209,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("large guardian notes are truncated to prevent oversized prompts", async () => {
-    mockGuardianResult = {
-      contact: { notes: "N".repeat(3000) },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("N".repeat(3000));
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -226,10 +233,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("fallback path works correctly without recipient context", async () => {
-    mockGuardianResult = {
-      contact: { notes: "Prefers formal tone." },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("Prefers formal tone.");
     // null provider forces fallback path
     configuredProvider = null;
 
@@ -247,10 +251,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context appears after user-preferences in prompt", async () => {
-    mockGuardianResult = {
-      contact: { notes: "Prefers brief updates." },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("Prefers brief updates.");
     setupLLMProvider();
 
     const signal = makeSignal();

--- a/assistant/src/notifications/__tests__/connected-channels.test.ts
+++ b/assistant/src/notifications/__tests__/connected-channels.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for getConnectedChannels connectivity resolution.
+ *
+ * Connectivity must mirror destination-resolver's `resolveGuardian`:
+ * gateway-first, with a LOCAL contacts fallback only when the gateway list is
+ * null (unreachable). This keeps a channel from being marked connected when it
+ * can't be delivered (and vice-versa).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  truncateForLog: (value: string) => value,
+}));
+
+let deliverableChannels: string[] = [];
+let gatewayGuardians: GuardianDelivery[] | null = null;
+let localChatId: string | null = null;
+
+const realConfig = await import("../../channels/config.js");
+
+mock.module("../../channels/config.js", () => ({
+  ...realConfig,
+  getDeliverableChannels: () => deliverableChannels,
+}));
+
+const realReader = await import("../../contacts/guardian-delivery-reader.js");
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  ...realReader,
+  getGuardianDelivery: async () => gatewayGuardians,
+}));
+
+const realContactStore = await import("../../contacts/contact-store.js");
+
+mock.module("../../contacts/contact-store.js", () => ({
+  ...realContactStore,
+  findGuardianForChannel: (_channelType: string) =>
+    localChatId === null
+      ? null
+      : { contact: { principalId: "p1" }, channel: { externalChatId: localChatId } },
+}));
+
+const { getConnectedChannels } = await import("../emit-signal.js");
+
+function gatewayBinding(channelType: string, externalChatId: string): GuardianDelivery {
+  return { channelType, contactId: "c1", address: "addr", externalChatId, status: "active" };
+}
+
+beforeEach(() => {
+  deliverableChannels = [];
+  gatewayGuardians = null;
+  localChatId = null;
+});
+
+describe("getConnectedChannels gateway-first-then-local connectivity", () => {
+  test("marks telegram connected from a gateway-only binding", async () => {
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = [gatewayBinding("telegram", "123")];
+    localChatId = null;
+
+    expect(await getConnectedChannels()).toContain("telegram");
+  });
+
+  test("falls back to a local binding when the gateway is unreachable (null)", async () => {
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = null;
+    localChatId = "456";
+
+    expect(await getConnectedChannels()).toContain("telegram");
+  });
+
+  test("marks telegram disconnected when neither source has a binding", async () => {
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = null;
+    localChatId = null;
+
+    expect(await getConnectedChannels()).not.toContain("telegram");
+  });
+
+  test("does not fall back to local when the gateway responds without that channel", async () => {
+    // Gateway present but empty for telegram ⇒ gateway is authoritative, no
+    // per-channel local fallback (mirrors destination-resolver).
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = [];
+    localChatId = "789";
+
+    expect(await getConnectedChannels()).not.toContain("telegram");
+  });
+
+  test("only marks slack connected for D-prefixed (DM) chat IDs", async () => {
+    deliverableChannels = ["slack"];
+    gatewayGuardians = [gatewayBinding("slack", "C-public")];
+    expect(await getConnectedChannels()).not.toContain("slack");
+
+    gatewayGuardians = [gatewayBinding("slack", "D-dm")];
+    expect(await getConnectedChannels()).toContain("slack");
+  });
+
+  test("always reports vellum and platform connected", async () => {
+    deliverableChannels = ["vellum", "platform"];
+    gatewayGuardians = null;
+
+    const connected = await getConnectedChannels();
+    expect(connected).toContain("vellum");
+    expect(connected).toContain("platform");
+  });
+});

--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -34,19 +34,38 @@ mock.module("../../prompts/system-prompt.js", () => ({
   buildCoreIdentityContext: () => null,
 }));
 
-mock.module("../../contacts/contact-store.js", () => ({
-  listGuardianChannels: () => null,
+// Guardian binding (ACL) is resolved via the gateway pull; notes (INFO) are
+// joined locally by contactId. Tests drive both via mutable slots.
+let guardianDeliveryFixture: Array<{ contactId: string }> = [];
+let contactInfoFixture: Record<string, { notes: string | null } | null> = {};
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => guardianDeliveryFixture,
+  anyGuardian: (list: Array<{ contactId: string }>) => list[0],
 }));
 
-// Provider mock — if `getConfiguredProvider` is ever called by the
-// assistant_tool pass-through path, this throw makes the test fail
-// loudly instead of silently exercising the LLM path.
+mock.module("../../contacts/contact-store.js", () => ({
+  findContactInfoById: (contactId: string) =>
+    contactInfoFixture[contactId] ?? null,
+}));
+
+// Provider mock. By default `sendMessage` throws so the assistant_tool
+// pass-through path (which must skip the LLM) fails loudly if it reaches the
+// provider. LLM-path tests override `providerSendMessage` to capture inputs.
+let providerSendMessage: (
+  messages: unknown[],
+  opts: { systemPrompt?: string },
+) => Promise<unknown> = () => {
+  throw new Error(
+    "provider.sendMessage should NOT be invoked for assistant_tool pass-through",
+  );
+};
+
 mock.module("../../providers/provider-send-message.js", () => ({
-  getConfiguredProvider: async () => {
-    throw new Error(
-      "getConfiguredProvider should NOT be invoked for assistant_tool pass-through",
-    );
-  },
+  getConfiguredProvider: async () => ({
+    sendMessage: (messages: unknown[], opts: { systemPrompt?: string }) =>
+      providerSendMessage(messages, opts),
+  }),
   createTimeout: () => ({
     signal: new AbortController().signal,
     cleanup: () => {},
@@ -279,5 +298,55 @@ describe("assistant_tool pass-through in notification decision engine", () => {
 
     expect(decision.selectedChannels).toEqual(["vellum"]);
     expect(decision.renderedCopy.vellum?.body).toBe("fyi");
+  });
+});
+
+describe("recipient notes injection (ACL from gateway, notes joined locally)", () => {
+  function makeLlmSignal(): NotificationSignal {
+    return {
+      signalId: "sig-llm-notes-1",
+      createdAt: Date.now(),
+      sourceChannel: "scheduler",
+      sourceContextId: "schedule-1",
+      sourceEventName: "schedule.notify",
+      contextPayload: {},
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+    };
+  }
+
+  test("injects the guardian's local notes, resolved via the gateway contactId", async () => {
+    guardianDeliveryFixture = [{ contactId: "contact-42" }];
+    contactInfoFixture = { "contact-42": { notes: "Prefers terse updates." } };
+
+    let capturedSystemPrompt: string | undefined;
+    providerSendMessage = async (_messages, opts) => {
+      capturedSystemPrompt = opts.systemPrompt;
+      return {};
+    };
+
+    await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
+
+    expect(capturedSystemPrompt).toContain("<recipient-context>");
+    expect(capturedSystemPrompt).toContain("Prefers terse updates.");
+  });
+
+  test("omits recipient context when no guardian is bound", async () => {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+
+    let capturedSystemPrompt: string | undefined;
+    providerSendMessage = async (_messages, opts) => {
+      capturedSystemPrompt = opts.systemPrompt;
+      return {};
+    };
+
+    await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
+
+    expect(capturedSystemPrompt).not.toContain("<recipient-context>");
   });
 });

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -12,7 +12,11 @@
 import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
-import { listGuardianChannels } from "../contacts/contact-store.js";
+import { findContactInfoById } from "../contacts/contact-store.js";
+import {
+  anyGuardian,
+  getGuardianDelivery,
+} from "../contacts/guardian-delivery-reader.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
 import {
   createTimeout,
@@ -963,15 +967,19 @@ async function classifyWithLLM(
     ? truncate(rawIdentityContext, MAX_IDENTITY_CONTEXT_CHARS, "\n…[truncated]")
     : undefined;
 
-  // Resolve guardian contact notes for recipient context. Use the channel-
-  // agnostic guardian lookup so notes are available even when the only
-  // deliverable channel is "vellum" (which has no contact channel type).
+  // Resolve guardian contact notes for recipient context. The guardian's
+  // identity (ACL) comes from the gateway pull, channel-agnostic so notes are
+  // available even when the only deliverable channel is "vellum". Notes (INFO)
+  // stay local and are joined by contactId.
   let recipientNotes: string | undefined;
   try {
-    const guardianResult = listGuardianChannels();
-    if (guardianResult?.contact.notes) {
+    const guardian = anyGuardian((await getGuardianDelivery()) ?? []);
+    const notes = guardian
+      ? findContactInfoById(guardian.contactId)?.notes
+      : undefined;
+    if (notes) {
       recipientNotes = truncate(
-        guardianResult.contact.notes,
+        notes,
         MAX_IDENTITY_CONTEXT_CHARS,
         "\n…[truncated]",
       );

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -12,7 +12,10 @@
 import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import type { ConversationCreateType } from "../memory/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
@@ -89,8 +92,12 @@ export function getBroadcaster(): NotificationBroadcaster {
 
 // ── Connected channels resolution ──────────────────────────────────────
 
-function getConnectedChannels(): NotificationChannel[] {
+async function getConnectedChannels(): Promise<NotificationChannel[]> {
   const channels: NotificationChannel[] = [];
+
+  // Guardian bindings (ACL) come from the gateway pull; null on failure ⇒ no
+  // binding-based channels are reported connected.
+  const guardians = (await getGuardianDelivery()) ?? [];
 
   // getDeliverableChannels() returns ChannelId[] but every returned channel
   // has deliveryEnabled: true, making it a valid NotificationChannel at
@@ -113,10 +120,10 @@ function getConnectedChannels(): NotificationChannel[] {
         // A binding-based channel is connected when the guardian has an
         // active channel entry with a valid delivery endpoint. The
         // externalChatId check ensures we don't report a channel as
-        // connected when the contacts record exists but lacks the
-        // delivery address the destination-resolver needs.
-        const guardian = findGuardianForChannel(channel);
-        if (guardian && guardian.channel.externalChatId) {
+        // connected when the binding exists but lacks the delivery address
+        // the destination-resolver needs.
+        const guardian = guardianForChannel(guardians, channel);
+        if (guardian && guardian.externalChatId) {
           channels.push(channel);
         }
         break;
@@ -125,8 +132,8 @@ function getConnectedChannels(): NotificationChannel[] {
         // Slack bindings can originate from shared channels (app_mention).
         // Only consider Slack connected when the stored chat ID is a DM
         // channel (D-prefixed) to prevent leaking notifications.
-        const slackGuardian = findGuardianForChannel("slack");
-        const chatId = slackGuardian?.channel.externalChatId;
+        const slackGuardian = guardianForChannel(guardians, "slack");
+        const chatId = slackGuardian?.externalChatId;
         if (slackGuardian && chatId && chatId.startsWith("D")) {
           channels.push(channel);
         }
@@ -290,7 +297,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     }
 
     // Step 2: Evaluate the signal through the decision engine
-    const connectedChannels = getConnectedChannels();
+    const connectedChannels = await getConnectedChannels();
 
     log.debug(
       {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -9,9 +9,11 @@
  * propagated unless `throwOnError` is enabled.
  */
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
 import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
+import { findGuardianForChannel } from "../contacts/contact-store.js";
 import {
   getGuardianDelivery,
   guardianForChannel,
@@ -92,12 +94,30 @@ export function getBroadcaster(): NotificationBroadcaster {
 
 // ── Connected channels resolution ──────────────────────────────────────
 
-async function getConnectedChannels(): Promise<NotificationChannel[]> {
+/**
+ * Resolve a binding-based channel's delivery endpoint (externalChatId) the
+ * SAME way destination-resolver's `resolveGuardian` does: gateway list when
+ * present, falling back to the LOCAL contacts read only when the list is null
+ * (gateway unreachable). The local fallback is removed in Combo 11. Keeping
+ * connectivity aligned with delivery prevents a channel being marked connected
+ * but then skipped with no destination (or vice-versa).
+ */
+function resolveChannelChatId(
+  guardians: GuardianDelivery[] | null,
+  channelType: string,
+): string | undefined {
+  if (guardians) {
+    return guardianForChannel(guardians, channelType)?.externalChatId ?? undefined;
+  }
+  return findGuardianForChannel(channelType)?.channel.externalChatId ?? undefined;
+}
+
+export async function getConnectedChannels(): Promise<NotificationChannel[]> {
   const channels: NotificationChannel[] = [];
 
-  // Guardian bindings (ACL) come from the gateway pull; null on failure ⇒ no
-  // binding-based channels are reported connected.
-  const guardians = (await getGuardianDelivery()) ?? [];
+  // Guardian bindings (ACL) come from the gateway pull; null ⇒ gateway
+  // unreachable, so binding-based connectivity falls back to the local read.
+  const guardians = await getGuardianDelivery();
 
   // getDeliverableChannels() returns ChannelId[] but every returned channel
   // has deliveryEnabled: true, making it a valid NotificationChannel at
@@ -117,24 +137,20 @@ async function getConnectedChannels(): Promise<NotificationChannel[]> {
         channels.push(channel);
         break;
       case "telegram": {
-        // A binding-based channel is connected when the guardian has an
-        // active channel entry with a valid delivery endpoint. The
-        // externalChatId check ensures we don't report a channel as
-        // connected when the binding exists but lacks the delivery address
-        // the destination-resolver needs.
-        const guardian = guardianForChannel(guardians, channel);
-        if (guardian && guardian.externalChatId) {
+        // Connected when the resolved guardian has a delivery endpoint —
+        // mirroring destination-resolver so we never mark connected what
+        // can't be delivered.
+        if (resolveChannelChatId(guardians, channel)) {
           channels.push(channel);
         }
         break;
       }
       case "slack": {
         // Slack bindings can originate from shared channels (app_mention).
-        // Only consider Slack connected when the stored chat ID is a DM
-        // channel (D-prefixed) to prevent leaking notifications.
-        const slackGuardian = guardianForChannel(guardians, "slack");
-        const chatId = slackGuardian?.externalChatId;
-        if (slackGuardian && chatId && chatId.startsWith("D")) {
+        // Only consider Slack connected when the resolved chat ID is a DM
+        // channel (D-prefixed), matching destination-resolver's DM gate.
+        const chatId = resolveChannelChatId(guardians, "slack");
+        if (chatId && chatId.startsWith("D")) {
           channels.push(channel);
         }
         break;


### PR DESCRIPTION
## Summary
- emit-signal connectivity + decision-engine recipient notes resolve the guardian via getGuardianDelivery (ACL); notes read locally by contactId (INFO).

Part of plan: gateway-guardian-binding-pull.md (PR 5 of 10)