### PR TITLE
feat(assistant): guardian-existence checks use gateway guardian binding

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -83,6 +83,29 @@ mock.module("../ipc/gateway-client.js", () => ({
   }),
 }));
 
+// Guardian-delivery reader mock — the inbound challenge guard reads guardian
+// existence from the gateway. Derive the list from the local binding state so
+// the gateway-backed presence guard mirrors the DB the rest of the test sets up.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async (input?: { channelTypes?: string[] }) => {
+    const { findGuardianForChannel } = await import(
+      "../contacts/contact-store.js"
+    );
+    const channels = input?.channelTypes ?? [];
+    return channels
+      .map((channelType) => {
+        const found = findGuardianForChannel(channelType);
+        return found ? { channelType, status: "active" } : null;
+      })
+      .filter((g): g is { channelType: string; status: string } => g !== null);
+  },
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 import { handleChannelVerificationSession } from "../daemon/handlers/config-channels.js";
 import type {
   ChannelVerificationSessionRequest,

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -86,19 +86,22 @@ mock.module("../ipc/gateway-client.js", () => ({
 // Guardian-delivery reader mock — the inbound challenge guard reads guardian
 // existence from the gateway. Derive the list from the local binding state so
 // the gateway-backed presence guard mirrors the DB the rest of the test sets up.
+const resolveGuardianList = async (input?: { channelTypes?: string[] }) => {
+  const { findGuardianForChannel } = await import(
+    "../contacts/contact-store.js"
+  );
+  const channels = input?.channelTypes ?? [];
+  return channels
+    .map((channelType) => {
+      const found = findGuardianForChannel(channelType);
+      return found ? { channelType, status: "active" } : null;
+    })
+    .filter((g): g is { channelType: string; status: string } => g !== null);
+};
+
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: async (input?: { channelTypes?: string[] }) => {
-    const { findGuardianForChannel } = await import(
-      "../contacts/contact-store.js"
-    );
-    const channels = input?.channelTypes ?? [];
-    return channels
-      .map((channelType) => {
-        const found = findGuardianForChannel(channelType);
-        return found ? { channelType, status: "active" } : null;
-      })
-      .filter((g): g is { channelType: string; status: string } => g !== null);
-  },
+  getGuardianDelivery: resolveGuardianList,
+  getGuardianDeliveryFresh: resolveGuardianList,
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -89,6 +89,7 @@ globalThis.fetch = (async (
 // list (not bound) rather than a null that would fail closed as already-bound.
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => [],
+  getGuardianDeliveryFresh: async () => [],
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -84,6 +84,18 @@ globalThis.fetch = (async (
   return originalFetch(input, init as never);
 }) as unknown as typeof fetch;
 
+// Guardian-delivery reader mock — the inbound challenge guard reads guardian
+// existence from the gateway. These tests seed no binding, so report an empty
+// list (not bound) rather than a null that would fail closed as already-bound.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [],
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 // ---------------------------------------------------------------------------
 // Now import modules under test (after mocks are in place)
 // ---------------------------------------------------------------------------

--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -42,6 +42,7 @@ import {
   __resetGuardianDeliveryCacheForTest,
   anyGuardian,
   getGuardianDelivery,
+  getGuardianDeliveryFresh,
   guardianForChannel,
   invalidateGuardianDeliveryCache,
 } from "../guardian-delivery-reader.js";
@@ -200,6 +201,69 @@ describe("getGuardianDelivery", () => {
     ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
     expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
     expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("forceRefresh ignores a stale cached entry and re-fetches", async () => {
+    // Seed the cache with an empty list (the stale gateway-side view).
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+    expect(await getGuardianDelivery()).toEqual([]);
+
+    // A cached read still serves the stale empty list (no new IPC)...
+    expect(await getGuardianDelivery()).toEqual([]);
+    expect(countCalls(METHOD)).toBe(1);
+
+    // ...but forceRefresh bypasses the cache and sees the now-present guardian.
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    expect(await getGuardianDelivery({ forceRefresh: true })).toEqual([
+      telegramGuardian,
+    ]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("forceRefresh updates the cache with the fresh result", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+    await getGuardianDelivery();
+
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    await getGuardianDelivery({ forceRefresh: true });
+
+    // A subsequent cached read serves the refreshed value without a new IPC.
+    expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("getGuardianDeliveryFresh bypasses a stale cached empty list", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+    expect(
+      await getGuardianDelivery({ channelTypes: ["telegram"] }),
+    ).toEqual([]);
+
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    expect(
+      await getGuardianDeliveryFresh({ channelTypes: ["telegram"] }),
+    ).toEqual([telegramGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("a burst of forceRefresh reads still coalesces single-flight", async () => {
+    let resolveIpc: ((value: unknown) => void) | undefined;
+    ipcHandlers.set(
+      METHOD,
+      () =>
+        new Promise((resolve) => {
+          resolveIpc = resolve;
+        }),
+    );
+
+    const burst = Promise.all([
+      getGuardianDeliveryFresh(),
+      getGuardianDeliveryFresh(),
+      getGuardianDeliveryFresh(),
+    ]);
+    resolveIpc?.({ guardians: [telegramGuardian] });
+    await burst;
+
+    expect(countCalls(METHOD)).toBe(1);
   });
 });
 

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -74,22 +74,32 @@ async function fetchGuardianDelivery(
  * Resolve active guardian deliveries, optionally filtered by channel type.
  * Returns the cached list when fresh, otherwise fetches (single-flight) and
  * caches on success. Returns `null` on failure without caching.
+ *
+ * Pass `forceRefresh` to bypass the cached entry and fetch fresh — still
+ * single-flight, and still populates the cache with the fresh result. Used by
+ * existence guards, since gateway-side binding writes don't invalidate the
+ * daemon cache.
  */
 export async function getGuardianDelivery(
-  input?: { channelTypes?: string[] },
+  input?: { channelTypes?: string[]; forceRefresh?: boolean },
 ): Promise<GuardianDelivery[] | null> {
   const key = cacheKey(input?.channelTypes);
 
-  const cached = cache.get(key);
-  if (cached && Date.now() - cached.fetchedAt < GUARDIAN_DELIVERY_CACHE_TTL_MS) {
-    return cached.guardians;
+  if (!input?.forceRefresh) {
+    const cached = cache.get(key);
+    if (
+      cached &&
+      Date.now() - cached.fetchedAt < GUARDIAN_DELIVERY_CACHE_TTL_MS
+    ) {
+      return cached.guardians;
+    }
   }
 
   const pending = inFlight.get(key);
   if (pending) return pending;
 
   const startGen = cacheGeneration;
-  const promise = fetchGuardianDelivery(input ?? {})
+  const promise = fetchGuardianDelivery({ channelTypes: input?.channelTypes })
     .then((guardians) => {
       // Skip the write if an invalidation fired during the fetch: the result
       // may predate the change. Return it to this caller (freshest it has) but
@@ -105,6 +115,16 @@ export async function getGuardianDelivery(
 
   inFlight.set(key, promise);
   return promise;
+}
+
+/**
+ * Fresh (uncached) variant of {@link getGuardianDelivery}. Existence guards read
+ * fresh because gateway-side binding writes don't invalidate the daemon cache.
+ */
+export async function getGuardianDeliveryFresh(
+  input?: { channelTypes?: string[] },
+): Promise<GuardianDelivery[] | null> {
+  return getGuardianDelivery({ ...input, forceRefresh: true });
 }
 
 /**

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -28,6 +28,7 @@ import {
   findActiveSession,
   getGuardianBinding,
   getPendingSession,
+  isGuardianBoundForChannel,
   revokeBinding,
   revokePendingSessions,
   updateSessionDelivery,
@@ -80,19 +81,18 @@ export function getReadinessService(): ChannelReadinessService {
 // Extracted business logic functions
 // ---------------------------------------------------------------------------
 
-export function createInboundChallenge(
+export async function createInboundChallenge(
   channel?: ChannelId,
   rebind?: boolean,
   conversationId?: string,
-): ChannelVerificationSessionResult {
-  const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+): Promise<ChannelVerificationSessionResult> {
   const resolvedChannel = channel ?? "telegram";
 
-  const existingBinding = getGuardianBinding(
-    resolvedAssistantId,
-    resolvedChannel,
-  );
-  if (existingBinding && !rebind) {
+  // Gateway-backed presence guard: block re-binding when a guardian is already
+  // bound. Null-list (gateway unreachable) is treated as bound, so a transient
+  // miss blocks rather than letting a second binding through.
+  const alreadyBound = await isGuardianBoundForChannel(resolvedChannel);
+  if (alreadyBound && !rebind) {
     return {
       success: false,
       error: "already_bound",
@@ -579,7 +579,7 @@ export async function handleChannelVerificationSession(
           ...publicResult,
         });
       } else {
-        const result = createInboundChallenge(
+        const result = await createInboundChallenge(
           channel,
           msg.rebind,
           msg.conversationId,

--- a/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
+++ b/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
@@ -3,9 +3,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Gateway guardian-delivery list: null = unreachable, [] = unbound,
 // one active entry = bound.
 let mockGuardianList: Array<Record<string, unknown>> | null = [];
+const freshCalls: Array<{ channelTypes?: string[] } | undefined> = [];
 
 mock.module("../../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: () => Promise.resolve(mockGuardianList),
+  // Existence guard must read fresh (uncached) — only this variant is stubbed.
+  getGuardianDeliveryFresh: (input?: { channelTypes?: string[] }) => {
+    freshCalls.push(input);
+    return Promise.resolve(mockGuardianList);
+  },
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,
@@ -19,6 +24,12 @@ const { isGuardianBoundForChannel } = await import(
 describe("isGuardianBoundForChannel", () => {
   beforeEach(() => {
     mockGuardianList = [];
+    freshCalls.length = 0;
+  });
+
+  test("reads fresh so a stale cached empty list can't mask a present guardian", async () => {
+    await isGuardianBoundForChannel("telegram");
+    expect(freshCalls).toEqual([{ channelTypes: ["telegram"] }]);
   });
 
   test("returns false when no guardian is bound", async () => {

--- a/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
+++ b/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Gateway guardian-delivery list: null = unreachable, [] = unbound,
+// one active entry = bound.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: () => Promise.resolve(mockGuardianList),
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+const { isGuardianBoundForChannel } = await import(
+  "../channel-verification-service.js"
+);
+
+describe("isGuardianBoundForChannel", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+  });
+
+  test("returns false when no guardian is bound", async () => {
+    mockGuardianList = [];
+    expect(await isGuardianBoundForChannel("telegram")).toBe(false);
+  });
+
+  test("returns true when a guardian is bound", async () => {
+    mockGuardianList = [{ channelType: "telegram", status: "active" }];
+    expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+
+  test("null list (gateway unreachable) is treated as bound", async () => {
+    mockGuardianList = null;
+    expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+});

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -12,7 +12,7 @@ import { v4 as uuid } from "uuid";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { revokeGuardianBinding } from "../contacts/contacts-write.js";
 import {
-  getGuardianDelivery,
+  getGuardianDeliveryFresh,
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
 import type {
@@ -365,7 +365,9 @@ export function getGuardianBinding(
 export async function isGuardianBoundForChannel(
   channel: string,
 ): Promise<boolean> {
-  const list = await getGuardianDelivery({ channelTypes: [channel] });
+  // Existence guards read fresh because gateway-side binding writes don't
+  // invalidate the daemon cache.
+  const list = await getGuardianDeliveryFresh({ channelTypes: [channel] });
   if (list === null) return true;
   return !!guardianForChannel(list, channel);
 }

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -11,6 +11,10 @@ import { v4 as uuid } from "uuid";
 
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { revokeGuardianBinding } from "../contacts/contacts-write.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import type {
   GuardianBinding,
   IdentityBindingStatus,
@@ -346,6 +350,24 @@ export function getGuardianBinding(
   }
 
   return null;
+}
+
+/**
+ * Gateway-backed guardian-existence check: is a guardian already bound for
+ * this channel? Presence-only idempotency guard, NOT an ACL-field read.
+ *
+ * Null-list fail direction: a `null` from the gateway (unreachable / malformed)
+ * is "unknown" — returns `true` so an unreachable gateway is treated as
+ * already-bound. Callers gate session creation on a falsy result, so this
+ * blocks a new binding on a transient miss rather than spuriously creating a
+ * second one.
+ */
+export async function isGuardianBoundForChannel(
+  channel: string,
+): Promise<boolean> {
+  const list = await getGuardianDelivery({ channelTypes: [channel] });
+  if (list === null) return true;
+  return !!guardianForChannel(list, channel);
 }
 
 /**

--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -24,7 +24,7 @@ mock.module("../../../daemon/handlers/config-channels.js", () => ({
     verifyTrustedContactCalls.push([contactChannelId, assistantId]);
     return verifyTrustedContactImpl(contactChannelId, assistantId);
   },
-  createInboundChallenge: () => ({ success: true }),
+  createInboundChallenge: async () => ({ success: true }),
   getVerificationStatus: () => ({ success: true }),
   revokeVerificationForChannel: () => ({ success: true }),
 }));

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -179,7 +179,7 @@ export async function handleCreateVerificationSession({
   }
 
   // Inbound challenge path
-  const result = createInboundChallenge(channel, rebind, conversationId);
+  const result = await createInboundChallenge(channel, rebind, conversationId);
   if (!result.success) {
     throw new BadRequestError(
       (result as { message?: string }).message ??

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -23,7 +23,8 @@ let emitNotificationSignalCalls: unknown[] = [];
 let messageIdCounter = 0;
 
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: () => Promise.resolve(mockGuardianList),
+  // Existence guard reads fresh (uncached) — only this variant is stubbed.
+  getGuardianDeliveryFresh: () => Promise.resolve(mockGuardianList),
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -4,7 +4,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-let mockGuardian: { contact: unknown; channel: unknown } | null = null;
+// Gateway guardian-delivery list: empty = unbound, one entry = bound,
+// null = gateway unreachable.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
 let mockActiveSession: Record<string, unknown> | null = null;
 let mockSessionResult = {
   sessionId: "sess-1",
@@ -20,8 +22,13 @@ let deliverChannelReplyCalls: unknown[][] = [];
 let emitNotificationSignalCalls: unknown[] = [];
 let messageIdCounter = 0;
 
-mock.module("../../../contacts/contact-store.js", () => ({
-  findGuardianForChannel: () => mockGuardian,
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: () => Promise.resolve(mockGuardianList),
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 mock.module("../../channel-verification-service.js", () => ({
@@ -96,7 +103,7 @@ function makeParams(
 
 describe("handleGuardianActivationIntercept", () => {
   beforeEach(() => {
-    mockGuardian = null;
+    mockGuardianList = [];
     mockActiveSession = null;
     mockSessionResult = {
       sessionId: "sess-1",
@@ -155,10 +162,15 @@ describe("handleGuardianActivationIntercept", () => {
   });
 
   test("bare /start with existing guardian returns null", async () => {
-    mockGuardian = {
-      contact: { id: "contact-1", role: "guardian" },
-      channel: { id: "ch-1", type: "telegram" },
-    };
+    mockGuardianList = [{ channelType: "telegram", status: "active" }];
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("null guardian list (gateway unreachable) does NOT auto-start", async () => {
+    mockGuardianList = null;
 
     const result = await handleGuardianActivationIntercept(makeParams());
     expect(result).toBeNull();

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -9,7 +9,10 @@
  * the guardian binding, and sends a success reply.
  */
 import type { ChannelId } from "../../../channels/types.js";
-import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../../contacts/guardian-delivery-reader.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { getLogger } from "../../../util/logger.js";
 import {
@@ -88,8 +91,15 @@ export async function handleGuardianActivationIntercept(
   // Only proceed for Telegram (can be extended later)
   if (sourceChannel !== "telegram") return null;
 
-  // If a guardian already exists for this channel, continue to normal flow
-  if (findGuardianForChannel(sourceChannel)) return null;
+  // If a guardian already exists for this channel, continue to normal flow.
+  // Null-list (gateway unreachable) is treated as guardian-present so a
+  // transient miss does NOT spuriously auto-start verification.
+  const guardianList = await getGuardianDelivery({
+    channelTypes: [sourceChannel],
+  });
+  if (guardianList === null || guardianForChannel(guardianList, sourceChannel)) {
+    return null;
+  }
 
   // Can't bind a session without sender identity
   if (!rawSenderId) return null;

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -10,7 +10,7 @@
  */
 import type { ChannelId } from "../../../channels/types.js";
 import {
-  getGuardianDelivery,
+  getGuardianDeliveryFresh,
   guardianForChannel,
 } from "../../../contacts/guardian-delivery-reader.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
@@ -94,7 +94,8 @@ export async function handleGuardianActivationIntercept(
   // If a guardian already exists for this channel, continue to normal flow.
   // Null-list (gateway unreachable) is treated as guardian-present so a
   // transient miss does NOT spuriously auto-start verification.
-  const guardianList = await getGuardianDelivery({
+  // Read fresh: gateway-side binding writes don't invalidate the daemon cache.
+  const guardianList = await getGuardianDeliveryFresh({
     channelTypes: [sourceChannel],
   });
   if (guardianList === null || guardianForChannel(guardianList, sourceChannel)) {


### PR DESCRIPTION
## Summary
- guardian-activation-intercept, channel-verification-service, config-channels determine guardian existence via getGuardianDelivery instead of local findGuardianForChannel/findContactChannel. Null-list treated as no-change (safe).

Part of plan: gateway-guardian-binding-pull.md (PR 8 of 10)