### PR TITLE
feat(assistant): bound-guardian auth gate + drift heal use gateway guardian binding

### DIFF
--- a/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
+++ b/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
@@ -70,6 +70,30 @@ describe("healGuardianBindingDrift", () => {
     expect(guardian!.channel.address).toBe("vellum-principal-old-uuid");
   });
 
+  test("repairs the stale local mirror even when the gateway already matches the JWT", async () => {
+    // Gateway binding already matches the incoming JWT principal, but the
+    // local mirror is stale — the gateway-source-of-truth drift mode. The
+    // /v1/messages trust path still reads the local mirror in this plan, so
+    // a stale row must be repaired or the actor stays classified `unknown`.
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "vellum-principal-stale-local",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "vellum-principal-stale-local",
+      verifiedVia: "startup-migration",
+    });
+    mockGuardians = [gatewayGuardian("vellum-principal-jwt")];
+
+    const healed = await healGuardianBindingDrift("vellum-principal-jwt");
+    expect(healed).toBe(true);
+
+    // Local mirror now matches the JWT, so a subsequent local trust
+    // resolution classifies the actor as guardian rather than unknown.
+    const guardian = findGuardianForChannel("vellum");
+    expect(guardian!.contact.principalId).toBe("vellum-principal-jwt");
+    expect(guardian!.channel.address).toBe("vellum-principal-jwt");
+  });
+
   test("no-op when principals already match", async () => {
     createGuardianBinding({
       channel: "vellum",

--- a/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
+++ b/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
@@ -7,6 +7,16 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+let mockGuardians: GuardianDelivery[] | null = [];
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardians,
+  guardianForChannel: (list: GuardianDelivery[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
@@ -21,12 +31,24 @@ function resetTables(): void {
   db.run("DELETE FROM contacts");
 }
 
+/** Gateway delivery mirroring the local guardian binding's principal. */
+function gatewayGuardian(principalId: string): GuardianDelivery {
+  return {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId,
+    address: principalId,
+    status: "active",
+  };
+}
+
 describe("healGuardianBindingDrift", () => {
   beforeEach(() => {
     resetTables();
+    mockGuardians = [];
   });
 
-  test("heals drift when both principals have vellum-principal- prefix", () => {
+  test("heals drift when both principals have vellum-principal- prefix", async () => {
     // Simulate DB reset: new guardian binding with a different UUID
     createGuardianBinding({
       channel: "vellum",
@@ -35,9 +57,10 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "vellum-principal-new-uuid",
       verifiedVia: "startup-migration",
     });
+    mockGuardians = [gatewayGuardian("vellum-principal-new-uuid")];
 
     // Client arrives with the old JWT principal
-    const healed = healGuardianBindingDrift("vellum-principal-old-uuid");
+    const healed = await healGuardianBindingDrift("vellum-principal-old-uuid");
     expect(healed).toBe(true);
 
     // Guardian binding now matches the old JWT
@@ -47,7 +70,7 @@ describe("healGuardianBindingDrift", () => {
     expect(guardian!.channel.address).toBe("vellum-principal-old-uuid");
   });
 
-  test("no-op when principals already match", () => {
+  test("no-op when principals already match", async () => {
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "vellum-principal-same",
@@ -55,12 +78,13 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "vellum-principal-same",
       verifiedVia: "startup-migration",
     });
+    mockGuardians = [gatewayGuardian("vellum-principal-same")];
 
-    const healed = healGuardianBindingDrift("vellum-principal-same");
+    const healed = await healGuardianBindingDrift("vellum-principal-same");
     expect(healed).toBe(false);
   });
 
-  test("refuses to heal when incoming principal lacks vellum-principal- prefix", () => {
+  test("refuses to heal when incoming principal lacks vellum-principal- prefix", async () => {
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "vellum-principal-aaa",
@@ -68,9 +92,10 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "vellum-principal-aaa",
       verifiedVia: "startup-migration",
     });
+    mockGuardians = [gatewayGuardian("vellum-principal-aaa")];
 
     // External/platform principal — should NOT be adopted
-    const healed = healGuardianBindingDrift("platform-user-12345");
+    const healed = await healGuardianBindingDrift("platform-user-12345");
     expect(healed).toBe(false);
 
     // Guardian unchanged
@@ -78,7 +103,7 @@ describe("healGuardianBindingDrift", () => {
     expect(guardian!.contact.principalId).toBe("vellum-principal-aaa");
   });
 
-  test("refuses to heal when stored principal lacks vellum-principal- prefix", () => {
+  test("refuses to heal when stored principal lacks vellum-principal- prefix", async () => {
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "verified-phone-guardian",
@@ -86,17 +111,33 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "verified-phone-guardian",
       verifiedVia: "challenge",
     });
+    mockGuardians = [gatewayGuardian("verified-phone-guardian")];
 
     // Even with a vellum-principal- incoming, don't overwrite a real binding
-    const healed = healGuardianBindingDrift("vellum-principal-attacker");
+    const healed = await healGuardianBindingDrift("vellum-principal-attacker");
     expect(healed).toBe(false);
 
     const guardian = findGuardianForChannel("vellum");
     expect(guardian!.contact.principalId).toBe("verified-phone-guardian");
   });
 
-  test("returns false when no guardian binding exists", () => {
-    const healed = healGuardianBindingDrift("vellum-principal-orphan");
+  test("returns false when gateway reports no guardian binding", async () => {
+    mockGuardians = [];
+    const healed = await healGuardianBindingDrift("vellum-principal-orphan");
+    expect(healed).toBe(false);
+  });
+
+  test("returns false when the gateway is unreachable (null list)", async () => {
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "vellum-principal-aaa",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "vellum-principal-aaa",
+      verifiedVia: "startup-migration",
+    });
+    mockGuardians = null;
+
+    const healed = await healGuardianBindingDrift("vellum-principal-old-uuid");
     expect(healed).toBe(false);
   });
 });

--- a/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
+++ b/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+let mockGuardians: GuardianDelivery[] | null = null;
+let authDisabled = false;
+
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardians,
+}));
+
+mock.module("../../../config/env.js", () => ({
+  isHttpAuthDisabled: () => authDisabled,
+}));
+
+import { requireBoundGuardian } from "../require-bound-guardian.js";
+import type { AuthContext } from "../types.js";
+
+function ctx(actorPrincipalId?: string): AuthContext {
+  return {
+    subject: "sub",
+    principalType: "actor",
+    assistantId: "self",
+    actorPrincipalId,
+    scopeProfile: "actor_client_v1",
+    scopes: new Set(),
+    policyEpoch: 0,
+  };
+}
+
+function guardian(principalId: string): GuardianDelivery {
+  return {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId,
+    address: principalId,
+    status: "active",
+  };
+}
+
+describe("requireBoundGuardian", () => {
+  beforeEach(() => {
+    mockGuardians = null;
+    authDisabled = false;
+  });
+
+  test("admits the bound guardian", async () => {
+    mockGuardians = [guardian("vellum-principal-abc")];
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).toBeNull();
+  });
+
+  test("denies a non-guardian actor", async () => {
+    mockGuardians = [guardian("vellum-principal-abc")];
+    const result = await requireBoundGuardian(ctx("vellum-principal-other"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("denies when actor principal is missing", async () => {
+    mockGuardians = [guardian("vellum-principal-abc")];
+    const result = await requireBoundGuardian(ctx(undefined));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("fails closed on a null list (gateway unreachable)", async () => {
+    mockGuardians = null;
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("denies when no vellum guardian is bound", async () => {
+    mockGuardians = [];
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("dev bypass admits when auth is disabled", async () => {
+    authDisabled = true;
+    mockGuardians = null;
+    const result = await requireBoundGuardian(ctx(undefined));
+    expect(result).toBeNull();
+  });
+});

--- a/assistant/src/runtime/auth/require-bound-guardian.ts
+++ b/assistant/src/runtime/auth/require-bound-guardian.ts
@@ -1,15 +1,17 @@
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
 import { httpError } from "../http-errors.js";
 import type { AuthContext } from "./types.js";
 
 /**
  * Verify the actor from AuthContext is the bound guardian for the vellum channel.
- * Returns an error Response if not, or null if allowed.
+ * Sources the guardian from the gateway binding and fails closed when the
+ * gateway is unreachable (null list). Returns an error Response if not
+ * authorized, or null if allowed.
  */
-export function requireBoundGuardian(
+export async function requireBoundGuardian(
   authContext: AuthContext,
-): Response | null {
+): Promise<Response | null> {
   // Dev bypass: when auth is disabled, skip guardian binding check
   // (mirrors enforcePolicy dev bypass in route-policy.ts)
   if (isHttpAuthDisabled()) {
@@ -22,17 +24,22 @@ export function requireBoundGuardian(
       403,
     );
   }
-  const guardianResult = findGuardianForChannel("vellum");
-  if (!guardianResult) {
-    // No guardian yet — in pre-bootstrap state, allow through
-    return null;
-  }
-  if (guardianResult.channel.address !== authContext.actorPrincipalId) {
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (!guardians) {
+    // Gateway unreachable — fail closed.
     return httpError(
       "FORBIDDEN",
       "Actor is not the bound guardian for this channel",
       403,
     );
   }
-  return null;
+  const guardian = guardians.find((g) => g.channelType === "vellum");
+  if (guardian && guardian.principalId === authContext.actorPrincipalId) {
+    return null;
+  }
+  return httpError(
+    "FORBIDDEN",
+    "Actor is not the bound guardian for this channel",
+    403,
+  );
 }

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -11,6 +11,10 @@ import {
   findGuardianForChannel,
   updateContactPrincipalAndChannel,
 } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("guardian-vellum-migration");
@@ -31,18 +35,29 @@ const log = getLogger("guardian-vellum-migration");
  * minted by this daemon's signing key.
  *
  * Returns true if healing occurred, false otherwise.
+ *
+ * The heal decision reads the bound guardian from the gateway binding; the
+ * local repair write resolves the assistant-mirror row to update.
  */
-export function healGuardianBindingDrift(incomingPrincipalId: string): boolean {
+export async function healGuardianBindingDrift(
+  incomingPrincipalId: string,
+): Promise<boolean> {
   if (!incomingPrincipalId.startsWith("vellum-principal-")) {
     return false;
   }
 
-  const guardianResult = findGuardianForChannel("vellum");
-  if (!guardianResult) return false;
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (!guardians) return false;
+  const guardian = guardianForChannel(guardians, "vellum");
+  if (!guardian) return false;
 
-  const currentPrincipalId = guardianResult.contact.principalId;
+  const currentPrincipalId = guardian.principalId;
   if (!currentPrincipalId?.startsWith("vellum-principal-")) return false;
   if (currentPrincipalId === incomingPrincipalId) return false;
+
+  // Resolve the assistant-mirror row for the repair write.
+  const guardianResult = findGuardianForChannel("vellum");
+  if (!guardianResult) return false;
 
   const updated = updateContactPrincipalAndChannel(
     guardianResult.contact.id,

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -36,8 +36,11 @@ const log = getLogger("guardian-vellum-migration");
  *
  * Returns true if healing occurred, false otherwise.
  *
- * The heal decision reads the bound guardian from the gateway binding; the
- * local repair write resolves the assistant-mirror row to update.
+ * The gateway binding supplies the authoritative principal; the local
+ * assistant-mirror row is repaired whenever it diverges from the JWT
+ * principal — even when the gateway binding already matches — because the
+ * /v1/messages trust path still resolves against the local mirror in this
+ * plan. A stale mirror must be repaired or valid guardians stay `unknown`.
  */
 export async function healGuardianBindingDrift(
   incomingPrincipalId: string,
@@ -53,11 +56,16 @@ export async function healGuardianBindingDrift(
 
   const currentPrincipalId = guardian.principalId;
   if (!currentPrincipalId?.startsWith("vellum-principal-")) return false;
-  if (currentPrincipalId === incomingPrincipalId) return false;
 
-  // Resolve the assistant-mirror row for the repair write.
+  // Resolve the assistant-mirror row whose principal drives local trust.
   const guardianResult = findGuardianForChannel("vellum");
   if (!guardianResult) return false;
+
+  const localPrincipalId = guardianResult.contact.principalId;
+  // Only repair auto-generated local principals — never overwrite a real one.
+  if (!localPrincipalId?.startsWith("vellum-principal-")) return false;
+  // No-op when the local mirror already matches the JWT principal.
+  if (localPrincipalId === incomingPrincipalId) return false;
 
   const updated = updateContactPrincipalAndChannel(
     guardianResult.contact.id,
@@ -68,7 +76,7 @@ export async function healGuardianBindingDrift(
   if (!updated) {
     log.warn(
       {
-        oldPrincipalId: currentPrincipalId,
+        oldPrincipalId: localPrincipalId,
         newPrincipalId: incomingPrincipalId,
       },
       "Skipped guardian binding drift heal — address collision on contact_channels",
@@ -78,10 +86,10 @@ export async function healGuardianBindingDrift(
 
   log.info(
     {
-      oldPrincipalId: currentPrincipalId,
+      oldPrincipalId: localPrincipalId,
       newPrincipalId: incomingPrincipalId,
     },
-    "Healed vellum guardian binding drift — updated principalId to match JWT actor",
+    "Healed vellum guardian binding drift — updated local mirror principalId to match JWT actor",
   );
 
   return true;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1462,7 +1462,7 @@ export async function handleSendMessage(
         // guardian binding gets a new vellum-principal-* UUID while the
         // client still holds a valid JWT with the old one. The signing
         // key survives the reset, so the JWT is authentic — just stale.
-        const healed = healGuardianBindingDrift(actorPrincipalId);
+        const healed = await healGuardianBindingDrift(actorPrincipalId);
         if (healed) {
           trustCtx = resolveTrustContext({
             assistantId,

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -51,7 +51,7 @@ export function routeDefinitionsToHTTPRoutes(
     handler: async ({ req, url, params, authContext }) => {
       try {
         if (r.requireGuardian) {
-          const guardianError = requireBoundGuardian(authContext);
+          const guardianError = await requireBoundGuardian(authContext);
           if (guardianError) return guardianError;
         }
 

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -45,7 +45,7 @@ const log = getLogger("surface-action-routes");
  * surface actions inherit the correct trust class (guardian vs trusted_contact)
  * rather than defaulting to unknown.
  */
-function applyTrustContext(
+async function applyTrustContext(
   conversation: {
     setTrustContext?(ctx: {
       trustClass: TrustClass;
@@ -53,7 +53,7 @@ function applyTrustContext(
     }): void;
   },
   actorPrincipalId: string | undefined,
-): void {
+): Promise<void> {
   if (!conversation.setTrustContext) return;
 
   const sourceChannel = "vellum";
@@ -70,7 +70,7 @@ function applyTrustContext(
         actorExternalId: actorPrincipalId,
       });
       if (trustCtx.trustClass === "unknown") {
-        const healed = healGuardianBindingDrift(actorPrincipalId);
+        const healed = await healGuardianBindingDrift(actorPrincipalId);
         if (healed) {
           trustCtx = resolveTrustContext({
             assistantId,
@@ -186,7 +186,7 @@ async function handleSurfaceAction({
   }
 
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
-  applyTrustContext(conversation, actorPrincipalId);
+  await applyTrustContext(conversation, actorPrincipalId);
 
   try {
     const raw = await conversation.handleSurfaceAction(


### PR DESCRIPTION
## Summary
- require-bound-guardian auth gate compares the actor principal to the gateway guardian's principalId (fails closed on a gateway miss); guardian-vellum-migration drift-heal decision reads the guardian from the gateway.

Part of plan: gateway-guardian-binding-pull.md (PR 9 of 10)