### PR TITLE
feat(assistant): voice guardian-routing reads use gateway guardian binding

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -168,6 +168,25 @@ mock.module("../notifications/emit-signal.js", () => ({
   }),
 }));
 
+// Guardian principalId is resolved from the gateway binding reader. Mirror the
+// vellum binding seeded by resetTables so guardian dispatch can resolve it.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-vellum",
+      principalId: "test-principal-id",
+      address: "local",
+      status: "active",
+    },
+  ],
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
+}));
+
 mock.module("../calls/voice-session-bridge.js", () => {
   mockStartVoiceTurn = mock(createMockVoiceTurn(["Hello", " there"]));
   return {

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -24,6 +24,25 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+// The guardian principalId for the pending_question request is sourced from the
+// gateway binding reader. Seed it with the vellum guardian.
+const mockGuardianDelivery: Array<{
+  channelType: string;
+  status: string;
+  principalId: string | null;
+}> = [
+  { channelType: "vellum", status: "active", principalId: "test-principal-id" },
+];
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardianDelivery,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
+}));
+
 const emitCalls: unknown[] = [];
 let conversationCreatedFromMock: ConversationCreatedInfo | null = null;
 let mockEmitResult: {
@@ -154,11 +173,18 @@ describe("guardian-dispatch", () => {
         "SELECT * FROM canonical_guardian_requests WHERE call_session_id = ?",
       )
       .get(session.id) as
-      | { id: string; status: string; question_text: string }
+      | {
+          id: string;
+          status: string;
+          question_text: string;
+          guardian_principal_id: string | null;
+        }
       | undefined;
     expect(request).toBeDefined();
     expect(request!.status).toBe("pending");
     expect(request!.question_text).toBe("What is the gate code?");
+    // principalId comes from the gateway guardian binding
+    expect(request!.guardian_principal_id).toBe("test-principal-id");
 
     const vellumDelivery = raw
       .query(

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -24,23 +24,15 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-// The guardian principalId for the pending_question request is sourced from the
-// gateway binding reader. Seed it with the vellum guardian.
-const mockGuardianDelivery: Array<{
-  channelType: string;
-  status: string;
-  principalId: string | null;
-}> = [
-  { channelType: "vellum", status: "active", principalId: "test-principal-id" },
-];
+// The pending_question request principal is resolved via the SAME source the
+// Vellum actor uses — findLocalGuardianPrincipalId — so the stamped principal
+// always equals the submitting actor principal. Stub it so we can model drift
+// (gateway != local) and empty-gateway fallback independently of the binding
+// row seeded for the actor-side resolution below.
+let mockLocalGuardianPrincipalId: string | undefined = "test-principal-id";
 
-mock.module("../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: async () => mockGuardianDelivery,
-  guardianForChannel: (
-    list: Array<{ channelType: string; status: string }>,
-    channelType: string,
-  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
-  anyGuardian: (list: unknown[]) => list[0],
+mock.module("../runtime/local-actor-identity.js", () => ({
+  findLocalGuardianPrincipalId: () => mockLocalGuardianPrincipalId,
 }));
 
 const emitCalls: unknown[] = [];
@@ -125,6 +117,7 @@ function resetTables(): void {
   });
   emitCalls.length = 0;
   conversationCreatedFromMock = null;
+  mockLocalGuardianPrincipalId = "test-principal-id";
   mockEmitResult = {
     signalId: "sig-1",
     deduplicated: false,
@@ -199,6 +192,79 @@ describe("guardian-dispatch", () => {
 
     const signalParams = emitCalls[0] as Record<string, unknown>;
     expect(typeof signalParams.onConversationCreated).toBe("function");
+  });
+
+  test("stamps the request principal from the actor resolver, not the (possibly drifted) gateway binding", async () => {
+    // Simulate gateway/local binding drift: the actor resolver returns a
+    // different principal than any direct gateway read would. The request must
+    // be stamped with the actor resolver's value so a later actor submission
+    // matches (no identity_mismatch under drift).
+    mockLocalGuardianPrincipalId = "actor-resolver-principal";
+
+    const convId = "conv-dispatch-drift";
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: "twilio",
+      fromNumber: "+15550001111",
+      toNumber: "+15550002222",
+    });
+    const pq = createPendingQuestion(session.id, "Drifted bindings?");
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: "self",
+      pendingQuestion: pq,
+    });
+
+    const db = getDb();
+    const raw = (db as unknown as { $client: import("bun:sqlite").Database })
+      .$client;
+    const request = raw
+      .query(
+        "SELECT * FROM canonical_guardian_requests WHERE call_session_id = ?",
+      )
+      .get(session.id) as
+      | { guardian_principal_id: string | null }
+      | undefined;
+    expect(request).toBeDefined();
+    expect(request!.guardian_principal_id).toBe("actor-resolver-principal");
+  });
+
+  test("skips dispatch when the actor resolver yields no principal (empty gateway, no local fallback)", async () => {
+    mockLocalGuardianPrincipalId = undefined;
+
+    const convId = "conv-dispatch-no-principal";
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: "twilio",
+      fromNumber: "+15550001111",
+      toNumber: "+15550002222",
+    });
+    const pq = createPendingQuestion(session.id, "No principal available");
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: "self",
+      pendingQuestion: pq,
+    });
+
+    // No request is created and the pipeline is never invoked.
+    const db = getDb();
+    const raw = (db as unknown as { $client: import("bun:sqlite").Database })
+      .$client;
+    const request = raw
+      .query(
+        "SELECT * FROM canonical_guardian_requests WHERE call_session_id = ?",
+      )
+      .get(session.id) as { id: string } | null;
+    expect(request).toBeNull();
+    expect(emitCalls).toHaveLength(0);
   });
 
   test("creates a telegram guardian delivery with binding metadata when pipeline sends telegram", async () => {

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -68,6 +68,25 @@ mock.module("../notifications/emit-signal.js", () => ({
   },
 }));
 
+// Guardian principalId is resolved from the gateway binding reader. Mirror the
+// seeded vellum binding so dispatch can resolve the principal.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-vellum",
+      principalId: "test-principal-id",
+      address: "local",
+      status: "active",
+    },
+  ],
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
+}));
+
 import {
   createCallSession,
   createPendingQuestion,

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -87,6 +87,23 @@ mock.module("../prompts/user-reference.js", () => ({
   },
 }));
 
+// ── Guardian delivery reader mock ───────────────────────────────────
+//
+// resolveGuardianLabel primes its displayName from the gateway binding via
+// getGuardianDelivery at setup. Tests drive the binding through this list.
+
+let mockGuardianDeliveryList:
+  | Array<{ channelType: string; status: string; displayName: string | null }>
+  | null = null;
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardianDeliveryList,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
+}));
+
 // ── Config mock ─────────────────────────────────────────────────────
 
 const mockConfig = {
@@ -532,6 +549,7 @@ describe("relay-server", () => {
     inviteClaimGate = null;
     mockUserReference = "my human";
     mockAssistantName = "Vellum";
+    mockGuardianDeliveryList = null;
     mockAdmissionPolicy = null;
     mockAdmissionGate = null;
     mockMidCallVerdict = null;
@@ -5008,15 +5026,10 @@ describe("relay-server", () => {
   test("guardian label: guardian persona name takes precedence over Contact.displayName", async () => {
     mockUserReference = "Alice";
 
-    // Create a guardian binding with a different displayName
-    createGuardianBinding({
-      channel: "phone",
-      guardianExternalUserId: "+15559990001",
-      guardianDeliveryChatId: "+15559990001",
-      guardianPrincipalId: "+15559990001",
-      verifiedVia: "test",
-      metadataJson: JSON.stringify({ displayName: "Bob" }),
-    });
+    // Gateway binding carries a different displayName
+    mockGuardianDeliveryList = [
+      { channelType: "phone", status: "active", displayName: "Bob" },
+    ];
 
     ensureConversation("conv-label-user-md");
     const session = createCallSession({
@@ -5053,15 +5066,10 @@ describe("relay-server", () => {
   test("guardian label: Contact.displayName used when guardian persona name is empty", async () => {
     mockUserReference = "my human";
 
-    // Create a guardian binding with a displayName
-    createGuardianBinding({
-      channel: "phone",
-      guardianExternalUserId: "+15559990002",
-      guardianDeliveryChatId: "+15559990002",
-      guardianPrincipalId: "+15559990002",
-      verifiedVia: "test",
-      metadataJson: JSON.stringify({ displayName: "Charlie" }),
-    });
+    // Gateway binding carries the guardian displayName
+    mockGuardianDeliveryList = [
+      { channelType: "phone", status: "active", displayName: "Charlie" },
+    ];
 
     ensureConversation("conv-label-contact");
     const session = createCallSession({
@@ -5097,10 +5105,8 @@ describe("relay-server", () => {
   test("guardian label: DEFAULT_USER_REFERENCE used when both guardian persona name and Contact.displayName are empty", async () => {
     mockUserReference = "my human";
 
-    // Clear guardian binding so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
-    const db = getDb();
-    db.run("DELETE FROM contact_channels");
-    db.run("DELETE FROM contacts");
+    // No guardian binding so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
+    mockGuardianDeliveryList = null;
 
     ensureConversation("conv-label-default");
     const session = createCallSession({

--- a/assistant/src/__tests__/stt-hints.test.ts
+++ b/assistant/src/__tests__/stt-hints.test.ts
@@ -13,6 +13,15 @@ let mockRecentContacts: ContactWithChannels[] = [];
 let mockFindContactByAddressThrows = false;
 let mockListContactsThrows = false;
 
+// Guardian deliveries returned by the mocked gateway reader. resolveGuardianName
+// is mocked to echo mockGuardianName, so the displayName here is captured below.
+let mockGuardianDelivery: Array<{
+  channelType: string;
+  status: string;
+  displayName: string | null;
+}> | null = null;
+let lastGuardianDisplayNameSeen: string | null | undefined;
+
 const logWarnFn = mock(() => {});
 
 // ---------------------------------------------------------------------------
@@ -25,7 +34,10 @@ mock.module("../daemon/identity-helpers.js", () => ({
 
 mock.module("../prompts/user-reference.js", () => ({
   DEFAULT_USER_REFERENCE: "my human",
-  resolveGuardianName: () => mockGuardianName,
+  resolveGuardianName: (displayName?: string | null) => {
+    lastGuardianDisplayNameSeen = displayName;
+    return mockGuardianName;
+  },
 }));
 
 mock.module("../contacts/contact-store.js", () => ({
@@ -35,14 +47,21 @@ mock.module("../contacts/contact-store.js", () => ({
     }
     return mockTargetContact;
   },
-  findGuardianForChannel: () => null,
-  listGuardianChannels: () => null,
   listContacts: (_limit?: number) => {
     if (mockListContactsThrows) {
       throw new Error("DB error: listContacts");
     }
     return mockRecentContacts;
   },
+}));
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardianDelivery,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
 }));
 
 // Bun's mock.module for "../util/logger.js" doesn't intercept the transitive
@@ -319,10 +338,22 @@ describe("resolveCallHints", () => {
     mockRecentContacts = [];
     mockFindContactByAddressThrows = false;
     mockListContactsThrows = false;
+    mockGuardianDelivery = null;
+    lastGuardianDisplayNameSeen = undefined;
     logWarnFn.mockClear();
   });
 
-  test("happy path wires all sources correctly", () => {
+  test("guardian displayName for hints comes from the gateway binding", async () => {
+    mockGuardianDelivery = [
+      { channelType: "phone", status: "active", displayName: "GatewayGuardian" },
+    ];
+
+    await resolveCallHints(null, []);
+
+    expect(lastGuardianDisplayNameSeen).toBe("GatewayGuardian");
+  });
+
+  test("happy path wires all sources correctly", async () => {
     mockTargetContact = makeContact("Alice");
     mockRecentContacts = [makeContact("Bob"), makeContact("Charlie")];
 
@@ -335,7 +366,7 @@ describe("resolveCallHints", () => {
       inviteGuardianName: "Eve",
     };
 
-    const result = resolveCallHints(session, ["StaticHint"]);
+    const result = await resolveCallHints(session, ["StaticHint"]);
     const parts = result.split(",");
 
     expect(parts).toContain("StaticHint");
@@ -351,7 +382,7 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).not.toHaveBeenCalled();
   });
 
-  test("findContactByAddress failure is caught and logged without throwing", () => {
+  test("findContactByAddress failure is caught and logged without throwing", async () => {
     mockFindContactByAddressThrows = true;
     mockRecentContacts = [makeContact("Bob")];
 
@@ -365,7 +396,7 @@ describe("resolveCallHints", () => {
     };
 
     // Should not throw
-    const result = resolveCallHints(session, []);
+    const result = await resolveCallHints(session, []);
     const parts = result.split(",");
 
     // Target contact should be absent (lookup failed)
@@ -376,7 +407,7 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).toHaveBeenCalled();
   });
 
-  test("listContacts failure is caught and logged without throwing", () => {
+  test("listContacts failure is caught and logged without throwing", async () => {
     mockListContactsThrows = true;
     mockTargetContact = makeContact("Alice");
 
@@ -390,7 +421,7 @@ describe("resolveCallHints", () => {
     };
 
     // Should not throw
-    const result = resolveCallHints(session, []);
+    const result = await resolveCallHints(session, []);
     const parts = result.split(",");
 
     // Recent contacts should be absent (listing failed)
@@ -401,7 +432,7 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).toHaveBeenCalled();
   });
 
-  test("inbound call resolves caller contact from fromNumber", () => {
+  test("inbound call resolves caller contact from fromNumber", async () => {
     mockTargetContact = makeContact("Alice");
     mockRecentContacts = [makeContact("Bob")];
 
@@ -414,7 +445,7 @@ describe("resolveCallHints", () => {
       inviteGuardianName: null,
     };
 
-    const result = resolveCallHints(session, []);
+    const result = await resolveCallHints(session, []);
     const parts = result.split(",");
 
     // For inbound, the contact found via fromNumber should appear as caller, not target
@@ -425,10 +456,10 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).not.toHaveBeenCalled();
   });
 
-  test("null session produces hints from assistant name, guardian name, and recent contacts", () => {
+  test("null session produces hints from assistant name, guardian name, and recent contacts", async () => {
     mockRecentContacts = [makeContact("RecentOne"), makeContact("RecentTwo")];
 
-    const result = resolveCallHints(null, ["Static"]);
+    const result = await resolveCallHints(null, ["Static"]);
     const parts = result.split(",");
 
     expect(parts).toContain("Static");

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -8,10 +8,6 @@
  */
 
 import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../contacts/guardian-delivery-reader.js";
-import {
   createCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
@@ -21,6 +17,7 @@ import {
   recordGuardianRequestDeliveries,
 } from "../notifications/canonical-delivery-recorder.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import { findLocalGuardianPrincipalId } from "../runtime/local-actor-identity.js";
 import { getLogger } from "../util/logger.js";
 import { getUserConsultationTimeoutMs } from "./call-constants.js";
 import type { CallPendingQuestion } from "./types.js";
@@ -89,12 +86,14 @@ async function dispatchGuardianQuestionInner(
   try {
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
-    // Voice decisions are handled in guardian conversations tied to the assistant-
-    // level guardian identity. Resolve the principal from the gateway binding.
-    const guardianList = await getGuardianDelivery();
-    const guardianPrincipalId = guardianList
-      ? (guardianForChannel(guardianList, "vellum")?.principalId ?? undefined)
-      : undefined;
+    // Stamp the request with the SAME principal the Vellum actor will submit.
+    // The actor resolves its guardianPrincipalId via findLocalGuardianPrincipalId
+    // (gateway-first, local fallback); applyCanonicalGuardianDecision requires
+    // strict equality with request.guardianPrincipalId. Resolving here through
+    // the identical source guarantees the stamped principal == the submitting
+    // principal, so decisions can't be rejected as identity_mismatch when the
+    // gateway and local bindings drift during migration.
+    const guardianPrincipalId = await findLocalGuardianPrincipalId();
 
     if (!guardianPrincipalId) {
       log.error(

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -7,7 +7,10 @@
  * 3. Records guardian_action_delivery rows from pipeline delivery results
  */
 
-import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import {
   createCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
@@ -87,13 +90,11 @@ async function dispatchGuardianQuestionInner(
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
     // Voice decisions are handled in guardian conversations tied to the assistant-
-    // level guardian identity. Resolve the principal from the contacts table.
-    let guardianPrincipalId: string | undefined;
-
-    const guardianResult = findGuardianForChannel("vellum");
-    if (guardianResult?.contact.principalId) {
-      guardianPrincipalId = guardianResult.contact.principalId;
-    }
+    // level guardian identity. Resolve the principal from the gateway binding.
+    const guardianList = await getGuardianDelivery();
+    const guardianPrincipalId = guardianList
+      ? (guardianForChannel(guardianList, "vellum")?.principalId ?? undefined)
+      : undefined;
 
     if (!guardianPrincipalId) {
       log.error(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -12,9 +12,10 @@ import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import {
-  findGuardianForChannel,
-  listGuardianChannels,
-} from "../contacts/contact-store.js";
+  anyGuardian,
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
@@ -261,6 +262,10 @@ export class RelayConnection {
     null;
   private accessRequestWaitStartedAt: number = 0;
   private heartbeatSequence = 0;
+
+  // Guardian displayName primed from the gateway binding at setup, read
+  // synchronously by the heartbeat-driven wait-label path.
+  private primedGuardianDisplayName: string | undefined;
 
   // In-wait prompt handling state
   private lastInWaitReplyAt = 0;
@@ -596,6 +601,8 @@ export class RelayConnection {
 
     const session = getCallSession(this.callSessionId);
     this.recordSetupBookkeeping(session, msg);
+
+    await this.primeGuardianDisplayName();
 
     // Resolve the phone channel's inbound admission floor. The reader fails
     // open to `null` by contract, so a transport hiccup admits the caller.
@@ -1828,15 +1835,23 @@ export class RelayConnection {
    * Resolve a human-readable guardian label for voice wait copy.
    * Delegates to the shared resolveGuardianName() which checks the
    * guardian's per-user persona file (users/<slug>.md) first, then falls
-   * back to Contact.displayName, then DEFAULT_USER_REFERENCE.
+   * back to the primed gateway-binding displayName, then
+   * DEFAULT_USER_REFERENCE.
    */
   private resolveGuardianLabel(): string {
-    // Look up the guardian contact for a displayName fallback
-    const voiceGuardian = findGuardianForChannel("phone");
-    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
-    const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
+    return resolveGuardianName(this.primedGuardianDisplayName);
+  }
 
-    return resolveGuardianName(guardianContact?.displayName);
+  /**
+   * Prime the guardian displayName from the gateway binding so the
+   * synchronous wait-label path can read it without an IPC round-trip.
+   */
+  private async primeGuardianDisplayName(): Promise<void> {
+    const list = await getGuardianDelivery();
+    const guardian = list
+      ? (guardianForChannel(list, "phone") ?? anyGuardian(list))
+      : undefined;
+    this.primedGuardianDisplayName = guardian?.displayName ?? undefined;
   }
 
   /**

--- a/assistant/src/calls/stt-hints.ts
+++ b/assistant/src/calls/stt-hints.ts
@@ -1,9 +1,9 @@
+import { findContactByAddress, listContacts } from "../contacts/contact-store.js";
 import {
-  findContactByAddress,
-  findGuardianForChannel,
-  listContacts,
-  listGuardianChannels,
-} from "../contacts/contact-store.js";
+  anyGuardian,
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { DEFAULT_USER_REFERENCE, resolveGuardianName } from "../prompts/user-reference.js";
 import { getLogger } from "../util/logger.js";
@@ -119,7 +119,7 @@ export function buildSttHints(input: SttHintsInput): string {
  * {@link buildSttHints}. All DB lookups are best-effort — errors are
  * logged but never propagate so hints can never fail a call.
  */
-export function resolveCallHints(
+export async function resolveCallHints(
   session: {
     task: string | null;
     toNumber: string;
@@ -129,16 +129,17 @@ export function resolveCallHints(
     inviteGuardianName: string | null;
   } | null,
   staticHints: string[],
-): string {
+): Promise<string> {
   const assistantName = getAssistantName();
 
-  // Look up the guardian contact for a displayName fallback (mirrors relay-server pattern)
+  // Resolve the guardian displayName from the gateway binding for STT vocabulary.
   let guardianDisplayName: string | undefined;
   try {
-    const voiceGuardian = findGuardianForChannel("phone");
-    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
-    const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
-    guardianDisplayName = guardianContact?.displayName;
+    const list = await getGuardianDelivery();
+    const guardian = list
+      ? (guardianForChannel(list, "phone") ?? anyGuardian(list))
+      : undefined;
+    guardianDisplayName = guardian?.displayName ?? undefined;
   } catch (err) {
     logger.warn({ err }, "Failed to look up guardian contact for STT hints");
   }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -532,7 +532,7 @@ async function buildVoiceWebhookTwiml(
 /**
  * Build ConversationRelay TwiML for Twilio-native STT providers.
  */
-function buildConversationRelayTwiml(
+async function buildConversationRelayTwiml(
   callSessionId: string,
   profile: ReturnType<typeof resolveVoiceQualityProfile>,
   sessionContext: {
@@ -545,8 +545,8 @@ function buildConversationRelayTwiml(
   } | null,
   verificationSessionId: string | null | undefined,
   sttAttrs: { transcriptionProvider: string; speechModel: string | undefined },
-): string {
-  const rawHints = resolveCallHints(sessionContext, profile.hints);
+): Promise<string> {
+  const rawHints = await resolveCallHints(sessionContext, profile.hints);
 
   const speechConfig: TwilioRelaySpeechConfig = {
     transcriptionProvider: sttAttrs.transcriptionProvider,


### PR DESCRIPTION
## Summary
- stt-hints + relay-server wait label (guardian displayName) and guardian-dispatch (guardian principalId) resolve the guardian via getGuardianDelivery instead of findGuardianForChannel/listGuardianChannels. Non-guardian INFO reads untouched.

Part of plan: gateway-guardian-binding-pull.md (PR 6 of 10)