### PR TITLE
feat(assistant): acl-enforcement guardian label + access-request guardian from gateway

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -61,6 +61,36 @@ mock.module("../runtime/gateway-client.js", () => ({
   },
 }));
 
+// Guardian identity for the access request resolves via the gateway delivery
+// reader, not the local contacts DB. Seed it per-test via seedGatewayGuardian.
+interface GatewayGuardian {
+  channelType: string;
+  contactId: string;
+  principalId?: string | null;
+  displayName?: string | null;
+  address: string;
+  externalChatId?: string | null;
+  status: string;
+  verifiedAt?: number | null;
+}
+let gatewayGuardians: GatewayGuardian[] = [];
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => gatewayGuardians,
+  guardianForChannel: (list: GatewayGuardian[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+function seedGatewayGuardian(g: Partial<GatewayGuardian> & {
+  channelType: string;
+  address: string;
+}): void {
+  gatewayGuardians.push({
+    contactId: `c-${g.channelType}`,
+    status: "active",
+    ...g,
+  });
+}
+
 import {
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
@@ -95,6 +125,7 @@ function resetState(): string {
   db.run("DELETE FROM contacts");
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
+  gatewayGuardians = [];
   mockEmitResult = {
     signalId: "mock-signal-id",
     deduplicated: false,
@@ -102,8 +133,15 @@ function resetState(): string {
     reason: "mock",
     deliveryResults: [],
   };
-  // Seed the vellum anchor binding (gateway does this at startup in production)
+  // Seed the vellum anchor binding in the gateway list (gateway does this at
+  // startup in production). The DB write mirrors it for any local INFO reads.
   const principalId = `vellum-principal-${crypto.randomUUID()}`;
+  seedGatewayGuardian({
+    channelType: "vellum",
+    address: principalId,
+    principalId,
+    displayName: principalId,
+  });
   createGuardianBinding({
     channel: "vellum",
     guardianExternalUserId: principalId,
@@ -172,6 +210,12 @@ describe("non-member access request notification", () => {
 
   test("guardian is notified when a non-member messages and a guardian binding exists", async () => {
     // Set up a guardian binding for this channel using the anchor principal
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-user-789",
+      externalChatId: "guardian-chat-789",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -217,6 +261,12 @@ describe("non-member access request notification", () => {
   });
 
   test("no duplicate approval requests for repeated messages from same non-member", async () => {
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-user-789",
+      externalChatId: "guardian-chat-789",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -289,6 +339,12 @@ describe("non-member access request notification", () => {
     // Only a voice guardian binding exists — no Telegram binding.
     // Since cross-channel fallback was removed, the access request resolves
     // to the assistant's vellum anchor identity instead.
+    seedGatewayGuardian({
+      channelType: "phone",
+      address: "guardian-voice-user",
+      externalChatId: "guardian-voice-chat",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "guardian-voice-user",
@@ -351,8 +407,8 @@ describe("access-request-helper unit tests", () => {
     anchorPrincipalId = resetState();
   });
 
-  test("notifyGuardianOfAccessRequest returns no_sender_id when actorExternalId is absent", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest returns no_sender_id when actorExternalId is absent", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -372,8 +428,8 @@ describe("access-request-helper unit tests", () => {
     expect(pending.length).toBe(0);
   });
 
-  test("notifyGuardianOfAccessRequest creates request with self-healed principal when no binding exists", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest creates request with self-healed principal when no binding exists", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -400,8 +456,14 @@ describe("access-request-helper unit tests", () => {
     expect(emitSignalCalls.length).toBe(1);
   });
 
-  test("notifyGuardianOfAccessRequest falls back to assistant-anchored vellum identity when source-channel binding is missing", () => {
+  test("notifyGuardianOfAccessRequest falls back to assistant-anchored vellum identity when source-channel binding is missing", async () => {
     // Only voice binding exists
+    seedGatewayGuardian({
+      channelType: "phone",
+      address: "guardian-voice",
+      externalChatId: "voice-chat",
+      principalId: "test-principal-id",
+    });
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "guardian-voice",
@@ -410,7 +472,7 @@ describe("access-request-helper unit tests", () => {
       verifiedVia: "test",
     });
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "tg-chat",
@@ -435,8 +497,20 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("vellum");
   });
 
-  test("notifyGuardianOfAccessRequest prefers source-channel binding over vellum anchor", () => {
+  test("notifyGuardianOfAccessRequest prefers source-channel binding over vellum anchor", async () => {
     // Both Telegram and voice bindings exist with the anchor principal
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-tg",
+      externalChatId: "tg-chat",
+      principalId: anchorPrincipalId,
+    });
+    seedGatewayGuardian({
+      channelType: "phone",
+      address: "guardian-voice",
+      externalChatId: "voice-chat",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-tg",
@@ -452,7 +526,7 @@ describe("access-request-helper unit tests", () => {
       verifiedVia: "test",
     });
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -477,8 +551,8 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("telegram");
   });
 
-  test("notifyGuardianOfAccessRequest for voice channel includes actorDisplayName in contextPayload", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest for voice channel includes actorDisplayName in contextPayload", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "phone",
       conversationExternalId: "+15559998888",
@@ -508,8 +582,8 @@ describe("access-request-helper unit tests", () => {
     expect(pending.length).toBe(1);
   });
 
-  test("notifyGuardianOfAccessRequest includes requestCode in contextPayload", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest includes requestCode in contextPayload", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -529,8 +603,8 @@ describe("access-request-helper unit tests", () => {
     expect((payload.requestCode as string).length).toBe(6);
   });
 
-  test("notifyGuardianOfAccessRequest includes previousMemberStatus in contextPayload", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest includes previousMemberStatus in contextPayload", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -570,7 +644,7 @@ describe("access-request-helper unit tests", () => {
       ],
     };
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "phone",
       conversationExternalId: "+15556667777",
@@ -603,6 +677,12 @@ describe("access-request-helper unit tests", () => {
     // Set up a telegram guardian binding with the anchor principal so
     // guardianResolutionSource resolves to "source-channel-contact" and
     // sameChannelOnly is true.
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-user-456",
+      externalChatId: "guardian-chat-456",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-user-456",
@@ -625,7 +705,7 @@ describe("access-request-helper unit tests", () => {
       ],
     };
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -551,6 +551,98 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("telegram");
   });
 
+  test("notifyGuardianOfAccessRequest falls back to local source-channel binding when gateway delivery is empty", async () => {
+    // Gateway delivery read yields nothing (restart/timeout/malformed IPC).
+    gatewayGuardians = [];
+    // Local dual-written mirror still has the vellum anchor + telegram binding.
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "guardian-tg",
+      guardianDeliveryChatId: "tg-chat",
+      guardianPrincipalId: anchorPrincipalId,
+      verifiedVia: "test",
+    });
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-123",
+      actorExternalId: "unknown-user",
+    });
+
+    expect(result.notified).toBe(true);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "unknown-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
+    // Request is decidable: local read supplied the principal + source binding.
+    expect(pending[0].guardianPrincipalId).toBe(anchorPrincipalId);
+    expect(pending[0].guardianExternalUserId).toBe("guardian-tg");
+
+    const payload = emitSignalCalls[0].contextPayload as Record<
+      string,
+      unknown
+    >;
+    expect(payload.guardianBindingChannel).toBe("telegram");
+  });
+
+  test("notifyGuardianOfAccessRequest falls back to local vellum anchor when gateway delivery is empty", async () => {
+    // Gateway empty; only the local vellum anchor from resetState remains.
+    gatewayGuardians = [];
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-123",
+      actorExternalId: "unknown-user",
+    });
+
+    expect(result.notified).toBe(true);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "unknown-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
+    // Decidable via the local vellum anchor principal.
+    expect(pending[0].guardianPrincipalId).toBe(anchorPrincipalId);
+
+    const payload = emitSignalCalls[0].contextPayload as Record<
+      string,
+      unknown
+    >;
+    expect(payload.guardianBindingChannel).toBe("vellum");
+  });
+
+  test("notifyGuardianOfAccessRequest does not create a decisionable request when both gateway and local reads are empty", async () => {
+    // Genuinely unbound assistant: gateway empty AND no local binding. Prior
+    // behavior rejects creation of a decisionable request without a principal.
+    gatewayGuardians = [];
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+
+    await expect(
+      notifyGuardianOfAccessRequest({
+        canonicalAssistantId: "self",
+        sourceChannel: "telegram",
+        conversationExternalId: "chat-123",
+        actorExternalId: "unknown-user",
+      }),
+    ).rejects.toThrow();
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "unknown-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(0);
+  });
+
   test("notifyGuardianOfAccessRequest for voice channel includes actorDisplayName in contextPayload", async () => {
     const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -196,6 +196,35 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
   },
 }));
 
+// ── Guardian delivery reader ────────────────────────────────────────
+//
+// Guardian identity now resolves via the gateway delivery reader. Derive the
+// list from the DB-seeded guardian bindings so the existing createGuardianBinding
+// setup keeps driving guardian resolution without per-test changes.
+const realContactStoreModule = {
+  ...(await import("../contacts/contact-store.js")),
+};
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => {
+    const guardians = realContactStoreModule.listGuardianChannels();
+    if (!guardians) return [];
+    return guardians.channels.map((ch) => ({
+      channelType: ch.type,
+      contactId: guardians.contact.id,
+      principalId: guardians.contact.principalId ?? null,
+      displayName: guardians.contact.displayName ?? null,
+      address: ch.address,
+      externalChatId: ch.externalChatId ?? null,
+      status: ch.status,
+      verifiedAt: ch.verifiedAt ?? null,
+    }));
+  },
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 // ── Trust verdict consumer spy ──────────────────────────────────────
 //
 // Tracks whether the verdict mapper produced the final mid-call context, so a

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -55,6 +55,35 @@ mock.module("../runtime/gateway-client.js", () => ({
   },
 }));
 
+// Guardian identity resolves via the gateway delivery reader, not the local
+// contacts DB. Seed it to mirror the createGuardianBinding calls below.
+interface GatewayGuardian {
+  channelType: string;
+  contactId: string;
+  principalId?: string | null;
+  displayName?: string | null;
+  address: string;
+  externalChatId?: string | null;
+  status: string;
+  verifiedAt?: number | null;
+}
+let gatewayGuardians: GatewayGuardian[] = [];
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => gatewayGuardians,
+  guardianForChannel: (list: GatewayGuardian[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+function seedGatewayGuardian(
+  g: Partial<GatewayGuardian> & { channelType: string; address: string },
+): void {
+  gatewayGuardians.push({
+    contactId: `c-${g.channelType}`,
+    status: "active",
+    ...g,
+  });
+}
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
@@ -80,7 +109,16 @@ function resetState(): void {
   db.run("DELETE FROM canonical_guardian_deliveries");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
-  // Seed the vellum guardian binding (gateway does this at startup in production)
+  gatewayGuardians = [];
+  // Seed the vellum guardian binding (gateway does this at startup in
+  // production). The gateway list is the source of truth for guardian
+  // resolution; the DB write mirrors it for any local INFO reads.
+  seedGatewayGuardian({
+    channelType: "vellum",
+    address: "guardian-principal",
+    principalId: "guardian-principal",
+    displayName: "guardian-principal",
+  });
   createGuardianBinding({
     channel: "vellum",
     guardianExternalUserId: "guardian-principal",
@@ -162,7 +200,14 @@ describe("Slack inbound trusted contact verification", () => {
   });
 
   test("guardian is notified of the access attempt alongside verification", async () => {
-    // Set up a guardian binding so the notification can target it
+    // Set up a guardian binding so the notification can target it. The gateway
+    // list resolves guardian identity; the DB write mirrors it.
+    seedGatewayGuardian({
+      channelType: "slack",
+      address: "U_GUARDIAN",
+      externalChatId: "D_GUARDIAN_DM",
+      principalId: "guardian-principal",
+    });
     createGuardianBinding({
       channel: "slack",
       guardianExternalUserId: "U_GUARDIAN",

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1393,7 +1393,7 @@ export class RelayConnection {
    * Creates a canonical access request, notifies the guardian, and
    * enters the bounded wait loop for the guardian decision.
    */
-  private handleNameCaptureResponse(callerName: string): void {
+  private async handleNameCaptureResponse(callerName: string): Promise<void> {
     if (!this.accessRequestAssistantId || !this.accessRequestFromNumber) {
       return;
     }
@@ -1414,7 +1414,7 @@ export class RelayConnection {
     // Create canonical access request and notify the guardian, including
     // the caller's spoken name and voice channel metadata.
     try {
-      const accessResult = notifyGuardianOfAccessRequest({
+      const accessResult = await notifyGuardianOfAccessRequest({
         canonicalAssistantId: this.accessRequestAssistantId,
         sourceChannel: "phone",
         conversationExternalId: this.accessRequestFromNumber,
@@ -2048,7 +2048,7 @@ export class RelayConnection {
         { callSessionId: this.callSessionId, callerName },
         "Name captured from unknown inbound caller",
       );
-      this.handleNameCaptureResponse(callerName);
+      await this.handleNameCaptureResponse(callerName);
       return;
     }
 

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -12,7 +12,10 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import type { ChannelStatus } from "../contacts/types.js";
 import {
   createCanonicalGuardianRequest,
@@ -70,12 +73,12 @@ export type AccessRequestResult =
  * trust anchor and only accepts source-channel contacts that match it. This
  * prevents stale or cross-assistant contacts from being bound to the request.
  *
- * This is intentionally synchronous with respect to the canonical store writes
- * and fire-and-forget for the notification signal emission.
+ * The canonical store writes complete before this resolves; the notification
+ * signal emission is fire-and-forget.
  */
-export function notifyGuardianOfAccessRequest(
+export async function notifyGuardianOfAccessRequest(
   params: AccessRequestParams,
-): AccessRequestResult {
+): Promise<AccessRequestResult> {
   const {
     canonicalAssistantId,
     sourceChannel,
@@ -103,27 +106,28 @@ export function notifyGuardianOfAccessRequest(
   let guardianBindingChannel: string | null = null;
   let guardianResolutionSource: GuardianResolutionSource = "none";
 
-  const vellumGuardian = findGuardianForChannel("vellum");
-  const assistantGuardianPrincipalId = vellumGuardian?.contact.principalId;
+  const guardians = (await getGuardianDelivery()) ?? [];
+  const vellumGuardian = guardianForChannel(guardians, "vellum");
+  const assistantGuardianPrincipalId = vellumGuardian?.principalId;
 
   // Try source-channel guardian, but only if it maps to the assistant's
-  // anchored principal. This blocks cross-assistant/stale contact selection.
-  const sourceGuardian = findGuardianForChannel(sourceChannel);
+  // anchored principal. This blocks cross-assistant/stale binding selection.
+  const sourceGuardian = guardianForChannel(guardians, sourceChannel);
   if (
     assistantGuardianPrincipalId &&
     sourceGuardian &&
-    sourceGuardian.contact.principalId === assistantGuardianPrincipalId
+    sourceGuardian.principalId === assistantGuardianPrincipalId
   ) {
-    guardianExternalUserId = sourceGuardian.channel.address;
-    guardianPrincipalId = sourceGuardian.contact.principalId;
-    guardianBindingChannel = sourceGuardian.channel.type;
+    guardianExternalUserId = sourceGuardian.address;
+    guardianPrincipalId = sourceGuardian.principalId;
+    guardianBindingChannel = sourceGuardian.channelType;
     guardianResolutionSource = "source-channel-contact";
   }
 
   // Access requests always require a principal. If source-channel resolution
   // did not match the assistant anchor, use the anchored vellum identity.
   if (!guardianPrincipalId && vellumGuardian) {
-    guardianExternalUserId = vellumGuardian.channel.address;
+    guardianExternalUserId = vellumGuardian.address;
     guardianPrincipalId = assistantGuardianPrincipalId ?? null;
     guardianBindingChannel = guardianBindingChannel ?? "vellum";
     guardianResolutionSource = "vellum-anchor";

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
+import { findGuardianForChannel } from "../contacts/contact-store.js";
 import {
   getGuardianDelivery,
   guardianForChannel,
@@ -131,6 +132,30 @@ export async function notifyGuardianOfAccessRequest(
     guardianPrincipalId = assistantGuardianPrincipalId ?? null;
     guardianBindingChannel = guardianBindingChannel ?? "vellum";
     guardianResolutionSource = "vellum-anchor";
+  }
+
+  // Fallback: gateway delivery read was empty/unavailable (restart, timeout,
+  // malformed IPC), so resolve from the LOCAL dual-written binding to avoid an
+  // undecidable request. Removed in Combo 11.
+  if (!guardianPrincipalId) {
+    const localVellum = findGuardianForChannel("vellum");
+    const localAnchorPrincipalId = localVellum?.contact.principalId;
+    const localSource = findGuardianForChannel(sourceChannel);
+    if (
+      localAnchorPrincipalId &&
+      localSource &&
+      localSource.contact.principalId === localAnchorPrincipalId
+    ) {
+      guardianExternalUserId = localSource.channel.address;
+      guardianPrincipalId = localSource.contact.principalId;
+      guardianBindingChannel = localSource.channel.type;
+      guardianResolutionSource = "source-channel-contact";
+    } else if (localVellum) {
+      guardianExternalUserId = localVellum.channel.address;
+      guardianPrincipalId = localAnchorPrincipalId ?? null;
+      guardianBindingChannel = guardianBindingChannel ?? "vellum";
+      guardianResolutionSource = "vellum-anchor";
+    }
   }
 
   log.debug(

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -801,7 +801,7 @@ export async function handleChannelInbound({
     // guardian sees "previously pending" etc.
     let guardianNotified = false;
     try {
-      const accessResult = notifyGuardianOfAccessRequest({
+      const accessResult = await notifyGuardianOfAccessRequest({
         canonicalAssistantId,
         sourceChannel,
         conversationExternalId,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -19,14 +19,28 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 // Track contact-store reads to prove findContactChannel is NOT used on the
-// verdict path. findGuardianForChannel is still called by resolveGuardianLabel.
+// verdict path.
 const findContactChannelCalls: unknown[] = [];
 mock.module("../../../contacts/contact-store.js", () => ({
   findContactChannel: (params: unknown) => {
     findContactChannelCalls.push(params);
     return null;
   },
-  findGuardianForChannel: () => null,
+}));
+
+// resolveGuardianLabel resolves the guardian via the gateway delivery reader.
+let guardianDeliveryList: Array<Record<string, unknown>> = [];
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => guardianDeliveryList,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+mock.module("../../../prompts/user-reference.js", () => ({
+  resolveGuardianName: (displayName?: string | null) =>
+    displayName && displayName.trim().length > 0 ? displayName.trim() : "my human",
 }));
 
 const deliverReplyCalls: Array<{ url: string; payload: unknown }> = [];
@@ -126,6 +140,7 @@ beforeEach(() => {
   deliverReplyCalls.length = 0;
   accessRequestCalls.length = 0;
   inviteTokenForTest = undefined;
+  guardianDeliveryList = [];
 });
 
 afterEach(() => {
@@ -287,6 +302,41 @@ describe("enforceIngressAcl — fail-closed on resolutionFailed verdict", () => 
 
     expect(result.earlyResponse!.inviteRedemption).toBe("redeemed");
     expect(result.resolvedMember).toBeNull();
+  });
+});
+
+describe("enforceIngressAcl — deny copy names the gateway guardian", () => {
+  test("non-member deny reply uses the guardian displayName from the gateway list", async () => {
+    guardianDeliveryList = [
+      {
+        channelType: "vellum",
+        contactId: "c-1",
+        principalId: "p-anchor",
+        displayName: "Alice Guardian",
+        address: "p-anchor",
+        status: "active",
+      },
+    ];
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+        }),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    const denyReply = deliverReplyCalls.find((c) =>
+      String((c.payload as { text?: string }).text ?? "").includes(
+        "tried talking to me",
+      ),
+    );
+    expect(denyReply).toBeDefined();
+    expect((denyReply!.payload as { text: string }).text).toContain(
+      "Alice Guardian",
+    );
   });
 });
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -7,7 +7,10 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
-import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../../contacts/guardian-delivery-reader.js";
 import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
 import type {
   ContactChannel,
@@ -46,12 +49,15 @@ const log = getLogger("runtime-http");
  * Resolve the guardian's display name for use in requester-facing messages.
  *
  * Uses the assistant's anchored vellum principal to validate the guardian
- * contact, matching the same strategy used by `notifyGuardianOfAccessRequest`.
- * This prevents stale or cross-assistant contacts from leaking a wrong name.
+ * binding, matching the same strategy used by `notifyGuardianOfAccessRequest`.
+ * This prevents stale or cross-assistant bindings from leaking a wrong name.
+ * Cosmetic copy, not an admission decision, so a null gateway list degrades
+ * gracefully to the default reference.
  */
-function resolveGuardianLabel(sourceChannel: ChannelId): string {
-  const vellumGuardian = findGuardianForChannel("vellum");
-  const anchoredPrincipalId = vellumGuardian?.contact.principalId;
+async function resolveGuardianLabel(sourceChannel: ChannelId): Promise<string> {
+  const guardians = await getGuardianDelivery();
+  const vellumGuardian = guardianForChannel(guardians ?? [], "vellum");
+  const anchoredPrincipalId = vellumGuardian?.principalId;
 
   if (!anchoredPrincipalId) {
     return resolveGuardianName(undefined);
@@ -59,15 +65,12 @@ function resolveGuardianLabel(sourceChannel: ChannelId): string {
 
   // Try source-channel guardian, but only accept it when the principal
   // matches the assistant's anchor.
-  const sourceGuardian = findGuardianForChannel(sourceChannel);
-  if (
-    sourceGuardian &&
-    sourceGuardian.contact.principalId === anchoredPrincipalId
-  ) {
-    return resolveGuardianName(sourceGuardian.contact.displayName);
+  const sourceGuardian = guardianForChannel(guardians ?? [], sourceChannel);
+  if (sourceGuardian && sourceGuardian.principalId === anchoredPrincipalId) {
+    return resolveGuardianName(sourceGuardian.displayName);
   }
 
-  return resolveGuardianName(vellumGuardian.contact.displayName);
+  return resolveGuardianName(vellumGuardian.displayName);
 }
 
 // ---------------------------------------------------------------------------
@@ -347,7 +350,7 @@ export async function enforceIngressAcl(
           if (slackVerifyResult.initiated) {
             // Still notify the guardian about the access attempt
             try {
-              notifyGuardianOfAccessRequest({
+              await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
@@ -387,7 +390,7 @@ export async function enforceIngressAcl(
               try {
                 await deliverChannelReply(dmCallbackUrl, {
                   chatId: senderUserId,
-                  text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                  text: `I don't recognize you yet! I've let ${await resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                   assistantId,
                 });
               } catch (err) {
@@ -422,7 +425,7 @@ export async function enforceIngressAcl(
 
           if (emailVerifyResult.initiated) {
             try {
-              notifyGuardianOfAccessRequest({
+              await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
@@ -461,7 +464,7 @@ export async function enforceIngressAcl(
         // deduplication, canonical request creation, and notification emission.
         let guardianNotified = false;
         try {
-          const accessResult = notifyGuardianOfAccessRequest({
+          const accessResult = await notifyGuardianOfAccessRequest({
             canonicalAssistantId,
             sourceChannel,
             conversationExternalId,
@@ -485,7 +488,7 @@ export async function enforceIngressAcl(
         }
 
         const replyText = guardianNotified
-          ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+          ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
           : "Sorry, you haven't been approved to message this assistant.";
         let replyDelivered = false;
         if (replyCallbackUrl) {
@@ -667,7 +670,7 @@ export async function enforceIngressAcl(
 
             if (slackVerifyResult.initiated) {
               try {
-                notifyGuardianOfAccessRequest({
+                await notifyGuardianOfAccessRequest({
                   canonicalAssistantId,
                   sourceChannel,
                   conversationExternalId,
@@ -706,7 +709,7 @@ export async function enforceIngressAcl(
                 try {
                   await deliverChannelReply(dmCallbackUrl, {
                     chatId: senderUserId,
-                    text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                    text: `I don't recognize you yet! I've let ${await resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                     assistantId,
                   });
                 } catch (err) {
@@ -735,7 +738,7 @@ export async function enforceIngressAcl(
           let guardianNotified = false;
           if (resolvedMember.channel.status !== "blocked") {
             try {
-              const accessResult = notifyGuardianOfAccessRequest({
+              const accessResult = await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
@@ -763,7 +766,7 @@ export async function enforceIngressAcl(
           }
 
           const inactiveReplyText = guardianNotified
-            ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+            ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
             : "Sorry, you haven't been approved to message this assistant.";
           let inactiveReplyDelivered = false;
           if (replyCallbackUrl) {


### PR DESCRIPTION
## Summary
- resolveGuardianLabel (deny copy) and access-request guardian identity resolve the guardian via getGuardianDelivery instead of findGuardianForChannel.

Part of plan: gateway-guardian-binding-pull.md (PR 7 of 10)