### PR TITLE
[codex] fix gmail full access scope resolution

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8380,6 +8380,36 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        error:
+                          anyOf:
+                            - type: object
+                              properties:
+                                name:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                message:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                code:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                provider:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                statusCode:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                retryAfterMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                              additionalProperties: false
+                            - type: "null"
                       required:
                         - id
                         - createdAt
@@ -15280,6 +15310,36 @@ paths:
                     anyOf:
                       - type: string
                       - type: "null"
+                  error:
+                    anyOf:
+                      - type: object
+                        properties:
+                          name:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          message:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          code:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          provider:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          statusCode:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          retryAfterMs:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        additionalProperties: false
+                      - type: "null"
                 required:
                   - id
                   - createdAt
@@ -17706,6 +17766,36 @@ paths:
                         callSite:
                           anyOf:
                             - type: string
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: object
+                              properties:
+                                name:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                message:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                code:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                provider:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                statusCode:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                retryAfterMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                              additionalProperties: false
                             - type: "null"
                       required:
                         - id

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -17,14 +17,13 @@ import type {
 const GMAIL_BATCH_URL = "https://www.googleapis.com/batch/gmail/v1";
 
 /**
- * Minimum Google OAuth scope a connection must carry to be usable for Gmail.
+ * Minimum Google OAuth scope a connection must carry for Gmail read access.
  *
  * The managed `google` OAuth app bundles Gmail + Calendar + Drive, but a
  * connection can be granted a narrow subset (e.g. the onboarding check-in flow
- * requests Calendar-only). Every Gmail read/search/send call needs at least
- * `gmail.readonly`, so a connection lacking it cannot serve Gmail at all —
- * resolving against this scope turns a downstream 403 into an actionable
- * "reconnect Google and grant Gmail" error at resolution time.
+ * requests Calendar-only). Resolving against Gmail read access turns a
+ * downstream 403 into an actionable "reconnect Google and grant Gmail" error
+ * at resolution time when the selected connection cannot read Gmail.
  */
 export const GMAIL_REQUIRED_SCOPES = [
   "https://www.googleapis.com/auth/gmail.readonly",

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -302,6 +302,7 @@ describe("resolveOAuthConnection", () => {
 
 describe("resolveOAuthConnection scope-awareness", () => {
   const GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
+  const GMAIL_FULL_ACCESS_SCOPE = "https://mail.google.com/";
   const CALENDAR_ONLY = [
     "https://www.googleapis.com/auth/calendar.events",
     "https://www.googleapis.com/auth/userinfo.email",
@@ -335,6 +336,21 @@ describe("resolveOAuthConnection scope-awareness", () => {
   test("managed: resolves when a connection carries the required Gmail scope", async () => {
     mockPlatformClient = clientReturning([
       { id: "full", account_label: null, scopes_granted: FULL_BUNDLE },
+    ]);
+
+    const result = await resolveOAuthConnection("google", {
+      requiredScopes: [GMAIL_SCOPE],
+    });
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+  });
+
+  test("managed: treats full Gmail access as covering Gmail read access", async () => {
+    mockPlatformClient = clientReturning([
+      {
+        id: "full-gmail-access",
+        account_label: null,
+        scopes_granted: [GMAIL_FULL_ACCESS_SCOPE],
+      },
     ]);
 
     const result = await resolveOAuthConnection("google", {
@@ -389,6 +405,18 @@ describe("resolveOAuthConnection scope-awareness", () => {
     await expect(
       resolveOAuthConnection("google", { requiredScopes: [GMAIL_SCOPE] }),
     ).rejects.toThrow(/missing required access/);
+  });
+
+  test("BYO: treats full Gmail access as covering Gmail read access", async () => {
+    (mockConfig.services as Record<string, unknown>)["google-oauth"] = {
+      mode: "your-own",
+    };
+    mockConnection!.grantedScopes = JSON.stringify([GMAIL_FULL_ACCESS_SCOPE]);
+
+    const result = await resolveOAuthConnection("google", {
+      requiredScopes: [GMAIL_SCOPE],
+    });
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
   });
 
   test("BYO: unknown granted scopes never block", async () => {

--- a/assistant/src/oauth/scope-utils.ts
+++ b/assistant/src/oauth/scope-utils.ts
@@ -16,6 +16,24 @@ export function scopeDifference(
   required: string[],
   granted: string[],
 ): string[] {
-  const grantedSet = new Set(granted);
-  return required.filter((s) => !grantedSet.has(s));
+  return required.filter(
+    (requiredScope) =>
+      !granted.some((grantedScope) =>
+        grantedScopeCoversRequiredScope(grantedScope, requiredScope),
+      ),
+  );
+}
+
+const GMAIL_FULL_ACCESS_SCOPE = "https://mail.google.com/";
+const GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
+
+function grantedScopeCoversRequiredScope(
+  grantedScope: string,
+  requiredScope: string,
+): boolean {
+  if (grantedScope === requiredScope) return true;
+  return (
+    grantedScope === GMAIL_FULL_ACCESS_SCOPE &&
+    requiredScope === GMAIL_READONLY_SCOPE
+  );
 }


### PR DESCRIPTION
## Summary

- Treat `https://mail.google.com/` as satisfying Gmail read access when resolving OAuth connections that require `gmail.readonly`.
- Add managed-platform and BYO regression coverage for full Gmail scope grants.
- Regenerate the OpenAPI artifact after rebasing onto current `main` so the PR merge commit passes the spec check.

## Root Cause

Gmail messaging tools resolve Google OAuth connections with `requiredScopes: ["https://www.googleapis.com/auth/gmail.readonly"]`. The shared scope comparison only accepted exact string matches, so a connection granted Google's broader `https://mail.google.com/` scope was rejected before any Gmail API request ran. Reconnecting returned the same broader scope and therefore did not help.

## Repro

1. Have an active Google OAuth connection whose granted scopes include `https://mail.google.com/` but not `https://www.googleapis.com/auth/gmail.readonly`.
2. Call a Gmail messaging read path, such as `messaging_search` or `messaging_list_conversations`.
3. Before this change, connection resolution throws a missing `gmail.readonly` access error even though the broader Gmail scope can read mail.

## Regression History

- 2026-03-18: managed Google OAuth began using the broad `https://mail.google.com/` Gmail scope in the platform OAuth provider config.
- 2026-06-17: assistant scoped Google OAuth plumbing landed, including a note that Google connections would need scope-aware resolution once multiple Google presets existed.
- 2026-06-22: Gmail messaging resolution became scope-aware to avoid using Calendar-only Google connections for Gmail. That correctly fixed one class of failures, but it also introduced this regression because the helper only accepted exact scope strings and did not recognize that `https://mail.google.com/` covers Gmail read access.

## Validation

- `cd assistant && bun test src/oauth/connection-resolver.test.ts`
- `cd assistant && bun run generate:openapi -- --check`
- `cd assistant && bunx tsc --noEmit`
- `git diff --check`
- GitHub PR checks: Lint, Type Check, Test, OpenAPI Spec Check, Lint Bundled Skills, and Socket Security all pass.