### PR TITLE
feat(assistant): local actor identity resolves the guardian from the gateway

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -29,6 +29,17 @@ mock.module("../config/env.js", () => ({
   checkUnrecognizedEnvVars: () => {},
 }));
 
+// No gateway in tests: force the reader to miss so resolution exercises the
+// local-store bootstrap fallback deterministically.
+let fakeGuardianDelivery: { principalId?: string | null } | null = null;
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () =>
+    fakeGuardianDelivery ? [fakeGuardianDelivery] : null,
+  guardianForChannel: (list: { principalId?: string | null }[]) => list[0],
+  invalidateGuardianDeliveryCache: () => {},
+  onContactChange: () => {},
+}));
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { resetExternalAssistantIdCache } from "../runtime/auth/external-assistant-id.js";
@@ -51,6 +62,7 @@ await initializeDb();
 beforeEach(async () => {
   initAuthSigningKey(TEST_KEY);
   resetExternalAssistantIdCache();
+  fakeGuardianDelivery = null;
   resetDbForTesting();
   await initializeDb();
 });
@@ -60,8 +72,8 @@ beforeEach(async () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveLocalTrustContext", () => {
-  test("falls back to minimal trust context when no vellum binding exists", () => {
-    const ctx = resolveLocalTrustContext();
+  test("falls back to minimal trust context when no vellum binding exists", async () => {
+    const ctx = await resolveLocalTrustContext();
     expect(ctx.sourceChannel).toBe("vellum");
   });
 });
@@ -71,38 +83,48 @@ describe("resolveLocalTrustContext", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveLocalAuthContext", () => {
-  test("returns AuthContext with local principal type", () => {
-    const ctx = resolveLocalAuthContext("session-123");
+  test("returns AuthContext with local principal type", async () => {
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.principalType).toBe("local");
   });
 
-  test("subject follows local:self:<conversationId> pattern", () => {
-    const ctx = resolveLocalAuthContext("session-abc");
+  test("subject follows local:self:<conversationId> pattern", async () => {
+    const ctx = await resolveLocalAuthContext("session-abc");
     expect(ctx.subject).toBe("local:self:session-abc");
   });
 
-  test("assistantId is always self", () => {
-    const ctx = resolveLocalAuthContext("session-123");
+  test("assistantId is always self", async () => {
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.assistantId).toBe("self");
   });
 
-  test("uses local_v1 scope profile with local.all scope", () => {
-    const ctx = resolveLocalAuthContext("session-123");
+  test("uses local_v1 scope profile with local.all scope", async () => {
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.scopeProfile).toBe("local_v1");
     expect(ctx.scopes.has("local.all")).toBe(true);
   });
 
-  test("actorPrincipalId is undefined when no vellum binding exists", () => {
+  test("actorPrincipalId is undefined when no vellum binding exists", async () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
 
-    const ctx = resolveLocalAuthContext("session-123");
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.actorPrincipalId).toBeUndefined();
   });
 
-  test("conversationId matches the provided argument", () => {
-    const ctx = resolveLocalAuthContext("my-session");
+  test("resolves the guardian principal from the gateway when available", async () => {
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+    fakeGuardianDelivery = { principalId: "gateway-guardian-id" };
+
+    const ctx = await resolveLocalAuthContext("session-123");
+    expect(ctx.actorPrincipalId).toBe("gateway-guardian-id");
+  });
+
+  test("conversationId matches the provided argument", async () => {
+    const ctx = await resolveLocalAuthContext("my-session");
     expect(ctx.conversationId).toBe("my-session");
   });
 });

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -173,9 +173,11 @@ describe("TwiML parameter propagation", () => {
 // ---------------------------------------------------------------------------
 
 describe("Call session mode metadata", () => {
+  // Cold DB init runs every migration; give it headroom over Bun's 5s default
+  // hook timeout so a loaded CI runner doesn't trip it.
   beforeEach(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   test("createCallSession persists callMode and verificationSessionId", async () => {
     // Dynamic import to avoid circular dependency issues
@@ -237,7 +239,7 @@ describe("Call session mode metadata", () => {
 describe("Verification control messages are deterministic (guard)", () => {
   beforeEach(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   test("handleChannelInbound does not call processMessage for /start gv_<token> bootstrap commands", async () => {
     const { createHash, randomBytes } = await import("node:crypto");

--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -29,7 +29,13 @@ mock.module("../config/env.js", () => ({
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
-  findLocalGuardianPrincipalId: () => fakeGuardianPrincipalId,
+  findLocalGuardianPrincipalIdFromStore: () => fakeGuardianPrincipalId,
+  resolveActorPrincipalIdForLocalGuardianSync: (
+    rawHeader: string | undefined,
+  ) => {
+    if (rawHeader !== "dev-bypass" || !fakeHttpAuthDisabled) return rawHeader;
+    return fakeGuardianPrincipalId;
+  },
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/host-app-control-routes.test.ts
+++ b/assistant/src/__tests__/host-app-control-routes.test.ts
@@ -62,7 +62,7 @@ afterAll(() => {
 
 const handleHostAppControlResult = ROUTES.find(
   (r) => r.endpoint === "host-app-control-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Tests ────────────────────────────────────────────────────────────
 
@@ -395,7 +395,7 @@ describe("handleHostAppControlResult — same-actor guard", () => {
     ).toThrow(BadRequestError);
   });
 
-  test("targeted + missing header: interaction is NOT consumed (still pending)", () => {
+  test("targeted + missing header: interaction is NOT consumed (still pending)", async () => {
     const requestId = "ac-req-targeted-no-header-stays";
     pending.set(requestId, {
       conversationId: "conv-1",
@@ -404,13 +404,11 @@ describe("handleHostAppControlResult — same-actor guard", () => {
       targetActorPrincipalId: "user-1",
     });
 
-    try {
-      handleHostAppControlResult({
-        body: { requestId, state: "running" },
-      });
-    } catch {
+    await handleHostAppControlResult({
+      body: { requestId, state: "running" },
+    }).catch(() => {
       // expected
-    }
+    });
 
     expect(pending.has(requestId)).toBe(true);
   });
@@ -437,7 +435,7 @@ describe("handleHostAppControlResult — same-actor guard", () => {
     ).toThrow(ForbiddenError);
   });
 
-  test("targeted + wrong client id: interaction is NOT consumed", () => {
+  test("targeted + wrong client id: interaction is NOT consumed", async () => {
     const requestId = "ac-req-targeted-wrong-client-stays";
     pending.set(requestId, {
       conversationId: "conv-1",
@@ -446,17 +444,15 @@ describe("handleHostAppControlResult — same-actor guard", () => {
       targetActorPrincipalId: "user-1",
     });
 
-    try {
-      handleHostAppControlResult({
-        body: { requestId, state: "running" },
-        headers: {
-          "x-vellum-client-id": "client-B",
-          "x-vellum-actor-principal-id": "user-1",
-        },
-      });
-    } catch {
+    await handleHostAppControlResult({
+      body: { requestId, state: "running" },
+      headers: {
+        "x-vellum-client-id": "client-B",
+        "x-vellum-actor-principal-id": "user-1",
+      },
+    }).catch(() => {
       // expected
-    }
+    });
 
     expect(pending.has(requestId)).toBe(true);
   });
@@ -483,7 +479,7 @@ describe("handleHostAppControlResult — same-actor guard", () => {
     ).toThrow(ForbiddenError);
   });
 
-  test("targeted + wrong actor principal: interaction is NOT consumed", () => {
+  test("targeted + wrong actor principal: interaction is NOT consumed", async () => {
     const requestId = "ac-req-targeted-wrong-actor-stays";
     pending.set(requestId, {
       conversationId: "conv-1",
@@ -492,17 +488,15 @@ describe("handleHostAppControlResult — same-actor guard", () => {
       targetActorPrincipalId: "user-1",
     });
 
-    try {
-      handleHostAppControlResult({
-        body: { requestId, state: "running" },
-        headers: {
-          "x-vellum-client-id": "client-A",
-          "x-vellum-actor-principal-id": "user-2",
-        },
-      });
-    } catch {
+    await handleHostAppControlResult({
+      body: { requestId, state: "running" },
+      headers: {
+        "x-vellum-client-id": "client-A",
+        "x-vellum-actor-principal-id": "user-2",
+      },
+    }).catch(() => {
       // expected
-    }
+    });
 
     expect(pending.has(requestId)).toBe(true);
   });

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -95,7 +95,7 @@ afterAll(() => {
 
 const handleHostBashResult = ROUTES.find(
   (r) => r.endpoint === "host-bash-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -244,22 +244,20 @@ describe("handleHostBashResult", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT resolved on cross-actor 403 (still pending)", () => {
+    test("interaction is NOT resolved on cross-actor 403 (still pending)", async () => {
       const requestId = "req-actor-mismatch-stays";
       clientActorPrincipals.set("client-abc", "principal-victim");
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-abc",
-            "x-vellum-actor-principal-id": "principal-attacker",
-          },
-        });
-      } catch {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-abc",
+          "x-vellum-actor-principal-id": "principal-attacker",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -278,19 +276,17 @@ describe("handleHostBashResult", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT resolved when submitting actor is missing (still pending)", () => {
+    test("interaction is NOT resolved when submitting actor is missing (still pending)", async () => {
       const requestId = "req-actor-missing-stays";
       clientActorPrincipals.set("client-abc", "principal-victim");
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: { "x-vellum-client-id": "client-abc" },
-        });
-      } catch {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: { "x-vellum-client-id": "client-abc" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -358,15 +354,13 @@ describe("handleHostBashResult", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT resolved on 400 (still pending)", () => {
+    test("interaction is NOT resolved on 400 (still pending)", async () => {
       const requestId = "req-targeted-no-header-stays";
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({ body: bashBody(requestId) });
-      } catch {
+      await handleHostBashResult({ body: bashBody(requestId) }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -388,19 +382,17 @@ describe("handleHostBashResult", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both the submitting and expected client", () => {
+    test("ForbiddenError message names both the submitting and expected client", async () => {
       const requestId = "req-targeted-mismatch-msg";
       registerPending(requestId, { targetClientId: "client-abc" });
 
       let caught: unknown;
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: { "x-vellum-client-id": "client-xyz" },
-        });
-      } catch (e) {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: { "x-vellum-client-id": "client-xyz" },
+      }).catch((e: unknown) => {
         caught = e;
-      }
+      });
 
       expect(caught).toBeInstanceOf(ForbiddenError);
       const msg = (caught as ForbiddenError).message;
@@ -408,18 +400,16 @@ describe("handleHostBashResult", () => {
       expect(msg).toContain("client-abc");
     });
 
-    test("interaction is NOT resolved on 403 (still pending)", () => {
+    test("interaction is NOT resolved on 403 (still pending)", async () => {
       const requestId = "req-targeted-mismatch-stays";
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: { "x-vellum-client-id": "client-xyz" },
-        });
-      } catch {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: { "x-vellum-client-id": "client-xyz" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);

--- a/assistant/src/__tests__/host-browser-routes.test.ts
+++ b/assistant/src/__tests__/host-browser-routes.test.ts
@@ -39,7 +39,7 @@ afterAll(() => {
 
 const handleHostBrowserResult = ROUTES.find(
   (r) => r.endpoint === "host-browser-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Tests ────────────────────────────────────────────────────────────
 
@@ -212,7 +212,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT consumed on 400 (still pending)", () => {
+    test("interaction is NOT consumed on 400 (still pending)", async () => {
       const requestId = "browser-req-targeted-no-header-stays";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -221,13 +221,11 @@ describe("handleHostBrowserResult — same-actor guard", () => {
         targetActorPrincipalId: "user-1",
       });
 
-      try {
-        handleHostBrowserResult({
-          body: { requestId, content: "ok", isError: false },
-        });
-      } catch {
+      await handleHostBrowserResult({
+        body: { requestId, content: "ok", isError: false },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(pendingInteractions.get(requestId)).toBeDefined();
     });
@@ -256,7 +254,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both submitting and expected client", () => {
+    test("ForbiddenError message names both submitting and expected client", async () => {
       const requestId = "browser-req-targeted-mismatch-msg";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -267,7 +265,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
 
       let caught: unknown;
       try {
-        handleHostBrowserResult({
+        await handleHostBrowserResult({
           body: { requestId, content: "ok", isError: false },
           headers: {
             "x-vellum-client-id": "client-B",
@@ -284,7 +282,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       expect(msg).toContain("client-B");
     });
 
-    test("interaction is NOT consumed on 403 (still pending)", () => {
+    test("interaction is NOT consumed on 403 (still pending)", async () => {
       const requestId = "browser-req-targeted-mismatch-stays";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -293,17 +291,15 @@ describe("handleHostBrowserResult — same-actor guard", () => {
         targetActorPrincipalId: "user-1",
       });
 
-      try {
-        handleHostBrowserResult({
-          body: { requestId, content: "ok", isError: false },
-          headers: {
-            "x-vellum-client-id": "client-B",
-            "x-vellum-actor-principal-id": "user-1",
-          },
-        });
-      } catch {
+      await handleHostBrowserResult({
+        body: { requestId, content: "ok", isError: false },
+        headers: {
+          "x-vellum-client-id": "client-B",
+          "x-vellum-actor-principal-id": "user-1",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(pendingInteractions.get(requestId)).toBeDefined();
     });
@@ -369,7 +365,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction NOT consumed on actor-mismatch 403", () => {
+    test("interaction NOT consumed on actor-mismatch 403", async () => {
       const requestId = "browser-req-actor-mismatch-stays";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -378,17 +374,15 @@ describe("handleHostBrowserResult — same-actor guard", () => {
         targetActorPrincipalId: "user-1",
       });
 
-      try {
-        handleHostBrowserResult({
-          body: { requestId, content: "ok", isError: false },
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "user-2",
-          },
-        });
-      } catch {
+      await handleHostBrowserResult({
+        body: { requestId, content: "ok", isError: false },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-2",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(pendingInteractions.get(requestId)).toBeDefined();
     });

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -104,7 +104,7 @@ afterAll(() => {
 
 const handleHostCuResult = ROUTES.find(
   (r: { endpoint: string }) => r.endpoint === "host-cu-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -226,15 +226,13 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT resolved on 400 (still pending)", () => {
+    test("interaction is NOT resolved on 400 (still pending)", async () => {
       const requestId = "req-cu-targeted-no-header-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostCuResult({ body: cuBody(requestId) });
-      } catch {
+      await handleHostCuResult({ body: cuBody(requestId) }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -256,19 +254,17 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both submitting and expected client", () => {
+    test("ForbiddenError message names both submitting and expected client", async () => {
       const requestId = "req-cu-targeted-mismatch-msg";
       registerPending(requestId, { targetClientId: "client-A" });
 
       let caught: unknown;
-      try {
-        handleHostCuResult({
-          body: cuBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch (e) {
+      await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch((e: unknown) => {
         caught = e;
-      }
+      });
 
       expect(caught).toBeInstanceOf(ForbiddenError);
       const msg = (caught as ForbiddenError).message;
@@ -276,18 +272,16 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       expect(msg).toContain("client-A");
     });
 
-    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", () => {
+    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", async () => {
       const requestId = "req-cu-targeted-mismatch-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostCuResult({
-          body: cuBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -331,22 +325,20 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction NOT consumed on 403 actor mismatch", () => {
+    test("interaction NOT consumed on 403 actor mismatch", async () => {
       const requestId = "req-cu-actor-mismatch-stays";
       actorPrincipalByClient.set("client-A", "user-1");
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostCuResult({
-          body: cuBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "user-2",
-          },
-        });
-      } catch {
+      await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-2",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -87,7 +87,7 @@ afterAll(() => {
 
 const handleHostFileResult = ROUTES.find(
   (r) => r.endpoint === "host-file-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -189,15 +189,13 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT resolved on 400 (still pending)", () => {
+    test("interaction is NOT resolved on 400 (still pending)", async () => {
       const requestId = "req-file-targeted-no-header-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({ body: fileBody(requestId) });
-      } catch {
+      await handleHostFileResult({ body: fileBody(requestId) }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -219,19 +217,17 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both submitting and expected client", () => {
+    test("ForbiddenError message names both submitting and expected client", async () => {
       const requestId = "req-file-targeted-mismatch-msg";
       registerPending(requestId, { targetClientId: "client-A" });
 
       let caught: unknown;
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch (e) {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch((e: unknown) => {
         caught = e;
-      }
+      });
 
       expect(caught).toBeInstanceOf(ForbiddenError);
       const msg = (caught as ForbiddenError).message;
@@ -239,18 +235,16 @@ describe("handleHostFileResult — targetClientId guard", () => {
       expect(msg).toContain("client-A");
     });
 
-    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", () => {
+    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", async () => {
       const requestId = "req-file-targeted-mismatch-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -306,22 +300,20 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT consumed on actor-mismatch 403", () => {
+    test("interaction is NOT consumed on actor-mismatch 403", async () => {
       const requestId = "req-file-actor-mismatch-stays";
       clientActors.set("client-A", "actor-1");
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "actor-2",
-          },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-2",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -360,19 +352,17 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT consumed when submitting actor is missing", () => {
+    test("interaction is NOT consumed when submitting actor is missing", async () => {
       const requestId = "req-file-actor-missing-stays";
       clientActors.set("client-A", "actor-1");
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: { "x-vellum-client-id": "client-A" },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: { "x-vellum-client-id": "client-A" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -398,21 +388,19 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT consumed when target client has no stored actor", () => {
+    test("interaction is NOT consumed when target client has no stored actor", async () => {
       const requestId = "req-file-target-no-actor-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "actor-1",
-          },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);

--- a/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
@@ -99,7 +99,7 @@ afterAll(() => {
 
 const handleTransferContentGet = ROUTES.find(
   (r) => r.endpoint === "transfers/:transferId/content" && r.method === "GET",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 const handleTransferContentPut = ROUTES.find(
   (r) => r.endpoint === "transfers/:transferId/content" && r.method === "PUT",
@@ -107,7 +107,7 @@ const handleTransferContentPut = ROUTES.find(
 
 const handleTransferResult = ROUTES.find(
   (r) => r.endpoint === "host-transfer-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -186,15 +186,13 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("getTransferContent NOT called on 400", () => {
+    test("getTransferContent NOT called on 400", async () => {
       stubTargetClientId = "client-A";
-      try {
-        handleTransferContentGet({
-          pathParams: { transferId: TEST_TRANSFER_ID },
-        });
-      } catch {
+      await handleTransferContentGet({
+        pathParams: { transferId: TEST_TRANSFER_ID },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(getTransferContentCalls).toHaveLength(0);
     });
   });
@@ -212,16 +210,14 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("getTransferContent NOT called on 403", () => {
+    test("getTransferContent NOT called on 403", async () => {
       stubTargetClientId = "client-A";
-      try {
-        handleTransferContentGet({
-          pathParams: { transferId: TEST_TRANSFER_ID },
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleTransferContentGet({
+        pathParams: { transferId: TEST_TRANSFER_ID },
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(getTransferContentCalls).toHaveLength(0);
     });
   });
@@ -526,23 +522,19 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
       );
     });
 
-    test("resolveTransferResult NOT called on 400", () => {
+    test("resolveTransferResult NOT called on 400", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({ body: resultBody() });
-      } catch {
+      await handleTransferResult({ body: resultBody() }).catch(() => {
         // expected
-      }
+      });
       expect(resolveTransferResultCalls).toHaveLength(0);
     });
 
-    test("pending interaction still present after 400", () => {
+    test("pending interaction still present after 400", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({ body: resultBody() });
-      } catch {
+      await handleTransferResult({ body: resultBody() }).catch(() => {
         // expected
-      }
+      });
       expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
     });
   });
@@ -560,29 +552,25 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("resolveTransferResult NOT called on 403", () => {
+    test("resolveTransferResult NOT called on 403", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({
-          body: resultBody(),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleTransferResult({
+        body: resultBody(),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(resolveTransferResultCalls).toHaveLength(0);
     });
 
-    test("pending interaction still present after 403", () => {
+    test("pending interaction still present after 403", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({
-          body: resultBody(),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleTransferResult({
+        body: resultBody(),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
     });
   });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -92,17 +92,13 @@ mock.module("../prompts/user-reference.js", () => ({
 // resolveGuardianLabel primes its displayName from the gateway binding via
 // getGuardianDelivery at setup. Tests drive the binding through this list.
 
+// Tests set this to drive the guardian binding directly. When null (the
+// default), the guardian-delivery-reader mock below derives the binding from
+// the DB-seeded createGuardianBinding setup. Single mock registration lives
+// below since `mock.module` is process-global and last-write-wins in Bun.
 let mockGuardianDeliveryList:
   | Array<{ channelType: string; status: string; displayName: string | null }>
   | null = null;
-mock.module("../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: async () => mockGuardianDeliveryList,
-  guardianForChannel: (
-    list: Array<{ channelType: string; status: string }>,
-    channelType: string,
-  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
-  anyGuardian: (list: unknown[]) => list[0],
-}));
 
 // ── Config mock ─────────────────────────────────────────────────────
 
@@ -223,6 +219,9 @@ const realContactStoreModule = {
 };
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => {
+    // Tests that set mockGuardianDeliveryList drive the binding directly;
+    // otherwise derive from the DB-seeded createGuardianBinding bindings.
+    if (mockGuardianDeliveryList) return mockGuardianDeliveryList;
     const guardians = realContactStoreModule.listGuardianChannels();
     if (!guardians) return [];
     return guardians.channels.map((ch) => ({
@@ -240,6 +239,7 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
     list: Array<{ channelType: string; status: string }>,
     channelType: string,
   ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
 }));
 
 // ── Trust verdict consumer spy ──────────────────────────────────────
@@ -5134,8 +5134,8 @@ describe("relay-server", () => {
   test("guardian label: DEFAULT_USER_REFERENCE used when both guardian persona name and Contact.displayName are empty", async () => {
     mockUserReference = "my human";
 
-    // No guardian binding so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
-    mockGuardianDeliveryList = null;
+    // Empty binding list so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
+    mockGuardianDeliveryList = [];
 
     ensureConversation("conv-label-default");
     const session = createCallSession({

--- a/assistant/src/__tests__/sse-actor-principal-guardian-source.test.ts
+++ b/assistant/src/__tests__/sse-actor-principal-guardian-source.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression: the SSE subscribe path must resolve the actor principal from the
+ * SAME guardian source as the send/result routes.
+ *
+ * The send/result routes resolve the actor principal via the async,
+ * gateway-first `findLocalGuardianPrincipalId`. The SSE eager-subscribe path
+ * cannot await and uses the sync `findLocalGuardianPrincipalIdFromStore`. When
+ * the gateway binding is canonical but the local contact row is stale/missing
+ * (after a guardian reset or gateway-owned binding update), the sync path must
+ * still land on the gateway principal — otherwise the event hub registers the
+ * SSE client under a DIFFERENT principal than the turn/result paths use, and
+ * targeted result submissions 403.
+ *
+ * These tests pin the invariant by priming the gateway-delivery cache with a
+ * principal that differs from the stale local store and asserting both
+ * resolvers agree; and that a cold cache falls back to the local store.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+// ── Controllable IPC mock (drives the gateway-delivery cache) ────────────────
+
+let ipcGuardians: GuardianDelivery[] = [];
+
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCall: async () => ({ guardians: ipcGuardians }),
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+// ── Local store mock (the stale fallback source) ─────────────────────────────
+
+let storePrincipalId: string | undefined;
+
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (channelType: string) =>
+    storePrincipalId && channelType === "vellum"
+      ? { contact: { principalId: storePrincipalId }, channel: {} }
+      : null,
+}));
+
+import {
+  __resetGuardianDeliveryCacheForTest,
+  getGuardianDelivery,
+} from "../contacts/guardian-delivery-reader.js";
+import {
+  findLocalGuardianPrincipalId,
+  findLocalGuardianPrincipalIdFromStore,
+} from "../runtime/local-actor-identity.js";
+
+const gatewayVellumGuardian: GuardianDelivery = {
+  channelType: "vellum",
+  contactId: "contact-gw",
+  principalId: "guardian-from-gateway",
+  address: "vellum:self",
+  status: "active",
+};
+
+describe("SSE actor principal resolves from the same guardian source as send/result routes", () => {
+  beforeEach(() => {
+    __resetGuardianDeliveryCacheForTest();
+    ipcGuardians = [];
+    storePrincipalId = undefined;
+  });
+
+  test("warm gateway cache: sync (SSE) and async (send/result) resolve the SAME principal despite a stale local store", async () => {
+    // Gateway binding is canonical; local store row is stale (different id).
+    ipcGuardians = [gatewayVellumGuardian];
+    storePrincipalId = "guardian-stale-local";
+
+    // Prime the cache the way the async hot paths do.
+    const asyncPrincipalId = await findLocalGuardianPrincipalId();
+    expect(asyncPrincipalId).toBe("guardian-from-gateway");
+
+    // SSE's sync resolver reads the same cached gateway snapshot, NOT the
+    // stale store — so the principals match and host-proxy targeting works.
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe(asyncPrincipalId);
+  });
+
+  test("cold cache: sync resolver falls back to the local store as before", () => {
+    // Nothing primed the cache; only the local store has a binding.
+    storePrincipalId = "guardian-stale-local";
+
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe("guardian-stale-local");
+  });
+
+  test("cold cache with no store binding: sync resolver returns undefined", () => {
+    expect(findLocalGuardianPrincipalIdFromStore()).toBeUndefined();
+  });
+
+  test("warm gateway cache primes via the vellum-filtered read the async path uses", async () => {
+    ipcGuardians = [gatewayVellumGuardian];
+
+    // The async path filters by channelType vellum; the sync peek must read
+    // the same cache key, not the unfiltered "ALL" entry.
+    await getGuardianDelivery({ channelTypes: ["vellum"] });
+
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe("guardian-from-gateway");
+  });
+});

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -30,6 +30,9 @@ import type {
  * Returns true when a guardian channel was found and revoked, false otherwise.
  */
 export function revokeGuardianBinding(channel: string): boolean {
+  // Local-store read, not the gateway: this read selects the row that the
+  // updateChannelStatus write below mutates, so it must stay transactionally
+  // consistent with that write. Leave for Combo 11 / gateway-bootstrap-binding.
   const guardian = findGuardianForChannel(channel);
   if (!guardian) return false;
 

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -108,6 +108,26 @@ export async function getGuardianDelivery(
 }
 
 /**
+ * Synchronous read of the already-cached guardian deliveries, without any IO.
+ *
+ * Returns the fresh cached list for the given channel filter, or `undefined`
+ * when the cache is cold or expired. Used by sync hot paths (SSE subscribe)
+ * that cannot await {@link getGuardianDelivery} but must resolve the SAME
+ * gateway-owned principal the async paths land on. A cold/expired return lets
+ * the caller fall back to the local store as before.
+ */
+export function peekCachedGuardianDelivery(
+  input?: { channelTypes?: string[] },
+): GuardianDelivery[] | undefined {
+  const cached = cache.get(cacheKey(input?.channelTypes));
+  if (!cached) return undefined;
+  if (Date.now() - cached.fetchedAt >= GUARDIAN_DELIVERY_CACHE_TTL_MS) {
+    return undefined;
+  }
+  return cached.guardians;
+}
+
+/**
  * Clear ALL cached guardian deliveries. Called event-driven on contact
  * mutations, and must also be called from guardian-binding mutation sites
  * (gateway onboarding / verification / revocation) so the next read refetches.

--- a/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
@@ -36,7 +36,7 @@ mock.module("../../config/env.js", () => ({
 }));
 
 mock.module("../../runtime/local-actor-identity.js", () => ({
-  findLocalGuardianPrincipalId: () => fakeLocalPrincipalId,
+  findLocalGuardianPrincipalIdFromStore: () => fakeLocalPrincipalId,
 }));
 
 // ── Real imports (after mocks) ────────────────────────────────────────────

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -33,7 +33,7 @@ import { createServer, type Server, type Socket } from "node:net";
 
 import { ensureSocketDir, SocketWatchdog } from "@vellumai/ipc-server-utils";
 
-import { findLocalGuardianPrincipalId } from "../runtime/local-actor-identity.js";
+import { findLocalGuardianPrincipalIdFromStore } from "../runtime/local-actor-identity.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/index.js";
 import type {
@@ -637,7 +637,7 @@ function injectLocalActorHeader(
   // that require the header will fail-closed on their own.
   let localActor: string | undefined;
   try {
-    localActor = findLocalGuardianPrincipalId();
+    localActor = findLocalGuardianPrincipalIdFromStore();
   } catch (err) {
     log.debug(
       { err },

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -17,6 +17,7 @@ import { findGuardianForChannel } from "../contacts/contact-store.js";
 import {
   getGuardianDelivery,
   guardianForChannel,
+  peekCachedGuardianDelivery,
 } from "../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
@@ -74,14 +75,23 @@ export async function findLocalGuardianPrincipalId(): Promise<
 }
 
 /**
- * Synchronous local-store read of the vellum guardian's principalId.
+ * Synchronous read of the vellum guardian's principalId for paths that cannot
+ * await {@link findLocalGuardianPrincipalId} — namely the SSE eager-subscribe
+ * path (`events-routes`), which registers before the stream is created.
  *
- * The async gateway-backed read is the primary source, but the SSE
- * eager-subscribe path (`events-routes`) registers synchronously before the
- * stream is created and cannot await. It reads the local store directly,
- * which is the same fallback the async path lands on during bootstrap.
+ * Reads the same gateway-owned binding as the async path via a sync, IO-free
+ * snapshot of the guardian-delivery cache (kept fresh by the async hot paths
+ * and event-driven invalidation), so SSE registers the SAME principal the
+ * send/result routes resolve. Falls back to the local store when the cache is
+ * cold — the same fallback the async path lands on during bootstrap.
  */
 export function findLocalGuardianPrincipalIdFromStore(): string | undefined {
+  const cached = peekCachedGuardianDelivery({ channelTypes: ["vellum"] });
+  if (cached) {
+    const principalId = guardianForChannel(cached, "vellum")?.principalId;
+    if (principalId) return principalId;
+  }
+
   return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
 }
 
@@ -123,9 +133,11 @@ export async function resolveActorPrincipalIdForLocalGuardian(
 /**
  * Synchronous variant of {@link resolveActorPrincipalIdForLocalGuardian} for
  * the SSE eager-subscribe path, which registers before the response stream is
- * created and cannot await. Resolves the guardian from the local store rather
- * than the gateway; on bootstrap the gateway-backed async path lands on the
- * same store read.
+ * created and cannot await. Resolves the guardian from the IO-free gateway
+ * cache snapshot first (same source the async path reads), falling back to the
+ * local store when the cache is cold — so SSE registers the SAME principal the
+ * send/result routes resolve and host-proxy targeting matches the same-user
+ * client even when the local contact row is stale.
  */
 export function resolveActorPrincipalIdForLocalGuardianSync(
   rawHeader: string | undefined,

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -14,6 +14,10 @@
 import type { ChannelId } from "../channels/types.js";
 import { isHttpAuthDisabled } from "../config/env.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -45,13 +49,39 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
 }
 
 /**
- * Look up the local vellum guardian's principalId from the contacts table.
+ * Resolve the local vellum guardian's principalId from the gateway.
  *
- * Returns `undefined` when no vellum guardian binding exists (e.g. fresh
- * install before bootstrap). Callers should treat that case as
+ * The gateway owns guardian binding; this reads it through the cached
+ * `getGuardianDelivery` reader (PR-3 TTL + single-flight) so hot paths don't
+ * storm the IPC. Falls back to the local contacts table for the bootstrap /
+ * first-run window where the gateway has no guardian yet or is unreachable
+ * (the reader returns `null`).
+ *
+ * Returns `undefined` when no vellum guardian binding exists in either source
+ * (e.g. fresh install before bootstrap). Callers should treat that case as
  * "not yet available" and either fall back or proceed without a principalId.
  */
-export function findLocalGuardianPrincipalId(): string | undefined {
+export async function findLocalGuardianPrincipalId(): Promise<
+  string | undefined
+> {
+  const list = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (list) {
+    const principalId = guardianForChannel(list, "vellum")?.principalId;
+    if (principalId) return principalId;
+  }
+
+  return findLocalGuardianPrincipalIdFromStore();
+}
+
+/**
+ * Synchronous local-store read of the vellum guardian's principalId.
+ *
+ * The async gateway-backed read is the primary source, but the SSE
+ * eager-subscribe path (`events-routes`) registers synchronously before the
+ * stream is created and cannot await. It reads the local store directly,
+ * which is the same fallback the async path lands on during bootstrap.
+ */
+export function findLocalGuardianPrincipalIdFromStore(): string | undefined {
   return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
 }
 
@@ -76,12 +106,33 @@ export function findLocalGuardianPrincipalId(): string | undefined {
  * yet (e.g. fresh install before bootstrap); callers must treat this the
  * same as a missing principal.
  */
-export function resolveActorPrincipalIdForLocalGuardian(
+export async function resolveActorPrincipalIdForLocalGuardian(
+  rawHeader: string | undefined,
+): Promise<string | undefined> {
+  if (rawHeader !== "dev-bypass" || !isHttpAuthDisabled()) return rawHeader;
+
+  const guardianPrincipalId = await findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) return guardianPrincipalId;
+
+  log.warn(
+    "dev-bypass actor principal received but no vellum guardian binding found; returning undefined",
+  );
+  return undefined;
+}
+
+/**
+ * Synchronous variant of {@link resolveActorPrincipalIdForLocalGuardian} for
+ * the SSE eager-subscribe path, which registers before the response stream is
+ * created and cannot await. Resolves the guardian from the local store rather
+ * than the gateway; on bootstrap the gateway-backed async path lands on the
+ * same store read.
+ */
+export function resolveActorPrincipalIdForLocalGuardianSync(
   rawHeader: string | undefined,
 ): string | undefined {
   if (rawHeader !== "dev-bypass" || !isHttpAuthDisabled()) return rawHeader;
 
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  const guardianPrincipalId = findLocalGuardianPrincipalIdFromStore();
   if (guardianPrincipalId) return guardianPrincipalId;
 
   log.warn(
@@ -102,12 +153,12 @@ export function resolveActorPrincipalIdForLocalGuardian(
  * bootstrap), falls back to a minimal guardian context so the local
  * user is not incorrectly denied.
  */
-export function resolveLocalTrustContext(
+export async function resolveLocalTrustContext(
   sourceChannel: ChannelId = "vellum",
-): TrustContext {
+): Promise<TrustContext> {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
 
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  const guardianPrincipalId = await findLocalGuardianPrincipalId();
   if (guardianPrincipalId) {
     const trustCtx = resolveTrustContext({
       assistantId,
@@ -139,10 +190,12 @@ export function resolveLocalTrustContext(
  * downstream code to resolve guardian context using the same
  * `authContext.actorPrincipalId` path as HTTP sessions.
  */
-export function resolveLocalAuthContext(conversationId: string): AuthContext {
+export async function resolveLocalAuthContext(
+  conversationId: string,
+): Promise<AuthContext> {
   const authContext = buildLocalAuthContext(conversationId);
 
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  const guardianPrincipalId = await findLocalGuardianPrincipalId();
   if (guardianPrincipalId) {
     return { ...authContext, actorPrincipalId: guardianPrincipalId };
   }

--- a/assistant/src/runtime/routes/browser-routes.ts
+++ b/assistant/src/runtime/routes/browser-routes.ts
@@ -92,7 +92,7 @@ async function handleBrowserExecute({
   // register with (dev-bypass otherwise mismatches).
   const headerActor =
     headers["x-vellum-actor-principal-id"]?.trim() || undefined;
-  const sourceActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+  const sourceActorPrincipalId = await resolveActorPrincipalIdForLocalGuardian(
     conversation?.getTurnActorPrincipalId() ?? headerActor,
   );
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -946,25 +946,28 @@ export function handleListMessages({
         .filter((block) => block.type !== "text" || block.text.length > 0);
     }
 
-  // Ensure every hydrated attachment has a corresponding content block.
-  // renderHistoryContent inlines attachment blocks only when it has
-  // file-block refs with matching DB rows; directives (assistant-authored
-  // <vellum-attachment/> tags) don't leave a file block after stripping,
-  // so their attachments end up in the flat `attachments` array but not in
-  // `contentBlocks`. Append any that are missing so the canonical
-  // projection is complete.
-  const existingAttachmentIds = new Set(
-    contentBlocks
-      .filter((b): b is Extract<ConversationContentBlock, { type: "attachment" }> => b.type === "attachment")
-      .map((b) => b.attachment.id),
-  );
-  for (const att of msgAttachments) {
-    if (!existingAttachmentIds.has(att.id)) {
-      contentBlocks.push({ type: "attachment", attachment: att });
+    // Ensure every hydrated attachment has a corresponding content block.
+    // renderHistoryContent inlines attachment blocks only when it has
+    // file-block refs with matching DB rows; directives (assistant-authored
+    // <vellum-attachment/> tags) don't leave a file block after stripping,
+    // so their attachments end up in the flat `attachments` array but not in
+    // `contentBlocks`. Append any that are missing so the canonical
+    // projection is complete.
+    const existingAttachmentIds = new Set(
+      contentBlocks
+        .filter(
+          (b): b is Extract<ConversationContentBlock, { type: "attachment" }> =>
+            b.type === "attachment",
+        )
+        .map((b) => b.attachment.id),
+    );
+    for (const att of msgAttachments) {
+      if (!existingAttachmentIds.has(att.id)) {
+        contentBlocks.push({ type: "attachment", attachment: att });
+      }
     }
-  }
 
-  const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
+    const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
 
     // Use sentAt (actual event time) for the display timestamp when available,
     // falling back to createdAt (persistence time). Clients use this display
@@ -1448,7 +1451,9 @@ export async function handleSendMessage(
     // won't match any guardian binding. Resolve from the local guardian
     // binding instead, which produces the correct guardian trust context.
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      conversation.setTrustContext(resolveLocalTrustContext(sourceChannel));
+      conversation.setTrustContext(
+        await resolveLocalTrustContext(sourceChannel),
+      );
     } else {
       const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
       let trustCtx = resolveTrustContext({

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -43,7 +43,7 @@ import type { ReplaySubscriber } from "../assistant-stream-state.js";
 import { getReplayWindow } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS, GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import { DEFAULT_HEARTBEAT_INTERVAL_MS } from "../client-health.js";
-import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import { resolveActorPrincipalIdForLocalGuardianSync } from "../local-actor-identity.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -311,7 +311,7 @@ export function handleSubscribeAssistantEvents(
   // bearer token's AuthContext. May be absent for legacy / service-token
   // connections that have no principal. See `resolveActorPrincipalId` for the
   // dev-bypass translation rationale.
-  const actorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+  const actorPrincipalId = resolveActorPrincipalIdForLocalGuardianSync(
     rawActorPrincipalId?.trim() || undefined,
   );
 

--- a/assistant/src/runtime/routes/host-app-control-routes.ts
+++ b/assistant/src/runtime/routes/host-app-control-routes.ts
@@ -39,7 +39,7 @@ const VALID_STATES: ReadonlySet<HostAppControlState> = new Set([
 // POST /v1/host-app-control-result
 // ---------------------------------------------------------------------------
 
-function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -95,9 +95,10 @@ function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
       );
     }
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     enforceSameActorOrThrow({
       sourceActorPrincipalId: submittingActorPrincipalId,
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -26,7 +26,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // POST /v1/host-bash-result
 // ---------------------------------------------------------------------------
 
-function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -45,9 +45,10 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
 
   const submittingClientId =
     headers?.["x-vellum-client-id"]?.trim() || undefined;
-  const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-    headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
-  );
+  const submittingActorPrincipalId =
+    await resolveActorPrincipalIdForLocalGuardian(
+      headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -61,14 +61,14 @@ export type HostBrowserResultResolution =
  * already authenticated the caller (the HTTP route uses
  * `requireBoundGuardian`).
  */
-export function resolveHostBrowserResultByRequestId(
+export async function resolveHostBrowserResultByRequestId(
   frame: {
     requestId?: unknown;
     content?: unknown;
     isError?: unknown;
   },
   headers?: Record<string, string | undefined>,
-): HostBrowserResultResolution {
+): Promise<HostBrowserResultResolution> {
   const { requestId, content, isError } = frame;
 
   if (!requestId || typeof requestId !== "string") {
@@ -127,9 +127,10 @@ export function resolveHostBrowserResultByRequestId(
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     try {
       enforceSameActorOrThrow({
         sourceActorPrincipalId: submittingActorPrincipalId,
@@ -260,12 +261,12 @@ export function resolveHostBrowserSessionInvalidated(frame: {
 // POST /v1/host-browser-result
 // ---------------------------------------------------------------------------
 
-function handleHostBrowserResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostBrowserResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
 
-  const resolution = resolveHostBrowserResultByRequestId(
+  const resolution = await resolveHostBrowserResultByRequestId(
     body,
     headers as Record<string, string | undefined> | undefined,
   );
@@ -399,10 +400,7 @@ export const ROUTES: RouteDefinition[] = [
       "Marks the target as invalidated in the runtime-side browser session registry.",
     tags: ["host"],
     requestBody: z.object({
-      targetId: z
-        .string()
-        .optional()
-        .describe("CDP target that was detached"),
+      targetId: z.string().optional().describe("CDP target that was detached"),
       reason: z.string().optional().describe("Detach reason"),
       clientId: z
         .string()

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -26,7 +26,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // POST /v1/host-cu-result
 // ---------------------------------------------------------------------------
 
-function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -95,9 +95,10 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     enforceSameActorOrThrow({
       sourceActorPrincipalId: submittingActorPrincipalId,
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -26,7 +26,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // POST /v1/host-file-result
 // ---------------------------------------------------------------------------
 
-function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -76,9 +76,10 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user somehow obtains the
     // target client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     enforceSameActorOrThrow({
       sourceActorPrincipalId: submittingActorPrincipalId,
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -39,10 +39,10 @@ function findProxyByTransferId(transferId: string) {
 // GET /v1/transfers/:transferId/content
 // ---------------------------------------------------------------------------
 
-function handleTransferContentGet({
+async function handleTransferContentGet({
   pathParams = {},
   headers = {},
-}: RouteHandlerArgs): Uint8Array {
+}: RouteHandlerArgs): Promise<Uint8Array> {
   const transferId = pathParams.transferId;
   if (!transferId) {
     throw new BadRequestError("transferId path parameter is required");
@@ -72,7 +72,7 @@ function handleTransferContentGet({
     // the value persisted at registration time so a brief reconnect does
     // not 403 a legitimate fetch.
     enforceSameActorOrThrow({
-      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+      sourceActorPrincipalId: await resolveActorPrincipalIdForLocalGuardian(
         headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
       ),
       targetActorPrincipalId:
@@ -151,7 +151,7 @@ async function handleTransferContentPut({
       );
 
     enforceSameActorOrThrow({
-      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+      sourceActorPrincipalId: await resolveActorPrincipalIdForLocalGuardian(
         headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
       ),
       targetActorPrincipalId:
@@ -181,7 +181,7 @@ async function handleTransferContentPut({
 // POST /v1/host-transfer-result
 // ---------------------------------------------------------------------------
 
-function handleTransferResult({ body, headers }: RouteHandlerArgs) {
+async function handleTransferResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -222,7 +222,7 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
       );
 
     enforceSameActorOrThrow({
-      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+      sourceActorPrincipalId: await resolveActorPrincipalIdForLocalGuardian(
         headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
       ),
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -45,7 +45,7 @@ const log = getLogger("surface-action-routes");
  * surface actions inherit the correct trust class (guardian vs trusted_contact)
  * rather than defaulting to unknown.
  */
-function applyTrustContext(
+async function applyTrustContext(
   conversation: {
     setTrustContext?(ctx: {
       trustClass: TrustClass;
@@ -53,14 +53,16 @@ function applyTrustContext(
     }): void;
   },
   actorPrincipalId: string | undefined,
-): void {
+): Promise<void> {
   if (!conversation.setTrustContext) return;
 
   const sourceChannel = "vellum";
 
   if (actorPrincipalId) {
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      conversation.setTrustContext(resolveLocalTrustContext(sourceChannel));
+      conversation.setTrustContext(
+        await resolveLocalTrustContext(sourceChannel),
+      );
     } else {
       const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
       let trustCtx = resolveTrustContext({
@@ -186,7 +188,7 @@ async function handleSurfaceAction({
   }
 
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
-  applyTrustContext(conversation, actorPrincipalId);
+  await applyTrustContext(conversation, actorPrincipalId);
 
   try {
     const raw = await conversation.handleSurfaceAction(


### PR DESCRIPTION
## Summary
- local-actor-identity resolves the local vellum guardian via the cached getGuardianDelivery reader, keeping the bootstrap/first-run local fallback. Any write-entangled contacts-write guard read left for Combo 11.

Part of plan: gateway-guardian-binding-pull.md (PR 10 of 10)