### PR TITLE
Fix empty dictation error handling

### DIFF
--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -290,6 +290,27 @@ describe("VoiceInputButton — native partials fallback", () => {
     useVoiceRecordingStore.getState().reset();
   });
 
+  test("configuration errors still surface when no native final is available", async () => {
+    postSttTranscribeSpy.mockImplementationOnce(async () => ({
+      status: "error",
+      reason: "config-missing",
+    }));
+
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("error");
+    });
+    expect(useVoiceRecordingStore.getState().errorCode).toBe(
+      "stt-not-configured",
+    );
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(lastBreadcrumb().data.outcome).toBe("error");
+  });
+
   test("native Apple Speech text becomes the final transcript when batch STT fails", async () => {
     nativePartialsImpl = async (onPartial) => {
       onPartial("offline transcript");
@@ -332,6 +353,62 @@ describe("VoiceInputButton — native partials fallback", () => {
       expect(onTranscript).toHaveBeenCalledWith("the full final sentence");
     });
     expect(lastBreadcrumb().data.outcome).toBe("completed");
+  });
+
+  test("empty native final makes an unconfigured daemon response an empty dictation", async () => {
+    nativePartialsImpl = async () => {
+      return () => Promise.resolve(null);
+    };
+    postSttTranscribeSpy.mockImplementationOnce(async () => ({
+      status: "error",
+      reason: "config-missing",
+    }));
+
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("idle");
+    });
+    expect(useVoiceRecordingStore.getState().errorCode).toBeNull();
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(postSttTranscribeSpy).toHaveBeenCalledTimes(1);
+    expect(lastBreadcrumb().data.outcome).toBe("empty");
+  });
+
+  test("waits for empty native final when stop races native startup", async () => {
+    let resolveNativeStart:
+      | ((stop: (() => Promise<string | null>) | null) => void)
+      | null = null;
+    nativePartialsImpl = () =>
+      new Promise<(() => Promise<string | null>) | null>((resolve) => {
+        resolveNativeStart = resolve;
+      });
+    postSttTranscribeSpy.mockImplementationOnce(async () => ({
+      status: "error",
+      reason: "config-missing",
+    }));
+
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+    await waitFor(() => {
+      expect(resolveNativeStart).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+    act(() => {
+      resolveNativeStart?.(() => Promise.resolve(null));
+    });
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("idle");
+    });
+    expect(useVoiceRecordingStore.getState().errorCode).toBeNull();
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(postSttTranscribeSpy).toHaveBeenCalledTimes(1);
+    expect(lastBreadcrumb().data.outcome).toBe("empty");
   });
 
   test("successful batch STT takes priority over native partials text", async () => {

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -411,6 +411,41 @@ describe("VoiceInputButton — native partials fallback", () => {
     expect(lastBreadcrumb().data.outcome).toBe("empty");
   });
 
+  test("configuration errors still surface when native startup resolves unavailable after stop", async () => {
+    let resolveNativeStart:
+      | ((stop: (() => Promise<string | null>) | null) => void)
+      | null = null;
+    nativePartialsImpl = () =>
+      new Promise<(() => Promise<string | null>) | null>((resolve) => {
+        resolveNativeStart = resolve;
+      });
+    postSttTranscribeSpy.mockImplementationOnce(async () => ({
+      status: "error",
+      reason: "config-missing",
+    }));
+
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+    await waitFor(() => {
+      expect(resolveNativeStart).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+    act(() => {
+      resolveNativeStart?.(null);
+    });
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("error");
+    });
+    expect(useVoiceRecordingStore.getState().errorCode).toBe(
+      "stt-not-configured",
+    );
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(postSttTranscribeSpy).toHaveBeenCalledTimes(1);
+    expect(lastBreadcrumb().data.outcome).toBe("error");
+  });
+
   test("successful batch STT takes priority over native partials text", async () => {
     nativePartialsImpl = async (onPartial) => {
       onPartial("offline transcript");

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -196,6 +196,11 @@ type DictationSessionOutcome =
   | "cancelled"
   | "aborted";
 
+interface NativeFinalResult {
+  text: string | null;
+  stopRan: boolean;
+}
+
 /**
  * One breadcrumb per dictation session, emitted when the session reaches a
  * terminal state. Carries only metrics (duration, locale, final transcript
@@ -326,7 +331,7 @@ export const VoiceInputButton = forwardRef<
   // Resolves with the recognizer's final transcript of the whole utterance
   // after stopNativePartials — short dictations end before the first
   // partial, so this is the only reliable native text source.
-  const nativeFinalPromiseRef = useRef<Promise<string | null> | null>(null);
+  const nativeFinalPromiseRef = useRef<Promise<NativeFinalResult> | null>(null);
 
   // Latest running transcript from the daemon stream — kept through
   // teardown so it can serve as the final-transcript fallback when batch
@@ -387,9 +392,18 @@ export const VoiceInputButton = forwardRef<
     // The promise resolves once the helper's recognizer drains the session
     // (dictation.finalized); recorder.onstop awaits it alongside batch STT.
     const final = stop
-      ? stop()
-      : pendingStart!.then((readyStop) => readyStop?.() ?? null);
-    if (final) nativeFinalPromiseRef.current = final;
+      ? Promise.resolve(stop()).then((text) => ({
+          text: text ?? null,
+          stopRan: true,
+        }))
+      : pendingStart!.then(async (readyStop) => {
+          if (!readyStop) return { text: null, stopRan: false };
+          return {
+            text: (await readyStop()) ?? null,
+            stopRan: true,
+          };
+        });
+    nativeFinalPromiseRef.current = final;
   }, []);
 
   // Run the mac helper's local speech recognizer alongside the whole
@@ -726,7 +740,6 @@ export const VoiceInputButton = forwardRef<
       const nativePartialText = nativePartialsTextRef.current;
       stopNativePartials();
       const pendingNativeFinal = nativeFinalPromiseRef.current;
-      const nativeFinalWasRequested = pendingNativeFinal !== null;
       nativeFinalPromiseRef.current = null;
       publishInterim("");
 
@@ -812,10 +825,12 @@ export const VoiceInputButton = forwardRef<
         // partials of a 1-2s dictation are usually still empty. The await
         // overlaps the batch POST above, so it adds ~no wall-clock time.
         let nativeText = nativePartialText;
+        let nativeFinalStopRan = false;
         if (pendingNativeFinal) {
-          const finalText = await pendingNativeFinal;
-          if (finalText) {
-            nativeText = finalText;
+          const finalResult = await pendingNativeFinal;
+          nativeFinalStopRan = finalResult.stopRan;
+          if (finalResult.text) {
+            nativeText = finalResult.text;
           }
         }
 
@@ -866,7 +881,7 @@ export const VoiceInputButton = forwardRef<
             onError?.("native-stt-no-transcript");
             vsFail("native-stt-no-transcript");
             return;
-          } else if (daemonFailure && !nativeFinalWasRequested) {
+          } else if (daemonFailure && !nativeFinalStopRan) {
             // The user-cancelled `aborted` reason should not trigger a
             // visible error — it's the expected outcome of stop().
             if (daemonFailure === "aborted") {

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -319,6 +319,9 @@ export const VoiceInputButton = forwardRef<
   const nativePartialsStopRef = useRef<StopNativeDictationPartials | null>(
     null,
   );
+  const nativePartialsStartRef = useRef<
+    Promise<StopNativeDictationPartials | null> | null
+  >(null);
   const nativePartialsTextRef = useRef("");
   // Resolves with the recognizer's final transcript of the whole utterance
   // after stopNativePartials — short dictations end before the first
@@ -379,10 +382,13 @@ export const VoiceInputButton = forwardRef<
     // fallback. startRecording resets it for the next session.
     const stop = nativePartialsStopRef.current;
     nativePartialsStopRef.current = null;
-    if (!stop) return;
+    const pendingStart = nativePartialsStartRef.current;
+    if (!stop && !pendingStart) return;
     // The promise resolves once the helper's recognizer drains the session
     // (dictation.finalized); recorder.onstop awaits it alongside batch STT.
-    const final = stop();
+    const final = stop
+      ? stop()
+      : pendingStart!.then((readyStop) => readyStop?.() ?? null);
     if (final) nativeFinalPromiseRef.current = final;
   }, []);
 
@@ -395,14 +401,19 @@ export const VoiceInputButton = forwardRef<
   // provider behind it is unreachable, so it just stays silent. Same role
   // the recognizer played in the legacy Swift client.
   const startNativePartials = useCallback(() => {
-    if (!mediaRecorderRef.current || nativePartialsStopRef.current) {
+    if (
+      !mediaRecorderRef.current ||
+      nativePartialsStopRef.current ||
+      nativePartialsStartRef.current
+    ) {
       console.info(
         "dictation: native partials not started (session ended or already running)",
       );
       return;
     }
+    const sessionIdAtStart = sessionIdRef.current;
     let partialCount = 0;
-    void startNativeDictationPartials(
+    const startPromise = startNativeDictationPartials(
       (text) => {
         partialCount += 1;
         if (partialCount === 1 || partialCount % 25 === 0) {
@@ -420,16 +431,30 @@ export const VoiceInputButton = forwardRef<
       // the device itself (a second capture client on the same device reads
       // silence or kills this recording's stream).
       { stream: streamRef.current ?? undefined },
-    ).then((stop) => {
-      // The unavailable case logs its reason in native-dictation-partials.
-      if (!stop) return;
-      console.info("dictation: native partials running");
-      // The session may have ended while the helper call was in flight.
-      if (!mediaRecorderRef.current) {
-        stop();
-        return;
+    )
+      .then((stop) => {
+        // The unavailable case logs its reason in native-dictation-partials.
+        if (!stop) return null;
+        console.info("dictation: native partials running");
+        // The session may have ended while the helper call was in flight.
+        if (
+          !mediaRecorderRef.current ||
+          sessionIdRef.current !== sessionIdAtStart
+        ) {
+          return stop;
+        }
+        nativePartialsStopRef.current = stop;
+        return stop;
+      })
+      .catch((err) => {
+        console.warn("dictation: native partials failed to start", err);
+        return null;
+      });
+    nativePartialsStartRef.current = startPromise;
+    void startPromise.finally(() => {
+      if (nativePartialsStartRef.current === startPromise) {
+        nativePartialsStartRef.current = null;
       }
-      nativePartialsStopRef.current = stop;
     });
   }, [publishInterim]);
 
@@ -582,6 +607,7 @@ export const VoiceInputButton = forwardRef<
     // pipeline first. Starting it after getUserMedia claims the mic causes
     // Chrome to silently starve SpeechRecognition of audio input.
     speechAccumulatorRef.current = "";
+    nativePartialsStartRef.current = null;
     nativePartialsTextRef.current = "";
     nativeFinalPromiseRef.current = null;
     streamTranscriptRef.current = "";
@@ -700,6 +726,7 @@ export const VoiceInputButton = forwardRef<
       const nativePartialText = nativePartialsTextRef.current;
       stopNativePartials();
       const pendingNativeFinal = nativeFinalPromiseRef.current;
+      const nativeFinalWasRequested = pendingNativeFinal !== null;
       nativeFinalPromiseRef.current = null;
       publishInterim("");
 
@@ -830,7 +857,16 @@ export const VoiceInputButton = forwardRef<
           if (text) {
             addDictationSessionBreadcrumb("completed", durationMs, text.length);
             await onTranscript(text);
-          } else if (daemonFailure) {
+          } else if (nativeSttForced && audioBlob) {
+            // Audio was captured but the forced-native recognizer produced
+            // nothing — most likely macOS Dictation (and its on-device
+            // model) isn't enabled. Surface that instead of resetting
+            // silently; there is no daemon failure to report here.
+            addDictationSessionBreadcrumb("error", durationMs, 0);
+            onError?.("native-stt-no-transcript");
+            vsFail("native-stt-no-transcript");
+            return;
+          } else if (daemonFailure && !nativeFinalWasRequested) {
             // The user-cancelled `aborted` reason should not trigger a
             // visible error — it's the expected outcome of stop().
             if (daemonFailure === "aborted") {
@@ -842,15 +878,6 @@ export const VoiceInputButton = forwardRef<
             const code = errorCodeForReason(daemonFailure);
             onError?.(code);
             vsFail(code);
-            return;
-          } else if (nativeSttForced && audioBlob) {
-            // Audio was captured but the forced-native recognizer produced
-            // nothing — most likely macOS Dictation (and its on-device
-            // model) isn't enabled. Surface that instead of resetting
-            // silently; there is no daemon failure to report here.
-            addDictationSessionBreadcrumb("error", durationMs, 0);
-            onError?.("native-stt-no-transcript");
-            vsFail("native-stt-no-transcript");
             return;
           } else {
             addDictationSessionBreadcrumb("empty", durationMs, 0);


### PR DESCRIPTION
## Summary
- Treat a native recognizer finalization with no transcript as an empty dictation instead of surfacing the daemon STT setup banner.
- Wait for in-flight native recognizer startup when recording stops quickly, and guard late native starts against attaching to a newer session.
- Add regression coverage for empty native-final, fast stop, and the no-native-fallback provider error case.

## Original prompt
The user reported that starting dictation, saying nothing, and stopping shows a misleading “Speech-to-text isn’t set up” banner, even though dictation works when they actually speak. They asked to implement the fix through the /do workflow so empty dictation stops quietly without breaking the configured speech path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->