### PR TITLE
fix(onboarding): stop double-hatching local assistants across the auth remount

### DIFF
--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -346,6 +346,10 @@ export function HatchingScreen() {
               }
             }
             if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
+              // The hatch succeeded but the gateway never went healthy. We never
+              // reached connectLocalAssistant(), so no remount occurred — release
+              // the guards so "Try again" runs a genuinely fresh hatch.
+              releaseHatchGuards();
               setError("Your assistant is taking longer than expected. Please try again.");
               return;
             }

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -44,10 +44,25 @@ const POLL_INTERVAL_MS = 3000;
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
 const MAX_HATCH_WAIT_MS = 300_000;
 
-// Module-level promises so HMR remounts and StrictMode double-mounts
-// can await the same in-flight hatch instead of spawning duplicates.
+// Module-level state so HMR remounts, StrictMode double-mounts, and — critically
+// — the auth-driven provider remount survive without spawning duplicate hatches.
+// The local-hatch handoff calls connectLocalAssistant(), which flips
+// `sessionStatus` to "authenticated"; that changes the scope `key` on the
+// query-client providers (see providers.tsx), unmounting and remounting this
+// whole screen mid-flow. The remounted instance must await the SAME in-flight
+// (or already-resolved) hatch — and reuse the SAME avatar traits — rather than
+// start over. These guards are released only on failure (so retry re-hatches)
+// and on genuine completion (so a later onboarding hatches fresh), never in the
+// window between the hatch resolving and the screen navigating away.
 let localHatchPromise: Promise<import("@/runtime/local-mode-host").LocalHatchResult> | null = null;
 let platformHatchPromise: Promise<import("@/assistant/api").HatchResult> | null = null;
+let hatchTraitsCache: CharacterTraits | null = null;
+
+function releaseHatchGuards(): void {
+  localHatchPromise = null;
+  platformHatchPromise = null;
+  hatchTraitsCache = null;
+}
 
 type HatchPhase = "initializing" | "provisioning" | "connecting" | "ready";
 
@@ -108,8 +123,8 @@ export function HatchingScreen() {
   const sessionGateKey = useLocalHatch
     ? isSessionSettled(sessionStatus)
     : sessionStatus;
-  const [hatchTraits] = useState<CharacterTraits>(() =>
-    randomCharacterTraits(BUNDLED_COMPONENTS),
+  const [hatchTraits] = useState<CharacterTraits>(
+    () => (hatchTraitsCache ??= randomCharacterTraits(BUNDLED_COMPONENTS)),
   );
   const avatarSvgDataUrl = useMemo(() => {
     const svg = composeSvg(
@@ -196,6 +211,11 @@ export function HatchingScreen() {
       phaseRef.current = "ready";
       navigateTimer = setTimeout(() => {
         if (cancelled) return;
+        // The hatch succeeded and we're leaving this screen for good. Release
+        // the module-level guards so a later onboarding session (e.g. after
+        // retiring this assistant) hatches a brand-new one instead of reusing
+        // this resolved promise and avatar.
+        releaseHatchGuards();
         void (async () => {
           await lifecycleService.checkAssistant();
           if (cancelled) return;
@@ -273,10 +293,15 @@ export function HatchingScreen() {
             const remote = hostingParam === "docker" ? "docker" : undefined;
             localHatchPromise = hatchLocalAssistant(undefined, remote);
           }
+          // Keep `localHatchPromise` set through the rest of the flow. The
+          // connectLocalAssistant() handoff below remounts this screen (see the
+          // module-level comment); the fresh instance must await this same
+          // resolved promise instead of starting a second hatch. Released only
+          // on failure (below / catch) and on completion (handleHatchReady).
           const result = await localHatchPromise;
-          localHatchPromise = null;
           if (cancelled) return;
           if (!result.ok) {
+            releaseHatchGuards();
             setError(result.error ?? "Failed to hatch local assistant.");
             return;
           }
@@ -363,7 +388,7 @@ export function HatchingScreen() {
 
           handleHatchReady();
         } catch {
-          localHatchPromise = null;
+          releaseHatchGuards();
           if (cancelled) return;
           setError("Failed to hatch local assistant. Check CLI logs for details.");
         }


### PR DESCRIPTION
## Problem

Choosing **Self-hosting** in onboarding (Electron/macOS app) hatches **two** local assistants. The tell is a flash during the hatching step where the avatar switches from one character to another.

This was *thought* to be fixed by #35152 (which keyed the hatch effect on `isSessionSettled()` instead of raw `sessionStatus`), but it still reproduces in the `release/v0.10.1` staging build. That earlier fix only prevents an effect *re-run*; the real cause is a full component **remount**.

## Root cause

The local-hatch handoff calls `connectLocalAssistant()`, which does `set(authenticatedLocalUser())` — flipping `sessionStatus` → `"authenticated"` and setting `user` → `GATEWAY_LOCAL_USER`.

That flip changes the scope `key` on both `AuthScopedQueryClientProvider` and `ScopeKeyedQueryClientProvider` (`clients/web/src/components/providers.tsx`), since the key encodes `isAuthenticated`/`user.id`. A changed `key` forces React to **unmount the entire subtree and remount a fresh `HatchingScreen`** mid-flow.

The module-level `localHatchPromise` is meant to be the dedup guard for exactly this kind of remount (its own comment says "so HMR remounts and StrictMode double-mounts can await the same in-flight hatch"). But it was nulled **immediately after the hatch resolved** — *before* the `connectLocalAssistant()` call that triggers the remount. So:

1. Mount A hatches **assistant #1**, resolves, nulls `localHatchPromise`.
2. `/readyz` passes → `connectLocalAssistant()` flips auth → provider `key` changes → **remount**.
3. Mount B (fresh instance, new random avatar) sees `localHatchPromise === null` → hatches **assistant #2**.

Two mounts → two random avatars (the flash) and two `hatchLocalAssistant()` calls (the duplicate assistant).

## Fix

- **Keep `localHatchPromise` set through the entire flow** so the remounted instance awaits the same resolved hatch instead of starting a second one. Release it only on **failure** (so "Try again" re-hatches) and on **genuine completion** (navigating away, so a later onboarding session hatches fresh) — never in the window between the hatch resolving and the screen navigating away.
- **Hoist the random avatar traits to a module-level cache** so the remount reuses the same character. This removes the visible avatar flash and makes avatar seeding deterministic (no race over which mount's traits win).

The fix is intentionally scoped to make the hatch flow *robust to remounts regardless of their cause* (HMR, StrictMode, auth transitions) rather than altering the provider keying, which is load-bearing for query-cache scope isolation and too risky to touch for a release.

## Testing

- `tsc --noEmit` passes for `hatching-screen.tsx` (validated against an equivalent checkout).
- Needs a manual repro check in the Electron app: go through onboarding → Self-hosting → confirm exactly one assistant is hatched and the avatar no longer flips.

## Follow-up

After this merges to `main`, it must be **cherry-picked onto `release/v0.10.1`** to actually ship in today's release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)