### PR TITLE
Pin platform upgrade polling to the upgraded assistant

### DIFF
--- a/clients/web/src/assistant/operational-status.ts
+++ b/clients/web/src/assistant/operational-status.ts
@@ -134,10 +134,12 @@ async function fetchOperationalStatus(
 
 export function useAssistantOperationalStatus(
   assistantId: string | null,
-  opts?: { ignoreLifecycleGate?: boolean },
+  opts?: { ignoreActiveAssistantGate?: boolean },
 ) {
   const platformHostedGate = usePlatformGate({ platformHostedOnly: true });
   const platformApiGate = usePlatformGate();
+  const ignoreActiveAssistantGate =
+    opts?.ignoreActiveAssistantGate === true;
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   const operationalStatusAssistantId =
     useAssistantLifecycleStore.use.operationalStatusAssistantId();
@@ -145,8 +147,8 @@ export function useAssistantOperationalStatus(
   const isOrgReady = useIsOrgReady();
   const targetIsLifecycleOperationAssistant =
     Boolean(assistantId) && assistantId === operationalStatusAssistantId;
-  const canPollForLifecycleState =
-    opts?.ignoreLifecycleGate === true ||
+  const canPollForActiveAssistant =
+    ignoreActiveAssistantGate ||
     canPollOperationalStatus({
       assistantState,
       activeAssistantIsPlatformHosted,
@@ -154,10 +156,10 @@ export function useAssistantOperationalStatus(
     });
   const enabled =
     Boolean(assistantId) &&
-    platformHostedGate === "full" &&
+    (ignoreActiveAssistantGate || platformHostedGate === "full") &&
     platformApiGate === "full" &&
     isOrgReady &&
-    canPollForLifecycleState;
+    canPollForActiveAssistant;
 
   return useQuery({
     queryKey: assistantsOperationalStatusDetailReadOptions({

--- a/clients/web/src/assistant/operational-status.ts
+++ b/clients/web/src/assistant/operational-status.ts
@@ -132,7 +132,10 @@ async function fetchOperationalStatus(
   return status;
 }
 
-export function useAssistantOperationalStatus(assistantId: string | null) {
+export function useAssistantOperationalStatus(
+  assistantId: string | null,
+  opts?: { ignoreLifecycleGate?: boolean },
+) {
   const platformHostedGate = usePlatformGate({ platformHostedOnly: true });
   const platformApiGate = usePlatformGate();
   const assistantState = useAssistantLifecycleStore.use.assistantState();
@@ -142,16 +145,19 @@ export function useAssistantOperationalStatus(assistantId: string | null) {
   const isOrgReady = useIsOrgReady();
   const targetIsLifecycleOperationAssistant =
     Boolean(assistantId) && assistantId === operationalStatusAssistantId;
-  const enabled =
-    Boolean(assistantId) &&
-    platformHostedGate === "full" &&
-    platformApiGate === "full" &&
-    isOrgReady &&
+  const canPollForLifecycleState =
+    opts?.ignoreLifecycleGate === true ||
     canPollOperationalStatus({
       assistantState,
       activeAssistantIsPlatformHosted,
       targetIsLifecycleOperationAssistant,
     });
+  const enabled =
+    Boolean(assistantId) &&
+    platformHostedGate === "full" &&
+    platformApiGate === "full" &&
+    isOrgReady &&
+    canPollForLifecycleState;
 
   return useQuery({
     queryKey: assistantsOperationalStatusDetailReadOptions({

--- a/clients/web/src/components/runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/runtime-upgrade-banner.tsx
@@ -296,8 +296,10 @@ function usePlatformRuntimeUpgrade({
     null,
   );
   const targetVersionRef = useRef<string | null>(null);
-  const { data: pollingOperationalStatus } =
-    useAssistantOperationalStatus(pollingAssistantId);
+  const { data: pollingOperationalStatus } = useAssistantOperationalStatus(
+    pollingAssistantId,
+    { ignoreLifecycleGate: true },
+  );
   const mutation = useMutation({
     mutationFn: async ({
       assistantId: upgradeAssistantId,

--- a/clients/web/src/components/runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/runtime-upgrade-banner.tsx
@@ -179,7 +179,6 @@ export function RuntimeUpgradeBanner({
   const platformUpgrade = usePlatformRuntimeUpgrade({
     assistantId,
     targetVersion: targetVersion ?? undefined,
-    shouldStopPolling: platformOperationalStatus?.detail_state === "failed",
   });
   const upgradePending =
     mode === "platform" ? platformUpgrade.isPending : localUpgrade.isPending;
@@ -287,23 +286,31 @@ export function RuntimeUpgradeBanner({
 function usePlatformRuntimeUpgrade({
   assistantId,
   targetVersion,
-  shouldStopPolling = false,
 }: {
   assistantId: string | null | undefined;
   targetVersion?: string;
-  shouldStopPolling?: boolean;
 }) {
   const queryClient = useQueryClient();
   const [isPollingUpgrade, setIsPollingUpgrade] = useState(false);
+  const [pollingAssistantId, setPollingAssistantId] = useState<string | null>(
+    null,
+  );
   const targetVersionRef = useRef<string | null>(null);
+  const { data: pollingOperationalStatus } =
+    useAssistantOperationalStatus(pollingAssistantId);
   const mutation = useMutation({
-    mutationFn: async () => {
-      if (!assistantId) {
-        throw new Error("No assistant is active.");
-      }
+    mutationFn: async ({
+      assistantId: upgradeAssistantId,
+      targetVersion: requestedTargetVersion,
+    }: {
+      assistantId: string;
+      targetVersion?: string;
+    }) => {
       const { data } = await assistantsUpgradeDetailCreate({
-        path: { id: assistantId },
-        body: targetVersion ? { version: targetVersion } : {},
+        path: { id: upgradeAssistantId },
+        body: requestedTargetVersion
+          ? { version: requestedTargetVersion }
+          : {},
         throwOnError: true,
       });
       return data;
@@ -311,16 +318,22 @@ function usePlatformRuntimeUpgrade({
   });
 
   useEffect(() => {
-    if (!isPollingUpgrade || !shouldStopPolling) return;
+    if (
+      !isPollingUpgrade ||
+      pollingOperationalStatus?.detail_state !== "failed"
+    ) {
+      return;
+    }
     targetVersionRef.current = null;
+    setPollingAssistantId(null);
     setIsPollingUpgrade(false);
-  }, [isPollingUpgrade, shouldStopPolling]);
+  }, [isPollingUpgrade, pollingOperationalStatus?.detail_state]);
 
   useQuery({
     ...assistantsRetrieveOptions({
-      path: { id: assistantId ?? "" },
+      path: { id: pollingAssistantId ?? "" },
     }),
-    enabled: isPollingUpgrade && !!assistantId,
+    enabled: isPollingUpgrade && !!pollingAssistantId,
     refetchInterval: (query) => {
       const version = query.state.data?.current_release_version;
       if (
@@ -335,6 +348,7 @@ function usePlatformRuntimeUpgrade({
               .upsertFromApi(query.state.data);
           }
           targetVersionRef.current = null;
+          setPollingAssistantId(null);
           setIsPollingUpgrade(false);
           toast.success("Update complete — assistant is healthy.");
         });
@@ -350,16 +364,23 @@ function usePlatformRuntimeUpgrade({
       if (!assistantId) {
         throw new Error("No assistant is active.");
       }
-      const result = await mutation.mutateAsync();
+      const upgradeAssistantId = assistantId;
+      const requestedTargetVersion = targetVersion;
+      const result = await mutation.mutateAsync({
+        assistantId: upgradeAssistantId,
+        targetVersion: requestedTargetVersion,
+      });
       const isNoOp = result.detail?.includes("Already on the latest");
       if (!isNoOp) {
-        targetVersionRef.current = result.version ?? targetVersion ?? null;
+        targetVersionRef.current =
+          result.version ?? requestedTargetVersion ?? null;
         if (targetVersionRef.current) {
+          setPollingAssistantId(upgradeAssistantId);
           setIsPollingUpgrade(true);
         }
         queryClient.invalidateQueries({
           queryKey: assistantsRetrieveQueryKey({
-            path: { id: assistantId },
+            path: { id: upgradeAssistantId },
           }),
         });
       }

--- a/clients/web/src/components/runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/runtime-upgrade-banner.tsx
@@ -298,7 +298,7 @@ function usePlatformRuntimeUpgrade({
   const targetVersionRef = useRef<string | null>(null);
   const { data: pollingOperationalStatus } = useAssistantOperationalStatus(
     pollingAssistantId,
-    { ignoreLifecycleGate: true },
+    { ignoreActiveAssistantGate: true },
   );
   const mutation = useMutation({
     mutationFn: async ({


### PR DESCRIPTION
## Summary
- Capture the platform assistant id used to start a runtime upgrade and reuse that fixed id for polling.
- Stop polling the captured assistant when its operational status reports a failed transition.
- Invalidate the retrieve query for the upgraded assistant instead of whichever assistant is active later.

## Original prompt
The platform runtime upgrade banner could keep polling the live active assistant id after a user switched assistants during an upgrade. The request was to address review feedback by capturing the assistant id used by the upgrade mutation and polling that fixed assistant until the operation resolves or fails, in a fresh `$do` branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->