### PR TITLE
Improve memory v3 selector diagnostics

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -49,6 +49,7 @@ interface ProviderCall {
   options: SendMessageOptions | undefined;
 }
 const providerCalls: ProviderCall[] = [];
+const warnCalls: Array<{ args: unknown[] }> = [];
 
 mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => providerStub,
@@ -57,10 +58,12 @@ mock.module("../../../../providers/provider-send-message.js", () => ({
 }));
 
 mock.module("../../../../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: (_t, prop) => (prop === "child" ? () => ({}) : () => {}),
+  getLogger: () => ({
+    warn: (...args: unknown[]) => warnCalls.push({ args }),
+    child: () => ({
+      warn: (...args: unknown[]) => warnCalls.push({ args }),
     }),
+  }),
 }));
 
 const { selectPool, MemoryV3RetrievalUnavailableError } =
@@ -97,7 +100,18 @@ function noToolResponse(): ProviderResponse {
     model: "stub-model",
     stopReason: "end_turn",
     usage: { inputTokens: 0, outputTokens: 0 },
+    rawRequest: { model: "MiniMaxAI/MiniMax-M3" },
+    rawResponse: { model: "accounts/fireworks/models/minimax-m3" },
     content: [{ type: "text", text: "no tool call" }],
+  };
+}
+
+function wrongToolResponse(): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "tool_use",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "tool_use", id: "tu-1", name: "wrong_tool", input: {} }],
   };
 }
 
@@ -118,12 +132,12 @@ function makeSequenceProvider(responses: ProviderResponse[]): Provider {
 
 /** Provider that records each call and then throws — the throw-after-retries
  * path (the provider's own RetryProvider has already exhausted its backoff). */
-function makeThrowingProvider(): Provider {
+function makeThrowingProvider(message = "boom"): Provider {
   return {
     name: "throwing",
     sendMessage: async (messages, options) => {
       providerCalls.push({ messages, options });
-      throw new Error("boom");
+      throw new Error(message);
     },
   };
 }
@@ -167,9 +181,19 @@ function sentBlocks(callIndex = 0): RenderedBlock[] {
     .content as unknown as RenderedBlock[];
 }
 
+function warnPayloads(): Array<Record<string, unknown>> {
+  return warnCalls
+    .map((call) => call.args[0])
+    .filter(
+      (payload): payload is Record<string, unknown> =>
+        payload !== null && typeof payload === "object",
+    );
+}
+
 beforeEach(() => {
   providerStub = null;
   providerCalls.length = 0;
+  warnCalls.length = 0;
 });
 
 // ---------------------------------------------------------------------------
@@ -250,6 +274,62 @@ describe("selectPool — infrastructure failures throw", () => {
       MemoryV3RetrievalUnavailableError,
     );
     expect(providerCalls).toHaveLength(3);
+    const payloads = warnPayloads();
+    const attemptPayloads = payloads.filter(
+      (payload) => payload.reason === "missing_tool_use",
+    );
+    expect(attemptPayloads).toHaveLength(3);
+    expect(attemptPayloads[0]).toMatchObject({
+      attempt: 1,
+      reason: "missing_tool_use",
+      providerName: "stub",
+      candidateCount: 4,
+      stableCount: 2,
+      finderCount: 2,
+      response: {
+        model: "stub-model",
+        stopReason: "end_turn",
+        requestModel: "MiniMaxAI/MiniMax-M3",
+        responseModel: "accounts/fireworks/models/minimax-m3",
+        contentBlockTypes: ["text"],
+        toolUseNames: [],
+      },
+    });
+    const aggregatePayload = payloads.find((payload) =>
+      Array.isArray(payload.failures),
+    );
+    expect(aggregatePayload?.providerName).toBe("stub");
+    const failures = aggregatePayload?.failures as
+      | Array<Record<string, unknown>>
+      | undefined;
+    expect(failures?.[0]).toMatchObject({ reason: "missing_tool_use" });
+  });
+
+  test("wrong tool_use name logs the unexpected name before throwing", async () => {
+    providerStub = makeProvider(wrongToolResponse());
+    await expect(selectPool(makePool(), makeTurn("x"))).rejects.toThrow(
+      MemoryV3RetrievalUnavailableError,
+    );
+    expect(providerCalls).toHaveLength(3);
+    expect(
+      warnPayloads().filter(
+        (payload) => payload.reason === "unexpected_tool_name",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        attempt: 1,
+        reason: "unexpected_tool_name",
+        providerName: "stub",
+        toolName: "wrong_tool",
+        response: expect.objectContaining({
+          stopReason: "tool_use",
+          contentBlockTypes: ["tool_use"],
+          toolUseNames: ["wrong_tool"],
+        }),
+      }),
+      expect.objectContaining({ attempt: 2 }),
+      expect.objectContaining({ attempt: 3 }),
+    ]);
   });
 
   test("schema mismatch → throws after retrying", async () => {
@@ -258,6 +338,17 @@ describe("selectPool — infrastructure failures throw", () => {
       MemoryV3RetrievalUnavailableError,
     );
     expect(providerCalls).toHaveLength(3);
+    expect(
+      warnPayloads().filter((payload) => payload.reason === "schema_mismatch"),
+    ).toEqual([
+      expect.objectContaining({
+        attempt: 1,
+        reason: "schema_mismatch",
+        schemaIssues: [expect.objectContaining({ path: "ids" })],
+      }),
+      expect.objectContaining({ attempt: 2 }),
+      expect.objectContaining({ attempt: 3 }),
+    ]);
   });
 
   test("provider throw → throws after retrying", async () => {
@@ -266,6 +357,44 @@ describe("selectPool — infrastructure failures throw", () => {
       MemoryV3RetrievalUnavailableError,
     );
     expect(providerCalls).toHaveLength(3);
+    expect(
+      warnPayloads().filter((payload) => payload.reason === "provider_error"),
+    ).toEqual([
+      expect.objectContaining({
+        attempt: 1,
+        reason: "provider_error",
+        providerName: "throwing",
+        error: { name: "Error", message: "boom" },
+      }),
+      expect.objectContaining({ attempt: 2 }),
+      expect.objectContaining({ attempt: 3 }),
+    ]);
+  });
+
+  test("provider throw redacts sensitive message details in diagnostics", async () => {
+    const providerSecret = ["sk-proj-", "a".repeat(40)].join("");
+    const message = `provider rejected Authorization: Bearer ${providerSecret}`;
+    providerStub = makeThrowingProvider(message);
+
+    let thrown: unknown;
+    try {
+      await selectPool(makePool(), makeTurn("x"));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(MemoryV3RetrievalUnavailableError);
+    expect((thrown as Error).message).not.toContain(providerSecret);
+    expect((thrown as Error).message).toContain("[REDACTED]");
+
+    const providerErrors = warnPayloads().filter(
+      (payload) => payload.reason === "provider_error",
+    );
+    const error = providerErrors[0]?.error as
+      | Record<string, unknown>
+      | undefined;
+    expect(error?.message).not.toContain(providerSecret);
+    expect(error?.message).toContain("[REDACTED]");
   });
 
   test("a malformed response that recovers on retry returns its pages", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -59,7 +59,9 @@ import type {
   ContentBlock,
   Message,
   ToolDefinition,
+  ToolUseContent,
 } from "../../../providers/types.js";
+import { redactLogString } from "../../../util/log-redact.js";
 import { getLogger } from "../../../util/logger.js";
 import { truncate } from "../../../util/truncate.js";
 import { retryForResult } from "./llm-retry.js";
@@ -118,9 +120,44 @@ export interface SelectorPool {
 
 /** Tool name forced via `tool_choice`. Shared constant so tests can match it. */
 const SELECT_PAGES_TOOL_NAME = "select_pages";
+const MEMORY_V3_SELECT_CALL_SITE = "memoryV3SelectL2" as const;
 
 /** Finder-line snippets are truncated to keep the dynamic tail compact. */
 const SNIPPET_MAX_CHARS = 300;
+const ERROR_MESSAGE_MAX_CHARS = 500;
+
+type PoolSelectorAttemptFailureReason =
+  | "provider_error"
+  | "missing_tool_use"
+  | "unexpected_tool_name"
+  | "schema_mismatch";
+
+interface PoolSelectorAttemptFailure {
+  attempt: number;
+  reason: PoolSelectorAttemptFailureReason;
+  callSite: typeof MEMORY_V3_SELECT_CALL_SITE;
+  providerName: string;
+  candidateCount: number;
+  stableCount: number;
+  finderCount: number;
+  response?: {
+    model: string;
+    actualProvider?: string;
+    stopReason: string;
+    requestModel?: string;
+    responseModel?: string;
+    contentBlockTypes: string[];
+    toolUseNames: string[];
+  };
+  error?: {
+    name: string;
+    message: string;
+    provider?: string;
+    statusCode?: number;
+  };
+  toolName?: string;
+  schemaIssues?: Array<{ path: string; code: string }>;
+}
 
 const SelectPagesSchema = z.object({
   // Optional: an omitted `ids` field is the recall-safe "keep everything"
@@ -167,6 +204,66 @@ If the conversation is centrally ABOUT a page (rather than only peripherally rel
 /** Collapse a descriptor to one line and cap its length for a finder line. */
 function renderSnippet(descriptor: string): string {
   return truncate(descriptor.replace(/\s+/g, " ").trim(), SNIPPET_MAX_CHARS);
+}
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function summarizeResponse(response: {
+  model: string;
+  actualProvider?: string;
+  stopReason: string;
+  rawRequest?: unknown;
+  rawResponse?: unknown;
+  content: ContentBlock[];
+}): NonNullable<PoolSelectorAttemptFailure["response"]> {
+  const requestModel = readStringField(response.rawRequest, "model");
+  const responseModel = readStringField(response.rawResponse, "model");
+  return {
+    model: response.model,
+    ...(response.actualProvider
+      ? { actualProvider: response.actualProvider }
+      : {}),
+    stopReason: response.stopReason,
+    ...(requestModel ? { requestModel } : {}),
+    ...(responseModel ? { responseModel } : {}),
+    contentBlockTypes: response.content.map((block) => block.type),
+    toolUseNames: response.content
+      .filter((block): block is ToolUseContent => block.type === "tool_use")
+      .map((block) => block.name),
+  };
+}
+
+function summarizeError(error: unknown): PoolSelectorAttemptFailure["error"] {
+  const record =
+    error !== null && typeof error === "object"
+      ? (error as Record<string, unknown>)
+      : {};
+  const name =
+    error instanceof Error
+      ? error.name
+      : typeof record.name === "string"
+        ? record.name
+        : "Error";
+  const rawMessage =
+    error instanceof Error
+      ? error.message
+      : typeof record.message === "string"
+        ? record.message
+        : String(error);
+  const provider =
+    typeof record.provider === "string" ? record.provider : undefined;
+  const statusCode =
+    typeof record.statusCode === "number" ? record.statusCode : undefined;
+  return {
+    name,
+    message: truncate(redactLogString(rawMessage), ERROR_MESSAGE_MAX_CHARS),
+    ...(provider ? { provider } : {}),
+    ...(statusCode !== undefined ? { statusCode } : {}),
+  };
 }
 
 /**
@@ -234,10 +331,15 @@ export async function selectPool(
   const keepAll = (): SelectedPage[] =>
     dedupeBySlug(ordered.map((slug) => ({ slug, pinned: false })));
 
-  const provider = await getConfiguredProvider("memoryV3SelectL2");
+  const provider = await getConfiguredProvider(MEMORY_V3_SELECT_CALL_SITE);
   if (!provider) {
     log.warn(
-      { candidateCount: ordered.length },
+      {
+        callSite: MEMORY_V3_SELECT_CALL_SITE,
+        candidateCount: ordered.length,
+        stableCount: pool.stable.length,
+        finderCount: pool.finder.length,
+      },
       "pool selector provider unavailable — failing the turn rather than dropping memory",
     );
     throw new MemoryV3RetrievalUnavailableError(
@@ -264,6 +366,29 @@ export async function selectPool(
   content.push({ type: "text", text: tailParts.join("\n") });
 
   const userMsg: Message = { role: "user", content };
+  const failures: PoolSelectorAttemptFailure[] = [];
+  let attempt = 0;
+  const recordFailure = (
+    failure: Omit<
+      PoolSelectorAttemptFailure,
+      | "callSite"
+      | "providerName"
+      | "candidateCount"
+      | "stableCount"
+      | "finderCount"
+    >,
+  ): void => {
+    const diagnostic: PoolSelectorAttemptFailure = {
+      ...failure,
+      callSite: MEMORY_V3_SELECT_CALL_SITE,
+      providerName: provider.name,
+      candidateCount: ordered.length,
+      stableCount: pool.stable.length,
+      finderCount: pool.finder.length,
+    };
+    failures.push(diagnostic);
+    log.warn(diagnostic, "pool selector attempt failed");
+  };
 
   // One forced-tool call, retried a few times so a transient malformed response
   // (no usable tool_use, or tool input that fails the schema) re-prompts before
@@ -277,12 +402,14 @@ export async function selectPool(
   // response, so it reflects the LAST attempt's failure mode.
   let lastError: unknown = null;
   const parsed = await retryForResult(async () => {
+    attempt += 1;
+    let response: Awaited<ReturnType<typeof provider.sendMessage>>;
     try {
-      const response = await provider.sendMessage([userMsg], {
+      response = await provider.sendMessage([userMsg], {
         tools: [SELECT_PAGES_TOOL],
         systemPrompt: SYSTEM_PROMPT,
         config: {
-          callSite: "memoryV3SelectL2" as const,
+          callSite: MEMORY_V3_SELECT_CALL_SITE,
           tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
           // The last block of this one-shot message varies every turn; the
           // provider's auto-applied turn-start breakpoint would land on it and
@@ -292,14 +419,47 @@ export async function selectPool(
         },
       });
       lastError = null;
-      const toolBlock = extractToolUse(response);
-      if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) return null;
-      const result = SelectPagesSchema.safeParse(toolBlock.input);
-      return result.success ? result.data : null;
-    } catch (err) {
-      lastError = err;
-      throw err;
+    } catch (error) {
+      lastError = error;
+      recordFailure({
+        attempt,
+        reason: "provider_error",
+        error: summarizeError(error),
+      });
+      throw error;
     }
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
+      recordFailure({
+        attempt,
+        reason: "missing_tool_use",
+        response: summarizeResponse(response),
+      });
+      return null;
+    }
+    if (toolBlock.name !== SELECT_PAGES_TOOL_NAME) {
+      recordFailure({
+        attempt,
+        reason: "unexpected_tool_name",
+        response: summarizeResponse(response),
+        toolName: toolBlock.name,
+      });
+      return null;
+    }
+    const result = SelectPagesSchema.safeParse(toolBlock.input);
+    if (!result.success) {
+      recordFailure({
+        attempt,
+        reason: "schema_mismatch",
+        response: summarizeResponse(response),
+        schemaIssues: result.error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          code: issue.code,
+        })),
+      });
+      return null;
+    }
+    return result.data;
   });
 
   if (parsed === null) {
@@ -309,16 +469,34 @@ export async function selectPool(
       // reporting it as a model-output problem.
       const detail =
         lastError instanceof Error ? lastError.message : String(lastError);
+      const redactedDetail = truncate(
+        redactLogString(detail),
+        ERROR_MESSAGE_MAX_CHARS,
+      );
       log.warn(
-        { candidateCount: ordered.length, err: lastError },
+        {
+          candidateCount: ordered.length,
+          stableCount: pool.stable.length,
+          finderCount: pool.finder.length,
+          callSite: MEMORY_V3_SELECT_CALL_SITE,
+          providerName: provider.name,
+          failures,
+        },
         "pool selector provider call failed after retries — failing the turn rather than dropping memory",
       );
       throw new MemoryV3RetrievalUnavailableError(
-        `memory-v3 pool selector provider call failed after retries: ${detail}`,
+        `memory-v3 pool selector provider call failed after retries: ${redactedDetail}`,
       );
     }
     log.warn(
-      { candidateCount: ordered.length },
+      {
+        candidateCount: ordered.length,
+        stableCount: pool.stable.length,
+        finderCount: pool.finder.length,
+        callSite: MEMORY_V3_SELECT_CALL_SITE,
+        providerName: provider.name,
+        failures,
+      },
       "pool selector returned no usable tool_use after retries — failing the turn rather than dropping memory",
     );
     throw new MemoryV3RetrievalUnavailableError(

--- a/assistant/src/util/log-redact.ts
+++ b/assistant/src/util/log-redact.ts
@@ -34,7 +34,7 @@ const SENSITIVE_HEADERS = new Set([
 // String redaction
 // ---------------------------------------------------------------------------
 
-function redactString(value: string): string {
+export function redactLogString(value: string): string {
   let result = value;
 
   // Redact bearer tokens
@@ -57,7 +57,7 @@ function redactValue(value: unknown, depth: number): unknown {
   if (depth > 8) return value;
 
   if (typeof value === "string") {
-    return redactString(value);
+    return redactLogString(value);
   }
 
   if (Array.isArray(value)) {
@@ -159,5 +159,3 @@ export const logSerializers: Record<string, (value: unknown) => unknown> = {
   req: reqSerializer,
   res: resSerializer,
 };
-
-// Exported for testing


### PR DESCRIPTION
## Summary
- Add structured warning logs for each failed memory-v3 pool selector retry, including provider name, call site, response model metadata, stop reason, content block types, tool names, schema issues, and sanitized provider errors.
- Preserve existing user-facing failure behavior while making missing tool calls, wrong tool names, schema mismatches, and upstream provider exceptions distinguishable.
- Extend selector tests to assert the new diagnostic payloads for each failure mode.

## Original prompt
The user asked for a PR that improves memory-v3 selector logging so future incidents can determine whether the model provider is causing `memory-v3 pool selector returned no usable selection after retries` failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->