### PR TITLE
fix(memory-v3): surface the real provider error from the pool selector

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for `pool-select.ts` `selectPool` — focused on error SURFACING:
+ *   - a provider call that THROWS on every attempt surfaces the underlying
+ *     provider error (e.g. an upstream HTTP 4xx) in the thrown
+ *     `MemoryV3RetrievalUnavailableError` message, rather than the generic
+ *     "no usable selection" string that hid it;
+ *   - a 200 response carrying no usable `tool_use` still throws the generic
+ *     "no usable selection" message;
+ *   - happy paths preserved: explicit ids → selection, omitted ids → keepAll,
+ *     empty pool → [].
+ *
+ * `mock.module` is process-global and leaks into sibling files in a directory
+ * run, so the provider-send-message stub DELEGATES to the real implementation
+ * (keeping the real `extractToolUse`) unless this test is actively running
+ * (`selectMockActive`) — mirrors `prune.test.ts` / `ever-injected-store.test.ts`.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ContentBlock,
+  Provider,
+  ProviderResponse,
+} from "../../../providers/types.js";
+import type { MemoryRoutingTurn, Slug } from "./types.js";
+
+const realProviderSend = {
+  ...(await import("../../../providers/provider-send-message.js")),
+};
+
+let selectMockActive = false;
+let sendMessageImpl: (() => Promise<ProviderResponse>) | null = null;
+
+const mockProvider = {
+  name: "mock-memory-v3-selector",
+  async sendMessage(): Promise<ProviderResponse> {
+    if (!sendMessageImpl) throw new Error("sendMessageImpl not configured");
+    return sendMessageImpl();
+  },
+} as unknown as Provider;
+
+mock.module("../../../providers/provider-send-message.js", () => ({
+  ...realProviderSend,
+  getConfiguredProvider: (
+    ...args: Parameters<typeof realProviderSend.getConfiguredProvider>
+  ) =>
+    selectMockActive
+      ? Promise.resolve(mockProvider)
+      : realProviderSend.getConfiguredProvider(...args),
+}));
+
+const { MemoryV3RetrievalUnavailableError, selectPool } =
+  await import("./pool-select.js");
+
+function response(content: ContentBlock[]): ProviderResponse {
+  return {
+    content,
+    model: "mock",
+    usage: { inputTokens: 0, outputTokens: 0 },
+  } as ProviderResponse;
+}
+
+const turn: MemoryRoutingTurn = {
+  conversationId: "conv-1",
+  turnNumber: 0,
+  currentMessage: "echo something back",
+  recentContext: "",
+};
+
+const pool = {
+  stable: [],
+  finder: [{ slug: "page-a" as Slug, descriptor: "a descriptor" }],
+};
+
+describe("selectPool", () => {
+  beforeEach(() => {
+    selectMockActive = true;
+    sendMessageImpl = null;
+  });
+  afterAll(() => {
+    selectMockActive = false;
+  });
+
+  test("a provider throw surfaces the underlying error in the thrown message", async () => {
+    const upstream = "Together AI API error (400): 400 status code (no body)";
+    sendMessageImpl = async () => {
+      throw new Error(upstream);
+    };
+    let caught: unknown;
+    try {
+      await selectPool(pool, turn);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MemoryV3RetrievalUnavailableError);
+    expect((caught as Error).message).toContain(
+      "provider call failed after retries",
+    );
+    // The real upstream error is no longer hidden behind the generic message.
+    expect((caught as Error).message).toContain(upstream);
+  });
+
+  test("a 200 with no usable tool_use throws the generic message", async () => {
+    sendMessageImpl = async () =>
+      response([{ type: "text", text: "I cannot call the tool." }]);
+    let caught: unknown;
+    try {
+      await selectPool(pool, turn);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MemoryV3RetrievalUnavailableError);
+    expect((caught as Error).message).toBe(
+      "memory-v3 pool selector returned no usable selection after retries",
+    );
+  });
+
+  test("explicit ids select the matching candidates", async () => {
+    sendMessageImpl = async () =>
+      response([
+        {
+          type: "tool_use",
+          id: "call-1",
+          name: "select_pages",
+          input: { ids: [1] },
+        },
+      ]);
+    expect(await selectPool(pool, turn)).toEqual([
+      { slug: "page-a", pinned: false },
+    ]);
+  });
+
+  test("omitted ids keep all candidates (recall-safe)", async () => {
+    sendMessageImpl = async () =>
+      response([
+        { type: "tool_use", id: "call-1", name: "select_pages", input: {} },
+      ]);
+    expect(await selectPool(pool, turn)).toEqual([
+      { slug: "page-a", pinned: false },
+    ]);
+  });
+
+  test("an empty candidate pool returns no selections", async () => {
+    expect(await selectPool({ stable: [], finder: [] }, turn)).toEqual([]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -269,30 +269,57 @@ export async function selectPool(
   // (no usable tool_use, or tool input that fails the schema) re-prompts before
   // we give up. `null` from an attempt means "unusable, retry"; the provider
   // layer already backs off transient throws, so this loop adds no delay.
+  //
+  // `lastError` captures the most recent attempt's thrown provider error —
+  // `retryForResult` swallows attempt throws, so without this an infrastructure
+  // failure (e.g. an upstream HTTP 4xx/5xx) is indistinguishable from a 200 that
+  // carried no usable tool_use. It is cleared on every attempt that reaches a
+  // response, so it reflects the LAST attempt's failure mode.
+  let lastError: unknown = null;
   const parsed = await retryForResult(async () => {
-    const response = await provider.sendMessage([userMsg], {
-      tools: [SELECT_PAGES_TOOL],
-      systemPrompt: SYSTEM_PROMPT,
-      config: {
-        callSite: "memoryV3SelectL2" as const,
-        tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
-        // The last block of this one-shot message varies every turn; the
-        // provider's auto-applied turn-start breakpoint would land on it and
-        // pay cache_creation with no future hit. The stable-prefix block
-        // above carries its own breakpoint instead.
-        disableTurnStartCache: true,
-      },
-    });
-    const toolBlock = extractToolUse(response);
-    if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) return null;
-    const result = SelectPagesSchema.safeParse(toolBlock.input);
-    return result.success ? result.data : null;
+    try {
+      const response = await provider.sendMessage([userMsg], {
+        tools: [SELECT_PAGES_TOOL],
+        systemPrompt: SYSTEM_PROMPT,
+        config: {
+          callSite: "memoryV3SelectL2" as const,
+          tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
+          // The last block of this one-shot message varies every turn; the
+          // provider's auto-applied turn-start breakpoint would land on it and
+          // pay cache_creation with no future hit. The stable-prefix block
+          // above carries its own breakpoint instead.
+          disableTurnStartCache: true,
+        },
+      });
+      lastError = null;
+      const toolBlock = extractToolUse(response);
+      if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) return null;
+      const result = SelectPagesSchema.safeParse(toolBlock.input);
+      return result.success ? result.data : null;
+    } catch (err) {
+      lastError = err;
+      throw err;
+    }
   });
 
   if (parsed === null) {
+    if (lastError !== null) {
+      // The selector's provider call threw on its final attempt (e.g. an
+      // upstream HTTP error). Surface the underlying error rather than
+      // reporting it as a model-output problem.
+      const detail =
+        lastError instanceof Error ? lastError.message : String(lastError);
+      log.warn(
+        { candidateCount: ordered.length, err: lastError },
+        "pool selector provider call failed after retries — failing the turn rather than dropping memory",
+      );
+      throw new MemoryV3RetrievalUnavailableError(
+        `memory-v3 pool selector provider call failed after retries: ${detail}`,
+      );
+    }
     log.warn(
       { candidateCount: ordered.length },
-      "pool selector could not obtain a selection after retries — failing the turn rather than dropping memory",
+      "pool selector returned no usable tool_use after retries — failing the turn rather than dropping memory",
     );
     throw new MemoryV3RetrievalUnavailableError(
       "memory-v3 pool selector returned no usable selection after retries",


### PR DESCRIPTION
## Summary
- The memory-v3 L2 pool selector collapsed *every* failure — including a thrown provider/transport error (e.g. an upstream HTTP 400 from the managed inference proxy) — into a single generic `MemoryV3RetrievalUnavailableError("…returned no usable selection after retries")`, because `retryForResult` swallows attempt throws. An infrastructure 400 was therefore reported (and shown to the user) as a model-output problem, with the real error logged nowhere.
- `selectPool` now captures the last attempt's thrown error: on a provider throw it logs the underlying error and includes its message in the thrown error (`…provider call failed after retries: <real error>`); a genuine 200-with-no-usable-tool_use keeps the existing generic message. Same error type, same live/shadow propagation — diagnosability only, no degrade/fallback added.
- Adds `pool-select.test.ts` covering the provider-throw (surfaced) vs no-tool_use (generic) paths plus the existing happy paths (explicit ids, omitted ids → keepAll, empty pool).

## Original prompt
Investigating a production "memory-v3 pool selector returned no usable selection after retries" report, the real cause turned out to be a plain HTTP 400 from the managed inference proxy that the selector swallowed and mislabeled, which made it nearly impossible to diagnose. This is the assistant-side half: surface the underlying provider error so the next occurrence reports the actual status/message instead of a generic memory failure. The root cause is platform-side (the proxy returning 400 for certain managed models) and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)