### PR TITLE
feat(web): stream live tool output in the tool-detail drawer

### DIFF
--- a/clients/web/src/domains/chat/api/event-types.ts
+++ b/clients/web/src/domains/chat/api/event-types.ts
@@ -36,6 +36,15 @@ export interface ChatMessageToolCall extends ConversationMessageToolCall {
    * Drop this narrowing once the wire `id` graduates to non-optional.
    */
   id: string;
+  /**
+   * Live, incremental tool output accumulated from `tool_output_chunk` events
+   * while the call is running (e.g. foreground bash stdout/stderr). Web-local
+   * and live-only: it is never part of the wire schema or re-ingested history,
+   * is bounded to a tail (see `appendToolOutputChunk`), and is cleared once the
+   * final `result` arrives via `applyToolResult`. The drawer renders it as a
+   * streaming preview; the complete output still arrives once in `result`.
+   */
+  streamedOutput?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -33,6 +33,8 @@ import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-mes
 import { RiskBadge } from "@/domains/chat/components/risk-badge";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
 import { useLiveThinkingText } from "@/domains/chat/hooks/use-live-thinking-text";
+import { useLiveToolCall } from "@/domains/chat/hooks/use-live-tool-call";
+import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
 import {
     deriveStepLabelFromName,
     type IconName,
@@ -214,13 +216,47 @@ export function ToolDetailPanel({
   if (detail.kind === "thinking") {
     return <ThinkingDetailBody detail={detail} onClose={onClose} />;
   }
+  // Tool variant lives in its own component so its store-subscribing hook
+  // (`useLiveToolCall`) is called unconditionally, never gated behind the
+  // thinking early-return above (Rules of Hooks).
+  return (
+    <ToolDetailBody
+      detail={detail}
+      onClose={onClose}
+      onRiskBadgeClick={onRiskBadgeClick}
+    />
+  );
+}
 
+/**
+ * Tool-call variant body. Reuses the shared shell and renders technical
+ * details + output. Subscribes to the chat-session store via `useLiveToolCall`
+ * so an open drawer streams `tool_output_chunk` output while the call runs and
+ * flips to the final `result` when it lands, falling back to the open-time
+ * snapshot when the call can't be resolved live (e.g. paged out).
+ */
+function ToolDetailBody({
+  detail,
+  onClose,
+  onRiskBadgeClick,
+}: {
+  detail: ToolDetailPayload;
+  onClose: () => void;
+  onRiskBadgeClick?: () => void;
+}) {
   const { iconName } = deriveStepLabelFromName(detail.toolName, detail.input);
   const Glyph = ICON_MAP[iconName] ?? Bolt;
 
+  const liveTc = useLiveToolCall(detail.toolCallId);
+  const result = liveTc?.result ?? detail.result;
+  const streamedOutput = liveTc?.streamedOutput ?? detail.streamedOutput;
+
   const title = detail.activity || detail.title;
-  const hasResult = detail.result !== undefined && detail.result !== "";
-  const isRunning = detail.status === "running";
+  const hasResult = result !== undefined && result !== "";
+  const isRunning = liveTc
+    ? isToolCallRunning(liveTc)
+    : detail.status === "running";
+  const hasStreamedOutput = !!streamedOutput;
   const inputJson = JSON.stringify(detail.input, null, 2);
 
   return (
@@ -267,12 +303,15 @@ export function ToolDetailPanel({
           </div>
         </div>
 
-        {/* Output section — omitted entirely when there's no result */}
+        {/* Output — the final result once present, else the live streamed
+            tail while running, else a bare running placeholder. */}
         {(hasResult || isRunning) && (
           <div className="mt-5">
             <SectionLabel>Output</SectionLabel>
             {hasResult ? (
-              <CodeBlock text={detail.result as string} />
+              <CodeBlock text={result as string} />
+            ) : hasStreamedOutput ? (
+              <CodeBlock text={streamedOutput as string} />
             ) : (
               <Typography
                 variant="body-small-default"

--- a/clients/web/src/domains/chat/hooks/use-live-tool-call.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-tool-call.ts
@@ -1,0 +1,29 @@
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+
+/**
+ * Live tool call looked up by id from the chat-session store, so an OPEN
+ * tool-detail drawer reflects streamed `tool_output_chunk` output (and the
+ * eventual final `result`) as events land — instead of freezing the snapshot
+ * captured when the drawer was opened. The streaming sibling of
+ * {@link useLiveThinkingText}.
+ *
+ * Returns the stored tool-call object, whose reference is stable until that
+ * specific call changes (the stream updaters clone only the touched call), so
+ * Zustand's `Object.is` comparison re-renders the caller only on a real update
+ * to this call — not on unrelated transcript churn. Returns `null` when the
+ * call can't be found (e.g. its message paged out of the transcript) so callers
+ * fall back to the open-time snapshot.
+ */
+export function useLiveToolCall(
+  toolCallId: string | undefined,
+): ChatMessageToolCall | null {
+  return useChatSessionStore((s) => {
+    if (!toolCallId) return null;
+    for (const m of s.messages) {
+      const tc = m.toolCalls?.find((t) => t.id === toolCallId);
+      if (tc) return tc;
+    }
+    return null;
+  });
+}

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -144,7 +144,7 @@ export function useStreamEventHandler(
   // that drains it, for coalesced (one-per-frame) flushes. See
   // handleToolOutputChunk / flushToolOutput.
   const toolOutputBufferRef = useRef<
-    Map<string, { messageId?: string; text: string }>
+    Map<string, { conversationId?: string; messageId?: string; text: string }>
   >(new Map());
   const toolOutputFlushHandleRef = useRef<number | null>(null);
 

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -49,6 +49,7 @@ import {
 import {
   handleToolUseStart,
   handleToolResult,
+  handleToolOutputChunk,
 } from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
 import {
   handleUsageUpdate,
@@ -139,6 +140,13 @@ export function useStreamEventHandler(
   const lastActivityVersionRef = useRef<Map<string, number>>(new Map());
   const toolCallIdCounterRef = useRef(0);
   const currentAssistantMessageIdRef = useRef<string | undefined>(undefined);
+  // Per-toolUseId buffer of pending tool_output_chunk text + the rAF handle
+  // that drains it, for coalesced (one-per-frame) flushes. See
+  // handleToolOutputChunk / flushToolOutput.
+  const toolOutputBufferRef = useRef<
+    Map<string, { messageId?: string; text: string }>
+  >(new Map());
+  const toolOutputFlushHandleRef = useRef<number | null>(null);
 
   // --- Main event handler ---
 
@@ -246,6 +254,8 @@ export function useStreamEventHandler(
         lastActivityVersionRef,
         toolCallIdCounterRef,
         currentAssistantMessageIdRef,
+        toolOutputBufferRef,
+        toolOutputFlushHandleRef,
       };
 
       switch (event.type) {
@@ -315,11 +325,15 @@ export function useStreamEventHandler(
         case "tool_result":
           handleToolResult(event, ctx);
           break;
-        // The web transcript renders tool activity from `tool_use_start`
-        // and `tool_result`. It does not surface the optimistic pre-input
-        // affordance or incremental output chunks, so these are ignored.
+        // The optimistic pre-input affordance has no transcript treatment.
         case "tool_use_preview_start":
+          break;
+        // Incremental tool output (e.g. foreground bash stdout/stderr) is
+        // buffered onto the matching tool call's live `streamedOutput` tail
+        // (coalesced per animation frame) and surfaced in the tool-detail
+        // drawer while the call runs.
         case "tool_output_chunk":
+          handleToolOutputChunk(event, ctx);
           break;
         case "usage_update":
           handleUsageUpdate(event, ctx);

--- a/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -106,6 +106,8 @@ export function makeCtx(
     lastActivityVersionRef: { current: new Map() },
     toolCallIdCounterRef: { current: 0 },
     currentAssistantMessageIdRef: { current: undefined },
+    toolOutputBufferRef: { current: new Map() },
+    toolOutputFlushHandleRef: { current: null },
     ...restOverrides,
   };
 }

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
@@ -1,13 +1,19 @@
 import {
+  MAX_STREAMED_OUTPUT_CHARS,
+  appendToolOutputChunk,
   applyToolResult,
   upsertToolCall,
 } from "@/domains/chat/utils/stream-updaters/tool-call-updaters";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type {
+  ToolOutputChunkEvent,
   ToolResultEvent,
   ToolUseStartEvent,
 } from "@vellumai/assistant-api";
+
+/** Buffer key for chunks that arrive without a `toolUseId` (pre-anchor daemons). */
+const NO_TOOL_ID = "no-tool-id";
 
 export function handleToolUseStart(
   event: ToolUseStartEvent,
@@ -44,6 +50,10 @@ export function handleToolResult(
   ctx: StreamHandlerContext,
 ): void {
   ctx.turnActions.onToolResult();
+  // Commit any buffered live output before the final result lands so the tail
+  // isn't lost and ordering is preserved (applyToolResult then clears
+  // `streamedOutput` in favor of the complete `result`).
+  flushToolOutput(ctx);
   // Forward structured tool activity metadata (web_search / web_fetch) onto
   // the turn store so the web-search inline link can render during the
   // active turn. Metadata is live-only — the store clears it on idle
@@ -77,4 +87,69 @@ export function handleToolResult(
           : undefined,
     }),
   );
+}
+
+/**
+ * Drain all buffered tool-output chunks into a single `setMessages` update,
+ * cancelling any pending scheduled flush. Called on the rAF tick and
+ * synchronously by `handleToolResult` (so a buffered tail commits before the
+ * final result). A no-op when the buffer is empty.
+ */
+export function flushToolOutput(ctx: StreamHandlerContext): void {
+  const handle = ctx.toolOutputFlushHandleRef.current;
+  if (handle != null) {
+    cancelAnimationFrame(handle);
+    ctx.toolOutputFlushHandleRef.current = null;
+  }
+  const buffer = ctx.toolOutputBufferRef.current;
+  if (buffer.size === 0) return;
+  const pending = [...buffer.entries()];
+  buffer.clear();
+  ctx.setMessages((prev) => {
+    let next = prev;
+    for (const [toolUseId, { messageId, text }] of pending) {
+      next = appendToolOutputChunk(next, {
+        chunk: text,
+        toolUseId: toolUseId === NO_TOOL_ID ? undefined : toolUseId,
+        messageId,
+      });
+    }
+    return next;
+  });
+}
+
+/**
+ * Buffer an incremental `tool_output_chunk` and schedule a coalesced flush.
+ *
+ * Foreground bash stdout/stderr can arrive at high frequency; batching one
+ * flush per animation frame keeps the (non-virtualized) transcript projection
+ * from re-running per chunk. Chunks accumulate per `toolUseId`, and the
+ * buffered text is itself bounded so a backgrounded tab (rAF paused) can't grow
+ * it without limit — only the tail matters for the drawer preview.
+ */
+export function handleToolOutputChunk(
+  event: ToolOutputChunkEvent,
+  ctx: StreamHandlerContext,
+): void {
+  if (!event.chunk) return;
+  const key = event.toolUseId ?? NO_TOOL_ID;
+  const buffer = ctx.toolOutputBufferRef.current;
+  const existing = buffer.get(key);
+  if (existing) {
+    const combined = existing.text + event.chunk;
+    existing.text =
+      combined.length > MAX_STREAMED_OUTPUT_CHARS
+        ? combined.slice(combined.length - MAX_STREAMED_OUTPUT_CHARS)
+        : combined;
+    // Prefer the latest non-empty row anchor.
+    if (event.messageId) existing.messageId = event.messageId;
+  } else {
+    buffer.set(key, { messageId: event.messageId, text: event.chunk });
+  }
+  if (ctx.toolOutputFlushHandleRef.current == null) {
+    ctx.toolOutputFlushHandleRef.current = requestAnimationFrame(() => {
+      ctx.toolOutputFlushHandleRef.current = null;
+      flushToolOutput(ctx);
+    });
+  }
 }

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
@@ -6,6 +6,7 @@ import {
 } from "@/domains/chat/utils/stream-updaters/tool-call-updaters";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import { useStreamStore } from "@/domains/chat/stream-store";
 import type {
   ToolOutputChunkEvent,
   ToolResultEvent,
@@ -105,9 +106,17 @@ export function flushToolOutput(ctx: StreamHandlerContext): void {
   if (buffer.size === 0) return;
   const pending = [...buffer.entries()];
   buffer.clear();
+  // A deferred flush (rAF) can fire after the user switched conversations (or
+  // while a background tab's rAF was paused). Drop buffered chunks whose
+  // conversation is no longer the active stream conversation, so a prior
+  // conversation's output is never grafted onto — or misattributed within (the
+  // id-less fallback path) — the now-active conversation's transcript.
+  const activeConversationId =
+    useStreamStore.getState().streamContext?.conversationId;
   ctx.setMessages((prev) => {
     let next = prev;
-    for (const [toolUseId, { messageId, text }] of pending) {
+    for (const [toolUseId, { conversationId, messageId, text }] of pending) {
+      if (conversationId && conversationId !== activeConversationId) continue;
       next = appendToolOutputChunk(next, {
         chunk: text,
         toolUseId: toolUseId === NO_TOOL_ID ? undefined : toolUseId,
@@ -141,10 +150,15 @@ export function handleToolOutputChunk(
       combined.length > MAX_STREAMED_OUTPUT_CHARS
         ? combined.slice(combined.length - MAX_STREAMED_OUTPUT_CHARS)
         : combined;
-    // Prefer the latest non-empty row anchor.
+    // Prefer the latest non-empty row/conversation anchor.
     if (event.messageId) existing.messageId = event.messageId;
+    if (event.conversationId) existing.conversationId = event.conversationId;
   } else {
-    buffer.set(key, { messageId: event.messageId, text: event.chunk });
+    buffer.set(key, {
+      conversationId: event.conversationId,
+      messageId: event.messageId,
+      text: event.chunk,
+    });
   }
   if (ctx.toolOutputFlushHandleRef.current == null) {
     ctx.toolOutputFlushHandleRef.current = requestAnimationFrame(() => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/types.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/types.ts
@@ -96,4 +96,17 @@ export interface StreamHandlerContext {
    *  subagent_spawned can read the correct parent without waiting for
    *  React's batched render. Mirrors macOS `currentAssistantMessageId`. */
   currentAssistantMessageIdRef: MutableRefObject<string | undefined>;
+
+  // --- Tool output streaming (coalesced) ---
+  /**
+   * Per-`toolUseId` buffer of pending `tool_output_chunk` text (with the row
+   * `messageId` anchor), drained by a single coalesced flush per animation
+   * frame. Keying by id keeps interleaved chunks from different running tools
+   * separate. See `handleToolOutputChunk` / `flushToolOutput`.
+   */
+  toolOutputBufferRef: MutableRefObject<
+    Map<string, { messageId?: string; text: string }>
+  >;
+  /** rAF handle for the pending coalesced flush, or `null` when idle. */
+  toolOutputFlushHandleRef: MutableRefObject<number | null>;
 }

--- a/clients/web/src/domains/chat/utils/stream-handlers/types.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/types.ts
@@ -105,7 +105,7 @@ export interface StreamHandlerContext {
    * separate. See `handleToolOutputChunk` / `flushToolOutput`.
    */
   toolOutputBufferRef: MutableRefObject<
-    Map<string, { messageId?: string; text: string }>
+    Map<string, { conversationId?: string; messageId?: string; text: string }>
   >;
   /** rAF handle for the pending coalesced flush, or `null` when idle. */
   toolOutputFlushHandleRef: MutableRefObject<number | null>;

--- a/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
@@ -1,7 +1,7 @@
 /**
  * Tool-call updaters for SSE stream events.
  *
- * Handles: tool_use_start, tool_result.
+ * Handles: tool_use_start, tool_result, tool_output_chunk.
  *
  * Each exported function has the signature
  * `(prev: DisplayMessage[], ...args) => DisplayMessage[]`.
@@ -217,7 +217,109 @@ export function applyToolResult(
       ? { activityMetadata: opts.activityMetadata }
       : {}),
     completedAt: opts.completedAt ?? Date.now(),
+    // The final result supersedes the live stream tail; drop it to free memory
+    // and so renderers prefer the complete `result`.
+    streamedOutput: undefined,
   };
+  updatedToolCalls[tcIdx] = updatedTc;
+
+  const updated = [...prev];
+  updated[msgIdx] = {
+    ...msg,
+    toolCalls: updatedToolCalls,
+    contentBlocks: upsertToolUseBlock(msg.contentBlocks, updatedTc),
+  };
+  return updated;
+}
+
+// ---------------------------------------------------------------------------
+// tool_output_chunk
+// ---------------------------------------------------------------------------
+
+/**
+ * Max chars of live streamed output retained per tool call. Foreground bash
+ * stdout/stderr can flood; we keep only a bounded tail for the drawer preview
+ * — the complete, untruncated output still arrives once via `tool_result`
+ * (`result`). Bounding caps both memory and the per-flush re-render cost.
+ */
+export const MAX_STREAMED_OUTPUT_CHARS = 16_384;
+
+function boundedTail(text: string): string {
+  return text.length <= MAX_STREAMED_OUTPUT_CHARS
+    ? text
+    : text.slice(text.length - MAX_STREAMED_OUTPUT_CHARS);
+}
+
+/**
+ * Append an incremental `tool_output_chunk` onto the matching tool call's live
+ * `streamedOutput` tail. Correlation mirrors `applyToolResult`: narrow to the
+ * `messageId` row when present, prefer the `toolUseId` id match (back-to-front),
+ * else fall back to the last running tool call. The `contentBlocks` `tool_use`
+ * entry is updated in lockstep so either slice reads the same live tail.
+ */
+export function appendToolOutputChunk(
+  prev: DisplayMessage[],
+  opts: { chunk: string; toolUseId?: string; messageId?: string },
+): DisplayMessage[] {
+  if (!opts.chunk) return prev;
+
+  let msgIdx = -1;
+  let tcIdx = -1;
+
+  if (opts.toolUseId) {
+    // id-based correlation only. `messageId` narrows the owning row first;
+    // otherwise scan back-to-front for the id. We deliberately do NOT fall
+    // back to a positional "last running tool" when the id isn't present: a
+    // chunk whose id is absent belongs to a tool in another (e.g.
+    // switched-away) conversation, and a positional match would misattribute
+    // it to an unrelated running tool.
+    if (opts.messageId) {
+      const rowIdx = findAssistantRowIndexByMessageId(prev, opts.messageId);
+      if (rowIdx >= 0) {
+        const j =
+          prev[rowIdx]!.toolCalls?.findIndex((tc) => tc.id === opts.toolUseId) ??
+          -1;
+        if (j !== -1) {
+          msgIdx = rowIdx;
+          tcIdx = j;
+        }
+      }
+    }
+    if (msgIdx === -1) {
+      for (let i = prev.length - 1; i >= 0; i--) {
+        const m = prev[i];
+        if (m?.role !== "assistant" || !m.toolCalls?.length) continue;
+        const j = m.toolCalls.findIndex((tc) => tc.id === opts.toolUseId);
+        if (j !== -1) {
+          msgIdx = i;
+          tcIdx = j;
+          break;
+        }
+      }
+    }
+  } else {
+    // Pre-anchor daemons omit `toolUseId`: attribute to the last running tool
+    // call in the latest assistant row (same-conversation by construction).
+    msgIdx = prev.findLastIndex(
+      (m) => m.role === "assistant" && m.toolCalls && m.toolCalls.length > 0,
+    );
+    if (msgIdx === -1) return prev;
+    const msg = prev[msgIdx];
+    if (!msg?.toolCalls) return prev;
+    tcIdx = msg.toolCalls.findLastIndex((tc) => isToolCallRunning(tc));
+  }
+
+  if (msgIdx === -1 || tcIdx === -1) return prev;
+
+  const msg = prev[msgIdx]!;
+  const existingTc = msg.toolCalls![tcIdx];
+  if (!existingTc) return prev;
+
+  const updatedTc = {
+    ...existingTc,
+    streamedOutput: boundedTail((existingTc.streamedOutput ?? "") + opts.chunk),
+  };
+  const updatedToolCalls = [...msg.toolCalls!];
   updatedToolCalls[tcIdx] = updatedTc;
 
   const updated = [...prev];

--- a/clients/web/src/domains/chat/utils/stream-updaters/tool-output-chunk.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/tool-output-chunk.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
+import type { ToolOutputChunkEvent } from "@vellumai/assistant-api";
+
+import {
+  MAX_STREAMED_OUTPUT_CHARS,
+  appendToolOutputChunk,
+  applyToolResult,
+} from "@/domains/chat/utils/stream-updaters/tool-call-updaters";
+import {
+  flushToolOutput,
+  handleToolOutputChunk,
+} from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
+import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
+import { textBody as seg } from "@/domains/chat/utils/message-test-helpers";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const userMsg: DisplayMessage = {
+  id: "user-1",
+  role: "user",
+  ...seg("hi"),
+  timestamp: 999,
+};
+
+function tc(
+  id: string,
+  over: Partial<ChatMessageToolCall> = {},
+): ChatMessageToolCall {
+  return { id, name: "bash", input: {}, startedAt: 1000, ...over };
+}
+
+function asstMsg(
+  toolCalls: ChatMessageToolCall[],
+  overrides: Partial<DisplayMessage> = {},
+): DisplayMessage {
+  return {
+    id: "asst-1",
+    role: "assistant",
+    ...seg(""),
+    timestamp: 1000,
+    toolCalls,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// appendToolOutputChunk
+// ---------------------------------------------------------------------------
+
+describe("appendToolOutputChunk", () => {
+  it("appends a chunk onto the matching tool call by id", () => {
+    const prev = [userMsg, asstMsg([tc("tc-1")])];
+    const next = appendToolOutputChunk(prev, {
+      chunk: "line 1\n",
+      toolUseId: "tc-1",
+    });
+    expect(next[1]!.toolCalls![0]!.streamedOutput).toBe("line 1\n");
+  });
+
+  it("accumulates successive chunks", () => {
+    let s = [userMsg, asstMsg([tc("tc-1")])];
+    s = appendToolOutputChunk(s, { chunk: "a", toolUseId: "tc-1" });
+    s = appendToolOutputChunk(s, { chunk: "b", toolUseId: "tc-1" });
+    s = appendToolOutputChunk(s, { chunk: "c", toolUseId: "tc-1" });
+    expect(s[1]!.toolCalls![0]!.streamedOutput).toBe("abc");
+  });
+
+  it("narrows to the messageId-owning row, beating the back-to-front scan", () => {
+    // Two rows carry the same tool id (pathological); messageId picks the
+    // earlier row, which a plain back-to-front scan would never reach first.
+    const rowA = asstMsg([tc("tc-1")], { id: "row-A" });
+    const rowB = asstMsg([tc("tc-1")], { id: "row-B" });
+    const next = appendToolOutputChunk([userMsg, rowA, rowB], {
+      chunk: "x",
+      toolUseId: "tc-1",
+      messageId: "row-A",
+    });
+    expect(next[1]!.toolCalls![0]!.streamedOutput).toBe("x");
+    expect(next[2]!.toolCalls![0]!.streamedOutput).toBeUndefined();
+  });
+
+  it("does NOT positionally misattribute a chunk whose id is absent", () => {
+    // A chunk for an unknown id (e.g. a switched-away conversation) must not
+    // attach to some unrelated running tool — it is a no-op.
+    const prev = [userMsg, asstMsg([tc("running-tc")])];
+    const next = appendToolOutputChunk(prev, {
+      chunk: "stray",
+      toolUseId: "other-convo-tc",
+    });
+    expect(next).toBe(prev);
+    expect(next[1]!.toolCalls![0]!.streamedOutput).toBeUndefined();
+  });
+
+  it("falls back to the last running tool call when no toolUseId (pre-anchor)", () => {
+    const completed = tc("done", { result: "ok", completedAt: 2000 });
+    const running = tc("live");
+    const prev = [userMsg, asstMsg([completed, running])];
+    const next = appendToolOutputChunk(prev, { chunk: "y" });
+    expect(next[1]!.toolCalls![1]!.streamedOutput).toBe("y");
+    expect(next[1]!.toolCalls![0]!.streamedOutput).toBeUndefined();
+  });
+
+  it("bounds the retained tail to MAX_STREAMED_OUTPUT_CHARS", () => {
+    const prev = [userMsg, asstMsg([tc("tc-1")])];
+    const big = "x".repeat(MAX_STREAMED_OUTPUT_CHARS + 500);
+    const next = appendToolOutputChunk(prev, { chunk: big, toolUseId: "tc-1" });
+    const out = next[1]!.toolCalls![0]!.streamedOutput!;
+    expect(out.length).toBe(MAX_STREAMED_OUTPUT_CHARS);
+    expect(out).toBe(big.slice(big.length - MAX_STREAMED_OUTPUT_CHARS));
+  });
+
+  it("ignores empty chunks", () => {
+    const prev = [userMsg, asstMsg([tc("tc-1")])];
+    expect(appendToolOutputChunk(prev, { chunk: "", toolUseId: "tc-1" })).toBe(
+      prev,
+    );
+  });
+
+  it("does not mutate the previous messages", () => {
+    const prev = [userMsg, asstMsg([tc("tc-1")])];
+    appendToolOutputChunk(prev, { chunk: "z", toolUseId: "tc-1" });
+    expect(prev[1]!.toolCalls![0]!.streamedOutput).toBeUndefined();
+  });
+
+  it("keeps the streamed call reading as running (never sets result)", () => {
+    const prev = [userMsg, asstMsg([tc("tc-1")])];
+    const next = appendToolOutputChunk(prev, {
+      chunk: "partial",
+      toolUseId: "tc-1",
+    });
+    expect(isToolCallRunning(next[1]!.toolCalls![0]!)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyToolResult clears the live tail
+// ---------------------------------------------------------------------------
+
+describe("applyToolResult + streamedOutput", () => {
+  it("drops the live tail when the final result lands", () => {
+    let s = [userMsg, asstMsg([tc("tc-1")])];
+    s = appendToolOutputChunk(s, { chunk: "streamed tail", toolUseId: "tc-1" });
+    expect(s[1]!.toolCalls![0]!.streamedOutput).toBe("streamed tail");
+
+    s = applyToolResult(s, { toolUseId: "tc-1", result: "final output" });
+    expect(s[1]!.toolCalls![0]!.result).toBe("final output");
+    expect(s[1]!.toolCalls![0]!.streamedOutput).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flushToolOutput / handleToolOutputChunk (coalescing)
+// ---------------------------------------------------------------------------
+
+function makeCtx(initial: DisplayMessage[]) {
+  let messages = initial;
+  const ctx = {
+    toolOutputBufferRef: {
+      current: new Map<string, { messageId?: string; text: string }>(),
+    },
+    toolOutputFlushHandleRef: { current: null as number | null },
+    setMessages: (
+      updater:
+        | DisplayMessage[]
+        | ((prev: DisplayMessage[]) => DisplayMessage[]),
+    ) => {
+      messages =
+        typeof updater === "function"
+          ? (updater as (p: DisplayMessage[]) => DisplayMessage[])(messages)
+          : updater;
+    },
+  } as unknown as StreamHandlerContext;
+  return { ctx, get: () => messages };
+}
+
+describe("flushToolOutput", () => {
+  it("drains buffered chunks for multiple tools in one pass", () => {
+    const { ctx, get } = makeCtx([userMsg, asstMsg([tc("a"), tc("b")])]);
+    ctx.toolOutputBufferRef.current.set("a", { text: "AA" });
+    ctx.toolOutputBufferRef.current.set("b", { text: "BB" });
+    flushToolOutput(ctx);
+    expect(get()[1]!.toolCalls![0]!.streamedOutput).toBe("AA");
+    expect(get()[1]!.toolCalls![1]!.streamedOutput).toBe("BB");
+    expect(ctx.toolOutputBufferRef.current.size).toBe(0);
+  });
+
+  it("is a no-op when the buffer is empty", () => {
+    const { ctx, get } = makeCtx([userMsg, asstMsg([tc("a")])]);
+    const before = get();
+    flushToolOutput(ctx);
+    expect(get()).toBe(before);
+  });
+});
+
+describe("handleToolOutputChunk", () => {
+  let scheduled: Array<() => void>;
+  let cancelled: Set<number>;
+  const origRaf = globalThis.requestAnimationFrame;
+  const origCancel = globalThis.cancelAnimationFrame;
+
+  beforeEach(() => {
+    scheduled = [];
+    cancelled = new Set();
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      scheduled.push(() => cb(0));
+      return scheduled.length;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      cancelled.add(id);
+    }) as typeof globalThis.cancelAnimationFrame;
+  });
+  afterEach(() => {
+    globalThis.requestAnimationFrame = origRaf;
+    globalThis.cancelAnimationFrame = origCancel;
+  });
+
+  function runScheduled() {
+    const cbs = scheduled.slice();
+    scheduled = [];
+    cbs.forEach((cb, i) => {
+      if (!cancelled.has(i + 1)) cb();
+    });
+  }
+
+  const ev = (chunk: string): ToolOutputChunkEvent =>
+    ({ type: "tool_output_chunk", chunk, toolUseId: "tc-1" }) as ToolOutputChunkEvent;
+
+  it("coalesces multiple chunks into a single flush", () => {
+    const { ctx, get } = makeCtx([userMsg, asstMsg([tc("tc-1")])]);
+    handleToolOutputChunk(ev("a"), ctx);
+    handleToolOutputChunk(ev("b"), ctx);
+    handleToolOutputChunk(ev("c"), ctx);
+    // One frame scheduled (coalesced); nothing applied to state yet.
+    expect(scheduled.length).toBe(1);
+    expect(get()[1]!.toolCalls![0]!.streamedOutput).toBeUndefined();
+
+    runScheduled();
+    expect(get()[1]!.toolCalls![0]!.streamedOutput).toBe("abc");
+  });
+
+  it("schedules no frame for an empty chunk", () => {
+    const { ctx } = makeCtx([userMsg, asstMsg([tc("tc-1")])]);
+    handleToolOutputChunk(
+      { type: "tool_output_chunk", chunk: "", toolUseId: "tc-1" } as ToolOutputChunkEvent,
+      ctx,
+    );
+    expect(scheduled.length).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/utils/stream-updaters/tool-output-chunk.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/tool-output-chunk.test.ts
@@ -162,7 +162,10 @@ function makeCtx(initial: DisplayMessage[]) {
   let messages = initial;
   const ctx = {
     toolOutputBufferRef: {
-      current: new Map<string, { messageId?: string; text: string }>(),
+      current: new Map<
+        string,
+        { conversationId?: string; messageId?: string; text: string }
+      >(),
     },
     toolOutputFlushHandleRef: { current: null as number | null },
     setMessages: (
@@ -195,6 +198,22 @@ describe("flushToolOutput", () => {
     const before = get();
     flushToolOutput(ctx);
     expect(get()).toBe(before);
+  });
+
+  it("drops buffered chunks from a non-active conversation", () => {
+    // A deferred flush after a conversation switch must not graft a prior
+    // conversation's output onto the active transcript. The active stream
+    // conversation defaults to none in tests, so an entry stamped with a
+    // conversation is dropped while an unstamped one still applies.
+    const { ctx, get } = makeCtx([userMsg, asstMsg([tc("a"), tc("b")])]);
+    ctx.toolOutputBufferRef.current.set("a", {
+      conversationId: "switched-away-convo",
+      text: "stale",
+    });
+    ctx.toolOutputBufferRef.current.set("b", { text: "kept" });
+    flushToolOutput(ctx);
+    expect(get()[1]!.toolCalls![0]!.streamedOutput).toBeUndefined();
+    expect(get()[1]!.toolCalls![1]!.streamedOutput).toBe("kept");
   });
 });
 

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -486,6 +486,7 @@ export function toolDetailPayloadFromToolCall(
     activity,
     input: tc.input ?? {},
     result: tc.result,
+    streamedOutput: tc.streamedOutput,
     status: deriveToolStepStatus(tc),
     riskLevel: tc.riskLevel,
     riskReason: tc.riskReason,

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -139,6 +139,13 @@ export interface ToolDetailPayload {
   activity: string; // rich sentence (may be "")
   input: Record<string, unknown>;
   result?: string;
+  /**
+   * Open-time snapshot of the live streamed tool output (e.g. foreground bash
+   * stdout/stderr). Only a fallback: an open drawer re-derives the live value
+   * from the chat-session store via `useLiveToolCall`, so this is used only
+   * when the tool call can't be resolved live (e.g. paged out).
+   */
+  streamedOutput?: string;
   status: "running" | "completed" | "error" | "denied";
   riskLevel?: string;
   riskReason?: string;


### PR DESCRIPTION
## What

Wires up live rendering of `tool_output_chunk` streaming events in the web client's **tool-detail side drawer**. These events — incremental stdout/stderr from foreground `bash`/`host_bash`, plus media/transcribe skill progress — were previously dropped at a no-op `case` in the stream handler. The CLI already rendered them live; no GUI client did.

Because macOS (Electron), iOS (Capacitor), and the chrome-extension all render the `clients/web` build, this covers **every GUI client** at once.

## How

**Accumulate** (mirrors the existing `assistant_text_delta` → `appendTextDelta` path):
- Web-local `streamedOutput?: string` on `ChatMessageToolCall`.
- `appendToolOutputChunk` updater — correlate by `toolUseId`/`messageId` (no positional misattribution when an id is present-but-absent), bounded ~16 KB tail, immutable dual-write into `toolCalls` + `contentBlocks`. `applyToolResult` clears it when the final `result` arrives.
- `handleToolOutputChunk` buffers per-`toolUseId` and flushes **once per animation frame** (coalescing — a bash stdout flood doesn't re-project the non-virtualized transcript per chunk); `handleToolResult` flushes before applying the result.

**Render** (mirrors the existing `useLiveThinkingText` precedent):
- New `useLiveToolCall(toolCallId)` re-derives the open drawer's payload live from the store, so it streams instead of showing a frozen open-time snapshot — also fixes the latent "open a running tool → see its final result" gap.
- `ToolDetailPanel` renders `streamedOutput` via `CodeBlock` while running, flipping to the final `result` on completion.

## Scope
- **Plain-text chunks only.** The structured `subType`/`subTool*` wire fields pass through but are not specially rendered (no producer emits them today).
- **No daemon/CLI changes** — the events are already produced, enriched, and broadcast to web unfiltered.

## Test
- New `tool-output-chunk.test.ts`: append/accumulate, id correlation, no-misattribution, pre-anchor fallback, bounded tail, clear-on-result, coalesced flush.
- Full stream-updaters suite, typecheck, lint, and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)