### PR TITLE
perf(migrations): run strip-thinking sweep off the event loop

### DIFF
--- a/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
+++ b/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
@@ -1,5 +1,85 @@
+import { getLogger } from "../../util/logger.js";
+import { getDbPath } from "../../util/platform.js";
+import { runAsyncSqlite } from "../db-async-query.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
+
+const log = getLogger("db-init");
+
+/**
+ * Checkpoint key holding the highest `messages.rowid` already swept by this
+ * migration. Persisted after every window so an interrupted run resumes from
+ * where it left off instead of restarting the whole table scan. The value is a
+ * plain integer string — deliberately not `started`/`rolling_back`, so
+ * `recoverCrashedMigrations` never mistakes it for a stalled step and clears
+ * it, and not `step:`-prefixed, so `validateMigrationState` ignores it.
+ */
+const WATERMARK_KEY = "migration_209_strip_thinking_watermark";
+
+/**
+ * Number of `rowid` values swept per `runAsyncSqlite` dispatch. Each window is
+ * one off-thread subprocess transaction, so the size bounds both the WAL growth
+ * per statement and how long a single write lock is held, while keeping the
+ * number of subprocess spawns low on a large table.
+ */
+const ROWID_WINDOW = 100_000;
+
+/** SQL predicate: this `json_each` element is an internal reasoning block. */
+const IS_THINKING = `json_extract(value, '$.type') IN ('thinking', 'redacted_thinking')`;
+
+/**
+ * SQL predicate: this `json_each` element is kept. `IS NOT` (not `!=`) so a
+ * block with a NULL/absent `type` is preserved, matching the JS filter the
+ * original migration used (`b.type !== 'thinking'`).
+ */
+const IS_KEPT = `json_extract(value, '$.type') IS NOT 'thinking' AND json_extract(value, '$.type') IS NOT 'redacted_thinking'`;
+
+/**
+ * Build the two set-based UPDATEs that sweep one rowid window `(lo, hi]`.
+ *
+ *  - Statement A strips thinking/redacted_thinking blocks from rows that retain
+ *    at least one kept block, rebuilding the content array in place. `json(value)`
+ *    re-embeds each surviving element as JSON rather than a quoted string.
+ *  - Statement B replaces all-thinking rows (no kept block survives) with the
+ *    null-byte placeholder sentinel so the message isn't left empty. `char(0)`
+ *    is evaluated inside SQLite, so the literal NUL is produced in the database
+ *    and never written into the SQL piped to the sqlite3 CLI.
+ *
+ * Both are gated by a cheap `content LIKE '%thinking%'` substring prefilter
+ * (covers both `thinking` and `redacted_thinking`) so the expensive `json_each`
+ * work only runs for rows that could possibly contain a reasoning block. The
+ * two statements touch disjoint row sets (A requires a kept block, B requires
+ * none), so their order within the window is immaterial.
+ */
+function windowSql(lo: number, hi: number): string {
+  const scope = `role = 'assistant'
+       AND rowid > ${lo} AND rowid <= ${hi}
+       AND content LIKE '%thinking%'
+       AND json_valid(content)
+       AND json_type(content) = 'array'`;
+
+  const stripMixed = /*sql*/ `
+    UPDATE messages
+    SET content = (
+      SELECT json_group_array(json(value))
+      FROM json_each(messages.content)
+      WHERE ${IS_KEPT}
+    )
+    WHERE ${scope}
+      AND EXISTS (SELECT 1 FROM json_each(messages.content) WHERE ${IS_THINKING})
+      AND EXISTS (SELECT 1 FROM json_each(messages.content) WHERE ${IS_KEPT});`;
+
+  const placeholderOnly = /*sql*/ `
+    UPDATE messages
+    SET content = json_array(
+      json_object('type', 'text', 'text', char(0) || '__PLACEHOLDER__[internal blocks omitted]')
+    )
+    WHERE ${scope}
+      AND EXISTS (SELECT 1 FROM json_each(messages.content) WHERE ${IS_THINKING})
+      AND NOT EXISTS (SELECT 1 FROM json_each(messages.content) WHERE ${IS_KEPT});`;
+
+  return `${stripMixed}\n${placeholderOnly}`;
+}
 
 /**
  * Strip thinking and redacted_thinking blocks from all assistant messages.
@@ -11,68 +91,62 @@ import { getSqliteFrom } from "../db-connection.js";
  * provider no longer needs to strip, enabling append-only conversation
  * history and stable prefix caching.
  *
- * Idempotent — safe to re-run.
+ * The rewrite runs entirely inside SQLite (via JSON1), dispatched through
+ * {@link runAsyncSqlite} a rowid window at a time. On a host with the `sqlite3`
+ * CLI each window executes in a subprocess, leaving the daemon's event loop
+ * free to answer `/healthz` while a multi-GB table is rewritten — the original
+ * synchronous in-process loop blocked the loop for minutes and tripped the
+ * startup probe into a restart loop. Progress is checkpointed per window, so an
+ * interrupted run resumes instead of rescanning from the start.
+ *
+ * Idempotent — safe to re-run. Already-cleaned rows no longer contain a
+ * thinking block, so the substring prefilter skips them.
  */
-export function migrateStripThinkingFromConsolidated(
+export async function migrateStripThinkingFromConsolidated(
   database: DrizzleDb,
-): void {
+): Promise<void> {
   const raw = getSqliteFrom(database);
+  const dbPath = getDbPath();
 
-  const BATCH_SIZE = 100;
-  let lastRowid = 0;
-
-  for (;;) {
-    const rows = raw
-      .query(
-        `SELECT rowid, id, content FROM messages
-         WHERE role = 'assistant'
-           AND rowid > ?
-         ORDER BY rowid
-         LIMIT ?`,
-      )
-      .all(lastRowid, BATCH_SIZE) as Array<{
-      rowid: number;
-      id: string;
-      content: string;
-    }>;
-
-    if (rows.length === 0) break;
-
-    for (const row of rows) {
-      lastRowid = row.rowid;
-
-      let blocks: Array<{ type: string }>;
-      try {
-        const parsed = JSON.parse(row.content);
-        if (!Array.isArray(parsed)) continue;
-        blocks = parsed;
-      } catch {
-        continue;
-      }
-
-      const hasThinking = blocks.some(
-        (b) => b.type === "thinking" || b.type === "redacted_thinking",
-      );
-      if (!hasThinking) continue;
-
-      const stripped = blocks.filter(
-        (b) => b.type !== "thinking" && b.type !== "redacted_thinking",
-      );
-
-      // Preserve at least one block so the message isn't empty.
-      const finalContent =
-        stripped.length > 0
-          ? stripped
-          : [
-              {
-                type: "text" as const,
-                text: "\x00__PLACEHOLDER__[internal blocks omitted]",
-              },
-            ];
-
-      raw
-        .query(`UPDATE messages SET content = ? WHERE id = ?`)
-        .run(JSON.stringify(finalContent), row.id);
+  const maxRow = (
+    raw.query(`SELECT MAX(rowid) AS m FROM messages`).get() as {
+      m: number | null;
     }
+  ).m;
+  if (maxRow == null) return; // empty table — nothing to sweep
+
+  const watermarkRow = raw
+    .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
+    .get(WATERMARK_KEY) as { value: string } | undefined;
+  let lo = watermarkRow ? Number.parseInt(watermarkRow.value, 10) || 0 : 0;
+
+  const setWatermark = raw.query(
+    `INSERT OR REPLACE INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+  );
+
+  while (lo < maxRow) {
+    const hi = Math.min(lo + ROWID_WINDOW, maxRow);
+
+    const res = await runAsyncSqlite(windowSql(lo, hi), { dbPath });
+    if (!res.ok) {
+      // Leave the watermark at the last completed window; throwing reports the
+      // step failed so the runner retries it (from the watermark) next boot
+      // rather than checkpointing it as done.
+      throw new Error(
+        `strip-thinking window (${lo}, ${hi}] failed: ${res.error}`,
+      );
+    }
+
+    lo = hi;
+    setWatermark.run(WATERMARK_KEY, String(lo), Date.now());
   }
+
+  // Bound WAL growth left by the windowed rewrites, then drop the watermark so
+  // a future re-run (e.g. after a rollback) starts clean.
+  await runAsyncSqlite(`PRAGMA wal_checkpoint(TRUNCATE);`, { dbPath });
+  raw.query(`DELETE FROM memory_checkpoints WHERE key = ?`).run(WATERMARK_KEY);
+
+  log.info(
+    "Migration 209: stripped thinking blocks from consolidated messages",
+  );
 }

--- a/assistant/src/memory/migrations/__tests__/209-strip-thinking-from-consolidated.test.ts
+++ b/assistant/src/memory/migrations/__tests__/209-strip-thinking-from-consolidated.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for migration 209 — stripping thinking / redacted_thinking blocks from
+ * persisted assistant messages.
+ *
+ * The migration rewrites content entirely inside SQLite (JSON1), dispatched a
+ * rowid window at a time through `runAsyncSqlite`. These tests drive the step
+ * directly against a real DB and assert the at-rest content, idempotency,
+ * scoping (assistant rows only), tolerance of malformed content, and that the
+ * persisted rowid watermark is honored for resume.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite } = await import("../../db-connection.js");
+const { initializeDb } = await import("../../db-init.js");
+const { migrateStripThinkingFromConsolidated } =
+  await import("../209-strip-thinking-from-consolidated.js");
+
+await initializeDb();
+
+const CONV = "conv-209";
+getSqlite()
+  .query(
+    `INSERT OR IGNORE INTO conversations (id, created_at, updated_at) VALUES (?, ?, ?)`,
+  )
+  .run(CONV, Date.now(), Date.now());
+
+let seq = 0;
+function insert(role: string, content: string): { id: string; rowid: number } {
+  const id = `m209-${seq++}`;
+  getSqlite()
+    .query(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(id, CONV, role, content, Date.now());
+  const rowid = (
+    getSqlite()
+      .query(`SELECT rowid AS r FROM messages WHERE id = ?`)
+      .get(id) as { r: number }
+  ).r;
+  return { id, rowid };
+}
+
+function content(id: string): string {
+  return (
+    getSqlite().query(`SELECT content FROM messages WHERE id = ?`).get(id) as {
+      content: string;
+    }
+  ).content;
+}
+
+function blocks(id: string): Array<Record<string, unknown>> {
+  return JSON.parse(content(id));
+}
+
+describe("migration 209 — strip thinking from consolidated assistant messages", () => {
+  test("strips thinking blocks but keeps text and tool_use, preserving order", async () => {
+    const { id } = insert(
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "secret", signature: "sig" },
+        { type: "text", text: "hello" },
+        { type: "tool_use", id: "t1", name: "x", input: { a: 1 } },
+      ]),
+    );
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    expect(blocks(id)).toEqual([
+      { type: "text", text: "hello" },
+      { type: "tool_use", id: "t1", name: "x", input: { a: 1 } },
+    ]);
+  });
+
+  test("strips redacted_thinking blocks", async () => {
+    const { id } = insert(
+      "assistant",
+      JSON.stringify([
+        { type: "redacted_thinking", data: "blob" },
+        { type: "text", text: "world" },
+      ]),
+    );
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    expect(blocks(id)).toEqual([{ type: "text", text: "world" }]);
+  });
+
+  test("all-thinking message becomes the null-byte placeholder sentinel", async () => {
+    const { id } = insert(
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "a", signature: "s1" },
+        { type: "redacted_thinking", data: "b" },
+      ]),
+    );
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    const result = blocks(id);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("text");
+    expect(result[0].text).toBe("\x00__PLACEHOLDER__[internal blocks omitted]");
+    // The leading byte must be a literal NUL, produced by SQLite's char(0).
+    expect((result[0].text as string).charCodeAt(0)).toBe(0);
+  });
+
+  test("preserves blocks with a missing/null type", async () => {
+    const { id } = insert(
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "x", signature: "s" },
+        { foo: "bar" },
+        { type: "text", text: "kept" },
+      ]),
+    );
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    expect(blocks(id)).toEqual([
+      { foo: "bar" },
+      { type: "text", text: "kept" },
+    ]);
+  });
+
+  test("leaves thinking-free assistant messages untouched", async () => {
+    const original = JSON.stringify([
+      { type: "text", text: "I was thinking about lunch" },
+    ]);
+    const { id } = insert("assistant", original);
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    // Substring 'thinking' appears in the text but no block is of thinking type.
+    expect(content(id)).toBe(original);
+  });
+
+  test("does not touch non-assistant roles", async () => {
+    const original = JSON.stringify([
+      { type: "thinking", thinking: "x", signature: "s" },
+      { type: "text", text: "u" },
+    ]);
+    const { id } = insert("user", original);
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    expect(content(id)).toBe(original);
+  });
+
+  test("tolerates non-array and invalid JSON content", async () => {
+    const obj = insert(
+      "assistant",
+      JSON.stringify({ type: "thinking", thinking: "x" }),
+    );
+    const invalid = insert("assistant", "{not json with thinking");
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    expect(content(obj.id)).toBe(
+      JSON.stringify({ type: "thinking", thinking: "x" }),
+    );
+    expect(content(invalid.id)).toBe("{not json with thinking");
+  });
+
+  test("is idempotent across repeated runs", async () => {
+    const { id } = insert(
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "x", signature: "s" },
+        { type: "text", text: "stable" },
+      ]),
+    );
+
+    await migrateStripThinkingFromConsolidated(getDb());
+    const once = content(id);
+    await migrateStripThinkingFromConsolidated(getDb());
+    const twice = content(id);
+
+    expect(twice).toBe(once);
+    expect(blocks(id)).toEqual([{ type: "text", text: "stable" }]);
+  });
+
+  test("honors the persisted rowid watermark and resumes above it", async () => {
+    const below = insert(
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "x", signature: "s" },
+        { type: "text", text: "below" },
+      ]),
+    );
+    const above = insert(
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "y", signature: "s" },
+        { type: "text", text: "above" },
+      ]),
+    );
+
+    // Pretend a prior run already swept through `below`'s rowid: the sweep must
+    // resume strictly above it, leaving `below` untouched and cleaning `above`.
+    getSqlite()
+      .query(
+        `INSERT OR REPLACE INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+      )
+      .run(
+        "migration_209_strip_thinking_watermark",
+        String(below.rowid),
+        Date.now(),
+      );
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    expect(blocks(below.id)).toEqual([
+      { type: "thinking", thinking: "x", signature: "s" },
+      { type: "text", text: "below" },
+    ]);
+    expect(blocks(above.id)).toEqual([{ type: "text", text: "above" }]);
+
+    // The watermark is cleared once the sweep reaches the end of the table.
+    const wm = getSqlite()
+      .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
+      .get("migration_209_strip_thinking_watermark");
+    expect(wm).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Migration 209 (`migrateStripThinkingFromConsolidated`) was taking the daemon down in a restart loop on large databases. The chain:

1. **It blocked the event loop.** The migration was a plain synchronous function that walked every assistant message, `JSON.parse`d its content, stripped thinking blocks, and wrote each row back — one row per implicit transaction. On a multi-GB DB that ran for minutes at ~98% CPU. The runtime HTTP server shares the daemon's single JS event loop, so while the migration churned, `/healthz` could not be answered even though the socket was bound.
2. **The probe killed it.** The startup probe timed out and the kubelet restarted the container ("failed startup probe, will be restarted").
3. **It never finished → infinite loop.** The migration runner checkpoints a step only *after* it completes. Because the probe killed the process mid-migration, the `step:` checkpoint was never written; on the next boot `recoverCrashedMigrations` cleared the stalled marker and it re-ran from scratch. Every restart hit the same wall.
4. **Full re-scan every boot.** It selected *all* assistant rows from rowid 0 and only skipped the *write* in JS, so the expensive read + parse was paid in full on every restart.

## What

Rewrite 209 as a set-based **JSON1** transform dispatched through `runAsyncSqlite` a **rowid window at a time**:

- On hosts with the `sqlite3` CLI (the k8s container, macOS), each window runs in a **subprocess**, leaving the daemon's event loop free to answer `/healthz` while the table is rewritten. Falls back to in-process execution where no `sqlite3` is present (desktop, no liveness probe) — same rationale the existing `runAsyncSqlite` abstraction already relies on.
- **Message content never leaves the database** — the rewrite happens entirely in SQL, so nothing is piped through subprocess stdout (which the in-process fallback discards anyway).
- **Resumable**: a rowid watermark is persisted to `memory_checkpoints` after every window, so an interrupted run resumes instead of rescanning from the start. The key is deliberately not `started`/`rolling_back` (so `recoverCrashedMigrations` won't clear it) and not `step:`-prefixed (so `validateMigrationState` ignores it).
- **Bounded WAL**: windowing keeps each subprocess transaction small; a final `wal_checkpoint(TRUNCATE)` cleans up.
- The all-thinking placeholder keeps its exact `\x00__PLACEHOLDER__[internal blocks omitted]` sentinel, produced via `char(0)` evaluated *inside* SQLite so no literal NUL is ever written into the SQL piped to the CLI.

Behavior is preserved: thinking/redacted_thinking blocks are stripped, other blocks (including null-typed ones) kept in order, all-thinking messages get the placeholder, and it remains idempotent.

## Tests

New `__tests__/209-strip-thinking-from-consolidated.test.ts` covers strip/keep ordering, `redacted_thinking`, the placeholder sentinel (incl. the literal NUL byte), null-typed blocks, role scoping, malformed/non-array content, idempotency, and watermark resume. Green on **both** backends — verified against the real `sqlite3` CLI subprocess and the in-process fallback. Existing migration-runner and rollback suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuCBCQjBiBZV8EPPzNZm8K)_