### PR TITLE
[codex] Use design system for quote reply

### DIFF
--- a/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
@@ -1,7 +1,7 @@
 /**
- * Overlay bubble that appears after the user clicks "Quote & Reply" on a
- * text selection. Displays the quoted passage and a text input for the
- * user's reply, with two actions:
+ * Overlay bubble that appears after the user starts a reply from a text
+ * selection. Displays the quoted passage and a text input for the user's
+ * reply, with two actions:
  *
  * - **Add to Chat** — stages the quote+reply for inclusion in the next
  *   message the user sends from the composer.
@@ -18,7 +18,13 @@ import {
 } from "react";
 
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
-import { Button } from "@vellumai/design-library";
+import {
+  Button,
+  Card,
+  Popover,
+  Textarea,
+  Typography,
+} from "@vellumai/design-library";
 
 interface QuoteReplyBubbleProps {
   onSendNow: (quotedText: string, replyText: string) => void;
@@ -31,7 +37,6 @@ export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
 
   const [replyText, setReplyText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const bubbleRef = useRef<HTMLDivElement | null>(null);
 
   // Reset reply text when the bubble opens with new content.
   useEffect(() => {
@@ -42,34 +47,6 @@ export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
       });
     }
   }, [replyBubble]);
-
-  // Dismiss on click outside the bubble.
-  useEffect(() => {
-    if (!replyBubble) {
-      return;
-    }
-
-    const handlePointerDown = (e: PointerEvent) => {
-      const target = e.target as Node | null;
-      if (target && bubbleRef.current && !bubbleRef.current.contains(target)) {
-        closeReplyBubble();
-      }
-    };
-
-    // Dismiss on Escape.
-    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
-      if (e.key === "Escape") {
-        closeReplyBubble();
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [replyBubble, closeReplyBubble]);
 
   const handleAddToChat = useCallback(() => {
     if (!replyBubble || !replyText.trim()) {
@@ -114,68 +91,100 @@ export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
       : replyBubble.quotedText;
 
   return (
-    <div
-      ref={bubbleRef}
-      className="fixed z-50 w-[360px] -translate-x-1/2 animate-in fade-in zoom-in-95 duration-150"
-      style={{
-        top: replyBubble.anchorRect.top - 8,
-        left: replyBubble.anchorRect.left,
-        transform: "translate(-50%, -100%)",
+    <Popover.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          closeReplyBubble();
+        }
       }}
     >
-      <div className="flex flex-col gap-3 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] p-3 shadow-lg">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5 text-body-small-default text-[var(--content-tertiary)]">
-            <MessageSquareQuote className="h-3.5 w-3.5" />
-            <span>Quote &amp; Reply</span>
-          </div>
-          <button
-            type="button"
-            onClick={closeReplyBubble}
-            className="flex h-5 w-5 cursor-pointer items-center justify-center rounded text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-default)]"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-
-        {/* Quoted text */}
-        <div className="rounded-lg border-l-2 border-[var(--border-active)] bg-[var(--surface-lift)] px-3 py-2 text-body-small-default text-[var(--content-secondary)]">
-          {truncatedQuote}
-        </div>
-
-        {/* Reply input */}
-        <textarea
-          ref={textareaRef}
-          value={replyText}
-          onChange={(e) => setReplyText(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Type your reply…"
-          rows={2}
-          className="w-full resize-none rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] px-3 py-2 text-body-small-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:border-[var(--border-active)] focus:outline-none"
+      <Popover.Anchor asChild>
+        <span
+          aria-hidden="true"
+          className="fixed h-0 w-0"
+          style={{
+            top: replyBubble.anchorRect.top,
+            left: replyBubble.anchorRect.left,
+          }}
         />
+      </Popover.Anchor>
+      <Popover.Content
+        side="top"
+        align="center"
+        sideOffset={8}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        className="w-[360px] rounded-xl bg-transparent p-0 shadow-none"
+      >
+        <Card.Root
+          padding="sm"
+          bordered
+          elevated
+          className="bg-[var(--surface-base)] shadow-lg"
+        >
+          <Card.Body padding="sm" className="flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-2">
+              <Typography
+                as="div"
+                variant="body-small-default"
+                className="flex min-w-0 items-center gap-1.5 text-[var(--content-tertiary)]"
+              >
+                <MessageSquareQuote className="h-3.5 w-3.5 shrink-0" />
+                <span>Quote &amp; Reply</span>
+              </Typography>
+              <Popover.Close asChild>
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  iconOnly={<X />}
+                  expandOnMobile={false}
+                  aria-label="Close reply"
+                />
+              </Popover.Close>
+            </div>
 
-        {/* Actions */}
-        <div className="flex items-center justify-end gap-2">
-          <Button
-            variant="outlined"
-            size="compact"
-            onClick={handleAddToChat}
-            disabled={!replyText.trim()}
-          >
-            Add to Chat
-          </Button>
-          <Button
-            variant="primary"
-            size="compact"
-            onClick={handleSendNow}
-            disabled={!replyText.trim()}
-            rightIcon={<Send className="h-3 w-3" />}
-          >
-            Send Now
-          </Button>
-        </div>
-      </div>
-    </div>
+            <Typography
+              as="div"
+              variant="body-small-default"
+              className="rounded-lg border-l-2 border-[var(--border-active)] bg-[var(--surface-lift)] px-3 py-2 text-[var(--content-secondary)]"
+            >
+              {truncatedQuote}
+            </Typography>
+
+            <Textarea
+              ref={textareaRef}
+              value={replyText}
+              onChange={(e) => setReplyText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Type your reply…"
+              rows={2}
+              fullWidth
+              className="min-h-[64px] resize-none text-body-small-default"
+            />
+
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={handleAddToChat}
+                disabled={!replyText.trim()}
+              >
+                Add to Chat
+              </Button>
+              <Button
+                variant="primary"
+                size="compact"
+                onClick={handleSendNow}
+                disabled={!replyText.trim()}
+                rightIcon={<Send />}
+              >
+                Send Now
+              </Button>
+            </div>
+          </Card.Body>
+        </Card.Root>
+      </Popover.Content>
+    </Popover.Root>
   );
 }

--- a/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { createRef } from "react";
+
+import { QuoteReplyBubble } from "@/domains/chat/components/quote-reply-bubble";
+import { StagedQuotesStrip } from "@/domains/chat/components/staged-quotes-strip";
+import { TextSelectionPopover } from "@/domains/chat/components/text-selection-popover";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+function resetQuoteReplyState() {
+  useQuoteReplyStore.setState({
+    stagedQuotes: [],
+    replyBubble: null,
+  });
+  useClientFeatureFlagStore.setState({ quoteReply: false });
+}
+
+function installFinePointer() {
+  const originalMatchMedia = window.matchMedia;
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => ({ matches: false }),
+  });
+  return () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+  };
+}
+
+function installImmediateAnimationFrame() {
+  const originalAnimationFrame = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  }) as typeof requestAnimationFrame;
+  return () => {
+    globalThis.requestAnimationFrame = originalAnimationFrame;
+  };
+}
+
+function installSelection(anchorNode: Node) {
+  const originalGetSelection = window.getSelection;
+  const selection = {
+    isCollapsed: false,
+    rangeCount: 1,
+    anchorNode,
+    toString: () => "competitive research",
+    getRangeAt: () => ({
+      getBoundingClientRect: () => ({
+        top: 120,
+        left: 80,
+        width: 160,
+        height: 24,
+        right: 240,
+        bottom: 144,
+        x: 80,
+        y: 120,
+        toJSON: () => ({}),
+      }),
+    }),
+    removeAllRanges: () => {},
+  } as unknown as Selection;
+
+  Object.defineProperty(window, "getSelection", {
+    configurable: true,
+    value: () => selection,
+  });
+
+  return () => {
+    Object.defineProperty(window, "getSelection", {
+      configurable: true,
+      value: originalGetSelection,
+    });
+  };
+}
+
+beforeEach(resetQuoteReplyState);
+afterEach(() => {
+  cleanup();
+  resetQuoteReplyState();
+});
+
+describe("TextSelectionPopover", () => {
+  test("shows a design-system Reply action for assistant text selections", async () => {
+    const restorePointer = installFinePointer();
+    const restoreAnimationFrame = installImmediateAnimationFrame();
+    try {
+      const containerRef = createRef<HTMLDivElement | null>();
+      render(
+        <>
+          <div ref={containerRef}>
+            <div data-message-id="msg-1" data-message-role="assistant">
+              <span data-testid="selected-text">competitive research</span>
+            </div>
+          </div>
+          <TextSelectionPopover containerRef={containerRef} />
+        </>,
+      );
+
+      const selectedText = screen.getByTestId("selected-text");
+      const restoreSelection = installSelection(
+        selectedText.firstChild ?? selectedText,
+      );
+      try {
+        fireEvent.mouseUp(selectedText);
+      } finally {
+        restoreSelection();
+      }
+
+      const button = await screen.findByRole("button", { name: "Reply" });
+      expect(button.getAttribute("data-slot")).toBe("button");
+      expect(
+        document.body.querySelector('[data-slot="popover-content"]'),
+      ).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Quote & Reply" })).toBeNull();
+    } finally {
+      restoreAnimationFrame();
+      restorePointer();
+    }
+  });
+});
+
+describe("QuoteReplyBubble", () => {
+  test("renders the reply editor with shared design-system primitives", async () => {
+    useQuoteReplyStore.setState({
+      replyBubble: {
+        quotedText:
+          "here's the anthropic competitive research brief from last night",
+        sourceMessageId: "msg-1",
+        anchorRect: { top: 120, left: 180, width: 0, height: 0 },
+      },
+    });
+
+    render(<QuoteReplyBubble onSendNow={() => {}} />);
+
+    await waitFor(() => {
+      expect(
+        document.body.querySelector('[data-slot="popover-content"]'),
+      ).toBeTruthy();
+    });
+    expect(document.body.querySelector('[data-slot="card"]')).toBeTruthy();
+    expect(document.body.querySelector('[data-slot="textarea"]')).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Close reply" }).getAttribute("data-slot"),
+    ).toBe("button");
+    expect(
+      screen.getByRole("button", { name: "Add to Chat" }).getAttribute("data-slot"),
+    ).toBe("button");
+    expect(
+      screen.getByRole("button", { name: "Send Now" }).getAttribute("data-slot"),
+    ).toBe("button");
+  });
+});
+
+describe("StagedQuotesStrip", () => {
+  test("renders staged quote previews with shared card and button primitives", () => {
+    useClientFeatureFlagStore.setState({ quoteReply: true });
+    useQuoteReplyStore.setState({
+      stagedQuotes: [
+        {
+          id: "quote-1",
+          quotedText: "competitive research",
+          replyText: "Can you expand this into a brief?",
+          sourceMessageId: "msg-1",
+        },
+      ],
+    });
+
+    render(<StagedQuotesStrip />);
+
+    expect(document.body.querySelector('[data-slot="card"]')).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Remove quote" }).getAttribute("data-slot"),
+    ).toBe("button");
+  });
+});

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -14,6 +14,7 @@ import {
   useQuoteReplyStore,
 } from "@/domains/chat/quote-reply-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { Button, Card, Typography } from "@vellumai/design-library";
 
 function truncate(text: string, maxLen: number): string {
   if (text.length <= maxLen) {
@@ -26,25 +27,40 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
   const removeStagedQuote = useQuoteReplyStore.use.removeStagedQuote();
 
   return (
-    <div className="group/quote flex items-start gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-lift)] px-3 py-2">
-      <MessageSquareQuote className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
-      <div className="min-w-0 flex-1">
-        <div className="text-body-small-default text-[var(--content-tertiary)]">
-          &ldquo;{truncate(quote.quotedText, 80)}&rdquo;
+    <Card.Root
+      padding="sm"
+      bordered
+      className="group/quote bg-[var(--surface-lift)]"
+    >
+      <Card.Body padding="sm" className="flex items-start gap-2">
+        <MessageSquareQuote className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
+        <div className="min-w-0 flex-1">
+          <Typography
+            as="div"
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+          >
+            &ldquo;{truncate(quote.quotedText, 80)}&rdquo;
+          </Typography>
+          <Typography
+            as="div"
+            variant="body-small-default"
+            className="mt-0.5 text-[var(--content-default)]"
+          >
+            {truncate(quote.replyText, 120)}
+          </Typography>
         </div>
-        <div className="mt-0.5 text-body-small-default text-[var(--content-default)]">
-          {truncate(quote.replyText, 120)}
-        </div>
-      </div>
-      <button
-        type="button"
-        onClick={() => removeStagedQuote(quote.id)}
-        className="flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded text-[var(--content-tertiary)] opacity-0 transition-opacity group-hover/quote:opacity-100"
-        aria-label="Remove quote"
-      >
-        <X className="h-3 w-3" />
-      </button>
-    </div>
+        <Button
+          variant="ghost"
+          size="compact"
+          iconOnly={<X />}
+          expandOnMobile={false}
+          onClick={() => removeStagedQuote(quote.id)}
+          className="shrink-0 opacity-0 transition-opacity group-hover/quote:opacity-100 focus-visible:opacity-100"
+          aria-label="Remove quote"
+        />
+      </Card.Body>
+    </Card.Root>
   );
 }
 

--- a/clients/web/src/domains/chat/components/text-selection-popover.tsx
+++ b/clients/web/src/domains/chat/components/text-selection-popover.tsx
@@ -1,17 +1,18 @@
 /**
  * Floating popover that appears when the user selects text inside an
- * assistant message bubble. Offers a single "Quote & Reply" action that
- * opens the reply bubble for the selected passage.
+ * assistant message bubble. Offers a single reply action for the selected
+ * passage.
  *
  * Desktop-only — `isPointerCoarse()` gates the entire listener so touch
  * devices never see the popover (OS text selection UX conflicts).
  */
 
 import { MessageSquareQuote } from "lucide-react";
-import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { type RefObject, useCallback, useEffect, useState } from "react";
 
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { isPointerCoarse } from "@/utils/pointer";
+import { Button, Popover } from "@vellumai/design-library";
 
 /**
  * Selector: the transcript container ref whose descendants contain
@@ -31,7 +32,6 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
     left: number;
   } | null>(null);
 
-  const popoverRef = useRef<HTMLDivElement | null>(null);
   const openReplyBubble = useQuoteReplyStore.use.openReplyBubble();
 
   const handleMouseUp = useCallback(() => {
@@ -84,7 +84,7 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
     });
   }, []);
 
-  // Dismiss the popover when the selection is cleared or clicking outside.
+  // Dismiss the popover when the selection is cleared.
   useEffect(() => {
     if (!popover) {
       return;
@@ -97,18 +97,9 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
       }
     };
 
-    const handlePointerDown = (e: PointerEvent) => {
-      const target = e.target as Node | null;
-      if (target && popoverRef.current && !popoverRef.current.contains(target)) {
-        setPopover(null);
-      }
-    };
-
     document.addEventListener("selectionchange", handleSelectionChange);
-    document.addEventListener("pointerdown", handlePointerDown);
     return () => {
       document.removeEventListener("selectionchange", handleSelectionChange);
-      document.removeEventListener("pointerdown", handlePointerDown);
     };
   }, [popover]);
 
@@ -154,23 +145,43 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
   };
 
   return (
-    <div
-      ref={popoverRef}
-      className="fixed z-50 -translate-x-1/2 animate-in fade-in zoom-in-95 duration-150"
-      style={{
-        top: popover.top - 40,
-        left: popover.left,
+    <Popover.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          setPopover(null);
+        }
       }}
     >
-      <button
-        type="button"
-        onClick={handleQuoteReply}
-        className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1.5 text-body-small-default text-[var(--content-default)] shadow-md transition-colors hover:bg-[var(--surface-active)]"
+      <Popover.Anchor asChild>
+        <span
+          aria-hidden="true"
+          className="fixed h-0 w-0"
+          style={{
+            top: popover.top,
+            left: popover.left,
+          }}
+        />
+      </Popover.Anchor>
+      <Popover.Content
+        side="top"
+        align="center"
+        sideOffset={8}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        className="rounded-md bg-transparent p-0 shadow-none"
       >
-        <MessageSquareQuote className="h-3.5 w-3.5" />
-        <span>Quote &amp; Reply</span>
-      </button>
-    </div>
+        <Button
+          variant="outlined"
+          size="regular"
+          onClick={handleQuoteReply}
+          leftIcon={<MessageSquareQuote />}
+          className="bg-[var(--surface-base)] shadow-md"
+        >
+          Reply
+        </Button>
+      </Popover.Content>
+    </Popover.Root>
   );
 }
 

--- a/clients/web/src/domains/chat/quote-reply-store.ts
+++ b/clients/web/src/domains/chat/quote-reply-store.ts
@@ -3,11 +3,10 @@
  *
  * Owns:
  * - Staged quotes (quoted text + user reply, pending inclusion in the next send)
- * - Active selection state (the text currently highlighted for quoting)
  * - Reply bubble state (open/closed, position, quoted text being replied to)
  *
  * The store is consumed by:
- * - `TextSelectionPopover` (reads activeSelection, writes via startReply)
+ * - `TextSelectionPopover` (opens a reply bubble from the current selection)
  * - `QuoteReplyBubble` (reads replyBubble state, writes via addToChat / dismiss)
  * - `StagedQuotesStrip` (reads stagedQuotes, removes individual quotes)
  * - `useSendMessage` / composer integration (reads + clears stagedQuotes on send)
@@ -24,13 +23,6 @@ export interface StagedQuote {
   sourceMessageId: string;
 }
 
-export interface ActiveSelection {
-  text: string;
-  sourceMessageId: string;
-  /** Bounding rect of the selection, relative to the viewport. */
-  rect: { top: number; left: number; width: number; height: number };
-}
-
 export interface ReplyBubbleState {
   quotedText: string;
   sourceMessageId: string;
@@ -40,12 +32,10 @@ export interface ReplyBubbleState {
 
 interface QuoteReplyState {
   stagedQuotes: StagedQuote[];
-  activeSelection: ActiveSelection | null;
   replyBubble: ReplyBubbleState | null;
 }
 
 interface QuoteReplyActions {
-  setActiveSelection: (selection: ActiveSelection | null) => void;
   openReplyBubble: (params: {
     quotedText: string;
     sourceMessageId: string;
@@ -65,15 +55,11 @@ function createQuoteId(): string {
 
 const useQuoteReplyStoreBase = create<QuoteReplyStore>()((set) => ({
   stagedQuotes: [],
-  activeSelection: null,
   replyBubble: null,
-
-  setActiveSelection: (selection) => set({ activeSelection: selection }),
 
   openReplyBubble: ({ quotedText, sourceMessageId, anchorRect }) =>
     set({
       replyBubble: { quotedText, sourceMessageId, anchorRect },
-      activeSelection: null,
     }),
 
   closeReplyBubble: () => set({ replyBubble: null }),


### PR DESCRIPTION
## Summary

- Change the selected-text hover action copy from “Quote & Reply” to “Reply”.
- Rebuild the quote-reply hover action, reply bubble, and staged quote preview with design-library primitives.
- Remove the unused active-selection state from the quote-reply store.
- Add focused component coverage for the hover action copy and design-system composition.

## Why

The quote-reply interaction had locally styled controls for popovers, cards, textareas, and remove buttons. This PR aligns those surfaces with the shared design system while preserving the existing quote staging and send behavior.

## Validation

- `cd clients/web && bun test src/domains/chat/components/quote-reply-components.test.tsx`
- `cd clients/web && bunx tsc --noEmit`
- `cd clients/web && bun run lint src/domains/chat/quote-reply-store.ts src/domains/chat/components/text-selection-popover.tsx src/domains/chat/components/quote-reply-bubble.tsx src/domains/chat/components/staged-quotes-strip.tsx src/domains/chat/components/quote-reply-components.test.tsx`
