### PR TITLE
fix(chat): hide subagent completion notifications from the transcript

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -2911,3 +2911,92 @@ describe("MessageQueue byte budget", () => {
     ).toBe(false);
   });
 });
+
+describe("subagent notification user_message_echo suppression", () => {
+  beforeEach(() => {
+    pendingRuns = [];
+    capturedAddMessages.length = 0;
+  });
+
+  test("drained subagent-notification message persists and wakes the agent but emits no user_message_echo", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const eventsNotif: ServerMessage[] = [];
+
+    // Occupy the conversation so the injected notification queues.
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+    expect(conversation.isProcessing()).toBe(true);
+
+    // A daemon-injected subagent completion notification carries
+    // `subagentNotification` metadata.
+    conversation.enqueueMessage({
+      content: '[Subagent "research" completed]',
+      onEvent: (e) => eventsNotif.push(e),
+      requestId: "req-notif",
+      metadata: {
+        subagentNotification: {
+          subagentId: "sub-1",
+          label: "research",
+          status: "completed",
+        },
+      },
+    });
+
+    // Resolving the first run drains the queued notification.
+    await resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // It is still persisted (so the orchestrator LLM sees it in the transcript)
+    // and still wakes the agent (a run was created for the drained message)...
+    expect(
+      capturedAddMessages.some((m) => m.content.includes("Subagent")),
+    ).toBe(true);
+    expect(pendingRuns.length).toBe(2);
+    // ...but no user_message_echo is broadcast, so the client never renders it
+    // as a live user bubble.
+    expect(eventsNotif.some((e) => e.type === "user_message_echo")).toBe(false);
+
+    await resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  test("drained ordinary message still emits user_message_echo", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const eventsNormal: ServerMessage[] = [];
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    conversation.enqueueMessage({
+      content: "ordinary message",
+      onEvent: (e) => eventsNormal.push(e),
+      requestId: "req-normal",
+    });
+
+    await resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    expect(eventsNormal.some((e) => e.type === "user_message_echo")).toBe(true);
+
+    await resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+});

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -60,6 +60,21 @@ import { resolveVerificationSessionIntent } from "./verification-session-intent.
 
 const log = getLogger("conversation-process");
 
+/**
+ * Daemon-injected subagent lifecycle notifications carry `subagentNotification`
+ * metadata. They are persisted into the parent conversation so the orchestrator
+ * wakes and reads the subagent's result, but they are internal scaffolding — the
+ * user sees subagent activity through the inline progress card, not a chat turn.
+ * Skip the `user_message_echo` broadcast for these so they never render as a live
+ * user bubble; the persisted row is filtered from the rendered transcript on the
+ * client.
+ */
+function isSubagentNotificationMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return metadata?.subagentNotification != null;
+}
+
 /** Format the result of a forced compaction into a user-facing message. */
 export function formatCompactResult(result: ContextWindowResult): string {
   const fmt = (n: number | undefined) => (n ?? 0).toLocaleString("en-US");
@@ -853,14 +868,16 @@ async function drainSingleMessage(
 
   // Broadcast the user message to all hub subscribers so passive devices
   // see the user turn before the assistant reply starts streaming.
-  next.onEvent({
-    type: "user_message_echo",
-    text: resolvedContent,
-    conversationId: conversation.conversationId,
-    messageId: userMessageId,
-    requestId: next.requestId,
-    clientMessageId: next.clientMessageId,
-  });
+  if (!isSubagentNotificationMessage(next.metadata)) {
+    next.onEvent({
+      type: "user_message_echo",
+      text: resolvedContent,
+      conversationId: conversation.conversationId,
+      messageId: userMessageId,
+      requestId: next.requestId,
+      clientMessageId: next.clientMessageId,
+    });
+  }
   publishConversationMessagesChanged(conversation.conversationId);
 
   // Set the active surface for the dequeued message so runAgentLoop can inject context
@@ -1204,14 +1221,16 @@ async function drainBatch(
 
     // Broadcast the user message to all hub subscribers so passive devices
     // see each batched user turn before the assistant reply starts streaming.
-    qm.onEvent({
-      type: "user_message_echo",
-      text: qmContent,
-      conversationId: conversation.conversationId,
-      messageId: lastUserMessageId,
-      requestId: qm.requestId,
-      clientMessageId: qm.clientMessageId,
-    });
+    if (!isSubagentNotificationMessage(qm.metadata)) {
+      qm.onEvent({
+        type: "user_message_echo",
+        text: qmContent,
+        conversationId: conversation.conversationId,
+        messageId: lastUserMessageId,
+        requestId: qm.requestId,
+        clientMessageId: qm.clientMessageId,
+      });
+    }
     publishConversationMessagesChanged(conversation.conversationId);
 
     // Persist succeeded. Update last-successful markers so a later tail

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -59,6 +59,30 @@ describe("buildTranscriptItems", () => {
     expectDistinctNonEmptyKeys(items);
   });
 
+  test("excludes subagent-notification messages from the projection but leaves input intact", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+    const notification = makeMessage({
+      id: "m2",
+      role: "user",
+      ...textBody('[Subagent "research" completed]'),
+      isSubagentNotification: true,
+    });
+    const assistant = makeMessage({ id: "m3", role: "assistant", ...textBody("Hi") });
+    const messages = [user, notification, assistant];
+
+    const items = buildTranscriptItems({ ...emptyInput(), messages });
+
+    // The subagent-notification row is never rendered in the transcript...
+    expect(items).toEqual([
+      { kind: "message", key: "m1", message: user },
+      { kind: "message", key: "m3", message: assistant },
+    ]);
+    // ...but it remains in the input `messages` state so the LLM transcript and
+    // subagent-store rehydration still see it (suppression is render-only).
+    expect(messages).toHaveLength(3);
+    expect(messages[1]).toBe(notification);
+  });
+
   test("emits empty list when there is no state", () => {
     const items = buildTranscriptItems(emptyInput());
     expect(items).toEqual([]);

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -66,11 +66,16 @@ export function buildTranscriptItems(
   const items: TranscriptItem[] = [];
 
   for (const message of messages) {
-    // Subagent notification messages are injected by the daemon as user-role
-    // messages for state reconstruction (history.ts extracts them). They
-    // pass through as normal `MessageItem`s so reconciliation sees the full
-    // row context — `TranscriptMessageBody` branches on `isSubagentNotification`
-    // and renders a narrow system pill instead of the user bubble.
+    // Daemon-injected subagent lifecycle notifications (user-role messages
+    // carrying subagentNotification metadata) stay in `messages` state so the
+    // LLM transcript and subagent-store rehydration (history.ts) still see
+    // them, but they are internal scaffolding and are never rendered in the
+    // transcript — subagent activity surfaces through the inline progress card.
+    if (message.isSubagentNotification) {
+      continue;
+    }
+
+    // Queued user messages surface via the queue drawer, not the transcript.
     const isQueuedUser =
       message.role === "user" && message.queueStatus === "queued";
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -492,23 +492,6 @@ export function TranscriptMessageBody({
     </>
   );
 
-  if (isUser && message.isSubagentNotification) {
-    // Daemon-injected subagent lifecycle notifications: visible but visually
-    // distinct from a real user bubble. Narrow centered pill, no hover
-    // affordances, no slack attribution, no MessageHoverActions trailer.
-    return (
-      <div
-        ref={wrapperRef}
-        data-testid="subagent-notification-row"
-        className="flex justify-start"
-      >
-        <div className="inline-flex max-w-full items-center rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-overlay)] px-3 py-1.5 text-body-small-default text-[var(--content-secondary)]">
-          Subagent update
-        </div>
-      </div>
-    );
-  }
-
   if (isUser) {
     const userItems = groups.map((group, gi) => ({
       kind: group.type === "text" ? ("text" as const) : ("nonText" as const),


### PR DESCRIPTION
## Summary
- Subagent completion notifications — the "Subagent update" pill **and** the duplicate raw `[Subagent "…" completed]` user-message bubble — are no longer rendered in the chat transcript.
- **Daemon:** skip the `user_message_echo` broadcast for daemon-injected subagent-notification messages (gated on `subagentNotification` metadata) in both queue-drain paths, so the live raw bubble is never created. Persistence and the agent wake are untouched.
- **Web:** filter `isSubagentNotification` rows out of the transcript projection (`buildTranscriptItems`) — render-only, the row stays in `messages` state — and remove the now-dead pill branch.

## Root cause
A subagent completion is one persisted `user`-role message (carrying `subagentNotification` metadata) injected into the parent conversation to wake the orchestrator. It reached the client two ways that disagreed: the live `user_message_echo` SSE event has **no metadata channel**, so the live copy rendered as a raw `[Subagent …]` bubble, while the reconciled `/messages` copy carried the metadata and rendered as the "Subagent update" pill (introduced by #35484). Both copies coexisted during the live window → the duplicated pill + bubble.

## Approach
Render-only suppression on both paths. The daemon stops echoing these internal-scaffolding messages as user turns — the idle-parent injection path already emits no echo, so this just makes the busy/queued path consistent. The web client filters them out of the rendered transcript. The message stays in the LLM transcript (`getMessages` is unfiltered) and in the `/messages` payload, so **orchestration and subagent-store rehydration are unaffected**, and the inline subagent progress card / detail panel (driven by separate `subagent_*` events) keep working. `reconcile-with-seq.ts` is intentionally left untouched — its duplication behavior is being reworked in #35753 / #34930.

## Testing
- **assistant:** new tests that the queue-drain path suppresses `user_message_echo` for a subagent-notification message (while still persisting it and waking the agent) and still emits it for an ordinary message.
- **clients/web:** new `buildTranscriptItems` test that `isSubagentNotification` rows are excluded from the projection but remain in the input `messages` state.
- Typecheck clean in all touched files.

## Original prompt
A bug report noted that after subagents finish, a "Subagent update" pill plus two extra `[Subagent …]` user-message bubbles appear in chat unexpectedly. The ask was to hide these subagent-notification pills and messages from the user **without affecting how the underlying system works**. Investigation traced the duplicate to the metadata-less live echo, surfaced by the recent pill-rendering change; the agreed fix hides them render-only while preserving the LLM wake and transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)