### PR TITLE
feat(advisor): stream the advisor's guidance live as it generates

### DIFF
--- a/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
@@ -8,12 +8,19 @@ let sendMessageArgs: Record<string, unknown> | null = null;
 let responseText = "Use a channel-based worker pool; drain on shutdown.";
 let sendMessageError: Error | null = null;
 let providerResolves = true;
+let streamDeltas: string[] = [];
 
 const fakeProvider = {
   name: "mock-advisor-provider",
   async sendMessage(messages: unknown, options: unknown) {
     sendMessageArgs = { messages, options } as Record<string, unknown>;
     if (sendMessageError) throw sendMessageError;
+    const onEvent = (
+      options as { onEvent?: (e: { type: string; text?: string }) => void }
+    ).onEvent;
+    if (onEvent) {
+      for (const text of streamDeltas) onEvent({ type: "text_delta", text });
+    }
     return {
       content: [{ type: "text", text: responseText }],
       model: "mock-model",
@@ -49,6 +56,7 @@ beforeEach(() => {
   responseText = "Use a channel-based worker pool; drain on shutdown.";
   sendMessageError = null;
   providerResolves = true;
+  streamDeltas = [];
   resetAdvisorStateForTests();
 });
 
@@ -123,6 +131,29 @@ describe("consultAdvisor", () => {
     });
     expect(advice).toContain("no guidance");
   });
+
+  test("streams the model's text deltas to `onText` as it generates", async () => {
+    streamDeltas = ["Use a ", "channel-based ", "worker pool."];
+    const chunks: string[] = [];
+
+    const advice = await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+      onText: (c) => chunks.push(c),
+    });
+
+    // Each visible delta is forwarded live...
+    expect(chunks).toEqual(["Use a ", "channel-based ", "worker pool."]);
+    // ...and the complete guidance is still returned.
+    expect(advice).toBe(responseText);
+  });
+
+  test("registers no `onEvent` sink when `onText` is absent", async () => {
+    streamDeltas = ["x"];
+    await consultAdvisor({ systemPrompt: null, messages: [userMsg("hi")] });
+    const options = sendMessageArgs?.options as { onEvent?: unknown };
+    expect(options.onEvent).toBeUndefined();
+  });
 });
 
 describe("advisor tool.execute", () => {
@@ -149,5 +180,20 @@ describe("advisor tool.execute", () => {
     expect(result?.isError).toBe(false);
     expect(result?.content).toContain("advisor unavailable");
     expect(result?.content).toContain("kaboom");
+  });
+
+  test("streams the consult live via `ctx.onOutput`", async () => {
+    recordMessages("c3", [userMsg("hi")]);
+    streamDeltas = ["plan: ", "do X"];
+    const out: string[] = [];
+
+    const result = await advisorTool.execute?.({}, {
+      conversationId: "c3",
+      onOutput: (c: string) => out.push(c),
+    } as never);
+
+    expect(out).toEqual(["plan: ", "do X"]);
+    expect(result?.isError).toBe(false);
+    expect(result?.content).toBe(responseText);
   });
 });

--- a/assistant/src/plugins/defaults/advisor/consult.ts
+++ b/assistant/src/plugins/defaults/advisor/consult.ts
@@ -16,7 +16,7 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../../../providers/provider-send-message.js";
-import type { Message } from "../../../providers/types.js";
+import type { Message, ProviderEvent } from "../../../providers/types.js";
 import { ADVISOR_CONFIG } from "./config.js";
 import { advisorRequestText, buildAdvisorSystem } from "./steering.js";
 import { toAdvisorMessages } from "./transcript.js";
@@ -46,6 +46,14 @@ export interface ConsultParams {
   systemPrompt: string | null;
   messages: ReadonlyArray<Message>;
   signal?: AbortSignal;
+  /**
+   * Optional sink for the advisor's generated text as it streams. Each call
+   * receives an incremental chunk (a provider `text_delta`). Wiring this to the
+   * tool's `onOutput` surfaces the consult live as `tool_output_chunk` while the
+   * advisor model is still generating; the complete guidance is still returned
+   * as the resolved string.
+   */
+  onText?: (chunk: string) => void;
 }
 
 /** Combine the caller's signal with a consult timeout. */
@@ -78,8 +86,17 @@ export async function consultAdvisor(params: ConsultParams): Promise<string> {
   // than an advisor-specific cap.
   const messages: Message[] = [...history, userMessage(advisorRequestText())];
 
+  const { onText } = params;
   const response = await provider.sendMessage(messages, {
     systemPrompt: buildAdvisorSystem(params.systemPrompt),
+    // Forward the model's visible text deltas to the caller's sink so the
+    // guidance streams live. Other event types (thinking, usage) ride their
+    // own channels and are intentionally not surfaced as tool output.
+    onEvent: onText
+      ? (event: ProviderEvent) => {
+          if (event.type === "text_delta" && event.text) onText(event.text);
+        }
+      : undefined,
     config: {
       callSite: ADVISOR_CALL_SITE,
       ...override,

--- a/assistant/src/plugins/defaults/advisor/tools/advisor.ts
+++ b/assistant/src/plugins/defaults/advisor/tools/advisor.ts
@@ -52,6 +52,10 @@ const advisorTool: ToolDefinition = {
         systemPrompt: capture?.systemPrompt ?? null,
         messages: capture?.messages ?? [],
         signal: ctx.signal,
+        // Stream the advisor's guidance live as it generates: each delta is
+        // surfaced as a `tool_output_chunk` for this tool call and rendered in
+        // the tool-detail drawer. The complete text is still returned below.
+        onText: (chunk) => ctx.onOutput?.(chunk),
       });
       return { content: advice, isError: false };
     } catch (err) {


### PR DESCRIPTION
## What

Streams the **advisor** tool's guidance live as the advisor model generates it, instead of only revealing the full text once the consult finishes. Companion producer to #35793 (which renders `tool_output_chunk` in the web tool-detail drawer).

## How

The advisor consult already runs through `provider.sendMessage`, and the provider surfaces token deltas via the existing `SendMessageOptions.onEvent` stream (`ProviderEvent` = `{ type: "text_delta", text }`). It just wasn't tapping it.

- `consultAdvisor` gains an optional `onText?: (chunk: string) => void` sink and passes an `onEvent` handler to `sendMessage` that forwards each `text_delta` to it.
- The advisor tool wires `onText: (chunk) => ctx.onOutput?.(chunk)`. The assistant's `ToolContext.onOutput` is already mapped to a `tool_output_chunk` (tagged with this tool call's `toolUseId`) by the agent loop, so the guidance streams into the tool-detail drawer — and the CLI already renders it inline today.

The complete guidance is still returned as the tool-result string, so the drawer shows the live stream, then flips to the final result on completion (same shape as foreground bash).

## Scope
- **No new API surface** — `ToolContext.onOutput` and the provider `onEvent` stream already exist; this just connects them for the advisor.
- Only visible `text_delta` text is streamed; thinking/usage events are intentionally not surfaced as tool output.

## Test
- `consult.test.ts`: forwards deltas to `onText`, registers no `onEvent` sink when `onText` is absent, and the tool streams via `ctx.onOutput`.
- Advisor suite (9 tests) + lint + formatting pass. (Advisor files typecheck clean; the local pre-commit/push typecheck trips only on a pre-existing missing `@slack/types` dep, unrelated to this change — CI typechecks with deps installed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)