### PR TITLE
fix(gateway): guardian-delivery resolver error surfaces as null, not empty

### DIFF
--- a/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
+++ b/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Gateway guardian-delivery list: null = unreachable, [] = unbound,
-// one active entry = bound.
+// Gateway guardian-delivery list: null = couldn't determine (transport failure
+// OR gateway-side resolver/DB error), [] = authoritative unbound, one active
+// entry = bound.
 let mockGuardianList: Array<Record<string, unknown>> | null = [];
 const freshCalls: Array<{ channelTypes?: string[] } | undefined> = [];
 
@@ -45,5 +46,19 @@ describe("isGuardianBoundForChannel", () => {
   test("null list (gateway unreachable) is treated as bound", async () => {
     mockGuardianList = null;
     expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+
+  test("gateway resolver error (null, not []) is treated as bound — no duplicate", async () => {
+    // A gateway-side DB/resolver error now reaches the reader as null (the
+    // handler no longer swallows it into an empty list), so the guard's
+    // null fail-safe applies and reports bound instead of mis-reading the
+    // error as "no guardian" and allowing a duplicate binding.
+    mockGuardianList = null;
+    expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+
+  test("genuine empty ([], not null) reports unbound so first-bind is allowed", async () => {
+    mockGuardianList = [];
+    expect(await isGuardianBoundForChannel("telegram")).toBe(false);
   });
 });

--- a/gateway/src/__tests__/guardian-delivery-resolver.test.ts
+++ b/gateway/src/__tests__/guardian-delivery-resolver.test.ts
@@ -229,11 +229,28 @@ describe("resolveGuardianDelivery", () => {
 });
 
 describe("guardianDeliveryRoutes handler", () => {
-  test("resolver throw → handler returns { guardians: [] }", async () => {
+  test("resolver throw → handler propagates (server maps to error envelope → daemon null)", async () => {
     mock.module("../risk/guardian-delivery-resolver.js", () => ({
       resolveGuardianDelivery: () => {
         throw new Error("boom");
       },
+    }));
+    const { guardianDeliveryRoutes } = await import(
+      "../ipc/guardian-delivery-handlers.js"
+    );
+
+    const route = guardianDeliveryRoutes[0]!;
+    // A resolver error must NOT be swallowed into {guardians:[]}: it propagates
+    // so the IPC server returns an error envelope, which the daemon reader maps
+    // to `null` ("couldn't determine") rather than an authoritative empty list.
+    expect(route.handler({})).rejects.toThrow("boom");
+
+    mock.restore();
+  });
+
+  test("successful resolve with no guardian → handler returns { guardians: [] }", async () => {
+    mock.module("../risk/guardian-delivery-resolver.js", () => ({
+      resolveGuardianDelivery: () => [],
     }));
     const { guardianDeliveryRoutes } = await import(
       "../ipc/guardian-delivery-handlers.js"

--- a/gateway/src/ipc/guardian-delivery-handlers.ts
+++ b/gateway/src/ipc/guardian-delivery-handlers.ts
@@ -17,13 +17,13 @@ export const guardianDeliveryRoutes: IpcRoute[] = [
     schema: ResolveGuardianDeliveryRequestSchema,
     handler: async (params?: Record<string, unknown>) => {
       const input = ResolveGuardianDeliveryRequestSchema.parse(params);
-      try {
-        return { guardians: resolveGuardianDelivery(input) };
-      } catch {
-        // Fails soft to [] — guardian delivery is not an admission decision;
-        // the daemon owns fallback.
-        return { guardians: [] };
-      }
+      // Let a resolver error propagate: the IPC server turns it into an error
+      // envelope, which the daemon reader maps to `null` ("couldn't
+      // determine"). A successful resolve with no active guardian returns `[]`
+      // (authoritative no-guardian). This distinction lets the daemon's
+      // existence guards apply their null fail-safe on a gateway DB error
+      // instead of mis-reading it as "no guardian".
+      return { guardians: resolveGuardianDelivery(input) };
     },
   },
 ];


### PR DESCRIPTION
## Summary
- A gateway resolver error now reaches the daemon as null (couldn't determine) instead of {guardians:[]}, so existence guards' null fail-safe applies; a genuine empty stays [] (first-bind allowed).

Self-review remediation for plan: gateway-guardian-binding-pull.md