### PR TITLE
fix(config): don't downgrade a call-site LLM override when recovery strips its profile ref

### DIFF
--- a/assistant/src/config/__tests__/loader-callsite-strip-fallback.test.ts
+++ b/assistant/src/config/__tests__/loader-callsite-strip-fallback.test.ts
@@ -1,0 +1,143 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { resolveCallSiteConfig } from "../llm-resolver.js";
+import { invalidateConfigCache, loadConfig } from "../loader.js";
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+/**
+ * Base config where the active profile resolves to a DIFFERENT model than the
+ * `balanced` profile that the shipped `memoryV3SelectL2` call-site default
+ * points at. This lets each test distinguish the two failure modes:
+ *   - call-site default applied (fixed)  -> model "balanced-model"
+ *   - silently downgraded to active      -> model "active-model"
+ */
+function baseLlm(callSites: Record<string, unknown>): unknown {
+  return {
+    llm: {
+      default: { provider: "anthropic", model: "default-model" },
+      profiles: {
+        balanced: { provider: "anthropic", model: "balanced-model" },
+        speedy: { provider: "anthropic", model: "active-model" },
+      },
+      activeProfile: "speedy",
+      callSites,
+    },
+  };
+}
+
+describe("config recovery prunes call-site overrides emptied by a strip", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    invalidateConfigCache();
+  });
+
+  test("an undefined call-site profile ref falls back to the shipped default, not the active profile", () => {
+    // The `.profile` ref is invalid (no such profile), so schema recovery
+    // strips it. Before the fix this left `callSites.memoryV3SelectL2 = {}`,
+    // which the resolver treats as a present override and so skips the shipped
+    // `{profile:"balanced"}` default — silently resolving to the active profile.
+    writeConfig(baseLlm({ memoryV3SelectL2: { profile: "ghost-profile" } }));
+
+    const config = loadConfig();
+
+    // The emptied call-site entry must be pruned entirely, not left as `{}`.
+    expect(config.llm.callSites?.memoryV3SelectL2).toBeUndefined();
+
+    // Resolution now lands on the shipped call-site default (balanced), not the
+    // active profile ("active-model"), which is what the bug produced.
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", config.llm);
+    expect(resolved.model).toBe("balanced-model");
+  });
+
+  test("a valid sibling call-site override survives while the invalid one is pruned", () => {
+    // memoryRouter -> balanced is valid and must be preserved; only the invalid
+    // memoryV3SelectL2 entry is pruned. Guards against over-pruning the parent.
+    writeConfig(
+      baseLlm({
+        memoryV3SelectL2: { profile: "missing" },
+        memoryRouter: { profile: "balanced" },
+      }),
+    );
+
+    const config = loadConfig();
+
+    expect(config.llm.callSites?.memoryV3SelectL2).toBeUndefined();
+    expect(config.llm.callSites?.memoryRouter).toEqual({ profile: "balanced" });
+  });
+
+  test("a partial override keeping other fields is not pruned", () => {
+    // Stripping the invalid `.profile` leaves a non-empty `{temperature:0.5}`,
+    // a legitimate user override the resolver should keep (and which therefore
+    // still shadows the shipped default per existing either/or semantics).
+    writeConfig(
+      baseLlm({ memoryV3SelectL2: { profile: "missing", temperature: 0.5 } }),
+    );
+
+    const config = loadConfig();
+
+    expect(config.llm.callSites?.memoryV3SelectL2).toEqual({
+      temperature: 0.5,
+    });
+  });
+});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -300,14 +300,20 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
   }
 
   // Strip invalid fields by setting them to undefined so Zod defaults apply,
-  // then re-parse. We walk the error paths and delete the offending keys.
+  // then re-parse. We walk the error paths and delete the offending keys,
+  // pruning any ancestor object the deletion leaves empty. Pruning matters for
+  // nested overrides like `llm.callSites.<id>.profile`: stripping just the
+  // invalid `.profile` leaf would leave `llm.callSites.<id> = {}`, which the
+  // resolver treats as a present (non-default) override and so skips the
+  // shipped call-site default — silently downgrading the call site to the
+  // active profile. Removing the emptied object lets that default apply.
   const cleaned = structuredClone(raw);
   for (const issue of result.error.issues) {
     if (issue.path.length === 0) {
       // Top-level error — return full defaults
       return cloneDefaultConfig();
     }
-    deleteNestedKey(cleaned, issue.path as (string | number)[]);
+    deleteNestedKey(cleaned, issue.path as (string | number)[], true);
   }
 
   const retry = AssistantConfigSchema.safeParse(cleaned);
@@ -320,17 +326,42 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
   return cloneDefaultConfig();
 }
 
+/**
+ * Delete the key at `path` from `obj`. When `pruneEmptyAncestors` is set, also
+ * remove any ancestor object the deletion leaves empty, walking up until the
+ * first ancestor that still holds other keys. Only empty plain objects are
+ * pruned (arrays are left alone), and a still-populated ancestor stops the walk
+ * so a container holding other config is never removed.
+ */
 function deleteNestedKey(
   obj: Record<string, unknown>,
   path: (string | number)[],
+  pruneEmptyAncestors = false,
 ): void {
+  // Record each (container, key) hop on the way down so we can prune upward
+  // after deleting the leaf.
+  const chain: Array<{ container: Record<string, unknown>; key: string }> = [];
   let current: unknown = obj;
   for (let i = 0; i < path.length - 1; i++) {
     if (current == null || typeof current !== "object") return;
-    current = (current as Record<string, unknown>)[String(path[i])];
+    const key = String(path[i]);
+    chain.push({ container: current as Record<string, unknown>, key });
+    current = (current as Record<string, unknown>)[key];
   }
-  if (current != null && typeof current === "object") {
-    delete (current as Record<string, unknown>)[String(path[path.length - 1])];
+  if (current == null || typeof current !== "object") return;
+  delete (current as Record<string, unknown>)[String(path[path.length - 1])];
+
+  if (!pruneEmptyAncestors) return;
+  // Remove ancestors emptied by the deletion, deepest first; stop at the first
+  // that still has keys.
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const { container, key } = chain[i];
+    const child = container[key];
+    if (isPlainObject(child) && Object.keys(child).length === 0) {
+      delete container[key];
+    } else {
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- `validateWithSchema` recovery deleted an invalid `llm.callSites.<id>.profile` leaf but left the parent as `{}`, which `resolveCallSiteConfig` treats as a present (non-default) override — so it skips the shipped call-site default and silently resolves the call site to the active profile.
- `deleteNestedKey` now optionally prunes ancestor objects the deletion leaves empty (stopping at the first still-populated ancestor; arrays untouched), so an emptied `callSites.<id>` is removed and the resolver's `effectiveDefault` fallback applies.
- Added regression tests: undefined-profile fallback to the shipped default (not the active profile), valid-sibling preservation, and partial-override retention.

## Original prompt
While investigating a managed-assistant feedback report where the memory-v3 L2 selector (callSite `memoryV3SelectL2`) appeared "not overridden", we found a latent config-loader hazard: when a call-site override references a managed profile that is transiently absent at validation time (e.g. before boot-time profile seeding, or after a failed gateway flag fetch), schema recovery strips the `.profile` ref and leaves an empty override object that silently resolves to the active profile rather than the call site's shipped default. This is the defensive fix for that silent-downgrade hazard; the resolver itself is correct when the referenced profile is present.