### PR TITLE
fix(assistant): guardian consumer consistency (connectivity fallback, active-status auth filter, bg-dispatch)

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -26,6 +26,12 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: () => undefined,
 }));
 
+// connectivity falls back to the local contacts read on a per-channel gateway
+// no-match; no local binding ⇒ telegram stays disconnected.
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => null,
+}));
+
 mock.module("../notifications/adapters/macos.js", () => ({
   VellumAdapter: class {
     constructor(_broadcastFn: unknown) {}

--- a/assistant/src/notifications/__tests__/connected-channels.test.ts
+++ b/assistant/src/notifications/__tests__/connected-channels.test.ts
@@ -2,9 +2,10 @@
  * Tests for getConnectedChannels connectivity resolution.
  *
  * Connectivity must mirror destination-resolver's `resolveGuardian`:
- * gateway-first, with a LOCAL contacts fallback only when the gateway list is
- * null (unreachable). This keeps a channel from being marked connected when it
- * can't be delivered (and vice-versa).
+ * gateway-first, with a LOCAL contacts fallback on ANY per-channel no-match
+ * (gateway list null OR no active gateway entry for the channel). This keeps a
+ * channel from being marked connected when it can't be delivered (and
+ * vice-versa).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -82,14 +83,15 @@ describe("getConnectedChannels gateway-first-then-local connectivity", () => {
     expect(await getConnectedChannels()).not.toContain("telegram");
   });
 
-  test("does not fall back to local when the gateway responds without that channel", async () => {
-    // Gateway present but empty for telegram ⇒ gateway is authoritative, no
-    // per-channel local fallback (mirrors destination-resolver).
+  test("falls back to local when the gateway responds without that channel", async () => {
+    // Gateway present but with no active telegram entry ⇒ per-channel no-match,
+    // so connectivity falls back to the local mirror (mirrors
+    // destination-resolver's per-channel fallback).
     deliverableChannels = ["telegram"];
     gatewayGuardians = [];
     localChatId = "789";
 
-    expect(await getConnectedChannels()).not.toContain("telegram");
+    expect(await getConnectedChannels()).toContain("telegram");
   });
 
   test("only marks slack connected for D-prefixed (DM) chat IDs", async () => {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -96,18 +96,20 @@ export function getBroadcaster(): NotificationBroadcaster {
 
 /**
  * Resolve a binding-based channel's delivery endpoint (externalChatId) the
- * SAME way destination-resolver's `resolveGuardian` does: gateway list when
- * present, falling back to the LOCAL contacts read only when the list is null
- * (gateway unreachable). The local fallback is removed in Combo 11. Keeping
- * connectivity aligned with delivery prevents a channel being marked connected
- * but then skipped with no destination (or vice-versa).
+ * SAME way destination-resolver's `resolveGuardian` does: gateway match first,
+ * falling back to the LOCAL contacts read on ANY per-channel no-match — gateway
+ * list null (unreachable) OR no active gateway entry for this channel. The
+ * local read is the transitional dual-written mirror, removed in Combo 11.
+ * Keeping connectivity aligned with delivery prevents a channel being marked
+ * connected but then skipped with no destination (or vice-versa).
  */
 function resolveChannelChatId(
   guardians: GuardianDelivery[] | null,
   channelType: string,
 ): string | undefined {
-  if (guardians) {
-    return guardianForChannel(guardians, channelType)?.externalChatId ?? undefined;
+  const g = guardians ? guardianForChannel(guardians, channelType) : undefined;
+  if (g) {
+    return g.externalChatId ?? undefined;
   }
   return findGuardianForChannel(channelType)?.channel.externalChatId ?? undefined;
 }

--- a/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
+++ b/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
@@ -7,6 +7,9 @@ let authDisabled = false;
 
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => mockGuardians,
+  // Real active-status selector so the auth gate enforces status==="active".
+  guardianForChannel: (list: GuardianDelivery[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 mock.module("../../../config/env.js", () => ({
@@ -73,6 +76,15 @@ describe("requireBoundGuardian", () => {
 
   test("denies when no vellum guardian is bound", async () => {
     mockGuardians = [];
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("denies a non-active (revoked) vellum row matching the actor", async () => {
+    mockGuardians = [
+      { ...guardian("vellum-principal-abc"), status: "revoked" },
+    ];
     const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);

--- a/assistant/src/runtime/auth/require-bound-guardian.ts
+++ b/assistant/src/runtime/auth/require-bound-guardian.ts
@@ -1,5 +1,8 @@
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../contacts/guardian-delivery-reader.js";
 import { httpError } from "../http-errors.js";
 import type { AuthContext } from "./types.js";
 
@@ -33,7 +36,7 @@ export async function requireBoundGuardian(
       403,
     );
   }
-  const guardian = guardians.find((g) => g.channelType === "vellum");
+  const guardian = guardianForChannel(guardians, "vellum");
   if (guardian && guardian.principalId === authContext.actorPrincipalId) {
     return null;
   }

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -9,6 +9,10 @@
  */
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../../contacts/guardian-delivery-reader.js";
 import type { ServerMessage } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context.js";
 import {
@@ -960,10 +964,18 @@ function startTrustedContactApprovalNotifier(params: {
 
         if (info && !globalNotifiedApprovalRequestIds.has(info.requestId)) {
           globalNotifiedApprovalRequestIds.set(info.requestId, conversationId);
-          const guardian = findGuardianForChannel(sourceChannel);
-          const guardianName = resolveGuardianName(
-            guardian?.contact.displayName,
-          );
+          // Gateway-resolved guardian display name with the transitional
+          // local fallback on null/no-match (display-only). Removed in Combo 11.
+          const guardians = await getGuardianDelivery({
+            channelTypes: [sourceChannel],
+          });
+          const gatewayDisplayName = guardians
+            ? guardianForChannel(guardians, sourceChannel)?.displayName
+            : undefined;
+          const displayName =
+            gatewayDisplayName ??
+            findGuardianForChannel(sourceChannel)?.contact.displayName;
+          const guardianName = resolveGuardianName(displayName);
           const waitingText = `Waiting for ${guardianName}'s approval...`;
           try {
             await deliverChannelReply(replyCallbackUrl, {


### PR DESCRIPTION
## Summary
- emit-signal connectivity falls back to local on per-channel no-match (aligned with destination-resolver).
- require-bound-guardian selects via guardianForChannel (status==active filter).
- background-dispatch guardian display name from the gateway reader with local fallback.

Self-review remediation for plan: gateway-guardian-binding-pull.md