### PR TITLE
refactor(assistant): shared anchored-guardian resolution helper

### DIFF
--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -12,11 +12,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
-import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../contacts/guardian-delivery-reader.js";
+import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
 import type { ChannelStatus } from "../contacts/types.js";
 import {
   createCanonicalGuardianRequest,
@@ -29,6 +25,7 @@ import {
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { GuardianResolutionSource } from "../notifications/signal.js";
 import { getLogger } from "../util/logger.js";
+import { resolveAnchoredGuardian } from "./anchored-guardian.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "./routes/channel-route-shared.js";
 
 const log = getLogger("access-request-helper");
@@ -98,65 +95,19 @@ export async function notifyGuardianOfAccessRequest(
     return { notified: false, reason: "no_sender_id" };
   }
 
-  // Resolve guardian identity with assistant-anchored strategy:
-  // 1. Ensure the assistant has a vellum guardian principal (trust anchor)
-  // 2. Use source-channel guardian only when principal matches anchor
-  // 3. Fallback to vellum guardian identity for this assistant principal
-  let guardianExternalUserId: string | null = null;
-  let guardianPrincipalId: string | null = null;
-  let guardianBindingChannel: string | null = null;
-  let guardianResolutionSource: GuardianResolutionSource = "none";
-
-  const guardians = (await getGuardianDelivery()) ?? [];
-  const vellumGuardian = guardianForChannel(guardians, "vellum");
-  const assistantGuardianPrincipalId = vellumGuardian?.principalId;
-
-  // Try source-channel guardian, but only if it maps to the assistant's
-  // anchored principal. This blocks cross-assistant/stale binding selection.
-  const sourceGuardian = guardianForChannel(guardians, sourceChannel);
-  if (
-    assistantGuardianPrincipalId &&
-    sourceGuardian &&
-    sourceGuardian.principalId === assistantGuardianPrincipalId
-  ) {
-    guardianExternalUserId = sourceGuardian.address;
-    guardianPrincipalId = sourceGuardian.principalId;
-    guardianBindingChannel = sourceGuardian.channelType;
-    guardianResolutionSource = "source-channel-contact";
-  }
-
-  // Access requests always require a principal. If source-channel resolution
-  // did not match the assistant anchor, use the anchored vellum identity.
-  if (!guardianPrincipalId && vellumGuardian) {
-    guardianExternalUserId = vellumGuardian.address;
-    guardianPrincipalId = assistantGuardianPrincipalId ?? null;
-    guardianBindingChannel = guardianBindingChannel ?? "vellum";
-    guardianResolutionSource = "vellum-anchor";
-  }
-
-  // Fallback: gateway delivery read was empty/unavailable (restart, timeout,
-  // malformed IPC), so resolve from the LOCAL dual-written binding to avoid an
-  // undecidable request. Removed in Combo 11.
-  if (!guardianPrincipalId) {
-    const localVellum = findGuardianForChannel("vellum");
-    const localAnchorPrincipalId = localVellum?.contact.principalId;
-    const localSource = findGuardianForChannel(sourceChannel);
-    if (
-      localAnchorPrincipalId &&
-      localSource &&
-      localSource.contact.principalId === localAnchorPrincipalId
-    ) {
-      guardianExternalUserId = localSource.channel.address;
-      guardianPrincipalId = localSource.contact.principalId;
-      guardianBindingChannel = localSource.channel.type;
-      guardianResolutionSource = "source-channel-contact";
-    } else if (localVellum) {
-      guardianExternalUserId = localVellum.channel.address;
-      guardianPrincipalId = localAnchorPrincipalId ?? null;
-      guardianBindingChannel = guardianBindingChannel ?? "vellum";
-      guardianResolutionSource = "vellum-anchor";
-    }
-  }
+  // Resolve guardian identity with the assistant-anchored strategy (gateway
+  // source-channel match validated against the vellum anchor, else the vellum
+  // anchor), with a LOCAL-store fallback when the gateway read is empty.
+  const anchored = resolveAnchoredGuardian({
+    guardians: await getGuardianDelivery(),
+    sourceChannel,
+    useLocalFallback: true,
+  });
+  const guardianExternalUserId = anchored?.address ?? null;
+  const guardianPrincipalId = anchored?.principalId ?? null;
+  const guardianBindingChannel = anchored?.channelType ?? null;
+  const guardianResolutionSource: GuardianResolutionSource =
+    anchored?.source ?? "none";
 
   log.debug(
     {

--- a/assistant/src/runtime/anchored-guardian.test.ts
+++ b/assistant/src/runtime/anchored-guardian.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for `resolveAnchoredGuardian`.
+ *
+ * Covers the gateway arms (source-channel match validated against the vellum
+ * anchor, vellum-anchor fallback), the LOCAL-store fallback when the gateway
+ * list is empty, and the cosmetic `requireAnchorPrincipal` guard.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+// Local store fallback is mocked so we can drive both arms deterministically.
+let localGuardians: Record<
+  string,
+  { contact: { principalId: string | null; displayName: string }; channel: { address: string; type: string } } | null
+> = {};
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (channelType: string) =>
+    localGuardians[channelType] ?? null,
+}));
+
+const { resolveAnchoredGuardian } = await import("./anchored-guardian.js");
+
+function gw(g: Partial<GuardianDelivery> & { channelType: string; address: string }): GuardianDelivery {
+  return {
+    contactId: `c-${g.channelType}`,
+    status: "active",
+    ...g,
+  };
+}
+
+afterEach(() => {
+  localGuardians = {};
+});
+
+describe("resolveAnchoredGuardian — gateway arm", () => {
+  test("source-channel guardian matching the anchor wins", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: "p-anchor", displayName: "Vellum" }),
+        gw({ channelType: "telegram", address: "tg-addr", principalId: "p-anchor", displayName: "Alice" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result).toEqual({
+      principalId: "p-anchor",
+      address: "tg-addr",
+      displayName: "Alice",
+      channelType: "telegram",
+      source: "source-channel-contact",
+    });
+  });
+
+  test("source-channel guardian NOT matching the anchor falls back to vellum-anchor", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: "p-anchor", displayName: "Vellum" }),
+        gw({ channelType: "telegram", address: "tg-addr", principalId: "p-other", displayName: "Stale" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result).toEqual({
+      principalId: "p-anchor",
+      address: "v-addr",
+      displayName: "Vellum",
+      channelType: "vellum",
+      source: "vellum-anchor",
+    });
+  });
+
+  test("no source-channel guardian falls back to vellum-anchor", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: "p-anchor", displayName: "Vellum" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result?.source).toBe("vellum-anchor");
+    expect(result?.principalId).toBe("p-anchor");
+  });
+});
+
+describe("resolveAnchoredGuardian — local fallback", () => {
+  test("gateway empty + local source-channel match returns the local record", () => {
+    localGuardians = {
+      vellum: { contact: { principalId: "p-local", displayName: "LocalVellum" }, channel: { address: "lv-addr", type: "vellum" } },
+      telegram: { contact: { principalId: "p-local", displayName: "LocalAlice" }, channel: { address: "ltg-addr", type: "telegram" } },
+    };
+    const result = resolveAnchoredGuardian({
+      guardians: null,
+      sourceChannel: "telegram",
+      useLocalFallback: true,
+    });
+    expect(result).toEqual({
+      principalId: "p-local",
+      address: "ltg-addr",
+      displayName: "LocalAlice",
+      channelType: "telegram",
+      source: "source-channel-contact",
+    });
+  });
+
+  test("gateway empty + only local vellum returns the local vellum-anchor", () => {
+    localGuardians = {
+      vellum: { contact: { principalId: "p-local", displayName: "LocalVellum" }, channel: { address: "lv-addr", type: "vellum" } },
+    };
+    const result = resolveAnchoredGuardian({
+      guardians: null,
+      sourceChannel: "telegram",
+      useLocalFallback: true,
+    });
+    expect(result?.source).toBe("vellum-anchor");
+    expect(result?.address).toBe("lv-addr");
+  });
+
+  test("gateway empty + no local + fallback disabled returns null", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: null,
+      sourceChannel: "telegram",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("nothing anywhere returns null", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [],
+      sourceChannel: "telegram",
+      useLocalFallback: true,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("resolveAnchoredGuardian — requireAnchorPrincipal (cosmetic label)", () => {
+  test("vellum guardian with a null principal degrades to null", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: null, displayName: "Vellum" }),
+      ],
+      sourceChannel: "telegram",
+      requireAnchorPrincipal: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("without requireAnchorPrincipal a null-principal vellum still resolves", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: null, displayName: "Vellum" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result?.source).toBe("vellum-anchor");
+    expect(result?.principalId).toBeNull();
+  });
+});

--- a/assistant/src/runtime/anchored-guardian.ts
+++ b/assistant/src/runtime/anchored-guardian.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared anchored-guardian resolution.
+ *
+ * Resolves the guardian identity for an inbound access request using the
+ * assistant's vellum principal as the trust anchor: a source-channel guardian
+ * is only accepted when its principal matches the anchor, otherwise the vellum
+ * anchor identity is used. This blocks stale or cross-assistant contacts from
+ * being bound to a request.
+ *
+ * Gateway-first: resolves from the gateway delivery list, then falls back to
+ * the LOCAL dual-written binding when the gateway read is empty/unavailable
+ * (restart, timeout, malformed IPC). The local fallback is transitional and is
+ * removed in a later step.
+ */
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+import type { ChannelId } from "../channels/types.js";
+import { findGuardianForChannel } from "../contacts/contact-store.js";
+import { guardianForChannel } from "../contacts/guardian-delivery-reader.js";
+import type { GuardianResolutionSource } from "../notifications/signal.js";
+
+/** Resolved guardian identity, anchored on the assistant's vellum principal. */
+export interface AnchoredGuardian {
+  principalId: string | null;
+  address: string;
+  displayName: string | null;
+  channelType: string;
+  source: GuardianResolutionSource;
+}
+
+export interface ResolveAnchoredGuardianInput {
+  /** Gateway delivery list; `null` when the gateway read failed/was empty. */
+  guardians: GuardianDelivery[] | null;
+  sourceChannel: ChannelId;
+  /**
+   * Fall back to the LOCAL dual-written binding when the gateway arm resolves
+   * nothing. Access-request enables this to avoid an undecidable request; the
+   * cosmetic guardian-label path leaves it off so a missing gateway read
+   * degrades gracefully to the default reference.
+   */
+  useLocalFallback?: boolean;
+  /**
+   * Require a non-null anchor principal for the vellum-anchor arm. When the
+   * vellum guardian has no principal, return `null` instead of a vellum-anchor
+   * record. Matches the cosmetic label path, which degrades to the default
+   * reference when the anchor principal is absent.
+   */
+  requireAnchorPrincipal?: boolean;
+}
+
+/**
+ * Resolve the anchored guardian for `sourceChannel`, or `null` when none can be
+ * resolved. Gateway source-channel match → that record; gateway anchor-only →
+ * vellum-anchor; gateway empty + local has it → local fallback record.
+ */
+export function resolveAnchoredGuardian(
+  input: ResolveAnchoredGuardianInput,
+): AnchoredGuardian | null {
+  const { sourceChannel, useLocalFallback, requireAnchorPrincipal } = input;
+  const guardians = input.guardians ?? [];
+
+  const vellumGuardian = guardianForChannel(guardians, "vellum");
+  const anchorPrincipalId = vellumGuardian?.principalId;
+
+  let resolved: AnchoredGuardian | null = null;
+
+  // Source-channel guardian, but only when it maps to the assistant's anchored
+  // principal. This blocks cross-assistant/stale binding selection.
+  const sourceGuardian = guardianForChannel(guardians, sourceChannel);
+  if (
+    anchorPrincipalId &&
+    sourceGuardian &&
+    sourceGuardian.principalId === anchorPrincipalId
+  ) {
+    resolved = {
+      principalId: sourceGuardian.principalId,
+      address: sourceGuardian.address,
+      displayName: sourceGuardian.displayName ?? null,
+      channelType: sourceGuardian.channelType,
+      source: "source-channel-contact",
+    };
+  } else if (vellumGuardian && !(requireAnchorPrincipal && !anchorPrincipalId)) {
+    // Source-channel resolution did not match the anchor → use the anchored
+    // vellum identity.
+    resolved = {
+      principalId: anchorPrincipalId ?? null,
+      address: vellumGuardian.address,
+      displayName: vellumGuardian.displayName ?? null,
+      channelType: "vellum",
+      source: "vellum-anchor",
+    };
+  }
+
+  // Gateway resolved a principal — done.
+  if (resolved?.principalId) {
+    return resolved;
+  }
+
+  if (!useLocalFallback) {
+    return resolved;
+  }
+
+  // Fallback: gateway read was empty/unavailable (or carried no principal), so
+  // resolve from the LOCAL dual-written binding to avoid an undecidable
+  // request. A local match overwrites the principal-less gateway record; with
+  // no local match the gateway record (if any) is retained.
+  const localVellum = findGuardianForChannel("vellum");
+  const localAnchorPrincipalId = localVellum?.contact.principalId;
+  const localSource = findGuardianForChannel(sourceChannel);
+  if (
+    localAnchorPrincipalId &&
+    localSource &&
+    localSource.contact.principalId === localAnchorPrincipalId
+  ) {
+    return {
+      principalId: localSource.contact.principalId,
+      address: localSource.channel.address,
+      displayName: localSource.contact.displayName,
+      channelType: localSource.channel.type,
+      source: "source-channel-contact",
+    };
+  }
+  if (localVellum) {
+    return {
+      principalId: localAnchorPrincipalId ?? null,
+      address: localVellum.channel.address,
+      displayName: localVellum.contact.displayName,
+      channelType: "vellum",
+      source: "vellum-anchor",
+    };
+  }
+
+  return resolved;
+}

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -7,10 +7,7 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
-import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../../contacts/guardian-delivery-reader.js";
+import { getGuardianDelivery } from "../../../contacts/guardian-delivery-reader.js";
 import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
 import type {
   ContactChannel,
@@ -28,6 +25,7 @@ import { getLogger } from "../../../util/logger.js";
 import { truncate } from "../../../util/truncate.js";
 import { hashVoiceCode } from "../../../util/voice-code.js";
 import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
+import { resolveAnchoredGuardian } from "../../anchored-guardian.js";
 import { getInviteAdapterRegistry } from "../../channel-invite-transport.js";
 import {
   createOutboundSession,
@@ -55,22 +53,14 @@ const log = getLogger("runtime-http");
  * gracefully to the default reference.
  */
 async function resolveGuardianLabel(sourceChannel: ChannelId): Promise<string> {
-  const guardians = await getGuardianDelivery();
-  const vellumGuardian = guardianForChannel(guardians ?? [], "vellum");
-  const anchoredPrincipalId = vellumGuardian?.principalId;
-
-  if (!anchoredPrincipalId) {
-    return resolveGuardianName(undefined);
-  }
-
-  // Try source-channel guardian, but only accept it when the principal
-  // matches the assistant's anchor.
-  const sourceGuardian = guardianForChannel(guardians ?? [], sourceChannel);
-  if (sourceGuardian && sourceGuardian.principalId === anchoredPrincipalId) {
-    return resolveGuardianName(sourceGuardian.displayName);
-  }
-
-  return resolveGuardianName(vellumGuardian.displayName);
+  // Cosmetic copy, not an admission decision: no local-store fallback, and a
+  // missing anchor principal degrades to the default reference.
+  const anchored = resolveAnchoredGuardian({
+    guardians: await getGuardianDelivery(),
+    sourceChannel,
+    requireAnchorPrincipal: true,
+  });
+  return resolveGuardianName(anchored?.displayName);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract `resolveAnchoredGuardian` (gateway-first anchor-validated guardian + local fallback) shared by access-request-helper and acl-enforcement's guardian label; removes the 3 copies of the security-relevant fallback. Behavior-preserving.

Self-review slop dedup for plan: gateway-guardian-binding-pull.md