### PR TITLE
Gateway guardian-binding/delivery pull — get guardian ACL reads off the assistant DB

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -29,6 +29,17 @@ mock.module("../config/env.js", () => ({
   checkUnrecognizedEnvVars: () => {},
 }));
 
+// No gateway in tests: force the reader to miss so resolution exercises the
+// local-store bootstrap fallback deterministically.
+let fakeGuardianDelivery: { principalId?: string | null } | null = null;
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () =>
+    fakeGuardianDelivery ? [fakeGuardianDelivery] : null,
+  guardianForChannel: (list: { principalId?: string | null }[]) => list[0],
+  invalidateGuardianDeliveryCache: () => {},
+  onContactChange: () => {},
+}));
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { resetExternalAssistantIdCache } from "../runtime/auth/external-assistant-id.js";
@@ -51,6 +62,7 @@ await initializeDb();
 beforeEach(async () => {
   initAuthSigningKey(TEST_KEY);
   resetExternalAssistantIdCache();
+  fakeGuardianDelivery = null;
   resetDbForTesting();
   await initializeDb();
 });
@@ -60,8 +72,8 @@ beforeEach(async () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveLocalTrustContext", () => {
-  test("falls back to minimal trust context when no vellum binding exists", () => {
-    const ctx = resolveLocalTrustContext();
+  test("falls back to minimal trust context when no vellum binding exists", async () => {
+    const ctx = await resolveLocalTrustContext();
     expect(ctx.sourceChannel).toBe("vellum");
   });
 });
@@ -71,38 +83,48 @@ describe("resolveLocalTrustContext", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveLocalAuthContext", () => {
-  test("returns AuthContext with local principal type", () => {
-    const ctx = resolveLocalAuthContext("session-123");
+  test("returns AuthContext with local principal type", async () => {
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.principalType).toBe("local");
   });
 
-  test("subject follows local:self:<conversationId> pattern", () => {
-    const ctx = resolveLocalAuthContext("session-abc");
+  test("subject follows local:self:<conversationId> pattern", async () => {
+    const ctx = await resolveLocalAuthContext("session-abc");
     expect(ctx.subject).toBe("local:self:session-abc");
   });
 
-  test("assistantId is always self", () => {
-    const ctx = resolveLocalAuthContext("session-123");
+  test("assistantId is always self", async () => {
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.assistantId).toBe("self");
   });
 
-  test("uses local_v1 scope profile with local.all scope", () => {
-    const ctx = resolveLocalAuthContext("session-123");
+  test("uses local_v1 scope profile with local.all scope", async () => {
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.scopeProfile).toBe("local_v1");
     expect(ctx.scopes.has("local.all")).toBe(true);
   });
 
-  test("actorPrincipalId is undefined when no vellum binding exists", () => {
+  test("actorPrincipalId is undefined when no vellum binding exists", async () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
 
-    const ctx = resolveLocalAuthContext("session-123");
+    const ctx = await resolveLocalAuthContext("session-123");
     expect(ctx.actorPrincipalId).toBeUndefined();
   });
 
-  test("conversationId matches the provided argument", () => {
-    const ctx = resolveLocalAuthContext("my-session");
+  test("resolves the guardian principal from the gateway when available", async () => {
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+    fakeGuardianDelivery = { principalId: "gateway-guardian-id" };
+
+    const ctx = await resolveLocalAuthContext("session-123");
+    expect(ctx.actorPrincipalId).toBe("gateway-guardian-id");
+  });
+
+  test("conversationId matches the provided argument", async () => {
+    const ctx = await resolveLocalAuthContext("my-session");
     expect(ctx.conversationId).toBe("my-session");
   });
 });

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -168,6 +168,25 @@ mock.module("../notifications/emit-signal.js", () => ({
   }),
 }));
 
+// Guardian principalId is resolved from the gateway binding reader. Mirror the
+// vellum binding seeded by resetTables so guardian dispatch can resolve it.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-vellum",
+      principalId: "test-principal-id",
+      address: "local",
+      status: "active",
+    },
+  ],
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
+}));
+
 mock.module("../calls/voice-session-bridge.js", () => {
   mockStartVoiceTurn = mock(createMockVoiceTurn(["Hello", " there"]));
   return {

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -83,6 +83,32 @@ mock.module("../ipc/gateway-client.js", () => ({
   }),
 }));
 
+// Guardian-delivery reader mock — the inbound challenge guard reads guardian
+// existence from the gateway. Derive the list from the local binding state so
+// the gateway-backed presence guard mirrors the DB the rest of the test sets up.
+const resolveGuardianList = async (input?: { channelTypes?: string[] }) => {
+  const { findGuardianForChannel } = await import(
+    "../contacts/contact-store.js"
+  );
+  const channels = input?.channelTypes ?? [];
+  return channels
+    .map((channelType) => {
+      const found = findGuardianForChannel(channelType);
+      return found ? { channelType, status: "active" } : null;
+    })
+    .filter((g): g is { channelType: string; status: string } => g !== null);
+};
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: resolveGuardianList,
+  getGuardianDeliveryFresh: resolveGuardianList,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 import { handleChannelVerificationSession } from "../daemon/handlers/config-channels.js";
 import type {
   ChannelVerificationSessionRequest,

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -173,9 +173,11 @@ describe("TwiML parameter propagation", () => {
 // ---------------------------------------------------------------------------
 
 describe("Call session mode metadata", () => {
+  // Cold DB init runs every migration; give it headroom over Bun's 5s default
+  // hook timeout so a loaded CI runner doesn't trip it.
   beforeEach(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   test("createCallSession persists callMode and verificationSessionId", async () => {
     // Dynamic import to avoid circular dependency issues
@@ -237,7 +239,7 @@ describe("Call session mode metadata", () => {
 describe("Verification control messages are deterministic (guard)", () => {
   beforeEach(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   test("handleChannelInbound does not call processMessage for /start gv_<token> bootstrap commands", async () => {
     const { createHash, randomBytes } = await import("node:crypto");

--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -26,6 +26,12 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: () => undefined,
 }));
 
+// connectivity falls back to the local contacts read on a per-channel gateway
+// no-match; no local binding ⇒ telegram stays disconnected.
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => null,
+}));
+
 mock.module("../notifications/adapters/macos.js", () => ({
   VellumAdapter: class {
     constructor(_broadcastFn: unknown) {}

--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -19,13 +19,12 @@ mock.module("../channels/config.js", () => ({
   getDeliverableChannels: () => ["vellum", "telegram"],
 }));
 
-mock.module("../contacts/contact-store.js", () => ({
-  findGuardianForChannel: (_channelType: string, _assistantId: string) => null,
+// Guardian connectivity is resolved from the gateway pull. No active guardian
+// binding ⇒ binding-based channels (telegram) are not reported connected.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [],
+  guardianForChannel: () => undefined,
 }));
-
-// Note: stale mock for channel-guardian-store.js removed — the barrel was
-// deleted and none of the functions it mocked (getActiveBinding) existed in
-// the barrel.
 
 mock.module("../notifications/adapters/macos.js", () => ({
   VellumAdapter: class {

--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -29,7 +29,13 @@ mock.module("../config/env.js", () => ({
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
-  findLocalGuardianPrincipalId: () => fakeGuardianPrincipalId,
+  findLocalGuardianPrincipalIdFromStore: () => fakeGuardianPrincipalId,
+  resolveActorPrincipalIdForLocalGuardianSync: (
+    rawHeader: string | undefined,
+  ) => {
+    if (rawHeader !== "dev-bypass" || !fakeHttpAuthDisabled) return rawHeader;
+    return fakeGuardianPrincipalId;
+  },
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
+++ b/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
@@ -7,6 +7,16 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+let mockGuardians: GuardianDelivery[] | null = [];
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardians,
+  guardianForChannel: (list: GuardianDelivery[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
@@ -21,12 +31,24 @@ function resetTables(): void {
   db.run("DELETE FROM contacts");
 }
 
+/** Gateway delivery mirroring the local guardian binding's principal. */
+function gatewayGuardian(principalId: string): GuardianDelivery {
+  return {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId,
+    address: principalId,
+    status: "active",
+  };
+}
+
 describe("healGuardianBindingDrift", () => {
   beforeEach(() => {
     resetTables();
+    mockGuardians = [];
   });
 
-  test("heals drift when both principals have vellum-principal- prefix", () => {
+  test("heals drift when both principals have vellum-principal- prefix", async () => {
     // Simulate DB reset: new guardian binding with a different UUID
     createGuardianBinding({
       channel: "vellum",
@@ -35,9 +57,10 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "vellum-principal-new-uuid",
       verifiedVia: "startup-migration",
     });
+    mockGuardians = [gatewayGuardian("vellum-principal-new-uuid")];
 
     // Client arrives with the old JWT principal
-    const healed = healGuardianBindingDrift("vellum-principal-old-uuid");
+    const healed = await healGuardianBindingDrift("vellum-principal-old-uuid");
     expect(healed).toBe(true);
 
     // Guardian binding now matches the old JWT
@@ -47,7 +70,31 @@ describe("healGuardianBindingDrift", () => {
     expect(guardian!.channel.address).toBe("vellum-principal-old-uuid");
   });
 
-  test("no-op when principals already match", () => {
+  test("repairs the stale local mirror even when the gateway already matches the JWT", async () => {
+    // Gateway binding already matches the incoming JWT principal, but the
+    // local mirror is stale — the gateway-source-of-truth drift mode. The
+    // /v1/messages trust path still reads the local mirror in this plan, so
+    // a stale row must be repaired or the actor stays classified `unknown`.
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "vellum-principal-stale-local",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "vellum-principal-stale-local",
+      verifiedVia: "startup-migration",
+    });
+    mockGuardians = [gatewayGuardian("vellum-principal-jwt")];
+
+    const healed = await healGuardianBindingDrift("vellum-principal-jwt");
+    expect(healed).toBe(true);
+
+    // Local mirror now matches the JWT, so a subsequent local trust
+    // resolution classifies the actor as guardian rather than unknown.
+    const guardian = findGuardianForChannel("vellum");
+    expect(guardian!.contact.principalId).toBe("vellum-principal-jwt");
+    expect(guardian!.channel.address).toBe("vellum-principal-jwt");
+  });
+
+  test("no-op when principals already match", async () => {
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "vellum-principal-same",
@@ -55,12 +102,13 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "vellum-principal-same",
       verifiedVia: "startup-migration",
     });
+    mockGuardians = [gatewayGuardian("vellum-principal-same")];
 
-    const healed = healGuardianBindingDrift("vellum-principal-same");
+    const healed = await healGuardianBindingDrift("vellum-principal-same");
     expect(healed).toBe(false);
   });
 
-  test("refuses to heal when incoming principal lacks vellum-principal- prefix", () => {
+  test("refuses to heal when incoming principal lacks vellum-principal- prefix", async () => {
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "vellum-principal-aaa",
@@ -68,9 +116,10 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "vellum-principal-aaa",
       verifiedVia: "startup-migration",
     });
+    mockGuardians = [gatewayGuardian("vellum-principal-aaa")];
 
     // External/platform principal — should NOT be adopted
-    const healed = healGuardianBindingDrift("platform-user-12345");
+    const healed = await healGuardianBindingDrift("platform-user-12345");
     expect(healed).toBe(false);
 
     // Guardian unchanged
@@ -78,7 +127,7 @@ describe("healGuardianBindingDrift", () => {
     expect(guardian!.contact.principalId).toBe("vellum-principal-aaa");
   });
 
-  test("refuses to heal when stored principal lacks vellum-principal- prefix", () => {
+  test("refuses to heal when stored principal lacks vellum-principal- prefix", async () => {
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "verified-phone-guardian",
@@ -86,17 +135,33 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "verified-phone-guardian",
       verifiedVia: "challenge",
     });
+    mockGuardians = [gatewayGuardian("verified-phone-guardian")];
 
     // Even with a vellum-principal- incoming, don't overwrite a real binding
-    const healed = healGuardianBindingDrift("vellum-principal-attacker");
+    const healed = await healGuardianBindingDrift("vellum-principal-attacker");
     expect(healed).toBe(false);
 
     const guardian = findGuardianForChannel("vellum");
     expect(guardian!.contact.principalId).toBe("verified-phone-guardian");
   });
 
-  test("returns false when no guardian binding exists", () => {
-    const healed = healGuardianBindingDrift("vellum-principal-orphan");
+  test("returns false when gateway reports no guardian binding", async () => {
+    mockGuardians = [];
+    const healed = await healGuardianBindingDrift("vellum-principal-orphan");
+    expect(healed).toBe(false);
+  });
+
+  test("returns false when the gateway is unreachable (null list)", async () => {
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "vellum-principal-aaa",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "vellum-principal-aaa",
+      verifiedVia: "startup-migration",
+    });
+    mockGuardians = null;
+
+    const healed = await healGuardianBindingDrift("vellum-principal-old-uuid");
     expect(healed).toBe(false);
   });
 });

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -24,6 +24,17 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+// The pending_question request principal is resolved via the SAME source the
+// Vellum actor uses — findLocalGuardianPrincipalId — so the stamped principal
+// always equals the submitting actor principal. Stub it so we can model drift
+// (gateway != local) and empty-gateway fallback independently of the binding
+// row seeded for the actor-side resolution below.
+let mockLocalGuardianPrincipalId: string | undefined = "test-principal-id";
+
+mock.module("../runtime/local-actor-identity.js", () => ({
+  findLocalGuardianPrincipalId: () => mockLocalGuardianPrincipalId,
+}));
+
 const emitCalls: unknown[] = [];
 let conversationCreatedFromMock: ConversationCreatedInfo | null = null;
 let mockEmitResult: {
@@ -106,6 +117,7 @@ function resetTables(): void {
   });
   emitCalls.length = 0;
   conversationCreatedFromMock = null;
+  mockLocalGuardianPrincipalId = "test-principal-id";
   mockEmitResult = {
     signalId: "sig-1",
     deduplicated: false,
@@ -154,11 +166,18 @@ describe("guardian-dispatch", () => {
         "SELECT * FROM canonical_guardian_requests WHERE call_session_id = ?",
       )
       .get(session.id) as
-      | { id: string; status: string; question_text: string }
+      | {
+          id: string;
+          status: string;
+          question_text: string;
+          guardian_principal_id: string | null;
+        }
       | undefined;
     expect(request).toBeDefined();
     expect(request!.status).toBe("pending");
     expect(request!.question_text).toBe("What is the gate code?");
+    // principalId comes from the gateway guardian binding
+    expect(request!.guardian_principal_id).toBe("test-principal-id");
 
     const vellumDelivery = raw
       .query(
@@ -173,6 +192,79 @@ describe("guardian-dispatch", () => {
 
     const signalParams = emitCalls[0] as Record<string, unknown>;
     expect(typeof signalParams.onConversationCreated).toBe("function");
+  });
+
+  test("stamps the request principal from the actor resolver, not the (possibly drifted) gateway binding", async () => {
+    // Simulate gateway/local binding drift: the actor resolver returns a
+    // different principal than any direct gateway read would. The request must
+    // be stamped with the actor resolver's value so a later actor submission
+    // matches (no identity_mismatch under drift).
+    mockLocalGuardianPrincipalId = "actor-resolver-principal";
+
+    const convId = "conv-dispatch-drift";
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: "twilio",
+      fromNumber: "+15550001111",
+      toNumber: "+15550002222",
+    });
+    const pq = createPendingQuestion(session.id, "Drifted bindings?");
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: "self",
+      pendingQuestion: pq,
+    });
+
+    const db = getDb();
+    const raw = (db as unknown as { $client: import("bun:sqlite").Database })
+      .$client;
+    const request = raw
+      .query(
+        "SELECT * FROM canonical_guardian_requests WHERE call_session_id = ?",
+      )
+      .get(session.id) as
+      | { guardian_principal_id: string | null }
+      | undefined;
+    expect(request).toBeDefined();
+    expect(request!.guardian_principal_id).toBe("actor-resolver-principal");
+  });
+
+  test("skips dispatch when the actor resolver yields no principal (empty gateway, no local fallback)", async () => {
+    mockLocalGuardianPrincipalId = undefined;
+
+    const convId = "conv-dispatch-no-principal";
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: "twilio",
+      fromNumber: "+15550001111",
+      toNumber: "+15550002222",
+    });
+    const pq = createPendingQuestion(session.id, "No principal available");
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: "self",
+      pendingQuestion: pq,
+    });
+
+    // No request is created and the pipeline is never invoked.
+    const db = getDb();
+    const raw = (db as unknown as { $client: import("bun:sqlite").Database })
+      .$client;
+    const request = raw
+      .query(
+        "SELECT * FROM canonical_guardian_requests WHERE call_session_id = ?",
+      )
+      .get(session.id) as { id: string } | null;
+    expect(request).toBeNull();
+    expect(emitCalls).toHaveLength(0);
   });
 
   test("creates a telegram guardian delivery with binding metadata when pipeline sends telegram", async () => {

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -24,17 +24,11 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-// The pending_question request principal is resolved via the SAME source the
-// Vellum actor uses — findLocalGuardianPrincipalId — so the stamped principal
-// always equals the submitting actor principal. Stub it so we can model drift
-// (gateway != local) and empty-gateway fallback independently of the binding
-// row seeded for the actor-side resolution below.
-let mockLocalGuardianPrincipalId: string | undefined = "test-principal-id";
-
-mock.module("../runtime/local-actor-identity.js", () => ({
-  findLocalGuardianPrincipalId: () => mockLocalGuardianPrincipalId,
-}));
-
+// The pending_question request principal is resolved via the SAME local source
+// the Vellum actor uses — findGuardianForChannel("vellum")?.contact.principalId
+// — so the stamped principal always equals the submitting actor principal. The
+// real contacts DB is seeded in resetTables(); tests model drift / missing
+// guardian by reseeding or clearing that local binding directly.
 const emitCalls: unknown[] = [];
 let conversationCreatedFromMock: ConversationCreatedInfo | null = null;
 let mockEmitResult: {
@@ -117,7 +111,6 @@ function resetTables(): void {
   });
   emitCalls.length = 0;
   conversationCreatedFromMock = null;
-  mockLocalGuardianPrincipalId = "test-principal-id";
   mockEmitResult = {
     signalId: "sig-1",
     deduplicated: false,
@@ -176,7 +169,7 @@ describe("guardian-dispatch", () => {
     expect(request).toBeDefined();
     expect(request!.status).toBe("pending");
     expect(request!.question_text).toBe("What is the gate code?");
-    // principalId comes from the gateway guardian binding
+    // principalId comes from the local guardian binding (same source the actor submits)
     expect(request!.guardian_principal_id).toBe("test-principal-id");
 
     const vellumDelivery = raw
@@ -194,12 +187,21 @@ describe("guardian-dispatch", () => {
     expect(typeof signalParams.onConversationCreated).toBe("function");
   });
 
-  test("stamps the request principal from the actor resolver, not the (possibly drifted) gateway binding", async () => {
-    // Simulate gateway/local binding drift: the actor resolver returns a
-    // different principal than any direct gateway read would. The request must
-    // be stamped with the actor resolver's value so a later actor submission
-    // matches (no identity_mismatch under drift).
-    mockLocalGuardianPrincipalId = "actor-resolver-principal";
+  test("stamps the request principal from the local source the actor submits, not the (possibly drifted) gateway binding", async () => {
+    // Simulate gateway/local binding drift: the local guardian binding (the
+    // source the actor submit path reads) carries a different principal than
+    // the gateway would. The request must be stamped with that local value so
+    // a later actor submission matches (no identity_mismatch under drift).
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "local-actor-principal",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "local-actor-principal",
+      verifiedVia: "bootstrap",
+    });
 
     const convId = "conv-dispatch-drift";
     ensureConversation(convId);
@@ -219,7 +221,6 @@ describe("guardian-dispatch", () => {
       pendingQuestion: pq,
     });
 
-    const db = getDb();
     const raw = (db as unknown as { $client: import("bun:sqlite").Database })
       .$client;
     const request = raw
@@ -230,11 +231,13 @@ describe("guardian-dispatch", () => {
       | { guardian_principal_id: string | null }
       | undefined;
     expect(request).toBeDefined();
-    expect(request!.guardian_principal_id).toBe("actor-resolver-principal");
+    expect(request!.guardian_principal_id).toBe("local-actor-principal");
   });
 
-  test("skips dispatch when the actor resolver yields no principal (empty gateway, no local fallback)", async () => {
-    mockLocalGuardianPrincipalId = undefined;
+  test("skips dispatch when no local guardian binding exists (no principal to stamp)", async () => {
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
 
     const convId = "conv-dispatch-no-principal";
     ensureConversation(convId);
@@ -255,7 +258,6 @@ describe("guardian-dispatch", () => {
     });
 
     // No request is created and the pipeline is never invoked.
-    const db = getDb();
     const raw = (db as unknown as { $client: import("bun:sqlite").Database })
       .$client;
     const request = raw

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -84,6 +84,19 @@ globalThis.fetch = (async (
   return originalFetch(input, init as never);
 }) as unknown as typeof fetch;
 
+// Guardian-delivery reader mock — the inbound challenge guard reads guardian
+// existence from the gateway. These tests seed no binding, so report an empty
+// list (not bound) rather than a null that would fail closed as already-bound.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [],
+  getGuardianDeliveryFresh: async () => [],
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 // ---------------------------------------------------------------------------
 // Now import modules under test (after mocks are in place)
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/host-app-control-routes.test.ts
+++ b/assistant/src/__tests__/host-app-control-routes.test.ts
@@ -62,7 +62,7 @@ afterAll(() => {
 
 const handleHostAppControlResult = ROUTES.find(
   (r) => r.endpoint === "host-app-control-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Tests ────────────────────────────────────────────────────────────
 
@@ -395,7 +395,7 @@ describe("handleHostAppControlResult — same-actor guard", () => {
     ).toThrow(BadRequestError);
   });
 
-  test("targeted + missing header: interaction is NOT consumed (still pending)", () => {
+  test("targeted + missing header: interaction is NOT consumed (still pending)", async () => {
     const requestId = "ac-req-targeted-no-header-stays";
     pending.set(requestId, {
       conversationId: "conv-1",
@@ -404,13 +404,11 @@ describe("handleHostAppControlResult — same-actor guard", () => {
       targetActorPrincipalId: "user-1",
     });
 
-    try {
-      handleHostAppControlResult({
-        body: { requestId, state: "running" },
-      });
-    } catch {
+    await handleHostAppControlResult({
+      body: { requestId, state: "running" },
+    }).catch(() => {
       // expected
-    }
+    });
 
     expect(pending.has(requestId)).toBe(true);
   });
@@ -437,7 +435,7 @@ describe("handleHostAppControlResult — same-actor guard", () => {
     ).toThrow(ForbiddenError);
   });
 
-  test("targeted + wrong client id: interaction is NOT consumed", () => {
+  test("targeted + wrong client id: interaction is NOT consumed", async () => {
     const requestId = "ac-req-targeted-wrong-client-stays";
     pending.set(requestId, {
       conversationId: "conv-1",
@@ -446,17 +444,15 @@ describe("handleHostAppControlResult — same-actor guard", () => {
       targetActorPrincipalId: "user-1",
     });
 
-    try {
-      handleHostAppControlResult({
-        body: { requestId, state: "running" },
-        headers: {
-          "x-vellum-client-id": "client-B",
-          "x-vellum-actor-principal-id": "user-1",
-        },
-      });
-    } catch {
+    await handleHostAppControlResult({
+      body: { requestId, state: "running" },
+      headers: {
+        "x-vellum-client-id": "client-B",
+        "x-vellum-actor-principal-id": "user-1",
+      },
+    }).catch(() => {
       // expected
-    }
+    });
 
     expect(pending.has(requestId)).toBe(true);
   });
@@ -483,7 +479,7 @@ describe("handleHostAppControlResult — same-actor guard", () => {
     ).toThrow(ForbiddenError);
   });
 
-  test("targeted + wrong actor principal: interaction is NOT consumed", () => {
+  test("targeted + wrong actor principal: interaction is NOT consumed", async () => {
     const requestId = "ac-req-targeted-wrong-actor-stays";
     pending.set(requestId, {
       conversationId: "conv-1",
@@ -492,17 +488,15 @@ describe("handleHostAppControlResult — same-actor guard", () => {
       targetActorPrincipalId: "user-1",
     });
 
-    try {
-      handleHostAppControlResult({
-        body: { requestId, state: "running" },
-        headers: {
-          "x-vellum-client-id": "client-A",
-          "x-vellum-actor-principal-id": "user-2",
-        },
-      });
-    } catch {
+    await handleHostAppControlResult({
+      body: { requestId, state: "running" },
+      headers: {
+        "x-vellum-client-id": "client-A",
+        "x-vellum-actor-principal-id": "user-2",
+      },
+    }).catch(() => {
       // expected
-    }
+    });
 
     expect(pending.has(requestId)).toBe(true);
   });

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -95,7 +95,7 @@ afterAll(() => {
 
 const handleHostBashResult = ROUTES.find(
   (r) => r.endpoint === "host-bash-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -244,22 +244,20 @@ describe("handleHostBashResult", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT resolved on cross-actor 403 (still pending)", () => {
+    test("interaction is NOT resolved on cross-actor 403 (still pending)", async () => {
       const requestId = "req-actor-mismatch-stays";
       clientActorPrincipals.set("client-abc", "principal-victim");
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-abc",
-            "x-vellum-actor-principal-id": "principal-attacker",
-          },
-        });
-      } catch {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-abc",
+          "x-vellum-actor-principal-id": "principal-attacker",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -278,19 +276,17 @@ describe("handleHostBashResult", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT resolved when submitting actor is missing (still pending)", () => {
+    test("interaction is NOT resolved when submitting actor is missing (still pending)", async () => {
       const requestId = "req-actor-missing-stays";
       clientActorPrincipals.set("client-abc", "principal-victim");
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: { "x-vellum-client-id": "client-abc" },
-        });
-      } catch {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: { "x-vellum-client-id": "client-abc" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -358,15 +354,13 @@ describe("handleHostBashResult", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT resolved on 400 (still pending)", () => {
+    test("interaction is NOT resolved on 400 (still pending)", async () => {
       const requestId = "req-targeted-no-header-stays";
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({ body: bashBody(requestId) });
-      } catch {
+      await handleHostBashResult({ body: bashBody(requestId) }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -388,19 +382,17 @@ describe("handleHostBashResult", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both the submitting and expected client", () => {
+    test("ForbiddenError message names both the submitting and expected client", async () => {
       const requestId = "req-targeted-mismatch-msg";
       registerPending(requestId, { targetClientId: "client-abc" });
 
       let caught: unknown;
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: { "x-vellum-client-id": "client-xyz" },
-        });
-      } catch (e) {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: { "x-vellum-client-id": "client-xyz" },
+      }).catch((e: unknown) => {
         caught = e;
-      }
+      });
 
       expect(caught).toBeInstanceOf(ForbiddenError);
       const msg = (caught as ForbiddenError).message;
@@ -408,18 +400,16 @@ describe("handleHostBashResult", () => {
       expect(msg).toContain("client-abc");
     });
 
-    test("interaction is NOT resolved on 403 (still pending)", () => {
+    test("interaction is NOT resolved on 403 (still pending)", async () => {
       const requestId = "req-targeted-mismatch-stays";
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      try {
-        handleHostBashResult({
-          body: bashBody(requestId),
-          headers: { "x-vellum-client-id": "client-xyz" },
-        });
-      } catch {
+      await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: { "x-vellum-client-id": "client-xyz" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);

--- a/assistant/src/__tests__/host-browser-routes.test.ts
+++ b/assistant/src/__tests__/host-browser-routes.test.ts
@@ -39,7 +39,7 @@ afterAll(() => {
 
 const handleHostBrowserResult = ROUTES.find(
   (r) => r.endpoint === "host-browser-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Tests ────────────────────────────────────────────────────────────
 
@@ -212,7 +212,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT consumed on 400 (still pending)", () => {
+    test("interaction is NOT consumed on 400 (still pending)", async () => {
       const requestId = "browser-req-targeted-no-header-stays";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -221,13 +221,11 @@ describe("handleHostBrowserResult — same-actor guard", () => {
         targetActorPrincipalId: "user-1",
       });
 
-      try {
-        handleHostBrowserResult({
-          body: { requestId, content: "ok", isError: false },
-        });
-      } catch {
+      await handleHostBrowserResult({
+        body: { requestId, content: "ok", isError: false },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(pendingInteractions.get(requestId)).toBeDefined();
     });
@@ -256,7 +254,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both submitting and expected client", () => {
+    test("ForbiddenError message names both submitting and expected client", async () => {
       const requestId = "browser-req-targeted-mismatch-msg";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -267,7 +265,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
 
       let caught: unknown;
       try {
-        handleHostBrowserResult({
+        await handleHostBrowserResult({
           body: { requestId, content: "ok", isError: false },
           headers: {
             "x-vellum-client-id": "client-B",
@@ -284,7 +282,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       expect(msg).toContain("client-B");
     });
 
-    test("interaction is NOT consumed on 403 (still pending)", () => {
+    test("interaction is NOT consumed on 403 (still pending)", async () => {
       const requestId = "browser-req-targeted-mismatch-stays";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -293,17 +291,15 @@ describe("handleHostBrowserResult — same-actor guard", () => {
         targetActorPrincipalId: "user-1",
       });
 
-      try {
-        handleHostBrowserResult({
-          body: { requestId, content: "ok", isError: false },
-          headers: {
-            "x-vellum-client-id": "client-B",
-            "x-vellum-actor-principal-id": "user-1",
-          },
-        });
-      } catch {
+      await handleHostBrowserResult({
+        body: { requestId, content: "ok", isError: false },
+        headers: {
+          "x-vellum-client-id": "client-B",
+          "x-vellum-actor-principal-id": "user-1",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(pendingInteractions.get(requestId)).toBeDefined();
     });
@@ -369,7 +365,7 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction NOT consumed on actor-mismatch 403", () => {
+    test("interaction NOT consumed on actor-mismatch 403", async () => {
       const requestId = "browser-req-actor-mismatch-stays";
       pendingInteractions.register(requestId, {
         conversationId: "conv-1",
@@ -378,17 +374,15 @@ describe("handleHostBrowserResult — same-actor guard", () => {
         targetActorPrincipalId: "user-1",
       });
 
-      try {
-        handleHostBrowserResult({
-          body: { requestId, content: "ok", isError: false },
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "user-2",
-          },
-        });
-      } catch {
+      await handleHostBrowserResult({
+        body: { requestId, content: "ok", isError: false },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-2",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(pendingInteractions.get(requestId)).toBeDefined();
     });

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -104,7 +104,7 @@ afterAll(() => {
 
 const handleHostCuResult = ROUTES.find(
   (r: { endpoint: string }) => r.endpoint === "host-cu-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -226,15 +226,13 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT resolved on 400 (still pending)", () => {
+    test("interaction is NOT resolved on 400 (still pending)", async () => {
       const requestId = "req-cu-targeted-no-header-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostCuResult({ body: cuBody(requestId) });
-      } catch {
+      await handleHostCuResult({ body: cuBody(requestId) }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -256,19 +254,17 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both submitting and expected client", () => {
+    test("ForbiddenError message names both submitting and expected client", async () => {
       const requestId = "req-cu-targeted-mismatch-msg";
       registerPending(requestId, { targetClientId: "client-A" });
 
       let caught: unknown;
-      try {
-        handleHostCuResult({
-          body: cuBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch (e) {
+      await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch((e: unknown) => {
         caught = e;
-      }
+      });
 
       expect(caught).toBeInstanceOf(ForbiddenError);
       const msg = (caught as ForbiddenError).message;
@@ -276,18 +272,16 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       expect(msg).toContain("client-A");
     });
 
-    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", () => {
+    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", async () => {
       const requestId = "req-cu-targeted-mismatch-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostCuResult({
-          body: cuBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -331,22 +325,20 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction NOT consumed on 403 actor mismatch", () => {
+    test("interaction NOT consumed on 403 actor mismatch", async () => {
       const requestId = "req-cu-actor-mismatch-stays";
       actorPrincipalByClient.set("client-A", "user-1");
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostCuResult({
-          body: cuBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "user-2",
-          },
-        });
-      } catch {
+      await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-2",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -87,7 +87,7 @@ afterAll(() => {
 
 const handleHostFileResult = ROUTES.find(
   (r) => r.endpoint === "host-file-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -189,15 +189,13 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("interaction is NOT resolved on 400 (still pending)", () => {
+    test("interaction is NOT resolved on 400 (still pending)", async () => {
       const requestId = "req-file-targeted-no-header-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({ body: fileBody(requestId) });
-      } catch {
+      await handleHostFileResult({ body: fileBody(requestId) }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -219,19 +217,17 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("ForbiddenError message names both submitting and expected client", () => {
+    test("ForbiddenError message names both submitting and expected client", async () => {
       const requestId = "req-file-targeted-mismatch-msg";
       registerPending(requestId, { targetClientId: "client-A" });
 
       let caught: unknown;
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch (e) {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch((e: unknown) => {
         caught = e;
-      }
+      });
 
       expect(caught).toBeInstanceOf(ForbiddenError);
       const msg = (caught as ForbiddenError).message;
@@ -239,18 +235,16 @@ describe("handleHostFileResult — targetClientId guard", () => {
       expect(msg).toContain("client-A");
     });
 
-    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", () => {
+    test("interaction is NOT consumed on 403 (pendingInteractions.get still returns it)", async () => {
       const requestId = "req-file-targeted-mismatch-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -306,22 +300,20 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT consumed on actor-mismatch 403", () => {
+    test("interaction is NOT consumed on actor-mismatch 403", async () => {
       const requestId = "req-file-actor-mismatch-stays";
       clientActors.set("client-A", "actor-1");
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "actor-2",
-          },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-2",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -360,19 +352,17 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT consumed when submitting actor is missing", () => {
+    test("interaction is NOT consumed when submitting actor is missing", async () => {
       const requestId = "req-file-actor-missing-stays";
       clientActors.set("client-A", "actor-1");
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: { "x-vellum-client-id": "client-A" },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: { "x-vellum-client-id": "client-A" },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
@@ -398,21 +388,19 @@ describe("handleHostFileResult — targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("interaction is NOT consumed when target client has no stored actor", () => {
+    test("interaction is NOT consumed when target client has no stored actor", async () => {
       const requestId = "req-file-target-no-actor-stays";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      try {
-        handleHostFileResult({
-          body: fileBody(requestId),
-          headers: {
-            "x-vellum-client-id": "client-A",
-            "x-vellum-actor-principal-id": "actor-1",
-          },
-        });
-      } catch {
+      await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
+      }).catch(() => {
         // expected
-      }
+      });
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);

--- a/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
@@ -99,7 +99,7 @@ afterAll(() => {
 
 const handleTransferContentGet = ROUTES.find(
   (r) => r.endpoint === "transfers/:transferId/content" && r.method === "GET",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 const handleTransferContentPut = ROUTES.find(
   (r) => r.endpoint === "transfers/:transferId/content" && r.method === "PUT",
@@ -107,7 +107,7 @@ const handleTransferContentPut = ROUTES.find(
 
 const handleTransferResult = ROUTES.find(
   (r) => r.endpoint === "host-transfer-result",
-)!.handler;
+)!.handler as (args: Record<string, unknown>) => Promise<unknown>;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -186,15 +186,13 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
       ).toThrow(BadRequestError);
     });
 
-    test("getTransferContent NOT called on 400", () => {
+    test("getTransferContent NOT called on 400", async () => {
       stubTargetClientId = "client-A";
-      try {
-        handleTransferContentGet({
-          pathParams: { transferId: TEST_TRANSFER_ID },
-        });
-      } catch {
+      await handleTransferContentGet({
+        pathParams: { transferId: TEST_TRANSFER_ID },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(getTransferContentCalls).toHaveLength(0);
     });
   });
@@ -212,16 +210,14 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("getTransferContent NOT called on 403", () => {
+    test("getTransferContent NOT called on 403", async () => {
       stubTargetClientId = "client-A";
-      try {
-        handleTransferContentGet({
-          pathParams: { transferId: TEST_TRANSFER_ID },
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleTransferContentGet({
+        pathParams: { transferId: TEST_TRANSFER_ID },
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(getTransferContentCalls).toHaveLength(0);
     });
   });
@@ -526,23 +522,19 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
       );
     });
 
-    test("resolveTransferResult NOT called on 400", () => {
+    test("resolveTransferResult NOT called on 400", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({ body: resultBody() });
-      } catch {
+      await handleTransferResult({ body: resultBody() }).catch(() => {
         // expected
-      }
+      });
       expect(resolveTransferResultCalls).toHaveLength(0);
     });
 
-    test("pending interaction still present after 400", () => {
+    test("pending interaction still present after 400", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({ body: resultBody() });
-      } catch {
+      await handleTransferResult({ body: resultBody() }).catch(() => {
         // expected
-      }
+      });
       expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
     });
   });
@@ -560,29 +552,25 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
       ).toThrow(ForbiddenError);
     });
 
-    test("resolveTransferResult NOT called on 403", () => {
+    test("resolveTransferResult NOT called on 403", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({
-          body: resultBody(),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleTransferResult({
+        body: resultBody(),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(resolveTransferResultCalls).toHaveLength(0);
     });
 
-    test("pending interaction still present after 403", () => {
+    test("pending interaction still present after 403", async () => {
       registerHostTransferPending("client-A");
-      try {
-        handleTransferResult({
-          body: resultBody(),
-          headers: { "x-vellum-client-id": "client-B" },
-        });
-      } catch {
+      await handleTransferResult({
+        body: resultBody(),
+        headers: { "x-vellum-client-id": "client-B" },
+      }).catch(() => {
         // expected
-      }
+      });
       expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
     });
   });

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -61,6 +61,36 @@ mock.module("../runtime/gateway-client.js", () => ({
   },
 }));
 
+// Guardian identity for the access request resolves via the gateway delivery
+// reader, not the local contacts DB. Seed it per-test via seedGatewayGuardian.
+interface GatewayGuardian {
+  channelType: string;
+  contactId: string;
+  principalId?: string | null;
+  displayName?: string | null;
+  address: string;
+  externalChatId?: string | null;
+  status: string;
+  verifiedAt?: number | null;
+}
+let gatewayGuardians: GatewayGuardian[] = [];
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => gatewayGuardians,
+  guardianForChannel: (list: GatewayGuardian[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+function seedGatewayGuardian(g: Partial<GatewayGuardian> & {
+  channelType: string;
+  address: string;
+}): void {
+  gatewayGuardians.push({
+    contactId: `c-${g.channelType}`,
+    status: "active",
+    ...g,
+  });
+}
+
 import {
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
@@ -95,6 +125,7 @@ function resetState(): string {
   db.run("DELETE FROM contacts");
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
+  gatewayGuardians = [];
   mockEmitResult = {
     signalId: "mock-signal-id",
     deduplicated: false,
@@ -102,8 +133,15 @@ function resetState(): string {
     reason: "mock",
     deliveryResults: [],
   };
-  // Seed the vellum anchor binding (gateway does this at startup in production)
+  // Seed the vellum anchor binding in the gateway list (gateway does this at
+  // startup in production). The DB write mirrors it for any local INFO reads.
   const principalId = `vellum-principal-${crypto.randomUUID()}`;
+  seedGatewayGuardian({
+    channelType: "vellum",
+    address: principalId,
+    principalId,
+    displayName: principalId,
+  });
   createGuardianBinding({
     channel: "vellum",
     guardianExternalUserId: principalId,
@@ -172,6 +210,12 @@ describe("non-member access request notification", () => {
 
   test("guardian is notified when a non-member messages and a guardian binding exists", async () => {
     // Set up a guardian binding for this channel using the anchor principal
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-user-789",
+      externalChatId: "guardian-chat-789",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -217,6 +261,12 @@ describe("non-member access request notification", () => {
   });
 
   test("no duplicate approval requests for repeated messages from same non-member", async () => {
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-user-789",
+      externalChatId: "guardian-chat-789",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -289,6 +339,12 @@ describe("non-member access request notification", () => {
     // Only a voice guardian binding exists — no Telegram binding.
     // Since cross-channel fallback was removed, the access request resolves
     // to the assistant's vellum anchor identity instead.
+    seedGatewayGuardian({
+      channelType: "phone",
+      address: "guardian-voice-user",
+      externalChatId: "guardian-voice-chat",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "guardian-voice-user",
@@ -351,8 +407,8 @@ describe("access-request-helper unit tests", () => {
     anchorPrincipalId = resetState();
   });
 
-  test("notifyGuardianOfAccessRequest returns no_sender_id when actorExternalId is absent", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest returns no_sender_id when actorExternalId is absent", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -372,8 +428,8 @@ describe("access-request-helper unit tests", () => {
     expect(pending.length).toBe(0);
   });
 
-  test("notifyGuardianOfAccessRequest creates request with self-healed principal when no binding exists", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest creates request with self-healed principal when no binding exists", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -400,8 +456,14 @@ describe("access-request-helper unit tests", () => {
     expect(emitSignalCalls.length).toBe(1);
   });
 
-  test("notifyGuardianOfAccessRequest falls back to assistant-anchored vellum identity when source-channel binding is missing", () => {
+  test("notifyGuardianOfAccessRequest falls back to assistant-anchored vellum identity when source-channel binding is missing", async () => {
     // Only voice binding exists
+    seedGatewayGuardian({
+      channelType: "phone",
+      address: "guardian-voice",
+      externalChatId: "voice-chat",
+      principalId: "test-principal-id",
+    });
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "guardian-voice",
@@ -410,7 +472,7 @@ describe("access-request-helper unit tests", () => {
       verifiedVia: "test",
     });
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "tg-chat",
@@ -435,8 +497,20 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("vellum");
   });
 
-  test("notifyGuardianOfAccessRequest prefers source-channel binding over vellum anchor", () => {
+  test("notifyGuardianOfAccessRequest prefers source-channel binding over vellum anchor", async () => {
     // Both Telegram and voice bindings exist with the anchor principal
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-tg",
+      externalChatId: "tg-chat",
+      principalId: anchorPrincipalId,
+    });
+    seedGatewayGuardian({
+      channelType: "phone",
+      address: "guardian-voice",
+      externalChatId: "voice-chat",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-tg",
@@ -452,7 +526,7 @@ describe("access-request-helper unit tests", () => {
       verifiedVia: "test",
     });
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -477,8 +551,100 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("telegram");
   });
 
-  test("notifyGuardianOfAccessRequest for voice channel includes actorDisplayName in contextPayload", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest falls back to local source-channel binding when gateway delivery is empty", async () => {
+    // Gateway delivery read yields nothing (restart/timeout/malformed IPC).
+    gatewayGuardians = [];
+    // Local dual-written mirror still has the vellum anchor + telegram binding.
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "guardian-tg",
+      guardianDeliveryChatId: "tg-chat",
+      guardianPrincipalId: anchorPrincipalId,
+      verifiedVia: "test",
+    });
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-123",
+      actorExternalId: "unknown-user",
+    });
+
+    expect(result.notified).toBe(true);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "unknown-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
+    // Request is decidable: local read supplied the principal + source binding.
+    expect(pending[0].guardianPrincipalId).toBe(anchorPrincipalId);
+    expect(pending[0].guardianExternalUserId).toBe("guardian-tg");
+
+    const payload = emitSignalCalls[0].contextPayload as Record<
+      string,
+      unknown
+    >;
+    expect(payload.guardianBindingChannel).toBe("telegram");
+  });
+
+  test("notifyGuardianOfAccessRequest falls back to local vellum anchor when gateway delivery is empty", async () => {
+    // Gateway empty; only the local vellum anchor from resetState remains.
+    gatewayGuardians = [];
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-123",
+      actorExternalId: "unknown-user",
+    });
+
+    expect(result.notified).toBe(true);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "unknown-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
+    // Decidable via the local vellum anchor principal.
+    expect(pending[0].guardianPrincipalId).toBe(anchorPrincipalId);
+
+    const payload = emitSignalCalls[0].contextPayload as Record<
+      string,
+      unknown
+    >;
+    expect(payload.guardianBindingChannel).toBe("vellum");
+  });
+
+  test("notifyGuardianOfAccessRequest does not create a decisionable request when both gateway and local reads are empty", async () => {
+    // Genuinely unbound assistant: gateway empty AND no local binding. Prior
+    // behavior rejects creation of a decisionable request without a principal.
+    gatewayGuardians = [];
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+
+    await expect(
+      notifyGuardianOfAccessRequest({
+        canonicalAssistantId: "self",
+        sourceChannel: "telegram",
+        conversationExternalId: "chat-123",
+        actorExternalId: "unknown-user",
+      }),
+    ).rejects.toThrow();
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "unknown-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(0);
+  });
+
+  test("notifyGuardianOfAccessRequest for voice channel includes actorDisplayName in contextPayload", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "phone",
       conversationExternalId: "+15559998888",
@@ -508,8 +674,8 @@ describe("access-request-helper unit tests", () => {
     expect(pending.length).toBe(1);
   });
 
-  test("notifyGuardianOfAccessRequest includes requestCode in contextPayload", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest includes requestCode in contextPayload", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -529,8 +695,8 @@ describe("access-request-helper unit tests", () => {
     expect((payload.requestCode as string).length).toBe(6);
   });
 
-  test("notifyGuardianOfAccessRequest includes previousMemberStatus in contextPayload", () => {
-    const result = notifyGuardianOfAccessRequest({
+  test("notifyGuardianOfAccessRequest includes previousMemberStatus in contextPayload", async () => {
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
@@ -570,7 +736,7 @@ describe("access-request-helper unit tests", () => {
       ],
     };
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "phone",
       conversationExternalId: "+15556667777",
@@ -603,6 +769,12 @@ describe("access-request-helper unit tests", () => {
     // Set up a telegram guardian binding with the anchor principal so
     // guardianResolutionSource resolves to "source-channel-contact" and
     // sameChannelOnly is true.
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-user-456",
+      externalChatId: "guardian-chat-456",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-user-456",
@@ -625,7 +797,7 @@ describe("access-request-helper unit tests", () => {
       ],
     };
 
-    const result = notifyGuardianOfAccessRequest({
+    const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",

--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -24,6 +24,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => null,
+}));
+
 // Mock destination-resolver to return a destination for every requested channel.
 // External channels (telegram, slack) include bindingContext.
 mock.module("../notifications/destination-resolver.js", () => ({

--- a/assistant/src/__tests__/notification-decision-recipient-context.test.ts
+++ b/assistant/src/__tests__/notification-decision-recipient-context.test.ts
@@ -36,16 +36,35 @@ mock.module("../prompts/system-prompt.js", () => ({
   buildCoreIdentityContext: () => null,
 }));
 
-// ── Guardian contact mock ────────────────────────────────────────────
+// ── Guardian binding + contact notes mocks ───────────────────────────
 
-let mockGuardianResult: {
-  contact: { notes: string | null };
-  channels: Record<string, unknown>[];
-} | null = null;
+// Guardian binding (ACL) is resolved via the gateway pull; notes (INFO) are
+// joined locally by contactId. Tests drive both via mutable slots.
+let guardianDeliveryFixture: Array<{ contactId: string }> = [];
+let contactInfoFixture: Record<string, { notes: string | null } | null> = {};
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => guardianDeliveryFixture,
+  anyGuardian: (list: Array<{ contactId: string }>) => list[0],
+}));
 
 mock.module("../contacts/contact-store.js", () => ({
-  listGuardianChannels: () => mockGuardianResult,
+  findContactInfoById: (contactId: string) =>
+    contactInfoFixture[contactId] ?? null,
 }));
+
+const GUARDIAN_CONTACT_ID = "guardian-contact-1";
+
+/** Bind a guardian with the given notes (or no guardian when notes is null). */
+function setGuardian(notes: string | null | undefined): void {
+  if (notes === undefined) {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+    return;
+  }
+  guardianDeliveryFixture = [{ contactId: GUARDIAN_CONTACT_ID }];
+  contactInfoFixture = { [GUARDIAN_CONTACT_ID]: { notes } };
+}
 
 // ── Provider mock with system prompt capture ──────────────────────────
 
@@ -134,15 +153,12 @@ describe("recipient context in notification decision engine", () => {
   beforeEach(() => {
     configuredProvider = null;
     extractedToolUse = null;
-    mockGuardianResult = null;
+    setGuardian(undefined);
     capturedSystemPrompt = undefined;
   });
 
   test("guardian contact notes appear in system prompt as <recipient-context>", async () => {
-    mockGuardianResult = {
-      contact: { notes: "Prefers formal tone. Address as Dr. Smith." },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("Prefers formal tone. Address as Dr. Smith.");
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -157,7 +173,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context is omitted when no guardian exists", async () => {
-    mockGuardianResult = null;
+    setGuardian(undefined);
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -169,10 +185,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context is omitted when guardian notes are null", async () => {
-    mockGuardianResult = {
-      contact: { notes: null },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian(null);
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -184,10 +197,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context is omitted when guardian notes are empty string", async () => {
-    mockGuardianResult = {
-      contact: { notes: "" },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("");
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -199,10 +209,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("large guardian notes are truncated to prevent oversized prompts", async () => {
-    mockGuardianResult = {
-      contact: { notes: "N".repeat(3000) },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("N".repeat(3000));
     setupLLMProvider();
 
     const signal = makeSignal();
@@ -226,10 +233,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("fallback path works correctly without recipient context", async () => {
-    mockGuardianResult = {
-      contact: { notes: "Prefers formal tone." },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("Prefers formal tone.");
     // null provider forces fallback path
     configuredProvider = null;
 
@@ -247,10 +251,7 @@ describe("recipient context in notification decision engine", () => {
   });
 
   test("recipient-context appears after user-preferences in prompt", async () => {
-    mockGuardianResult = {
-      contact: { notes: "Prefers brief updates." },
-      channels: [{ type: "vellum" }],
-    };
+    setGuardian("Prefers brief updates.");
     setupLLMProvider();
 
     const signal = makeSignal();

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -20,6 +20,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => null,
+}));
+
 // Mock destination-resolver for broadcaster tests
 mock.module("../notifications/destination-resolver.js", () => ({
   resolveDestinations: (channels: string[]) => {

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -68,6 +68,25 @@ mock.module("../notifications/emit-signal.js", () => ({
   },
 }));
 
+// Guardian principalId is resolved from the gateway binding reader. Mirror the
+// seeded vellum binding so dispatch can resolve the principal.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-vellum",
+      principalId: "test-principal-id",
+      address: "local",
+      status: "active",
+    },
+  ],
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
+}));
+
 import {
   createCallSession,
   createPendingQuestion,

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -87,6 +87,23 @@ mock.module("../prompts/user-reference.js", () => ({
   },
 }));
 
+// ── Guardian delivery reader mock ───────────────────────────────────
+//
+// resolveGuardianLabel primes its displayName from the gateway binding via
+// getGuardianDelivery at setup. Tests drive the binding through this list.
+
+let mockGuardianDeliveryList:
+  | Array<{ channelType: string; status: string; displayName: string | null }>
+  | null = null;
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardianDeliveryList,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
+}));
+
 // ── Config mock ─────────────────────────────────────────────────────
 
 const mockConfig = {
@@ -532,6 +549,7 @@ describe("relay-server", () => {
     inviteClaimGate = null;
     mockUserReference = "my human";
     mockAssistantName = "Vellum";
+    mockGuardianDeliveryList = null;
     mockAdmissionPolicy = null;
     mockAdmissionGate = null;
     mockMidCallVerdict = null;
@@ -5008,15 +5026,10 @@ describe("relay-server", () => {
   test("guardian label: guardian persona name takes precedence over Contact.displayName", async () => {
     mockUserReference = "Alice";
 
-    // Create a guardian binding with a different displayName
-    createGuardianBinding({
-      channel: "phone",
-      guardianExternalUserId: "+15559990001",
-      guardianDeliveryChatId: "+15559990001",
-      guardianPrincipalId: "+15559990001",
-      verifiedVia: "test",
-      metadataJson: JSON.stringify({ displayName: "Bob" }),
-    });
+    // Gateway binding carries a different displayName
+    mockGuardianDeliveryList = [
+      { channelType: "phone", status: "active", displayName: "Bob" },
+    ];
 
     ensureConversation("conv-label-user-md");
     const session = createCallSession({
@@ -5053,15 +5066,10 @@ describe("relay-server", () => {
   test("guardian label: Contact.displayName used when guardian persona name is empty", async () => {
     mockUserReference = "my human";
 
-    // Create a guardian binding with a displayName
-    createGuardianBinding({
-      channel: "phone",
-      guardianExternalUserId: "+15559990002",
-      guardianDeliveryChatId: "+15559990002",
-      guardianPrincipalId: "+15559990002",
-      verifiedVia: "test",
-      metadataJson: JSON.stringify({ displayName: "Charlie" }),
-    });
+    // Gateway binding carries the guardian displayName
+    mockGuardianDeliveryList = [
+      { channelType: "phone", status: "active", displayName: "Charlie" },
+    ];
 
     ensureConversation("conv-label-contact");
     const session = createCallSession({
@@ -5097,10 +5105,8 @@ describe("relay-server", () => {
   test("guardian label: DEFAULT_USER_REFERENCE used when both guardian persona name and Contact.displayName are empty", async () => {
     mockUserReference = "my human";
 
-    // Clear guardian binding so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
-    const db = getDb();
-    db.run("DELETE FROM contact_channels");
-    db.run("DELETE FROM contacts");
+    // No guardian binding so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
+    mockGuardianDeliveryList = null;
 
     ensureConversation("conv-label-default");
     const session = createCallSession({

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -92,17 +92,13 @@ mock.module("../prompts/user-reference.js", () => ({
 // resolveGuardianLabel primes its displayName from the gateway binding via
 // getGuardianDelivery at setup. Tests drive the binding through this list.
 
+// Tests set this to drive the guardian binding directly. When null (the
+// default), the guardian-delivery-reader mock below derives the binding from
+// the DB-seeded createGuardianBinding setup. Single mock registration lives
+// below since `mock.module` is process-global and last-write-wins in Bun.
 let mockGuardianDeliveryList:
   | Array<{ channelType: string; status: string; displayName: string | null }>
   | null = null;
-mock.module("../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: async () => mockGuardianDeliveryList,
-  guardianForChannel: (
-    list: Array<{ channelType: string; status: string }>,
-    channelType: string,
-  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
-  anyGuardian: (list: unknown[]) => list[0],
-}));
 
 // ── Config mock ─────────────────────────────────────────────────────
 
@@ -223,6 +219,9 @@ const realContactStoreModule = {
 };
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => {
+    // Tests that set mockGuardianDeliveryList drive the binding directly;
+    // otherwise derive from the DB-seeded createGuardianBinding bindings.
+    if (mockGuardianDeliveryList) return mockGuardianDeliveryList;
     const guardians = realContactStoreModule.listGuardianChannels();
     if (!guardians) return [];
     return guardians.channels.map((ch) => ({
@@ -240,6 +239,7 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
     list: Array<{ channelType: string; status: string }>,
     channelType: string,
   ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
 }));
 
 // ── Trust verdict consumer spy ──────────────────────────────────────
@@ -5134,8 +5134,8 @@ describe("relay-server", () => {
   test("guardian label: DEFAULT_USER_REFERENCE used when both guardian persona name and Contact.displayName are empty", async () => {
     mockUserReference = "my human";
 
-    // No guardian binding so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
-    mockGuardianDeliveryList = null;
+    // Empty binding list so resolveGuardianLabel falls back to DEFAULT_USER_REFERENCE
+    mockGuardianDeliveryList = [];
 
     ensureConversation("conv-label-default");
     const session = createCallSession({

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -213,6 +213,35 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
   },
 }));
 
+// ── Guardian delivery reader ────────────────────────────────────────
+//
+// Guardian identity now resolves via the gateway delivery reader. Derive the
+// list from the DB-seeded guardian bindings so the existing createGuardianBinding
+// setup keeps driving guardian resolution without per-test changes.
+const realContactStoreModule = {
+  ...(await import("../contacts/contact-store.js")),
+};
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => {
+    const guardians = realContactStoreModule.listGuardianChannels();
+    if (!guardians) return [];
+    return guardians.channels.map((ch) => ({
+      channelType: ch.type,
+      contactId: guardians.contact.id,
+      principalId: guardians.contact.principalId ?? null,
+      displayName: guardians.contact.displayName ?? null,
+      address: ch.address,
+      externalChatId: ch.externalChatId ?? null,
+      status: ch.status,
+      verifiedAt: ch.verifiedAt ?? null,
+    }));
+  },
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
 // ── Trust verdict consumer spy ──────────────────────────────────────
 //
 // Tracks whether the verdict mapper produced the final mid-call context, so a

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -55,6 +55,35 @@ mock.module("../runtime/gateway-client.js", () => ({
   },
 }));
 
+// Guardian identity resolves via the gateway delivery reader, not the local
+// contacts DB. Seed it to mirror the createGuardianBinding calls below.
+interface GatewayGuardian {
+  channelType: string;
+  contactId: string;
+  principalId?: string | null;
+  displayName?: string | null;
+  address: string;
+  externalChatId?: string | null;
+  status: string;
+  verifiedAt?: number | null;
+}
+let gatewayGuardians: GatewayGuardian[] = [];
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => gatewayGuardians,
+  guardianForChannel: (list: GatewayGuardian[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+function seedGatewayGuardian(
+  g: Partial<GatewayGuardian> & { channelType: string; address: string },
+): void {
+  gatewayGuardians.push({
+    contactId: `c-${g.channelType}`,
+    status: "active",
+    ...g,
+  });
+}
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
@@ -80,7 +109,16 @@ function resetState(): void {
   db.run("DELETE FROM canonical_guardian_deliveries");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
-  // Seed the vellum guardian binding (gateway does this at startup in production)
+  gatewayGuardians = [];
+  // Seed the vellum guardian binding (gateway does this at startup in
+  // production). The gateway list is the source of truth for guardian
+  // resolution; the DB write mirrors it for any local INFO reads.
+  seedGatewayGuardian({
+    channelType: "vellum",
+    address: "guardian-principal",
+    principalId: "guardian-principal",
+    displayName: "guardian-principal",
+  });
   createGuardianBinding({
     channel: "vellum",
     guardianExternalUserId: "guardian-principal",
@@ -162,7 +200,14 @@ describe("Slack inbound trusted contact verification", () => {
   });
 
   test("guardian is notified of the access attempt alongside verification", async () => {
-    // Set up a guardian binding so the notification can target it
+    // Set up a guardian binding so the notification can target it. The gateway
+    // list resolves guardian identity; the DB write mirrors it.
+    seedGatewayGuardian({
+      channelType: "slack",
+      address: "U_GUARDIAN",
+      externalChatId: "D_GUARDIAN_DM",
+      principalId: "guardian-principal",
+    });
     createGuardianBinding({
       channel: "slack",
       guardianExternalUserId: "U_GUARDIAN",

--- a/assistant/src/__tests__/sse-actor-principal-guardian-source.test.ts
+++ b/assistant/src/__tests__/sse-actor-principal-guardian-source.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression: the SSE subscribe path must resolve the actor principal from the
+ * SAME guardian source as the send/result routes.
+ *
+ * The send/result routes resolve the actor principal via the async,
+ * gateway-first `findLocalGuardianPrincipalId`. The SSE eager-subscribe path
+ * cannot await and uses the sync `findLocalGuardianPrincipalIdFromStore`. When
+ * the gateway binding is canonical but the local contact row is stale/missing
+ * (after a guardian reset or gateway-owned binding update), the sync path must
+ * still land on the gateway principal — otherwise the event hub registers the
+ * SSE client under a DIFFERENT principal than the turn/result paths use, and
+ * targeted result submissions 403.
+ *
+ * These tests pin the invariant by priming the gateway-delivery cache with a
+ * principal that differs from the stale local store and asserting both
+ * resolvers agree; and that a cold cache falls back to the local store.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+// ── Controllable IPC mock (drives the gateway-delivery cache) ────────────────
+
+let ipcGuardians: GuardianDelivery[] = [];
+
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCall: async () => ({ guardians: ipcGuardians }),
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+// ── Local store mock (the stale fallback source) ─────────────────────────────
+
+let storePrincipalId: string | undefined;
+
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (channelType: string) =>
+    storePrincipalId && channelType === "vellum"
+      ? { contact: { principalId: storePrincipalId }, channel: {} }
+      : null,
+}));
+
+import {
+  __resetGuardianDeliveryCacheForTest,
+  getGuardianDelivery,
+} from "../contacts/guardian-delivery-reader.js";
+import {
+  findLocalGuardianPrincipalId,
+  findLocalGuardianPrincipalIdFromStore,
+} from "../runtime/local-actor-identity.js";
+
+const gatewayVellumGuardian: GuardianDelivery = {
+  channelType: "vellum",
+  contactId: "contact-gw",
+  principalId: "guardian-from-gateway",
+  address: "vellum:self",
+  status: "active",
+};
+
+describe("SSE actor principal resolves from the same guardian source as send/result routes", () => {
+  beforeEach(() => {
+    __resetGuardianDeliveryCacheForTest();
+    ipcGuardians = [];
+    storePrincipalId = undefined;
+  });
+
+  test("warm gateway cache: sync (SSE) and async (send/result) resolve the SAME principal despite a stale local store", async () => {
+    // Gateway binding is canonical; local store row is stale (different id).
+    ipcGuardians = [gatewayVellumGuardian];
+    storePrincipalId = "guardian-stale-local";
+
+    // Prime the cache the way the async hot paths do.
+    const asyncPrincipalId = await findLocalGuardianPrincipalId();
+    expect(asyncPrincipalId).toBe("guardian-from-gateway");
+
+    // SSE's sync resolver reads the same cached gateway snapshot, NOT the
+    // stale store — so the principals match and host-proxy targeting works.
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe(asyncPrincipalId);
+  });
+
+  test("cold cache: sync resolver falls back to the local store as before", () => {
+    // Nothing primed the cache; only the local store has a binding.
+    storePrincipalId = "guardian-stale-local";
+
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe("guardian-stale-local");
+  });
+
+  test("cold cache with no store binding: sync resolver returns undefined", () => {
+    expect(findLocalGuardianPrincipalIdFromStore()).toBeUndefined();
+  });
+
+  test("warm gateway cache primes via the vellum-filtered read the async path uses", async () => {
+    ipcGuardians = [gatewayVellumGuardian];
+
+    // The async path filters by channelType vellum; the sync peek must read
+    // the same cache key, not the unfiltered "ALL" entry.
+    await getGuardianDelivery({ channelTypes: ["vellum"] });
+
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe("guardian-from-gateway");
+  });
+});

--- a/assistant/src/__tests__/stt-hints.test.ts
+++ b/assistant/src/__tests__/stt-hints.test.ts
@@ -13,6 +13,15 @@ let mockRecentContacts: ContactWithChannels[] = [];
 let mockFindContactByAddressThrows = false;
 let mockListContactsThrows = false;
 
+// Guardian deliveries returned by the mocked gateway reader. resolveGuardianName
+// is mocked to echo mockGuardianName, so the displayName here is captured below.
+let mockGuardianDelivery: Array<{
+  channelType: string;
+  status: string;
+  displayName: string | null;
+}> | null = null;
+let lastGuardianDisplayNameSeen: string | null | undefined;
+
 const logWarnFn = mock(() => {});
 
 // ---------------------------------------------------------------------------
@@ -25,7 +34,10 @@ mock.module("../daemon/identity-helpers.js", () => ({
 
 mock.module("../prompts/user-reference.js", () => ({
   DEFAULT_USER_REFERENCE: "my human",
-  resolveGuardianName: () => mockGuardianName,
+  resolveGuardianName: (displayName?: string | null) => {
+    lastGuardianDisplayNameSeen = displayName;
+    return mockGuardianName;
+  },
 }));
 
 mock.module("../contacts/contact-store.js", () => ({
@@ -35,14 +47,21 @@ mock.module("../contacts/contact-store.js", () => ({
     }
     return mockTargetContact;
   },
-  findGuardianForChannel: () => null,
-  listGuardianChannels: () => null,
   listContacts: (_limit?: number) => {
     if (mockListContactsThrows) {
       throw new Error("DB error: listContacts");
     }
     return mockRecentContacts;
   },
+}));
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardianDelivery,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  anyGuardian: (list: unknown[]) => list[0],
 }));
 
 // Bun's mock.module for "../util/logger.js" doesn't intercept the transitive
@@ -319,10 +338,22 @@ describe("resolveCallHints", () => {
     mockRecentContacts = [];
     mockFindContactByAddressThrows = false;
     mockListContactsThrows = false;
+    mockGuardianDelivery = null;
+    lastGuardianDisplayNameSeen = undefined;
     logWarnFn.mockClear();
   });
 
-  test("happy path wires all sources correctly", () => {
+  test("guardian displayName for hints comes from the gateway binding", async () => {
+    mockGuardianDelivery = [
+      { channelType: "phone", status: "active", displayName: "GatewayGuardian" },
+    ];
+
+    await resolveCallHints(null, []);
+
+    expect(lastGuardianDisplayNameSeen).toBe("GatewayGuardian");
+  });
+
+  test("happy path wires all sources correctly", async () => {
     mockTargetContact = makeContact("Alice");
     mockRecentContacts = [makeContact("Bob"), makeContact("Charlie")];
 
@@ -335,7 +366,7 @@ describe("resolveCallHints", () => {
       inviteGuardianName: "Eve",
     };
 
-    const result = resolveCallHints(session, ["StaticHint"]);
+    const result = await resolveCallHints(session, ["StaticHint"]);
     const parts = result.split(",");
 
     expect(parts).toContain("StaticHint");
@@ -351,7 +382,7 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).not.toHaveBeenCalled();
   });
 
-  test("findContactByAddress failure is caught and logged without throwing", () => {
+  test("findContactByAddress failure is caught and logged without throwing", async () => {
     mockFindContactByAddressThrows = true;
     mockRecentContacts = [makeContact("Bob")];
 
@@ -365,7 +396,7 @@ describe("resolveCallHints", () => {
     };
 
     // Should not throw
-    const result = resolveCallHints(session, []);
+    const result = await resolveCallHints(session, []);
     const parts = result.split(",");
 
     // Target contact should be absent (lookup failed)
@@ -376,7 +407,7 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).toHaveBeenCalled();
   });
 
-  test("listContacts failure is caught and logged without throwing", () => {
+  test("listContacts failure is caught and logged without throwing", async () => {
     mockListContactsThrows = true;
     mockTargetContact = makeContact("Alice");
 
@@ -390,7 +421,7 @@ describe("resolveCallHints", () => {
     };
 
     // Should not throw
-    const result = resolveCallHints(session, []);
+    const result = await resolveCallHints(session, []);
     const parts = result.split(",");
 
     // Recent contacts should be absent (listing failed)
@@ -401,7 +432,7 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).toHaveBeenCalled();
   });
 
-  test("inbound call resolves caller contact from fromNumber", () => {
+  test("inbound call resolves caller contact from fromNumber", async () => {
     mockTargetContact = makeContact("Alice");
     mockRecentContacts = [makeContact("Bob")];
 
@@ -414,7 +445,7 @@ describe("resolveCallHints", () => {
       inviteGuardianName: null,
     };
 
-    const result = resolveCallHints(session, []);
+    const result = await resolveCallHints(session, []);
     const parts = result.split(",");
 
     // For inbound, the contact found via fromNumber should appear as caller, not target
@@ -425,10 +456,10 @@ describe("resolveCallHints", () => {
     expect(logWarnFn).not.toHaveBeenCalled();
   });
 
-  test("null session produces hints from assistant name, guardian name, and recent contacts", () => {
+  test("null session produces hints from assistant name, guardian name, and recent contacts", async () => {
     mockRecentContacts = [makeContact("RecentOne"), makeContact("RecentTwo")];
 
-    const result = resolveCallHints(null, ["Static"]);
+    const result = await resolveCallHints(null, ["Static"]);
     const parts = result.split(",");
 
     expect(parts).toContain("Static");

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -7,7 +7,6 @@
  * 3. Records guardian_action_delivery rows from pipeline delivery results
  */
 
-import { findGuardianForChannel } from "../contacts/contact-store.js";
 import {
   createCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
@@ -18,6 +17,7 @@ import {
   recordGuardianRequestDeliveries,
 } from "../notifications/canonical-delivery-recorder.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import { findLocalGuardianPrincipalId } from "../runtime/local-actor-identity.js";
 import { getLogger } from "../util/logger.js";
 import { getUserConsultationTimeoutMs } from "./call-constants.js";
 import type { CallPendingQuestion } from "./types.js";
@@ -86,14 +86,14 @@ async function dispatchGuardianQuestionInner(
   try {
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
-    // Voice decisions are handled in guardian conversations tied to the assistant-
-    // level guardian identity. Resolve the principal from the contacts table.
-    let guardianPrincipalId: string | undefined;
-
-    const guardianResult = findGuardianForChannel("vellum");
-    if (guardianResult?.contact.principalId) {
-      guardianPrincipalId = guardianResult.contact.principalId;
-    }
+    // Stamp the request with the SAME principal the Vellum actor will submit.
+    // The actor resolves its guardianPrincipalId via findLocalGuardianPrincipalId
+    // (gateway-first, local fallback); applyCanonicalGuardianDecision requires
+    // strict equality with request.guardianPrincipalId. Resolving here through
+    // the identical source guarantees the stamped principal == the submitting
+    // principal, so decisions can't be rejected as identity_mismatch when the
+    // gateway and local bindings drift during migration.
+    const guardianPrincipalId = await findLocalGuardianPrincipalId();
 
     if (!guardianPrincipalId) {
       log.error(

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -7,6 +7,7 @@
  * 3. Records guardian_action_delivery rows from pipeline delivery results
  */
 
+import { findGuardianForChannel } from "../contacts/contact-store.js";
 import {
   createCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
@@ -17,7 +18,6 @@ import {
   recordGuardianRequestDeliveries,
 } from "../notifications/canonical-delivery-recorder.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
-import { findLocalGuardianPrincipalId } from "../runtime/local-actor-identity.js";
 import { getLogger } from "../util/logger.js";
 import { getUserConsultationTimeoutMs } from "./call-constants.js";
 import type { CallPendingQuestion } from "./types.js";
@@ -86,14 +86,16 @@ async function dispatchGuardianQuestionInner(
   try {
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
-    // Stamp the request with the SAME principal the Vellum actor will submit.
-    // The actor resolves its guardianPrincipalId via findLocalGuardianPrincipalId
-    // (gateway-first, local fallback); applyCanonicalGuardianDecision requires
-    // strict equality with request.guardianPrincipalId. Resolving here through
-    // the identical source guarantees the stamped principal == the submitting
-    // principal, so decisions can't be rejected as identity_mismatch when the
-    // gateway and local bindings drift during migration.
-    const guardianPrincipalId = await findLocalGuardianPrincipalId();
+    // Resolve the request principal from the same local source as the
+    // submitting actor (guardian-action-routes / actor-trust-resolver both read
+    // findGuardianForChannel("vellum")?.contact.principalId), so they cannot
+    // diverge. applyCanonicalGuardianDecision requires strict equality with
+    // request.guardianPrincipalId; sharing this local source guarantees the
+    // stamped principal == the submitting principal even when the gateway and
+    // local bindings drift during migration. This pair converts to the gateway
+    // together with the actor-trust path.
+    const guardianPrincipalId =
+      findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
 
     if (!guardianPrincipalId) {
       log.error(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -12,9 +12,8 @@ import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import {
-  anyGuardian,
   getGuardianDelivery,
-  guardianForChannel,
+  voiceGuardianDisplayName,
 } from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
@@ -1848,10 +1847,7 @@ export class RelayConnection {
    */
   private async primeGuardianDisplayName(): Promise<void> {
     const list = await getGuardianDelivery();
-    const guardian = list
-      ? (guardianForChannel(list, "phone") ?? anyGuardian(list))
-      : undefined;
-    this.primedGuardianDisplayName = guardian?.displayName ?? undefined;
+    this.primedGuardianDisplayName = voiceGuardianDisplayName(list);
   }
 
   /**

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1400,7 +1400,7 @@ export class RelayConnection {
    * Creates a canonical access request, notifies the guardian, and
    * enters the bounded wait loop for the guardian decision.
    */
-  private handleNameCaptureResponse(callerName: string): void {
+  private async handleNameCaptureResponse(callerName: string): Promise<void> {
     if (!this.accessRequestAssistantId || !this.accessRequestFromNumber) {
       return;
     }
@@ -1421,7 +1421,7 @@ export class RelayConnection {
     // Create canonical access request and notify the guardian, including
     // the caller's spoken name and voice channel metadata.
     try {
-      const accessResult = notifyGuardianOfAccessRequest({
+      const accessResult = await notifyGuardianOfAccessRequest({
         canonicalAssistantId: this.accessRequestAssistantId,
         sourceChannel: "phone",
         conversationExternalId: this.accessRequestFromNumber,
@@ -2063,7 +2063,7 @@ export class RelayConnection {
         { callSessionId: this.callSessionId, callerName },
         "Name captured from unknown inbound caller",
       );
-      this.handleNameCaptureResponse(callerName);
+      await this.handleNameCaptureResponse(callerName);
       return;
     }
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -12,9 +12,10 @@ import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import {
-  findGuardianForChannel,
-  listGuardianChannels,
-} from "../contacts/contact-store.js";
+  anyGuardian,
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
@@ -261,6 +262,10 @@ export class RelayConnection {
     null;
   private accessRequestWaitStartedAt: number = 0;
   private heartbeatSequence = 0;
+
+  // Guardian displayName primed from the gateway binding at setup, read
+  // synchronously by the heartbeat-driven wait-label path.
+  private primedGuardianDisplayName: string | undefined;
 
   // In-wait prompt handling state
   private lastInWaitReplyAt = 0;
@@ -596,6 +601,8 @@ export class RelayConnection {
 
     const session = getCallSession(this.callSessionId);
     this.recordSetupBookkeeping(session, msg);
+
+    await this.primeGuardianDisplayName();
 
     // Resolve the phone channel's inbound admission floor. The reader fails
     // open to `null` by contract, so a transport hiccup admits the caller.
@@ -1828,15 +1835,23 @@ export class RelayConnection {
    * Resolve a human-readable guardian label for voice wait copy.
    * Delegates to the shared resolveGuardianName() which checks the
    * guardian's per-user persona file (users/<slug>.md) first, then falls
-   * back to Contact.displayName, then DEFAULT_USER_REFERENCE.
+   * back to the primed gateway-binding displayName, then
+   * DEFAULT_USER_REFERENCE.
    */
   private resolveGuardianLabel(): string {
-    // Look up the guardian contact for a displayName fallback
-    const voiceGuardian = findGuardianForChannel("phone");
-    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
-    const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
+    return resolveGuardianName(this.primedGuardianDisplayName);
+  }
 
-    return resolveGuardianName(guardianContact?.displayName);
+  /**
+   * Prime the guardian displayName from the gateway binding so the
+   * synchronous wait-label path can read it without an IPC round-trip.
+   */
+  private async primeGuardianDisplayName(): Promise<void> {
+    const list = await getGuardianDelivery();
+    const guardian = list
+      ? (guardianForChannel(list, "phone") ?? anyGuardian(list))
+      : undefined;
+    this.primedGuardianDisplayName = guardian?.displayName ?? undefined;
   }
 
   /**

--- a/assistant/src/calls/stt-hints.ts
+++ b/assistant/src/calls/stt-hints.ts
@@ -1,8 +1,7 @@
 import { findContactByAddress, listContacts } from "../contacts/contact-store.js";
 import {
-  anyGuardian,
   getGuardianDelivery,
-  guardianForChannel,
+  voiceGuardianDisplayName,
 } from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { DEFAULT_USER_REFERENCE, resolveGuardianName } from "../prompts/user-reference.js";
@@ -136,10 +135,7 @@ export async function resolveCallHints(
   let guardianDisplayName: string | undefined;
   try {
     const list = await getGuardianDelivery();
-    const guardian = list
-      ? (guardianForChannel(list, "phone") ?? anyGuardian(list))
-      : undefined;
-    guardianDisplayName = guardian?.displayName ?? undefined;
+    guardianDisplayName = voiceGuardianDisplayName(list);
   } catch (err) {
     logger.warn({ err }, "Failed to look up guardian contact for STT hints");
   }

--- a/assistant/src/calls/stt-hints.ts
+++ b/assistant/src/calls/stt-hints.ts
@@ -1,9 +1,9 @@
+import { findContactByAddress, listContacts } from "../contacts/contact-store.js";
 import {
-  findContactByAddress,
-  findGuardianForChannel,
-  listContacts,
-  listGuardianChannels,
-} from "../contacts/contact-store.js";
+  anyGuardian,
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { DEFAULT_USER_REFERENCE, resolveGuardianName } from "../prompts/user-reference.js";
 import { getLogger } from "../util/logger.js";
@@ -119,7 +119,7 @@ export function buildSttHints(input: SttHintsInput): string {
  * {@link buildSttHints}. All DB lookups are best-effort — errors are
  * logged but never propagate so hints can never fail a call.
  */
-export function resolveCallHints(
+export async function resolveCallHints(
   session: {
     task: string | null;
     toNumber: string;
@@ -129,16 +129,17 @@ export function resolveCallHints(
     inviteGuardianName: string | null;
   } | null,
   staticHints: string[],
-): string {
+): Promise<string> {
   const assistantName = getAssistantName();
 
-  // Look up the guardian contact for a displayName fallback (mirrors relay-server pattern)
+  // Resolve the guardian displayName from the gateway binding for STT vocabulary.
   let guardianDisplayName: string | undefined;
   try {
-    const voiceGuardian = findGuardianForChannel("phone");
-    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
-    const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
-    guardianDisplayName = guardianContact?.displayName;
+    const list = await getGuardianDelivery();
+    const guardian = list
+      ? (guardianForChannel(list, "phone") ?? anyGuardian(list))
+      : undefined;
+    guardianDisplayName = guardian?.displayName ?? undefined;
   } catch (err) {
     logger.warn({ err }, "Failed to look up guardian contact for STT hints");
   }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -532,7 +532,7 @@ async function buildVoiceWebhookTwiml(
 /**
  * Build ConversationRelay TwiML for Twilio-native STT providers.
  */
-function buildConversationRelayTwiml(
+async function buildConversationRelayTwiml(
   callSessionId: string,
   profile: ReturnType<typeof resolveVoiceQualityProfile>,
   sessionContext: {
@@ -545,8 +545,8 @@ function buildConversationRelayTwiml(
   } | null,
   verificationSessionId: string | null | undefined,
   sttAttrs: { transcriptionProvider: string; speechModel: string | undefined },
-): string {
-  const rawHints = resolveCallHints(sessionContext, profile.hints);
+): Promise<string> {
+  const rawHints = await resolveCallHints(sessionContext, profile.hints);
 
   const speechConfig: TwilioRelaySpeechConfig = {
     transcriptionProvider: sttAttrs.transcriptionProvider,

--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -203,7 +203,7 @@ describe("getGuardianDelivery", () => {
     expect(countCalls(METHOD)).toBe(2);
   });
 
-  test("forceRefresh ignores a stale cached entry and re-fetches", async () => {
+  test("fresh read ignores a stale cached entry and re-fetches", async () => {
     // Seed the cache with an empty list (the stale gateway-side view).
     ipcHandlers.set(METHOD, () => ({ guardians: [] }));
     expect(await getGuardianDelivery()).toEqual([]);
@@ -212,20 +212,18 @@ describe("getGuardianDelivery", () => {
     expect(await getGuardianDelivery()).toEqual([]);
     expect(countCalls(METHOD)).toBe(1);
 
-    // ...but forceRefresh bypasses the cache and sees the now-present guardian.
+    // ...but a fresh read bypasses the cache and sees the now-present guardian.
     ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
-    expect(await getGuardianDelivery({ forceRefresh: true })).toEqual([
-      telegramGuardian,
-    ]);
+    expect(await getGuardianDeliveryFresh()).toEqual([telegramGuardian]);
     expect(countCalls(METHOD)).toBe(2);
   });
 
-  test("forceRefresh updates the cache with the fresh result", async () => {
+  test("fresh read updates the cache with the fresh result", async () => {
     ipcHandlers.set(METHOD, () => ({ guardians: [] }));
     await getGuardianDelivery();
 
     ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
-    await getGuardianDelivery({ forceRefresh: true });
+    await getGuardianDeliveryFresh();
 
     // A subsequent cached read serves the refreshed value without a new IPC.
     expect(await getGuardianDelivery()).toEqual([telegramGuardian]);

--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the gateway-backed guardian delivery reader.
+ *
+ * Guardian binding is near-static, so the reader caches behind a minutes-scale
+ * TTL, clears event-driven on invalidation, and coalesces concurrent cold-cache
+ * reads single-flight. These tests pin the parse contract plus all three cache
+ * behaviors (TTL hit, invalidation, single-flight) and the failure-no-poison
+ * rule.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+// ── Controllable IPC mock ────────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+
+const ipcHandlers = new Map<string, IpcHandler>();
+const ipcCallLog: Array<{
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+}> = [];
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCallLog.push({ method, params, timeoutMs });
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+import { emitContactChange } from "../contact-events.js";
+import {
+  __resetGuardianDeliveryCacheForTest,
+  anyGuardian,
+  getGuardianDelivery,
+  guardianForChannel,
+  invalidateGuardianDeliveryCache,
+} from "../guardian-delivery-reader.js";
+
+const METHOD = "resolve_guardian_delivery";
+
+function countCalls(method: string): number {
+  return ipcCallLog.filter((c) => c.method === method).length;
+}
+
+const telegramGuardian: GuardianDelivery = {
+  channelType: "telegram",
+  contactId: "contact-123",
+  address: "@guardian",
+  status: "active",
+};
+
+const emailGuardian: GuardianDelivery = {
+  channelType: "email",
+  contactId: "contact-456",
+  address: "guardian@example.com",
+  status: "active",
+};
+
+describe("getGuardianDelivery", () => {
+  beforeEach(() => {
+    __resetGuardianDeliveryCacheForTest();
+    ipcHandlers.clear();
+    ipcCallLog.length = 0;
+  });
+
+  test("returns the parsed guardian list", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
+  });
+
+  test("bounds the IPC read with a short timeout", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+
+    await getGuardianDelivery();
+
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.timeoutMs).toBe(2_000);
+  });
+
+  test("returns null when IPC transport fails (undefined)", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await getGuardianDelivery()).toBeNull();
+  });
+
+  test("returns null when the IPC call throws", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("socket exploded");
+    });
+    expect(await getGuardianDelivery()).toBeNull();
+  });
+
+  test("returns null for a malformed response shape", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: "not-an-array" }));
+    expect(await getGuardianDelivery()).toBeNull();
+  });
+
+  test("two calls within the TTL issue only ONE IPC call (cache hit)", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    await getGuardianDelivery();
+
+    expect(countCalls(METHOD)).toBe(1);
+  });
+
+  test("caches per channelTypes filter key", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    await getGuardianDelivery({ channelTypes: ["telegram"] });
+
+    // Distinct keys ("ALL" vs "telegram") miss each other → two IPC calls.
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("invalidateGuardianDeliveryCache() forces the next call to re-fetch", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    invalidateGuardianDeliveryCache();
+    await getGuardianDelivery();
+
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("a contact-change event clears the cache", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+
+    await getGuardianDelivery();
+    emitContactChange();
+    await getGuardianDelivery();
+
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("a burst of concurrent cold-cache calls issues only ONE IPC call (single-flight)", async () => {
+    let resolveIpc: ((value: unknown) => void) | undefined;
+    ipcHandlers.set(
+      METHOD,
+      () =>
+        new Promise((resolve) => {
+          resolveIpc = resolve;
+        }),
+    );
+
+    const burst = Promise.all([
+      getGuardianDelivery(),
+      getGuardianDelivery(),
+      getGuardianDelivery(),
+    ]);
+    resolveIpc?.({ guardians: [telegramGuardian] });
+    const results = await burst;
+
+    expect(countCalls(METHOD)).toBe(1);
+    expect(results).toEqual([
+      [telegramGuardian],
+      [telegramGuardian],
+      [telegramGuardian],
+    ]);
+  });
+
+  test("an invalidation DURING an in-flight fetch is not masked — the next call re-fetches", async () => {
+    let resolveIpc: ((value: unknown) => void) | undefined;
+    ipcHandlers.set(
+      METHOD,
+      () =>
+        new Promise((resolve) => {
+          resolveIpc = resolve;
+        }),
+    );
+
+    // Start a cold fetch, invalidate before it resolves, then resolve it.
+    const inFlight = getGuardianDelivery();
+    invalidateGuardianDeliveryCache();
+    resolveIpc?.({ guardians: [telegramGuardian] });
+    expect(await inFlight).toEqual([telegramGuardian]);
+
+    // The pre-invalidation result must NOT have been cached: the next read
+    // issues a fresh IPC rather than serving the now-stale value.
+    ipcHandlers.set(METHOD, () => ({ guardians: [emailGuardian] }));
+    expect(await getGuardianDelivery()).toEqual([emailGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("a failure does NOT poison the cache — the next call retries", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await getGuardianDelivery()).toBeNull();
+
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+});
+
+describe("selectors", () => {
+  test("guardianForChannel picks the first active match for the type", () => {
+    const inactive: GuardianDelivery = {
+      ...telegramGuardian,
+      contactId: "contact-999",
+      status: "revoked",
+    };
+    const list = [inactive, telegramGuardian, emailGuardian];
+
+    expect(guardianForChannel(list, "telegram")).toBe(telegramGuardian);
+    expect(guardianForChannel(list, "email")).toBe(emailGuardian);
+    expect(guardianForChannel(list, "phone")).toBeUndefined();
+  });
+
+  test("anyGuardian returns the first overall", () => {
+    expect(anyGuardian([emailGuardian, telegramGuardian])).toBe(emailGuardian);
+    expect(anyGuardian([])).toBeUndefined();
+  });
+});

--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -42,6 +42,7 @@ import {
   __resetGuardianDeliveryCacheForTest,
   anyGuardian,
   getGuardianDelivery,
+  getGuardianDeliveryFresh,
   guardianForChannel,
   invalidateGuardianDeliveryCache,
 } from "../guardian-delivery-reader.js";
@@ -200,6 +201,69 @@ describe("getGuardianDelivery", () => {
     ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
     expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
     expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("forceRefresh ignores a stale cached entry and re-fetches", async () => {
+    // Seed the cache with an empty list (the stale gateway-side view).
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+    expect(await getGuardianDelivery()).toEqual([]);
+
+    // A cached read still serves the stale empty list (no new IPC)...
+    expect(await getGuardianDelivery()).toEqual([]);
+    expect(countCalls(METHOD)).toBe(1);
+
+    // ...but forceRefresh bypasses the cache and sees the now-present guardian.
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    expect(await getGuardianDelivery({ forceRefresh: true })).toEqual([
+      telegramGuardian,
+    ]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("forceRefresh updates the cache with the fresh result", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+    await getGuardianDelivery();
+
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    await getGuardianDelivery({ forceRefresh: true });
+
+    // A subsequent cached read serves the refreshed value without a new IPC.
+    expect(await getGuardianDelivery()).toEqual([telegramGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("getGuardianDeliveryFresh bypasses a stale cached empty list", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [] }));
+    expect(
+      await getGuardianDelivery({ channelTypes: ["telegram"] }),
+    ).toEqual([]);
+
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    expect(
+      await getGuardianDeliveryFresh({ channelTypes: ["telegram"] }),
+    ).toEqual([telegramGuardian]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("a burst of forceRefresh reads still coalesces single-flight", async () => {
+    let resolveIpc: ((value: unknown) => void) | undefined;
+    ipcHandlers.set(
+      METHOD,
+      () =>
+        new Promise((resolve) => {
+          resolveIpc = resolve;
+        }),
+    );
+
+    const burst = Promise.all([
+      getGuardianDeliveryFresh(),
+      getGuardianDeliveryFresh(),
+      getGuardianDeliveryFresh(),
+    ]);
+    resolveIpc?.({ guardians: [telegramGuardian] });
+    await burst;
+
+    expect(countCalls(METHOD)).toBe(1);
   });
 });
 

--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -263,6 +263,32 @@ describe("getGuardianDelivery", () => {
 
     expect(countCalls(METHOD)).toBe(1);
   });
+
+  test("a fresh read does NOT coalesce with an in-flight non-force fetch (issues its own IPC)", async () => {
+    // A normal read starts a fetch that will resolve to the pre-write empty
+    // list and is still in flight when the fresh read arrives.
+    let resolveStale: ((value: unknown) => void) | undefined;
+    ipcHandlers.set(
+      METHOD,
+      () =>
+        new Promise((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+    const stale = getGuardianDelivery();
+
+    // The gateway-side write lands (not reflected in the in-flight fetch). The
+    // fresh read must NOT reuse the stale in-flight promise — it issues its own
+    // IPC observing the post-write guardian.
+    ipcHandlers.set(METHOD, () => ({ guardians: [telegramGuardian] }));
+    const fresh = await getGuardianDeliveryFresh();
+    expect(fresh).toEqual([telegramGuardian]);
+
+    // Release the stale fetch last; it must not have masked the fresh result.
+    resolveStale?.({ guardians: [] });
+    expect(await stale).toEqual([]);
+    expect(countCalls(METHOD)).toBe(2);
+  });
 });
 
 describe("selectors", () => {

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -30,6 +30,9 @@ import type {
  * Returns true when a guardian channel was found and revoked, false otherwise.
  */
 export function revokeGuardianBinding(channel: string): boolean {
+  // Local-store read, not the gateway: this read selects the row that the
+  // updateChannelStatus write below mutates, so it must stay transactionally
+  // consistent with that write. Leave for Combo 11 / gateway-bootstrap-binding.
   const guardian = findGuardianForChannel(channel);
   if (!guardian) return false;
 

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -1,0 +1,145 @@
+/**
+ * Gateway-backed guardian binding + delivery reader.
+ *
+ * Resolves the active guardian binding(s) and their per-channel delivery
+ * endpoints from the gateway via the `resolve_guardian_delivery` IPC route,
+ * validating the response against {@link ResolveGuardianDeliveryResponseSchema}.
+ *
+ * Guardian binding is near-static — it only changes on guardian onboarding /
+ * verification or revocation — yet this reader sits on many hot paths. To keep
+ * those paths off the IPC, results are cached behind a minutes-scale TTL,
+ * cleared event-driven via {@link invalidateGuardianDeliveryCache} (subscribed
+ * to contact mutations, and called explicitly by guardian-binding mutations),
+ * and coalesced single-flight so a cold cache storms the gateway at most once.
+ *
+ * Returns `null` on ANY failure (transport failure, malformed shape, timeout,
+ * or thrown error); failures are NOT cached, so a recovered gateway is retried
+ * on the next call.
+ */
+
+import {
+  type GuardianDelivery,
+  ResolveGuardianDeliveryResponseSchema,
+} from "@vellumai/gateway-client";
+
+import { ipcCall } from "../ipc/gateway-client.js";
+import { onContactChange } from "./contact-events.js";
+
+// Short IPC timeout so the read resolves promptly rather than stalling a hot
+// path on a gateway that accepts the socket but hangs.
+const GUARDIAN_DELIVERY_IPC_TIMEOUT_MS = 2_000;
+
+// Guardian binding is near-static, so a minutes-scale TTL is safe; freshness is
+// driven primarily by event-based invalidation, not by this backstop expiry.
+const GUARDIAN_DELIVERY_CACHE_TTL_MS = 300_000;
+
+interface CacheEntry {
+  guardians: GuardianDelivery[];
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inFlight = new Map<string, Promise<GuardianDelivery[] | null>>();
+
+// Bumped on every invalidation. A fetch captures the generation when it starts
+// and only writes its result to the cache if the generation is unchanged on
+// resolve, so an invalidation mid-flight can't repopulate a stale pre-change
+// result and mask a guardian-binding change.
+let cacheGeneration = 0;
+
+function cacheKey(channelTypes?: string[]): string {
+  if (!channelTypes || channelTypes.length === 0) return "ALL";
+  return [...channelTypes].sort().join(",");
+}
+
+async function fetchGuardianDelivery(
+  input: { channelTypes?: string[] },
+): Promise<GuardianDelivery[] | null> {
+  try {
+    const result = await ipcCall(
+      "resolve_guardian_delivery",
+      input,
+      GUARDIAN_DELIVERY_IPC_TIMEOUT_MS,
+    );
+    if (!result) return null;
+
+    const parsed = ResolveGuardianDeliveryResponseSchema.safeParse(result);
+    return parsed.success ? parsed.data.guardians : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve active guardian deliveries, optionally filtered by channel type.
+ * Returns the cached list when fresh, otherwise fetches (single-flight) and
+ * caches on success. Returns `null` on failure without caching.
+ */
+export async function getGuardianDelivery(
+  input?: { channelTypes?: string[] },
+): Promise<GuardianDelivery[] | null> {
+  const key = cacheKey(input?.channelTypes);
+
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < GUARDIAN_DELIVERY_CACHE_TTL_MS) {
+    return cached.guardians;
+  }
+
+  const pending = inFlight.get(key);
+  if (pending) return pending;
+
+  const startGen = cacheGeneration;
+  const promise = fetchGuardianDelivery(input ?? {})
+    .then((guardians) => {
+      // Skip the write if an invalidation fired during the fetch: the result
+      // may predate the change. Return it to this caller (freshest it has) but
+      // leave the cache empty so the next call re-fetches.
+      if (guardians && cacheGeneration === startGen) {
+        cache.set(key, { guardians, fetchedAt: Date.now() });
+      }
+      return guardians;
+    })
+    .finally(() => {
+      inFlight.delete(key);
+    });
+
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/**
+ * Clear ALL cached guardian deliveries. Called event-driven on contact
+ * mutations, and must also be called from guardian-binding mutation sites
+ * (gateway onboarding / verification / revocation) so the next read refetches.
+ */
+export function invalidateGuardianDeliveryCache(): void {
+  cacheGeneration += 1;
+  cache.clear();
+  inFlight.clear();
+}
+
+onContactChange(invalidateGuardianDeliveryCache);
+
+/** First active guardian delivery for the given channel type, if any. */
+export function guardianForChannel(
+  list: GuardianDelivery[],
+  channelType: string,
+): GuardianDelivery | undefined {
+  return list.find(
+    (g) => g.channelType === channelType && g.status === "active",
+  );
+}
+
+/** First guardian delivery overall — the `listGuardianChannels` fallback. */
+export function anyGuardian(
+  list: GuardianDelivery[],
+): GuardianDelivery | undefined {
+  return list[0];
+}
+
+/** Test-only: reset cache + in-flight state for deterministic test runs. */
+export function __resetGuardianDeliveryCacheForTest(): void {
+  cache.clear();
+  inFlight.clear();
+  cacheGeneration = 0;
+}

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -7,10 +7,13 @@
  *
  * Guardian binding is near-static — it only changes on guardian onboarding /
  * verification or revocation — yet this reader sits on many hot paths. To keep
- * those paths off the IPC, results are cached behind a minutes-scale TTL,
- * cleared event-driven via {@link invalidateGuardianDeliveryCache} (subscribed
- * to contact mutations, and called explicitly by guardian-binding mutations),
- * and coalesced single-flight so a cold cache storms the gateway at most once.
+ * those paths off the IPC, results are cached behind a minutes-scale TTL and
+ * coalesced single-flight so a cold cache storms the gateway at most once.
+ *
+ * Freshness comes from two sources: the {@link invalidateGuardianDeliveryCache}
+ * subscription to `onContactChange` (contact mutations clear the cache), and
+ * {@link getGuardianDeliveryFresh} reads on existence guards (gateway-side
+ * binding writes don't invalidate the daemon cache, so those paths read fresh).
  *
  * Returns `null` on ANY failure (transport failure, malformed shape, timeout,
  * or thrown error); failures are NOT cached, so a recovered gateway is retried
@@ -70,22 +73,15 @@ async function fetchGuardianDelivery(
   }
 }
 
-/**
- * Resolve active guardian deliveries, optionally filtered by channel type.
- * Returns the cached list when fresh, otherwise fetches (single-flight) and
- * caches on success. Returns `null` on failure without caching.
- *
- * Pass `forceRefresh` to bypass the cached entry and fetch fresh — still
- * single-flight, and still populates the cache with the fresh result. Used by
- * existence guards, since gateway-side binding writes don't invalidate the
- * daemon cache.
- */
-export async function getGuardianDelivery(
-  input?: { channelTypes?: string[]; forceRefresh?: boolean },
+// Shared fetch path for both the cached and fresh public surfaces. When
+// `forceRefresh` is set the cached entry is bypassed; the read is still
+// single-flight and still populates the cache with the fresh result.
+async function readGuardianDelivery(
+  input: { channelTypes?: string[]; forceRefresh?: boolean },
 ): Promise<GuardianDelivery[] | null> {
-  const key = cacheKey(input?.channelTypes);
+  const key = cacheKey(input.channelTypes);
 
-  if (!input?.forceRefresh) {
+  if (!input.forceRefresh) {
     const cached = cache.get(key);
     if (
       cached &&
@@ -99,7 +95,7 @@ export async function getGuardianDelivery(
   if (pending) return pending;
 
   const startGen = cacheGeneration;
-  const promise = fetchGuardianDelivery({ channelTypes: input?.channelTypes })
+  const promise = fetchGuardianDelivery({ channelTypes: input.channelTypes })
     .then((guardians) => {
       // Skip the write if an invalidation fired during the fetch: the result
       // may predate the change. Return it to this caller (freshest it has) but
@@ -115,6 +111,20 @@ export async function getGuardianDelivery(
 
   inFlight.set(key, promise);
   return promise;
+}
+
+/**
+ * Resolve active guardian deliveries, optionally filtered by channel type.
+ * Returns the cached list when fresh, otherwise fetches (single-flight) and
+ * caches on success. Returns `null` on failure without caching.
+ *
+ * To force an uncached read, call {@link getGuardianDeliveryFresh} — the only
+ * public fresh-read entry point.
+ */
+export async function getGuardianDelivery(
+  input?: { channelTypes?: string[] },
+): Promise<GuardianDelivery[] | null> {
+  return readGuardianDelivery({ channelTypes: input?.channelTypes });
 }
 
 /**
@@ -140,17 +150,21 @@ export function peekCachedGuardianDelivery(
 /**
  * Fresh (uncached) variant of {@link getGuardianDelivery}. Existence guards read
  * fresh because gateway-side binding writes don't invalidate the daemon cache.
+ * Still single-flight, and still populates the cache with the fresh result.
  */
 export async function getGuardianDeliveryFresh(
   input?: { channelTypes?: string[] },
 ): Promise<GuardianDelivery[] | null> {
-  return getGuardianDelivery({ ...input, forceRefresh: true });
+  return readGuardianDelivery({
+    channelTypes: input?.channelTypes,
+    forceRefresh: true,
+  });
 }
 
 /**
- * Clear ALL cached guardian deliveries. Called event-driven on contact
- * mutations, and must also be called from guardian-binding mutation sites
- * (gateway onboarding / verification / revocation) so the next read refetches.
+ * Clear ALL cached guardian deliveries. Subscribed to `onContactChange` so
+ * contact mutations refetch on the next read; also exported for any caller that
+ * wants to invalidate explicitly.
  */
 export function invalidateGuardianDeliveryCache(): void {
   cacheGeneration += 1;
@@ -175,6 +189,20 @@ export function anyGuardian(
   list: GuardianDelivery[],
 ): GuardianDelivery | undefined {
   return list[0];
+}
+
+/**
+ * Resolve a guardian displayName for voice surfaces: prefer the phone-channel
+ * guardian, falling back to any guardian. Returns `undefined` when the list is
+ * absent or no guardian carries a displayName.
+ */
+export function voiceGuardianDisplayName(
+  list: GuardianDelivery[] | null,
+): string | undefined {
+  const guardian = list
+    ? (guardianForChannel(list, "phone") ?? anyGuardian(list))
+    : undefined;
+  return guardian?.displayName ?? undefined;
 }
 
 /** Test-only: reset cache + in-flight state for deterministic test runs. */

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -42,7 +42,12 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
-const inFlight = new Map<string, Promise<GuardianDelivery[] | null>>();
+// Tracks whether the in-flight fetch was a force-refresh, so a fresh read never
+// coalesces with an older non-force fetch that may predate a gateway-side write.
+const inFlight = new Map<
+  string,
+  { promise: Promise<GuardianDelivery[] | null>; fresh: boolean }
+>();
 
 // Bumped on every invalidation. A fetch captures the generation when it starts
 // and only writes its result to the cache if the generation is unchanged on
@@ -91,8 +96,11 @@ async function readGuardianDelivery(
     }
   }
 
+  // A non-force read may coalesce with any in-flight fetch. A force read may
+  // only coalesce with another force fetch — never with a non-force fetch that
+  // could have started before a gateway-side binding write and resolve stale.
   const pending = inFlight.get(key);
-  if (pending) return pending;
+  if (pending && (!input.forceRefresh || pending.fresh)) return pending.promise;
 
   const startGen = cacheGeneration;
   const promise = fetchGuardianDelivery({ channelTypes: input.channelTypes })
@@ -106,10 +114,12 @@ async function readGuardianDelivery(
       return guardians;
     })
     .finally(() => {
-      inFlight.delete(key);
+      // Only clear the slot if it still holds this fetch — a concurrent force
+      // read may have replaced a non-force entry (or vice versa).
+      if (inFlight.get(key)?.promise === promise) inFlight.delete(key);
     });
 
-  inFlight.set(key, promise);
+  inFlight.set(key, { promise, fresh: !!input.forceRefresh });
   return promise;
 }
 

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -74,22 +74,32 @@ async function fetchGuardianDelivery(
  * Resolve active guardian deliveries, optionally filtered by channel type.
  * Returns the cached list when fresh, otherwise fetches (single-flight) and
  * caches on success. Returns `null` on failure without caching.
+ *
+ * Pass `forceRefresh` to bypass the cached entry and fetch fresh — still
+ * single-flight, and still populates the cache with the fresh result. Used by
+ * existence guards, since gateway-side binding writes don't invalidate the
+ * daemon cache.
  */
 export async function getGuardianDelivery(
-  input?: { channelTypes?: string[] },
+  input?: { channelTypes?: string[]; forceRefresh?: boolean },
 ): Promise<GuardianDelivery[] | null> {
   const key = cacheKey(input?.channelTypes);
 
-  const cached = cache.get(key);
-  if (cached && Date.now() - cached.fetchedAt < GUARDIAN_DELIVERY_CACHE_TTL_MS) {
-    return cached.guardians;
+  if (!input?.forceRefresh) {
+    const cached = cache.get(key);
+    if (
+      cached &&
+      Date.now() - cached.fetchedAt < GUARDIAN_DELIVERY_CACHE_TTL_MS
+    ) {
+      return cached.guardians;
+    }
   }
 
   const pending = inFlight.get(key);
   if (pending) return pending;
 
   const startGen = cacheGeneration;
-  const promise = fetchGuardianDelivery(input ?? {})
+  const promise = fetchGuardianDelivery({ channelTypes: input?.channelTypes })
     .then((guardians) => {
       // Skip the write if an invalidation fired during the fetch: the result
       // may predate the change. Return it to this caller (freshest it has) but
@@ -105,6 +115,16 @@ export async function getGuardianDelivery(
 
   inFlight.set(key, promise);
   return promise;
+}
+
+/**
+ * Fresh (uncached) variant of {@link getGuardianDelivery}. Existence guards read
+ * fresh because gateway-side binding writes don't invalidate the daemon cache.
+ */
+export async function getGuardianDeliveryFresh(
+  input?: { channelTypes?: string[] },
+): Promise<GuardianDelivery[] | null> {
+  return getGuardianDelivery({ ...input, forceRefresh: true });
 }
 
 /**

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -118,6 +118,26 @@ export async function getGuardianDelivery(
 }
 
 /**
+ * Synchronous read of the already-cached guardian deliveries, without any IO.
+ *
+ * Returns the fresh cached list for the given channel filter, or `undefined`
+ * when the cache is cold or expired. Used by sync hot paths (SSE subscribe)
+ * that cannot await {@link getGuardianDelivery} but must resolve the SAME
+ * gateway-owned principal the async paths land on. A cold/expired return lets
+ * the caller fall back to the local store as before.
+ */
+export function peekCachedGuardianDelivery(
+  input?: { channelTypes?: string[] },
+): GuardianDelivery[] | undefined {
+  const cached = cache.get(cacheKey(input?.channelTypes));
+  if (!cached) return undefined;
+  if (Date.now() - cached.fetchedAt >= GUARDIAN_DELIVERY_CACHE_TTL_MS) {
+    return undefined;
+  }
+  return cached.guardians;
+}
+
+/**
  * Fresh (uncached) variant of {@link getGuardianDelivery}. Existence guards read
  * fresh because gateway-side binding writes don't invalidate the daemon cache.
  */

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -28,6 +28,7 @@ import {
   findActiveSession,
   getGuardianBinding,
   getPendingSession,
+  isGuardianBoundForChannel,
   revokeBinding,
   revokePendingSessions,
   updateSessionDelivery,
@@ -80,19 +81,18 @@ export function getReadinessService(): ChannelReadinessService {
 // Extracted business logic functions
 // ---------------------------------------------------------------------------
 
-export function createInboundChallenge(
+export async function createInboundChallenge(
   channel?: ChannelId,
   rebind?: boolean,
   conversationId?: string,
-): ChannelVerificationSessionResult {
-  const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+): Promise<ChannelVerificationSessionResult> {
   const resolvedChannel = channel ?? "telegram";
 
-  const existingBinding = getGuardianBinding(
-    resolvedAssistantId,
-    resolvedChannel,
-  );
-  if (existingBinding && !rebind) {
+  // Gateway-backed presence guard: block re-binding when a guardian is already
+  // bound. Null-list (gateway unreachable) is treated as bound, so a transient
+  // miss blocks rather than letting a second binding through.
+  const alreadyBound = await isGuardianBoundForChannel(resolvedChannel);
+  if (alreadyBound && !rebind) {
     return {
       success: false,
       error: "already_bound",
@@ -579,7 +579,7 @@ export async function handleChannelVerificationSession(
           ...publicResult,
         });
       } else {
-        const result = createInboundChallenge(
+        const result = await createInboundChallenge(
           channel,
           msg.rebind,
           msg.conversationId,

--- a/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
@@ -36,7 +36,7 @@ mock.module("../../config/env.js", () => ({
 }));
 
 mock.module("../../runtime/local-actor-identity.js", () => ({
-  findLocalGuardianPrincipalId: () => fakeLocalPrincipalId,
+  findLocalGuardianPrincipalIdFromStore: () => fakeLocalPrincipalId,
 }));
 
 // ── Real imports (after mocks) ────────────────────────────────────────────

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -33,7 +33,7 @@ import { createServer, type Server, type Socket } from "node:net";
 
 import { ensureSocketDir, SocketWatchdog } from "@vellumai/ipc-server-utils";
 
-import { findLocalGuardianPrincipalId } from "../runtime/local-actor-identity.js";
+import { findLocalGuardianPrincipalIdFromStore } from "../runtime/local-actor-identity.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/index.js";
 import type {
@@ -637,7 +637,7 @@ function injectLocalActorHeader(
   // that require the header will fail-closed on their own.
   let localActor: string | undefined;
   try {
-    localActor = findLocalGuardianPrincipalId();
+    localActor = findLocalGuardianPrincipalIdFromStore();
   } catch (err) {
     log.debug(
       { err },

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -27,14 +27,22 @@ mock.module("../copy-composer.js", () => ({
   composeFallbackCopy: () => composeFallbackReturn,
 }));
 
-mock.module("../destination-resolver.js", () => ({
-  resolveDestinations: (channels: string[]) => {
-    const map = new Map<string, ChannelDestination>();
-    for (const ch of channels) {
-      map.set(ch, { channel: ch as ChannelDestination["channel"] });
-    }
-    return map;
-  },
+// Stub only getGuardianDelivery; keep the real selectors so this mock is
+// harmless if it leaks into destination-resolver.test.ts under a shared run.
+const realGuardianReader = await import(
+  "../../contacts/guardian-delivery-reader.js"
+);
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  ...realGuardianReader,
+  getGuardianDelivery: async () => null,
+}));
+
+// Use the real destination-resolver (DB-free via the local-read stub below)
+// so this mock does not leak into destination-resolver.test.ts under a shared
+// bun-test invocation. With no guardian, the resolver still yields a vellum
+// destination, which is all these tests exercise.
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => null,
 }));
 
 mock.module("../conversation-pairing.js", () => ({

--- a/assistant/src/notifications/__tests__/connected-channels.test.ts
+++ b/assistant/src/notifications/__tests__/connected-channels.test.ts
@@ -2,9 +2,10 @@
  * Tests for getConnectedChannels connectivity resolution.
  *
  * Connectivity must mirror destination-resolver's `resolveGuardian`:
- * gateway-first, with a LOCAL contacts fallback only when the gateway list is
- * null (unreachable). This keeps a channel from being marked connected when it
- * can't be delivered (and vice-versa).
+ * gateway-first, with a LOCAL contacts fallback on ANY per-channel no-match
+ * (gateway list null OR no active gateway entry for the channel). This keeps a
+ * channel from being marked connected when it can't be delivered (and
+ * vice-versa).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -82,14 +83,15 @@ describe("getConnectedChannels gateway-first-then-local connectivity", () => {
     expect(await getConnectedChannels()).not.toContain("telegram");
   });
 
-  test("does not fall back to local when the gateway responds without that channel", async () => {
-    // Gateway present but empty for telegram ⇒ gateway is authoritative, no
-    // per-channel local fallback (mirrors destination-resolver).
+  test("falls back to local when the gateway responds without that channel", async () => {
+    // Gateway present but with no active telegram entry ⇒ per-channel no-match,
+    // so connectivity falls back to the local mirror (mirrors
+    // destination-resolver's per-channel fallback).
     deliverableChannels = ["telegram"];
     gatewayGuardians = [];
     localChatId = "789";
 
-    expect(await getConnectedChannels()).not.toContain("telegram");
+    expect(await getConnectedChannels()).toContain("telegram");
   });
 
   test("only marks slack connected for D-prefixed (DM) chat IDs", async () => {

--- a/assistant/src/notifications/__tests__/connected-channels.test.ts
+++ b/assistant/src/notifications/__tests__/connected-channels.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for getConnectedChannels connectivity resolution.
+ *
+ * Connectivity must mirror destination-resolver's `resolveGuardian`:
+ * gateway-first, with a LOCAL contacts fallback only when the gateway list is
+ * null (unreachable). This keeps a channel from being marked connected when it
+ * can't be delivered (and vice-versa).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  truncateForLog: (value: string) => value,
+}));
+
+let deliverableChannels: string[] = [];
+let gatewayGuardians: GuardianDelivery[] | null = null;
+let localChatId: string | null = null;
+
+const realConfig = await import("../../channels/config.js");
+
+mock.module("../../channels/config.js", () => ({
+  ...realConfig,
+  getDeliverableChannels: () => deliverableChannels,
+}));
+
+const realReader = await import("../../contacts/guardian-delivery-reader.js");
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  ...realReader,
+  getGuardianDelivery: async () => gatewayGuardians,
+}));
+
+const realContactStore = await import("../../contacts/contact-store.js");
+
+mock.module("../../contacts/contact-store.js", () => ({
+  ...realContactStore,
+  findGuardianForChannel: (_channelType: string) =>
+    localChatId === null
+      ? null
+      : { contact: { principalId: "p1" }, channel: { externalChatId: localChatId } },
+}));
+
+const { getConnectedChannels } = await import("../emit-signal.js");
+
+function gatewayBinding(channelType: string, externalChatId: string): GuardianDelivery {
+  return { channelType, contactId: "c1", address: "addr", externalChatId, status: "active" };
+}
+
+beforeEach(() => {
+  deliverableChannels = [];
+  gatewayGuardians = null;
+  localChatId = null;
+});
+
+describe("getConnectedChannels gateway-first-then-local connectivity", () => {
+  test("marks telegram connected from a gateway-only binding", async () => {
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = [gatewayBinding("telegram", "123")];
+    localChatId = null;
+
+    expect(await getConnectedChannels()).toContain("telegram");
+  });
+
+  test("falls back to a local binding when the gateway is unreachable (null)", async () => {
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = null;
+    localChatId = "456";
+
+    expect(await getConnectedChannels()).toContain("telegram");
+  });
+
+  test("marks telegram disconnected when neither source has a binding", async () => {
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = null;
+    localChatId = null;
+
+    expect(await getConnectedChannels()).not.toContain("telegram");
+  });
+
+  test("does not fall back to local when the gateway responds without that channel", async () => {
+    // Gateway present but empty for telegram ⇒ gateway is authoritative, no
+    // per-channel local fallback (mirrors destination-resolver).
+    deliverableChannels = ["telegram"];
+    gatewayGuardians = [];
+    localChatId = "789";
+
+    expect(await getConnectedChannels()).not.toContain("telegram");
+  });
+
+  test("only marks slack connected for D-prefixed (DM) chat IDs", async () => {
+    deliverableChannels = ["slack"];
+    gatewayGuardians = [gatewayBinding("slack", "C-public")];
+    expect(await getConnectedChannels()).not.toContain("slack");
+
+    gatewayGuardians = [gatewayBinding("slack", "D-dm")];
+    expect(await getConnectedChannels()).toContain("slack");
+  });
+
+  test("always reports vellum and platform connected", async () => {
+    deliverableChannels = ["vellum", "platform"];
+    gatewayGuardians = null;
+
+    const connected = await getConnectedChannels();
+    expect(connected).toContain("vellum");
+    expect(connected).toContain("platform");
+  });
+});

--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -34,19 +34,38 @@ mock.module("../../prompts/system-prompt.js", () => ({
   buildCoreIdentityContext: () => null,
 }));
 
-mock.module("../../contacts/contact-store.js", () => ({
-  listGuardianChannels: () => null,
+// Guardian binding (ACL) is resolved via the gateway pull; notes (INFO) are
+// joined locally by contactId. Tests drive both via mutable slots.
+let guardianDeliveryFixture: Array<{ contactId: string }> = [];
+let contactInfoFixture: Record<string, { notes: string | null } | null> = {};
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => guardianDeliveryFixture,
+  anyGuardian: (list: Array<{ contactId: string }>) => list[0],
 }));
 
-// Provider mock — if `getConfiguredProvider` is ever called by the
-// assistant_tool pass-through path, this throw makes the test fail
-// loudly instead of silently exercising the LLM path.
+mock.module("../../contacts/contact-store.js", () => ({
+  findContactInfoById: (contactId: string) =>
+    contactInfoFixture[contactId] ?? null,
+}));
+
+// Provider mock. By default `sendMessage` throws so the assistant_tool
+// pass-through path (which must skip the LLM) fails loudly if it reaches the
+// provider. LLM-path tests override `providerSendMessage` to capture inputs.
+let providerSendMessage: (
+  messages: unknown[],
+  opts: { systemPrompt?: string },
+) => Promise<unknown> = () => {
+  throw new Error(
+    "provider.sendMessage should NOT be invoked for assistant_tool pass-through",
+  );
+};
+
 mock.module("../../providers/provider-send-message.js", () => ({
-  getConfiguredProvider: async () => {
-    throw new Error(
-      "getConfiguredProvider should NOT be invoked for assistant_tool pass-through",
-    );
-  },
+  getConfiguredProvider: async () => ({
+    sendMessage: (messages: unknown[], opts: { systemPrompt?: string }) =>
+      providerSendMessage(messages, opts),
+  }),
   createTimeout: () => ({
     signal: new AbortController().signal,
     cleanup: () => {},
@@ -279,5 +298,55 @@ describe("assistant_tool pass-through in notification decision engine", () => {
 
     expect(decision.selectedChannels).toEqual(["vellum"]);
     expect(decision.renderedCopy.vellum?.body).toBe("fyi");
+  });
+});
+
+describe("recipient notes injection (ACL from gateway, notes joined locally)", () => {
+  function makeLlmSignal(): NotificationSignal {
+    return {
+      signalId: "sig-llm-notes-1",
+      createdAt: Date.now(),
+      sourceChannel: "scheduler",
+      sourceContextId: "schedule-1",
+      sourceEventName: "schedule.notify",
+      contextPayload: {},
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+    };
+  }
+
+  test("injects the guardian's local notes, resolved via the gateway contactId", async () => {
+    guardianDeliveryFixture = [{ contactId: "contact-42" }];
+    contactInfoFixture = { "contact-42": { notes: "Prefers terse updates." } };
+
+    let capturedSystemPrompt: string | undefined;
+    providerSendMessage = async (_messages, opts) => {
+      capturedSystemPrompt = opts.systemPrompt;
+      return {};
+    };
+
+    await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
+
+    expect(capturedSystemPrompt).toContain("<recipient-context>");
+    expect(capturedSystemPrompt).toContain("Prefers terse updates.");
+  });
+
+  test("omits recipient context when no guardian is bound", async () => {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+
+    let capturedSystemPrompt: string | undefined;
+    providerSendMessage = async (_messages, opts) => {
+      capturedSystemPrompt = opts.systemPrompt;
+      return {};
+    };
+
+    await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
+
+    expect(capturedSystemPrompt).not.toContain("<recipient-context>");
   });
 });

--- a/assistant/src/notifications/__tests__/destination-resolver.test.ts
+++ b/assistant/src/notifications/__tests__/destination-resolver.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Verifies resolveDestinations resolves guardian delivery endpoints from the
+ * gateway-provided guardian list, with shapes identical to the local read, and
+ * falls back to the local contacts read when the list is null.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Local fallback read; mocked so the null-list path is deterministic.
+let localGuardian:
+  | { contact: { principalId?: string }; channel: { address: string; externalChatId?: string } }
+  | null = null;
+
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (_channelType: string) => localGuardian,
+}));
+
+const { resolveDestinations } = await import("../destination-resolver.js");
+
+function guardian(
+  overrides: Partial<GuardianDelivery> & Pick<GuardianDelivery, "channelType" | "address">,
+): GuardianDelivery {
+  return {
+    contactId: "contact-1",
+    status: "active",
+    ...overrides,
+  } as GuardianDelivery;
+}
+
+describe("resolveDestinations — gateway guardian list", () => {
+  beforeEach(() => {
+    localGuardian = null;
+  });
+
+  test("vellum carries guardianPrincipalId from the gateway list", () => {
+    const list = [
+      guardian({ channelType: "vellum", address: "user@example.com", principalId: "prin-1" }),
+    ];
+    const result = resolveDestinations(["vellum"], list);
+    expect(result.get("vellum")).toEqual({
+      channel: "vellum",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+
+  test("platform carries guardianPrincipalId from the vellum guardian", () => {
+    const list = [
+      guardian({ channelType: "vellum", address: "user@example.com", principalId: "prin-1" }),
+    ];
+    const result = resolveDestinations(["platform"], list);
+    expect(result.get("platform")).toEqual({
+      channel: "platform",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+
+  test("telegram resolves endpoint and binding context", () => {
+    const list = [
+      guardian({
+        channelType: "telegram",
+        address: "tg-user",
+        externalChatId: "12345",
+      }),
+    ];
+    const result = resolveDestinations(["telegram"], list);
+    expect(result.get("telegram")).toEqual({
+      channel: "telegram",
+      endpoint: "12345",
+      metadata: { externalUserId: "tg-user" },
+      bindingContext: {
+        sourceChannel: "telegram",
+        externalChatId: "12345",
+        externalUserId: "tg-user",
+      },
+    });
+  });
+
+  test("telegram without externalChatId is omitted", () => {
+    const list = [guardian({ channelType: "telegram", address: "tg-user" })];
+    const result = resolveDestinations(["telegram"], list);
+    expect(result.has("telegram")).toBe(false);
+  });
+
+  test("slack resolves DM endpoint and binding context", () => {
+    const list = [
+      guardian({
+        channelType: "slack",
+        address: "slack-user",
+        externalChatId: "D123",
+      }),
+    ];
+    const result = resolveDestinations(["slack"], list);
+    expect(result.get("slack")).toEqual({
+      channel: "slack",
+      endpoint: "D123",
+      metadata: { externalUserId: "slack-user" },
+      bindingContext: {
+        sourceChannel: "slack",
+        externalChatId: "D123",
+        externalUserId: "slack-user",
+      },
+    });
+  });
+
+  test("slack non-DM channel is dropped", () => {
+    const list = [
+      guardian({
+        channelType: "slack",
+        address: "slack-user",
+        externalChatId: "C123",
+      }),
+    ];
+    const result = resolveDestinations(["slack"], list);
+    expect(result.has("slack")).toBe(false);
+  });
+
+  test("inactive guardian is ignored", () => {
+    const list = [
+      guardian({
+        channelType: "telegram",
+        address: "tg-user",
+        externalChatId: "12345",
+        status: "revoked",
+      }),
+    ];
+    const result = resolveDestinations(["telegram"], list);
+    expect(result.has("telegram")).toBe(false);
+  });
+});
+
+describe("resolveDestinations — null list falls back to local read", () => {
+  beforeEach(() => {
+    localGuardian = null;
+  });
+
+  test("telegram resolves from the local contacts read", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "tg-user", externalChatId: "12345" },
+    };
+    const result = resolveDestinations(["telegram"], null);
+    expect(result.get("telegram")).toEqual({
+      channel: "telegram",
+      endpoint: "12345",
+      metadata: { externalUserId: "tg-user" },
+      bindingContext: {
+        sourceChannel: "telegram",
+        externalChatId: "12345",
+        externalUserId: "tg-user",
+      },
+    });
+  });
+
+  test("slack DM resolves from the local contacts read", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "slack-user", externalChatId: "D123" },
+    };
+    const result = resolveDestinations(["slack"], null);
+    expect(result.get("slack")).toEqual({
+      channel: "slack",
+      endpoint: "D123",
+      metadata: { externalUserId: "slack-user" },
+      bindingContext: {
+        sourceChannel: "slack",
+        externalChatId: "D123",
+        externalUserId: "slack-user",
+      },
+    });
+  });
+
+  test("vellum carries principalId from the local contacts read", () => {
+    localGuardian = {
+      contact: { principalId: "prin-1" },
+      channel: { address: "user@example.com" },
+    };
+    const result = resolveDestinations(["vellum"], null);
+    expect(result.get("vellum")).toEqual({
+      channel: "vellum",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+});
+
+describe("resolveDestinations — gateway yields no channel match falls back to local", () => {
+  beforeEach(() => {
+    localGuardian = null;
+  });
+
+  test("empty gateway list falls back to local telegram binding", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "tg-user", externalChatId: "12345" },
+    };
+    const result = resolveDestinations(["telegram"], []);
+    expect(result.get("telegram")).toEqual({
+      channel: "telegram",
+      endpoint: "12345",
+      metadata: { externalUserId: "tg-user" },
+      bindingContext: {
+        sourceChannel: "telegram",
+        externalChatId: "12345",
+        externalUserId: "tg-user",
+      },
+    });
+  });
+
+  test("gateway list missing the channel falls back to local slack DM", () => {
+    localGuardian = {
+      contact: {},
+      channel: { address: "slack-user", externalChatId: "D123" },
+    };
+    // Gateway returns a telegram guardian but no slack entry.
+    const list = [
+      guardian({ channelType: "telegram", address: "tg", externalChatId: "999" }),
+    ];
+    const result = resolveDestinations(["slack"], list);
+    expect(result.get("slack")).toEqual({
+      channel: "slack",
+      endpoint: "D123",
+      metadata: { externalUserId: "slack-user" },
+      bindingContext: {
+        sourceChannel: "slack",
+        externalChatId: "D123",
+        externalUserId: "slack-user",
+      },
+    });
+  });
+
+  test("empty gateway list falls back to local vellum principalId", () => {
+    localGuardian = {
+      contact: { principalId: "prin-1" },
+      channel: { address: "user@example.com" },
+    };
+    const result = resolveDestinations(["vellum"], []);
+    expect(result.get("vellum")).toEqual({
+      channel: "vellum",
+      metadata: { guardianPrincipalId: "prin-1" },
+    });
+  });
+
+  test("empty gateway list with no local binding omits telegram", () => {
+    localGuardian = null;
+    const result = resolveDestinations(["telegram"], []);
+    expect(result.has("telegram")).toBe(false);
+  });
+});

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -11,6 +11,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
 import { getConversation } from "../memory/conversation-crud.js";
 import type { ApprovalUIMetadata } from "../runtime/channel-approval-types.js";
 import { getLogger } from "../util/logger.js";
@@ -171,7 +172,13 @@ export class NotificationBroadcaster {
     decision: NotificationDecision,
     options?: BroadcastDecisionOptions,
   ): Promise<NotificationDeliveryResult[]> {
-    const destinations = resolveDestinations(decision.selectedChannels);
+    // Pull the guardian list once so the resolver stays pure. A null list
+    // (gateway unreachable) falls back to the local contacts read.
+    const guardians = await getGuardianDelivery();
+    const destinations = resolveDestinations(
+      decision.selectedChannels,
+      guardians,
+    );
 
     // Ensure vellum is processed first so the notification_conversation_created
     // event fires immediately, before slower channel sends (e.g. Telegram 30s

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -12,7 +12,11 @@
 import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
-import { listGuardianChannels } from "../contacts/contact-store.js";
+import { findContactInfoById } from "../contacts/contact-store.js";
+import {
+  anyGuardian,
+  getGuardianDelivery,
+} from "../contacts/guardian-delivery-reader.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
 import {
   createTimeout,
@@ -963,15 +967,19 @@ async function classifyWithLLM(
     ? truncate(rawIdentityContext, MAX_IDENTITY_CONTEXT_CHARS, "\n…[truncated]")
     : undefined;
 
-  // Resolve guardian contact notes for recipient context. Use the channel-
-  // agnostic guardian lookup so notes are available even when the only
-  // deliverable channel is "vellum" (which has no contact channel type).
+  // Resolve guardian contact notes for recipient context. The guardian's
+  // identity (ACL) comes from the gateway pull, channel-agnostic so notes are
+  // available even when the only deliverable channel is "vellum". Notes (INFO)
+  // stay local and are joined by contactId.
   let recipientNotes: string | undefined;
   try {
-    const guardianResult = listGuardianChannels();
-    if (guardianResult?.contact.notes) {
+    const guardian = anyGuardian((await getGuardianDelivery()) ?? []);
+    const notes = guardian
+      ? findContactInfoById(guardian.contactId)?.notes
+      : undefined;
+    if (notes) {
       recipientNotes = truncate(
-        guardianResult.contact.notes,
+        notes,
         MAX_IDENTITY_CONTEXT_CHARS,
         "\n…[truncated]",
       );

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -1,7 +1,7 @@
 /**
  * Resolves per-channel destination endpoints for notification delivery.
  *
- * Reads guardian delivery info from the contacts table.
+ * Reads guardian delivery info from the gateway-backed guardian list.
  *
  * - Vellum: no external endpoint needed — delivery goes through the event
  *   broadcast mechanism to connected desktop/mobile clients. The
@@ -11,13 +11,53 @@
  *   sourced from the guardian contact's channel record.
  */
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
 import { isNotificationDeliverable } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import { guardianForChannel } from "../contacts/guardian-delivery-reader.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDestination, NotificationChannel } from "./types.js";
 
 const log = getLogger("destination-resolver");
+
+/** Guardian delivery endpoint for a channel, flattened from either source. */
+interface ResolvedGuardian {
+  principalId?: string;
+  address: string;
+  externalChatId?: string;
+}
+
+/**
+ * Resolve the guardian delivery endpoint for a channel: gateway list first,
+ * else the local contacts read. The local read is the transitional
+ * dual-written mirror and covers a transient gateway failure (null list) or a
+ * gateway list missing this channel, so a soft-failed gateway read does not
+ * drop a binding the local store still holds. Removed in Combo 11.
+ */
+function resolveGuardian(
+  guardians: GuardianDelivery[] | null,
+  channelType: string,
+): ResolvedGuardian | undefined {
+  const g = guardians
+    ? guardianForChannel(guardians, channelType)
+    : undefined;
+  if (g) {
+    return {
+      principalId: g.principalId ?? undefined,
+      address: g.address,
+      externalChatId: g.externalChatId ?? undefined,
+    };
+  }
+  const local = findGuardianForChannel(channelType);
+  if (!local) return undefined;
+  return {
+    principalId: local.contact.principalId ?? undefined,
+    address: local.channel.address,
+    externalChatId: local.channel.externalChatId ?? undefined,
+  };
+}
 
 /**
  * Resolve destination information for each requested channel.
@@ -26,9 +66,14 @@ const log = getLogger("destination-resolver");
  * the function skips non-deliverable channels via `isNotificationDeliverable`.
  * Returns a map keyed by `NotificationChannel`. Channels that cannot be
  * resolved (e.g. no Telegram binding configured) are omitted from the result.
+ *
+ * `guardians` is the gateway-resolved guardian list; per channel, a missing
+ * match (null list or no entry for the channel) falls back to the local
+ * contacts read for this release.
  */
 export function resolveDestinations(
   channels: readonly (ChannelId | NotificationChannel)[],
+  guardians: GuardianDelivery[] | null,
 ): Map<NotificationChannel, ChannelDestination> {
   const result = new Map<NotificationChannel, ChannelDestination>();
 
@@ -43,10 +88,10 @@ export function resolveDestinations(
         // Vellum delivery is local — no external endpoint required.
         // Include the guardianPrincipalId so the adapter can annotate
         // guardian-sensitive notifications for scoped delivery.
-        const guardianResult = findGuardianForChannel("vellum");
+        const guardian = resolveGuardian(guardians, "vellum");
         const metadata: Record<string, unknown> = {};
-        if (guardianResult) {
-          metadata.guardianPrincipalId = guardianResult.contact.principalId;
+        if (guardian?.principalId) {
+          metadata.guardianPrincipalId = guardian.principalId;
         }
         result.set("vellum", {
           channel: "vellum",
@@ -55,7 +100,7 @@ export function resolveDestinations(
         log.debug(
           {
             channel: "vellum",
-            source: "contacts",
+            source: "guardian-delivery",
             hasEndpoint: false,
           },
           "destination resolved",
@@ -63,52 +108,52 @@ export function resolveDestinations(
         break;
       }
       case "telegram": {
-        const guardianResult = findGuardianForChannel(channel);
-        if (guardianResult && guardianResult.channel.externalChatId) {
-          const externalChatId = guardianResult.channel.externalChatId;
+        const guardian = resolveGuardian(guardians, channel);
+        if (guardian?.externalChatId) {
+          const externalChatId = guardian.externalChatId;
           result.set(channel as NotificationChannel, {
             channel: channel as NotificationChannel,
             endpoint: externalChatId,
             metadata: {
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
             bindingContext: {
               sourceChannel: channel as NotificationChannel,
               externalChatId,
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
           });
         }
         log.debug(
           {
             channel,
-            source: "contacts",
-            hasEndpoint: !!guardianResult?.channel.externalChatId,
+            source: "guardian-delivery",
+            hasEndpoint: !!guardian?.externalChatId,
           },
           "destination resolved",
         );
         break;
       }
       case "slack": {
-        const guardianResult = findGuardianForChannel("slack");
-        const chatId = guardianResult?.channel.externalChatId;
+        const guardian = resolveGuardian(guardians, "slack");
+        const chatId = guardian?.externalChatId;
         // Slack bindings can originate from app_mention in shared channels.
         // Only route notifications to DM channels (IDs starting with "D")
         // to prevent leaking notifications into shared workspaces.
-        if (guardianResult && chatId && isSlackDmChannel(chatId)) {
+        if (guardian && chatId && isSlackDmChannel(chatId)) {
           result.set("slack", {
             channel: "slack",
             endpoint: chatId,
             metadata: {
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
             bindingContext: {
               sourceChannel: "slack",
               externalChatId: chatId,
-              externalUserId: guardianResult.channel.address,
+              externalUserId: guardian.address,
             },
           });
-        } else if (guardianResult && chatId) {
+        } else if (guardian && chatId) {
           log.warn(
             { channel: "slack", chatId },
             "skipping non-DM Slack channel for notification delivery",
@@ -117,7 +162,7 @@ export function resolveDestinations(
         log.debug(
           {
             channel: "slack",
-            source: "contacts",
+            source: "guardian-delivery",
             hasEndpoint: !!(chatId && isSlackDmChannel(chatId)),
           },
           "destination resolved",
@@ -128,11 +173,10 @@ export function resolveDestinations(
         // Platform delivery goes through the daemon's VellumPlatformClient —
         // no external binding needed. Include guardianPrincipalId so the
         // adapter can scope guardian-sensitive notifications.
-        const platformGuardian = findGuardianForChannel("vellum");
+        const platformGuardian = resolveGuardian(guardians, "vellum");
         const platformMeta: Record<string, unknown> = {};
-        if (platformGuardian) {
-          platformMeta.guardianPrincipalId =
-            platformGuardian.contact.principalId;
+        if (platformGuardian?.principalId) {
+          platformMeta.guardianPrincipalId = platformGuardian.principalId;
         }
         result.set("platform", {
           channel: "platform",
@@ -140,7 +184,7 @@ export function resolveDestinations(
             Object.keys(platformMeta).length > 0 ? platformMeta : undefined,
         });
         log.debug(
-          { channel: "platform", source: "contacts", hasEndpoint: false },
+          { channel: "platform", source: "guardian-delivery", hasEndpoint: false },
           "destination resolved",
         );
         break;

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -96,18 +96,20 @@ export function getBroadcaster(): NotificationBroadcaster {
 
 /**
  * Resolve a binding-based channel's delivery endpoint (externalChatId) the
- * SAME way destination-resolver's `resolveGuardian` does: gateway list when
- * present, falling back to the LOCAL contacts read only when the list is null
- * (gateway unreachable). The local fallback is removed in Combo 11. Keeping
- * connectivity aligned with delivery prevents a channel being marked connected
- * but then skipped with no destination (or vice-versa).
+ * SAME way destination-resolver's `resolveGuardian` does: gateway match first,
+ * falling back to the LOCAL contacts read on ANY per-channel no-match — gateway
+ * list null (unreachable) OR no active gateway entry for this channel. The
+ * local read is the transitional dual-written mirror, removed in Combo 11.
+ * Keeping connectivity aligned with delivery prevents a channel being marked
+ * connected but then skipped with no destination (or vice-versa).
  */
 function resolveChannelChatId(
   guardians: GuardianDelivery[] | null,
   channelType: string,
 ): string | undefined {
-  if (guardians) {
-    return guardianForChannel(guardians, channelType)?.externalChatId ?? undefined;
+  const g = guardians ? guardianForChannel(guardians, channelType) : undefined;
+  if (g) {
+    return g.externalChatId ?? undefined;
   }
   return findGuardianForChannel(channelType)?.channel.externalChatId ?? undefined;
 }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -9,10 +9,15 @@
  * propagated unless `throwOnError` is enabled.
  */
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
 import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import type { ConversationCreateType } from "../memory/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
@@ -89,8 +94,30 @@ export function getBroadcaster(): NotificationBroadcaster {
 
 // ── Connected channels resolution ──────────────────────────────────────
 
-function getConnectedChannels(): NotificationChannel[] {
+/**
+ * Resolve a binding-based channel's delivery endpoint (externalChatId) the
+ * SAME way destination-resolver's `resolveGuardian` does: gateway list when
+ * present, falling back to the LOCAL contacts read only when the list is null
+ * (gateway unreachable). The local fallback is removed in Combo 11. Keeping
+ * connectivity aligned with delivery prevents a channel being marked connected
+ * but then skipped with no destination (or vice-versa).
+ */
+function resolveChannelChatId(
+  guardians: GuardianDelivery[] | null,
+  channelType: string,
+): string | undefined {
+  if (guardians) {
+    return guardianForChannel(guardians, channelType)?.externalChatId ?? undefined;
+  }
+  return findGuardianForChannel(channelType)?.channel.externalChatId ?? undefined;
+}
+
+export async function getConnectedChannels(): Promise<NotificationChannel[]> {
   const channels: NotificationChannel[] = [];
+
+  // Guardian bindings (ACL) come from the gateway pull; null ⇒ gateway
+  // unreachable, so binding-based connectivity falls back to the local read.
+  const guardians = await getGuardianDelivery();
 
   // getDeliverableChannels() returns ChannelId[] but every returned channel
   // has deliveryEnabled: true, making it a valid NotificationChannel at
@@ -110,24 +137,20 @@ function getConnectedChannels(): NotificationChannel[] {
         channels.push(channel);
         break;
       case "telegram": {
-        // A binding-based channel is connected when the guardian has an
-        // active channel entry with a valid delivery endpoint. The
-        // externalChatId check ensures we don't report a channel as
-        // connected when the contacts record exists but lacks the
-        // delivery address the destination-resolver needs.
-        const guardian = findGuardianForChannel(channel);
-        if (guardian && guardian.channel.externalChatId) {
+        // Connected when the resolved guardian has a delivery endpoint —
+        // mirroring destination-resolver so we never mark connected what
+        // can't be delivered.
+        if (resolveChannelChatId(guardians, channel)) {
           channels.push(channel);
         }
         break;
       }
       case "slack": {
         // Slack bindings can originate from shared channels (app_mention).
-        // Only consider Slack connected when the stored chat ID is a DM
-        // channel (D-prefixed) to prevent leaking notifications.
-        const slackGuardian = findGuardianForChannel("slack");
-        const chatId = slackGuardian?.channel.externalChatId;
-        if (slackGuardian && chatId && chatId.startsWith("D")) {
+        // Only consider Slack connected when the resolved chat ID is a DM
+        // channel (D-prefixed), matching destination-resolver's DM gate.
+        const chatId = resolveChannelChatId(guardians, "slack");
+        if (chatId && chatId.startsWith("D")) {
           channels.push(channel);
         }
         break;
@@ -290,7 +313,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     }
 
     // Step 2: Evaluate the signal through the decision engine
-    const connectedChannels = getConnectedChannels();
+    const connectedChannels = await getConnectedChannels();
 
     log.debug(
       {

--- a/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
+++ b/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Gateway guardian-delivery list: null = unreachable, [] = unbound,
-// one active entry = bound.
+// Gateway guardian-delivery list: null = couldn't determine (transport failure
+// OR gateway-side resolver/DB error), [] = authoritative unbound, one active
+// entry = bound.
 let mockGuardianList: Array<Record<string, unknown>> | null = [];
 const freshCalls: Array<{ channelTypes?: string[] } | undefined> = [];
 
@@ -45,5 +46,19 @@ describe("isGuardianBoundForChannel", () => {
   test("null list (gateway unreachable) is treated as bound", async () => {
     mockGuardianList = null;
     expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+
+  test("gateway resolver error (null, not []) is treated as bound — no duplicate", async () => {
+    // A gateway-side DB/resolver error now reaches the reader as null (the
+    // handler no longer swallows it into an empty list), so the guard's
+    // null fail-safe applies and reports bound instead of mis-reading the
+    // error as "no guardian" and allowing a duplicate binding.
+    mockGuardianList = null;
+    expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+
+  test("genuine empty ([], not null) reports unbound so first-bind is allowed", async () => {
+    mockGuardianList = [];
+    expect(await isGuardianBoundForChannel("telegram")).toBe(false);
   });
 });

--- a/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
+++ b/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Gateway guardian-delivery list: null = unreachable, [] = unbound,
+// one active entry = bound.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+const freshCalls: Array<{ channelTypes?: string[] } | undefined> = [];
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  // Existence guard must read fresh (uncached) — only this variant is stubbed.
+  getGuardianDeliveryFresh: (input?: { channelTypes?: string[] }) => {
+    freshCalls.push(input);
+    return Promise.resolve(mockGuardianList);
+  },
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+const { isGuardianBoundForChannel } = await import(
+  "../channel-verification-service.js"
+);
+
+describe("isGuardianBoundForChannel", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    freshCalls.length = 0;
+  });
+
+  test("reads fresh so a stale cached empty list can't mask a present guardian", async () => {
+    await isGuardianBoundForChannel("telegram");
+    expect(freshCalls).toEqual([{ channelTypes: ["telegram"] }]);
+  });
+
+  test("returns false when no guardian is bound", async () => {
+    mockGuardianList = [];
+    expect(await isGuardianBoundForChannel("telegram")).toBe(false);
+  });
+
+  test("returns true when a guardian is bound", async () => {
+    mockGuardianList = [{ channelType: "telegram", status: "active" }];
+    expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+
+  test("null list (gateway unreachable) is treated as bound", async () => {
+    mockGuardianList = null;
+    expect(await isGuardianBoundForChannel("telegram")).toBe(true);
+  });
+});

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -13,6 +13,10 @@
 
 import type { ChannelId } from "../channels/types.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import type { ChannelStatus } from "../contacts/types.js";
 import {
   createCanonicalGuardianRequest,
@@ -70,12 +74,12 @@ export type AccessRequestResult =
  * trust anchor and only accepts source-channel contacts that match it. This
  * prevents stale or cross-assistant contacts from being bound to the request.
  *
- * This is intentionally synchronous with respect to the canonical store writes
- * and fire-and-forget for the notification signal emission.
+ * The canonical store writes complete before this resolves; the notification
+ * signal emission is fire-and-forget.
  */
-export function notifyGuardianOfAccessRequest(
+export async function notifyGuardianOfAccessRequest(
   params: AccessRequestParams,
-): AccessRequestResult {
+): Promise<AccessRequestResult> {
   const {
     canonicalAssistantId,
     sourceChannel,
@@ -103,30 +107,55 @@ export function notifyGuardianOfAccessRequest(
   let guardianBindingChannel: string | null = null;
   let guardianResolutionSource: GuardianResolutionSource = "none";
 
-  const vellumGuardian = findGuardianForChannel("vellum");
-  const assistantGuardianPrincipalId = vellumGuardian?.contact.principalId;
+  const guardians = (await getGuardianDelivery()) ?? [];
+  const vellumGuardian = guardianForChannel(guardians, "vellum");
+  const assistantGuardianPrincipalId = vellumGuardian?.principalId;
 
   // Try source-channel guardian, but only if it maps to the assistant's
-  // anchored principal. This blocks cross-assistant/stale contact selection.
-  const sourceGuardian = findGuardianForChannel(sourceChannel);
+  // anchored principal. This blocks cross-assistant/stale binding selection.
+  const sourceGuardian = guardianForChannel(guardians, sourceChannel);
   if (
     assistantGuardianPrincipalId &&
     sourceGuardian &&
-    sourceGuardian.contact.principalId === assistantGuardianPrincipalId
+    sourceGuardian.principalId === assistantGuardianPrincipalId
   ) {
-    guardianExternalUserId = sourceGuardian.channel.address;
-    guardianPrincipalId = sourceGuardian.contact.principalId;
-    guardianBindingChannel = sourceGuardian.channel.type;
+    guardianExternalUserId = sourceGuardian.address;
+    guardianPrincipalId = sourceGuardian.principalId;
+    guardianBindingChannel = sourceGuardian.channelType;
     guardianResolutionSource = "source-channel-contact";
   }
 
   // Access requests always require a principal. If source-channel resolution
   // did not match the assistant anchor, use the anchored vellum identity.
   if (!guardianPrincipalId && vellumGuardian) {
-    guardianExternalUserId = vellumGuardian.channel.address;
+    guardianExternalUserId = vellumGuardian.address;
     guardianPrincipalId = assistantGuardianPrincipalId ?? null;
     guardianBindingChannel = guardianBindingChannel ?? "vellum";
     guardianResolutionSource = "vellum-anchor";
+  }
+
+  // Fallback: gateway delivery read was empty/unavailable (restart, timeout,
+  // malformed IPC), so resolve from the LOCAL dual-written binding to avoid an
+  // undecidable request. Removed in Combo 11.
+  if (!guardianPrincipalId) {
+    const localVellum = findGuardianForChannel("vellum");
+    const localAnchorPrincipalId = localVellum?.contact.principalId;
+    const localSource = findGuardianForChannel(sourceChannel);
+    if (
+      localAnchorPrincipalId &&
+      localSource &&
+      localSource.contact.principalId === localAnchorPrincipalId
+    ) {
+      guardianExternalUserId = localSource.channel.address;
+      guardianPrincipalId = localSource.contact.principalId;
+      guardianBindingChannel = localSource.channel.type;
+      guardianResolutionSource = "source-channel-contact";
+    } else if (localVellum) {
+      guardianExternalUserId = localVellum.channel.address;
+      guardianPrincipalId = localAnchorPrincipalId ?? null;
+      guardianBindingChannel = guardianBindingChannel ?? "vellum";
+      guardianResolutionSource = "vellum-anchor";
+    }
   }
 
   log.debug(

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -12,11 +12,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
-import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../contacts/guardian-delivery-reader.js";
+import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
 import type { ChannelStatus } from "../contacts/types.js";
 import {
   createCanonicalGuardianRequest,
@@ -29,6 +25,7 @@ import {
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { GuardianResolutionSource } from "../notifications/signal.js";
 import { getLogger } from "../util/logger.js";
+import { resolveAnchoredGuardian } from "./anchored-guardian.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "./routes/channel-route-shared.js";
 
 const log = getLogger("access-request-helper");
@@ -98,65 +95,19 @@ export async function notifyGuardianOfAccessRequest(
     return { notified: false, reason: "no_sender_id" };
   }
 
-  // Resolve guardian identity with assistant-anchored strategy:
-  // 1. Ensure the assistant has a vellum guardian principal (trust anchor)
-  // 2. Use source-channel guardian only when principal matches anchor
-  // 3. Fallback to vellum guardian identity for this assistant principal
-  let guardianExternalUserId: string | null = null;
-  let guardianPrincipalId: string | null = null;
-  let guardianBindingChannel: string | null = null;
-  let guardianResolutionSource: GuardianResolutionSource = "none";
-
-  const guardians = (await getGuardianDelivery()) ?? [];
-  const vellumGuardian = guardianForChannel(guardians, "vellum");
-  const assistantGuardianPrincipalId = vellumGuardian?.principalId;
-
-  // Try source-channel guardian, but only if it maps to the assistant's
-  // anchored principal. This blocks cross-assistant/stale binding selection.
-  const sourceGuardian = guardianForChannel(guardians, sourceChannel);
-  if (
-    assistantGuardianPrincipalId &&
-    sourceGuardian &&
-    sourceGuardian.principalId === assistantGuardianPrincipalId
-  ) {
-    guardianExternalUserId = sourceGuardian.address;
-    guardianPrincipalId = sourceGuardian.principalId;
-    guardianBindingChannel = sourceGuardian.channelType;
-    guardianResolutionSource = "source-channel-contact";
-  }
-
-  // Access requests always require a principal. If source-channel resolution
-  // did not match the assistant anchor, use the anchored vellum identity.
-  if (!guardianPrincipalId && vellumGuardian) {
-    guardianExternalUserId = vellumGuardian.address;
-    guardianPrincipalId = assistantGuardianPrincipalId ?? null;
-    guardianBindingChannel = guardianBindingChannel ?? "vellum";
-    guardianResolutionSource = "vellum-anchor";
-  }
-
-  // Fallback: gateway delivery read was empty/unavailable (restart, timeout,
-  // malformed IPC), so resolve from the LOCAL dual-written binding to avoid an
-  // undecidable request. Removed in Combo 11.
-  if (!guardianPrincipalId) {
-    const localVellum = findGuardianForChannel("vellum");
-    const localAnchorPrincipalId = localVellum?.contact.principalId;
-    const localSource = findGuardianForChannel(sourceChannel);
-    if (
-      localAnchorPrincipalId &&
-      localSource &&
-      localSource.contact.principalId === localAnchorPrincipalId
-    ) {
-      guardianExternalUserId = localSource.channel.address;
-      guardianPrincipalId = localSource.contact.principalId;
-      guardianBindingChannel = localSource.channel.type;
-      guardianResolutionSource = "source-channel-contact";
-    } else if (localVellum) {
-      guardianExternalUserId = localVellum.channel.address;
-      guardianPrincipalId = localAnchorPrincipalId ?? null;
-      guardianBindingChannel = guardianBindingChannel ?? "vellum";
-      guardianResolutionSource = "vellum-anchor";
-    }
-  }
+  // Resolve guardian identity with the assistant-anchored strategy (gateway
+  // source-channel match validated against the vellum anchor, else the vellum
+  // anchor), with a LOCAL-store fallback when the gateway read is empty.
+  const anchored = resolveAnchoredGuardian({
+    guardians: await getGuardianDelivery(),
+    sourceChannel,
+    useLocalFallback: true,
+  });
+  const guardianExternalUserId = anchored?.address ?? null;
+  const guardianPrincipalId = anchored?.principalId ?? null;
+  const guardianBindingChannel = anchored?.channelType ?? null;
+  const guardianResolutionSource: GuardianResolutionSource =
+    anchored?.source ?? "none";
 
   log.debug(
     {

--- a/assistant/src/runtime/anchored-guardian.test.ts
+++ b/assistant/src/runtime/anchored-guardian.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for `resolveAnchoredGuardian`.
+ *
+ * Covers the gateway arms (source-channel match validated against the vellum
+ * anchor, vellum-anchor fallback), the LOCAL-store fallback when the gateway
+ * list is empty, and the cosmetic `requireAnchorPrincipal` guard.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+// Local store fallback is mocked so we can drive both arms deterministically.
+let localGuardians: Record<
+  string,
+  { contact: { principalId: string | null; displayName: string }; channel: { address: string; type: string } } | null
+> = {};
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (channelType: string) =>
+    localGuardians[channelType] ?? null,
+}));
+
+const { resolveAnchoredGuardian } = await import("./anchored-guardian.js");
+
+function gw(g: Partial<GuardianDelivery> & { channelType: string; address: string }): GuardianDelivery {
+  return {
+    contactId: `c-${g.channelType}`,
+    status: "active",
+    ...g,
+  };
+}
+
+afterEach(() => {
+  localGuardians = {};
+});
+
+describe("resolveAnchoredGuardian — gateway arm", () => {
+  test("source-channel guardian matching the anchor wins", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: "p-anchor", displayName: "Vellum" }),
+        gw({ channelType: "telegram", address: "tg-addr", principalId: "p-anchor", displayName: "Alice" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result).toEqual({
+      principalId: "p-anchor",
+      address: "tg-addr",
+      displayName: "Alice",
+      channelType: "telegram",
+      source: "source-channel-contact",
+    });
+  });
+
+  test("source-channel guardian NOT matching the anchor falls back to vellum-anchor", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: "p-anchor", displayName: "Vellum" }),
+        gw({ channelType: "telegram", address: "tg-addr", principalId: "p-other", displayName: "Stale" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result).toEqual({
+      principalId: "p-anchor",
+      address: "v-addr",
+      displayName: "Vellum",
+      channelType: "vellum",
+      source: "vellum-anchor",
+    });
+  });
+
+  test("no source-channel guardian falls back to vellum-anchor", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: "p-anchor", displayName: "Vellum" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result?.source).toBe("vellum-anchor");
+    expect(result?.principalId).toBe("p-anchor");
+  });
+});
+
+describe("resolveAnchoredGuardian — local fallback", () => {
+  test("gateway empty + local source-channel match returns the local record", () => {
+    localGuardians = {
+      vellum: { contact: { principalId: "p-local", displayName: "LocalVellum" }, channel: { address: "lv-addr", type: "vellum" } },
+      telegram: { contact: { principalId: "p-local", displayName: "LocalAlice" }, channel: { address: "ltg-addr", type: "telegram" } },
+    };
+    const result = resolveAnchoredGuardian({
+      guardians: null,
+      sourceChannel: "telegram",
+      useLocalFallback: true,
+    });
+    expect(result).toEqual({
+      principalId: "p-local",
+      address: "ltg-addr",
+      displayName: "LocalAlice",
+      channelType: "telegram",
+      source: "source-channel-contact",
+    });
+  });
+
+  test("gateway empty + only local vellum returns the local vellum-anchor", () => {
+    localGuardians = {
+      vellum: { contact: { principalId: "p-local", displayName: "LocalVellum" }, channel: { address: "lv-addr", type: "vellum" } },
+    };
+    const result = resolveAnchoredGuardian({
+      guardians: null,
+      sourceChannel: "telegram",
+      useLocalFallback: true,
+    });
+    expect(result?.source).toBe("vellum-anchor");
+    expect(result?.address).toBe("lv-addr");
+  });
+
+  test("gateway empty + no local + fallback disabled returns null", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: null,
+      sourceChannel: "telegram",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("nothing anywhere returns null", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [],
+      sourceChannel: "telegram",
+      useLocalFallback: true,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("resolveAnchoredGuardian — requireAnchorPrincipal (cosmetic label)", () => {
+  test("vellum guardian with a null principal degrades to null", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: null, displayName: "Vellum" }),
+      ],
+      sourceChannel: "telegram",
+      requireAnchorPrincipal: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("without requireAnchorPrincipal a null-principal vellum still resolves", () => {
+    const result = resolveAnchoredGuardian({
+      guardians: [
+        gw({ channelType: "vellum", address: "v-addr", principalId: null, displayName: "Vellum" }),
+      ],
+      sourceChannel: "telegram",
+    });
+    expect(result?.source).toBe("vellum-anchor");
+    expect(result?.principalId).toBeNull();
+  });
+});

--- a/assistant/src/runtime/anchored-guardian.ts
+++ b/assistant/src/runtime/anchored-guardian.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared anchored-guardian resolution.
+ *
+ * Resolves the guardian identity for an inbound access request using the
+ * assistant's vellum principal as the trust anchor: a source-channel guardian
+ * is only accepted when its principal matches the anchor, otherwise the vellum
+ * anchor identity is used. This blocks stale or cross-assistant contacts from
+ * being bound to a request.
+ *
+ * Gateway-first: resolves from the gateway delivery list, then falls back to
+ * the LOCAL dual-written binding when the gateway read is empty/unavailable
+ * (restart, timeout, malformed IPC). The local fallback is transitional and is
+ * removed in a later step.
+ */
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+import type { ChannelId } from "../channels/types.js";
+import { findGuardianForChannel } from "../contacts/contact-store.js";
+import { guardianForChannel } from "../contacts/guardian-delivery-reader.js";
+import type { GuardianResolutionSource } from "../notifications/signal.js";
+
+/** Resolved guardian identity, anchored on the assistant's vellum principal. */
+export interface AnchoredGuardian {
+  principalId: string | null;
+  address: string;
+  displayName: string | null;
+  channelType: string;
+  source: GuardianResolutionSource;
+}
+
+export interface ResolveAnchoredGuardianInput {
+  /** Gateway delivery list; `null` when the gateway read failed/was empty. */
+  guardians: GuardianDelivery[] | null;
+  sourceChannel: ChannelId;
+  /**
+   * Fall back to the LOCAL dual-written binding when the gateway arm resolves
+   * nothing. Access-request enables this to avoid an undecidable request; the
+   * cosmetic guardian-label path leaves it off so a missing gateway read
+   * degrades gracefully to the default reference.
+   */
+  useLocalFallback?: boolean;
+  /**
+   * Require a non-null anchor principal for the vellum-anchor arm. When the
+   * vellum guardian has no principal, return `null` instead of a vellum-anchor
+   * record. Matches the cosmetic label path, which degrades to the default
+   * reference when the anchor principal is absent.
+   */
+  requireAnchorPrincipal?: boolean;
+}
+
+/**
+ * Resolve the anchored guardian for `sourceChannel`, or `null` when none can be
+ * resolved. Gateway source-channel match → that record; gateway anchor-only →
+ * vellum-anchor; gateway empty + local has it → local fallback record.
+ */
+export function resolveAnchoredGuardian(
+  input: ResolveAnchoredGuardianInput,
+): AnchoredGuardian | null {
+  const { sourceChannel, useLocalFallback, requireAnchorPrincipal } = input;
+  const guardians = input.guardians ?? [];
+
+  const vellumGuardian = guardianForChannel(guardians, "vellum");
+  const anchorPrincipalId = vellumGuardian?.principalId;
+
+  let resolved: AnchoredGuardian | null = null;
+
+  // Source-channel guardian, but only when it maps to the assistant's anchored
+  // principal. This blocks cross-assistant/stale binding selection.
+  const sourceGuardian = guardianForChannel(guardians, sourceChannel);
+  if (
+    anchorPrincipalId &&
+    sourceGuardian &&
+    sourceGuardian.principalId === anchorPrincipalId
+  ) {
+    resolved = {
+      principalId: sourceGuardian.principalId,
+      address: sourceGuardian.address,
+      displayName: sourceGuardian.displayName ?? null,
+      channelType: sourceGuardian.channelType,
+      source: "source-channel-contact",
+    };
+  } else if (vellumGuardian && !(requireAnchorPrincipal && !anchorPrincipalId)) {
+    // Source-channel resolution did not match the anchor → use the anchored
+    // vellum identity.
+    resolved = {
+      principalId: anchorPrincipalId ?? null,
+      address: vellumGuardian.address,
+      displayName: vellumGuardian.displayName ?? null,
+      channelType: "vellum",
+      source: "vellum-anchor",
+    };
+  }
+
+  // Gateway resolved a principal — done.
+  if (resolved?.principalId) {
+    return resolved;
+  }
+
+  if (!useLocalFallback) {
+    return resolved;
+  }
+
+  // Fallback: gateway read was empty/unavailable (or carried no principal), so
+  // resolve from the LOCAL dual-written binding to avoid an undecidable
+  // request. A local match overwrites the principal-less gateway record; with
+  // no local match the gateway record (if any) is retained.
+  const localVellum = findGuardianForChannel("vellum");
+  const localAnchorPrincipalId = localVellum?.contact.principalId;
+  const localSource = findGuardianForChannel(sourceChannel);
+  if (
+    localAnchorPrincipalId &&
+    localSource &&
+    localSource.contact.principalId === localAnchorPrincipalId
+  ) {
+    return {
+      principalId: localSource.contact.principalId,
+      address: localSource.channel.address,
+      displayName: localSource.contact.displayName,
+      channelType: localSource.channel.type,
+      source: "source-channel-contact",
+    };
+  }
+  if (localVellum) {
+    return {
+      principalId: localAnchorPrincipalId ?? null,
+      address: localVellum.channel.address,
+      displayName: localVellum.contact.displayName,
+      channelType: "vellum",
+      source: "vellum-anchor",
+    };
+  }
+
+  return resolved;
+}

--- a/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
+++ b/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
@@ -7,6 +7,9 @@ let authDisabled = false;
 
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => mockGuardians,
+  // Real active-status selector so the auth gate enforces status==="active".
+  guardianForChannel: (list: GuardianDelivery[], channelType: string) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 mock.module("../../../config/env.js", () => ({
@@ -73,6 +76,15 @@ describe("requireBoundGuardian", () => {
 
   test("denies when no vellum guardian is bound", async () => {
     mockGuardians = [];
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("denies a non-active (revoked) vellum row matching the actor", async () => {
+    mockGuardians = [
+      { ...guardian("vellum-principal-abc"), status: "revoked" },
+    ];
     const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);

--- a/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
+++ b/assistant/src/runtime/auth/__tests__/require-bound-guardian.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+let mockGuardians: GuardianDelivery[] | null = null;
+let authDisabled = false;
+
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardians,
+}));
+
+mock.module("../../../config/env.js", () => ({
+  isHttpAuthDisabled: () => authDisabled,
+}));
+
+import { requireBoundGuardian } from "../require-bound-guardian.js";
+import type { AuthContext } from "../types.js";
+
+function ctx(actorPrincipalId?: string): AuthContext {
+  return {
+    subject: "sub",
+    principalType: "actor",
+    assistantId: "self",
+    actorPrincipalId,
+    scopeProfile: "actor_client_v1",
+    scopes: new Set(),
+    policyEpoch: 0,
+  };
+}
+
+function guardian(principalId: string): GuardianDelivery {
+  return {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId,
+    address: principalId,
+    status: "active",
+  };
+}
+
+describe("requireBoundGuardian", () => {
+  beforeEach(() => {
+    mockGuardians = null;
+    authDisabled = false;
+  });
+
+  test("admits the bound guardian", async () => {
+    mockGuardians = [guardian("vellum-principal-abc")];
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).toBeNull();
+  });
+
+  test("denies a non-guardian actor", async () => {
+    mockGuardians = [guardian("vellum-principal-abc")];
+    const result = await requireBoundGuardian(ctx("vellum-principal-other"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("denies when actor principal is missing", async () => {
+    mockGuardians = [guardian("vellum-principal-abc")];
+    const result = await requireBoundGuardian(ctx(undefined));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("fails closed on a null list (gateway unreachable)", async () => {
+    mockGuardians = null;
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("denies when no vellum guardian is bound", async () => {
+    mockGuardians = [];
+    const result = await requireBoundGuardian(ctx("vellum-principal-abc"));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("dev bypass admits when auth is disabled", async () => {
+    authDisabled = true;
+    mockGuardians = null;
+    const result = await requireBoundGuardian(ctx(undefined));
+    expect(result).toBeNull();
+  });
+});

--- a/assistant/src/runtime/auth/require-bound-guardian.ts
+++ b/assistant/src/runtime/auth/require-bound-guardian.ts
@@ -1,15 +1,17 @@
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
 import { httpError } from "../http-errors.js";
 import type { AuthContext } from "./types.js";
 
 /**
  * Verify the actor from AuthContext is the bound guardian for the vellum channel.
- * Returns an error Response if not, or null if allowed.
+ * Sources the guardian from the gateway binding and fails closed when the
+ * gateway is unreachable (null list). Returns an error Response if not
+ * authorized, or null if allowed.
  */
-export function requireBoundGuardian(
+export async function requireBoundGuardian(
   authContext: AuthContext,
-): Response | null {
+): Promise<Response | null> {
   // Dev bypass: when auth is disabled, skip guardian binding check
   // (mirrors enforcePolicy dev bypass in route-policy.ts)
   if (isHttpAuthDisabled()) {
@@ -22,17 +24,22 @@ export function requireBoundGuardian(
       403,
     );
   }
-  const guardianResult = findGuardianForChannel("vellum");
-  if (!guardianResult) {
-    // No guardian yet — in pre-bootstrap state, allow through
-    return null;
-  }
-  if (guardianResult.channel.address !== authContext.actorPrincipalId) {
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (!guardians) {
+    // Gateway unreachable — fail closed.
     return httpError(
       "FORBIDDEN",
       "Actor is not the bound guardian for this channel",
       403,
     );
   }
-  return null;
+  const guardian = guardians.find((g) => g.channelType === "vellum");
+  if (guardian && guardian.principalId === authContext.actorPrincipalId) {
+    return null;
+  }
+  return httpError(
+    "FORBIDDEN",
+    "Actor is not the bound guardian for this channel",
+    403,
+  );
 }

--- a/assistant/src/runtime/auth/require-bound-guardian.ts
+++ b/assistant/src/runtime/auth/require-bound-guardian.ts
@@ -1,5 +1,8 @@
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../contacts/guardian-delivery-reader.js";
 import { httpError } from "../http-errors.js";
 import type { AuthContext } from "./types.js";
 
@@ -33,7 +36,7 @@ export async function requireBoundGuardian(
       403,
     );
   }
-  const guardian = guardians.find((g) => g.channelType === "vellum");
+  const guardian = guardianForChannel(guardians, "vellum");
   if (guardian && guardian.principalId === authContext.actorPrincipalId) {
     return null;
   }

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -11,6 +11,10 @@ import { v4 as uuid } from "uuid";
 
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { revokeGuardianBinding } from "../contacts/contacts-write.js";
+import {
+  getGuardianDeliveryFresh,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import type {
   GuardianBinding,
   IdentityBindingStatus,
@@ -346,6 +350,26 @@ export function getGuardianBinding(
   }
 
   return null;
+}
+
+/**
+ * Gateway-backed guardian-existence check: is a guardian already bound for
+ * this channel? Presence-only idempotency guard, NOT an ACL-field read.
+ *
+ * Null-list fail direction: a `null` from the gateway (unreachable / malformed)
+ * is "unknown" — returns `true` so an unreachable gateway is treated as
+ * already-bound. Callers gate session creation on a falsy result, so this
+ * blocks a new binding on a transient miss rather than spuriously creating a
+ * second one.
+ */
+export async function isGuardianBoundForChannel(
+  channel: string,
+): Promise<boolean> {
+  // Existence guards read fresh because gateway-side binding writes don't
+  // invalidate the daemon cache.
+  const list = await getGuardianDeliveryFresh({ channelTypes: [channel] });
+  if (list === null) return true;
+  return !!guardianForChannel(list, channel);
 }
 
 /**

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -11,6 +11,10 @@ import {
   findGuardianForChannel,
   updateContactPrincipalAndChannel,
 } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../contacts/guardian-delivery-reader.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("guardian-vellum-migration");
@@ -31,18 +35,37 @@ const log = getLogger("guardian-vellum-migration");
  * minted by this daemon's signing key.
  *
  * Returns true if healing occurred, false otherwise.
+ *
+ * The gateway binding supplies the authoritative principal; the local
+ * assistant-mirror row is repaired whenever it diverges from the JWT
+ * principal — even when the gateway binding already matches — because the
+ * /v1/messages trust path still resolves against the local mirror in this
+ * plan. A stale mirror must be repaired or valid guardians stay `unknown`.
  */
-export function healGuardianBindingDrift(incomingPrincipalId: string): boolean {
+export async function healGuardianBindingDrift(
+  incomingPrincipalId: string,
+): Promise<boolean> {
   if (!incomingPrincipalId.startsWith("vellum-principal-")) {
     return false;
   }
 
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (!guardians) return false;
+  const guardian = guardianForChannel(guardians, "vellum");
+  if (!guardian) return false;
+
+  const currentPrincipalId = guardian.principalId;
+  if (!currentPrincipalId?.startsWith("vellum-principal-")) return false;
+
+  // Resolve the assistant-mirror row whose principal drives local trust.
   const guardianResult = findGuardianForChannel("vellum");
   if (!guardianResult) return false;
 
-  const currentPrincipalId = guardianResult.contact.principalId;
-  if (!currentPrincipalId?.startsWith("vellum-principal-")) return false;
-  if (currentPrincipalId === incomingPrincipalId) return false;
+  const localPrincipalId = guardianResult.contact.principalId;
+  // Only repair auto-generated local principals — never overwrite a real one.
+  if (!localPrincipalId?.startsWith("vellum-principal-")) return false;
+  // No-op when the local mirror already matches the JWT principal.
+  if (localPrincipalId === incomingPrincipalId) return false;
 
   const updated = updateContactPrincipalAndChannel(
     guardianResult.contact.id,
@@ -53,7 +76,7 @@ export function healGuardianBindingDrift(incomingPrincipalId: string): boolean {
   if (!updated) {
     log.warn(
       {
-        oldPrincipalId: currentPrincipalId,
+        oldPrincipalId: localPrincipalId,
         newPrincipalId: incomingPrincipalId,
       },
       "Skipped guardian binding drift heal — address collision on contact_channels",
@@ -63,10 +86,10 @@ export function healGuardianBindingDrift(incomingPrincipalId: string): boolean {
 
   log.info(
     {
-      oldPrincipalId: currentPrincipalId,
+      oldPrincipalId: localPrincipalId,
       newPrincipalId: incomingPrincipalId,
     },
-    "Healed vellum guardian binding drift — updated principalId to match JWT actor",
+    "Healed vellum guardian binding drift — updated local mirror principalId to match JWT actor",
   );
 
   return true;

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -14,6 +14,11 @@
 import type { ChannelId } from "../channels/types.js";
 import { isHttpAuthDisabled } from "../config/env.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+  peekCachedGuardianDelivery,
+} from "../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -45,13 +50,48 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
 }
 
 /**
- * Look up the local vellum guardian's principalId from the contacts table.
+ * Resolve the local vellum guardian's principalId from the gateway.
  *
- * Returns `undefined` when no vellum guardian binding exists (e.g. fresh
- * install before bootstrap). Callers should treat that case as
+ * The gateway owns guardian binding; this reads it through the cached
+ * `getGuardianDelivery` reader (PR-3 TTL + single-flight) so hot paths don't
+ * storm the IPC. Falls back to the local contacts table for the bootstrap /
+ * first-run window where the gateway has no guardian yet or is unreachable
+ * (the reader returns `null`).
+ *
+ * Returns `undefined` when no vellum guardian binding exists in either source
+ * (e.g. fresh install before bootstrap). Callers should treat that case as
  * "not yet available" and either fall back or proceed without a principalId.
  */
-export function findLocalGuardianPrincipalId(): string | undefined {
+export async function findLocalGuardianPrincipalId(): Promise<
+  string | undefined
+> {
+  const list = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (list) {
+    const principalId = guardianForChannel(list, "vellum")?.principalId;
+    if (principalId) return principalId;
+  }
+
+  return findLocalGuardianPrincipalIdFromStore();
+}
+
+/**
+ * Synchronous read of the vellum guardian's principalId for paths that cannot
+ * await {@link findLocalGuardianPrincipalId} — namely the SSE eager-subscribe
+ * path (`events-routes`), which registers before the stream is created.
+ *
+ * Reads the same gateway-owned binding as the async path via a sync, IO-free
+ * snapshot of the guardian-delivery cache (kept fresh by the async hot paths
+ * and event-driven invalidation), so SSE registers the SAME principal the
+ * send/result routes resolve. Falls back to the local store when the cache is
+ * cold — the same fallback the async path lands on during bootstrap.
+ */
+export function findLocalGuardianPrincipalIdFromStore(): string | undefined {
+  const cached = peekCachedGuardianDelivery({ channelTypes: ["vellum"] });
+  if (cached) {
+    const principalId = guardianForChannel(cached, "vellum")?.principalId;
+    if (principalId) return principalId;
+  }
+
   return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
 }
 
@@ -76,12 +116,35 @@ export function findLocalGuardianPrincipalId(): string | undefined {
  * yet (e.g. fresh install before bootstrap); callers must treat this the
  * same as a missing principal.
  */
-export function resolveActorPrincipalIdForLocalGuardian(
+export async function resolveActorPrincipalIdForLocalGuardian(
+  rawHeader: string | undefined,
+): Promise<string | undefined> {
+  if (rawHeader !== "dev-bypass" || !isHttpAuthDisabled()) return rawHeader;
+
+  const guardianPrincipalId = await findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) return guardianPrincipalId;
+
+  log.warn(
+    "dev-bypass actor principal received but no vellum guardian binding found; returning undefined",
+  );
+  return undefined;
+}
+
+/**
+ * Synchronous variant of {@link resolveActorPrincipalIdForLocalGuardian} for
+ * the SSE eager-subscribe path, which registers before the response stream is
+ * created and cannot await. Resolves the guardian from the IO-free gateway
+ * cache snapshot first (same source the async path reads), falling back to the
+ * local store when the cache is cold — so SSE registers the SAME principal the
+ * send/result routes resolve and host-proxy targeting matches the same-user
+ * client even when the local contact row is stale.
+ */
+export function resolveActorPrincipalIdForLocalGuardianSync(
   rawHeader: string | undefined,
 ): string | undefined {
   if (rawHeader !== "dev-bypass" || !isHttpAuthDisabled()) return rawHeader;
 
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  const guardianPrincipalId = findLocalGuardianPrincipalIdFromStore();
   if (guardianPrincipalId) return guardianPrincipalId;
 
   log.warn(
@@ -102,12 +165,12 @@ export function resolveActorPrincipalIdForLocalGuardian(
  * bootstrap), falls back to a minimal guardian context so the local
  * user is not incorrectly denied.
  */
-export function resolveLocalTrustContext(
+export async function resolveLocalTrustContext(
   sourceChannel: ChannelId = "vellum",
-): TrustContext {
+): Promise<TrustContext> {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
 
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  const guardianPrincipalId = await findLocalGuardianPrincipalId();
   if (guardianPrincipalId) {
     const trustCtx = resolveTrustContext({
       assistantId,
@@ -139,10 +202,12 @@ export function resolveLocalTrustContext(
  * downstream code to resolve guardian context using the same
  * `authContext.actorPrincipalId` path as HTTP sessions.
  */
-export function resolveLocalAuthContext(conversationId: string): AuthContext {
+export async function resolveLocalAuthContext(
+  conversationId: string,
+): Promise<AuthContext> {
   const authContext = buildLocalAuthContext(conversationId);
 
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  const guardianPrincipalId = await findLocalGuardianPrincipalId();
   if (guardianPrincipalId) {
     return { ...authContext, actorPrincipalId: guardianPrincipalId };
   }

--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -24,7 +24,7 @@ mock.module("../../../daemon/handlers/config-channels.js", () => ({
     verifyTrustedContactCalls.push([contactChannelId, assistantId]);
     return verifyTrustedContactImpl(contactChannelId, assistantId);
   },
-  createInboundChallenge: () => ({ success: true }),
+  createInboundChallenge: async () => ({ success: true }),
   getVerificationStatus: () => ({ success: true }),
   revokeVerificationForChannel: () => ({ success: true }),
 }));

--- a/assistant/src/runtime/routes/browser-routes.ts
+++ b/assistant/src/runtime/routes/browser-routes.ts
@@ -92,7 +92,7 @@ async function handleBrowserExecute({
   // register with (dev-bypass otherwise mismatches).
   const headerActor =
     headers["x-vellum-actor-principal-id"]?.trim() || undefined;
-  const sourceActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+  const sourceActorPrincipalId = await resolveActorPrincipalIdForLocalGuardian(
     conversation?.getTurnActorPrincipalId() ?? headerActor,
   );
 

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -179,7 +179,7 @@ export async function handleCreateVerificationSession({
   }
 
   // Inbound challenge path
-  const result = createInboundChallenge(channel, rebind, conversationId);
+  const result = await createInboundChallenge(channel, rebind, conversationId);
   if (!result.success) {
     throw new BadRequestError(
       (result as { message?: string }).message ??

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1462,7 +1462,7 @@ export async function handleSendMessage(
         // guardian binding gets a new vellum-principal-* UUID while the
         // client still holds a valid JWT with the old one. The signing
         // key survives the reset, so the JWT is authentic — just stale.
-        const healed = healGuardianBindingDrift(actorPrincipalId);
+        const healed = await healGuardianBindingDrift(actorPrincipalId);
         if (healed) {
           trustCtx = resolveTrustContext({
             assistantId,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -946,25 +946,28 @@ export function handleListMessages({
         .filter((block) => block.type !== "text" || block.text.length > 0);
     }
 
-  // Ensure every hydrated attachment has a corresponding content block.
-  // renderHistoryContent inlines attachment blocks only when it has
-  // file-block refs with matching DB rows; directives (assistant-authored
-  // <vellum-attachment/> tags) don't leave a file block after stripping,
-  // so their attachments end up in the flat `attachments` array but not in
-  // `contentBlocks`. Append any that are missing so the canonical
-  // projection is complete.
-  const existingAttachmentIds = new Set(
-    contentBlocks
-      .filter((b): b is Extract<ConversationContentBlock, { type: "attachment" }> => b.type === "attachment")
-      .map((b) => b.attachment.id),
-  );
-  for (const att of msgAttachments) {
-    if (!existingAttachmentIds.has(att.id)) {
-      contentBlocks.push({ type: "attachment", attachment: att });
+    // Ensure every hydrated attachment has a corresponding content block.
+    // renderHistoryContent inlines attachment blocks only when it has
+    // file-block refs with matching DB rows; directives (assistant-authored
+    // <vellum-attachment/> tags) don't leave a file block after stripping,
+    // so their attachments end up in the flat `attachments` array but not in
+    // `contentBlocks`. Append any that are missing so the canonical
+    // projection is complete.
+    const existingAttachmentIds = new Set(
+      contentBlocks
+        .filter(
+          (b): b is Extract<ConversationContentBlock, { type: "attachment" }> =>
+            b.type === "attachment",
+        )
+        .map((b) => b.attachment.id),
+    );
+    for (const att of msgAttachments) {
+      if (!existingAttachmentIds.has(att.id)) {
+        contentBlocks.push({ type: "attachment", attachment: att });
+      }
     }
-  }
 
-  const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
+    const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
 
     // Use sentAt (actual event time) for the display timestamp when available,
     // falling back to createdAt (persistence time). Clients use this display
@@ -1448,7 +1451,9 @@ export async function handleSendMessage(
     // won't match any guardian binding. Resolve from the local guardian
     // binding instead, which produces the correct guardian trust context.
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      conversation.setTrustContext(resolveLocalTrustContext(sourceChannel));
+      conversation.setTrustContext(
+        await resolveLocalTrustContext(sourceChannel),
+      );
     } else {
       const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
       let trustCtx = resolveTrustContext({

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -43,7 +43,7 @@ import type { ReplaySubscriber } from "../assistant-stream-state.js";
 import { getReplayWindow } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS, GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import { DEFAULT_HEARTBEAT_INTERVAL_MS } from "../client-health.js";
-import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import { resolveActorPrincipalIdForLocalGuardianSync } from "../local-actor-identity.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -311,7 +311,7 @@ export function handleSubscribeAssistantEvents(
   // bearer token's AuthContext. May be absent for legacy / service-token
   // connections that have no principal. See `resolveActorPrincipalId` for the
   // dev-bypass translation rationale.
-  const actorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+  const actorPrincipalId = resolveActorPrincipalIdForLocalGuardianSync(
     rawActorPrincipalId?.trim() || undefined,
   );
 

--- a/assistant/src/runtime/routes/host-app-control-routes.ts
+++ b/assistant/src/runtime/routes/host-app-control-routes.ts
@@ -39,7 +39,7 @@ const VALID_STATES: ReadonlySet<HostAppControlState> = new Set([
 // POST /v1/host-app-control-result
 // ---------------------------------------------------------------------------
 
-function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -95,9 +95,10 @@ function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
       );
     }
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     enforceSameActorOrThrow({
       sourceActorPrincipalId: submittingActorPrincipalId,
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -26,7 +26,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // POST /v1/host-bash-result
 // ---------------------------------------------------------------------------
 
-function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -45,9 +45,10 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
 
   const submittingClientId =
     headers?.["x-vellum-client-id"]?.trim() || undefined;
-  const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-    headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
-  );
+  const submittingActorPrincipalId =
+    await resolveActorPrincipalIdForLocalGuardian(
+      headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -61,14 +61,14 @@ export type HostBrowserResultResolution =
  * already authenticated the caller (the HTTP route uses
  * `requireBoundGuardian`).
  */
-export function resolveHostBrowserResultByRequestId(
+export async function resolveHostBrowserResultByRequestId(
   frame: {
     requestId?: unknown;
     content?: unknown;
     isError?: unknown;
   },
   headers?: Record<string, string | undefined>,
-): HostBrowserResultResolution {
+): Promise<HostBrowserResultResolution> {
   const { requestId, content, isError } = frame;
 
   if (!requestId || typeof requestId !== "string") {
@@ -127,9 +127,10 @@ export function resolveHostBrowserResultByRequestId(
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     try {
       enforceSameActorOrThrow({
         sourceActorPrincipalId: submittingActorPrincipalId,
@@ -260,12 +261,12 @@ export function resolveHostBrowserSessionInvalidated(frame: {
 // POST /v1/host-browser-result
 // ---------------------------------------------------------------------------
 
-function handleHostBrowserResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostBrowserResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
 
-  const resolution = resolveHostBrowserResultByRequestId(
+  const resolution = await resolveHostBrowserResultByRequestId(
     body,
     headers as Record<string, string | undefined> | undefined,
   );
@@ -399,10 +400,7 @@ export const ROUTES: RouteDefinition[] = [
       "Marks the target as invalidated in the runtime-side browser session registry.",
     tags: ["host"],
     requestBody: z.object({
-      targetId: z
-        .string()
-        .optional()
-        .describe("CDP target that was detached"),
+      targetId: z.string().optional().describe("CDP target that was detached"),
       reason: z.string().optional().describe("Detach reason"),
       clientId: z
         .string()

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -26,7 +26,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // POST /v1/host-cu-result
 // ---------------------------------------------------------------------------
 
-function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -95,9 +95,10 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     enforceSameActorOrThrow({
       sourceActorPrincipalId: submittingActorPrincipalId,
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -26,7 +26,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // POST /v1/host-file-result
 // ---------------------------------------------------------------------------
 
-function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
+async function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -76,9 +76,10 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user somehow obtains the
     // target client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
     enforceSameActorOrThrow({
       sourceActorPrincipalId: submittingActorPrincipalId,
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -39,10 +39,10 @@ function findProxyByTransferId(transferId: string) {
 // GET /v1/transfers/:transferId/content
 // ---------------------------------------------------------------------------
 
-function handleTransferContentGet({
+async function handleTransferContentGet({
   pathParams = {},
   headers = {},
-}: RouteHandlerArgs): Uint8Array {
+}: RouteHandlerArgs): Promise<Uint8Array> {
   const transferId = pathParams.transferId;
   if (!transferId) {
     throw new BadRequestError("transferId path parameter is required");
@@ -72,7 +72,7 @@ function handleTransferContentGet({
     // the value persisted at registration time so a brief reconnect does
     // not 403 a legitimate fetch.
     enforceSameActorOrThrow({
-      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+      sourceActorPrincipalId: await resolveActorPrincipalIdForLocalGuardian(
         headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
       ),
       targetActorPrincipalId:
@@ -151,7 +151,7 @@ async function handleTransferContentPut({
       );
 
     enforceSameActorOrThrow({
-      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+      sourceActorPrincipalId: await resolveActorPrincipalIdForLocalGuardian(
         headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
       ),
       targetActorPrincipalId:
@@ -181,7 +181,7 @@ async function handleTransferContentPut({
 // POST /v1/host-transfer-result
 // ---------------------------------------------------------------------------
 
-function handleTransferResult({ body, headers }: RouteHandlerArgs) {
+async function handleTransferResult({ body, headers }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
@@ -222,7 +222,7 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
       );
 
     enforceSameActorOrThrow({
-      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+      sourceActorPrincipalId: await resolveActorPrincipalIdForLocalGuardian(
         headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
       ),
       targetActorPrincipalId: peeked.targetActorPrincipalId,

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -51,7 +51,7 @@ export function routeDefinitionsToHTTPRoutes(
     handler: async ({ req, url, params, authContext }) => {
       try {
         if (r.requireGuardian) {
-          const guardianError = requireBoundGuardian(authContext);
+          const guardianError = await requireBoundGuardian(authContext);
           if (guardianError) return guardianError;
         }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -801,7 +801,7 @@ export async function handleChannelInbound({
     // guardian sees "previously pending" etc.
     let guardianNotified = false;
     try {
-      const accessResult = notifyGuardianOfAccessRequest({
+      const accessResult = await notifyGuardianOfAccessRequest({
         canonicalAssistantId,
         sourceChannel,
         conversationExternalId,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -19,14 +19,28 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 // Track contact-store reads to prove findContactChannel is NOT used on the
-// verdict path. findGuardianForChannel is still called by resolveGuardianLabel.
+// verdict path.
 const findContactChannelCalls: unknown[] = [];
 mock.module("../../../contacts/contact-store.js", () => ({
   findContactChannel: (params: unknown) => {
     findContactChannelCalls.push(params);
     return null;
   },
-  findGuardianForChannel: () => null,
+}));
+
+// resolveGuardianLabel resolves the guardian via the gateway delivery reader.
+let guardianDeliveryList: Array<Record<string, unknown>> = [];
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => guardianDeliveryList,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+mock.module("../../../prompts/user-reference.js", () => ({
+  resolveGuardianName: (displayName?: string | null) =>
+    displayName && displayName.trim().length > 0 ? displayName.trim() : "my human",
 }));
 
 const deliverReplyCalls: Array<{ url: string; payload: unknown }> = [];
@@ -126,6 +140,7 @@ beforeEach(() => {
   deliverReplyCalls.length = 0;
   accessRequestCalls.length = 0;
   inviteTokenForTest = undefined;
+  guardianDeliveryList = [];
 });
 
 afterEach(() => {
@@ -287,6 +302,41 @@ describe("enforceIngressAcl — fail-closed on resolutionFailed verdict", () => 
 
     expect(result.earlyResponse!.inviteRedemption).toBe("redeemed");
     expect(result.resolvedMember).toBeNull();
+  });
+});
+
+describe("enforceIngressAcl — deny copy names the gateway guardian", () => {
+  test("non-member deny reply uses the guardian displayName from the gateway list", async () => {
+    guardianDeliveryList = [
+      {
+        channelType: "vellum",
+        contactId: "c-1",
+        principalId: "p-anchor",
+        displayName: "Alice Guardian",
+        address: "p-anchor",
+        status: "active",
+      },
+    ];
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+        }),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    const denyReply = deliverReplyCalls.find((c) =>
+      String((c.payload as { text?: string }).text ?? "").includes(
+        "tried talking to me",
+      ),
+    );
+    expect(denyReply).toBeDefined();
+    expect((denyReply!.payload as { text: string }).text).toContain(
+      "Alice Guardian",
+    );
   });
 });
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -7,7 +7,10 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
-import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../../contacts/guardian-delivery-reader.js";
 import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
 import type {
   ContactChannel,
@@ -46,12 +49,15 @@ const log = getLogger("runtime-http");
  * Resolve the guardian's display name for use in requester-facing messages.
  *
  * Uses the assistant's anchored vellum principal to validate the guardian
- * contact, matching the same strategy used by `notifyGuardianOfAccessRequest`.
- * This prevents stale or cross-assistant contacts from leaking a wrong name.
+ * binding, matching the same strategy used by `notifyGuardianOfAccessRequest`.
+ * This prevents stale or cross-assistant bindings from leaking a wrong name.
+ * Cosmetic copy, not an admission decision, so a null gateway list degrades
+ * gracefully to the default reference.
  */
-function resolveGuardianLabel(sourceChannel: ChannelId): string {
-  const vellumGuardian = findGuardianForChannel("vellum");
-  const anchoredPrincipalId = vellumGuardian?.contact.principalId;
+async function resolveGuardianLabel(sourceChannel: ChannelId): Promise<string> {
+  const guardians = await getGuardianDelivery();
+  const vellumGuardian = guardianForChannel(guardians ?? [], "vellum");
+  const anchoredPrincipalId = vellumGuardian?.principalId;
 
   if (!anchoredPrincipalId) {
     return resolveGuardianName(undefined);
@@ -59,15 +65,12 @@ function resolveGuardianLabel(sourceChannel: ChannelId): string {
 
   // Try source-channel guardian, but only accept it when the principal
   // matches the assistant's anchor.
-  const sourceGuardian = findGuardianForChannel(sourceChannel);
-  if (
-    sourceGuardian &&
-    sourceGuardian.contact.principalId === anchoredPrincipalId
-  ) {
-    return resolveGuardianName(sourceGuardian.contact.displayName);
+  const sourceGuardian = guardianForChannel(guardians ?? [], sourceChannel);
+  if (sourceGuardian && sourceGuardian.principalId === anchoredPrincipalId) {
+    return resolveGuardianName(sourceGuardian.displayName);
   }
 
-  return resolveGuardianName(vellumGuardian.contact.displayName);
+  return resolveGuardianName(vellumGuardian.displayName);
 }
 
 // ---------------------------------------------------------------------------
@@ -347,7 +350,7 @@ export async function enforceIngressAcl(
           if (slackVerifyResult.initiated) {
             // Still notify the guardian about the access attempt
             try {
-              notifyGuardianOfAccessRequest({
+              await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
@@ -387,7 +390,7 @@ export async function enforceIngressAcl(
               try {
                 await deliverChannelReply(dmCallbackUrl, {
                   chatId: senderUserId,
-                  text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                  text: `I don't recognize you yet! I've let ${await resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                   assistantId,
                 });
               } catch (err) {
@@ -422,7 +425,7 @@ export async function enforceIngressAcl(
 
           if (emailVerifyResult.initiated) {
             try {
-              notifyGuardianOfAccessRequest({
+              await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
@@ -461,7 +464,7 @@ export async function enforceIngressAcl(
         // deduplication, canonical request creation, and notification emission.
         let guardianNotified = false;
         try {
-          const accessResult = notifyGuardianOfAccessRequest({
+          const accessResult = await notifyGuardianOfAccessRequest({
             canonicalAssistantId,
             sourceChannel,
             conversationExternalId,
@@ -485,7 +488,7 @@ export async function enforceIngressAcl(
         }
 
         const replyText = guardianNotified
-          ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+          ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
           : "Sorry, you haven't been approved to message this assistant.";
         let replyDelivered = false;
         if (replyCallbackUrl) {
@@ -667,7 +670,7 @@ export async function enforceIngressAcl(
 
             if (slackVerifyResult.initiated) {
               try {
-                notifyGuardianOfAccessRequest({
+                await notifyGuardianOfAccessRequest({
                   canonicalAssistantId,
                   sourceChannel,
                   conversationExternalId,
@@ -706,7 +709,7 @@ export async function enforceIngressAcl(
                 try {
                   await deliverChannelReply(dmCallbackUrl, {
                     chatId: senderUserId,
-                    text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                    text: `I don't recognize you yet! I've let ${await resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                     assistantId,
                   });
                 } catch (err) {
@@ -735,7 +738,7 @@ export async function enforceIngressAcl(
           let guardianNotified = false;
           if (resolvedMember.channel.status !== "blocked") {
             try {
-              const accessResult = notifyGuardianOfAccessRequest({
+              const accessResult = await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
@@ -763,7 +766,7 @@ export async function enforceIngressAcl(
           }
 
           const inactiveReplyText = guardianNotified
-            ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+            ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
             : "Sorry, you haven't been approved to message this assistant.";
           let inactiveReplyDelivered = false;
           if (replyCallbackUrl) {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -7,10 +7,7 @@ import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
 
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
-import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../../contacts/guardian-delivery-reader.js";
+import { getGuardianDelivery } from "../../../contacts/guardian-delivery-reader.js";
 import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
 import type {
   ContactChannel,
@@ -28,6 +25,7 @@ import { getLogger } from "../../../util/logger.js";
 import { truncate } from "../../../util/truncate.js";
 import { hashVoiceCode } from "../../../util/voice-code.js";
 import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
+import { resolveAnchoredGuardian } from "../../anchored-guardian.js";
 import { getInviteAdapterRegistry } from "../../channel-invite-transport.js";
 import {
   createOutboundSession,
@@ -55,22 +53,14 @@ const log = getLogger("runtime-http");
  * gracefully to the default reference.
  */
 async function resolveGuardianLabel(sourceChannel: ChannelId): Promise<string> {
-  const guardians = await getGuardianDelivery();
-  const vellumGuardian = guardianForChannel(guardians ?? [], "vellum");
-  const anchoredPrincipalId = vellumGuardian?.principalId;
-
-  if (!anchoredPrincipalId) {
-    return resolveGuardianName(undefined);
-  }
-
-  // Try source-channel guardian, but only accept it when the principal
-  // matches the assistant's anchor.
-  const sourceGuardian = guardianForChannel(guardians ?? [], sourceChannel);
-  if (sourceGuardian && sourceGuardian.principalId === anchoredPrincipalId) {
-    return resolveGuardianName(sourceGuardian.displayName);
-  }
-
-  return resolveGuardianName(vellumGuardian.displayName);
+  // Cosmetic copy, not an admission decision: no local-store fallback, and a
+  // missing anchor principal degrades to the default reference.
+  const anchored = resolveAnchoredGuardian({
+    guardians: await getGuardianDelivery(),
+    sourceChannel,
+    requireAnchorPrincipal: true,
+  });
+  return resolveGuardianName(anchored?.displayName);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -9,6 +9,10 @@
  */
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../../contacts/guardian-delivery-reader.js";
 import type { ServerMessage } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context.js";
 import {
@@ -960,10 +964,18 @@ function startTrustedContactApprovalNotifier(params: {
 
         if (info && !globalNotifiedApprovalRequestIds.has(info.requestId)) {
           globalNotifiedApprovalRequestIds.set(info.requestId, conversationId);
-          const guardian = findGuardianForChannel(sourceChannel);
-          const guardianName = resolveGuardianName(
-            guardian?.contact.displayName,
-          );
+          // Gateway-resolved guardian display name with the transitional
+          // local fallback on null/no-match (display-only). Removed in Combo 11.
+          const guardians = await getGuardianDelivery({
+            channelTypes: [sourceChannel],
+          });
+          const gatewayDisplayName = guardians
+            ? guardianForChannel(guardians, sourceChannel)?.displayName
+            : undefined;
+          const displayName =
+            gatewayDisplayName ??
+            findGuardianForChannel(sourceChannel)?.contact.displayName;
+          const guardianName = resolveGuardianName(displayName);
           const waitingText = `Waiting for ${guardianName}'s approval...`;
           try {
             await deliverChannelReply(replyCallbackUrl, {

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -4,7 +4,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-let mockGuardian: { contact: unknown; channel: unknown } | null = null;
+// Gateway guardian-delivery list: empty = unbound, one entry = bound,
+// null = gateway unreachable.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
 let mockActiveSession: Record<string, unknown> | null = null;
 let mockSessionResult = {
   sessionId: "sess-1",
@@ -20,8 +22,14 @@ let deliverChannelReplyCalls: unknown[][] = [];
 let emitNotificationSignalCalls: unknown[] = [];
 let messageIdCounter = 0;
 
-mock.module("../../../contacts/contact-store.js", () => ({
-  findGuardianForChannel: () => mockGuardian,
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  // Existence guard reads fresh (uncached) — only this variant is stubbed.
+  getGuardianDeliveryFresh: () => Promise.resolve(mockGuardianList),
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 mock.module("../../channel-verification-service.js", () => ({
@@ -96,7 +104,7 @@ function makeParams(
 
 describe("handleGuardianActivationIntercept", () => {
   beforeEach(() => {
-    mockGuardian = null;
+    mockGuardianList = [];
     mockActiveSession = null;
     mockSessionResult = {
       sessionId: "sess-1",
@@ -155,10 +163,15 @@ describe("handleGuardianActivationIntercept", () => {
   });
 
   test("bare /start with existing guardian returns null", async () => {
-    mockGuardian = {
-      contact: { id: "contact-1", role: "guardian" },
-      channel: { id: "ch-1", type: "telegram" },
-    };
+    mockGuardianList = [{ channelType: "telegram", status: "active" }];
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("null guardian list (gateway unreachable) does NOT auto-start", async () => {
+    mockGuardianList = null;
 
     const result = await handleGuardianActivationIntercept(makeParams());
     expect(result).toBeNull();

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -9,7 +9,10 @@
  * the guardian binding, and sends a success reply.
  */
 import type { ChannelId } from "../../../channels/types.js";
-import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import {
+  getGuardianDeliveryFresh,
+  guardianForChannel,
+} from "../../../contacts/guardian-delivery-reader.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { getLogger } from "../../../util/logger.js";
 import {
@@ -88,8 +91,16 @@ export async function handleGuardianActivationIntercept(
   // Only proceed for Telegram (can be extended later)
   if (sourceChannel !== "telegram") return null;
 
-  // If a guardian already exists for this channel, continue to normal flow
-  if (findGuardianForChannel(sourceChannel)) return null;
+  // If a guardian already exists for this channel, continue to normal flow.
+  // Null-list (gateway unreachable) is treated as guardian-present so a
+  // transient miss does NOT spuriously auto-start verification.
+  // Read fresh: gateway-side binding writes don't invalidate the daemon cache.
+  const guardianList = await getGuardianDeliveryFresh({
+    channelTypes: [sourceChannel],
+  });
+  if (guardianList === null || guardianForChannel(guardianList, sourceChannel)) {
+    return null;
+  }
 
   // Can't bind a session without sender identity
   if (!rawSenderId) return null;

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -60,7 +60,9 @@ async function applyTrustContext(
 
   if (actorPrincipalId) {
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      conversation.setTrustContext(resolveLocalTrustContext(sourceChannel));
+      conversation.setTrustContext(
+        await resolveLocalTrustContext(sourceChannel),
+      );
     } else {
       const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
       let trustCtx = resolveTrustContext({

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -45,7 +45,7 @@ const log = getLogger("surface-action-routes");
  * surface actions inherit the correct trust class (guardian vs trusted_contact)
  * rather than defaulting to unknown.
  */
-function applyTrustContext(
+async function applyTrustContext(
   conversation: {
     setTrustContext?(ctx: {
       trustClass: TrustClass;
@@ -53,7 +53,7 @@ function applyTrustContext(
     }): void;
   },
   actorPrincipalId: string | undefined,
-): void {
+): Promise<void> {
   if (!conversation.setTrustContext) return;
 
   const sourceChannel = "vellum";
@@ -70,7 +70,7 @@ function applyTrustContext(
         actorExternalId: actorPrincipalId,
       });
       if (trustCtx.trustClass === "unknown") {
-        const healed = healGuardianBindingDrift(actorPrincipalId);
+        const healed = await healGuardianBindingDrift(actorPrincipalId);
         if (healed) {
           trustCtx = resolveTrustContext({
             assistantId,
@@ -186,7 +186,7 @@ async function handleSurfaceAction({
   }
 
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
-  applyTrustContext(conversation, actorPrincipalId);
+  await applyTrustContext(conversation, actorPrincipalId);
 
   try {
     const raw = await conversation.handleSurfaceAction(

--- a/gateway/src/__tests__/guardian-delivery-resolver.test.ts
+++ b/gateway/src/__tests__/guardian-delivery-resolver.test.ts
@@ -229,11 +229,28 @@ describe("resolveGuardianDelivery", () => {
 });
 
 describe("guardianDeliveryRoutes handler", () => {
-  test("resolver throw → handler returns { guardians: [] }", async () => {
+  test("resolver throw → handler propagates (server maps to error envelope → daemon null)", async () => {
     mock.module("../risk/guardian-delivery-resolver.js", () => ({
       resolveGuardianDelivery: () => {
         throw new Error("boom");
       },
+    }));
+    const { guardianDeliveryRoutes } = await import(
+      "../ipc/guardian-delivery-handlers.js"
+    );
+
+    const route = guardianDeliveryRoutes[0]!;
+    // A resolver error must NOT be swallowed into {guardians:[]}: it propagates
+    // so the IPC server returns an error envelope, which the daemon reader maps
+    // to `null` ("couldn't determine") rather than an authoritative empty list.
+    expect(route.handler({})).rejects.toThrow("boom");
+
+    mock.restore();
+  });
+
+  test("successful resolve with no guardian → handler returns { guardians: [] }", async () => {
+    mock.module("../risk/guardian-delivery-resolver.js", () => ({
+      resolveGuardianDelivery: () => [],
     }));
     const { guardianDeliveryRoutes } = await import(
       "../ipc/guardian-delivery-handlers.js"

--- a/gateway/src/__tests__/guardian-delivery-resolver.test.ts
+++ b/gateway/src/__tests__/guardian-delivery-resolver.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the gateway-side guardian binding + delivery resolver.
+ *
+ * Seeds the gateway ACL DB directly (contacts + contact_channels) and asserts
+ * that every active guardian channel is returned (with correct delivery
+ * fields), that non-active channels and non-guardian contacts are excluded,
+ * that the `channelTypes` filter narrows the result, and that the handler
+ * fails soft to [] when the resolver throws.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+await import("./test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../db/connection.js"
+);
+const { contacts: gwContacts, contactChannels: gwContactChannels } =
+  await import("../db/schema.js");
+const { resolveGuardianDelivery } = await import(
+  "../risk/guardian-delivery-resolver.js"
+);
+
+function insertContact(args: {
+  id: string;
+  displayName: string;
+  role?: string;
+  principalId?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: args.id,
+      displayName: args.displayName,
+      role: args.role ?? "contact",
+      principalId: args.principalId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  type: string;
+  address: string;
+  externalChatId?: string | null;
+  status?: string;
+  policy?: string;
+  verifiedAt?: number | null;
+  verifiedVia?: string | null;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwContactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: args.type,
+      address: args.address,
+      externalChatId: args.externalChatId ?? null,
+      status: args.status ?? "active",
+      policy: args.policy ?? "allow",
+      verifiedAt: args.verifiedAt ?? now,
+      verifiedVia: args.verifiedVia ?? "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  // initGatewayDb reconnects to the same on-disk DB, so clear any rows a prior
+  // test left behind (channels first — FK cascade from contacts).
+  getGatewayDb().delete(gwContactChannels).run();
+  getGatewayDb().delete(gwContacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("resolveGuardianDelivery", () => {
+  test("active phone + telegram guardian channels → both returned with fields", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-phone",
+      contactId: "c-guardian",
+      type: "phone",
+      address: "+15555550100",
+      externalChatId: null,
+      verifiedAt: 1000,
+    });
+    insertChannel({
+      id: "ch-telegram",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+      verifiedAt: 2000,
+    });
+
+    const result = resolveGuardianDelivery({});
+
+    expect(result).toHaveLength(2);
+    const byType = Object.fromEntries(result.map((g) => [g.channelType, g]));
+    expect(byType.phone).toMatchObject({
+      channelType: "phone",
+      contactId: "c-guardian",
+      principalId: "principal-1",
+      displayName: "The Guardian",
+      address: "+15555550100",
+      externalChatId: null,
+      status: "active",
+      verifiedAt: 1000,
+    });
+    expect(byType.telegram).toMatchObject({
+      channelType: "telegram",
+      address: "U_GUARDIAN",
+      externalChatId: "chat-guardian",
+      verifiedAt: 2000,
+    });
+  });
+
+  test("revoked/blocked guardian channels are excluded", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+    });
+    insertChannel({
+      id: "ch-active",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_ACTIVE",
+      status: "active",
+    });
+    insertChannel({
+      id: "ch-revoked",
+      contactId: "c-guardian",
+      type: "phone",
+      address: "+15555550111",
+      status: "revoked",
+    });
+    insertChannel({
+      id: "ch-blocked",
+      contactId: "c-guardian",
+      type: "slack",
+      address: "U_BLOCKED",
+      status: "blocked",
+    });
+
+    const result = resolveGuardianDelivery({});
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.channelType).toBe("telegram");
+    expect(result[0]?.address).toBe("U_ACTIVE");
+  });
+
+  test("channelTypes filter narrows the result", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+    });
+    insertChannel({
+      id: "ch-phone",
+      contactId: "c-guardian",
+      type: "phone",
+      address: "+15555550100",
+    });
+    insertChannel({
+      id: "ch-telegram",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_GUARDIAN",
+    });
+
+    const result = resolveGuardianDelivery({ channelTypes: ["telegram"] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.channelType).toBe("telegram");
+  });
+
+  test("no guardian → empty array", () => {
+    insertContact({ id: "c-member", displayName: "Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      type: "telegram",
+      address: "U_MEMBER",
+    });
+
+    expect(resolveGuardianDelivery({})).toEqual([]);
+  });
+
+  test("non-guardian contact's active channel is NOT returned", () => {
+    insertContact({
+      id: "c-guardian",
+      displayName: "Guardian",
+      role: "guardian",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      type: "telegram",
+      address: "U_GUARDIAN",
+    });
+    insertContact({ id: "c-member", displayName: "Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      type: "telegram",
+      address: "U_MEMBER",
+    });
+
+    const result = resolveGuardianDelivery({});
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.contactId).toBe("c-guardian");
+  });
+});
+
+describe("guardianDeliveryRoutes handler", () => {
+  test("resolver throw → handler returns { guardians: [] }", async () => {
+    mock.module("../risk/guardian-delivery-resolver.js", () => ({
+      resolveGuardianDelivery: () => {
+        throw new Error("boom");
+      },
+    }));
+    const { guardianDeliveryRoutes } = await import(
+      "../ipc/guardian-delivery-handlers.js"
+    );
+
+    const route = guardianDeliveryRoutes[0]!;
+    expect(await route.handler({})).toEqual({ guardians: [] });
+
+    mock.restore();
+  });
+});

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -191,6 +191,7 @@ import { inviteRoutes } from "./ipc/invite-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
 import { trustVerdictRoutes } from "./ipc/trust-verdict-handlers.js";
+import { guardianDeliveryRoutes } from "./ipc/guardian-delivery-handlers.js";
 import { createLogTailRoutes } from "./ipc/log-tail-handlers.js";
 import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
@@ -2468,6 +2469,7 @@ async function main() {
     ...thresholdRoutes,
     ...admissionPolicyRoutes,
     ...trustVerdictRoutes,
+    ...guardianDeliveryRoutes,
     ...riskClassificationRoutes,
     ...createLogTailRoutes(config),
     ...trustRulesRoutes,

--- a/gateway/src/ipc/guardian-delivery-handlers.ts
+++ b/gateway/src/ipc/guardian-delivery-handlers.ts
@@ -17,13 +17,13 @@ export const guardianDeliveryRoutes: IpcRoute[] = [
     schema: ResolveGuardianDeliveryRequestSchema,
     handler: async (params?: Record<string, unknown>) => {
       const input = ResolveGuardianDeliveryRequestSchema.parse(params);
-      try {
-        return { guardians: resolveGuardianDelivery(input) };
-      } catch {
-        // Fails soft to [] — guardian delivery is not an admission decision;
-        // the daemon owns fallback.
-        return { guardians: [] };
-      }
+      // Let a resolver error propagate: the IPC server turns it into an error
+      // envelope, which the daemon reader maps to `null` ("couldn't
+      // determine"). A successful resolve with no active guardian returns `[]`
+      // (authoritative no-guardian). This distinction lets the daemon's
+      // existence guards apply their null fail-safe on a gateway DB error
+      // instead of mis-reading it as "no guardian".
+      return { guardians: resolveGuardianDelivery(input) };
     },
   },
 ];

--- a/gateway/src/ipc/guardian-delivery-handlers.ts
+++ b/gateway/src/ipc/guardian-delivery-handlers.ts
@@ -1,0 +1,29 @@
+/**
+ * IPC route definitions for gateway-owned guardian binding + delivery reads.
+ *
+ * Exposes `resolve_guardian_delivery` to the assistant daemon over the IPC
+ * socket: returns every active guardian binding + delivery endpoint from the
+ * gateway ACL DB.
+ */
+
+import { ResolveGuardianDeliveryRequestSchema } from "@vellumai/gateway-client";
+
+import { resolveGuardianDelivery } from "../risk/guardian-delivery-resolver.js";
+import type { IpcRoute } from "./server.js";
+
+export const guardianDeliveryRoutes: IpcRoute[] = [
+  {
+    method: "resolve_guardian_delivery",
+    schema: ResolveGuardianDeliveryRequestSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const input = ResolveGuardianDeliveryRequestSchema.parse(params);
+      try {
+        return { guardians: resolveGuardianDelivery(input) };
+      } catch {
+        // Fails soft to [] — guardian delivery is not an admission decision;
+        // the daemon owns fallback.
+        return { guardians: [] };
+      }
+    },
+  },
+];

--- a/gateway/src/risk/guardian-delivery-resolver.ts
+++ b/gateway/src/risk/guardian-delivery-resolver.ts
@@ -1,0 +1,58 @@
+/**
+ * Gateway-side guardian binding + delivery resolver.
+ *
+ * Reads ONLY the gateway ACL DB to return every active guardian channel and
+ * its delivery endpoint as a {@link GuardianDelivery}. Mirrors the guardian
+ * binding query in `trust-verdict-resolver.ts`, but returns ALL active
+ * guardian channels (not LIMIT 1), optionally filtered to `channelTypes`.
+ * Read-only — no writes, no assistant DB, no IPC.
+ */
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import { getGatewayDb } from "../db/connection.js";
+import {
+  contacts as gwContacts,
+  contactChannels as gwContactChannels,
+} from "../db/schema.js";
+
+export interface ResolveGuardianDeliveryInput {
+  channelTypes?: string[];
+}
+
+/**
+ * Resolve the active guardian binding(s) + delivery endpoints from the gateway
+ * ACL DB, optionally narrowed to `channelTypes`.
+ */
+export function resolveGuardianDelivery(
+  input: ResolveGuardianDeliveryInput,
+): GuardianDelivery[] {
+  const db = getGatewayDb();
+
+  const filters = [
+    eq(gwContacts.role, "guardian"),
+    eq(gwContactChannels.status, "active"),
+  ];
+  if (input.channelTypes && input.channelTypes.length > 0) {
+    filters.push(inArray(gwContactChannels.type, input.channelTypes));
+  }
+
+  // Projection matches GuardianDelivery exactly.
+  return db
+    .select({
+      channelType: gwContactChannels.type,
+      contactId: gwContactChannels.contactId,
+      principalId: gwContacts.principalId,
+      displayName: gwContacts.displayName,
+      address: gwContactChannels.address,
+      externalChatId: gwContactChannels.externalChatId,
+      status: gwContactChannels.status,
+      verifiedAt: gwContactChannels.verifiedAt,
+    })
+    .from(gwContacts)
+    .innerJoin(gwContactChannels, eq(gwContactChannels.contactId, gwContacts.id))
+    .where(and(...filters))
+    .orderBy(desc(gwContactChannels.verifiedAt))
+    .all();
+}

--- a/packages/gateway-client/src/__tests__/guardian-delivery-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/guardian-delivery-contract.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the guardian binding + delivery pull contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  GuardianDeliverySchema,
+  ResolveGuardianDeliveryRequestSchema,
+  type GuardianDelivery,
+} from "../guardian-delivery-contract.js";
+
+const fullGuardian: GuardianDelivery = {
+  channelType: "imessage",
+  contactId: "c1",
+  principalId: "p1",
+  displayName: "Guardian Name",
+  address: "+15555550100",
+  externalChatId: "ext-chat-1",
+  status: "active",
+  verifiedAt: 1699999999,
+};
+
+describe("ResolveGuardianDeliveryRequestSchema", () => {
+  test("parses with channelTypes", () => {
+    const req = { channelTypes: ["imessage", "sms"] };
+    expect(ResolveGuardianDeliveryRequestSchema.parse(req)).toEqual(req);
+  });
+
+  test("parses with channelTypes omitted", () => {
+    expect(ResolveGuardianDeliveryRequestSchema.parse({})).toEqual({});
+  });
+
+  test("defaults to {} when params are undefined (no-param IPC call)", () => {
+    expect(ResolveGuardianDeliveryRequestSchema.parse(undefined)).toEqual({});
+  });
+});
+
+describe("GuardianDeliverySchema", () => {
+  test("round-trips a fully-populated row", () => {
+    expect(GuardianDeliverySchema.parse(fullGuardian)).toEqual(fullGuardian);
+  });
+
+  test("requires channelType", () => {
+    const { channelType: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("requires contactId", () => {
+    const { contactId: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("requires address", () => {
+    const { address: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("requires status", () => {
+    const { status: _omit, ...rest } = fullGuardian;
+    expect(() => GuardianDeliverySchema.parse(rest)).toThrow();
+  });
+
+  test("optional fields accept null", () => {
+    const row = {
+      channelType: "imessage",
+      contactId: "c1",
+      address: "+15555550100",
+      status: "active",
+      principalId: null,
+      displayName: null,
+      externalChatId: null,
+      verifiedAt: null,
+    } satisfies GuardianDelivery;
+    expect(GuardianDeliverySchema.parse(row)).toEqual(row);
+  });
+
+  test("optional fields accept undefined (omitted)", () => {
+    const row = {
+      channelType: "imessage",
+      contactId: "c1",
+      address: "+15555550100",
+      status: "active",
+    } satisfies GuardianDelivery;
+    const parsed = GuardianDeliverySchema.parse(row);
+    expect(parsed.principalId).toBeUndefined();
+    expect(parsed.displayName).toBeUndefined();
+    expect(parsed.externalChatId).toBeUndefined();
+    expect(parsed.verifiedAt).toBeUndefined();
+  });
+});

--- a/packages/gateway-client/src/guardian-delivery-contract.ts
+++ b/packages/gateway-client/src/guardian-delivery-contract.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared contract for the gateway-owned guardian binding + delivery pull.
+ *
+ * The gateway resolves the active guardian binding(s) and their per-channel
+ * delivery endpoints from its DB; the daemon pulls them via the
+ * `resolve_guardian_delivery` IPC route. INFO (notes / userFile) is NOT
+ * carried here — the daemon joins it locally by `contactId`.
+ */
+
+import { z } from "zod";
+
+/**
+ * IPC request for `resolve_guardian_delivery`. `channelTypes` is an optional
+ * filter; omitted ⇒ all active guardian channels.
+ */
+export const ResolveGuardianDeliveryRequestSchema = z
+  .object({
+    channelTypes: z.array(z.string()).optional(),
+  })
+  .default({});
+
+export type ResolveGuardianDeliveryRequest = z.infer<
+  typeof ResolveGuardianDeliveryRequestSchema
+>;
+
+/**
+ * One active guardian binding + delivery endpoint for a single channel.
+ */
+export const GuardianDeliverySchema = z.object({
+  channelType: z.string(),
+  contactId: z.string(),
+  principalId: z.string().nullable().optional(),
+  displayName: z.string().nullable().optional(),
+  address: z.string(),
+  externalChatId: z.string().nullable().optional(),
+  status: z.string(),
+  verifiedAt: z.number().nullable().optional(),
+});
+
+export type GuardianDelivery = z.infer<typeof GuardianDeliverySchema>;
+
+export const ResolveGuardianDeliveryResponseSchema = z.object({
+  guardians: z.array(GuardianDeliverySchema),
+});
+
+export type ResolveGuardianDeliveryResponse = z.infer<
+  typeof ResolveGuardianDeliveryResponseSchema
+>;

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -85,3 +85,16 @@ export type {
   TrustClass,
   TrustVerdict,
 } from "./trust-verdict-contract.js";
+
+// Guardian delivery contract (daemon → gateway pull) — Zod schemas + derived types
+export {
+  GuardianDeliverySchema,
+  ResolveGuardianDeliveryRequestSchema,
+  ResolveGuardianDeliveryResponseSchema,
+} from "./guardian-delivery-contract.js";
+
+export type {
+  GuardianDelivery,
+  ResolveGuardianDeliveryRequest,
+  ResolveGuardianDeliveryResponse,
+} from "./guardian-delivery-contract.js";


### PR DESCRIPTION
## Summary
Adds a gateway-owned `resolve_guardian_delivery` IPC (+ a cached daemon reader `getGuardianDelivery`) and converts every daemon GUARDIAN-resolution read (notifications, voice routing, bootstrap/config/auth guard checks) off the local `findGuardianForChannel`/`listGuardianChannels` ACL reads. This is a **Combo 11 prerequisite** — it removes the guardian-binding ACL reads from the assistant DB so those columns can later be dropped. Covers Linear JARVIS-1215 (notifications), JARVIS-1216 (voice routing), and the guardian-binding subset of JARVIS-1218.

**2×2 ownership:** the guardian binding (role/principalId/status) comes from the gateway; INFO (notes/userFile) stays a local read keyed by `contactId`.

## Caching (per the requirement: don't hit the IPC for near-static data)
`getGuardianDelivery` caches with a **5-min TTL** + **event-driven invalidation** on the existing `onContactChange` hub + **single-flight** coalescing + a **generation guard** (an invalidation during an in-flight fetch can't repopulate stale data). Existence guards use an uncached `getGuardianDeliveryFresh` because gateway-side binding writes don't fire the daemon's contact-change event.

## Transitional fallback (important)
Until Combo 11 drops the columns, the local mirror is still dual-written, so **every consumer falls back to the local guardian read when the gateway yields no guardian** (null/error or empty). A gateway resolver **error** now surfaces to the daemon as `null` (the IPC no longer masks it as `[]`), so existence guards' fail-safe applies while a genuine empty still allows first-time binding.

## PRs merged into this feature branch
Foundation: #35763 contract · #35767 gateway IPC · #35768 cached reader.
Consumers: #35773 destination-resolver · #35775 emit-signal/decision-engine · #35778 voice routing · #35780 acl-label/access-request · #35776 guard-checks · #35777 auth/drift · #35782 local-actor-identity.
Self-review fixes: #35799 gateway error→null · #35801 dispatch principal alignment · #35802 consumer consistency (connectivity fallback, active-status auth filter, bg-dispatch) · #35805 shared anchored-guardian helper · #35804 reader dedups.

## Self-review
4 fresh-eyes passes → remediation (5 fix PRs) → focused re-review PASS. Notable issues caught + fixed: gateway-error-masked-as-empty (existence guards), emit-signal connectivity fallback inconsistency, `require-bound-guardian` missing the active-status filter (security), guardian-dispatch↔actor principal divergence (`identity_mismatch` under drift), plus dedup of the anchored-guardian + voice-display + fresh-read surfaces.

## Out of scope (follow-ons)
- The actor-trust submit path (`actor-trust-resolver`, `guardian-action-routes`) stays on the local mirror — its gateway conversion lands with the **local-principal-trust** plan; guardian-dispatch is intentionally kept on the same local source so the request/actor principals can't diverge until then.
- `createGuardianBinding` id-resolution reads — `gateway-bootstrap-binding-reads.md` (JARVIS-1219).
- Dropping the columns + removing the transitional local fallbacks + the ACL writers — **Combo 11**.

Part of plan: gateway-guardian-binding-pull.md