### PR TITLE
feat(memory-v3): make the selector prompt configurable via memory.v3.selectorPromptPath

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -22,6 +22,7 @@ describe("MemoryV3ConfigSchema", () => {
       needleK: 100,
       denseK: 100,
       replyQueryK: 12,
+      selectorPromptPath: null,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
     });
   });

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -259,6 +259,13 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Per-lane article budget for the reply-query finder pass: needle and dense each re-run over the assistant's previous message as separate queries (never concatenated with the user's message). 0 disables the pass. Deliberately small next to needleK/denseK — the pass adds the assistant-side retrieval signal, not a second full sweep.",
       ),
+    selectorPromptPath: z
+      .string({ error: "memory.v3.selectorPromptPath must be a string" })
+      .nullable()
+      .default(null)
+      .describe(
+        "Optional path to a file whose contents replace the bundled per-turn selector system prompt (the instructions that tell the selector which candidate pages to keep). Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The selector prompt takes no placeholders — the candidate pool is supplied separately as the user message — so the file is used verbatim. If the file is missing, unreadable, empty, or over 1 MiB, the bundled prompt is used and a warning is logged.",
+      ),
     edge: MemoryV3EdgeSchema.default(MemoryV3EdgeSchema.parse({})),
   })
   .describe("Memory v3 — section-grain lane retrieval");

--- a/assistant/src/memory/__tests__/prompt-override.test.ts
+++ b/assistant/src/memory/__tests__/prompt-override.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the shared prompt-override loader
+ * (`assistant/src/memory/prompt-override.ts`) and the memory-v3
+ * `resolveSelectorPrompt` built on it. Mirrors the v2 router/consolidation
+ * prompt-path suites: a configured file replaces the bundled prompt, and any
+ * missing / empty / oversized / non-regular / unreadable file degrades to the
+ * bundled prompt with a diagnostic warning.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveSelectorPrompt } from "../../plugins/defaults/memory-v3-shadow/pool-select.js";
+import {
+  loadPromptOverride,
+  MAX_PROMPT_OVERRIDE_BYTES,
+  resolveOverridePath,
+} from "../prompt-override.js";
+
+const warnCalls: Array<{ data: Record<string, unknown>; msg: string }> = [];
+const recordingLogger = {
+  warn: (data: object, msg: string) => {
+    warnCalls.push({ data: data as Record<string, unknown>, msg });
+  },
+};
+
+let tmpDir: string;
+
+beforeEach(() => {
+  warnCalls.length = 0;
+  tmpDir = mkdtempSync(join(tmpdir(), "prompt-override-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Load against the per-test temp dir with the recording logger. */
+const load = (
+  overridePath: string | null,
+  label = "test prompt",
+): string | null =>
+  loadPromptOverride({
+    overridePath,
+    workspaceDir: tmpDir,
+    log: recordingLogger,
+    label,
+  });
+
+describe("resolveOverridePath", () => {
+  test("expands a leading ~/ to the home directory", () => {
+    expect(resolveOverridePath("~/sub/x.md", tmpDir)).toBe(
+      join(homedir(), "sub/x.md"),
+    );
+  });
+
+  test("uses an absolute path as-is", () => {
+    expect(resolveOverridePath("/abs/x.md", tmpDir)).toBe("/abs/x.md");
+  });
+
+  test("resolves a relative path under the workspace dir", () => {
+    expect(resolveOverridePath("rel/x.md", tmpDir)).toBe(
+      join(tmpDir, "rel/x.md"),
+    );
+  });
+});
+
+describe("loadPromptOverride — usable override", () => {
+  test("null overridePath returns null without touching the filesystem", () => {
+    expect(load(null)).toBeNull();
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("returns an absolute-path file's contents verbatim", () => {
+    const p = join(tmpDir, "abs.md");
+    writeFileSync(p, "absolute body\n");
+    expect(load(p)).toBe("absolute body\n");
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("resolves a relative path under the workspace dir", () => {
+    writeFileSync(join(tmpDir, "rel.md"), "relative body\n");
+    expect(load("rel.md")).toBe("relative body\n");
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("expands a leading ~/ to the home directory", () => {
+    const filename = `.vellum-prompt-override-test-${process.pid}.md`;
+    const p = join(homedir(), filename);
+    writeFileSync(p, "home body\n");
+    try {
+      expect(load(`~/${filename}`)).toBe("home body\n");
+      expect(warnCalls).toHaveLength(0);
+    } finally {
+      rmSync(p, { force: true });
+    }
+  });
+});
+
+describe("loadPromptOverride — fallback to null with a diagnostic warning", () => {
+  test("missing file logs ENOENT and returns null", () => {
+    expect(load(join(tmpDir, "missing.md"))).toBeNull();
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0].data.code).toBe("ENOENT");
+    expect(warnCalls[0].data.fallback).toBe("bundled");
+  });
+
+  test("empty file is rejected", () => {
+    const p = join(tmpDir, "empty.md");
+    writeFileSync(p, "");
+    expect(load(p)).toBeNull();
+    expect(warnCalls[0].data.reason).toBe("empty_override");
+  });
+
+  test("whitespace-only file is rejected", () => {
+    const p = join(tmpDir, "ws.md");
+    writeFileSync(p, "   \n\t\n");
+    expect(load(p)).toBeNull();
+    expect(warnCalls[0].data.reason).toBe("empty_override");
+  });
+
+  test("oversized file is rejected with its size", () => {
+    const p = join(tmpDir, "huge.md");
+    // 1 MiB + 1 byte — just over the cap so we don't waste test memory.
+    writeFileSync(p, Buffer.alloc(MAX_PROMPT_OVERRIDE_BYTES + 1, 0x61));
+    expect(load(p)).toBeNull();
+    expect(warnCalls[0].data.reason).toBe("oversized_override");
+    expect(warnCalls[0].data.size).toBe(MAX_PROMPT_OVERRIDE_BYTES + 1);
+  });
+
+  test("a directory is not a regular file", () => {
+    expect(load(tmpDir)).toBeNull();
+    expect(warnCalls[0].data.reason).toBe("not_regular_file");
+  });
+
+  test("a symlink is not a regular file (lstat does not follow it)", () => {
+    const target = join(tmpDir, "target.md");
+    writeFileSync(target, "real body\n");
+    const link = join(tmpDir, "link.md");
+    symlinkSync(target, link);
+    expect(load(link)).toBeNull();
+    expect(warnCalls[0].data.reason).toBe("not_regular_file");
+  });
+
+  test("a FIFO is not a regular file", () => {
+    const fifoPath = join(tmpDir, "fifo");
+    try {
+      execFileSync("mkfifo", [fifoPath]);
+    } catch {
+      // mkfifo unavailable on this platform — skip without failing.
+      return;
+    }
+    expect(load(fifoPath)).toBeNull();
+    expect(warnCalls[0].data.reason).toBe("not_regular_file");
+  });
+
+  test("the label names the prompt in the warning message", () => {
+    load(join(tmpDir, "missing.md"), "router prompt");
+    expect(warnCalls[0].msg).toContain("router prompt override");
+  });
+});
+
+describe("resolveSelectorPrompt", () => {
+  // A stable phrase from the bundled selector prompt (`SYSTEM_PROMPT`).
+  const BUNDLED_PHRASE =
+    "Select EVERY candidate whose content the upcoming reply would draw on";
+
+  test("null path returns the bundled selector prompt", () => {
+    expect(resolveSelectorPrompt(null, tmpDir)).toContain(BUNDLED_PHRASE);
+  });
+
+  test("a configured file replaces the bundled prompt verbatim — no placeholder substitution", () => {
+    const body = "Custom selector instructions {{NOT_A_PLACEHOLDER}}\n";
+    writeFileSync(join(tmpDir, "selector.md"), body);
+    const out = resolveSelectorPrompt("selector.md", tmpDir);
+    expect(out).toBe(body);
+    expect(out).not.toContain(BUNDLED_PHRASE);
+  });
+
+  test("a missing override falls back to the bundled prompt", () => {
+    expect(resolveSelectorPrompt(join(tmpDir, "nope.md"), tmpDir)).toContain(
+      BUNDLED_PHRASE,
+    );
+  });
+});

--- a/assistant/src/memory/prompt-override.ts
+++ b/assistant/src/memory/prompt-override.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared loader for file-based prompt overrides.
+ *
+ * The memory router, consolidation, and v3 selector prompts each ship a bundled
+ * default that operators may replace by pointing a config field at a file. The
+ * load-with-fallback semantics are identical across all three, so they live
+ * here: path resolution, the size guard, and the permissive fallback that keeps
+ * retrieval/consolidation working when an override is missing or malformed.
+ *
+ * The caller owns the bundled default and any placeholder substitution — this
+ * module only decides whether a usable override file exists and returns its raw
+ * contents, or `null` to mean "fall back to the bundled prompt."
+ */
+
+import { lstatSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+/**
+ * Minimal logger surface the loader needs. Structurally compatible with
+ * `pino.Logger`, so callers pass their module logger directly and the warnings
+ * keep that logger's namespace; tests pass a lightweight recorder.
+ */
+export interface PromptOverrideLogger {
+  warn(obj: object, msg: string): void;
+}
+
+/**
+ * Hard upper bound on an override file. The bundled prompts are kilobytes; 1 MiB
+ * is generous headroom for a hand-edit while preventing a `settings.write`
+ * principal from pointing the field at a giant file (or an unsizeable stream
+ * `lstat` can't cap on its own) and slurping it into memory on every call.
+ */
+export const MAX_PROMPT_OVERRIDE_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Resolve a configured override path to an absolute path: a leading `~/` expands
+ * to the home directory, an absolute path is used as-is, and a relative path
+ * resolves under `workspaceDir`.
+ */
+export function resolveOverridePath(
+  overridePath: string,
+  workspaceDir: string,
+): string {
+  if (overridePath.startsWith("~/")) {
+    return join(homedir(), overridePath.slice(2));
+  }
+  if (isAbsolute(overridePath)) return overridePath;
+  return join(workspaceDir, overridePath);
+}
+
+/**
+ * Load a prompt-override file, returning its raw contents when the override is
+ * present and usable, or `null` (after logging a warning describing why) when
+ * the caller should fall back to its bundled prompt. A `null` `overridePath`
+ * returns `null` without touching the filesystem.
+ *
+ * Fallback is intentionally total — a missing, non-regular, oversized,
+ * unreadable, or empty/whitespace-only file all degrade to `null`. Memory
+ * retrieval and consolidation must never break because of a bad override.
+ *
+ * `label` names the prompt in the warning messages (e.g. `"router prompt"`).
+ */
+export function loadPromptOverride(opts: {
+  overridePath: string | null;
+  workspaceDir: string;
+  log: PromptOverrideLogger;
+  label: string;
+}): string | null {
+  const { overridePath, workspaceDir, log, label } = opts;
+  if (overridePath === null) return null;
+
+  const resolvedPath = resolveOverridePath(overridePath, workspaceDir);
+  let contents: string;
+  try {
+    const stat = lstatSync(resolvedPath);
+    if (!stat.isFile()) {
+      log.warn(
+        {
+          configuredPath: overridePath,
+          resolvedPath,
+          reason: "not_regular_file",
+          fallback: "bundled",
+        },
+        `${label} override is not a regular file; using bundled prompt`,
+      );
+      return null;
+    }
+    if (stat.size > MAX_PROMPT_OVERRIDE_BYTES) {
+      log.warn(
+        {
+          configuredPath: overridePath,
+          resolvedPath,
+          size: stat.size,
+          limit: MAX_PROMPT_OVERRIDE_BYTES,
+          reason: "oversized_override",
+          fallback: "bundled",
+        },
+        `${label} override exceeds size limit; using bundled prompt`,
+      );
+      return null;
+    }
+    contents = readFileSync(resolvedPath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    log.warn(
+      { configuredPath: overridePath, resolvedPath, code, fallback: "bundled" },
+      `${label} override unreadable; using bundled prompt`,
+    );
+    return null;
+  }
+
+  if (contents.trim().length === 0) {
+    log.warn(
+      {
+        configuredPath: overridePath,
+        resolvedPath,
+        reason: "empty_override",
+        fallback: "bundled",
+      },
+      `${label} override is empty; using bundled prompt`,
+    );
+    return null;
+  }
+
+  return contents;
+}

--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -18,12 +18,9 @@
  * the convention established for the sweep prompt.
  */
 
-import { lstatSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { isAbsolute, join } from "node:path";
-
 import { getLogger } from "../../../util/logger.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
+import { loadPromptOverride } from "../../prompt-override.js";
 
 const log = getLogger("memory-v2-consolidate-prompt");
 
@@ -60,14 +57,6 @@ export const CORE_PAGES_CONSOLIDATION_SECTION = `## 10. Review \`memory/core-pag
 - **Fix** entries whose page you renamed or deleted this pass (maintenance reports dangling entries, but never edits the file).
 
 `;
-
-/**
- * Upper bound for the override file. Real consolidation prompts are kilobytes;
- * 1 MiB is generous headroom while preventing a `settings.write` principal from
- * pointing the field at a multi-gigabyte file (or `/dev/zero`-like stream that
- * `lstat` can't size cap on its own) and exfiltrating it through the wake hint.
- */
-const MAX_PROMPT_BYTES = 1 * 1024 * 1024;
 
 /**
  * Consolidation prompt — live-mode only. The agent runs as itself (full
@@ -837,90 +826,32 @@ export function renderConsolidationPrompt(
 /**
  * Load the consolidation prompt template, optionally overridden from the file
  * referenced by `memory.v2.consolidation_prompt_path`, then substitute
- * `{{CUTOFF}}`. Path-resolution rules are documented on the schema field.
+ * `{{CUTOFF}}`. File loading (path resolution, size guard, and the permissive
+ * fall-back to the bundled prompt on a missing/unreadable/empty/oversized
+ * override) is handled by the shared {@link loadPromptOverride}.
  *
  * Override files get the same placeholder substitutions as the bundled
  * template: `{{CUTOFF}}` always, and `{{CORE_PAGES_SECTION}}` per the same
  * flag gate — so a prompt copied from the bundled source never leaks a raw
  * placeholder, and a customized prompt can opt into the managed section.
- *
- * Failure handling is intentionally permissive — missing file, read error, or
- * empty/whitespace-only body all log a warning and fall back to the bundled
- * prompt. Consolidation must never break because of a bad override: the
- * daemon's startup philosophy is "log and recover."
  */
 export function resolveConsolidationPrompt(
   overridePath: string | null,
   cutoff: string,
   options: ConsolidationPromptOptions,
 ): string {
-  if (overridePath === null) return renderConsolidationPrompt(cutoff, options);
+  const override = loadPromptOverride({
+    overridePath,
+    workspaceDir: getWorkspaceDir(),
+    log,
+    label: "consolidation prompt",
+  });
+  if (override === null) return renderConsolidationPrompt(cutoff, options);
 
-  const resolvedPath = resolveOverridePath(overridePath);
-  let contents: string;
-  try {
-    const stat = lstatSync(resolvedPath);
-    if (!stat.isFile()) {
-      log.warn(
-        {
-          configuredPath: overridePath,
-          resolvedPath,
-          reason: "not_regular_file",
-          fallback: "bundled",
-        },
-        "consolidation prompt override is not a regular file; using bundled prompt",
-      );
-      return renderConsolidationPrompt(cutoff, options);
-    }
-    if (stat.size > MAX_PROMPT_BYTES) {
-      log.warn(
-        {
-          configuredPath: overridePath,
-          resolvedPath,
-          size: stat.size,
-          limit: MAX_PROMPT_BYTES,
-          reason: "oversized_override",
-          fallback: "bundled",
-        },
-        "consolidation prompt override exceeds size limit; using bundled prompt",
-      );
-      return renderConsolidationPrompt(cutoff, options);
-    }
-    contents = readFileSync(resolvedPath, "utf-8");
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    log.warn(
-      { configuredPath: overridePath, resolvedPath, code, fallback: "bundled" },
-      "consolidation prompt override unreadable; using bundled prompt",
-    );
-    return renderConsolidationPrompt(cutoff, options);
-  }
-
-  if (contents.trim().length === 0) {
-    log.warn(
-      {
-        configuredPath: overridePath,
-        resolvedPath,
-        reason: "empty_override",
-        fallback: "bundled",
-      },
-      "consolidation prompt override is empty; using bundled prompt",
-    );
-    return renderConsolidationPrompt(cutoff, options);
-  }
-
-  return contents
+  return override
     .replaceAll(CUTOFF_PLACEHOLDER, cutoff)
     .replaceAll(
       CORE_PAGES_PLACEHOLDER,
       options.includeCorePagesSection ? CORE_PAGES_CONSOLIDATION_SECTION : "",
     );
-}
-
-function resolveOverridePath(overridePath: string): string {
-  if (overridePath.startsWith("~/")) {
-    return join(homedir(), overridePath.slice(2));
-  }
-  if (isAbsolute(overridePath)) return overridePath;
-  return join(getWorkspaceDir(), overridePath);
 }

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -22,21 +22,13 @@
  * same placeholder substitution applies to overrides.
  */
 
-import { lstatSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { isAbsolute, join } from "node:path";
-
 import { getLogger } from "../../../util/logger.js";
+import {
+  loadPromptOverride,
+  MAX_PROMPT_OVERRIDE_BYTES,
+} from "../../prompt-override.js";
 
 const log = getLogger("memory-v2-router-prompt");
-
-/**
- * Hard upper bound on the override file size. The bundled prompt is well
- * under 4 KiB; 1 MiB is generous-enough for any reasonable hand-edit while
- * still preventing pathological inputs from being slurped into memory on
- * every router call.
- */
-const MAX_PROMPT_BYTES = 1 * 1024 * 1024;
 
 /** Sentinel substituted with the assistant's display name at runtime. */
 const ASSISTANT_NAME_PLACEHOLDER = "{{ASSISTANT_NAME}}";
@@ -102,14 +94,12 @@ export function renderRouterPrompt(opts: RenderRouterPromptOpts): string {
 /**
  * Load the router prompt template, optionally overridden from the file
  * referenced by `memory.v2.router.router_prompt_path`, then substitute the
- * standard placeholders. Path-resolution rules mirror the consolidation
- * prompt override: absolute paths used as-is, leading `~/` expanded to home,
- * relative paths resolved under `workspaceDir`.
+ * standard placeholders. File loading (path resolution, size guard, and the
+ * permissive fall-back to the bundled prompt on a missing/unreadable/empty/
+ * oversized override) is handled by the shared {@link loadPromptOverride}.
  *
- * Failure handling is intentionally permissive — missing file, read error,
- * oversized file, or empty/whitespace-only body all log a warning and fall
- * back to the bundled prompt. Router selection must never break because of
- * a bad override.
+ * An `inlineOverride` (e.g. the simulator playground) takes precedence over the
+ * configured file path; same placeholder substitution and size guard apply.
  */
 export function resolveRouterPrompt(
   overridePath: string | null,
@@ -117,17 +107,15 @@ export function resolveRouterPrompt(
   opts: RenderRouterPromptOpts,
   inlineOverride?: string | null,
 ): string {
-  // Inline override (e.g. simulator playground) takes precedence over the
-  // configured file path and the bundled prompt. Same placeholder
-  // substitution + size guard as the file-path branch; empty/whitespace
-  // bodies fall through to file/bundled resolution so a "cleared" textarea
-  // is treated as no override.
+  // Inline override takes precedence over the configured file path and the
+  // bundled prompt. Empty/whitespace bodies fall through to file/bundled
+  // resolution so a "cleared" textarea is treated as no override.
   if (inlineOverride !== undefined && inlineOverride !== null) {
-    if (inlineOverride.length > MAX_PROMPT_BYTES) {
+    if (inlineOverride.length > MAX_PROMPT_OVERRIDE_BYTES) {
       log.warn(
         {
           size: inlineOverride.length,
-          limit: MAX_PROMPT_BYTES,
+          limit: MAX_PROMPT_OVERRIDE_BYTES,
           reason: "oversized_inline_override",
           fallback: "path_or_bundled",
         },
@@ -138,62 +126,13 @@ export function resolveRouterPrompt(
     }
   }
 
-  if (overridePath === null) return renderRouterPrompt(opts);
-
-  const resolvedPath = resolveOverridePath(overridePath, workspaceDir);
-  let contents: string;
-  try {
-    const stat = lstatSync(resolvedPath);
-    if (!stat.isFile()) {
-      log.warn(
-        {
-          configuredPath: overridePath,
-          resolvedPath,
-          reason: "not_regular_file",
-          fallback: "bundled",
-        },
-        "router prompt override is not a regular file; using bundled prompt",
-      );
-      return renderRouterPrompt(opts);
-    }
-    if (stat.size > MAX_PROMPT_BYTES) {
-      log.warn(
-        {
-          configuredPath: overridePath,
-          resolvedPath,
-          size: stat.size,
-          limit: MAX_PROMPT_BYTES,
-          reason: "oversized_override",
-          fallback: "bundled",
-        },
-        "router prompt override exceeds size limit; using bundled prompt",
-      );
-      return renderRouterPrompt(opts);
-    }
-    contents = readFileSync(resolvedPath, "utf-8");
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    log.warn(
-      { configuredPath: overridePath, resolvedPath, code, fallback: "bundled" },
-      "router prompt override unreadable; using bundled prompt",
-    );
-    return renderRouterPrompt(opts);
-  }
-
-  if (contents.trim().length === 0) {
-    log.warn(
-      {
-        configuredPath: overridePath,
-        resolvedPath,
-        reason: "empty_override",
-        fallback: "bundled",
-      },
-      "router prompt override is empty; using bundled prompt",
-    );
-    return renderRouterPrompt(opts);
-  }
-
-  return substitutePlaceholders(contents, opts);
+  const override = loadPromptOverride({
+    overridePath,
+    workspaceDir,
+    log,
+    label: "router prompt",
+  });
+  return substitutePlaceholders(override ?? ROUTER_PROMPT, opts);
 }
 
 function substitutePlaceholders(
@@ -206,15 +145,4 @@ function substitutePlaceholders(
     .replaceAll(ASSISTANT_NAME_PLACEHOLDER, () => assistant)
     .replaceAll(USER_NAME_PLACEHOLDER, () => user)
     .replaceAll(PAGE_INDEX_PLACEHOLDER, () => opts.pageIndexBlock);
-}
-
-function resolveOverridePath(
-  overridePath: string,
-  workspaceDir: string,
-): string {
-  if (overridePath.startsWith("~/")) {
-    return join(homedir(), overridePath.slice(2));
-  }
-  if (isAbsolute(overridePath)) return overridePath;
-  return join(workspaceDir, overridePath);
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -119,6 +119,10 @@ export interface OrchestrateDeps {
   /** Hard cap on total learned-lane surfaced articles; `0` disables the pass
    *  (canonical value: `memory.v3.learnedEdges.cap`). */
   learnedCap?: number;
+  /** The selector's system prompt. Omitted → the selector's bundled default.
+   *  The live caller resolves `memory.v3.selectorPromptPath` (workspace-relative
+   *  file override) via `resolveSelectorPrompt` and threads the result here. */
+  selectorPrompt?: string;
 }
 
 /** A finder-lane candidate: the slug, the descriptor that justified it, and
@@ -378,8 +382,13 @@ export async function orchestrate(
 
   // Step 3: a SINGLE forced-tool select over the cache-ordered pool. The
   // selections come back slug-deduped (pinned flags ORed) — `selectPool`'s
-  // contract.
-  const selections = await selectPool({ stable, finder: finderTail }, turn);
+  // contract. `selectorPrompt` is the (optionally overridden) instruction
+  // scaffold; `undefined` falls through to the bundled default.
+  const selections = await selectPool(
+    { stable, finder: finderTail },
+    turn,
+    deps.selectorPrompt,
+  );
 
   return {
     selections,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -50,6 +50,7 @@
 
 import { z } from "zod";
 
+import { loadPromptOverride } from "../../../memory/prompt-override.js";
 import { cachedTextBlock } from "../../../providers/cache-control.js";
 import {
   extractToolUse,
@@ -201,6 +202,28 @@ A page can be relevant because of the current situation — the date or the live
 
 If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the pool (keeps every candidate); return \`[]\` when candidates are present but none are relevant.`;
 
+/**
+ * Resolve the selector system prompt: the file at `overridePath` when it is set
+ * and usable, otherwise the bundled {@link SYSTEM_PROMPT}. Path resolution and
+ * fallback follow the shared override loader (workspace-relative; a missing,
+ * empty, oversized, or unreadable file degrades to the bundled prompt with a
+ * warning). The selector prompt takes no placeholders — the candidate pool is
+ * the user message — so an override file is used verbatim.
+ */
+export function resolveSelectorPrompt(
+  overridePath: string | null,
+  workspaceDir: string,
+): string {
+  return (
+    loadPromptOverride({
+      overridePath,
+      workspaceDir,
+      log,
+      label: "memory-v3 selector prompt",
+    }) ?? SYSTEM_PROMPT
+  );
+}
+
 /** Collapse a descriptor to one line and cap its length for a finder line. */
 function renderSnippet(descriptor: string): string {
   return truncate(descriptor.replace(/\s+/g, " ").trim(), SNIPPET_MAX_CHARS);
@@ -315,10 +338,15 @@ function dedupeBySlug(
  * relevant" signal); an explicit `[]` keeps none; an infrastructure failure
  * (after a short re-prompt retry) keeps none, degrading to the deterministic
  * recall lanes the orchestrator unions in.
+ *
+ * `systemPrompt` is the selector's instruction scaffold; it defaults to the
+ * bundled {@link SYSTEM_PROMPT} and is overridable via `memory.v3.selectorPromptPath`
+ * (resolved by {@link resolveSelectorPrompt} at the call site).
  */
 export async function selectPool(
   pool: SelectorPool,
   turn: MemoryRoutingTurn,
+  systemPrompt: string = SYSTEM_PROMPT,
 ): Promise<SelectedPage[]> {
   // The concatenated numbering: ids 1…m are the stable-prefix cards, ids
   // m+1… are the finder lines.
@@ -407,7 +435,7 @@ export async function selectPool(
     try {
       response = await provider.sendMessage([userMsg], {
         tools: [SELECT_PAGES_TOOL],
-        systemPrompt: SYSTEM_PROMPT,
+        systemPrompt,
         config: {
           callSite: MEMORY_V3_SELECT_CALL_SITE,
           tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -56,7 +56,10 @@ import { computeHotSet } from "./hot-set.js";
 import { computeLearnedEdgeGraph } from "./learned-edges.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { orchestrate } from "./orchestrate.js";
-import { MemoryV3RetrievalUnavailableError } from "./pool-select.js";
+import {
+  MemoryV3RetrievalUnavailableError,
+  resolveSelectorPrompt,
+} from "./pool-select.js";
 import { ensureSectionCollection } from "./section-dense-store.js";
 import type { SectionNeedle } from "./section-needle.js";
 import { buildSectionNeedle } from "./section-needle.js";
@@ -576,6 +579,10 @@ export async function observeTurn(
       learnedGraph: lanes.learnedGraph,
       learnedPerSeed: v3.learnedEdges.perSeed,
       learnedCap: v3.learnedEdges.cap,
+      selectorPrompt: resolveSelectorPrompt(
+        v3.selectorPromptPath,
+        getWorkspaceDir(),
+      ),
     });
 
     // A zero-selection turn over a non-trivial pool is unusual enough to be


### PR DESCRIPTION
## Summary

- Add `memory.v3.selectorPromptPath`: when set, the memory-v3 per-turn selector's system prompt is loaded from that file (absolute path as-is, leading `~/` expanded, otherwise resolved under the workspace root). When unset — or the file is missing, empty, oversized, or unreadable — it falls back to the bundled prompt with a warning. **Default behavior is unchanged** for anyone who doesn't set the field.
- The selector prompt takes no placeholders (the candidate pool is supplied separately as the user message), so an override file is used **verbatim**. Resolution happens in `shadow-plugin` (where config + workspace dir are real) and threads through `orchestrate` → `selectPool` as an optional param, keeping `selectPool` pure and its existing tests untouched.
- Since v3 would be the third consumer of the same load-with-fallback logic, extracted it into `assistant/src/memory/prompt-override.ts` and routed the **v2 router**, **v2 consolidation**, and **v3 selector** prompts through it — removing the duplicated loaders (net −89 lines). The shared util reproduces v2's exact warning payloads (`reason`/`code`/`size`/`fallback`), so the existing v2 prompt-path tests pass unchanged.

## Original prompt

Sidd asked whether the memory-v3 selector prompt was configurable. It wasn't — it's a hardcoded `SYSTEM_PROMPT` in `pool-select.ts` — even though memory-v2 already supports `router_prompt_path` / `consolidation_prompt_path` file overrides. He then asked to make it configurable, matching v2's override pattern (verified against the v2 code, not assumed) and reusing the same loader so behavior stays consistent.

## Testing

- New focused suite `assistant/src/memory/__tests__/prompt-override.test.ts` (loader path resolution + every fallback mode + `resolveSelectorPrompt`), mirroring the v2 `prompts-router` / `prompts-consolidation` suites.
- `bunx tsc --noEmit` clean (only pre-existing `@slack/types` worktree-install noise, unrelated).
- Green: `prompt-override`, `prompts-router`, `prompts-consolidation`, `consolidation-prompt-flag-gating-guard`, `memory-v3`/`memory-v2` schema, both `pool-select` suites, `orchestrate`, `memory-v2-simulate-route`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)