### PR TITLE
feat(web): recreate teleport UI behind the teleport flag for the Electron client

### DIFF
--- a/clients/macos/src/main/csp.ts
+++ b/clients/macos/src/main/csp.ts
@@ -29,11 +29,19 @@ const WILDCARD_HOST = `*${ROOT_HOSTNAME}`;
 // loopback ingress is the one shape a static CSP can allowlist. A REMOTE
 // self-hosted ingress (e.g. an ngrok wss:// URL) still can't be — those
 // connections need the planned proxy-through-main follow-up.
+//
+// https://storage.googleapis.com (+ wildcard) in connect-src: teleport streams
+// assistant `.vbundle` bytes directly to/from GCS via platform-issued signed
+// URLs (PUT on export-to-cloud, GET on import-to-local). Those requests leave
+// the renderer for Google's storage host, which isn't a Vellum origin, so the
+// transfer is CSP-blocked without an explicit allowlist. Both the path-style
+// (`storage.googleapis.com/<bucket>/...`) and virtual-hosted
+// (`<bucket>.storage.googleapis.com/...`) URL shapes are covered.
 export const CSP_POLICY = [
   "default-src 'self'",
   `script-src 'self' 'unsafe-inline' https://${WILDCARD_HOST}`,
   "style-src 'self' 'unsafe-inline'",
-  `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com ws://localhost:* ws://127.0.0.1:*`,
+  `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com https://storage.googleapis.com https://*.storage.googleapis.com ws://localhost:* ws://127.0.0.1:*`,
   "img-src 'self' https: data: blob:",
   "media-src 'self' blob:",
   "worker-src 'self' blob: https://cdn.jsdelivr.net",

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -26,6 +26,7 @@ import { PreviewReleaseChannel } from "@/domains/settings/components/preview-rel
 import { ResizeCard } from "@/domains/settings/components/resize-card";
 import { RetireAssistant } from "@/domains/settings/components/retire-assistant";
 import { TimezonePicker } from "@/domains/settings/components/timezone-picker";
+import { TeleportCard } from "@/domains/settings/teleport/teleport-card";
 import { SegmentControl } from "@vellumai/design-library/components/segment-control";
 
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -225,6 +226,7 @@ export function GeneralPage() {
     refetchUntilResized,
   } = useAssistantWithHealthz();
   const multiPlatformAssistant = useClientFeatureFlagStore.use.multiPlatformAssistant();
+  const teleportEnabled = useClientFeatureFlagStore.use.teleport();
   const settingsSleepPolicy = useAssistantFeatureFlagStore.use.settingsSleepPolicy();
   const isAuthenticated = useIsAuthenticated();
   const navigate = useNavigate();
@@ -314,6 +316,8 @@ export function GeneralPage() {
       <ComposerSendCard />
 
       {isElectron() && <LaunchAtLoginCard />}
+
+      {teleportEnabled && isElectron() && <TeleportCard />}
 
       {infraGate === "full" && platformAssistant && (
         <DetailCard title="Software Updates">

--- a/clients/web/src/domains/settings/teleport/bundle-stream.ts
+++ b/clients/web/src/domains/settings/teleport/bundle-stream.ts
@@ -1,0 +1,36 @@
+/**
+ * Read a response body into an `ArrayBuffer`, reporting progress (0..1) when the
+ * server sends a `Content-Length`. Shared by the platform signed-URL download
+ * and the local gateway export, which both stream `.vbundle` bytes.
+ */
+export async function readArrayBufferWithProgress(
+  response: Response,
+  onProgress?: (fraction: number) => void,
+): Promise<ArrayBuffer> {
+  const total = Number(response.headers.get("Content-Length") ?? 0);
+  if (!response.body || !onProgress || total <= 0) {
+    const bytes = await response.arrayBuffer();
+    onProgress?.(1);
+    return bytes;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    received += value.length;
+    onProgress(received / total);
+  }
+
+  const out = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  onProgress(1);
+  return out.buffer;
+}

--- a/clients/web/src/domains/settings/teleport/platform-migration-client.ts
+++ b/clients/web/src/domains/settings/teleport/platform-migration-client.ts
@@ -1,0 +1,261 @@
+/**
+ * Client for the platform's org-scoped migration endpoints, ported from the
+ * macOS `PlatformMigrationClient.swift`.
+ *
+ * The JSON control-plane calls (`signed-url`, `import-from-gcs`, `jobs`) go
+ * through the generated API `client` so the central interceptor attaches the
+ * session + organization auth headers — those headers must never be set by
+ * feature code. The binary data-plane (`PUT`/`GET` of bundle bytes) talks
+ * directly to the GCS signed URLs, which carry their own auth in the URL and
+ * need no Vellum headers.
+ */
+
+import { client } from "@/generated/api/client.gen";
+
+import { readArrayBufferWithProgress } from "./bundle-stream";
+import { parseVersionMismatch, TeleportError } from "./teleport-types";
+
+/** Response from the platform's unified signed-URL endpoint. */
+export interface SignedUrlResponse {
+  /** Signed URL for a direct GCS PUT/GET of bundle bytes. */
+  url: string;
+  /** Opaque bundle key the runtime/platform use to reference the object. */
+  bundleKey: string;
+  /** ISO-8601 expiry of the signed URL. */
+  expiresAt: string;
+}
+
+/** Status of an async migration job returned by the unified job-status endpoint. */
+export interface JobStatus {
+  status: string;
+  jobId: string | null;
+  error: string | null;
+}
+
+const RETRYABLE_STATUS = new Set([500, 502, 503, 504]);
+const MAX_RETRIES = 3;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+interface ClientResult {
+  response?: Response;
+  data?: unknown;
+  error?: unknown;
+}
+
+/**
+ * Run a generated-client call with retry on transient 5xx server errors, using
+ * the same 1s/2s/4s exponential backoff as the Swift client. `nonRetryable`
+ * lets callers treat specific codes (e.g. 422 version-mismatch, 404/503
+ * unavailable) as permanent semantic signals rather than transient errors.
+ */
+async function requestWithRetry(
+  call: () => Promise<ClientResult>,
+  nonRetryable: Set<number> = new Set(),
+): Promise<{ status: number; data: unknown; error: unknown }> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const { response, data, error } = await call();
+    const status = response?.status ?? 0;
+    if (
+      attempt < MAX_RETRIES &&
+      RETRYABLE_STATUS.has(status) &&
+      !nonRetryable.has(status)
+    ) {
+      await sleep(2 ** attempt * 1000);
+      continue;
+    }
+    return { status, data, error };
+  }
+  throw new TeleportError("unknown", "Unexpected retry loop exit");
+}
+
+/**
+ * Request a signed upload URL: `POST /v1/migrations/signed-url/` with
+ * `{operation:"upload"}`. The returned URL is suitable for a direct GCS PUT.
+ */
+export async function requestSignedUploadUrl(): Promise<SignedUrlResponse> {
+  const { status, data } = await requestWithRetry(
+    () =>
+      client.post<unknown, unknown, false>({
+        url: "/v1/migrations/signed-url/",
+        body: { operation: "upload" },
+        throwOnError: false,
+      }),
+    new Set([404, 503]),
+  );
+
+  if (status === 503 || status === 404) {
+    throw new TeleportError(
+      "export_failed",
+      "Signed URL uploads are not available — the platform may not support this feature yet.",
+    );
+  }
+  if (status !== 201) {
+    throw new TeleportError(
+      "export_failed",
+      `Migration request failed (HTTP ${status}).`,
+    );
+  }
+  const json = data as { url: string; bundle_key: string; expires_at: string };
+  return { url: json.url, bundleKey: json.bundle_key, expiresAt: json.expires_at };
+}
+
+/**
+ * Request a signed download URL: `POST /v1/migrations/signed-url/` with
+ * `{operation:"download", bundle_key, target_runtime_version}`. The platform
+ * validates the bundle's runtime-compat range against the target runtime and
+ * rejects with 422 + `reason:"version_mismatch"` when there's no overlap.
+ */
+export async function requestSignedDownloadUrl(
+  bundleKey: string,
+  targetRuntimeVersion: string,
+): Promise<string> {
+  const { status, data, error } = await requestWithRetry(
+    () =>
+      client.post<unknown, unknown, false>({
+        url: "/v1/migrations/signed-url/",
+        body: {
+          operation: "download",
+          bundle_key: bundleKey,
+          target_runtime_version: targetRuntimeVersion,
+        },
+        throwOnError: false,
+      }),
+    new Set([422]),
+  );
+
+  if (status === 422) {
+    const message = parseVersionMismatch(error);
+    if (message) throw new TeleportError("version_mismatch", message);
+  }
+  if (status !== 200 && status !== 201) {
+    throw new TeleportError(
+      "import_failed",
+      `Migration request failed (HTTP ${status}).`,
+    );
+  }
+  return (data as { url: string }).url;
+}
+
+/**
+ * Upload bundle bytes to a GCS signed URL via `PUT`, reporting progress through
+ * `onProgress` (0..1). Uses `XMLHttpRequest` because `fetch` can't report
+ * upload progress. Retries transient 5xx with the same backoff as the Swift
+ * client.
+ */
+export async function uploadToSignedUrl(
+  url: string,
+  bundle: ArrayBuffer | Blob,
+  onProgress?: (fraction: number) => void,
+): Promise<void> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const status = await putWithProgress(url, bundle, onProgress);
+    if (attempt < MAX_RETRIES && RETRYABLE_STATUS.has(status)) {
+      await sleep(2 ** attempt * 1000);
+      onProgress?.(0);
+      continue;
+    }
+    if (status < 200 || status >= 300) {
+      throw new TeleportError(
+        "export_failed",
+        `Bundle upload failed (HTTP ${status}).`,
+      );
+    }
+    return;
+  }
+}
+
+function putWithProgress(
+  url: string,
+  bundle: ArrayBuffer | Blob,
+  onProgress?: (fraction: number) => void,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("PUT", url);
+    xhr.setRequestHeader("Content-Type", "application/octet-stream");
+    xhr.timeout = 3_600_000;
+    if (onProgress) {
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable) onProgress(event.loaded / event.total);
+      };
+    }
+    xhr.onload = () => {
+      onProgress?.(1);
+      resolve(xhr.status);
+    };
+    xhr.onerror = () =>
+      reject(new TeleportError("export_failed", "Bundle upload failed."));
+    xhr.ontimeout = () =>
+      reject(new TeleportError("export_timed_out", "Bundle upload timed out."));
+    xhr.send(bundle);
+  });
+}
+
+/**
+ * Download bundle bytes from a GCS signed URL via `GET`, reporting progress
+ * through `onProgress` (0..1) by streaming the response body. Retries transient
+ * 5xx with the same backoff as the Swift client.
+ */
+export async function downloadFromSignedUrl(
+  url: string,
+  onProgress?: (fraction: number) => void,
+): Promise<ArrayBuffer> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetch(url, { method: "GET" });
+    if (attempt < MAX_RETRIES && RETRYABLE_STATUS.has(response.status)) {
+      await sleep(2 ** attempt * 1000);
+      onProgress?.(0);
+      continue;
+    }
+    if (!response.ok) {
+      throw new TeleportError(
+        "import_failed",
+        `Bundle download failed (HTTP ${response.status}).`,
+      );
+    }
+    return readArrayBufferWithProgress(response, onProgress);
+  }
+  throw new TeleportError("import_failed", "Unexpected retry loop exit");
+}
+
+/**
+ * Trigger a GCS-based import on the platform after the bundle has been
+ * uploaded: `POST /v1/migrations/import-from-gcs/` with `{bundle_key}`.
+ */
+export async function importFromGcs(
+  bundleKey: string,
+): Promise<{ status: number; body: unknown }> {
+  const { status, data, error } = await requestWithRetry(() =>
+    client.post<unknown, unknown, false>({
+      url: "/v1/migrations/import-from-gcs/",
+      body: { bundle_key: bundleKey },
+      throwOnError: false,
+    }),
+  );
+  return { status, body: data ?? error ?? null };
+}
+
+/** Poll an async platform migration job: `GET /v1/migrations/jobs/{jobId}/`. */
+export async function pollJobStatus(jobId: string): Promise<JobStatus> {
+  const { status, data } = await requestWithRetry(() =>
+    client.get<unknown, unknown, false>({
+      url: "/v1/migrations/jobs/{job_id}/",
+      path: { job_id: jobId },
+      throwOnError: false,
+    }),
+  );
+  if (status !== 200) {
+    throw new TeleportError(
+      "import_failed",
+      `Job status check failed (HTTP ${status})`,
+    );
+  }
+  const json = (data ?? {}) as Record<string, unknown>;
+  return {
+    status: typeof json.status === "string" ? json.status : "unknown",
+    jobId: typeof json.job_id === "string" ? json.job_id : null,
+    error: typeof json.error === "string" ? json.error : null,
+  };
+}

--- a/clients/web/src/domains/settings/teleport/platform-migration-client.ts
+++ b/clients/web/src/domains/settings/teleport/platform-migration-client.ts
@@ -73,13 +73,25 @@ async function requestWithRetry(
 /**
  * Request a signed upload URL: `POST /v1/migrations/signed-url/` with
  * `{operation:"upload"}`. The returned URL is suitable for a direct GCS PUT.
+ *
+ * `sourceRuntimeVersion` stamps the bundle's compat band (`min_runtime_version`
+ * with no upper bound) so the later download-side `target_runtime_version`
+ * check can enforce a real version-mismatch guard — matching the CLI teleport
+ * path, which sends the source runtime version before upload.
  */
-export async function requestSignedUploadUrl(): Promise<SignedUrlResponse> {
+export async function requestSignedUploadUrl(
+  sourceRuntimeVersion?: string,
+): Promise<SignedUrlResponse> {
+  const body: Record<string, unknown> = { operation: "upload" };
+  if (sourceRuntimeVersion) {
+    body.min_runtime_version = sourceRuntimeVersion;
+    body.max_runtime_version = null;
+  }
   const { status, data } = await requestWithRetry(
     () =>
       client.post<unknown, unknown, false>({
         url: "/v1/migrations/signed-url/",
-        body: { operation: "upload" },
+        body,
         throwOnError: false,
       }),
     new Set([404, 503]),

--- a/clients/web/src/domains/settings/teleport/teleport-card.tsx
+++ b/clients/web/src/domains/settings/teleport/teleport-card.tsx
@@ -1,0 +1,113 @@
+/**
+ * Teleport settings card — the web/Electron port of the macOS
+ * `TeleportSection.swift` UI. Lets the user move the active assistant between
+ * hosting environments (local / Docker / cloud), preserving the source until
+ * the new one is confirmed working.
+ *
+ * Rendered only when the `teleport` client feature flag is on AND the client is
+ * the Electron host (gated by the caller in `general-page.tsx`).
+ */
+
+import { CheckCircle2, Loader2 } from "lucide-react";
+
+import { DetailCard } from "@/components/detail-card";
+import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { Notice } from "@vellumai/design-library/components/notice";
+import { ProgressBar } from "@vellumai/design-library/components/progress-bar";
+
+import {
+  destinationDescription,
+  destinationLabel,
+} from "./teleport-types";
+import { useTeleport } from "./use-teleport";
+
+export function TeleportCard() {
+  const teleport = useTeleport();
+  const { destination, phase } = teleport;
+
+  // No eligible destination for this assistant — leave teleport hidden, matching
+  // the Swift picker which renders nothing for out-of-scope assistants.
+  if (!destination) return null;
+
+  return (
+    <DetailCard
+      title="Teleport"
+      subtitle="Move your assistant to a different hosting environment."
+    >
+      {phase.kind === "idle" && (
+        <div className="flex flex-col gap-2">
+          <p className="text-body-medium-default text-[var(--content-tertiary)]">
+            {destinationDescription(destination)}
+          </p>
+          <Button
+            variant="outlined"
+            className="self-start"
+            onClick={teleport.requestTeleport}
+          >
+            {destinationLabel(destination)}
+          </Button>
+        </div>
+      )}
+
+      {phase.kind === "transferring" && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            {phase.progress == null && (
+              <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
+            )}
+            <span className="text-body-medium-default text-[var(--content-tertiary)]">
+              {phase.step}
+            </span>
+          </div>
+          {phase.progress != null && (
+            <ProgressBar
+              value={phase.progress}
+              aria-label="Teleport progress"
+              className="max-w-[240px]"
+            />
+          )}
+        </div>
+      )}
+
+      {phase.kind === "verifying" && (
+        <Notice
+          tone="success"
+          icon={<CheckCircle2 className="h-4 w-4" />}
+          title="Transfer complete — verify your new assistant is working."
+          actions={
+            <div className="flex gap-2">
+              <Button variant="primary" onClick={teleport.confirmAndSwitch}>
+                Confirm &amp; Switch
+              </Button>
+              <Button variant="outlined" onClick={teleport.cancelTeleport}>
+                Cancel
+              </Button>
+            </div>
+          }
+        />
+      )}
+
+      {phase.kind === "failed" && (
+        <Notice
+          tone="error"
+          title={phase.error}
+          actions={
+            <Button variant="outlined" onClick={teleport.reset}>
+              Try Again
+            </Button>
+          }
+        />
+      )}
+
+      <ConfirmDialog
+        open={teleport.confirmOpen}
+        title={destinationLabel(destination)}
+        message="Your data will be copied to the new environment. The current assistant will remain available until you confirm the new one works."
+        confirmLabel="Teleport"
+        onConfirm={teleport.confirm}
+        onCancel={teleport.cancelConfirm}
+      />
+    </DetailCard>
+  );
+}

--- a/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
@@ -1,0 +1,187 @@
+/**
+ * Assistant-scoped gateway/runtime calls for teleport, ported from the macOS
+ * `GatewayHTTPClient.withAssistant(...)` usage in `TeleportSection.swift`.
+ *
+ * Two transports, picked per assistant:
+ *   - **local / docker** assistants are reached directly over their local
+ *     gateway proxy (`/assistant/__gateway/<port>`), authenticated with a
+ *     gateway token freshly minted from the assistant's guardian token. This
+ *     mirrors the Swift `bootstrapActorToken` + `withAssistant` scoping and is
+ *     isolated from the globally-active self-hosted connection so a teleport
+ *     never disturbs the current session's token.
+ *   - **managed (cloud)** assistants are reached through the platform's
+ *     assistant proxy (`/v1/assistants/{id}/...`) via the generated API client,
+ *     which already attaches the session + organization headers.
+ */
+
+import { client } from "@/generated/api/client.gen";
+import { getLocalGatewayUrl } from "@/lib/local-mode";
+import type { LockfileAssistant } from "@/runtime/local-mode-host";
+import { fetchGuardianTokenHost } from "@/runtime/local-mode-host";
+
+import { readArrayBufferWithProgress } from "./bundle-stream";
+import { TeleportError } from "./teleport-types";
+
+/** Resolve the absolute local gateway base URL for a local/docker assistant. */
+function localGatewayBase(assistant: LockfileAssistant): string {
+  const path = getLocalGatewayUrl(assistant);
+  if (!path) {
+    throw new TeleportError(
+      "local_assistant_not_found",
+      `Assistant ${assistant.assistantId} has no resolved local gateway.`,
+    );
+  }
+  return `${window.location.origin}${path}`;
+}
+
+/**
+ * Mint a gateway token for a specific local/docker assistant by exchanging its
+ * guardian token at the gateway's `/auth/token` mint. Kept separate from the
+ * shared `ensureGatewayToken` cache so teleporting to a target gateway doesn't
+ * clobber the active session's token.
+ */
+async function mintLocalGatewayToken(
+  assistant: LockfileAssistant,
+  base: string,
+): Promise<string> {
+  const guardianToken = await fetchGuardianTokenHost(assistant.assistantId);
+  const res = await fetch(`${base}/auth/token`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${guardianToken}` },
+  });
+  if (!res.ok) {
+    throw new TeleportError(
+      "not_signed_in",
+      `Gateway token request failed (HTTP ${res.status}).`,
+    );
+  }
+  const { token } = (await res.json()) as { token: string };
+  return token;
+}
+
+/**
+ * Export a local/docker assistant's data as a `.vbundle` byte stream from its
+ * gateway: `POST /v1/migrations/export`. Reports download progress (0..1).
+ */
+export async function exportLocalBundle(
+  assistant: LockfileAssistant,
+  onProgress?: (fraction: number) => void,
+): Promise<ArrayBuffer> {
+  const base = localGatewayBase(assistant);
+  const token = await mintLocalGatewayToken(assistant, base);
+  const response = await fetch(`${base}/v1/migrations/export`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new TeleportError(
+      "export_failed",
+      `Export failed (HTTP ${response.status}).`,
+    );
+  }
+  return readArrayBufferWithProgress(response, onProgress);
+}
+
+/**
+ * Import `.vbundle` bytes into a local/docker assistant via its gateway:
+ * `POST /v1/migrations/import` (octet-stream body). Throws on a non-2xx status
+ * or a `{success:false}` body.
+ */
+export async function importLocalBundle(
+  assistant: LockfileAssistant,
+  bundle: ArrayBuffer,
+): Promise<void> {
+  const base = localGatewayBase(assistant);
+  const token = await mintLocalGatewayToken(assistant, base);
+  const response = await fetch(`${base}/v1/migrations/import`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/octet-stream",
+    },
+    body: bundle,
+  });
+  if (!response.ok) {
+    throw new TeleportError(
+      "import_failed",
+      `Import failed (HTTP ${response.status}).`,
+    );
+  }
+  const json = (await safeJson(response)) as { success?: boolean; error?: string } | null;
+  if (json && json.success === false) {
+    throw new TeleportError(
+      "import_failed",
+      json.error ?? "Import reported failure",
+    );
+  }
+}
+
+/**
+ * Ask a managed (cloud) assistant's runtime to export to a signed GCS URL:
+ * `POST /v1/assistants/{id}/migrations/export-to-gcs/`. The export is async —
+ * the runtime returns 202 + `job_id` and uploads in the background.
+ */
+export async function exportManagedToGcs(
+  managedId: string,
+  uploadUrl: string,
+): Promise<string> {
+  const { data, response } = await client.post<unknown, unknown, false>({
+    url: "/v1/assistants/{assistant_id}/migrations/export-to-gcs/",
+    path: { assistant_id: managedId },
+    body: { upload_url: uploadUrl },
+    throwOnError: false,
+  });
+  const status = response?.status ?? 0;
+  if (!(response?.ok ?? false) && status !== 202) {
+    throw new TeleportError("export_failed", `Export failed (HTTP ${status}).`);
+  }
+  const jobId = (data as { job_id?: string } | undefined)?.job_id;
+  if (!jobId) {
+    throw new TeleportError(
+      "export_failed",
+      "Export accepted but no job ID was returned.",
+    );
+  }
+  return jobId;
+}
+
+/**
+ * Poll a managed assistant's runtime-local export job until it completes:
+ * `GET /v1/assistants/{id}/migrations/jobs/{jobId}`. Routes through the
+ * assistant proxy so it reaches the runtime's in-memory job registry rather
+ * than the platform job DB.
+ */
+export async function pollManagedExportJob(
+  managedId: string,
+  jobId: string,
+): Promise<string> {
+  const { data, response } = await client.get<unknown, unknown, false>({
+    url: "/v1/assistants/{assistant_id}/migrations/jobs/{job_id}",
+    path: { assistant_id: managedId, job_id: jobId },
+    throwOnError: false,
+  });
+  const status = response?.status ?? 0;
+  if (status >= 500) return "processing"; // transient — caller retries
+  if (!(response?.ok ?? false)) {
+    throw new TeleportError(
+      "export_job_failed",
+      `Job status check failed (HTTP ${status})`,
+    );
+  }
+  const job = data as { status?: string; error?: string } | undefined;
+  if (job?.status === "failed") {
+    throw new TeleportError(
+      "export_job_failed",
+      job.error ?? "Export job failed",
+    );
+  }
+  return job?.status ?? "processing";
+}
+
+async function safeJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}

--- a/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
@@ -22,7 +22,13 @@ import { fetchGuardianTokenHost } from "@/runtime/local-mode-host";
 import { readArrayBufferWithProgress } from "./bundle-stream";
 import { TeleportError } from "./teleport-types";
 
-/** Resolve the absolute local gateway base URL for a local/docker assistant. */
+/**
+ * Resolve the absolute local gateway base URL for a local assistant. Only
+ * `cloud === "local"` assistants are reachable this way (`getLocalGatewayUrl`
+ * resolves the `/assistant/__gateway/<port>` proxy for them); Docker and other
+ * hosting kinds never reach here because `resolveDestination` doesn't offer
+ * teleport for them.
+ */
 function localGatewayBase(assistant: LockfileAssistant): string {
   const path = getLocalGatewayUrl(assistant);
   if (!path) {

--- a/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
@@ -99,13 +99,16 @@ export async function importLocalBundle(
 ): Promise<void> {
   const base = localGatewayBase(assistant);
   const token = await mintLocalGatewayToken(assistant, base);
+  // Send the body as a Blob, not a raw ArrayBuffer. The local gateway proxy
+  // runs over plain HTTP, and Chromium streams an ArrayBuffer body through a
+  // fixed-capacity (~1-2 MB) renderer data pipe — a larger `.vbundle` stalls
+  // forever when the local consumer drains it slowly, hanging on "Importing
+  // data...". A Blob is passed by handle and read directly, with no pipe to
+  // block on (the same fix `api-interceptors.ts` applies to local-mode bodies).
   const response = await fetch(`${base}/v1/migrations/import`, {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/octet-stream",
-    },
-    body: bundle,
+    headers: { Authorization: `Bearer ${token}` },
+    body: new Blob([bundle], { type: "application/octet-stream" }),
   });
   if (!response.ok) {
     throw new TeleportError(

--- a/clients/web/src/domains/settings/teleport/teleport-types.test.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-types.test.ts
@@ -28,12 +28,13 @@ describe("resolveDestination", () => {
     expect(resolveDestination("vellum")).toBe("local");
   });
 
-  it("offers platform for local and docker assistants", () => {
+  it("offers platform for local assistants", () => {
     expect(resolveDestination("local")).toBe("platform");
-    expect(resolveDestination("docker")).toBe("platform");
   });
 
-  it("offers nothing for out-of-scope assistants", () => {
+  it("offers nothing for assistants without a local-gateway transport", () => {
+    // Docker has no web export transport; apple-container/unknown are out of scope.
+    expect(resolveDestination("docker")).toBeNull();
     expect(resolveDestination("apple-container")).toBeNull();
     expect(resolveDestination(undefined)).toBeNull();
   });

--- a/clients/web/src/domains/settings/teleport/teleport-types.test.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-types.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  classifyHosting,
+  destinationDescription,
+  destinationLabel,
+  parseVersionMismatch,
+  resolveDestination,
+} from "./teleport-types";
+
+describe("classifyHosting", () => {
+  it("maps known cloud values, case-insensitively", () => {
+    expect(classifyHosting("local")).toBe("local");
+    expect(classifyHosting("docker")).toBe("docker");
+    expect(classifyHosting("vellum")).toBe("managed");
+    expect(classifyHosting("Vellum")).toBe("managed");
+  });
+
+  it("treats unknown or missing values as other", () => {
+    expect(classifyHosting(undefined)).toBe("other");
+    expect(classifyHosting("")).toBe("other");
+    expect(classifyHosting("apple-container")).toBe("other");
+  });
+});
+
+describe("resolveDestination", () => {
+  it("offers local for managed assistants", () => {
+    expect(resolveDestination("vellum")).toBe("local");
+  });
+
+  it("offers platform for local and docker assistants", () => {
+    expect(resolveDestination("local")).toBe("platform");
+    expect(resolveDestination("docker")).toBe("platform");
+  });
+
+  it("offers nothing for out-of-scope assistants", () => {
+    expect(resolveDestination("apple-container")).toBeNull();
+    expect(resolveDestination(undefined)).toBeNull();
+  });
+});
+
+describe("destination copy", () => {
+  it("has a label and description for each destination", () => {
+    for (const dest of ["docker", "platform", "local"] as const) {
+      expect(destinationLabel(dest).length).toBeGreaterThan(0);
+      expect(destinationDescription(dest).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("parseVersionMismatch", () => {
+  it("formats a bounded compat range", () => {
+    const message = parseVersionMismatch({
+      reason: "version_mismatch",
+      target_runtime_version: "1.2.0",
+      bundle_compat: {
+        min_runtime_version: "1.5.0",
+        max_runtime_version: "2.0.0",
+      },
+    });
+    expect(message).toContain("1.5.0–2.0.0");
+    expect(message).toContain("1.2.0");
+  });
+
+  it("formats an open-ended compat range", () => {
+    const message = parseVersionMismatch({
+      reason: "version_mismatch",
+      target_runtime_version: "1.2.0",
+      bundle_compat: { min_runtime_version: "1.5.0" },
+    });
+    expect(message).toContain("1.5.0+");
+  });
+
+  it("returns null for non-version-mismatch or malformed bodies", () => {
+    expect(parseVersionMismatch(null)).toBeNull();
+    expect(parseVersionMismatch({ reason: "other" })).toBeNull();
+    expect(
+      parseVersionMismatch({ reason: "version_mismatch", bundle_compat: {} }),
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/teleport/teleport-types.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-types.ts
@@ -68,18 +68,22 @@ export function classifyHosting(cloud: string | undefined): AssistantHosting {
 }
 
 /**
- * The single destination the picker offers for an assistant, mirroring the
- * Swift `destinationPicker`:
+ * The single destination the picker offers for an assistant:
  *   - managed (cloud)            → move to local
- *   - local or docker            → move to cloud (platform)
+ *   - local                      → move to cloud (platform)
  *   - anything else              → no teleport offered
+ *
+ * Docker is intentionally excluded: the web client only reaches local-kind
+ * assistants over the local gateway proxy (`getLocalGatewayUrl` resolves
+ * `cloud === "local"` only), so there is no transport to export a Docker
+ * assistant. Offering it would fail before export.
  */
 export function resolveDestination(
   cloud: string | undefined,
 ): TeleportDestination | null {
   const hosting = classifyHosting(cloud);
   if (hosting === "managed") return "local";
-  if (hosting === "local" || hosting === "docker") return "platform";
+  if (hosting === "local") return "platform";
   return null;
 }
 

--- a/clients/web/src/domains/settings/teleport/teleport-types.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-types.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure types and decision logic for the teleport feature — the web/Electron
+ * port of the macOS `TeleportSection.swift`.
+ *
+ * Teleport moves an assistant between hosting environments (local, Docker, or
+ * the Vellum cloud platform) *without* retiring the source until the user
+ * confirms the new one works. Everything in this file is side-effect-free so it
+ * can be unit-tested without the gateway/platform transport.
+ */
+
+/** Where an assistant can be teleported to. */
+export type TeleportDestination = "docker" | "platform" | "local";
+
+/** Coarse hosting classification of an assistant, derived from its lockfile `cloud`. */
+export type AssistantHosting = "local" | "docker" | "managed" | "other";
+
+/** UI/state-machine phase, mirroring the Swift `TeleportPhase` enum. */
+export type TeleportPhase =
+  | { kind: "idle" }
+  | { kind: "transferring"; step: string; progress: number | null }
+  | { kind: "verifying" }
+  | { kind: "failed"; error: string };
+
+/** Stable error codes for teleport failures, mirroring Swift `TeleportError`. */
+export type TeleportErrorCode =
+  | "not_signed_in"
+  | "export_failed"
+  | "export_timed_out"
+  | "export_job_failed"
+  | "import_failed"
+  | "managed_entry_not_found"
+  | "local_assistant_not_found"
+  | "docker_assistant_not_found"
+  | "no_organizations"
+  | "multiple_organizations"
+  | "existing_platform_assistant"
+  | "version_mismatch"
+  | "unknown";
+
+/** A teleport error carrying a stable code plus a human-readable message. */
+export class TeleportError extends Error {
+  readonly code: TeleportErrorCode;
+
+  constructor(code: TeleportErrorCode, message: string) {
+    super(message);
+    this.name = "TeleportError";
+    this.code = code;
+  }
+}
+
+/** The lockfile `cloud` value reported for each hosting kind. */
+const LOCAL_CLOUD = "local";
+const DOCKER_CLOUD = "docker";
+const MANAGED_CLOUD = "vellum";
+
+/** Classify an assistant's hosting from its lockfile `cloud` string. */
+export function classifyHosting(cloud: string | undefined): AssistantHosting {
+  switch ((cloud ?? "").toLowerCase()) {
+    case LOCAL_CLOUD:
+      return "local";
+    case DOCKER_CLOUD:
+      return "docker";
+    case MANAGED_CLOUD:
+      return "managed";
+    default:
+      return "other";
+  }
+}
+
+/**
+ * The single destination the picker offers for an assistant, mirroring the
+ * Swift `destinationPicker`:
+ *   - managed (cloud)            → move to local
+ *   - local or docker            → move to cloud (platform)
+ *   - anything else              → no teleport offered
+ */
+export function resolveDestination(
+  cloud: string | undefined,
+): TeleportDestination | null {
+  const hosting = classifyHosting(cloud);
+  if (hosting === "managed") return "local";
+  if (hosting === "local" || hosting === "docker") return "platform";
+  return null;
+}
+
+/** Human-facing label for a destination, mirroring Swift `displayLabel`. */
+export function destinationLabel(destination: TeleportDestination): string {
+  switch (destination) {
+    case "docker":
+      return "Move to Docker";
+    case "platform":
+      return "Move to Cloud (Platform)";
+    case "local":
+      return "Move to Local";
+  }
+}
+
+/** One-line description for a destination, mirroring Swift `description`. */
+export function destinationDescription(
+  destination: TeleportDestination,
+): string {
+  switch (destination) {
+    case "docker":
+      return "Run your assistant in a Docker container on this Mac.";
+    case "platform":
+      return "Run your assistant in the cloud, managed by the Vellum platform.";
+    case "local":
+      return "Run your assistant locally on this Mac.";
+  }
+}
+
+/**
+ * Parse a platform `signed-url` (download) 422 body into a version-mismatch
+ * error message, mirroring the Swift `versionMismatch` decoding. Returns
+ * `null` when the body isn't a recognizable version-mismatch payload.
+ */
+export function parseVersionMismatch(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const json = body as Record<string, unknown>;
+  if (json.reason !== "version_mismatch") return null;
+
+  const compat = json.bundle_compat;
+  const targetVersion = json.target_runtime_version;
+  if (!compat || typeof compat !== "object" || typeof targetVersion !== "string") {
+    return null;
+  }
+  const compatObj = compat as Record<string, unknown>;
+  const minVersion = compatObj.min_runtime_version;
+  if (typeof minVersion !== "string") return null;
+  const maxVersion =
+    typeof compatObj.max_runtime_version === "string"
+      ? compatObj.max_runtime_version
+      : null;
+
+  const range = maxVersion ? `${minVersion}–${maxVersion}` : `${minVersion}+`;
+  return `Cannot import: bundle requires runtime ${range}, but this local runtime is ${targetVersion}. Update your local runtime before importing.`;
+}

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -267,7 +267,9 @@ async function teleportToPlatform(
   }
 
   setStep("Uploading data to cloud...");
-  const upload = await requestSignedUploadUrl();
+  // Stamp the upload with the source runtime version so the platform records
+  // the bundle's compat band for the download-side version-mismatch guard.
+  const upload = await requestSignedUploadUrl(source.resources?.runtimeVersion);
   await uploadToSignedUrl(upload.url, bundle, setProgress);
 
   setStep("Setting up cloud assistant...");
@@ -345,10 +347,16 @@ async function teleportToLocal(
   const jobId = await exportManagedToGcs(source.assistantId, upload.url);
   await awaitManagedExportJob(source.assistantId, jobId);
 
-  // The bundled app version is the local runtime version that will perform the
-  // import — used to enforce the bundle's compat range.
-  const versionInfo = await getAppVersionInfo();
-  const targetRuntimeVersion = versionInfo?.version ?? "0.0.0";
+  // Resolve the local target BEFORE requesting the download so the version
+  // check runs against the local *runtime* version, not the Electron shell —
+  // local runtimes upgrade independently of the app, so the shell version can
+  // wrongly block a newer runtime or wrongly pass a stale one.
+  setStep("Preparing local assistant...");
+  const { assistant: local, createdFresh } = await resolveLocalTarget();
+  const targetRuntimeVersion =
+    local.resources?.runtimeVersion ??
+    (await getAppVersionInfo())?.version ??
+    "0.0.0";
 
   setStep("Preparing import...");
   const downloadUrl = await requestSignedDownloadUrl(
@@ -358,9 +366,6 @@ async function teleportToLocal(
 
   setStep("Downloading data...");
   const bundle = await downloadFromSignedUrl(downloadUrl, setProgress);
-
-  setStep("Preparing local assistant...");
-  const { assistant: local, createdFresh } = await resolveLocalTarget();
 
   setStep("Importing data...");
   await importWithRetry(local, bundle);
@@ -466,7 +471,7 @@ async function resolveLocalTarget(): Promise<{
   assistant: LockfileAssistant;
   createdFresh: boolean;
 }> {
-  let local = getLocalAssistants()[0];
+  let local = newestLocalAssistant();
   if (local) {
     // Wake is the repair path — it can populate a fresh gateway port for a
     // stopped/legacy assistant. Fail loudly on a failed wake, and reload the
@@ -494,7 +499,7 @@ async function resolveLocalTarget(): Promise<{
     );
   }
   await loadLockfile();
-  local = getLocalAssistants()[0];
+  local = newestLocalAssistant();
   if (!local) {
     throw new TeleportError(
       "local_assistant_not_found",
@@ -502,6 +507,18 @@ async function resolveLocalTarget(): Promise<{
     );
   }
   return { assistant: local, createdFresh: true };
+}
+
+/**
+ * The newest local assistant by `hatchedAt`. `getLocalAssistants()` preserves
+ * lockfile order, which appends newly-hatched entries at the end — so a naive
+ * `[0]` would target the *oldest* local and risk importing into the wrong
+ * assistant's workspace. Sort newest-first to honor the "newest local" target.
+ */
+function newestLocalAssistant(): LockfileAssistant | undefined {
+  return getLocalAssistants()
+    .slice()
+    .sort((a, b) => (b.hatchedAt ?? "").localeCompare(a.hatchedAt ?? ""))[0];
 }
 
 /** Import with a short readiness retry, in lieu of an explicit healthz gate. */

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -11,7 +11,7 @@
 import { type MutableRefObject, useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
-import { hatchAssistant } from "@/assistant/api";
+import { getAssistantHealthz, hatchAssistant } from "@/assistant/api";
 import { retireAssistant } from "@/assistant/retire-service";
 import {
   assistantsList,
@@ -25,7 +25,6 @@ import {
   saveLockfileAssistant,
   setActiveLockfileAssistant,
 } from "@/lib/local-mode";
-import { getAppVersionInfo } from "@/runtime/app-info";
 import type { LockfileAssistant } from "@/runtime/local-mode-host";
 import {
   hatchLocalAssistant,
@@ -341,7 +340,12 @@ async function teleportToLocal(
   targetRef: MutableRefObject<AssistantRef | null>,
 ): Promise<void> {
   setStep("Preparing export...");
-  const upload = await requestSignedUploadUrl();
+  // Stamp the upload with the managed source's runtime version so the platform
+  // records the bundle's compat band — without it the download-side
+  // version-mismatch guard has nothing to compare against and a newer-cloud →
+  // older-local import only fails late at runtime import.
+  const sourceRuntimeVersion = await resolveRuntimeVersion(source.assistantId);
+  const upload = await requestSignedUploadUrl(sourceRuntimeVersion);
 
   setStep("Exporting cloud data...");
   const jobId = await exportManagedToGcs(source.assistantId, upload.url);
@@ -349,14 +353,20 @@ async function teleportToLocal(
 
   // Resolve the local target BEFORE requesting the download so the version
   // check runs against the local *runtime* version, not the Electron shell —
-  // local runtimes upgrade independently of the app, so the shell version can
-  // wrongly block a newer runtime or wrongly pass a stale one.
+  // local runtimes upgrade independently of the app. Don't fall back to the
+  // shell version: a legacy entry without a recorded runtime version would
+  // make the compat check use the wrong value, so fail with a repairable error.
   setStep("Preparing local assistant...");
   const { assistant: local, createdFresh } = await resolveLocalTarget();
   const targetRuntimeVersion =
     local.resources?.runtimeVersion ??
-    (await getAppVersionInfo())?.version ??
-    "0.0.0";
+    (await resolveRuntimeVersion(local.assistantId));
+  if (!targetRuntimeVersion) {
+    throw new TeleportError(
+      "local_assistant_not_found",
+      "Could not determine the local assistant's runtime version. Restart or upgrade the local assistant, then retry the teleport.",
+    );
+  }
 
   setStep("Preparing import...");
   const downloadUrl = await requestSignedDownloadUrl(
@@ -380,6 +390,18 @@ async function teleportToLocal(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * The runtime version reported by an assistant's gateway healthz, or
+ * `undefined` if it can't be read. Used to stamp the bundle's compat band and
+ * to validate the import target against the real runtime (not the app shell).
+ */
+async function resolveRuntimeVersion(
+  assistantId: string,
+): Promise<string | undefined> {
+  const health = await getAssistantHealthz(assistantId);
+  return health.ok ? (health.data.version ?? undefined) : undefined;
+}
 
 /**
  * Resolve and validate the organization id, mirroring the Swift logic: use the

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -13,6 +13,7 @@ import { useNavigate } from "react-router";
 
 import { getAssistantHealthz, hatchAssistant } from "@/assistant/api";
 import { retireAssistant } from "@/assistant/retire-service";
+import { resolveManagedOAuthPlatformAssistantId } from "@/lib/local-managed-oauth-identity";
 import { getAppVersionInfo } from "@/runtime/app-info";
 import {
   assistantsList,
@@ -175,6 +176,17 @@ export function useTeleport(): TeleportController {
           await auth.connectPlatformAssistant(target.id);
         } else {
           await auth.connectLocalAssistant(target.id);
+          // The platform→local import strips `vellum:*` platform-identity
+          // credentials, so the freshly-imported local has no platform identity.
+          // Now that it's the active assistant, re-register it with the platform
+          // and inject those credentials (the web equivalent of the CLI's
+          // post-import injection) so managed/platform integrations keep working.
+          // Best-effort: a failure here shouldn't block the switch.
+          void resolveManagedOAuthPlatformAssistantId(target.id).catch((error) =>
+            captureError(error, {
+              context: "teleport-inject-platform-identity",
+            }),
+          );
         }
       } catch (error) {
         // The switch failed — keep the target around and surface the error

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -335,6 +335,17 @@ async function teleportToPlatform(
       );
     }
     await awaitPlatformJob(jobId);
+  } else {
+    // A synchronous 2xx can still report a validation/import failure in the
+    // body (`{success:false}`); without this check the flow would advance to
+    // verifying and let the user retire the source despite a failed import.
+    const body = result.body as { success?: boolean; error?: string } | null;
+    if (body && body.success === false) {
+      throw new TeleportError(
+        "import_failed",
+        body.error ?? "Import reported failure.",
+      );
+    }
   }
 }
 

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -11,8 +11,12 @@
 import { type MutableRefObject, useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
-import { getAssistant, hatchAssistant, retireAssistantById } from "@/assistant/api";
-import { assistantsOperationalStatusDetailRead } from "@/generated/api/sdk.gen";
+import { hatchAssistant } from "@/assistant/api";
+import { retireAssistant } from "@/assistant/retire-service";
+import {
+  assistantsList,
+  assistantsOperationalStatusDetailRead,
+} from "@/generated/api/sdk.gen";
 import {
   getLocalAssistants,
   getPlatformRuntimeUrl,
@@ -25,7 +29,6 @@ import { getAppVersionInfo } from "@/runtime/app-info";
 import type { LockfileAssistant } from "@/runtime/local-mode-host";
 import {
   hatchLocalAssistant,
-  retireLocalAssistantHost,
   wakeLocalAssistantHost,
 } from "@/runtime/local-mode-host";
 import { useAuthStore } from "@/stores/auth-store";
@@ -178,10 +181,16 @@ export function useTeleport(): TeleportController {
 
       // Fire-and-forget retirement of the source — mirrors the Swift flow,
       // which never blocks the switch on the old assistant going away.
+      // `retireAssistant` (the retire service) also reconciles the lockfile +
+      // resolved-assistants store, so the retired source stops being selectable.
       if (original) {
-        void retireRef(original).catch((error) =>
-          captureError(error, { context: "teleport-retire-source" }),
-        );
+        void retireAssistant(original.id).then((result) => {
+          if (!result.ok) {
+            captureError(new Error(result.error), {
+              context: "teleport-retire-source",
+            });
+          }
+        });
       }
 
       reset();
@@ -194,13 +203,17 @@ export function useTeleport(): TeleportController {
     const original = originalRef.current;
     void (async () => {
       // The transfer already created the target (and the lockfile may have
-      // briefly pointed at it). Restore the original as the active assistant and
-      // retire the target if the teleport created it — otherwise a cancelled
-      // teleport leaves a stray (possibly active) assistant behind.
+      // briefly pointed at it). Retire the target if the teleport created it,
+      // then restore the original as the active assistant — otherwise a
+      // cancelled teleport leaves a stray (possibly active) assistant behind.
+      // `retireAssistant` reconciles the lockfile + resolved-assistants store.
       if (target?.createdFresh) {
-        await retireRef(target).catch((error) =>
-          captureError(error, { context: "teleport-cancel-retire-target" }),
-        );
+        const result = await retireAssistant(target.id);
+        if (!result.ok) {
+          captureError(new Error(result.error), {
+            context: "teleport-cancel-retire-target",
+          });
+        }
       }
       if (original) await setActiveLockfileAssistant(original.id);
       reset();
@@ -220,14 +233,6 @@ export function useTeleport(): TeleportController {
   };
 }
 
-async function retireRef(original: AssistantRef): Promise<void> {
-  if (original.kind === "managed") {
-    await retireAssistantById(original.id);
-  } else {
-    await retireLocalAssistantHost(original.id);
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Local → Platform
 // ---------------------------------------------------------------------------
@@ -245,13 +250,19 @@ async function teleportToPlatform(
   const organizationId = await resolveOrganizationId();
 
   // Pre-check before the expensive upload: block if a platform assistant
-  // already exists for this account.
+  // already exists for this account. Query the platform directly rather than
+  // `getAssistant()` — that helper short-circuits to the (local) selected
+  // assistant while a local source is active, which would bypass this guard.
   setStep("Checking for existing assistant...");
-  const existing = await getAssistant();
-  if (existing.ok && existing.data && existing.data.is_local === false) {
+  const platformList = await assistantsList({
+    query: { hosting: "platform" },
+    throwOnError: false,
+  });
+  const existingPlatform = platformList.data?.results?.[0];
+  if (existingPlatform) {
     throw new TeleportError(
       "existing_platform_assistant",
-      `You already have a platform assistant '${existing.data.id}'. Retire it first, then retry the teleport.`,
+      `You already have a platform assistant '${existingPlatform.id}'. Retire it first, then retry the teleport.`,
     );
   }
 
@@ -457,8 +468,22 @@ async function resolveLocalTarget(): Promise<{
 }> {
   let local = getLocalAssistants()[0];
   if (local) {
-    await wakeLocalAssistantHost(local.assistantId);
-    return { assistant: local, createdFresh: false };
+    // Wake is the repair path — it can populate a fresh gateway port for a
+    // stopped/legacy assistant. Fail loudly on a failed wake, and reload the
+    // lockfile afterwards so the import uses the repaired entry (with its
+    // resolved gateway) rather than the stale pre-wake object.
+    const wake = await wakeLocalAssistantHost(local.assistantId);
+    if (!wake.ok) {
+      throw new TeleportError(
+        "local_assistant_not_found",
+        wake.error ?? "Could not wake the local assistant.",
+      );
+    }
+    await loadLockfile();
+    const refreshed = getLocalAssistants().find(
+      (a) => a.assistantId === local!.assistantId,
+    );
+    return { assistant: refreshed ?? local, createdFresh: false };
   }
 
   const hatched = await hatchLocalAssistant(undefined, undefined);

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -1,0 +1,453 @@
+/**
+ * Orchestration hook for teleport, ported from `TeleportSection.swift`.
+ *
+ * Drives the phase state machine (idle → transferring → verifying → switched,
+ * or → failed) and runs the per-direction transfer flows. Like the Swift
+ * original, the source assistant is preserved until the user confirms the new
+ * one works; "Confirm & Switch" then switches to the target and retires the
+ * source, while "Cancel" discards the target.
+ */
+
+import { type MutableRefObject, useCallback, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+
+import { getAssistant, hatchAssistant, retireAssistantById } from "@/assistant/api";
+import { assistantsOperationalStatusDetailRead } from "@/generated/api/sdk.gen";
+import {
+  getLocalAssistants,
+  getPlatformRuntimeUrl,
+  getSelectedAssistant,
+  loadLockfile,
+  saveLockfileAssistant,
+} from "@/lib/local-mode";
+import { getAppVersionInfo } from "@/runtime/app-info";
+import type { LockfileAssistant } from "@/runtime/local-mode-host";
+import {
+  hatchLocalAssistant,
+  retireLocalAssistantHost,
+  wakeLocalAssistantHost,
+} from "@/runtime/local-mode-host";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  getActiveOrganizationIdForRequests,
+  useOrganizationStore,
+} from "@/stores/organization-store";
+import { captureError } from "@/lib/sentry/capture-error";
+import { routes } from "@/utils/routes";
+
+import {
+  classifyHosting,
+  resolveDestination,
+  TeleportError,
+  type TeleportDestination,
+  type TeleportPhase,
+} from "./teleport-types";
+import {
+  exportLocalBundle,
+  exportManagedToGcs,
+  importLocalBundle,
+  pollManagedExportJob,
+} from "./teleport-gateway-client";
+import {
+  downloadFromSignedUrl,
+  importFromGcs,
+  pollJobStatus,
+  requestSignedDownloadUrl,
+  requestSignedUploadUrl,
+  uploadToSignedUrl,
+} from "./platform-migration-client";
+
+/** Reference to a teleport endpoint plus how to reach/retire it. */
+interface AssistantRef {
+  id: string;
+  kind: "managed" | "local";
+}
+
+const POLL_INTERVAL_MS = 5_000;
+const JOB_TIMEOUT_MS = 3_600_000;
+const PROVISION_TIMEOUT_MS = 5 * 60_000;
+const GATEWAY_READY_ATTEMPTS = 30;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface TeleportController {
+  destination: TeleportDestination | null;
+  phase: TeleportPhase;
+  confirmOpen: boolean;
+  requestTeleport: () => void;
+  cancelConfirm: () => void;
+  confirm: () => void;
+  confirmAndSwitch: () => void;
+  cancelTeleport: () => void;
+  reset: () => void;
+}
+
+export function useTeleport(): TeleportController {
+  const navigate = useNavigate();
+  const source = getSelectedAssistant();
+  const destination = resolveDestination(source?.cloud);
+
+  const [phase, setPhase] = useState<TeleportPhase>({ kind: "idle" });
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const targetRef = useRef<AssistantRef | null>(null);
+  const originalRef = useRef<AssistantRef | null>(null);
+
+  const setStep = useCallback((step: string) => {
+    setPhase({ kind: "transferring", step, progress: null });
+  }, []);
+
+  const setProgress = useCallback((progress: number) => {
+    setPhase((prev) =>
+      prev.kind === "transferring" ? { ...prev, progress } : prev,
+    );
+  }, []);
+
+  const execute = useCallback(async () => {
+    if (!source || !destination) return;
+    originalRef.current = {
+      id: source.assistantId,
+      kind: classifyHosting(source.cloud) === "managed" ? "managed" : "local",
+    };
+    try {
+      if (destination === "platform") {
+        await teleportToPlatform(source, setStep, setProgress, targetRef);
+      } else if (destination === "local") {
+        await teleportToLocal(source, setStep, setProgress, targetRef);
+      } else {
+        throw new TeleportError("unknown", "Unsupported teleport destination.");
+      }
+      setPhase({ kind: "verifying" });
+    } catch (error) {
+      const message =
+        error instanceof TeleportError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : "Teleport failed.";
+      setPhase({ kind: "failed", error: `Teleport failed: ${message}` });
+      captureError(error, { context: "teleport-execute" });
+    }
+  }, [source, destination, setStep, setProgress]);
+
+  const requestTeleport = useCallback(() => setConfirmOpen(true), []);
+  const cancelConfirm = useCallback(() => setConfirmOpen(false), []);
+
+  const confirm = useCallback(() => {
+    setConfirmOpen(false);
+    void execute();
+  }, [execute]);
+
+  const reset = useCallback(() => {
+    targetRef.current = null;
+    originalRef.current = null;
+    setPhase({ kind: "idle" });
+  }, []);
+
+  const confirmAndSwitch = useCallback(() => {
+    const target = targetRef.current;
+    const original = originalRef.current;
+    if (!target) return;
+
+    void (async () => {
+      const auth = useAuthStore.getState();
+      if (target.kind === "managed") {
+        await auth.connectPlatformAssistant(target.id);
+      } else {
+        await auth.connectLocalAssistant(target.id);
+      }
+
+      // Fire-and-forget retirement of the source — mirrors the Swift flow,
+      // which never blocks the switch on the old assistant going away.
+      if (original) {
+        void retireSource(original).catch((error) =>
+          captureError(error, { context: "teleport-retire-source" }),
+        );
+      }
+
+      reset();
+      void navigate(routes.assistant, { replace: true });
+    })();
+  }, [navigate, reset]);
+
+  const cancelTeleport = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  return {
+    destination,
+    phase,
+    confirmOpen,
+    requestTeleport,
+    cancelConfirm,
+    confirm,
+    confirmAndSwitch,
+    cancelTeleport,
+    reset,
+  };
+}
+
+async function retireSource(original: AssistantRef): Promise<void> {
+  if (original.kind === "managed") {
+    await retireAssistantById(original.id);
+  } else {
+    await retireLocalAssistantHost(original.id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local / Docker → Platform
+// ---------------------------------------------------------------------------
+
+async function teleportToPlatform(
+  source: LockfileAssistant,
+  setStep: (step: string) => void,
+  setProgress: (fraction: number) => void,
+  targetRef: MutableRefObject<AssistantRef | null>,
+): Promise<void> {
+  setStep("Exporting assistant data...");
+  const bundle = await exportLocalBundle(source, setProgress);
+
+  setStep("Resolving organization...");
+  const organizationId = await resolveOrganizationId();
+
+  // Pre-check before the expensive upload: block if a platform assistant
+  // already exists for this account.
+  setStep("Checking for existing assistant...");
+  const existing = await getAssistant();
+  if (existing.ok && existing.data && existing.data.is_local === false) {
+    throw new TeleportError(
+      "existing_platform_assistant",
+      `You already have a platform assistant '${existing.data.id}'. Retire it first, then retry the teleport.`,
+    );
+  }
+
+  setStep("Uploading data to cloud...");
+  const upload = await requestSignedUploadUrl();
+  await uploadToSignedUrl(upload.url, bundle, setProgress);
+
+  setStep("Setting up cloud assistant...");
+  const hatch = await hatchAssistant(undefined, "create");
+  if (!hatch.ok) {
+    throw new TeleportError(
+      "import_failed",
+      "Failed to set up the cloud assistant.",
+    );
+  }
+  if (hatch.status === 200) {
+    // Server deduped to an existing managed assistant — mirror the Swift
+    // defensive guard and block rather than silently importing into it.
+    throw new TeleportError(
+      "existing_platform_assistant",
+      `You already have a platform assistant '${hatch.data.id}'. Retire it first, then retry the teleport.`,
+    );
+  }
+  const managedId = hatch.data.id;
+  await saveLockfileAssistant({
+    assistantId: managedId,
+    name: hatch.data.name,
+    cloud: "vellum",
+    runtimeUrl: getPlatformRuntimeUrl(),
+    hatchedAt: hatch.data.created ?? new Date().toISOString(),
+    organizationId,
+  });
+
+  // Wait for post-hatch provisioning to finish before importing — otherwise the
+  // import's workspace swap can race the runtime's secret provisioning.
+  setStep("Finalizing cloud assistant...");
+  await awaitAssistantProvisioned(managedId);
+
+  setStep("Importing data to cloud...");
+  const result = await importFromGcs(upload.bundleKey);
+  if (result.status < 200 || result.status >= 300) {
+    const body = result.body as { error?: string } | null;
+    throw new TeleportError(
+      "import_failed",
+      body?.error ?? `Import failed (HTTP ${result.status}).`,
+    );
+  }
+  if (result.status === 202) {
+    const jobId = (result.body as { job_id?: string } | null)?.job_id;
+    if (!jobId) {
+      throw new TeleportError(
+        "import_failed",
+        "Import accepted but no job ID returned.",
+      );
+    }
+    await awaitPlatformJob(jobId);
+  }
+
+  targetRef.current = { id: managedId, kind: "managed" };
+}
+
+// ---------------------------------------------------------------------------
+// Platform → Local
+// ---------------------------------------------------------------------------
+
+async function teleportToLocal(
+  source: LockfileAssistant,
+  setStep: (step: string) => void,
+  setProgress: (fraction: number) => void,
+  targetRef: MutableRefObject<AssistantRef | null>,
+): Promise<void> {
+  setStep("Preparing export...");
+  const upload = await requestSignedUploadUrl();
+
+  setStep("Exporting cloud data...");
+  const jobId = await exportManagedToGcs(source.assistantId, upload.url);
+  await awaitManagedExportJob(source.assistantId, jobId);
+
+  // The bundled app version is the local runtime version that will perform the
+  // import — used to enforce the bundle's compat range.
+  const versionInfo = await getAppVersionInfo();
+  const targetRuntimeVersion = versionInfo?.version ?? "0.0.0";
+
+  setStep("Preparing import...");
+  const downloadUrl = await requestSignedDownloadUrl(
+    upload.bundleKey,
+    targetRuntimeVersion,
+  );
+
+  setStep("Downloading data...");
+  const bundle = await downloadFromSignedUrl(downloadUrl, setProgress);
+
+  setStep("Preparing local assistant...");
+  const local = await resolveLocalTarget();
+
+  setStep("Importing data...");
+  await importWithRetry(local, bundle);
+
+  targetRef.current = { id: local.assistantId, kind: "local" };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve and validate the organization id, mirroring the Swift logic: use the
+ * connected org if valid; otherwise re-resolve — exactly one org is required.
+ */
+async function resolveOrganizationId(): Promise<string> {
+  const store = useOrganizationStore.getState();
+  if (store.organizations.length === 0) await store.fetchOrganizations();
+  const orgs = useOrganizationStore.getState().organizations;
+
+  const connected = getActiveOrganizationIdForRequests();
+  if (connected && orgs.some((org) => org.id === connected)) return connected;
+
+  if (orgs.length === 0) {
+    throw new TeleportError(
+      "no_organizations",
+      "No organizations found for this account.",
+    );
+  }
+  if (orgs.length > 1) {
+    throw new TeleportError(
+      "multiple_organizations",
+      "Multiple organizations found — please select one in account settings first.",
+    );
+  }
+  const orgId = orgs[0]!.id;
+  useOrganizationStore.getState().setCurrentOrganizationId(orgId);
+  return orgId;
+}
+
+/** Poll operational status until the managed assistant is provisioned/active. */
+async function awaitAssistantProvisioned(assistantId: string): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < PROVISION_TIMEOUT_MS) {
+    const { data, response } = await assistantsOperationalStatusDetailRead({
+      path: { id: assistantId },
+      throwOnError: false,
+    });
+    if (response?.ok && data?.state === "active") return;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  // Timed out — proceed anyway; the import will surface a hard error if the
+  // runtime genuinely isn't ready, matching the Swift best-effort wait.
+}
+
+/** Poll a platform migration job until complete, mirroring Swift `importBundleToManaged`. */
+async function awaitPlatformJob(jobId: string): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < JOB_TIMEOUT_MS) {
+    await sleep(POLL_INTERVAL_MS);
+    let status;
+    try {
+      status = await pollJobStatus(jobId);
+    } catch {
+      continue; // transient — retry
+    }
+    if (status.status === "complete") return;
+    if (status.status === "failed") {
+      throw new TeleportError(
+        "import_failed",
+        status.error ?? "Import job failed",
+      );
+    }
+  }
+  throw new TeleportError("import_failed", "Import timed out after 60 minutes.");
+}
+
+/** Poll a managed runtime-local export job until complete. */
+async function awaitManagedExportJob(
+  managedId: string,
+  jobId: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < JOB_TIMEOUT_MS) {
+    await sleep(POLL_INTERVAL_MS);
+    const status = await pollManagedExportJob(managedId, jobId);
+    if (status === "complete") return;
+  }
+  throw new TeleportError("export_timed_out", "Export timed out.");
+}
+
+/**
+ * Resolve (or hatch, or wake) the local assistant that will receive the
+ * imported bundle. Mirrors the Swift "newest local, else hatch, else wake".
+ */
+async function resolveLocalTarget(): Promise<LockfileAssistant> {
+  let local = getLocalAssistants()[0];
+  if (!local) {
+    const hatched = await hatchLocalAssistant(undefined, undefined);
+    if (!hatched.ok) {
+      throw new TeleportError(
+        "local_assistant_not_found",
+        hatched.error ?? "Could not create a local assistant.",
+      );
+    }
+    await loadLockfile();
+    local = getLocalAssistants()[0];
+  } else {
+    await wakeLocalAssistantHost(local.assistantId);
+  }
+  if (!local) {
+    throw new TeleportError(
+      "local_assistant_not_found",
+      "Could not find or create a local assistant.",
+    );
+  }
+  return local;
+}
+
+/** Import with a short readiness retry, in lieu of an explicit healthz gate. */
+async function importWithRetry(
+  local: LockfileAssistant,
+  bundle: ArrayBuffer,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < GATEWAY_READY_ATTEMPTS; attempt++) {
+    try {
+      await importLocalBundle(local, bundle);
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(1_000);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new TeleportError("import_failed", "Import failed.");
+}

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -27,10 +27,7 @@ import {
   setActiveLockfileAssistant,
 } from "@/lib/local-mode";
 import type { LockfileAssistant } from "@/runtime/local-mode-host";
-import {
-  hatchLocalAssistant,
-  wakeLocalAssistantHost,
-} from "@/runtime/local-mode-host";
+import { hatchLocalAssistant } from "@/runtime/local-mode-host";
 import { useAuthStore } from "@/stores/auth-store";
 import {
   getActiveOrganizationIdForRequests,
@@ -491,12 +488,11 @@ async function awaitPlatformJob(jobId: string): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < JOB_TIMEOUT_MS) {
     await sleep(POLL_INTERVAL_MS);
-    let status;
-    try {
-      status = await pollJobStatus(jobId);
-    } catch {
-      continue; // transient — retry
-    }
+    // `pollJobStatus` already retries transient 5xx via `requestWithRetry`, so a
+    // thrown error here is a permanent failure (expired session, 4xx, missing
+    // job) — let it propagate and fail the teleport promptly rather than
+    // swallowing it and grinding to the 60-minute timeout.
+    const status = await pollJobStatus(jobId);
     if (status.status === "complete") return;
     if (status.status === "failed") {
       throw new TeleportError(
@@ -523,35 +519,18 @@ async function awaitManagedExportJob(
 }
 
 /**
- * Resolve (or hatch, or wake) the local assistant that will receive the
- * imported bundle. Mirrors the Swift "newest local, else hatch, else wake".
- * `createdFresh` is true only when a new local assistant was hatched here, so
- * the cancel path knows it's safe to retire (a pre-existing local must not be).
+ * Hatch a fresh local assistant to receive the imported bundle.
+ *
+ * The import is destructive — it overwrites the target's workspace — and the
+ * verification step doesn't undo it, so we never import into a pre-existing
+ * local assistant (that would silently destroy data the user never chose to
+ * replace). Always hatch a new local: it's `createdFresh`, so Cancel cleanly
+ * retires it and the user's existing locals are left untouched.
  */
 async function resolveLocalTarget(): Promise<{
   assistant: LockfileAssistant;
   createdFresh: boolean;
 }> {
-  let local = newestLocalAssistant();
-  if (local) {
-    // Wake is the repair path — it can populate a fresh gateway port for a
-    // stopped/legacy assistant. Fail loudly on a failed wake, and reload the
-    // lockfile afterwards so the import uses the repaired entry (with its
-    // resolved gateway) rather than the stale pre-wake object.
-    const wake = await wakeLocalAssistantHost(local.assistantId);
-    if (!wake.ok) {
-      throw new TeleportError(
-        "local_assistant_not_found",
-        wake.error ?? "Could not wake the local assistant.",
-      );
-    }
-    await loadLockfile();
-    const refreshed = getLocalAssistants().find(
-      (a) => a.assistantId === local!.assistantId,
-    );
-    return { assistant: refreshed ?? local, createdFresh: false };
-  }
-
   const hatched = await hatchLocalAssistant(undefined, undefined);
   if (!hatched.ok) {
     throw new TeleportError(
@@ -560,7 +539,10 @@ async function resolveLocalTarget(): Promise<{
     );
   }
   await loadLockfile();
-  local = newestLocalAssistant();
+  // The just-hatched assistant is the newest local entry.
+  const local = hatched.assistantId
+    ? getLocalAssistants().find((a) => a.assistantId === hatched.assistantId)
+    : newestLocalAssistant();
   if (!local) {
     throw new TeleportError(
       "local_assistant_not_found",
@@ -573,8 +555,8 @@ async function resolveLocalTarget(): Promise<{
 /**
  * The newest local assistant by `hatchedAt`. `getLocalAssistants()` preserves
  * lockfile order, which appends newly-hatched entries at the end — so a naive
- * `[0]` would target the *oldest* local and risk importing into the wrong
- * assistant's workspace. Sort newest-first to honor the "newest local" target.
+ * `[0]` would target the *oldest* local. Sort newest-first to find the
+ * just-hatched target when its id isn't reported back.
  */
 function newestLocalAssistant(): LockfileAssistant | undefined {
   return getLocalAssistants()

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -19,6 +19,7 @@ import {
   getSelectedAssistant,
   loadLockfile,
   saveLockfileAssistant,
+  setActiveLockfileAssistant,
 } from "@/lib/local-mode";
 import { getAppVersionInfo } from "@/runtime/app-info";
 import type { LockfileAssistant } from "@/runtime/local-mode-host";
@@ -61,6 +62,13 @@ import {
 interface AssistantRef {
   id: string;
   kind: "managed" | "local";
+  /**
+   * Whether this assistant was created by the teleport itself (a hatched
+   * managed assistant, or a freshly-hatched local target). Only freshly-created
+   * targets are retired when the user cancels — never a pre-existing assistant
+   * the import wrote into.
+   */
+  createdFresh: boolean;
 }
 
 const POLL_INTERVAL_MS = 5_000;
@@ -108,6 +116,7 @@ export function useTeleport(): TeleportController {
     originalRef.current = {
       id: source.assistantId,
       kind: classifyHosting(source.cloud) === "managed" ? "managed" : "local",
+      createdFresh: false,
     };
     try {
       if (destination === "platform") {
@@ -160,7 +169,7 @@ export function useTeleport(): TeleportController {
       // Fire-and-forget retirement of the source — mirrors the Swift flow,
       // which never blocks the switch on the old assistant going away.
       if (original) {
-        void retireSource(original).catch((error) =>
+        void retireRef(original).catch((error) =>
           captureError(error, { context: "teleport-retire-source" }),
         );
       }
@@ -171,7 +180,21 @@ export function useTeleport(): TeleportController {
   }, [navigate, reset]);
 
   const cancelTeleport = useCallback(() => {
-    reset();
+    const target = targetRef.current;
+    const original = originalRef.current;
+    void (async () => {
+      // The transfer already created the target (and the lockfile may have
+      // briefly pointed at it). Restore the original as the active assistant and
+      // retire the target if the teleport created it — otherwise a cancelled
+      // teleport leaves a stray (possibly active) assistant behind.
+      if (target?.createdFresh) {
+        await retireRef(target).catch((error) =>
+          captureError(error, { context: "teleport-cancel-retire-target" }),
+        );
+      }
+      if (original) await setActiveLockfileAssistant(original.id);
+      reset();
+    })();
   }, [reset]);
 
   return {
@@ -187,7 +210,7 @@ export function useTeleport(): TeleportController {
   };
 }
 
-async function retireSource(original: AssistantRef): Promise<void> {
+async function retireRef(original: AssistantRef): Promise<void> {
   if (original.kind === "managed") {
     await retireAssistantById(original.id);
   } else {
@@ -196,7 +219,7 @@ async function retireSource(original: AssistantRef): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Local / Docker → Platform
+// Local → Platform
 // ---------------------------------------------------------------------------
 
 async function teleportToPlatform(
@@ -251,6 +274,10 @@ async function teleportToPlatform(
     hatchedAt: hatch.data.created ?? new Date().toISOString(),
     organizationId,
   });
+  // `saveLockfileAssistant` marks the new entry active; keep the source active
+  // until the user confirms the switch so a cancel/restart never lands on the
+  // half-built target.
+  await setActiveLockfileAssistant(source.assistantId);
 
   // Wait for post-hatch provisioning to finish before importing — otherwise the
   // import's workspace swap can race the runtime's secret provisioning.
@@ -277,7 +304,7 @@ async function teleportToPlatform(
     await awaitPlatformJob(jobId);
   }
 
-  targetRef.current = { id: managedId, kind: "managed" };
+  targetRef.current = { id: managedId, kind: "managed", createdFresh: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -312,12 +339,16 @@ async function teleportToLocal(
   const bundle = await downloadFromSignedUrl(downloadUrl, setProgress);
 
   setStep("Preparing local assistant...");
-  const local = await resolveLocalTarget();
+  const { assistant: local, createdFresh } = await resolveLocalTarget();
 
   setStep("Importing data...");
   await importWithRetry(local, bundle);
 
-  targetRef.current = { id: local.assistantId, kind: "local" };
+  // Hatching/waking the local target may have flipped the active assistant;
+  // keep the source active until the user confirms the switch.
+  await setActiveLockfileAssistant(source.assistantId);
+
+  targetRef.current = { id: local.assistantId, kind: "local", createdFresh };
 }
 
 // ---------------------------------------------------------------------------
@@ -407,29 +438,35 @@ async function awaitManagedExportJob(
 /**
  * Resolve (or hatch, or wake) the local assistant that will receive the
  * imported bundle. Mirrors the Swift "newest local, else hatch, else wake".
+ * `createdFresh` is true only when a new local assistant was hatched here, so
+ * the cancel path knows it's safe to retire (a pre-existing local must not be).
  */
-async function resolveLocalTarget(): Promise<LockfileAssistant> {
+async function resolveLocalTarget(): Promise<{
+  assistant: LockfileAssistant;
+  createdFresh: boolean;
+}> {
   let local = getLocalAssistants()[0];
-  if (!local) {
-    const hatched = await hatchLocalAssistant(undefined, undefined);
-    if (!hatched.ok) {
-      throw new TeleportError(
-        "local_assistant_not_found",
-        hatched.error ?? "Could not create a local assistant.",
-      );
-    }
-    await loadLockfile();
-    local = getLocalAssistants()[0];
-  } else {
+  if (local) {
     await wakeLocalAssistantHost(local.assistantId);
+    return { assistant: local, createdFresh: false };
   }
+
+  const hatched = await hatchLocalAssistant(undefined, undefined);
+  if (!hatched.ok) {
+    throw new TeleportError(
+      "local_assistant_not_found",
+      hatched.error ?? "Could not create a local assistant.",
+    );
+  }
+  await loadLockfile();
+  local = getLocalAssistants()[0];
   if (!local) {
     throw new TeleportError(
       "local_assistant_not_found",
       "Could not find or create a local assistant.",
     );
   }
-  return local;
+  return { assistant: local, createdFresh: true };
 }
 
 /** Import with a short readiness retry, in lieu of an explicit healthz gate. */

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -13,6 +13,7 @@ import { useNavigate } from "react-router";
 
 import { getAssistantHealthz, hatchAssistant } from "@/assistant/api";
 import { retireAssistant } from "@/assistant/retire-service";
+import { getAppVersionInfo } from "@/runtime/app-info";
 import {
   assistantsList,
   assistantsOperationalStatusDetailRead,
@@ -138,6 +139,16 @@ export function useTeleport(): TeleportController {
             : "Teleport failed.";
       setPhase({ kind: "failed", error: `Teleport failed: ${message}` });
       captureError(error, { context: "teleport-execute" });
+      // A failure after the target was created (e.g. import non-2xx, job
+      // failure) would otherwise orphan the fresh assistant — and the retry
+      // pre-check would then reject because it already exists. Clean it up the
+      // same way Cancel does.
+      await cleanupFreshTarget(
+        targetRef.current,
+        originalRef.current,
+        "teleport-execute-cleanup",
+      );
+      targetRef.current = null;
     }
   }, [source, destination, setStep, setProgress]);
 
@@ -201,20 +212,7 @@ export function useTeleport(): TeleportController {
     const target = targetRef.current;
     const original = originalRef.current;
     void (async () => {
-      // The transfer already created the target (and the lockfile may have
-      // briefly pointed at it). Retire the target if the teleport created it,
-      // then restore the original as the active assistant — otherwise a
-      // cancelled teleport leaves a stray (possibly active) assistant behind.
-      // `retireAssistant` reconciles the lockfile + resolved-assistants store.
-      if (target?.createdFresh) {
-        const result = await retireAssistant(target.id);
-        if (!result.ok) {
-          captureError(new Error(result.error), {
-            context: "teleport-cancel-retire-target",
-          });
-        }
-      }
-      if (original) await setActiveLockfileAssistant(original.id);
+      await cleanupFreshTarget(target, original, "teleport-cancel-retire-target");
       reset();
     })();
   }, [reset]);
@@ -301,6 +299,10 @@ async function teleportToPlatform(
   // half-built target.
   await setActiveLockfileAssistant(source.assistantId);
 
+  // Record the target now (not just at the end) so a failure during the
+  // remaining steps cleans up this freshly-hatched managed assistant.
+  targetRef.current = { id: managedId, kind: "managed", createdFresh: true };
+
   // Wait for post-hatch provisioning to finish before importing — otherwise the
   // import's workspace swap can race the runtime's secret provisioning.
   setStep("Finalizing cloud assistant...");
@@ -325,8 +327,6 @@ async function teleportToPlatform(
     }
     await awaitPlatformJob(jobId);
   }
-
-  targetRef.current = { id: managedId, kind: "managed", createdFresh: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -352,15 +352,17 @@ async function teleportToLocal(
   await awaitManagedExportJob(source.assistantId, jobId);
 
   // Resolve the local target BEFORE requesting the download so the version
-  // check runs against the local *runtime* version, not the Electron shell —
-  // local runtimes upgrade independently of the app. Don't fall back to the
-  // shell version: a legacy entry without a recorded runtime version would
-  // make the compat check use the wrong value, so fail with a repairable error.
+  // check runs against the local *runtime* version, not the Electron shell.
   setStep("Preparing local assistant...");
   const { assistant: local, createdFresh } = await resolveLocalTarget();
-  const targetRuntimeVersion =
-    local.resources?.runtimeVersion ??
-    (await resolveRuntimeVersion(local.assistantId));
+  // Record the target now so a failure during download/import cleans up a
+  // freshly-hatched local instead of orphaning it.
+  targetRef.current = { id: local.assistantId, kind: "local", createdFresh };
+
+  const targetRuntimeVersion = await resolveLocalTargetRuntimeVersion(
+    local,
+    createdFresh,
+  );
   if (!targetRuntimeVersion) {
     throw new TeleportError(
       "local_assistant_not_found",
@@ -383,13 +385,50 @@ async function teleportToLocal(
   // Hatching/waking the local target may have flipped the active assistant;
   // keep the source active until the user confirms the switch.
   await setActiveLockfileAssistant(source.assistantId);
+}
 
-  targetRef.current = { id: local.assistantId, kind: "local", createdFresh };
+/**
+ * The runtime version to validate a `platform → local` import against.
+ *
+ * A freshly-hatched local assistant runs the runtime bundled with this app, so
+ * the bundled app version is its runtime version (matching the macOS original,
+ * which used `Bundle.main` for the bundled local runtime). A pre-existing local
+ * can have been upgraded independently of the app shell, so it must report its
+ * own recorded `resources.runtimeVersion`; if it doesn't, return `undefined` so
+ * the caller fails with a repairable error rather than comparing against the
+ * wrong (shell) version.
+ */
+async function resolveLocalTargetRuntimeVersion(
+  local: LockfileAssistant,
+  createdFresh: boolean,
+): Promise<string | undefined> {
+  if (local.resources?.runtimeVersion) return local.resources.runtimeVersion;
+  if (!createdFresh) return undefined;
+  return (await getAppVersionInfo())?.version ?? undefined;
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Discard a teleport target the user cancelled or that a failed transfer left
+ * behind: retire it only if the teleport created it (never a pre-existing
+ * assistant the import wrote into), then restore the original as the active
+ * assistant. `retireAssistant` reconciles the lockfile + resolved-assistants
+ * store so the target stops being selectable.
+ */
+async function cleanupFreshTarget(
+  target: AssistantRef | null,
+  original: AssistantRef | null,
+  context: string,
+): Promise<void> {
+  if (target?.createdFresh) {
+    const result = await retireAssistant(target.id);
+    if (!result.ok) captureError(new Error(result.error), { context });
+  }
+  if (original) await setActiveLockfileAssistant(original.id);
+}
 
 /**
  * The runtime version reported by an assistant's gateway healthz, or

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -220,11 +220,16 @@ export function useTeleport(): TeleportController {
   const cancelTeleport = useCallback(() => {
     const target = targetRef.current;
     const original = originalRef.current;
-    void (async () => {
-      await cleanupFreshTarget(target, original, "teleport-cancel-retire-target");
-      reset();
-    })();
-  }, [reset]);
+    // Leave the verifying phase and clear the refs *synchronously*, before the
+    // async retire/restore runs. Otherwise a Confirm & Switch click while
+    // cleanup is in flight would connect to the same target and retire the
+    // source — racing the cancel that's retiring the target, and potentially
+    // switching the user to a retired assistant or deleting both sides.
+    targetRef.current = null;
+    originalRef.current = null;
+    setPhase({ kind: "idle" });
+    void cleanupFreshTarget(target, original, "teleport-cancel-retire-target");
+  }, []);
 
   return {
     destination,

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -159,11 +159,21 @@ export function useTeleport(): TeleportController {
     if (!target) return;
 
     void (async () => {
-      const auth = useAuthStore.getState();
-      if (target.kind === "managed") {
-        await auth.connectPlatformAssistant(target.id);
-      } else {
-        await auth.connectLocalAssistant(target.id);
+      try {
+        const auth = useAuthStore.getState();
+        if (target.kind === "managed") {
+          await auth.connectPlatformAssistant(target.id);
+        } else {
+          await auth.connectLocalAssistant(target.id);
+        }
+      } catch (error) {
+        // The switch failed — keep the target around and surface the error
+        // rather than leaving the UI stuck in the verifying phase.
+        const message =
+          error instanceof Error ? error.message : "Failed to switch assistant.";
+        setPhase({ kind: "failed", error: `Switch failed: ${message}` });
+        captureError(error, { context: "teleport-confirm-switch" });
+        return;
       }
 
       // Fire-and-forget retirement of the source — mirrors the Swift flow,


### PR DESCRIPTION
## Summary
- Port the macOS `TeleportSection` teleport feature to the web/Electron client: a **Teleport** card in General settings that moves the active assistant between hosting environments (local/Docker ↔ Vellum cloud), preserving the source until the user confirms the new one works (transfer → verify → Confirm & Switch / Cancel), mirroring the Swift phase machine.
- Rendered only when the `teleport` client feature flag is on **and** the client is the Electron host — `{teleportEnabled && isElectron() && <TeleportCard />}` in `general-page.tsx`, reusing the existing `isElectron()` pattern (same shape as the adjacent `LaunchAtLoginCard`). The `teleport` flag already exists in the client feature-flag registry.
- New modules under `clients/web/src/domains/settings/teleport/`: pure types + destination/error/version-mismatch logic (`teleport-types.ts`), the platform org-scoped migration client (signed-URL + import-from-gcs + job polling via the generated API client, raw `fetch`/XHR only for the GCS binary transfer so the central interceptor stays the sole setter of session/org headers), the assistant-scoped gateway client (local/docker direct-gateway vs managed platform-proxied), the orchestration hook (`use-teleport.ts`), a shared streaming helper, and the card UI.
- Pure decision logic is covered by unit tests; `bun run typecheck` and `eslint` are clean.

## Original prompt
The `teleport` feature flag used to gate the teleport UI in the now-removed Swift macOS app. Recreate that button in the Electron client behind the same flag, shown only when the flag is on and the client is the Electron app (reusing the existing electron-detection pattern). Scope was confirmed as a **full functional port** of the teleport transfer flow, not just the UI entry point.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->