### PR TITLE
fix(memory-v3): treat nullish selector-prompt override path as no override

### DIFF
--- a/assistant/src/memory/__tests__/prompt-override.test.ts
+++ b/assistant/src/memory/__tests__/prompt-override.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
 
 /** Load against the per-test temp dir with the recording logger. */
 const load = (
-  overridePath: string | null,
+  overridePath: string | null | undefined,
   label = "test prompt",
 ): string | null =>
   loadPromptOverride({
@@ -70,6 +70,11 @@ describe("resolveOverridePath", () => {
 describe("loadPromptOverride — usable override", () => {
   test("null overridePath returns null without touching the filesystem", () => {
     expect(load(null)).toBeNull();
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("undefined overridePath (unset config field) returns null without throwing", () => {
+    expect(load(undefined)).toBeNull();
     expect(warnCalls).toHaveLength(0);
   });
 

--- a/assistant/src/memory/prompt-override.ts
+++ b/assistant/src/memory/prompt-override.ts
@@ -52,23 +52,25 @@ export function resolveOverridePath(
 /**
  * Load a prompt-override file, returning its raw contents when the override is
  * present and usable, or `null` (after logging a warning describing why) when
- * the caller should fall back to its bundled prompt. A `null` `overridePath`
- * returns `null` without touching the filesystem.
+ * the caller should fall back to its bundled prompt. A nullish `overridePath`
+ * (`null` or `undefined`) returns `null` without touching the filesystem.
  *
- * Fallback is intentionally total — a missing, non-regular, oversized,
- * unreadable, or empty/whitespace-only file all degrade to `null`. Memory
- * retrieval and consolidation must never break because of a bad override.
+ * Fallback is intentionally total — an absent override, a missing, non-regular,
+ * oversized, unreadable, or empty/whitespace-only file all degrade to `null`.
+ * Memory retrieval and consolidation must never break because of a bad
+ * override, so `undefined` (an unset config field) is treated as "no override"
+ * rather than crashing on path resolution.
  *
  * `label` names the prompt in the warning messages (e.g. `"router prompt"`).
  */
 export function loadPromptOverride(opts: {
-  overridePath: string | null;
+  overridePath: string | null | undefined;
   workspaceDir: string;
   log: PromptOverrideLogger;
   label: string;
 }): string | null {
   const { overridePath, workspaceDir, log, label } = opts;
-  if (overridePath === null) return null;
+  if (overridePath == null) return null;
 
   const resolvedPath = resolveOverridePath(overridePath, workspaceDir);
   let contents: string;


### PR DESCRIPTION
## Summary

- `loadPromptOverride` guarded only `overridePath === null`, so an `undefined` path (an unset `memory.v3.selectorPromptPath` on any config object not carrying the schema's `null` default) reached `resolveOverridePath` and threw `undefined is not an object (evaluating 'overridePath.startsWith')`. The throw surfaced as a swallowed "memory-v3 orchestration failed (non-fatal)", silently disabling retrieval — which is what broke the `shadow-plugin.test.ts` suite after #35807.
- Widen the nullish guard to `== null` and the param type to `string | null | undefined` so an absent override degrades to the bundled prompt like every other bad override, honoring the loader's documented total-fallback contract ("retrieval and consolidation must never break because of a bad override").
- Add a regression test asserting an `undefined` override path returns `null` without throwing.

## Original prompt

Fix the specific failing CI job (Test) on `main` run 28052808044, where `assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts` failed with `undefined is not an object (evaluating 'overridePath.startsWith')`. Scope: address only that job's failure, root-causing rather than papering over the symptom.