### PR TITLE
fix(memory-v3): don't let a hung capability reseed block the v3 maintain enqueue

### DIFF
--- a/assistant/src/daemon/memory-v2-startup.test.ts
+++ b/assistant/src/daemon/memory-v2-startup.test.ts
@@ -59,6 +59,18 @@ function configWithV2(enabled: boolean): AssistantConfig {
   return { memory: { v2: { enabled } } } as unknown as AssistantConfig;
 }
 
+/** Poll until `m` has been called at least `n` times, or `timeoutMs` elapses. */
+async function waitForCalls(
+  m: { mock: { calls: unknown[] } },
+  n: number,
+  timeoutMs = 1000,
+): Promise<void> {
+  const start = Date.now();
+  while (m.mock.calls.length < n && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 afterEach(() => {
   seedSkill.mockClear();
   seedCli.mockClear();
@@ -127,5 +139,65 @@ describe("maybeReseedCapabilitiesAfterManagedCredential", () => {
     await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true));
 
     expect(seedCli).toHaveBeenCalledTimes(1);
+  });
+
+  test("enqueues the v3 maintain pass even when one catalog reseed rejects", async () => {
+    proxyState.prereqs = true;
+    v3State.live = true;
+    seedSkill.mockImplementationOnce(async () => {
+      throw new Error('Embedding backend "gemini" is not configured');
+    });
+
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true));
+
+    // The CLI catalog seeded, so v3 must still rebuild its lanes — a single
+    // catalog failure cannot suppress the maintain pass.
+    expect(seedCli).toHaveBeenCalledTimes(1);
+    expect(enqueueJob).toHaveBeenCalledTimes(1);
+    expect(enqueueJob).toHaveBeenCalledWith("memory_v3_maintain", {});
+  });
+
+  test("enqueues the v3 maintain pass without blocking when a catalog reseed exceeds the timeout", async () => {
+    proxyState.prereqs = true;
+    v3State.live = true;
+    // Skill reseed never settles — mirrors the wedged getCatalog()/embed seen in
+    // the field. The CLI reseed completes normally.
+    seedSkill.mockImplementationOnce(() => new Promise<void>(() => {}));
+
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true), {
+      reseedTimeoutMs: 20,
+    });
+
+    // An unbounded `Promise.all` barrier would hang here forever; the bounded
+    // barrier lets the CLI catalog's maintain pass enqueue regardless.
+    expect(seedCli).toHaveBeenCalledTimes(1);
+    expect(enqueueJob).toHaveBeenCalledTimes(1);
+    expect(enqueueJob).toHaveBeenCalledWith("memory_v3_maintain", {});
+  });
+
+  test("re-enqueues the v3 maintain pass when a straggler catalog finishes after the timeout", async () => {
+    proxyState.prereqs = true;
+    v3State.live = true;
+    let resolveSkill!: () => void;
+    seedSkill.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSkill = resolve;
+        }),
+    );
+
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true), {
+      reseedTimeoutMs: 10,
+    });
+
+    // Post-barrier enqueue fires once even though the skill catalog is still
+    // embedding.
+    expect(enqueueJob).toHaveBeenCalledTimes(1);
+
+    // The straggler lands; maintain re-enqueues so its late capability rows are
+    // reconciled without waiting out the 6h backstop.
+    resolveSkill();
+    await waitForCalls(enqueueJob, 2);
+    expect(enqueueJob).toHaveBeenCalledTimes(2);
   });
 });

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -50,6 +50,36 @@ export function maybeSeedMemoryV2CliCommands(config: AssistantConfig): void {
 }
 
 /**
+ * Default upper bound on how long
+ * {@link maybeReseedCapabilitiesAfterManagedCredential} waits for the capability
+ * reseeds before enqueuing the v3 maintain pass. The reseeds keep running
+ * detached past this bound — it only stops the barrier from waiting on a wedged
+ * catalog (a stalled `getCatalog()` or a managed-proxy embed that never
+ * returns). A straggler that finishes later re-enqueues maintain.
+ */
+const RESEED_BARRIER_TIMEOUT_MS = 120_000;
+
+/**
+ * Resolve to `true` if `p` settles within `ms`, or `false` if the timeout wins.
+ * Always clears the timer, so a `p` that settles first leaves no pending timer
+ * keeping the event loop (or a test) alive.
+ */
+async function settledWithin(
+  p: Promise<unknown>,
+  ms: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), ms);
+  });
+  try {
+    return await Promise.race([p.then(() => true), timedOut]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
  * Re-seed the v2 skill and CLI-command capability entries once a managed-proxy
  * credential lands, closing the first-boot race where the daemon's startup seed
  * runs before the platform has provisioned the managed embedding credential.
@@ -83,9 +113,23 @@ export function maybeSeedMemoryV2CliCommands(config: AssistantConfig): void {
  * dense store and its lane-invalidation stage forces a rebuild against the now-
  * populated index, so v3 surfaces the skill/CLI pages within seconds instead of
  * waiting out the backstop.
+ *
+ * The maintain enqueue must NOT be gated on both catalogs settling. The two
+ * embeds are independent, and a single wedged catalog (a stalled `getCatalog()`
+ * or a managed-proxy embed that never returns) would otherwise block the v3 lane
+ * rebuild indefinitely, so the catalog that DID seed never reaches the selector.
+ * The barrier is therefore bounded by `reseedTimeoutMs`: maintain is enqueued
+ * once the barrier resolves (the pass is idempotent and reconciles whatever the
+ * page index currently holds), and a straggler catalog that finishes after the
+ * timeout re-enqueues maintain so its late rows are picked up without waiting out
+ * the backstop.
+ *
+ * `reseedTimeoutMs` is injectable for tests; production uses
+ * {@link RESEED_BARRIER_TIMEOUT_MS}.
  */
 export async function maybeReseedCapabilitiesAfterManagedCredential(
   config: AssistantConfig,
+  opts: { reseedTimeoutMs?: number } = {},
 ): Promise<void> {
   if (!config.memory.v2.enabled) return;
 
@@ -115,35 +159,59 @@ export async function maybeReseedCapabilitiesAfterManagedCredential(
     ],
   ];
 
-  await Promise.all(
-    catalogs.map(async ([label, seed]) => {
-      try {
-        await seed();
+  // Each reseed is contained so one catalog's embed failure (or hang) never
+  // rejects the caller or aborts the other. Started here but not awaited as a
+  // single barrier — the bounded wait below decides when to stop waiting.
+  const reseeds = catalogs.map(([label, seed]) =>
+    seed().then(
+      () =>
         log.info(
           `Memory v2 ${label} entries seeded after managed proxy credential update`,
-        );
-      } catch (err) {
+        ),
+      (err: unknown) =>
         log.warn(
           { err },
           `Failed to seed v2 ${label} entries after managed proxy credential update`,
-        );
-      }
-    }),
+        ),
+    ),
   );
 
-  // The stores (and the page index) are now populated; when v3 is live, kick a
-  // maintain pass so it embeds the capability rows into `memory_v3_sections` and
-  // invalidates its lanes immediately rather than waiting out the 6h backstop.
+  // When v3 is live, a maintain pass embeds the freshly-seeded capability rows
+  // into `memory_v3_sections` and invalidates the lanes so v3 surfaces the
+  // skill/CLI pages within seconds instead of waiting out the 6h backstop.
+  // Resolve the gate + enqueuer once and reuse for the post-barrier enqueue and
+  // the straggler re-enqueue below.
   const { isMemoryV3Live } = await import("../config/memory-v3-gate.js");
-  if (!isMemoryV3Live(config)) return;
-  try {
-    const { enqueueMemoryJob } = await import("../memory/jobs-store.js");
-    enqueueMemoryJob("memory_v3_maintain", {});
-  } catch (err) {
+  const v3Live = isMemoryV3Live(config);
+  const enqueueMaintain = async (): Promise<void> => {
+    if (!v3Live) return;
+    try {
+      const { enqueueMemoryJob } = await import("../memory/jobs-store.js");
+      enqueueMemoryJob("memory_v3_maintain", {});
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to enqueue memory_v3_maintain after managed proxy credential update",
+      );
+    }
+  };
+
+  // Bound the barrier so a wedged catalog can't block the maintain enqueue
+  // indefinitely; the reseeds keep running detached past the timeout.
+  const timeoutMs = opts.reseedTimeoutMs ?? RESEED_BARRIER_TIMEOUT_MS;
+  const allReseeds = Promise.allSettled(reseeds);
+  const settledInTime = await settledWithin(allReseeds, timeoutMs);
+
+  await enqueueMaintain();
+
+  if (!settledInTime) {
     log.warn(
-      { err },
-      "Failed to enqueue memory_v3_maintain after managed proxy credential update",
+      { timeoutMs },
+      "Capability reseed still running after the barrier timeout — enqueued v3 maintain now; will re-enqueue when the straggler catalog finishes",
     );
+    // The straggler is still embedding; re-enqueue maintain once it lands so its
+    // late capability rows are reconciled without waiting out the 6h backstop.
+    void allReseeds.then(() => enqueueMaintain());
   }
 }
 


### PR DESCRIPTION
## Summary

- On a brand-new managed assistant, the startup skill/CLI capability seed runs before the managed Gemini embedding credential (`vellum:assistant_api_key`) is provisioned, so `seedV2SkillEntries`/`seedV2CliCommandEntries` throw `EmbeddingBackendUnavailableError` and leave their caches empty — no synthetic `skills/<id>` rows reach the page index, so the v3 selector surfaces **zero skills**.
- The secret-route self-heal (`maybeReseedCapabilitiesAfterManagedCredential`) reseeds both catalogs then enqueues a `memory_v3_maintain` to rebuild the memoized v3 lanes. But the enqueue sat behind an unbounded `await Promise.all([skillReseed, cliReseed])`. In a real staging session the CLI reseed finished while the skill reseed never settled, so the barrier never resolved and the maintain pass never ran — even the successfully-reseeded CLI commands never reached the selector.
- **Fix:** bound the reseed barrier with a timeout (injectable `reseedTimeoutMs`, default 120s) so a wedged `getCatalog()`/embed can't starve the maintain enqueue; enqueue `memory_v3_maintain` once the barrier resolves (idempotent — reconciles whatever the page index currently holds); and re-enqueue when a straggler catalog finishes *after* the timeout so its late rows are picked up without waiting out the 6h backstop. The reseeds keep running detached past the timeout.
- Each catalog reseed remains individually contained (one catalog's failure/hang never aborts the other or rejects the detached caller).
- Tests: a rejecting catalog still enqueues maintain; a catalog that exceeds the timeout doesn't block the enqueue; a straggler that lands after the timeout re-enqueues maintain; plus the existing v3-not-live / no-managed-prereqs / v2-disabled gates still hold. 9/9 pass.

## Original prompt

Diagnosed from a staging feedback bundle: a brand-new managed assistant wasn't injecting any skills via memory v3. Root cause was a first-boot embedding-credential race that left the v2 skill cache empty, compounded by the self-heal's maintain enqueue being gated behind an unbounded `Promise.all` over both capability reseeds — so one hung reseed (the skill catalog) blocked the v3 lane rebuild entirely. This PR is fix #1 of the hardening follow-ups: decouple the `memory_v3_maintain` enqueue from the reseeds so a slow/hung catalog can no longer wedge the self-heal.