### PR TITLE
feat(assistant): map a local principal to a TrustContext via the gateway guardian binding

### DIFF
--- a/assistant/src/runtime/__tests__/local-principal-trust.test.ts
+++ b/assistant/src/runtime/__tests__/local-principal-trust.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ChannelId } from "../../channels/types.js";
+
+// Gateway guardian-delivery list: null = couldn't determine (gateway
+// unreachable), [] = authoritatively no guardian, one active entry = bound.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: (_input?: { channelTypes?: string[] }) =>
+    Promise.resolve(mockGuardianList),
+}));
+
+// Local-resolver guardian binding, used to construct the expected guardian
+// TrustContext via the existing resolver and prove equivalence.
+let mockGuardianRecord: {
+  contact: Record<string, unknown>;
+  channel: Record<string, unknown>;
+} | null = null;
+
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (_channelType: string) => mockGuardianRecord,
+  findContactByAddress: (_channelType: string, _address: string) => null,
+}));
+
+const { resolveLocalPrincipalTrustContext } = await import(
+  "../local-principal-trust.js"
+);
+const { resolveActorTrust, toTrustContext } = await import(
+  "../actor-trust-resolver.js"
+);
+
+const SOURCE_CHANNEL: ChannelId = "vellum";
+const CONVERSATION_ID = "conv-1";
+const GUARDIAN_PRINCIPAL_ID = "principal-guardian";
+const GUARDIAN_ADDRESS = "guardian-address";
+const GUARDIAN_CHAT_ID = "guardian-chat";
+
+describe("resolveLocalPrincipalTrustContext", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    mockGuardianRecord = null;
+  });
+
+  test("principal matching the gateway guardian → guardian ctx", async () => {
+    mockGuardianList = [
+      {
+        channelType: "vellum",
+        contactId: "contact-1",
+        principalId: GUARDIAN_PRINCIPAL_ID,
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    ];
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_PRINCIPAL_ID,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("guardian");
+    expect(ctx.guardianPrincipalId).toBe(GUARDIAN_PRINCIPAL_ID);
+    expect(ctx.guardianExternalUserId).toBe(GUARDIAN_ADDRESS);
+    expect(ctx.guardianChatId).toBe(GUARDIAN_CHAT_ID);
+    expect(ctx.requesterExternalUserId).toBe(GUARDIAN_PRINCIPAL_ID);
+    expect(ctx.requesterChatId).toBe(CONVERSATION_ID);
+    expect(ctx.sourceChannel).toBe(SOURCE_CHANNEL);
+  });
+
+  test("guardian ctx is equivalent to the prior toTrustContext output", async () => {
+    // The actor IS the guardian: its principal id is the guardian binding's
+    // address (vellum canonicalization is pass-through) so the local resolver
+    // classifies it guardian and we can compare the two outputs directly.
+    mockGuardianList = [
+      {
+        channelType: "vellum",
+        contactId: "contact-1",
+        principalId: GUARDIAN_ADDRESS,
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    ];
+    mockGuardianRecord = {
+      contact: { id: "contact-1", principalId: GUARDIAN_ADDRESS },
+      channel: {
+        type: "vellum",
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    };
+
+    const expected = toTrustContext(
+      resolveActorTrust({
+        assistantId: "assistant-1",
+        sourceChannel: SOURCE_CHANNEL,
+        conversationExternalId: CONVERSATION_ID,
+        actorExternalId: GUARDIAN_ADDRESS,
+      }),
+      CONVERSATION_ID,
+    );
+
+    const actual = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_ADDRESS,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(actual).toEqual(expected);
+  });
+
+  test("non-matching principal → unknown ctx", async () => {
+    mockGuardianList = [
+      {
+        channelType: "vellum",
+        contactId: "contact-1",
+        principalId: GUARDIAN_PRINCIPAL_ID,
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    ];
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: "principal-other",
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("unknown");
+    expect(ctx.requesterExternalUserId).toBe("principal-other");
+    expect(ctx.requesterChatId).toBe(CONVERSATION_ID);
+    expect(ctx.sourceChannel).toBe(SOURCE_CHANNEL);
+    expect(ctx.guardianPrincipalId).toBeUndefined();
+  });
+
+  test("empty guardian list → unknown ctx", async () => {
+    mockGuardianList = [];
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_PRINCIPAL_ID,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("unknown");
+  });
+
+  test("null guardian list (gateway unreachable) → unknown (fail closed)", async () => {
+    mockGuardianList = null;
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_PRINCIPAL_ID,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("unknown");
+    expect(ctx.requesterExternalUserId).toBe(GUARDIAN_PRINCIPAL_ID);
+  });
+});

--- a/assistant/src/runtime/local-principal-trust.ts
+++ b/assistant/src/runtime/local-principal-trust.ts
@@ -1,0 +1,64 @@
+/**
+ * Local-principal trust mapper.
+ *
+ * Derives a local principal's runtime {@link TrustContext} from the gateway
+ * guardian binding instead of the assistant DB. A `vellum` principal is the
+ * guardian (owner) or nobody, so "trust of this principal on the vellum
+ * channel" reduces to "does `actorPrincipalId` match the gateway guardian's
+ * principalId?" — which {@link getGuardianDelivery} answers.
+ *
+ * The mapper is pure: it does not heal binding drift or read local ACL. The
+ * routes own the heal/re-resolve loop and call this mapper.
+ */
+
+import type { ChannelId } from "../channels/types.js";
+import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
+
+export interface ResolveLocalPrincipalTrustInput {
+  actorPrincipalId: string;
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+}
+
+/**
+ * Resolve the trust context for a local principal from the gateway guardian
+ * binding. Guardian match → guardian ctx; otherwise → unknown. A null gateway
+ * read fails closed to unknown rather than granting guardian on a miss.
+ */
+export async function resolveLocalPrincipalTrustContext(
+  input: ResolveLocalPrincipalTrustInput,
+): Promise<TrustContext> {
+  const unknownContext: TrustContext = {
+    sourceChannel: input.sourceChannel,
+    trustClass: "unknown",
+    requesterExternalUserId: input.actorPrincipalId,
+    requesterChatId: input.conversationExternalId,
+  };
+
+  // Fail closed: a null read means the gateway is unreachable — never grant
+  // guardian on a miss.
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (!guardians) return unknownContext;
+
+  const guardian = guardians.find(
+    (g) => g.principalId === input.actorPrincipalId,
+  );
+  if (!guardian) return unknownContext;
+
+  return {
+    sourceChannel: input.sourceChannel,
+    trustClass: "guardian",
+    guardianChatId: guardian.externalChatId ?? input.conversationExternalId,
+    guardianExternalUserId:
+      canonicalizeInboundIdentity(input.sourceChannel, guardian.address) ??
+      undefined,
+    guardianPrincipalId: guardian.principalId ?? undefined,
+    // Mirror toTrustContext: with no username the requester identifier is the
+    // canonical sender id, which for a vellum principal is actorPrincipalId.
+    requesterIdentifier: input.actorPrincipalId,
+    requesterExternalUserId: input.actorPrincipalId,
+    requesterChatId: input.conversationExternalId,
+  };
+}


### PR DESCRIPTION
## Summary
- Add resolveLocalPrincipalTrustContext: derives a local principal's TrustContext from the gateway guardian binding (getGuardianDelivery), guardian-match → guardian ctx else unknown, fail-closed on a null gateway read.
- Pure mapper (no drift-heal, no local ACL read); guardian ctx proven equivalent to the prior toTrustContext output.

Part of plan: local-principal-trust-from-binding.md (PR 1 of 3)