### PR TITLE
fix(gateway): createGuardianBinding resolves contact/channel ids from the gateway DB

### DIFF
--- a/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
+++ b/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
@@ -1,4 +1,22 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+/**
+ * Tests for createGuardianBinding's id resolution (guardian-by-principal,
+ * claimable channel by (type,address), existing channel by (contactId,type)).
+ *
+ * These reads run against the gateway DB; the resolved contactId/channelId
+ * are then adopted by the assistant + gateway dual-write. Guardian/channel
+ * rows are seeded in the gateway DB; the assistant DB is an in-memory store
+ * behind the proxy mock that receives the writes.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { Database } from "bun:sqlite";
 
 import type { SqliteValue } from "../db/assistant-db-proxy.js";
@@ -32,30 +50,86 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   },
 }));
 
-const fakeGatewayTx = {
-  insert: () => ({
-    values: () => ({
-      onConflictDoUpdate: () => ({ run: () => {} }),
-    }),
-  }),
-};
+import { createGuardianBinding } from "../auth/guardian-bootstrap.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
 
-mock.module("../db/connection.js", () => ({
-  getGatewayDb: () => ({
-    transaction: (fn: (tx: typeof fakeGatewayTx) => void) => fn(fakeGatewayTx),
-  }),
-}));
+function seedGwGuardianContact(): void {
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: "guardian-contact",
+      displayName: "Example User",
+      role: "guardian",
+      principalId: "guardian-principal",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    .run();
+}
 
-mock.module("../db/schema.js", () => ({
-  actorRefreshTokenRecords: {},
-  actorTokenRecords: {},
-  contacts: {},
-  contactChannels: {},
-}));
+function seedGwSlackChannel(address: string): void {
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: "seed-contact",
+      displayName: "Example User",
+      role: "contact",
+      principalId: null,
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    .run();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: "seed-channel",
+      contactId: "seed-contact",
+      type: "slack",
+      address,
+      externalChatId: "D123EXAMPLE",
+      isPrimary: false,
+      status: "unverified",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    .run();
+}
 
-const { createGuardianBinding } = await import("../auth/guardian-bootstrap.js");
+function seedGwRevokedGuardianSlackChannel(): void {
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: "guardian-channel",
+      contactId: "guardian-contact",
+      type: "slack",
+      address: "U123EXAMPLE",
+      externalChatId: "D123EXAMPLE",
+      isPrimary: true,
+      status: "revoked",
+      policy: "deny",
+      interactionCount: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    .run();
+}
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
 
 beforeEach(() => {
+  const gw = getGatewayDb();
+  gw.delete(contactChannels).run();
+  gw.delete(contacts).run();
+
   assistantDb = new Database(":memory:");
   assistantDb.exec(`
     CREATE TABLE contacts (
@@ -81,6 +155,7 @@ beforeEach(() => {
       verified_via TEXT,
       revoked_reason TEXT,
       blocked_reason TEXT,
+      interaction_count INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL,
       updated_at INTEGER
     );
@@ -90,60 +165,16 @@ beforeEach(() => {
   `);
 });
 
-afterEach(() => {
+afterAll(() => {
+  resetGatewayDb();
   assistantDb?.close();
   assistantDb = null;
 });
 
-function seedGuardianContact(): void {
-  db()
-    .prepare(
-      `INSERT INTO contacts
-         (id, display_name, role, principal_id, notes, created_at, updated_at)
-       VALUES
-         ('guardian-contact', 'Example User', 'guardian', 'guardian-principal', 'guardian', 1, 1)`,
-    )
-    .run();
-}
-
-function seedSlackContactChannel(address: string): void {
-  db()
-    .prepare(
-      `INSERT INTO contacts
-         (id, display_name, role, principal_id, notes, created_at, updated_at)
-       VALUES
-         ('seed-contact', 'Example User', 'contact', NULL, NULL, 1, 1)`,
-    )
-    .run();
-  db()
-    .prepare(
-      `INSERT INTO contact_channels
-         (id, contact_id, type, address, external_chat_id,
-          is_primary, status, policy, created_at, updated_at)
-       VALUES
-         ('seed-channel', 'seed-contact', 'slack', ?,
-          'D123EXAMPLE', 0, 'unverified', 'allow', 1, 1)`,
-    )
-    .run(address);
-}
-
-function seedRevokedGuardianSlackChannel(): void {
-  db()
-    .prepare(
-      `INSERT INTO contact_channels
-         (id, contact_id, type, address, external_chat_id,
-          is_primary, status, policy, created_at, updated_at)
-       VALUES
-         ('guardian-channel', 'guardian-contact', 'slack', 'U123EXAMPLE',
-          'D123EXAMPLE', 1, 'revoked', 'deny', 1, 1)`,
-    )
-    .run();
-}
-
-describe("createGuardianBinding", () => {
-  test("claims a preseeded Slack channel for the guardian instead of inserting a duplicate", async () => {
-    seedGuardianContact();
-    seedSlackContactChannel("U123EXAMPLE");
+describe("createGuardianBinding id resolution", () => {
+  test("claims a preseeded Slack channel for the guardian instead of minting", async () => {
+    seedGwGuardianContact();
+    seedGwSlackChannel("U123EXAMPLE");
 
     const result = await createGuardianBinding({
       channel: "slack",
@@ -156,72 +187,11 @@ describe("createGuardianBinding", () => {
 
     expect(result.contactId).toBe("guardian-contact");
     expect(result.channelId).toBe("seed-channel");
-
-    const rows = db()
-      .query<
-        {
-          id: string;
-          contact_id: string;
-          address: string;
-          status: string;
-          policy: string;
-          is_primary: number;
-        },
-        []
-      >("SELECT * FROM contact_channels WHERE type = 'slack'")
-      .all();
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      id: "seed-channel",
-      contact_id: "guardian-contact",
-      address: "U123EXAMPLE",
-      status: "active",
-      policy: "allow",
-      is_primary: 1,
-    });
   });
 
-  test("claims an existing Slack channel with matching address", async () => {
-    seedGuardianContact();
-    seedSlackContactChannel("U123EXAMPLE");
-
-    await createGuardianBinding({
-      channel: "slack",
-      externalUserId: "U123EXAMPLE",
-      deliveryChatId: "D123EXAMPLE",
-      guardianPrincipalId: "guardian-principal",
-      displayName: "Example User",
-      verifiedVia: "challenge",
-    });
-
-    const rows = db()
-      .query<
-        {
-          id: string;
-          contact_id: string;
-          address: string;
-          status: string;
-        },
-        []
-      >(
-        `SELECT id, contact_id, address, status
-         FROM contact_channels
-         WHERE type = 'slack'`,
-      )
-      .all();
-    expect(rows).toEqual([
-      {
-        id: "seed-channel",
-        contact_id: "guardian-contact",
-        address: "U123EXAMPLE",
-        status: "active",
-      },
-    ]);
-  });
-
-  test("reactivates a revoked guardian channel instead of creating a new one", async () => {
-    seedGuardianContact();
-    seedRevokedGuardianSlackChannel();
+  test("reactivates a revoked guardian channel instead of minting a new one", async () => {
+    seedGwGuardianContact();
+    seedGwRevokedGuardianSlackChannel();
 
     const result = await createGuardianBinding({
       channel: "slack",
@@ -234,30 +204,5 @@ describe("createGuardianBinding", () => {
 
     expect(result.contactId).toBe("guardian-contact");
     expect(result.channelId).toBe("guardian-channel");
-
-    const rows = db()
-      .query<
-        {
-          id: string;
-          contact_id: string;
-          address: string;
-          status: string;
-        },
-        []
-      >(
-        `SELECT id, contact_id, address, status
-         FROM contact_channels
-         WHERE type = 'slack'
-         ORDER BY id`,
-      )
-      .all();
-    expect(rows).toEqual([
-      {
-        id: "guardian-channel",
-        contact_id: "guardian-contact",
-        address: "U123EXAMPLE",
-        status: "active",
-      },
-    ]);
   });
 });

--- a/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
@@ -246,3 +246,83 @@ describe("createGuardianBinding gateway dual-write", () => {
     expect(row.contactId).toBe(result.contactId);
   });
 });
+
+describe("createGuardianBinding id resolution (gateway reads)", () => {
+  test("reuses an existing gateway guardian by principal — no new id minted", async () => {
+    seedGwChannel({
+      contactId: "existing-guardian-contact",
+      channelId: "existing-guardian-channel",
+      type: "telegram",
+      address: "OTHER_ADDR",
+      principalId: "guardian-principal",
+    });
+
+    const result = await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U_OWNER",
+      deliveryChatId: "D_OWNER",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    // Contact id is reused from the gateway guardian-by-principal lookup —
+    // no fresh uuid minted.
+    expect(result.contactId).toBe("existing-guardian-contact");
+  });
+
+  test("adopts a claimable gateway channel by (type, address COLLATE NOCASE)", async () => {
+    seedGwChannel({
+      contactId: "claimable-contact",
+      channelId: "claimable-channel",
+      type: "slack",
+      address: "u_owner", // lowercased — matched case-insensitively
+      principalId: "other-principal",
+      status: "unverified",
+    });
+
+    const result = await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U_OWNER",
+      deliveryChatId: "D_OWNER",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    // No guardian-by-principal match, so contact + channel come from the
+    // claimable channel resolved via the case-insensitive address match.
+    expect(result.contactId).toBe("claimable-contact");
+    expect(result.channelId).toBe("claimable-channel");
+  });
+
+  test("mints a fresh id for a brand-new guardian, written to both DBs", async () => {
+    const result = await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U_FRESH",
+      deliveryChatId: "D_FRESH",
+      guardianPrincipalId: "fresh-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    const gwRows = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.type, "slack"))
+      .all();
+    expect(gwRows).toHaveLength(1);
+    expect(gwRows[0]!.id).toBe(result.channelId);
+    expect(gwRows[0]!.contactId).toBe(result.contactId);
+
+    const asstRows = asstDb()
+      .query<
+        { id: string; contact_id: string },
+        []
+      >(`SELECT id, contact_id FROM contact_channels WHERE type = 'slack'`)
+      .all();
+    expect(asstRows).toEqual([
+      { id: result.channelId, contact_id: result.contactId },
+    ]);
+  });
+});

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -237,9 +237,6 @@ export async function createGuardianBinding(
   const displayName = params.displayName ?? params.externalUserId;
   const verifiedVia = params.verifiedVia ?? "challenge";
 
-  let contactId: string;
-  let channelId: string;
-
   // --- Id resolution (reads the gateway DB; ids feed the dual-write) ---
   const gwReadDb = getGatewayDb();
 
@@ -277,7 +274,7 @@ export async function createGuardianBinding(
     .limit(1)
     .all() as ExistingChannelRow[];
 
-  contactId =
+  const contactId =
     existingContacts[0]?.id ?? claimableChannels[0]?.contactId ?? uuid();
 
   let existingChannels: { id: string }[] = [];
@@ -295,7 +292,8 @@ export async function createGuardianBinding(
       .all();
   }
 
-  channelId = claimableChannels[0]?.id ?? existingChannels[0]?.id ?? uuid();
+  const channelId =
+    claimableChannels[0]?.id ?? existingChannels[0]?.id ?? uuid();
 
   // --- Assistant DB write (primary, via IPC proxy) ---
   await assistantDbExec("BEGIN IMMEDIATE");

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -8,7 +8,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import {
@@ -240,46 +240,66 @@ export async function createGuardianBinding(
   let contactId: string;
   let channelId: string;
 
+  // --- Id resolution (reads the gateway DB; ids feed the dual-write) ---
+  const gwReadDb = getGatewayDb();
+
+  const existingContacts = gwReadDb
+    .select({ id: gwContacts.id })
+    .from(gwContacts)
+    .where(
+      and(
+        eq(gwContacts.role, "guardian"),
+        eq(gwContacts.principalId, params.guardianPrincipalId),
+      ),
+    )
+    .limit(1)
+    .all();
+  const existingGuardianContactId = existingContacts[0]?.id;
+
+  const claimableChannels = gwReadDb
+    .select({
+      id: gwContactChannels.id,
+      contactId: gwContactChannels.contactId,
+    })
+    .from(gwContactChannels)
+    .where(
+      and(
+        eq(gwContactChannels.type, params.channel),
+        ne(gwContactChannels.status, "blocked"),
+        sql`${gwContactChannels.address} = ${params.externalUserId} COLLATE NOCASE`,
+      ),
+    )
+    .orderBy(
+      sql`CASE WHEN ${gwContactChannels.contactId} = ${existingGuardianContactId ?? ""} THEN 0 ELSE 1 END`,
+      sql`CASE ${gwContactChannels.status} WHEN 'active' THEN 0 WHEN 'unverified' THEN 1 ELSE 2 END`,
+      desc(gwContactChannels.updatedAt),
+    )
+    .limit(1)
+    .all() as ExistingChannelRow[];
+
+  contactId =
+    existingContacts[0]?.id ?? claimableChannels[0]?.contactId ?? uuid();
+
+  let existingChannels: { id: string }[] = [];
+  if (!claimableChannels[0] && existingContacts[0]) {
+    existingChannels = gwReadDb
+      .select({ id: gwContactChannels.id })
+      .from(gwContactChannels)
+      .where(
+        and(
+          eq(gwContactChannels.contactId, contactId),
+          eq(gwContactChannels.type, params.channel),
+        ),
+      )
+      .limit(1)
+      .all();
+  }
+
+  channelId = claimableChannels[0]?.id ?? existingChannels[0]?.id ?? uuid();
+
   // --- Assistant DB write (primary, via IPC proxy) ---
   await assistantDbExec("BEGIN IMMEDIATE");
   try {
-    const existingContacts = await assistantDbQuery<{ id: string }>(
-      `SELECT id FROM contacts WHERE role = 'guardian' AND principal_id = ? LIMIT 1`,
-      [params.guardianPrincipalId],
-    );
-    const existingGuardianContactId = existingContacts[0]?.id;
-
-    const claimableChannels = await assistantDbQuery<ExistingChannelRow>(
-      `SELECT cc.id, cc.contact_id AS contactId
-       FROM contact_channels cc
-       WHERE cc.type = ?
-         AND cc.status != 'blocked'
-         AND cc.address = ? COLLATE NOCASE
-       ORDER BY
-         CASE WHEN cc.contact_id = ? THEN 0 ELSE 1 END,
-         CASE cc.status
-           WHEN 'active' THEN 0
-           WHEN 'unverified' THEN 1
-           ELSE 2
-         END,
-         cc.updated_at DESC
-       LIMIT 1`,
-      [params.channel, params.externalUserId, existingGuardianContactId ?? ""],
-    );
-
-    contactId =
-      existingContacts[0]?.id ?? claimableChannels[0]?.contactId ?? uuid();
-
-    let existingChannels: { id: string }[] = [];
-    if (!claimableChannels[0] && existingContacts[0]) {
-      existingChannels = await assistantDbQuery<{ id: string }>(
-        `SELECT id FROM contact_channels WHERE contact_id = ? AND type = ? LIMIT 1`,
-        [contactId, params.channel],
-      );
-    }
-
-    channelId = claimableChannels[0]?.id ?? existingChannels[0]?.id ?? uuid();
-
     if (existingContacts[0] || claimableChannels[0]) {
       await assistantDbRun(
         `UPDATE contacts


### PR DESCRIPTION
## Summary
- Move createGuardianBinding's three id-resolution SELECTs (guardian-by-principal, claimable channel by (type,address), existing channel by (contactId,type)) off the assistant DB onto getGatewayDb(), preserving query semantics and the id-adoption precedence.
- Writes unchanged: the assistant BEGIN IMMEDIATE dual-write and gateway gwContacts/gwContactChannels inserts stay as-is.
- Adds tests for guardian reuse by principal, claimable-channel adoption, and fresh-id minting.

Part of plan: gateway-bootstrap-binding-reads.md (PR 1 of 1)