### PR TITLE
[codex] Document design system first UI guidance

### DIFF
--- a/clients/web/AGENTS.md
+++ b/clients/web/AGENTS.md
@@ -20,7 +20,7 @@ Read these before making changes:
   `@vellumai/design-library` when adding or changing controls, surfaces,
   typography, popovers, inputs, cards, or button/icon affordances. Use existing
   design-library primitives when they are available; only build custom
-  Tailwind/HTML equivalents when the design library does not provide an
+  components when the design library does not provide an
   appropriate primitive, and call out that choice in the PR body if the UI is
   non-trivial.
 - **`conversationId` vs `conversationKey`**: API queries must send `conversationId` (UUID), never `conversationKey`. See [`docs/CONVENTIONS.md` — Conversation identifiers](./docs/CONVENTIONS.md#conversation-identifiers-conversationid-vs-conversationkey).

--- a/clients/web/AGENTS.md
+++ b/clients/web/AGENTS.md
@@ -16,6 +16,13 @@ Read these before making changes:
 
 ## Common pitfalls
 
+- **Design system first for UI changes.** Always start from
+  `@vellumai/design-library` when adding or changing controls, surfaces,
+  typography, popovers, inputs, cards, or button/icon affordances. Use existing
+  design-library primitives when they are available; only build custom
+  Tailwind/HTML equivalents when the design library does not provide an
+  appropriate primitive, and call out that choice in the PR body if the UI is
+  non-trivial.
 - **`conversationId` vs `conversationKey`**: API queries must send `conversationId` (UUID), never `conversationKey`. See [`docs/CONVENTIONS.md` — Conversation identifiers](./docs/CONVENTIONS.md#conversation-identifiers-conversationid-vs-conversationkey).
 - **Don't ship cross-route state through outlet context.** React Router outlet context [re-renders every consumer when any field changes](https://reactrouter.com/start/framework/outlet), forces a bundled value through every layout, and silently resolves to `undefined` whenever an intermediate `<Outlet />` (a gate, a wrapper) sits between writer and reader. Cross-route state — auth, lifecycle, selection, feature flags, layout slots — belongs in a Zustand store so consumers can subscribe atomically and so intermediate routes don't break the channel. Use outlet context only for one-shot parent→direct-child wiring with no intermediate routes.
 - **HeyAPI generated artifacts**: For **queries**, spread the generated factory into `useQuery()`: `useQuery({ ...xxxOptions(), enabled })` — the generated `useXxxQuery()` hooks do **not** accept TanStack Query options (`enabled`, `select`, `staleTime`). For **mutations**, use the generated hooks directly: `useXxxMutation({ onSuccess })` — they accept all TQ callbacks. Use typed cache helpers (`setXxxQueryData()`) for optimistic writes. See [`docs/CONVENTIONS.md` — Generated artifacts](./docs/CONVENTIONS.md#generated-artifacts-and-when-to-use-each).


### PR DESCRIPTION
## Summary

- Add a web AGENTS instruction that UI changes must start from `@vellumai/design-library` primitives when available.
- Require non-trivial custom Tailwind/HTML UI choices to be called out in the PR body.

## Original prompt

The user asked to update AGENTS.md and open a PR after noting that PR #35795 was an avoidable follow-up caused by agents hand-rolling UI instead of using the design system from the start.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->