### PR TITLE
Fix gateway startup probe during post-ready work

### DIFF
--- a/gateway/src/__tests__/credential-watcher.test.ts
+++ b/gateway/src/__tests__/credential-watcher.test.ts
@@ -254,6 +254,35 @@ async function startGateway(): Promise<void> {
   );
 }
 
+async function fetchTelegramWebhook(base: string): Promise<{
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const res = await fetch(`${base}/webhooks/telegram`, {
+    method: "POST",
+  });
+  return {
+    status: res.status,
+    body: (await res.json()) as Record<string, unknown>,
+  };
+}
+
+async function waitForTelegramWebhookPastStartup(base: string): Promise<{
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const deadline = Date.now() + 5_000;
+  let last: { status: number; body: Record<string, unknown> } | null = null;
+  while (Date.now() < deadline) {
+    last = await fetchTelegramWebhook(base);
+    if (last.body.status !== "starting") return last;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    `Telegram webhook stayed behind startup gate: ${JSON.stringify(last)}`,
+  );
+}
+
 afterEach(async () => {
   fakeAssistantIpc?.close();
   fakeAssistantIpc = null;
@@ -295,12 +324,9 @@ describe("gateway telegram hot-reload (e2e)", () => {
     const base = `http://localhost:${port}`;
 
     // --- Step 1: confirm Telegram is NOT configured ---
-    const before = await fetch(`${base}/webhooks/telegram`, {
-      method: "POST",
-    });
+    const before = await waitForTelegramWebhookPastStartup(base);
     expect(before.status).toBe(503);
-    const beforeBody = (await before.json()) as { error: string };
-    expect(beforeBody.error).toBe("Telegram integration not configured");
+    expect(before.body.error).toBe("Telegram integration not configured");
 
     // --- Step 2: simulate daemon writing credentials ---
     writeEncryptedStore("fake-bot-token:ABC123", "fake-webhook-secret");
@@ -331,9 +357,7 @@ describe("gateway telegram hot-reload (e2e)", () => {
 
     const base = `http://localhost:${port}`;
 
-    const before = await fetch(`${base}/webhooks/telegram`, {
-      method: "POST",
-    });
+    const before = await waitForTelegramWebhookPastStartup(base);
     expect(before.status).toBe(503);
 
     // First rewrite after startup stales a file-scoped fs.watch() subscription
@@ -372,12 +396,9 @@ describe("gateway telegram hot-reload (e2e)", () => {
     const base = `http://localhost:${port}`;
 
     // --- Step 1: confirm Telegram is NOT configured ---
-    const before = await fetch(`${base}/webhooks/telegram`, {
-      method: "POST",
-    });
+    const before = await waitForTelegramWebhookPastStartup(base);
     expect(before.status).toBe(503);
-    const beforeBody = (await before.json()) as { error: string };
-    expect(beforeBody.error).toBe("Telegram integration not configured");
+    expect(before.body.error).toBe("Telegram integration not configured");
 
     // --- Step 2: simulate daemon writing v2 credentials ---
     writeEncryptedStoreV2("fake-v2-bot-token:XYZ", "fake-v2-webhook-secret");

--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -21,6 +21,7 @@ const config = await loadConfig();
 const { handler: handleTelegramWebhook } = createTelegramWebhookHandler(config);
 
 let draining = false;
+let postAssistantReadyComplete = true;
 
 async function handleRequest(req: Request): Promise<Response> {
   const url = new URL(req.url);
@@ -33,7 +34,14 @@ async function handleRequest(req: Request): Promise<Response> {
     if (draining) {
       return Response.json({ status: "draining" }, { status: 503 });
     }
+    if (!postAssistantReadyComplete) {
+      return Response.json({ status: "starting" }, { status: 503 });
+    }
     return Response.json({ status: "ok" });
+  }
+
+  if (!postAssistantReadyComplete) {
+    return Response.json({ status: "starting" }, { status: 503 });
   }
 
   if (url.pathname === "/webhooks/telegram") {
@@ -57,6 +65,20 @@ describe("/healthz", () => {
     const body = await res.json();
     expect(body.status).toBe("ok");
   });
+
+  test("returns 200 while post-assistant-ready startup work is incomplete", async () => {
+    postAssistantReadyComplete = false;
+    try {
+      const res = await handleRequest(
+        new Request("http://gateway.test/healthz"),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("ok");
+    } finally {
+      postAssistantReadyComplete = true;
+    }
+  });
 });
 
 describe("/readyz", () => {
@@ -78,6 +100,34 @@ describe("/readyz", () => {
       expect(body.status).toBe("draining");
     } finally {
       draining = false;
+    }
+  });
+
+  test("returns 503 while post-assistant-ready startup work is incomplete", async () => {
+    postAssistantReadyComplete = false;
+    try {
+      const res = await handleRequest(
+        new Request("http://gateway.test/readyz"),
+      );
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.status).toBe("starting");
+    } finally {
+      postAssistantReadyComplete = true;
+    }
+  });
+
+  test("blocks regular traffic while post-assistant-ready startup work is incomplete", async () => {
+    postAssistantReadyComplete = false;
+    try {
+      const res = await handleRequest(
+        new Request("http://gateway.test/webhooks/telegram"),
+      );
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.status).toBe("starting");
+    } finally {
+      postAssistantReadyComplete = true;
     }
   });
 });

--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -30,18 +30,19 @@ async function handleRequest(req: Request): Promise<Response> {
     return Response.json({ status: "ok" });
   }
 
+  if (!postAssistantReadyComplete) {
+    return Response.json({ status: "starting" }, { status: 503 });
+  }
+
+  if (url.pathname === "/schema") {
+    return Response.json({ openapi: "3.1.0" });
+  }
+
   if (url.pathname === "/readyz") {
     if (draining) {
       return Response.json({ status: "draining" }, { status: 503 });
     }
-    if (!postAssistantReadyComplete) {
-      return Response.json({ status: "starting" }, { status: 503 });
-    }
     return Response.json({ status: "ok" });
-  }
-
-  if (!postAssistantReadyComplete) {
-    return Response.json({ status: "starting" }, { status: 503 });
   }
 
   if (url.pathname === "/webhooks/telegram") {
@@ -122,6 +123,20 @@ describe("/readyz", () => {
     try {
       const res = await handleRequest(
         new Request("http://gateway.test/webhooks/telegram"),
+      );
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.status).toBe("starting");
+    } finally {
+      postAssistantReadyComplete = true;
+    }
+  });
+
+  test("blocks schema while post-assistant-ready startup work is incomplete", async () => {
+    postAssistantReadyComplete = false;
+    try {
+      const res = await handleRequest(
+        new Request("http://gateway.test/schema"),
       );
       expect(res.status).toBe(503);
       const body = await res.json();

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -129,7 +129,7 @@ describe("buildSchema()", () => {
     const schemaNames = Object.keys(components.schemas);
     expect(schemaNames).toContain("HealthResponse");
     expect(schemaNames).toContain("ReadyResponse");
-    expect(schemaNames).toContain("DrainingResponse");
+    expect(schemaNames).toContain("ReadyUnavailableResponse");
     expect(schemaNames).toContain("ErrorResponse");
     expect(schemaNames).toContain("TelegramOk");
     expect(schemaNames).toContain("TelegramUpdate");

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1718,23 +1718,9 @@ async function main() {
   ): Promise<Response | undefined> {
     const url = new URL(req.url);
 
-    // ── CORS: webview preflight & origin tracking ──
-    // The macOS WKWebView loads pages from https://{appId}.vellum.local/
-    // which is cross-origin to the gateway at http://127.0.0.1:{port}.
-    // Reflect the origin back on matched requests so window.vellum.fetch
-    // calls succeed.
-    const extensionOrigin = resolveExtensionOrigin(req);
-    if (extensionOrigin && req.method === "OPTIONS") {
-      return handleExtensionPreflight(extensionOrigin);
-    }
-
-    const webviewOrigin = resolveWebviewOrigin(req);
-    if (webviewOrigin && req.method === "OPTIONS") {
-      return handlePreflight(webviewOrigin);
-    }
-
-    // ── Pre-router: health/readiness probes ──
-    // These bypass rate limiting and tracing for minimal overhead.
+    // ── Pre-router: health probe ──
+    // This stays available during post-assistant-ready startup work so
+    // Kubernetes startup/liveness probes can observe the bound process.
     if (url.pathname === "/healthz") {
       const includeMigrations =
         url.searchParams.get("include") === "migrations";
@@ -1770,6 +1756,25 @@ async function main() {
       return Response.json({ status: "ok" });
     }
 
+    if (!postAssistantReadyComplete) {
+      return Response.json({ status: "starting" }, { status: 503 });
+    }
+
+    // ── CORS: webview preflight & origin tracking ──
+    // The macOS WKWebView loads pages from https://{appId}.vellum.local/
+    // which is cross-origin to the gateway at http://127.0.0.1:{port}.
+    // Reflect the origin back on matched requests so window.vellum.fetch
+    // calls succeed.
+    const extensionOrigin = resolveExtensionOrigin(req);
+    if (extensionOrigin && req.method === "OPTIONS") {
+      return handleExtensionPreflight(extensionOrigin);
+    }
+
+    const webviewOrigin = resolveWebviewOrigin(req);
+    if (webviewOrigin && req.method === "OPTIONS") {
+      return handlePreflight(webviewOrigin);
+    }
+
     if (url.pathname === "/schema") {
       return Response.json(buildSchema());
     }
@@ -1777,9 +1782,6 @@ async function main() {
     if (url.pathname === "/readyz") {
       if (draining) {
         return Response.json({ status: "draining" }, { status: 503 });
-      }
-      if (!postAssistantReadyComplete) {
-        return Response.json({ status: "starting" }, { status: 503 });
       }
       // Check that the upstream assistant is also reachable so callers
       // know the full stack is ready, not just the gateway process.
@@ -1801,10 +1803,6 @@ async function main() {
         );
       }
       return Response.json({ status: "ok" });
-    }
-
-    if (!postAssistantReadyComplete) {
-      return Response.json({ status: "starting" }, { status: 503 });
     }
 
     // Per-request IP resolver — scoped to this request so it remains
@@ -1917,7 +1915,7 @@ async function main() {
   log.info({ port: server.port }, "Gateway HTTP server listening");
 
   // Complete post-assistant-ready startup work after binding /healthz.
-  // /readyz and regular routes stay closed until this finishes.
+  // All non-health routes stay closed until this finishes.
   try {
     await runPostAssistantReady();
     postAssistantReadyComplete = true;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -217,6 +217,7 @@ function generateTraceId(): string {
 }
 
 let draining = false;
+let postAssistantReadyComplete = false;
 
 /**
  * Detect which services had credential changes and log them.
@@ -307,13 +308,6 @@ async function main() {
   await initGatewayDb();
   initTrustRuleCache();
   initAdmissionPolicyCache();
-
-  // Wait for the assistant runtime to be healthy before serving traffic.
-  // Data migrations (e.g. m0002 actor-token-tables-to-gateway) must
-  // complete before the HTTP server starts accepting auth requests —
-  // otherwise newly minted tokens can be overwritten by stale rows
-  // migrated from the assistant DB.
-  await runPostAssistantReady();
 
   // ── TTL caches ──
   // Instantiate caches for credential and config file reads.
@@ -1784,6 +1778,9 @@ async function main() {
       if (draining) {
         return Response.json({ status: "draining" }, { status: 503 });
       }
+      if (!postAssistantReadyComplete) {
+        return Response.json({ status: "starting" }, { status: 503 });
+      }
       // Check that the upstream assistant is also reachable so callers
       // know the full stack is ready, not just the gateway process.
       try {
@@ -1804,6 +1801,10 @@ async function main() {
         );
       }
       return Response.json({ status: "ok" });
+    }
+
+    if (!postAssistantReadyComplete) {
+      return Response.json({ status: "starting" }, { status: 503 });
     }
 
     // Per-request IP resolver — scoped to this request so it remains
@@ -1914,6 +1915,12 @@ async function main() {
   }
 
   log.info({ port: server.port }, "Gateway HTTP server listening");
+
+  // Complete post-assistant-ready startup work after binding /healthz.
+  // /readyz and regular routes stay closed until this finishes.
+  await runPostAssistantReady();
+  postAssistantReadyComplete = true;
+
   logAuthBypassState();
 
   // Start periodic background cleanup for dedup caches

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1918,8 +1918,14 @@ async function main() {
 
   // Complete post-assistant-ready startup work after binding /healthz.
   // /readyz and regular routes stay closed until this finishes.
-  await runPostAssistantReady();
-  postAssistantReadyComplete = true;
+  try {
+    await runPostAssistantReady();
+    postAssistantReadyComplete = true;
+  } catch (err) {
+    log.error({ err }, "Post-assistant-ready startup work failed");
+    server.stop(true);
+    process.exit(1);
+  }
 
   logAuthBypassState();
 

--- a/gateway/src/post-assistant-ready.ts
+++ b/gateway/src/post-assistant-ready.ts
@@ -8,9 +8,9 @@
  * assistant DB doesn't exist yet.
  *
  * This module polls the assistant IPC health route and, once the assistant
- * is ready, runs data migrations and other deferred tasks. It is awaited
- * during startup — the HTTP server does not start until this completes,
- * preventing auth traffic from racing with data migrations.
+ * is ready, runs data migrations and other deferred tasks. The gateway keeps
+ * readiness and regular traffic closed until this completes, preventing auth
+ * traffic from racing with data migrations.
  */
 
 import type { Database } from "bun:sqlite";
@@ -57,7 +57,7 @@ export async function waitForAssistant(): Promise<boolean> {
 
 /**
  * Wait for the assistant runtime to become healthy, then run deferred
- * startup tasks. Awaited at startup — blocks Bun.serve().
+ * startup tasks.
  */
 export async function runPostAssistantReady(): Promise<void> {
   const ready = await waitForAssistant();

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -37,7 +37,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Readiness probe",
           description:
-            "Returns 200 when the gateway is ready to accept traffic. Returns 503 during graceful shutdown drain.",
+            "Returns 200 when the gateway is ready to accept traffic. Returns 503 while startup work is incomplete, during graceful shutdown drain, or when the upstream assistant is unavailable.",
           operationId: "readyz",
           responses: {
             "200": {
@@ -49,11 +49,12 @@ export function buildSchema(): Record<string, unknown> {
               },
             },
             "503": {
-              description:
-                "Gateway is draining (graceful shutdown in progress)",
+              description: "Gateway is not ready to accept traffic",
               content: {
                 "application/json": {
-                  schema: { $ref: "#/components/schemas/DrainingResponse" },
+                  schema: {
+                    $ref: "#/components/schemas/ReadyUnavailableResponse",
+                  },
                 },
               },
             },
@@ -4230,11 +4231,20 @@ export function buildSchema(): Record<string, unknown> {
             status: { type: "string", enum: ["ok"] },
           },
         },
-        DrainingResponse: {
+        ReadyUnavailableResponse: {
           type: "object",
           required: ["status"],
           properties: {
-            status: { type: "string", enum: ["draining"] },
+            status: {
+              type: "string",
+              enum: [
+                "starting",
+                "draining",
+                "upstream_unhealthy",
+                "upstream_unreachable",
+              ],
+            },
+            upstream: { type: "integer" },
           },
         },
         ErrorResponse: {


### PR DESCRIPTION
## Summary
- Bind the gateway HTTP server before long post-assistant-ready startup work so /healthz can satisfy Kubernetes startup probes.
- Keep /readyz and regular traffic at 503 until post-ready startup work completes.
- Update probe/schema coverage for the new starting readiness state.

## Why
Managed preview upgrades swap the assistant image, then Kubernetes evaluates the gateway sidecar startup probe while the platform waits for the assistant to become ready. The gateway could previously spend several minutes waiting for post-assistant-ready work before `Bun.serve()` bound the port, so `/healthz` returned connection refused long enough for Kubernetes to restart the sidecar. That restart loop could outlive the platform readiness timeout and surface as a preview opt-in failure.

This keeps the liveness/startup signal separate from traffic readiness: `/healthz` answers as soon as the gateway process has bound its HTTP server, while `/readyz` and normal requests stay unavailable until post-assistant-ready startup work has completed.

## Test plan
- cd gateway && bun test src/__tests__/credential-watcher.test.ts src/__tests__/probes.test.ts src/__tests__/schema.test.ts
- cd gateway && bun run typecheck
- cd gateway && bunx prettier --check src/index.ts src/schema.ts src/post-assistant-ready.ts src/__tests__/probes.test.ts src/__tests__/schema.test.ts src/__tests__/credential-watcher.test.ts
- cd gateway && bun run lint src/index.ts src/schema.ts src/post-assistant-ready.ts src/__tests__/probes.test.ts src/__tests__/schema.test.ts src/__tests__/credential-watcher.test.ts

Note: cd gateway && bun run test was attempted locally, but unrelated Unix socket path-length failures in other IPC tests occurred under macOS /var/folders. The CI failure file, src/__tests__/credential-watcher.test.ts, passes locally after this fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->