### PR TITLE
fix(anthropic): strip deprecated temperature/top_p for opus-4.7/4.8 models

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -3191,3 +3191,61 @@ describe("AnthropicProvider — thinking block send-time filtering", () => {
     expect(signatures).toContain("sig-step2");
   });
 });
+
+describe("AnthropicProvider — deprecated sampling params (temperature / top_p)", () => {
+  beforeEach(() => {
+    lastStreamParams = null;
+  });
+
+  // opus-4-7 / opus-4-8 (and, conservatively, fable) reject `temperature` and
+  // `top_p` with a 400; the provider must strip them.
+  for (const model of [
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-fable-5",
+  ]) {
+    test(`strips temperature and top_p for ${model}`, async () => {
+      const provider = new AnthropicProvider("sk-ant-test", model);
+      await provider.sendMessage([userMsg("Hi")], {
+        systemPrompt: "You are helpful.",
+        config: { temperature: 0, top_p: 0.95 },
+      });
+      expect(lastStreamParams!).not.toHaveProperty("temperature");
+      expect(lastStreamParams!).not.toHaveProperty("top_p");
+    });
+  }
+
+  // opus-4-6 / sonnet-4-6 still accept the params — they must pass through,
+  // including `temperature: 0` (a value check, not truthiness).
+  test("forwards temperature (including 0) and top_p for opus-4-6", async () => {
+    const provider = new AnthropicProvider("sk-ant-test", "claude-opus-4-6");
+    await provider.sendMessage([userMsg("Hi")], {
+      systemPrompt: "You are helpful.",
+      config: { temperature: 0, top_p: 0.95 },
+    });
+    expect(lastStreamParams!.temperature).toBe(0);
+    expect(lastStreamParams!.top_p).toBe(0.95);
+  });
+
+  test("forwards temperature and top_p for sonnet-4-6", async () => {
+    const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+    await provider.sendMessage([userMsg("Hi")], {
+      systemPrompt: "You are helpful.",
+      config: { temperature: 0.7, top_p: 0.9 },
+    });
+    expect(lastStreamParams!.temperature).toBe(0.7);
+    expect(lastStreamParams!.top_p).toBe(0.9);
+  });
+
+  // A per-call model override targeting a deprecating model must win over the
+  // provider's default (accepting) model.
+  test("strips params when a per-call model override deprecates them", async () => {
+    const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+    await provider.sendMessage([userMsg("Hi")], {
+      systemPrompt: "You are helpful.",
+      config: { temperature: 0, top_p: 0.95, model: "claude-opus-4-8" },
+    });
+    expect(lastStreamParams!).not.toHaveProperty("temperature");
+    expect(lastStreamParams!).not.toHaveProperty("top_p");
+  });
+});

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -835,6 +835,10 @@ export class AnthropicProvider implements Provider {
         disableCache: _disableCache,
         max_tokens: callerMaxTokens,
         usageAttributionHeaders,
+        // Pulled out of `restConfig` so they are forwarded conditionally below:
+        // newer models reject them outright (see `deprecatesSamplingParams`).
+        temperature: callerTemperature,
+        top_p: callerTopP,
         ...restConfig
       } = (config ?? {}) as Record<string, unknown> & {
         // "xhigh" is an intermediate tier between "high" and "max" supported
@@ -847,6 +851,8 @@ export class AnthropicProvider implements Provider {
         speed?: "standard" | "fast";
         output_config?: Record<string, unknown>;
         usageAttributionHeaders?: Record<string, string>;
+        temperature?: number;
+        top_p?: number;
       };
       // Haiku does not support the effort / output_config parameter or
       // extended cache TTL betas.
@@ -856,6 +862,16 @@ export class AnthropicProvider implements Provider {
         (restConfig as Record<string, unknown>).model?.toString() ?? this.model;
       const isHaiku = effectiveModel.includes("haiku");
       const supportsEffort = !isHaiku;
+      // opus-4-7 / opus-4-8 reject `temperature` and `top_p` with a 400
+      // "`temperature`/`top_p` is deprecated for this model" — model-wide, not
+      // effort-conditional (verified 2026-06-23). opus-4-6 / sonnet-4-6 /
+      // haiku-4-5 still accept them. fable-5 is included conservatively (a
+      // frontier model that could not be verified directly but follows the same
+      // deprecation direction). Stripping the params here keeps callers that set
+      // them (e.g. the memory-v3 L2 selector's `temperature: 0`) from 400ing.
+      const deprecatesSamplingParams =
+        /claude-opus-4-[78]\b/.test(effectiveModel) ||
+        effectiveModel.startsWith("claude-fable-");
       const mergedOutputConfig = {
         ...(output_config ?? {}),
         ...(effort && effort !== "none" && supportsEffort
@@ -883,6 +899,17 @@ export class AnthropicProvider implements Provider {
             : 64000,
         messages: sentMessages,
         ...restConfig,
+        // Forward `temperature` / `top_p` only to models that still accept them;
+        // newer models 400 on either. `temperature: 0` is preserved for accepting
+        // models (a `typeof === "number"` check, not truthiness).
+        ...(deprecatesSamplingParams
+          ? {}
+          : {
+              ...(typeof callerTemperature === "number"
+                ? { temperature: callerTemperature }
+                : {}),
+              ...(typeof callerTopP === "number" ? { top_p: callerTopP } : {}),
+            }),
         ...(Object.keys(mergedOutputConfig).length > 0
           ? { output_config: mergedOutputConfig }
           : {}),


### PR DESCRIPTION
## Summary
- `claude-opus-4-7` / `claude-opus-4-8` reject `temperature` and `top_p` with an HTTP 400 ("`temperature`/`top_p` is deprecated for this model") — model-wide, not effort-conditional (verified live against the API on 2026-06-23). The Anthropic client forwarded both straight through via `...restConfig`, so the memory-v3 L2 selector — which sets `temperature: 0` at its callsite plus `top_p: 0.95` from the `balanced` profile — 400'd on every opus-4.7/4.8 model. mainAgent rode the user's active profile (no such params) and OpenRouter tolerated them, so only the selector visibly broke.
- `anthropic/client.ts` now strips `temperature`/`top_p` for models that deprecate them (`opus-4-7`/`opus-4-8`, plus `claude-fable-*` conservatively) and forwards them unchanged — including `temperature: 0` — for models that still accept them (`opus-4-6` / `sonnet-4-6` / haiku). The gate keys off the already-computed `effectiveModel`, so a per-call model override is honored.
- Adds `anthropic-provider.test.ts` cases asserting the wire request omits the params for deprecating models and keeps them (incl. `temperature: 0`) for accepting ones, plus the per-call-override path.

## Original prompt
While diagnosing a prod incident where the memory-v3 L2 pool selector failed, BYOK experiments showed the selector specifically 400'd on Anthropic-direct (while mainAgent worked and OpenRouter worked). Reproduced live: opus-4.7/4.8 deprecated `temperature`/`top_p`, and the daemon was still sending them. This strips those params only for the models that reject them. Empirical boundary: 4.6 still accepts; 4.7/4.8 reject; fable-5 included conservatively (unverified — 404 on the test key). This is one of two bugs from the incident; the other (managed-proxy 400 for unpriced models on Together/M3) is platform-side and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)