### PR TITLE
Fix quote reply chat body test mock

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -75,6 +75,28 @@ mock.module("@vellumai/design-library", () => ({
       {actions ? <div data-testid="notice-actions">{actions}</div> : null}
     </div>
   ),
+  Card: {
+    Root: ({
+      children,
+      padding: _padding,
+      bordered: _bordered,
+      elevated: _elevated,
+      ...props
+    }: {
+      children?: ReactNode;
+      padding?: unknown;
+      bordered?: unknown;
+      elevated?: unknown;
+    }) => <div {...props}>{children}</div>,
+    Body: ({
+      children,
+      padding: _padding,
+      ...props
+    }: {
+      children?: ReactNode;
+      padding?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
   ResizablePanel: () => <div data-testid="resizable-panel" />,
   Typography: ({ children }: { children?: ReactNode }) => (
     <span>{children}</span>


### PR DESCRIPTION
## Summary
- Add the missing `Card` compound mock to `chat-body.test.tsx`
- Fix the CI failure introduced by the quote-reply design-system import path in #35795

## Testing
- `cd clients/web && bun test src/domains/chat/components/chat-body.test.tsx`
- `cd clients/web && bun test src/domains/chat/components/quote-reply-components.test.tsx`
- `cd clients/web && bun run lint src/domains/chat/components/chat-body.test.tsx`
- `cd clients/web && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->