### PR TITLE
feat(memory): add memory.worker.enabled to select worker implementation at startup

### DIFF
--- a/assistant/eslint-rules/cli-no-daemon-internals.js
+++ b/assistant/eslint-rules/cli-no-daemon-internals.js
@@ -57,6 +57,11 @@ const ALLOWED_PREFIXES = {
     // job handler directly. Depth-2 for commands/memory/ nesting.
     "../../memory/memory-retrospective-job",
     "../../../memory/memory-retrospective-job",
+    // Memory worker control — the `memory worker` CLI spawns/probes/stops
+    // the worker OS process directly (no daemon, no IPC), so it imports the
+    // shared PID-file control helpers. Depth-2 for commands/memory/ nesting.
+    "../../memory/worker-control",
+    "../../../memory/worker-control",
     "../logger",
     "../output",
     "../../logger",

--- a/assistant/src/cli/commands/memory/worker.ts
+++ b/assistant/src/cli/commands/memory/worker.ts
@@ -15,53 +15,16 @@
  * round-trip to the daemon.
  */
 
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
-
 import type { Command } from "commander";
 
+import {
+  probeMemoryWorker,
+  spawnMemoryWorkerProcess,
+} from "../../../memory/worker-control.js";
 import { getMemoryWorkerPidPath } from "../../../util/platform.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-
-// ---------------------------------------------------------------------------
-// PID file helpers
-// ---------------------------------------------------------------------------
-
-interface PidStatus {
-  status: "running" | "not_running";
-  pid?: number;
-}
-
-function probeWorker(): PidStatus {
-  const pidPath = getMemoryWorkerPidPath();
-  if (!existsSync(pidPath)) return { status: "not_running" };
-
-  const raw = readFileSync(pidPath, "utf-8").trim();
-  const pid = parseInt(raw, 10);
-  if (!Number.isFinite(pid) || pid <= 0) return { status: "not_running" };
-
-  try {
-    process.kill(pid, 0);
-    return { status: "running", pid };
-  } catch (err: unknown) {
-    if (
-      err &&
-      typeof err === "object" &&
-      "code" in err &&
-      err.code === "ESRCH"
-    ) {
-      // Stale PID file — clean it up.
-      try {
-        unlinkSync(pidPath);
-      } catch {
-        // best-effort
-      }
-      return { status: "not_running" };
-    }
-    throw err;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // `start`
@@ -71,44 +34,11 @@ async function startWorker(
   opts: { json?: boolean },
   cmd: Command,
 ): Promise<void> {
-  const current = probeWorker();
-  if (current.status === "running") {
-    const msg = `Memory worker is already running (PID ${current.pid})`;
-    if (shouldOutputJson(cmd)) {
-      writeOutput(cmd, { ok: false, error: msg, pid: current.pid });
-    } else {
-      log.error(msg);
-    }
-    process.exitCode = 1;
-    return;
-  }
-
-  const pidPath = getMemoryWorkerPidPath();
-  const entry = new URL("../../../memory/worker-process.ts", import.meta.url);
-
-  // Spawn detached so the worker survives the CLI process exiting.
-  const child = Bun.spawn({
-    cmd: ["bun", "run", entry.pathname],
-    stdio: ["ignore", "ignore", "ignore"],
-    detached: true,
-  });
-
-  // Unreference so the CLI process doesn't wait for the child.
-  child.unref();
-
-  // Wait briefly for the PID file to appear (the worker writes it on startup).
-  let pidWritten = false;
-  for (let i = 0; i < 10; i++) {
-    await Bun.sleep(100);
-    if (existsSync(pidPath)) {
-      pidWritten = true;
-      break;
-    }
-  }
-
-  if (!pidWritten) {
-    const msg =
-      "Memory worker was spawned but PID file did not appear within 1s";
+  let result: { pid: number; alreadyRunning: boolean };
+  try {
+    result = await spawnMemoryWorkerProcess();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
     if (shouldOutputJson(cmd)) {
       writeOutput(cmd, { ok: false, error: msg });
     } else {
@@ -118,11 +48,25 @@ async function startWorker(
     return;
   }
 
-  const pid = parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
+  if (result.alreadyRunning) {
+    const msg = `Memory worker is already running (PID ${result.pid})`;
+    if (shouldOutputJson(cmd)) {
+      writeOutput(cmd, { ok: false, error: msg, pid: result.pid });
+    } else {
+      log.error(msg);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
   if (shouldOutputJson(cmd)) {
-    writeOutput(cmd, { ok: true, pid, pidPath });
+    writeOutput(cmd, {
+      ok: true,
+      pid: result.pid,
+      pidPath: getMemoryWorkerPidPath(),
+    });
   } else {
-    log.info(`Memory worker started (PID ${pid})`);
+    log.info(`Memory worker started (PID ${result.pid})`);
   }
 }
 
@@ -131,7 +75,7 @@ async function startWorker(
 // ---------------------------------------------------------------------------
 
 function stopWorker(opts: { json?: boolean }, cmd: Command): void {
-  const current = probeWorker();
+  const current = probeMemoryWorker();
   if (current.status !== "running" || current.pid == null) {
     const msg = "Memory worker is not running";
     if (shouldOutputJson(cmd)) {
@@ -169,7 +113,7 @@ function stopWorker(opts: { json?: boolean }, cmd: Command): void {
 // ---------------------------------------------------------------------------
 
 function statusWorker(opts: { json?: boolean }, cmd: Command): void {
-  const result = probeWorker();
+  const result = probeMemoryWorker();
   if (shouldOutputJson(cmd)) {
     writeOutput(cmd, result);
   } else {

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -78,6 +78,17 @@ export const MemoryJobsConfigSchema = MemoryJobsConfigInputSchema.transform(
   },
 ).describe("Memory background job processing configuration");
 
+export const MemoryWorkerConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "memory.worker.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether the memory jobs worker runs as a separate OS process spawned at daemon startup (the `assistant memory worker` implementation) instead of on the daemon's main event loop. Only affects daemon startup; shutdown stops whichever worker is actually running.",
+      ),
+  })
+  .describe("Memory jobs worker process configuration");
+
 export const MemoryRetentionConfigSchema = z
   .object({
     keepRawForever: z
@@ -185,6 +196,7 @@ export const MemoryMaintenanceConfigSchema = z
   );
 
 export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
+export type MemoryWorkerConfig = z.infer<typeof MemoryWorkerConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryCleanupConfig = z.infer<typeof MemoryCleanupConfigSchema>;
 export type MemoryMaintenanceConfig = z.infer<

--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -5,6 +5,7 @@ import {
   MemoryJobsConfigSchema,
   MemoryMaintenanceConfigSchema,
   MemoryRetentionConfigSchema,
+  MemoryWorkerConfigSchema,
 } from "./memory-lifecycle.js";
 import {
   MemoryExtractionConfigSchema,
@@ -39,6 +40,9 @@ export const MemoryConfigSchema = z
       MemorySegmentationConfigSchema.parse({}),
     ),
     jobs: MemoryJobsConfigSchema.default(MemoryJobsConfigSchema.parse({})),
+    worker: MemoryWorkerConfigSchema.default(
+      MemoryWorkerConfigSchema.parse({}),
+    ),
     retention: MemoryRetentionConfigSchema.default(
       MemoryRetentionConfigSchema.parse({}),
     ),

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -58,6 +58,7 @@ import { initQdrantClient, resolveQdrantUrl } from "../memory/qdrant-client.js";
 import { QdrantManager } from "../memory/qdrant-manager.js";
 import { rotateToolInvocations } from "../memory/tool-usage-store.js";
 import { sweepConceptPageFrontmatter } from "../memory/v2/frontmatter-sweep.js";
+import { spawnMemoryWorkerProcess } from "../memory/worker-control.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
@@ -966,8 +967,33 @@ export async function runDaemon(): Promise<void> {
         }
       }
 
-      log.info("Daemon startup: starting memory worker");
-      bgRefs.memoryWorker = startMemoryJobsWorker();
+      // `memory.worker.enabled` selects which worker implementation the daemon
+      // starts: the out-of-process worker (spawned like `assistant memory
+      // worker start`) or the in-process worker on the daemon's event loop.
+      // This flag only affects startup — shutdown stops whichever worker is
+      // actually running (see shutdown-handlers.ts).
+      if (config.memory.worker.enabled) {
+        log.info(
+          "Daemon startup: starting memory worker as a separate process",
+        );
+        try {
+          const { pid, alreadyRunning } = await spawnMemoryWorkerProcess();
+          log.info(
+            { pid, alreadyRunning },
+            alreadyRunning
+              ? "Memory worker process already running — reusing it"
+              : "Memory worker process started",
+          );
+        } catch (err) {
+          log.warn(
+            { err },
+            "Failed to start memory worker process — memory jobs will not be processed",
+          );
+        }
+      } else {
+        log.info("Daemon startup: starting memory worker");
+        bgRefs.memoryWorker = startMemoryJobsWorker();
+      }
 
       // Seed capability graph nodes (new memory graph system)
       try {

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -5,6 +5,7 @@ import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import type { McpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
+import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
 import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
@@ -117,7 +118,26 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     await browserManager.closeAllPages();
     cleanupShellOutputTempFiles();
     deps.scheduler.stop();
+
+    // Stop the in-process memory worker if one was started on the daemon's
+    // event loop (memory.worker.enabled = false).
     deps.getMemoryWorker()?.stop();
+
+    // Stop the out-of-process memory worker if it's actually running. This is
+    // keyed off live state rather than config: the worker may have been
+    // spawned at startup (memory.worker.enabled = true) or out of band via
+    // `assistant memory worker start`, so we stop whatever is actually there.
+    try {
+      const workerStatus = stopMemoryWorkerProcess();
+      if (workerStatus.status === "running") {
+        log.info(
+          { pid: workerStatus.pid },
+          "Sent SIGTERM to memory worker process",
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to stop memory worker process (non-fatal)");
+    }
 
     if (deps.mcpManager) {
       try {

--- a/assistant/src/memory/worker-control.ts
+++ b/assistant/src/memory/worker-control.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared control surface for the memory jobs worker *process* — the detached
+ * OS process whose entry point is `worker-process.ts`.
+ *
+ * Both the `assistant memory worker` CLI and the daemon lifecycle (when
+ * `memory.worker.enabled` is set) need to probe, spawn, and stop this process,
+ * so the PID-file bookkeeping lives here in one place.
+ */
+
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+
+import { getMemoryWorkerPidPath } from "../util/platform.js";
+
+export interface MemoryWorkerStatus {
+  status: "running" | "not_running";
+  pid?: number;
+}
+
+/**
+ * Inspect the PID file to determine whether the worker process is alive.
+ * A stale PID file (pointing at a dead process) is cleaned up and reported
+ * as not_running.
+ */
+export function probeMemoryWorker(): MemoryWorkerStatus {
+  const pidPath = getMemoryWorkerPidPath();
+  if (!existsSync(pidPath)) return { status: "not_running" };
+
+  const raw = readFileSync(pidPath, "utf-8").trim();
+  const pid = parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) return { status: "not_running" };
+
+  try {
+    process.kill(pid, 0);
+    return { status: "running", pid };
+  } catch (err: unknown) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code === "ESRCH"
+    ) {
+      // Stale PID file — clean it up.
+      try {
+        unlinkSync(pidPath);
+      } catch {
+        // best-effort
+      }
+      return { status: "not_running" };
+    }
+    throw err;
+  }
+}
+
+export class MemoryWorkerSpawnError extends Error {}
+
+/**
+ * Spawn the memory worker as a detached background process.
+ *
+ * If a worker is already running, returns its PID with `alreadyRunning: true`
+ * rather than spawning a second one. Throws {@link MemoryWorkerSpawnError} if
+ * the child is spawned but never writes its PID file (i.e. failed to start).
+ */
+export async function spawnMemoryWorkerProcess(): Promise<{
+  pid: number;
+  alreadyRunning: boolean;
+}> {
+  const current = probeMemoryWorker();
+  if (current.status === "running" && current.pid != null) {
+    return { pid: current.pid, alreadyRunning: true };
+  }
+
+  const pidPath = getMemoryWorkerPidPath();
+  const entry = new URL("./worker-process.ts", import.meta.url);
+
+  // Spawn detached so the worker survives the spawning process exiting.
+  const child = Bun.spawn({
+    cmd: ["bun", "run", entry.pathname],
+    stdio: ["ignore", "ignore", "ignore"],
+    detached: true,
+  });
+
+  // Unreference so the spawning process doesn't wait for the child.
+  child.unref();
+
+  // Wait briefly for the PID file to appear (the worker writes it on startup).
+  let pidWritten = false;
+  for (let i = 0; i < 10; i++) {
+    await Bun.sleep(100);
+    if (existsSync(pidPath)) {
+      pidWritten = true;
+      break;
+    }
+  }
+
+  if (!pidWritten) {
+    throw new MemoryWorkerSpawnError(
+      "Memory worker was spawned but PID file did not appear within 1s",
+    );
+  }
+
+  const pid = parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
+  return { pid, alreadyRunning: false };
+}
+
+/**
+ * Send SIGTERM to the worker process if it is actually running.
+ *
+ * Returns the status observed before signalling, so callers can report
+ * whether anything was stopped. Only throws if `process.kill` itself fails
+ * (e.g. EPERM) — a not-running worker is a no-op.
+ */
+export function stopMemoryWorkerProcess(): MemoryWorkerStatus {
+  const current = probeMemoryWorker();
+  if (current.status === "running" && current.pid != null) {
+    process.kill(current.pid, "SIGTERM");
+  }
+  return current;
+}


### PR DESCRIPTION
## Why

We recently added the `assistant memory worker` CLI, which runs the memory jobs worker as its own detached OS process. This PR lets the daemon choose, at startup, between that out-of-process worker and the existing in-process worker via config:

```
assistant config set memory.worker.enabled true
```

## What

- **New config `memory.worker.enabled`** (boolean, default `false`) under `memory.worker`. Defined in `config/schemas/memory-lifecycle.ts` and wired into the memory schema. Because `config set` is schema-driven, the key works through the CLI automatically.
- **Startup (`daemon/lifecycle.ts`)** branches on the flag:
  - `false` (default): start the in-process worker on the daemon's event loop (unchanged behavior).
  - `true`: spawn the out-of-process worker, the same way `assistant memory worker start` does.
- **Shutdown (`daemon/shutdown-handlers.ts`)** no longer keys off the flag. It stops whichever worker is *actually* running: the in-process ref if present, **and** the worker OS process if its PID file shows it alive. This is deliberate — the `assistant memory worker` CLI can spin the process up out of band, so shutdown must reflect live state rather than the config value.
- **Shared `memory/worker-control.ts`** extracts the PID-file probe/spawn/stop logic so the CLI, daemon startup, and daemon shutdown share one implementation. The `memory worker` CLI is refactored onto it.
- **ESLint allowlist**: the `local`-transport CLI gains a `worker-control` entry, mirroring the existing `memory-retrospective-job` escape hatch — the worker CLI manages the process in-process, with no daemon/IPC round-trip.

## Notes

- The flag only affects which implementation **startup** launches; both can technically coexist (config off + CLI-started process), and shutdown now handles that case.
- The `worker-control` module imports only `node:fs` and `util/platform.js` — no new circular dependencies.

## Testing

- `bun test src/cli/commands/memory/__tests__/worker.test.ts` — 8/8 pass after refactor.
- Lint + format + typecheck clean on all changed files.
- Verified schema: defaults to `false`, accepts `true`, rejects non-boolean with `memory.worker.enabled must be a boolean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy66BQcGQ9FHq78dg8kA8R)_