### PR TITLE
fix(anthropic): also strip deprecated top_k for opus-4.7/4.8 models

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -3192,49 +3192,52 @@ describe("AnthropicProvider — thinking block send-time filtering", () => {
   });
 });
 
-describe("AnthropicProvider — deprecated sampling params (temperature / top_p)", () => {
+describe("AnthropicProvider — deprecated sampling params (temperature / top_p / top_k)", () => {
   beforeEach(() => {
     lastStreamParams = null;
   });
 
-  // opus-4-7 / opus-4-8 (and, conservatively, fable) reject `temperature` and
-  // `top_p` with a 400; the provider must strip them.
+  // opus-4-7 / opus-4-8 (and, conservatively, fable) reject `temperature`,
+  // `top_p`, and `top_k` with a 400; the provider must strip all three.
   for (const model of [
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-fable-5",
   ]) {
-    test(`strips temperature and top_p for ${model}`, async () => {
+    test(`strips temperature, top_p, and top_k for ${model}`, async () => {
       const provider = new AnthropicProvider("sk-ant-test", model);
       await provider.sendMessage([userMsg("Hi")], {
         systemPrompt: "You are helpful.",
-        config: { temperature: 0, top_p: 0.95 },
+        config: { temperature: 0, top_p: 0.95, top_k: 40 },
       });
       expect(lastStreamParams!).not.toHaveProperty("temperature");
       expect(lastStreamParams!).not.toHaveProperty("top_p");
+      expect(lastStreamParams!).not.toHaveProperty("top_k");
     });
   }
 
   // opus-4-6 / sonnet-4-6 still accept the params — they must pass through,
   // including `temperature: 0` (a value check, not truthiness).
-  test("forwards temperature (including 0) and top_p for opus-4-6", async () => {
+  test("forwards temperature (including 0), top_p, and top_k for opus-4-6", async () => {
     const provider = new AnthropicProvider("sk-ant-test", "claude-opus-4-6");
     await provider.sendMessage([userMsg("Hi")], {
       systemPrompt: "You are helpful.",
-      config: { temperature: 0, top_p: 0.95 },
+      config: { temperature: 0, top_p: 0.95, top_k: 40 },
     });
     expect(lastStreamParams!.temperature).toBe(0);
     expect(lastStreamParams!.top_p).toBe(0.95);
+    expect(lastStreamParams!.top_k).toBe(40);
   });
 
-  test("forwards temperature and top_p for sonnet-4-6", async () => {
+  test("forwards temperature, top_p, and top_k for sonnet-4-6", async () => {
     const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
     await provider.sendMessage([userMsg("Hi")], {
       systemPrompt: "You are helpful.",
-      config: { temperature: 0.7, top_p: 0.9 },
+      config: { temperature: 0.7, top_p: 0.9, top_k: 20 },
     });
     expect(lastStreamParams!.temperature).toBe(0.7);
     expect(lastStreamParams!.top_p).toBe(0.9);
+    expect(lastStreamParams!.top_k).toBe(20);
   });
 
   // A per-call model override targeting a deprecating model must win over the
@@ -3243,9 +3246,15 @@ describe("AnthropicProvider — deprecated sampling params (temperature / top_p)
     const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
     await provider.sendMessage([userMsg("Hi")], {
       systemPrompt: "You are helpful.",
-      config: { temperature: 0, top_p: 0.95, model: "claude-opus-4-8" },
+      config: {
+        temperature: 0,
+        top_p: 0.95,
+        top_k: 40,
+        model: "claude-opus-4-8",
+      },
     });
     expect(lastStreamParams!).not.toHaveProperty("temperature");
     expect(lastStreamParams!).not.toHaveProperty("top_p");
+    expect(lastStreamParams!).not.toHaveProperty("top_k");
   });
 });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -839,6 +839,7 @@ export class AnthropicProvider implements Provider {
         // newer models reject them outright (see `deprecatesSamplingParams`).
         temperature: callerTemperature,
         top_p: callerTopP,
+        top_k: callerTopK,
         ...restConfig
       } = (config ?? {}) as Record<string, unknown> & {
         // "xhigh" is an intermediate tier between "high" and "max" supported
@@ -853,6 +854,7 @@ export class AnthropicProvider implements Provider {
         usageAttributionHeaders?: Record<string, string>;
         temperature?: number;
         top_p?: number;
+        top_k?: number;
       };
       // Haiku does not support the effort / output_config parameter or
       // extended cache TTL betas.
@@ -899,9 +901,10 @@ export class AnthropicProvider implements Provider {
             : 64000,
         messages: sentMessages,
         ...restConfig,
-        // Forward `temperature` / `top_p` only to models that still accept them;
-        // newer models 400 on either. `temperature: 0` is preserved for accepting
-        // models (a `typeof === "number"` check, not truthiness).
+        // Forward `temperature` / `top_p` / `top_k` only to models that still
+        // accept them; newer models 400 on any of the deprecated sampler params.
+        // `temperature: 0` is preserved for accepting models (a `typeof ===
+        // "number"` check, not truthiness).
         ...(deprecatesSamplingParams
           ? {}
           : {
@@ -909,6 +912,7 @@ export class AnthropicProvider implements Provider {
                 ? { temperature: callerTemperature }
                 : {}),
               ...(typeof callerTopP === "number" ? { top_p: callerTopP } : {}),
+              ...(typeof callerTopK === "number" ? { top_k: callerTopK } : {}),
             }),
         ...(Object.keys(mergedOutputConfig).length > 0
           ? { output_config: mergedOutputConfig }


### PR DESCRIPTION
## Summary
- Follow-up to #35817 addressing a Codex P2 review comment. `top_k` is the third member of the deprecated sampler trio: `claude-opus-4-7`/`claude-opus-4-8` return a 400 ("`top_k` is deprecated for this model") — verified live on 2026-06-23 (opus-4-6 still accepts it). #35817 only stripped `temperature`/`top_p`, so a pass-through caller setting `config.top_k` still 400'd.
- `anthropic/client.ts` now strips `top_k` alongside `temperature`/`top_p` for the deprecating models (`opus-4-7`/`opus-4-8`, plus `fable-*`) and still forwards it for `opus-4-6`/`sonnet-4-6`/haiku. Same `deprecatesSamplingParams` model gate — no boundary change.
- Extends the `anthropic-provider.test.ts` deprecated-sampling-params block to assert `top_k` is stripped for deprecating models and kept for accepting ones (incl. the per-call model-override path).

## Original prompt
Codex flagged on #35817 that `top_k` belongs to the same Anthropic Opus 4.7/4.8 deprecated-sampler group as `temperature`/`top_p` but was left flowing through. Confirmed empirically and extended the existing strip to cover `top_k`.

Addresses the Codex comment on #35817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)