### PR TITLE
feat(assistant): surface-action trust context comes from the gateway guardian binding

### DIFF
--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -25,6 +25,7 @@ interface StubConversation {
   handleSurfaceActionThrows?: Error;
   handleSurfaceUndoCalled?: boolean;
   handleSurfaceUndoThrows?: Error;
+  trustContext?: { trustClass: string; sourceChannel: string };
   surfaceActionCalls: Array<{
     surfaceId: string;
     actionId: string;
@@ -41,6 +42,47 @@ const findConvCalls: string[] = [];
 const findBySurfaceCalls: string[] = [];
 const getOrCreateCalls: string[] = [];
 const rawGetCalls: Array<{ sql: string; params: unknown[] }> = [];
+
+// Gateway guardian-delivery list (shared by the route's dev-bypass lookup and
+// the local-principal-trust mapper): null = unreachable, [] = no guardian.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+// Local store fallback used only on the dev-bypass path when the gateway is
+// empty.
+let mockGuardianRecord: { contact: Record<string, unknown> } | null = null;
+let httpAuthDisabled = false;
+// Tracks heal invocations and lets a test flip the guardian list to simulate
+// drift being reconciled on the second mapper resolve.
+const healCalls: string[] = [];
+let healResult = false;
+let onHeal: (() => void) | null = null;
+
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: (_input?: { channelTypes?: string[] }) =>
+    Promise.resolve(mockGuardianList),
+  peekCachedGuardianDelivery: () => mockGuardianList ?? undefined,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (_channelType: string) => mockGuardianRecord,
+  findContactByAddress: () => null,
+}));
+
+mock.module("../../../config/env.js", () => ({
+  isHttpAuthDisabled: () => httpAuthDisabled,
+}));
+
+mock.module("../../guardian-vellum-migration.js", () => ({
+  healGuardianBindingDrift: async (principalId: string) => {
+    healCalls.push(principalId);
+    onHeal?.();
+    return healResult;
+  },
+}));
 
 mock.module("../../../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => {
@@ -115,6 +157,9 @@ function makeStub(id: string): StubConversation {
       stub.handleSurfaceUndoCalled = true;
       if (stub.handleSurfaceUndoThrows) throw stub.handleSurfaceUndoThrows;
     },
+    setTrustContext: (ctx: { trustClass: string; sourceChannel: string }) => {
+      stub.trustContext = ctx;
+    },
   });
   return stub;
 }
@@ -132,6 +177,12 @@ beforeEach(() => {
   findBySurfaceCalls.length = 0;
   getOrCreateCalls.length = 0;
   rawGetCalls.length = 0;
+  mockGuardianList = [];
+  mockGuardianRecord = null;
+  httpAuthDisabled = false;
+  healCalls.length = 0;
+  healResult = false;
+  onHeal = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -332,6 +383,119 @@ describe("triggerSurfaceAction handler", () => {
     // BadRequestError is a RouteError — verify the error message bubbled.
     expect(caught).toBeDefined();
     expect((caught as Error).message).toContain("surface already completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust context resolution
+// ---------------------------------------------------------------------------
+
+const GUARDIAN_PRINCIPAL = "principal-guardian";
+
+function guardianDelivery(principalId: string): Record<string, unknown> {
+  return {
+    channelType: "vellum",
+    contactId: "contact-1",
+    principalId,
+    address: "guardian-address",
+    externalChatId: "guardian-chat",
+    status: "active",
+  };
+}
+
+describe("triggerSurfaceAction trust context", () => {
+  test("guardian principal → guardian trust context from the gateway binding", async () => {
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-guardian");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-g", actionId: "act-g" },
+      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(live.trustContext?.sourceChannel).toBe("vellum");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("unknown principal → unknown trust context", async () => {
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-unknown");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-u", actionId: "act-u" },
+      headers: { "x-vellum-actor-principal-id": "principal-other" },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    // Drift-heal attempted once on the unknown-first path, no match after.
+    expect(healCalls).toEqual(["principal-other"]);
+  });
+
+  test("drift: heal makes the principal match → guardian after re-resolve", async () => {
+    // First mapper resolve sees no guardian (drift), heal flips the binding so
+    // the second resolve matches.
+    mockGuardianList = [];
+    healResult = true;
+    onHeal = () => {
+      mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    };
+    const live = makeStub("conv-drift");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-d", actionId: "act-d" },
+      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+    });
+
+    expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
+    expect(live.trustContext?.trustClass).toBe("guardian");
+  });
+
+  test("dev-bypass resolves the real guardian principal from the gateway", async () => {
+    httpAuthDisabled = true;
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-dev");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-dev", actionId: "act-dev" },
+      headers: { "x-vellum-actor-principal-id": "dev-bypass" },
+    });
+
+    // The synthetic dev-bypass principal is translated to the real guardian,
+    // yielding a guardian trust context without any heal.
+    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("dev-bypass falls back to the local store when the gateway is empty", async () => {
+    httpAuthDisabled = true;
+    mockGuardianList = [];
+    mockGuardianRecord = { contact: { principalId: GUARDIAN_PRINCIPAL } };
+    onHeal = () => {
+      mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    };
+    healResult = true;
+    const live = makeStub("conv-dev-fallback");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-devf", actionId: "act-devf" },
+      headers: { "x-vellum-actor-principal-id": "dev-bypass" },
+    });
+
+    // The local store supplies the guardian principal; the first mapper resolve
+    // misses (gateway empty), heal populates it, second resolve matches.
+    expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
+    expect(live.trustContext?.trustClass).toBe("guardian");
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -481,6 +481,30 @@ describe("triggerSurfaceAction trust context", () => {
     expect(live.trustContext?.trustClass).toBe("guardian");
   });
 
+  test("drift second request: heal no-ops (false) but local mirror already matches → guardian", async () => {
+    // Later requests in the drift window reuse the same stale JWT: the gateway
+    // binding still mismatches, and heal returns false because the local mirror
+    // was already repaired on the first request. The local re-resolve must run
+    // regardless of heal's return and recover guardian trust.
+    mockGuardianList = [guardianDelivery("principal-stale")];
+    mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
+    healResult = false;
+    const live = makeStub("conv-drift-2");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-d2", actionId: "act-d2" },
+      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+    });
+
+    expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
+    // Gateway binding never matched; guardian comes from the local mirror even
+    // though no heal write occurred.
+    expect(mockGuardianList).toEqual([guardianDelivery("principal-stale")]);
+    expect(live.trustContext?.trustClass).toBe("guardian");
+  });
+
   test("dev-bypass resolves the real guardian principal from the gateway", async () => {
     httpAuthDisabled = true;
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -394,6 +394,10 @@ describe("triggerSurfaceAction handler", () => {
 // ---------------------------------------------------------------------------
 
 const GUARDIAN_PRINCIPAL = "principal-guardian";
+// Daemon-minted vellum-principal-* ids: the DB-reset drift signature. The
+// gateway rebinds to a fresh id while the client still holds a JWT for the old.
+const VELLUM_PRINCIPAL_OLD = "vellum-principal-old";
+const VELLUM_PRINCIPAL_NEW = "vellum-principal-new";
 
 function guardianDelivery(principalId: string): Record<string, unknown> {
   return {
@@ -453,18 +457,20 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     expect(live.trustContext?.trustClass).toBe("unknown");
-    // Drift-heal attempted once on the unknown-first path, no match after.
-    expect(healCalls).toEqual(["principal-other"]);
+    // Neither principal is a vellum-principal-*, so the reset-drift gate is
+    // closed and no heal runs.
+    expect(healCalls).toEqual([]);
   });
 
-  test("drift: heal repairs the local mirror → guardian from local re-resolve", async () => {
-    // The gateway binding stays mismatched throughout, so the gateway mapper
-    // returns unknown both before and after heal. Heal repairs the local mirror;
-    // the post-heal re-resolve reads that mirror and matches.
-    mockGuardianList = [guardianDelivery("principal-stale")];
+  test("reset drift: heal repairs the local mirror → guardian from local re-resolve", async () => {
+    // DB-reset signature: the gateway active guardian is a fresh vellum-principal
+    // while the client holds a JWT for the old one. The gateway binding stays
+    // mismatched, so the mapper returns unknown both before and after heal. Heal
+    // repairs the local mirror; the post-heal re-resolve reads it and matches.
+    mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
     healResult = true;
     onHeal = () => {
-      mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
+      mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
     };
     const live = makeStub("conv-drift");
     memoryBySurface = live;
@@ -472,22 +478,22 @@ describe("triggerSurfaceAction trust context", () => {
     const handler = findHandler("triggerSurfaceAction");
     await handler({
       body: { surfaceId: "surf-d", actionId: "act-d" },
-      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
     });
 
-    expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
+    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
     // Gateway binding never matched; guardian comes from the local mirror.
-    expect(mockGuardianList).toEqual([guardianDelivery("principal-stale")]);
+    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
     expect(live.trustContext?.trustClass).toBe("guardian");
   });
 
-  test("drift second request: heal no-ops (false) but local mirror already matches → guardian", async () => {
+  test("reset drift second request: heal no-ops (false) but local mirror already matches → guardian", async () => {
     // Later requests in the drift window reuse the same stale JWT: the gateway
     // binding still mismatches, and heal returns false because the local mirror
     // was already repaired on the first request. The local re-resolve must run
     // regardless of heal's return and recover guardian trust.
-    mockGuardianList = [guardianDelivery("principal-stale")];
-    mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
+    mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
     healResult = false;
     const live = makeStub("conv-drift-2");
     memoryBySurface = live;
@@ -495,14 +501,74 @@ describe("triggerSurfaceAction trust context", () => {
     const handler = findHandler("triggerSurfaceAction");
     await handler({
       body: { surfaceId: "surf-d2", actionId: "act-d2" },
-      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
     });
 
-    expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
+    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
     // Gateway binding never matched; guardian comes from the local mirror even
     // though no heal write occurred.
-    expect(mockGuardianList).toEqual([guardianDelivery("principal-stale")]);
+    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
     expect(live.trustContext?.trustClass).toBe("guardian");
+  });
+
+  test("fail-closed: revoked gateway guardian (empty list) blocks the local fallback → unknown", async () => {
+    // The gateway authoritatively revoked the guardian (no active binding) while
+    // the local mirror WOULD still grant guardian. With no active gateway
+    // principal there is no reset signature, so trust stays unknown (fail closed).
+    mockGuardianList = [];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    const live = makeStub("conv-revoked");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-rv", actionId: "act-rv" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("fail-closed: non-active gateway guardian blocks the local fallback → unknown", async () => {
+    // The gateway binding exists but is not active (e.g. pending revocation):
+    // guardianForChannel filters it out, so there is no active reset principal
+    // and the fallback stays closed.
+    mockGuardianList = [
+      { ...guardianDelivery(VELLUM_PRINCIPAL_NEW), status: "revoked" },
+    ];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    const live = makeStub("conv-inactive");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-ia", actionId: "act-ia" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("fail-closed: rebind to a real external identity blocks the local fallback → unknown", async () => {
+    // The gateway active guardian principal is a real external id (not a
+    // vellum-principal-*) that differs from the actor — a genuine rebind, not a
+    // DB reset. The fallback must stay closed even though the local mirror would
+    // grant guardian.
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    const live = makeStub("conv-rebind");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-rb", actionId: "act-rb" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
   });
 
   test("fail-closed: unreachable gateway (null) blocks the local drift fallback → unknown", async () => {
@@ -510,14 +576,14 @@ describe("triggerSurfaceAction trust context", () => {
     // mirror WOULD classify this principal as guardian. The drift fallback must
     // stay gated off a null read, so trust must remain unknown (fail closed).
     mockGuardianList = null;
-    mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
     const live = makeStub("conv-fail-closed");
     memoryBySurface = live;
 
     const handler = findHandler("triggerSurfaceAction");
     await handler({
       body: { surfaceId: "surf-fc", actionId: "act-fc" },
-      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
     });
 
     expect(live.trustContext?.trustClass).toBe("unknown");
@@ -543,19 +609,16 @@ describe("triggerSurfaceAction trust context", () => {
     expect(healCalls).toEqual([]);
   });
 
-  test("dev-bypass falls back to the local store when the gateway is empty", async () => {
+  test("dev-bypass with an empty gateway and stale local mirror → unknown (fail closed)", async () => {
     httpAuthDisabled = true;
     mockGuardianList = [];
-    // Local store supplies the guardian principal for dev-bypass; its channel
-    // address starts mismatched so the pre-heal local resolve misses.
+    // Local store supplies the guardian principal for dev-bypass, but the gateway
+    // has no active binding. With no active gateway principal there is no reset
+    // signature, so the fallback stays closed and trust is unknown.
     mockGuardianRecord = {
       contact: { principalId: GUARDIAN_PRINCIPAL },
       channel: { type: "vellum", address: "stale-address", status: "active" },
     };
-    onHeal = () => {
-      mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
-    };
-    healResult = true;
     const live = makeStub("conv-dev-fallback");
     memoryBySurface = live;
 
@@ -565,10 +628,8 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": "dev-bypass" },
     });
 
-    // The local store supplies the guardian principal; the gateway resolve
-    // misses, heal repairs the local mirror, post-heal local resolve matches.
-    expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
-    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -505,6 +505,26 @@ describe("triggerSurfaceAction trust context", () => {
     expect(live.trustContext?.trustClass).toBe("guardian");
   });
 
+  test("fail-closed: unreachable gateway (null) blocks the local drift fallback → unknown", async () => {
+    // Gateway unreadable: the mapper fails closed to unknown, and the local
+    // mirror WOULD classify this principal as guardian. The drift fallback must
+    // stay gated off a null read, so trust must remain unknown (fail closed).
+    mockGuardianList = null;
+    mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
+    const live = makeStub("conv-fail-closed");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-fc", actionId: "act-fc" },
+      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    // No fallback ran: heal is skipped on a null read.
+    expect(healCalls).toEqual([]);
+  });
+
   test("dev-bypass resolves the real guardian principal from the gateway", async () => {
     httpAuthDisabled = true;
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -46,12 +46,15 @@ const rawGetCalls: Array<{ sql: string; params: unknown[] }> = [];
 // Gateway guardian-delivery list (shared by the route's dev-bypass lookup and
 // the local-principal-trust mapper): null = unreachable, [] = no guardian.
 let mockGuardianList: Array<Record<string, unknown>> | null = [];
-// Local store fallback used only on the dev-bypass path when the gateway is
-// empty.
-let mockGuardianRecord: { contact: Record<string, unknown> } | null = null;
+// Local-mirror guardian record: dev-bypass reads .contact.principalId; the
+// post-heal local resolver reads .contact and .channel.
+let mockGuardianRecord: {
+  contact: Record<string, unknown>;
+  channel?: Record<string, unknown>;
+} | null = null;
 let httpAuthDisabled = false;
-// Tracks heal invocations and lets a test flip the guardian list to simulate
-// drift being reconciled on the second mapper resolve.
+// Tracks heal invocations; onHeal lets a test repair the local mirror to
+// simulate the post-heal re-resolve matching.
 const healCalls: string[] = [];
 let healResult = false;
 let onHeal: (() => void) | null = null;
@@ -403,6 +406,24 @@ function guardianDelivery(principalId: string): Record<string, unknown> {
   };
 }
 
+// Local-mirror guardian record as returned by findGuardianForChannel and read
+// by resolveActorTrust. The channel address equals the principal so the local
+// resolver classifies it as guardian on the vellum channel.
+function localGuardianRecord(principalId: string): {
+  contact: Record<string, unknown>;
+  channel: Record<string, unknown>;
+} {
+  return {
+    contact: { principalId, displayName: "Guardian" },
+    channel: {
+      type: "vellum",
+      address: principalId,
+      externalChatId: "guardian-chat",
+      status: "active",
+    },
+  };
+}
+
 describe("triggerSurfaceAction trust context", () => {
   test("guardian principal → guardian trust context from the gateway binding", async () => {
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
@@ -436,13 +457,14 @@ describe("triggerSurfaceAction trust context", () => {
     expect(healCalls).toEqual(["principal-other"]);
   });
 
-  test("drift: heal makes the principal match → guardian after re-resolve", async () => {
-    // First mapper resolve sees no guardian (drift), heal flips the binding so
-    // the second resolve matches.
-    mockGuardianList = [];
+  test("drift: heal repairs the local mirror → guardian from local re-resolve", async () => {
+    // The gateway binding stays mismatched throughout, so the gateway mapper
+    // returns unknown both before and after heal. Heal repairs the local mirror;
+    // the post-heal re-resolve reads that mirror and matches.
+    mockGuardianList = [guardianDelivery("principal-stale")];
     healResult = true;
     onHeal = () => {
-      mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+      mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
     };
     const live = makeStub("conv-drift");
     memoryBySurface = live;
@@ -454,6 +476,8 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
+    // Gateway binding never matched; guardian comes from the local mirror.
+    expect(mockGuardianList).toEqual([guardianDelivery("principal-stale")]);
     expect(live.trustContext?.trustClass).toBe("guardian");
   });
 
@@ -478,9 +502,14 @@ describe("triggerSurfaceAction trust context", () => {
   test("dev-bypass falls back to the local store when the gateway is empty", async () => {
     httpAuthDisabled = true;
     mockGuardianList = [];
-    mockGuardianRecord = { contact: { principalId: GUARDIAN_PRINCIPAL } };
+    // Local store supplies the guardian principal for dev-bypass; its channel
+    // address starts mismatched so the pre-heal local resolve misses.
+    mockGuardianRecord = {
+      contact: { principalId: GUARDIAN_PRINCIPAL },
+      channel: { type: "vellum", address: "stale-address", status: "active" },
+    };
     onHeal = () => {
-      mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+      mockGuardianRecord = localGuardianRecord(GUARDIAN_PRINCIPAL);
     };
     healResult = true;
     const live = makeStub("conv-dev-fallback");
@@ -492,8 +521,8 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": "dev-bypass" },
     });
 
-    // The local store supplies the guardian principal; the first mapper resolve
-    // misses (gateway empty), heal populates it, second resolve matches.
+    // The local store supplies the guardian principal; the gateway resolve
+    // misses, heal repairs the local mirror, post-heal local resolve matches.
     expect(healCalls).toEqual([GUARDIAN_PRINCIPAL]);
     expect(live.trustContext?.trustClass).toBe("guardian");
   });

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -11,7 +11,10 @@ import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
-import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
@@ -74,10 +77,19 @@ async function applyTrustContext(
     conversationExternalId: "local",
   });
   if (trustCtx.trustClass === "unknown") {
-    // Only fall back for genuine drift: a readable gateway whose binding doesn't
-    // match the principal. A null read (gateway unreachable) fails closed.
     const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-    if (guardians) {
+    const gatewayPrincipal = guardians
+      ? guardianForChannel(guardians, sourceChannel)?.principalId
+      : undefined;
+    // Narrow drift only: a DB reset rebound the gateway to a fresh
+    // vellum-principal while the client holds a valid JWT for the old one. Both
+    // are daemon-minted vellum-principal-* ids, so a genuine revocation or rebind
+    // to a real identity fails closed instead of re-granting from a stale mirror.
+    const isResetDrift =
+      principalId.startsWith("vellum-principal-") &&
+      !!gatewayPrincipal?.startsWith("vellum-principal-") &&
+      gatewayPrincipal !== principalId;
+    if (isResetDrift) {
       await healGuardianBindingDrift(principalId);
       trustCtx = withSourceChannel(
         sourceChannel,
@@ -90,7 +102,7 @@ async function applyTrustContext(
       );
       log.info(
         { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
-        "Trust re-resolved from local mirror after gateway drift (surface action)",
+        "Trust re-resolved from local mirror after gateway reset drift (surface action)",
       );
     }
   }

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -9,20 +9,15 @@
  */
 import { z } from "zod";
 
-import type { ChannelId } from "../../channels/types.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
-import type { TrustClass } from "../actor-trust-resolver.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
-import { resolveLocalTrustContext } from "../local-actor-identity.js";
-import {
-  resolveTrustContext,
-  withSourceChannel,
-} from "../trust-context-resolver.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
+import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import { parseCallbackData } from "./channel-route-shared.js";
 import {
   BadRequestError,
@@ -40,17 +35,13 @@ const log = getLogger("surface-action-routes");
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve trust context from the actor principal ID and set it on the
- * conversation, following the same pattern as POST /v1/messages. This ensures
- * surface actions inherit the correct trust class (guardian vs trusted_contact)
- * rather than defaulting to unknown.
+ * Resolve trust context for the actor principal from the gateway guardian
+ * binding and set it on the conversation. A vellum principal is the guardian or
+ * nobody, so the mapper yields guardian or unknown.
  */
 async function applyTrustContext(
   conversation: {
-    setTrustContext?(ctx: {
-      trustClass: TrustClass;
-      sourceChannel: ChannelId;
-    }): void;
+    setTrustContext?(ctx: TrustContext): void;
   },
   actorPrincipalId: string | undefined,
 ): Promise<void> {
@@ -58,42 +49,39 @@ async function applyTrustContext(
 
   const sourceChannel = "vellum";
 
-  if (actorPrincipalId) {
-    if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      conversation.setTrustContext(
-        await resolveLocalTrustContext(sourceChannel),
-      );
-    } else {
-      const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-      let trustCtx = resolveTrustContext({
-        assistantId,
+  if (!actorPrincipalId) {
+    conversation.setTrustContext({ trustClass: "guardian", sourceChannel });
+    return;
+  }
+
+  // Dev-bypass injects a synthetic principal that won't match the real
+  // guardian binding, so resolve the actual guardian principalId (gateway
+  // first, local store fallback) before mapping trust.
+  let principalId = actorPrincipalId;
+  if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
+    principalId = (await findLocalGuardianPrincipalId()) ?? actorPrincipalId;
+  }
+
+  let trustCtx = await resolveLocalPrincipalTrustContext({
+    actorPrincipalId: principalId,
+    sourceChannel,
+    conversationExternalId: "local",
+  });
+  if (trustCtx.trustClass === "unknown") {
+    const healed = await healGuardianBindingDrift(principalId);
+    if (healed) {
+      trustCtx = await resolveLocalPrincipalTrustContext({
+        actorPrincipalId: principalId,
         sourceChannel,
         conversationExternalId: "local",
-        actorExternalId: actorPrincipalId,
       });
-      if (trustCtx.trustClass === "unknown") {
-        const healed = await healGuardianBindingDrift(actorPrincipalId);
-        if (healed) {
-          trustCtx = resolveTrustContext({
-            assistantId,
-            sourceChannel,
-            conversationExternalId: "local",
-            actorExternalId: actorPrincipalId,
-          });
-          log.info(
-            {
-              actorPrincipalId,
-              trustClass: trustCtx.trustClass,
-            },
-            "Trust re-resolved after guardian binding drift heal (surface action)",
-          );
-        }
-      }
-      conversation.setTrustContext(withSourceChannel(sourceChannel, trustCtx));
+      log.info(
+        { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
+        "Trust re-resolved after guardian binding drift heal (surface action)",
+      );
     }
-  } else {
-    conversation.setTrustContext({ trustClass: "guardian", sourceChannel });
   }
+  conversation.setTrustContext(trustCtx);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -13,11 +13,16 @@ import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
 import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
+import {
+  resolveTrustContext,
+  withSourceChannel,
+} from "../trust-context-resolver.js";
 import { parseCallbackData } from "./channel-route-shared.js";
 import {
   BadRequestError,
@@ -70,11 +75,17 @@ async function applyTrustContext(
   if (trustCtx.trustClass === "unknown") {
     const healed = await healGuardianBindingDrift(principalId);
     if (healed) {
-      trustCtx = await resolveLocalPrincipalTrustContext({
-        actorPrincipalId: principalId,
+      // Heal repairs the local mirror, not the gateway binding, so re-resolve
+      // from the local mirror. Transitional; removed in Combo 11.
+      trustCtx = withSourceChannel(
         sourceChannel,
-        conversationExternalId: "local",
-      });
+        resolveTrustContext({
+          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+          sourceChannel,
+          conversationExternalId: "local",
+          actorExternalId: principalId,
+        }),
+      );
       log.info(
         { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
         "Trust re-resolved after guardian binding drift heal (surface action)",

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -73,24 +73,26 @@ async function applyTrustContext(
     conversationExternalId: "local",
   });
   if (trustCtx.trustClass === "unknown") {
-    const healed = await healGuardianBindingDrift(principalId);
-    if (healed) {
-      // Heal repairs the local mirror, not the gateway binding, so re-resolve
-      // from the local mirror. Transitional; removed in Combo 11.
-      trustCtx = withSourceChannel(
+    // Best-effort: repair the local mirror if it drifted from the JWT principal.
+    await healGuardianBindingDrift(principalId);
+    // Re-resolve from the dual-written local mirror whenever the gateway mapper
+    // yields unknown, since the gateway mismatch persists across requests while
+    // heal writes once. Safe on the vellum channel: only the daemon mints
+    // signature-valid vellum-principal JWTs, so a valid principal is the owner.
+    // Transitional; removed once the gateway binding is authoritative.
+    trustCtx = withSourceChannel(
+      sourceChannel,
+      resolveTrustContext({
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         sourceChannel,
-        resolveTrustContext({
-          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-          sourceChannel,
-          conversationExternalId: "local",
-          actorExternalId: principalId,
-        }),
-      );
-      log.info(
-        { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
-        "Trust re-resolved after guardian binding drift heal (surface action)",
-      );
-    }
+        conversationExternalId: "local",
+        actorExternalId: principalId,
+      }),
+    );
+    log.info(
+      { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
+      "Trust re-resolved from local mirror after gateway returned unknown (surface action)",
+    );
   }
   conversation.setTrustContext(trustCtx);
 }

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
@@ -73,26 +74,25 @@ async function applyTrustContext(
     conversationExternalId: "local",
   });
   if (trustCtx.trustClass === "unknown") {
-    // Best-effort: repair the local mirror if it drifted from the JWT principal.
-    await healGuardianBindingDrift(principalId);
-    // Re-resolve from the dual-written local mirror whenever the gateway mapper
-    // yields unknown, since the gateway mismatch persists across requests while
-    // heal writes once. Safe on the vellum channel: only the daemon mints
-    // signature-valid vellum-principal JWTs, so a valid principal is the owner.
-    // Transitional; removed once the gateway binding is authoritative.
-    trustCtx = withSourceChannel(
-      sourceChannel,
-      resolveTrustContext({
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    // Only fall back for genuine drift: a readable gateway whose binding doesn't
+    // match the principal. A null read (gateway unreachable) fails closed.
+    const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+    if (guardians) {
+      await healGuardianBindingDrift(principalId);
+      trustCtx = withSourceChannel(
         sourceChannel,
-        conversationExternalId: "local",
-        actorExternalId: principalId,
-      }),
-    );
-    log.info(
-      { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
-      "Trust re-resolved from local mirror after gateway returned unknown (surface action)",
-    );
+        resolveTrustContext({
+          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+          sourceChannel,
+          conversationExternalId: "local",
+          actorExternalId: principalId,
+        }),
+      );
+      log.info(
+        { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
+        "Trust re-resolved from local mirror after gateway drift (surface action)",
+      );
+    }
   }
   conversation.setTrustContext(trustCtx);
 }


### PR DESCRIPTION
## Summary
- surface-action-routes resolves the actor principal's TrustContext from the gateway guardian binding via resolveLocalPrincipalTrustContext, dropping the local resolveTrustContext read.
- Preserves the drift-heal re-resolve loop and the dev-bypass branch (now gateway-first with a local fallback).

Part of plan: local-principal-trust-from-binding.md (PR 2 of 3)