### PR TITLE
fix(llm-resolver): stop cross-profile temperature/top_p leak onto Anthropic call sites

### DIFF
--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -509,10 +509,13 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.model).toBe("claude-opus-4-7");
   });
 
-  test("thinking and contextWindow deep-merge across all five layers for non-main call sites", () => {
+  test("thinking and contextWindow deep-merge across the contributing layers for non-main call sites", () => {
     // Each layer touches a different leaf inside `thinking` and
     // `contextWindow.overflowRecovery` so we can verify deep merge composes
     // every contribution rather than wholesale-replacing the nested objects.
+    // The call site pins `siteProfile`, so the active profile is excluded — its
+    // leaves fall through to default while override, site profile, and the
+    // call-site fragment still compose.
     const llm = LLMSchema.parse({
       default: fullDefault,
       profiles: {
@@ -539,13 +542,15 @@ describe("resolveCallSiteConfig", () => {
     const resolved = resolveCallSiteConfig("memoryExtraction", llm, {
       overrideProfile: "override",
     });
-    // Each layer's leaf survives because no higher layer touches it.
-    expect(resolved.thinking.enabled).toBe(false); // active
+    // Override, site profile, and the call-site fragment each contribute a leaf.
     expect(resolved.thinking.streamThinking).toBe(false); // override
-    expect(resolved.contextWindow.overflowRecovery.maxAttempts).toBe(7); // active
     expect(resolved.contextWindow.overflowRecovery.safetyMarginRatio).toBe(0.1); // override
     expect(resolved.contextWindow.targetBudgetRatio).toBe(0.5); // siteProfile
     expect(resolved.contextWindow.compactThreshold).toBe(0.9); // callsite
+    // The active profile is excluded (the call site pins its own profile), so
+    // its leaves fall through to default instead of contributing.
+    expect(resolved.thinking.enabled).toBe(true); // default, NOT active's false
+    expect(resolved.contextWindow.overflowRecovery.maxAttempts).toBe(3); // default, NOT active's 7
     // Untouched leaves at depth 2 fall through to default.
     expect(resolved.contextWindow.overflowRecovery.enabled).toBe(true);
     expect(
@@ -582,7 +587,9 @@ describe("resolveCallSiteConfig", () => {
     // Lower layers contribute fields the site fragment does not touch.
     expect(resolved.verbosity).toBe("high"); // from siteProfile
     expect(resolved.speed).toBe("fast"); // from override
-    expect(resolved.effort).toBe("low"); // from active
+    // The active profile is excluded when the call site pins its own profile,
+    // so `effort` falls through to default rather than active's "low".
+    expect(resolved.effort).toBe("max"); // default, NOT active's "low"
   });
 
   test("mainAgent activeProfile overrides static call-site defaults", () => {
@@ -1432,6 +1439,121 @@ describe("resolveCallSiteConfig logitBias provenance", () => {
       activeProfile: "plain",
     });
     expect(resolveCallSiteConfig("mainAgent", llm).logitBias).toBeUndefined();
+  });
+});
+
+describe("resolveCallSiteConfig sampling-param provenance (temperature / top_p)", () => {
+  // Mirrors production: the active `balanced` profile carries `topP: 0.95` (a
+  // MiniMax tuning), while background call sites resolve to the Anthropic
+  // `cost-optimized` profile. A field-by-field deep-merge would leak the active
+  // profile's `top_p` onto those Anthropic requests.
+  const balancedActive = LLMSchema.parse({
+    default: fullDefault,
+    profiles: {
+      balanced: {
+        provider: "together",
+        model: "MiniMaxAI/MiniMax-M3",
+        topP: 0.95,
+      },
+      "cost-optimized": {
+        provider: "anthropic",
+        model: "claude-haiku-4-5-20251001",
+        effort: "low",
+        thinking: { enabled: false },
+      },
+    },
+    activeProfile: "balanced",
+  });
+
+  test("active profile's top_p does not leak into a profile-pinned call site (Option 1 + 2)", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        balanced: {
+          provider: "together",
+          model: "MiniMaxAI/MiniMax-M3",
+          topP: 0.95,
+        },
+        "cost-optimized": {
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+        },
+      },
+      activeProfile: "balanced",
+      callSites: { memoryExtraction: { profile: "cost-optimized" } },
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    // balanced (active) is shadowed by the pinned cost-optimized profile, so
+    // its top_p must not ride along onto the Anthropic request.
+    expect(resolved.topP).toBeNull();
+  });
+
+  test("homeGreeting / commitMessage resolve to a temperature with NO top_p", () => {
+    const greeting = resolveCallSiteConfig("homeGreeting", balancedActive);
+    expect(greeting.model).toBe("claude-haiku-4-5-20251001");
+    // Per-call-site temperature from CALL_SITE_DEFAULTS survives.
+    expect(greeting.temperature).toBe(0.7);
+    // The active profile's top_p does NOT — both together would trip
+    // Anthropic's "temperature and top_p cannot both be specified".
+    expect(greeting.topP).toBeNull();
+
+    const commit = resolveCallSiteConfig("commitMessage", balancedActive);
+    expect(commit.temperature).toBe(0.2);
+    expect(commit.topP).toBeNull();
+  });
+
+  test("profile-less call site still inherits the active profile's provider AND sampling", () => {
+    // `workflowLeaf` pins no profile, so the active profile is the legitimate
+    // fallback (Option 1 keeps it): it supplies provider/model and its own
+    // (coherent, same-provider) sampling.
+    const resolved = resolveCallSiteConfig("workflowLeaf", balancedActive);
+    expect(resolved.provider).toBe("together");
+    expect(resolved.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(resolved.topP).toBe(0.95);
+  });
+
+  test("mainAgent keeps the active profile's top_p (balanced wins there)", () => {
+    const resolved = resolveCallSiteConfig("mainAgent", balancedActive);
+    expect(resolved.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(resolved.topP).toBe(0.95);
+  });
+
+  test("an explicit call-site temperature override still wins over the winning profile", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: { nucleus: { topP: 0.9, temperature: 0.1 } },
+      callSites: { memoryExtraction: { profile: "nucleus", temperature: 0.5 } },
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+    // Call-site override wins for the field it sets.
+    expect(resolved.temperature).toBe(0.5);
+    // The winning profile's top_p (no call-site override) still applies.
+    expect(resolved.topP).toBe(0.9);
+  });
+
+  test("a higher-precedence profile that omits top_p clears a lower profile's top_p (Option 2)", () => {
+    // No site profile is involved here, so the active profile IS folded in —
+    // this isolates Option 2: the override profile wins and omits top_p, so
+    // balanced's 0.95 must be cleared rather than surviving the merge.
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        balanced: {
+          provider: "together",
+          model: "MiniMaxAI/MiniMax-M3",
+          topP: 0.95,
+        },
+        plain: { provider: "anthropic", model: "claude-opus-4-7" },
+      },
+      activeProfile: "balanced",
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "plain",
+    });
+    expect(resolved.model).toBe("claude-opus-4-7");
+    expect(resolved.topP).toBeNull();
   });
 });
 

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -17,7 +17,13 @@ import {
  * Merge layers (low → high precedence; later layers override earlier) for
  * non-main-agent call sites:
  *   1. `llm.default` fields (required base)
- *   2. `llm.profiles[llm.activeProfile]` (workspace-wide active profile)
+ *   2. `llm.profiles[llm.activeProfile]` (workspace-wide active profile) —
+ *      folded in ONLY when the call site resolves no profile of its own (a
+ *      profile-less leaf like `vision`/`workflowLeaf`, or a BYOK install whose
+ *      pinned managed profile was stripped). When the call site resolves a
+ *      profile, that profile is the authoritative provider config and the
+ *      active profile does not contribute — otherwise a deep-merge would let
+ *      its orphan fields bleed onto a different provider.
  *   3. `llm.profiles[opts.overrideProfile]` (per-call ad-hoc override)
  *   4. `llm.profiles[site.profile]` fields (call-site's named profile)
  *   5. `llm.callSites[callSite]` fields (call-site override)
@@ -49,6 +55,15 @@ import {
  * `contextWindow.overflowRecovery`) are deep-merged so partial overrides at
  * any nesting level merge into — rather than replace — the corresponding
  * base value.
+ *
+ * `temperature` and `top_p` are provider-coupled, so they do NOT deep-merge
+ * field-by-field with the rest of the config: only the winning profile (the
+ * highest-precedence profile that determines provider/model) contributes them,
+ * and an explicit `llm.callSites[callSite]` override still wins. A lower-
+ * precedence profile whose model is shadowed never leaks its sampling onto a
+ * different provider (which would trip e.g. Anthropic's "temperature and top_p
+ * cannot both be specified" constraint). `logitBias` is winning-profile-scoped
+ * the same way.
  *
  * `activeProfile` and `overrideProfile` are resolved by name lookup against
  * `llm.profiles`. Missing references silently fall through (no throw) so the
@@ -108,6 +123,14 @@ export function resolveCallSiteConfig(
   // call-site default selected by `effectiveDefault`.
   const biasRef: LogitBiasRef = { preset: undefined };
 
+  // Effective sampling params, tracked outside the deep-merge for the same
+  // reason as `logitBias`: `temperature`/`top_p` are provider-coupled, so only
+  // the winning profile may contribute them. Each profile fully determines the
+  // pair (REPLACE — a profile that omits a param clears what a lower-precedence
+  // profile set), while an explicit call-site override COALESCES on top (see
+  // `appendProfileLayer` / `appendCallSiteLayers`).
+  const samplingRef: SamplingRef = { temperature: undefined, topP: undefined };
+
   const activeFragment = resolveProfileFragment(llm.activeProfile, llm, opts);
   const overrideFragment = resolveProfileFragment(
     opts.overrideProfile,
@@ -119,22 +142,55 @@ export function resolveCallSiteConfig(
     effectiveDefault(callSite, llm, opts.overrideProfile != null);
 
   if (callSite === "mainAgent") {
-    appendCallSiteLayers(layers, callSite, llm, site, opts, biasRef);
-    appendProfileLayer(layers, activeFragment, biasRef);
-    appendProfileLayer(layers, overrideFragment, biasRef);
+    appendCallSiteLayers(
+      layers,
+      callSite,
+      llm,
+      site,
+      opts,
+      biasRef,
+      samplingRef,
+    );
+    appendProfileLayer(layers, activeFragment, biasRef, samplingRef);
+    appendProfileLayer(layers, overrideFragment, biasRef, samplingRef);
   } else if (opts.forceOverrideProfile === true && overrideFragment != null) {
     // Escape hatch: float the override profile above the call-site layers,
     // mirroring mainAgent's treatment of the user's chat-model selection.
     // Guarded on a resolved fragment so a missing profile reference degrades
     // to the normal precedence below instead of silently dropping the
-    // call-site layers' standing.
-    appendProfileLayer(layers, activeFragment, biasRef);
-    appendCallSiteLayers(layers, callSite, llm, site, opts, biasRef);
-    appendProfileLayer(layers, overrideFragment, biasRef);
+    // call-site layers' standing. The active profile stays the bottom fallback
+    // (its sampling can't leak — a higher profile's REPLACE clears it).
+    appendProfileLayer(layers, activeFragment, biasRef, samplingRef);
+    appendCallSiteLayers(
+      layers,
+      callSite,
+      llm,
+      site,
+      opts,
+      biasRef,
+      samplingRef,
+    );
+    appendProfileLayer(layers, overrideFragment, biasRef, samplingRef);
   } else {
-    appendProfileLayer(layers, activeFragment, biasRef);
-    appendProfileLayer(layers, overrideFragment, biasRef);
-    appendCallSiteLayers(layers, callSite, llm, site, opts, biasRef);
+    // The active profile is a low-precedence FALLBACK for call sites that
+    // resolve no profile of their own — profile-less leaves (`vision`,
+    // `workflowLeaf`) and BYOK installs where the pinned managed profile was
+    // stripped. When the call site DOES resolve its own profile, that profile
+    // is the authoritative provider config, so the active profile must not
+    // contribute its orphan fields to a different provider.
+    if (site?.profile == null) {
+      appendProfileLayer(layers, activeFragment, biasRef, samplingRef);
+    }
+    appendProfileLayer(layers, overrideFragment, biasRef, samplingRef);
+    appendCallSiteLayers(
+      layers,
+      callSite,
+      llm,
+      site,
+      opts,
+      biasRef,
+      samplingRef,
+    );
   }
 
   const resolved = finalize(
@@ -149,10 +205,26 @@ export function resolveCallSiteConfig(
   } else {
     delete (resolved as { logitBias?: unknown }).logitBias;
   }
+  // `temperature`/`top_p` are winning-profile-scoped like `logitBias`, but an
+  // explicit call-site override may also set them. Apply the tracked value,
+  // overriding whatever a shadowed profile may have left in the merge. An
+  // `undefined` ref means no profile or override opted in, so the `llm.default`
+  // base already in `resolved` stands.
+  if (samplingRef.temperature !== undefined) {
+    resolved.temperature = samplingRef.temperature;
+  }
+  if (samplingRef.topP !== undefined) {
+    resolved.topP = samplingRef.topP;
+  }
   return resolved;
 }
 
 type LogitBiasRef = { preset: ProfileEntry["logitBias"] };
+
+type SamplingRef = {
+  temperature: ProfileEntry["temperature"];
+  topP: ProfileEntry["topP"];
+};
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -315,9 +387,15 @@ function appendProfileLayer(
   layers: Mergeable[],
   profile: ProfileEntry | undefined,
   biasRef: LogitBiasRef,
+  samplingRef: SamplingRef,
 ): void {
   if (profile != null) {
     biasRef.preset = profile.logitBias;
+    // Each profile fully determines the sampling pair: a profile that omits
+    // `temperature`/`topP` clears what a lower-precedence profile set, so the
+    // winning (last-appended) profile is the sole profile source.
+    samplingRef.temperature = profile.temperature;
+    samplingRef.topP = profile.topP;
     layers.push(profileConfigFragment(profile));
   }
 }
@@ -329,6 +407,7 @@ function appendCallSiteLayers(
   site: z.infer<typeof LLMSchema>["callSites"][LLMCallSite] | undefined,
   opts: ResolveCallSiteOpts,
   biasRef: LogitBiasRef,
+  samplingRef: SamplingRef,
 ): void {
   if (site != null) {
     if (site.profile != null) {
@@ -343,11 +422,24 @@ function appendCallSiteLayers(
         );
       }
       biasRef.preset = profileFragment.logitBias;
+      samplingRef.temperature = profileFragment.temperature;
+      samplingRef.topP = profileFragment.topP;
       layers.push(profileConfigFragment(profileFragment));
     }
-    // Strip the `profile` discriminator before merging — it isn't a
-    // `LLMConfigBase` field.
-    const { profile: _profile, ...siteFragment } = site;
+    // Strip the `profile` discriminator (not a `LLMConfigBase` field) and the
+    // sampling params before merging. An explicit call-site `temperature` /
+    // `topP` is a deliberate per-site choice, so it COALESCES over the winning
+    // profile's pair (only overriding the fields it sets) — routed through
+    // `samplingRef` so it never inherits a shadowed profile's value via merge.
+    const {
+      profile: _profile,
+      temperature: siteTemperature,
+      topP: siteTopP,
+      ...siteFragment
+    } = site;
+    if (siteTemperature !== undefined)
+      samplingRef.temperature = siteTemperature;
+    if (siteTopP !== undefined) samplingRef.topP = siteTopP;
     layers.push(siteFragment as Mergeable);
   }
 }
@@ -369,6 +461,12 @@ function profileConfigFragment(profile: ProfileEntry): Mergeable {
     // Per-profile advisor toggle is profile identity, not inheritable model
     // config — strip it so it can't leak into the merged `LLMConfigBase`.
     advisorEnabled: _advisorEnabled,
+    // `temperature`/`top_p` are provider-coupled: only the winning profile
+    // contributes them (tracked via `samplingRef`, applied post-merge), so a
+    // shadowed profile's sampling can never reach a different provider through
+    // the deep-merge. Strip here so no profile's sampling enters the merge.
+    temperature: _temperature,
+    topP: _topP,
     ...config
   } = profile;
   return config as Mergeable;


### PR DESCRIPTION
## Summary
- Background call sites that pin an Anthropic profile (e.g. `homeGreeting`, `commitMessage` → `cost-optimized`/haiku) were receiving `top_p: 0.95` leaked from the active `balanced`/MiniMax profile through the resolver's field-by-field deep-merge, **plus** their own `temperature` — so Anthropic 400'd with *"temperature and top_p cannot both be specified for this model"*. The existing `retry.ts` guards only strip a param when *thinking* is enabled, so the non-thinking haiku path slipped through.
- **Option 1 — gate the active profile**: for non-`mainAgent` call sites the active profile is folded in only when the call site resolves no profile of its own (profile-less leaves like `vision`/`workflowLeaf`, or BYOK installs whose managed profile was stripped). A call site that pins its own profile no longer inherits the active profile's orphan fields.
- **Option 2 — atomic sampling params (backstop)**: `temperature`/`top_p` are now tracked outside the deep-merge and bound to the winning profile (the one that determines provider/model), exactly like `logitBias`. An explicit call-site override still wins; a shadowed profile's sampling can never reach a different provider.
- Updated two resolver tests that encoded the old leaky behavior (active profile contributing orphan fields to a profile-pinned call site); added a `sampling-param provenance` suite covering the leak, the profile-less fallback, `mainAgent`, explicit call-site overrides, and Option-2 isolation.

## Original prompt
While diagnosing why memory-v3 skills weren't injecting on a staging assistant, we found a separate bug: home-greeting generation was 400ing with "temperature and top_p cannot both be specified for this model". Tracing it showed the active `balanced` profile's `top_p` leaking through the resolver's field-by-field deep-merge onto Anthropic-resolved background call sites that also set a temperature. The ask was to fix it structurally — stop provider-coupled sampling params from crossing profile boundaries — both by not folding the active profile into call sites that pin their own profile, and by binding `temperature`/`top_p` atomically to the winning profile (generalizing the existing `logitBias` treatment).

## Reviewer note
This changes resolver precedence semantics: the active profile no longer contributes **any** fields (not just sampling) to non-`mainAgent` call sites that resolve their own profile. In practice managed profiles already set provider/model/effort/thinking/contextWindow, so the observable delta is the (intended) removal of leaked sampling plus rare orphan fields like `verbosity`/`speed`. Complements #35817 (which strips temperature/top_p model-wide for opus-4.7/4.8); this PR covers the haiku/sonnet/opus-4-6 *mutual-exclusion* case at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)