### PR TITLE
feat(assistant): /v1/messages trust context comes from the gateway guardian binding

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -104,6 +104,18 @@ mock.module("../runtime/trust-context-resolver.js", () => ({
   }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-contact",
+      principalId: "test-user",
+      address: "test-user",
+      status: "active",
+    },
+  ],
+}));
+
 import type { AuthContext } from "../runtime/auth/types.js";
 import { handleSendMessage } from "../runtime/routes/conversation-routes.js";
 import { callHandler } from "./helpers/call-route-handler.js";

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -190,6 +190,18 @@ mock.module("../runtime/trust-context-resolver.js", () => ({
   }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-contact",
+      principalId: "test-user",
+      address: "test-user",
+      status: "active",
+    },
+  ],
+}));
+
 const ipcCallMock = mock(
   async (): Promise<Record<string, unknown> | undefined> => ({ ok: true }),
 );

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -501,7 +501,7 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
     healGuardianBindingDriftMock.mockClear();
   });
 
-  function requestAs(principalId: string) {
+  function requestAs(principalId: string, sourceChannel = "vellum") {
     return new Request("http://localhost/v1/messages", {
       method: "POST",
       headers: {
@@ -512,13 +512,16 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
       body: JSON.stringify({
         conversationKey: "trust-test-key",
         content: "hi",
-        sourceChannel: "vellum",
+        sourceChannel,
         interface: "macos",
       }),
     });
   }
 
-  async function trustClassFor(principalId: string): Promise<string> {
+  async function trustContextFor(
+    principalId: string,
+    sourceChannel = "vellum",
+  ): Promise<Record<string, unknown>> {
     let captured: Record<string, unknown> | undefined;
     const conversation = makeConversation({
       setTrustContext: (ctx: Record<string, unknown>) => {
@@ -534,12 +537,16 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
             resolveAttachments: () => [],
           },
         }),
-      requestAs(principalId),
+      requestAs(principalId, sourceChannel),
       undefined,
       202,
     );
     expect(res.status).toBe(202);
-    return captured?.trustClass as string;
+    return captured ?? {};
+  }
+
+  async function trustClassFor(principalId: string): Promise<string> {
+    return (await trustContextFor(principalId)).trustClass as string;
   }
 
   test("guardian principal resolves to guardian context", async () => {
@@ -594,5 +601,21 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
 
   test("dev-bypass maps the gateway guardian principal to guardian", async () => {
     expect(await trustClassFor("dev-bypass")).toBe("guardian");
+  });
+
+  test("fails closed to unknown when the gateway is unreachable", async () => {
+    // Gateway read returns null (unreachable) while the local mirror WOULD
+    // grant guardian. The drift fallback must not fall open to the mirror.
+    mockGuardians = null;
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("preserves the request body channel on the guardian-match happy path", async () => {
+    const ctx = await trustContextFor("test-user", "telegram");
+    expect(ctx.trustClass).toBe("guardian");
+    expect(ctx.sourceChannel).toBe("telegram");
   });
 });

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -543,27 +543,23 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
     expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
   });
 
-  test("re-resolves to guardian after a drift heal", async () => {
+  test("re-resolves to guardian from the local mirror after a drift heal", async () => {
     healDriftReturn = true;
-    // First read misses; heal "repairs" the binding so the second read matches.
-    let call = 0;
-    mockGuardians = [];
-    healGuardianBindingDriftMock.mockImplementation(async () => {
-      mockGuardians = [
-        {
-          channelType: "vellum",
-          contactId: "guardian-contact",
-          principalId: "vellum-principal-healed",
-          address: "vellum-principal-healed",
-          status: "active",
-        },
-      ];
-      call += 1;
-      return true;
-    });
+    // The gateway binding mismatches the JWT throughout — heal repairs the
+    // local mirror, not the gateway. Post-heal trust comes from the local
+    // resolver (resolveTrustContext), not a still-mismatched gateway read.
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "vellum-principal-stale",
+        address: "vellum-principal-stale",
+        status: "active",
+      },
+    ];
 
     expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
-    expect(call).toBe(1);
+    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
   });
 
   test("dev-bypass maps the gateway guardian principal to guardian", async () => {

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -130,9 +130,16 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => mockGuardians,
 }));
 
+// The local mirror grants guardian only to principals present in this set;
+// everyone else resolves unknown. Models the dual-written local mirror that
+// the gateway-first resolve falls back to.
+let localMirrorGuardians = new Set<string>(["test-user"]);
 mock.module("../runtime/trust-context-resolver.js", () => ({
-  resolveTrustContext: () => ({
-    trustClass: "guardian",
+  resolveTrustContext: (input: { actorExternalId?: string }) => ({
+    trustClass:
+      input.actorExternalId && localMirrorGuardians.has(input.actorExternalId)
+        ? "guardian"
+        : "unknown",
     sourceChannel: "vellum",
   }),
   withSourceChannel: (sourceChannel: unknown, ctx: unknown) => ({
@@ -490,6 +497,7 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
       },
     ];
     healDriftReturn = false;
+    localMirrorGuardians = new Set<string>(["test-user"]);
     healGuardianBindingDriftMock.mockClear();
   });
 
@@ -557,6 +565,28 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
         status: "active",
       },
     ];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
+    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-resolves to guardian on later drift requests where heal is a no-op", async () => {
+    // Second-request drift window: the gateway binding still mismatches the
+    // JWT, so heal is a no-op and returns false. The local re-resolve must
+    // still run (gated on the gateway returning unknown, not on a heal write)
+    // and keep guardian trust from the already-repaired local mirror.
+    healDriftReturn = false;
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "vellum-principal-stale",
+        address: "vellum-principal-stale",
+        status: "active",
+      },
+    ];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
 
     expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
     expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -128,6 +128,11 @@ let mockGuardians: Array<Record<string, unknown>> | null = [
 
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => mockGuardians,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 // The local mirror grants guardian only to principals present in this set;
@@ -555,7 +560,7 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
 
   test("non-guardian principal resolves to unknown", async () => {
     expect(await trustClassFor("vellum-principal-stranger")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
   });
 
   test("re-resolves to guardian from the local mirror after a drift heal", async () => {
@@ -607,6 +612,54 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
     // Gateway read returns null (unreachable) while the local mirror WOULD
     // grant guardian. The drift fallback must not fall open to the mirror.
     mockGuardians = null;
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed to unknown when the gateway guardian is revoked", async () => {
+    // Empty active guardian list (revoked/rebind in flight) while the local
+    // mirror WOULD grant guardian. No active gateway principal means no
+    // narrow-drift heal — re-granting revoked trust is a security regression.
+    mockGuardians = [];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed to unknown when only a non-active guardian remains", async () => {
+    // A revoked binding lingers with status !== "active"; guardianForChannel
+    // skips it, so there is no active gateway principal to drift against.
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "vellum-principal-stale",
+        address: "vellum-principal-stale",
+        status: "revoked",
+      },
+    ];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed to unknown on rebind to a real external identity", async () => {
+    // The gateway's active guardian is a real identity (not a daemon-minted
+    // vellum-principal-*), so a stale vellum-principal JWT must not re-grant
+    // from the mirror — a genuine rebind, not DB-reset drift.
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "user@example.com",
+        address: "user@example.com",
+        status: "active",
+      },
+    ];
     localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
 
     expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -62,6 +62,12 @@ mock.module("../runtime/guardian-reply-router.js", () => ({
   routeGuardianReply: routeGuardianReplyMock,
 }));
 
+let healDriftReturn = false;
+const healGuardianBindingDriftMock = mock(async () => healDriftReturn);
+mock.module("../runtime/guardian-vellum-migration.js", () => ({
+  healGuardianBindingDrift: healGuardianBindingDriftMock,
+}));
+
 mock.module("../memory/canonical-guardian-store.js", () => ({
   createCanonicalGuardianRequest: () => ({
     id: "canonical-id",
@@ -108,6 +114,20 @@ mock.module("../runtime/local-actor-identity.js", () => ({
     trustClass: "guardian",
     sourceChannel: "vellum",
   }),
+}));
+
+let mockGuardians: Array<Record<string, unknown>> | null = [
+  {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId: "test-user",
+    address: "test-user",
+    status: "active",
+  },
+];
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardians,
 }));
 
 mock.module("../runtime/trust-context-resolver.js", () => ({
@@ -452,5 +472,101 @@ describe("HTTP POST /v1/messages clientTimezone transport metadata", () => {
     });
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// TRUST CONTEXT — derived from the gateway guardian binding
+// ============================================================================
+describe("HTTP POST /v1/messages trust context from the gateway binding", () => {
+  beforeEach(() => {
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "test-user",
+        address: "test-user",
+        status: "active",
+      },
+    ];
+    healDriftReturn = false;
+    healGuardianBindingDriftMock.mockClear();
+  });
+
+  function requestAs(principalId: string) {
+    return new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-vellum-actor-principal-id": principalId,
+        "x-vellum-principal-type": "actor",
+      },
+      body: JSON.stringify({
+        conversationKey: "trust-test-key",
+        content: "hi",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+  }
+
+  async function trustClassFor(principalId: string): Promise<string> {
+    let captured: Record<string, unknown> | undefined;
+    const conversation = makeConversation({
+      setTrustContext: (ctx: Record<string, unknown>) => {
+        captured = ctx;
+      },
+    });
+    const res = await callHandler(
+      (args) =>
+        handleSendMessage(args, {
+          sendMessageDeps: {
+            getOrCreateConversation: async () => conversation,
+            assistantEventHub: { publish: async () => {} } as any,
+            resolveAttachments: () => [],
+          },
+        }),
+      requestAs(principalId),
+      undefined,
+      202,
+    );
+    expect(res.status).toBe(202);
+    return captured?.trustClass as string;
+  }
+
+  test("guardian principal resolves to guardian context", async () => {
+    expect(await trustClassFor("test-user")).toBe("guardian");
+  });
+
+  test("non-guardian principal resolves to unknown", async () => {
+    expect(await trustClassFor("vellum-principal-stranger")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-resolves to guardian after a drift heal", async () => {
+    healDriftReturn = true;
+    // First read misses; heal "repairs" the binding so the second read matches.
+    let call = 0;
+    mockGuardians = [];
+    healGuardianBindingDriftMock.mockImplementation(async () => {
+      mockGuardians = [
+        {
+          channelType: "vellum",
+          contactId: "guardian-contact",
+          principalId: "vellum-principal-healed",
+          address: "vellum-principal-healed",
+          status: "active",
+        },
+      ];
+      call += 1;
+      return true;
+    });
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
+    expect(call).toBe(1);
+  });
+
+  test("dev-bypass maps the gateway guardian principal to guardian", async () => {
+    expect(await trustClassFor("dev-bypass")).toBe("guardian");
   });
 });

--- a/assistant/src/__tests__/secret-ingress-http.test.ts
+++ b/assistant/src/__tests__/secret-ingress-http.test.ts
@@ -127,6 +127,18 @@ mock.module("../runtime/trust-context-resolver.js", () => ({
   }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-contact",
+      principalId: "test-user",
+      address: "test-user",
+      status: "active",
+    },
+  ],
+}));
+
 mock.module("../runtime/guardian-reply-router.js", () => ({
   routeGuardianReply: async () => ({
     consumed: false,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1457,55 +1457,63 @@ export async function handleSendMessage(
       const guardianPrincipalId = guardians?.[0]?.principalId;
       conversation.setTrustContext(
         guardianPrincipalId
-          ? await resolveLocalPrincipalTrustContext({
-              actorPrincipalId: guardianPrincipalId,
-              sourceChannel: "vellum",
-              conversationExternalId: "local",
-            })
+          ? withSourceChannel(
+              sourceChannel,
+              await resolveLocalPrincipalTrustContext({
+                actorPrincipalId: guardianPrincipalId,
+                sourceChannel: "vellum",
+                conversationExternalId: "local",
+              }),
+            )
           : await resolveLocalTrustContext(sourceChannel),
       );
     } else {
-      let trustCtx = await resolveLocalPrincipalTrustContext({
-        actorPrincipalId,
-        sourceChannel: "vellum",
-        conversationExternalId: "local",
-      });
+      let trustCtx = withSourceChannel(
+        sourceChannel,
+        await resolveLocalPrincipalTrustContext({
+          actorPrincipalId,
+          sourceChannel: "vellum",
+          conversationExternalId: "local",
+        }),
+      );
       if (trustCtx.trustClass === "unknown") {
         // Guardian binding drift: a DB reset rebinds to a new
         // vellum-principal-* UUID while the client holds a valid JWT for the
         // old one. The signing key survives, so the JWT is authentic but
-        // stale. Best-effort repair the local mirror (no-op once repaired),
-        // then re-resolve from it on every gateway-unknown — not just the
-        // request that writes the heal. Safe on vellum: only the daemon mints
-        // signature-valid vellum-principal-* JWTs, so a valid one is the owner.
-        await healGuardianBindingDrift(actorPrincipalId);
-        trustCtx = withSourceChannel(
-          sourceChannel,
-          resolveTrustContext({
-            assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-            sourceChannel: "vellum",
-            conversationExternalId: "local",
-            actorExternalId: actorPrincipalId,
-          }),
-        );
-        if (trustCtx.trustClass === "unknown") {
-          log.warn(
-            {
-              actorPrincipalId: actorPrincipalId,
-              sourceChannel,
-              trustClass: trustCtx.trustClass,
-              principalType: principalType,
-            },
-            "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+        // stale. Re-resolve from the local mirror only when the gateway read
+        // is non-null; a null read means the gateway is unreachable and must
+        // fail closed (stay unknown) rather than fall open to the mirror.
+        const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+        if (guardians) {
+          await healGuardianBindingDrift(actorPrincipalId);
+          trustCtx = withSourceChannel(
+            sourceChannel,
+            resolveTrustContext({
+              assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+              sourceChannel: "vellum",
+              conversationExternalId: "local",
+              actorExternalId: actorPrincipalId,
+            }),
           );
-        } else {
-          log.info(
-            {
-              actorPrincipalId: actorPrincipalId,
-              trustClass: trustCtx.trustClass,
-            },
-            "Trust re-resolved from local mirror after gateway returned unknown",
-          );
+          if (trustCtx.trustClass === "unknown") {
+            log.warn(
+              {
+                actorPrincipalId,
+                sourceChannel,
+                trustClass: trustCtx.trustClass,
+                principalType,
+              },
+              "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+            );
+          } else {
+            log.info(
+              {
+                actorPrincipalId,
+                trustClass: trustCtx.trustClass,
+              },
+              "Trust re-resolved from local mirror after gateway returned unknown",
+            );
+          }
         }
       }
       conversation.setTrustContext(trustCtx);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -25,7 +25,10 @@ import {
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
-import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../contacts/guardian-delivery-reader.js";
 import {
   mergeConsecutiveAssistantMessages,
   mergeToolResultsIntoAssistantMessages,
@@ -1477,14 +1480,20 @@ export async function handleSendMessage(
         }),
       );
       if (trustCtx.trustClass === "unknown") {
-        // Guardian binding drift: a DB reset rebinds to a new
-        // vellum-principal-* UUID while the client holds a valid JWT for the
-        // old one. The signing key survives, so the JWT is authentic but
-        // stale. Re-resolve from the local mirror only when the gateway read
-        // is non-null; a null read means the gateway is unreachable and must
-        // fail closed (stay unknown) rather than fall open to the mirror.
         const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-        if (guardians) {
+        const gatewayPrincipal = guardians
+          ? guardianForChannel(guardians, "vellum")?.principalId
+          : undefined;
+        // Narrow drift only: a DB reset rebound the gateway to a fresh
+        // vellum-principal while the client holds a valid JWT for the old one.
+        // Both are daemon-minted vellum-principal-* ids, so a genuine
+        // revocation or rebind to a real identity fails closed instead of
+        // re-granting from a stale mirror.
+        const isResetDrift =
+          actorPrincipalId.startsWith("vellum-principal-") &&
+          !!gatewayPrincipal?.startsWith("vellum-principal-") &&
+          gatewayPrincipal !== actorPrincipalId;
+        if (isResetDrift) {
           await healGuardianBindingDrift(actorPrincipalId);
           trustCtx = withSourceChannel(
             sourceChannel,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -25,6 +25,7 @@ import {
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
+import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
 import {
   mergeConsecutiveAssistantMessages,
   mergeToolResultsIntoAssistantMessages,
@@ -121,7 +122,6 @@ import {
 } from "../../util/platform.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { getPersistedSeq } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -136,15 +136,12 @@ import type {
   SendMessageDeps,
 } from "../http-types.js";
 import { resolveLocalTrustContext } from "../local-actor-identity.js";
+import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   publishConversationListAndMetadataChanged,
   publishConversationMessagesChanged,
 } from "../sync/resource-sync-events.js";
-import {
-  resolveTrustContext,
-  withSourceChannel,
-} from "../trust-context-resolver.js";
 import {
   BadRequestError,
   InternalError,
@@ -1444,24 +1441,29 @@ export async function handleSendMessage(
     conversation.setOnboardingContext(body.onboarding!);
   }
 
-  // Resolve guardian context from the AuthContext's actorPrincipalId.
-  // The JWT-verified principal is used as the sender identity through
-  // the same trust resolution pipeline that channel ingress uses.
+  // Resolve guardian context from the AuthContext's actorPrincipalId via the
+  // gateway guardian binding: a vellum principal is the guardian or nobody.
   if (actorPrincipalId) {
     // Dev bypass (HTTP auth disabled): the synthetic "dev-bypass" principal
-    // won't match any guardian binding. Resolve from the local guardian
-    // binding instead, which produces the correct guardian trust context.
+    // won't match any guardian binding. Resolve the real guardian principal
+    // from the gateway binding and map that through instead.
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
+      const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+      const guardianPrincipalId = guardians?.[0]?.principalId;
       conversation.setTrustContext(
-        await resolveLocalTrustContext(sourceChannel),
+        guardianPrincipalId
+          ? await resolveLocalPrincipalTrustContext({
+              actorPrincipalId: guardianPrincipalId,
+              sourceChannel: "vellum",
+              conversationExternalId: "local",
+            })
+          : await resolveLocalTrustContext(sourceChannel),
       );
     } else {
-      const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-      let trustCtx = resolveTrustContext({
-        assistantId,
+      let trustCtx = await resolveLocalPrincipalTrustContext({
+        actorPrincipalId,
         sourceChannel: "vellum",
         conversationExternalId: "local",
-        actorExternalId: actorPrincipalId,
       });
       if (trustCtx.trustClass === "unknown") {
         // Attempt to heal guardian binding drift: after a DB reset the
@@ -1470,11 +1472,10 @@ export async function handleSendMessage(
         // key survives the reset, so the JWT is authentic — just stale.
         const healed = await healGuardianBindingDrift(actorPrincipalId);
         if (healed) {
-          trustCtx = resolveTrustContext({
-            assistantId,
+          trustCtx = await resolveLocalPrincipalTrustContext({
+            actorPrincipalId,
             sourceChannel: "vellum",
             conversationExternalId: "local",
-            actorExternalId: actorPrincipalId,
           });
           log.info(
             {
@@ -1495,7 +1496,7 @@ export async function handleSendMessage(
           );
         }
       }
-      conversation.setTrustContext(withSourceChannel(sourceChannel, trustCtx));
+      conversation.setTrustContext(trustCtx);
     }
   } else {
     // Service principals (svc_gateway) or tokens without an actor ID

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1471,31 +1471,24 @@ export async function handleSendMessage(
         conversationExternalId: "local",
       });
       if (trustCtx.trustClass === "unknown") {
-        // Attempt to heal guardian binding drift: after a DB reset the
-        // guardian binding gets a new vellum-principal-* UUID while the
-        // client still holds a valid JWT with the old one. The signing
-        // key survives the reset, so the JWT is authentic — just stale.
-        const healed = await healGuardianBindingDrift(actorPrincipalId);
-        if (healed) {
-          // Heal repairs the local mirror, not the gateway binding, so
-          // re-resolve trust from the local mirror.
-          trustCtx = withSourceChannel(
-            sourceChannel,
-            resolveTrustContext({
-              assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-              sourceChannel: "vellum",
-              conversationExternalId: "local",
-              actorExternalId: actorPrincipalId,
-            }),
-          );
-          log.info(
-            {
-              actorPrincipalId: actorPrincipalId,
-              trustClass: trustCtx.trustClass,
-            },
-            "Trust re-resolved after guardian binding drift heal",
-          );
-        } else {
+        // Guardian binding drift: a DB reset rebinds to a new
+        // vellum-principal-* UUID while the client holds a valid JWT for the
+        // old one. The signing key survives, so the JWT is authentic but
+        // stale. Best-effort repair the local mirror (no-op once repaired),
+        // then re-resolve from it on every gateway-unknown — not just the
+        // request that writes the heal. Safe on vellum: only the daemon mints
+        // signature-valid vellum-principal-* JWTs, so a valid one is the owner.
+        await healGuardianBindingDrift(actorPrincipalId);
+        trustCtx = withSourceChannel(
+          sourceChannel,
+          resolveTrustContext({
+            assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+            sourceChannel: "vellum",
+            conversationExternalId: "local",
+            actorExternalId: actorPrincipalId,
+          }),
+        );
+        if (trustCtx.trustClass === "unknown") {
           log.warn(
             {
               actorPrincipalId: actorPrincipalId,
@@ -1504,6 +1497,14 @@ export async function handleSendMessage(
               principalType: principalType,
             },
             "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+          );
+        } else {
+          log.info(
+            {
+              actorPrincipalId: actorPrincipalId,
+              trustClass: trustCtx.trustClass,
+            },
+            "Trust re-resolved from local mirror after gateway returned unknown",
           );
         }
       }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -122,6 +122,7 @@ import {
 } from "../../util/platform.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { getPersistedSeq } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -142,6 +143,10 @@ import {
   publishConversationListAndMetadataChanged,
   publishConversationMessagesChanged,
 } from "../sync/resource-sync-events.js";
+import {
+  resolveTrustContext,
+  withSourceChannel,
+} from "../trust-context-resolver.js";
 import {
   BadRequestError,
   InternalError,
@@ -1472,11 +1477,17 @@ export async function handleSendMessage(
         // key survives the reset, so the JWT is authentic — just stale.
         const healed = await healGuardianBindingDrift(actorPrincipalId);
         if (healed) {
-          trustCtx = await resolveLocalPrincipalTrustContext({
-            actorPrincipalId,
-            sourceChannel: "vellum",
-            conversationExternalId: "local",
-          });
+          // Heal repairs the local mirror, not the gateway binding, so
+          // re-resolve trust from the local mirror.
+          trustCtx = withSourceChannel(
+            sourceChannel,
+            resolveTrustContext({
+              assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+              sourceChannel: "vellum",
+              conversationExternalId: "local",
+              actorExternalId: actorPrincipalId,
+            }),
+          );
           log.info(
             {
               actorPrincipalId: actorPrincipalId,


### PR DESCRIPTION
## Summary
- /v1/messages resolves the principal-header actor's TrustContext from the gateway guardian binding via resolveLocalPrincipalTrustContext, dropping the local resolveTrustContext read on that path.
- Preserves the drift-heal re-resolve loop, the dev-bypass branch, and any inbound gateway-verdict branch.

Part of plan: local-principal-trust-from-binding.md (PR 3 of 3)