### PR TITLE
feat(macos): re-introduce computer-use & app-control tools in the Electron client

### DIFF
--- a/clients/macos/native/mac-helper/Package.swift
+++ b/clients/macos/native/mac-helper/Package.swift
@@ -17,9 +17,11 @@ let package = Package(
             exclude: ["Info.plist"],
             linkerSettings: [
                 .linkedFramework("AppKit"),
+                .linkedFramework("ApplicationServices"),
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("Carbon"),
                 .linkedFramework("IOKit"),
+                .linkedFramework("ScreenCaptureKit"),
                 .linkedFramework("Speech"),
             ]
         ),

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppControlExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppControlExecutor.swift
@@ -1,0 +1,741 @@
+#if os(macOS)
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+import os
+
+private let log = Logger(subsystem: "ai.vellum.mac-helper", category: "AppControlExecutor")
+
+/// Hard cap on how long we'll wait for a target app to become frontmost
+/// after `NSRunningApplication.activate()`. macOS focus transitions are
+/// usually well under 50ms; capping at 100ms keeps cold-start cases from
+/// stalling the input pipeline indefinitely.
+private let ACTIVATE_WAIT_DEADLINE_MS = 100
+
+/// Poll interval used while waiting for the target app's `isActive` to flip
+/// to true after `activate()`.
+private let ACTIVATE_POLL_INTERVAL_MS = 5
+
+/// Extra settle applied AFTER `isActive` flips to true (or after the activate
+/// deadline expires). The WindowServer's keyboard-focus routing lags AppKit's
+/// `isActive` flag by 1-2 frames — without this settle, the very first
+/// synthesized key in a sequence can land mid-focus-transition and get
+/// dropped by the WindowServer (observed: a 3-key "delete name" prefix only
+/// landed twice). 30ms ≈ 2 frames at 60fps.
+private let ACTIVATE_POSTFLIP_SETTLE_MS = 30
+
+/// Default settle delay applied at the start of `observe` so the target
+/// app and the WindowServer have time to composite a fresh frame after
+/// recent synthetic input events. ~12 frames at 60fps — sized for
+/// emulator-class apps where the input → game-state-update → render →
+/// composite → ScreenCaptureKit-pickup pipeline is the limiting factor.
+/// Callers can override per-request via `HostAppControlInput.observe`'s
+/// `settleMs` field.
+private let DEFAULT_OBSERVE_SETTLE_DELAY_MS = 200
+
+/// Default per-step gap inside `app_control_sequence` when a step omits its
+/// own `gap_ms`. Keeps consecutive presses far enough apart that emulators
+/// and games register them as discrete inputs.
+private let SEQUENCE_DEFAULT_GAP_MS = 30
+
+/// Default per-step hold duration inside `app_control_sequence` when a step
+/// omits its own `duration_ms`.
+private let SEQUENCE_DEFAULT_DURATION_MS = 50
+
+/// Dispatches a `HostAppControlRequest` to the appropriate per-process input
+/// helper (`AppKeyboard`, `AppMouse`, `AppWindowCapture`) and returns a
+/// `HostAppControlResultPayload` for the daemon.
+///
+/// All catch-paths surface as a result payload tagged with the originating
+/// `requestId` so the daemon can correlate failures with the request that
+/// produced them.
+enum AppControlExecutor {
+
+    // MARK: - Focus management
+
+    /// Bring the target process to the front of macOS's keyboard-focus stack
+    /// before posting synthetic input. `CGEvent.postToPid(_:)` queues events
+    /// at the target's port, but the WindowServer still routes keystrokes by
+    /// global keyboard focus — if another app holds focus, the events get
+    /// queued and never delivered. Activating the target app first
+    /// eliminates that drop window.
+    ///
+    /// Polls briefly until `isActive` flips to true (capped at
+    /// `ACTIVATE_WAIT_DEADLINE_MS`). Best-effort: returns even if the
+    /// deadline expires without focus transferring, so callers still attempt
+    /// the input.
+    private static func ensureActive(pid: pid_t) async {
+        guard let runningApp = NSRunningApplication(processIdentifier: pid) else { return }
+        if runningApp.isActive {
+            // Already active. Skip the activate call but still apply a tiny
+            // post-flip settle: even when the AppKit-level `isActive` is true,
+            // a recent focus transition (e.g., the user clicked into another
+            // app, then we got called immediately) can leave the WindowServer
+            // routing keys to the previous owner for 1-2 frames. Cheap
+            // insurance against the first key getting dropped.
+            try? await Task.sleep(nanoseconds: UInt64(ACTIVATE_POSTFLIP_SETTLE_MS) * 1_000_000)
+            return
+        }
+        runningApp.activate()
+        let deadline = Date().addingTimeInterval(Double(ACTIVATE_WAIT_DEADLINE_MS) / 1000.0)
+        while !runningApp.isActive && Date() < deadline {
+            try? await Task.sleep(
+                nanoseconds: UInt64(ACTIVATE_POLL_INTERVAL_MS) * 1_000_000
+            )
+        }
+        // Even after `isActive` flips, the WindowServer's keyboard-focus
+        // route can lag by 1-2 frames. Settle here so the very first
+        // synthesized key isn't lost to an in-flight focus transition.
+        try? await Task.sleep(nanoseconds: UInt64(ACTIVATE_POSTFLIP_SETTLE_MS) * 1_000_000)
+    }
+
+    /// Restore any of the app's windows that are minimized to the Dock. `start`
+    /// must report a visible (`running`) window for the daemon to promote the
+    /// session, and neither `unhide()` nor `activate()` brings a Dock-minimized
+    /// window back.
+    private static func restoreMinimizedWindows(pid: pid_t) {
+        // Reading/clearing window minimized state needs Accessibility. This is
+        // app-control's first AX access, so prompt on first use (matching the
+        // computer-use path) instead of silently no-opping for users who
+        // haven't granted it yet.
+        guard ActionExecutor.checkAccessibilityPermission(prompt: true) else { return }
+        let appElement = AXUIElementCreateApplication(pid)
+        var windowsValue: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(
+                appElement, kAXWindowsAttribute as CFString, &windowsValue
+            ) == .success,
+            let windows = windowsValue as? [AXUIElement]
+        else { return }
+        for window in windows {
+            var minimized: CFTypeRef?
+            guard
+                AXUIElementCopyAttributeValue(
+                    window, kAXMinimizedAttribute as CFString, &minimized
+                ) == .success,
+                (minimized as? Bool) == true
+            else { continue }
+            AXUIElementSetAttributeValue(
+                window, kAXMinimizedAttribute as CFString, kCFBooleanFalse
+            )
+        }
+    }
+
+    /// Capture the app's window, polling briefly for a cold-launched (or
+    /// just-restored) app whose first on-screen window appears asynchronously.
+    /// Returns as soon as a `running` capture (visible layer-0 window) is
+    /// available, or the last capture once the deadline passes. `start` must
+    /// report `running` for the daemon to promote the session.
+    private static func captureWhenReady(
+        pid: pid_t,
+        timeoutMs: Int = 3000
+    ) async -> AppWindowCapture.CaptureResult {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
+        var capture = await AppWindowCapture.capture(forPid: pid)
+        while capture.state != .running && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            capture = await AppWindowCapture.capture(forPid: pid)
+        }
+        return capture
+    }
+
+    /// Execute `request` and produce a wire result. Never throws — every
+    /// failure is reported as a result payload with `executionError` set.
+    static func perform(requestId: String, input: HostAppControlInput) async -> HostAppControlResultPayload {
+        // Input synthesis (CGEvent.postToPid) silently no-ops without
+        // Accessibility. Gate-and-prompt up front so a first-time user gets the
+        // permission dialog and a clear error instead of an action that reports
+        // success but did nothing.
+        if input.needsAccessibility,
+           !ActionExecutor.checkAccessibilityPermission(prompt: true) {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: "Accessibility permission not granted. Grant Vellum access in System Settings > Privacy & Security > Accessibility, then retry."
+            )
+        }
+
+        switch input {
+        case .start(let app, let args):
+            return await performStart(requestId: requestId, app: app, args: args)
+        case .observe(let app, let settleMs):
+            return await performObserve(
+                requestId: requestId,
+                app: app,
+                settleMs: settleMs
+            )
+        case .press(let app, let key, let modifiers, let durationMs):
+            return await performPress(
+                requestId: requestId,
+                app: app,
+                key: key,
+                modifiers: modifiers ?? [],
+                durationMs: durationMs ?? 50
+            )
+        case .combo(let app, let keys, let durationMs):
+            return await performCombo(
+                requestId: requestId,
+                app: app,
+                keys: keys,
+                durationMs: durationMs ?? 50
+            )
+        case .sequence(let app, let steps):
+            return await performSequence(
+                requestId: requestId,
+                app: app,
+                steps: steps
+            )
+        case .type(let app, let text):
+            return await performType(requestId: requestId, app: app, text: text)
+        case .click(let app, let x, let y, let button, let double):
+            return await performClick(
+                requestId: requestId,
+                app: app,
+                x: x,
+                y: y,
+                button: button,
+                double: double ?? false
+            )
+        case .drag(let app, let fromX, let fromY, let toX, let toY, let button):
+            return await performDrag(
+                requestId: requestId,
+                app: app,
+                fromX: fromX,
+                fromY: fromY,
+                toX: toX,
+                toY: toY,
+                button: button
+            )
+        case .stop:
+            return performStop(requestId: requestId)
+        }
+    }
+
+    // MARK: - start
+
+    private static func performStart(
+        requestId: String,
+        app: String,
+        args: [String]?
+    ) async -> HostAppControlResultPayload {
+        if let resolved = resolvePid(forApp: app) {
+            // Already running — unhide and bring it forward before capturing so
+            // a hidden or backgrounded app reports a visible window. The daemon
+            // only promotes the app-control session when start returns
+            // `running`, so a bare capture of a hidden app (state=minimized)
+            // would fail the whole session even though start is meant to focus
+            // or launch the app.
+            NSRunningApplication(processIdentifier: resolved.pid)?.unhide()
+            restoreMinimizedWindows(pid: resolved.pid)
+            await ensureActive(pid: resolved.pid)
+            let capture = await captureWhenReady(pid: resolved.pid)
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionResult: "started: \(resolved.name) (already running, pid=\(resolved.pid))",
+                executionError: nil
+            )
+        }
+
+        // Not running — try to launch.
+        guard let appURL = locateApplicationURL(for: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not found: \(app)"
+            )
+        }
+
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        if let args, !args.isEmpty {
+            config.arguments = args
+        }
+
+        do {
+            let runningApp = try await NSWorkspace.shared.openApplication(
+                at: appURL,
+                configuration: config
+            )
+            let pid = runningApp.processIdentifier
+            let displayName = runningApp.localizedName ?? runningApp.bundleIdentifier ?? app
+            // Poll for the first window — a cold-launched app's window appears
+            // asynchronously, and an immediate capture would report
+            // missing/minimized and get the session rolled back.
+            let capture = await captureWhenReady(pid: pid)
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionResult: "started: \(displayName) (launched, pid=\(pid))",
+                executionError: nil
+            )
+        } catch {
+            log.warning("AppControlExecutor: openApplication failed for \(app, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "Failed to launch \(app): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    // MARK: - observe
+
+    private static func performObserve(
+        requestId: String,
+        app: String,
+        settleMs: Int?
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+        // Settle delay before capture: lets the target app finish processing
+        // any pending synthetic input events and lets the window server
+        // composite a fresh frame for ScreenCaptureKit. Without this,
+        // back-to-back press → observe sequences can return a screenshot
+        // captured one input behind the latest state. Caller may override
+        // via `settleMs` (clamped at zero); omit it to use the default.
+        let effectiveSettle = max(0, settleMs ?? DEFAULT_OBSERVE_SETTLE_DELAY_MS)
+        if effectiveSettle > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(effectiveSettle) * 1_000_000)
+        }
+        let capture = await AppWindowCapture.capture(forPid: resolved.pid)
+        return HostAppControlResultPayload(
+            requestId: requestId,
+            state: capture.state,
+            pngBase64: capture.pngBase64,
+            windowBounds: capture.bounds,
+            executionResult: "observed: \(resolved.name) (pid=\(resolved.pid))",
+            // Surface ScreenCaptureKit failures (commonly missing Screen
+            // Recording permission) so the daemon/LLM doesn't see a "successful"
+            // observe with no image and no signal to the user.
+            executionError: capture.captureError
+        )
+    }
+
+    // MARK: - press
+
+    private static func performPress(
+        requestId: String,
+        app: String,
+        key: String,
+        modifiers: [String],
+        durationMs: Int
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        await ensureActive(pid: resolved.pid)
+
+        do {
+            try await AppKeyboard.press(
+                pid: resolved.pid,
+                key: key,
+                modifiers: modifiers,
+                durationMs: durationMs
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionResult: "pressed \(key) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - combo
+
+    private static func performCombo(
+        requestId: String,
+        app: String,
+        keys: [String],
+        durationMs: Int
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        await ensureActive(pid: resolved.pid)
+
+        do {
+            try await AppKeyboard.combo(
+                pid: resolved.pid,
+                keys: keys,
+                durationMs: durationMs
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionResult: "combo \(keys.joined(separator: "+")) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - sequence
+
+    /// Run an ordered batch of single-key presses serially against the same
+    /// target app. Activates the app once at the start (rather than before
+    /// every step) so synthesis runs without any window for keyboard focus
+    /// to drift between presses. On any per-step failure, halts immediately
+    /// and surfaces the failing step's error in `executionError`; steps
+    /// already executed are not undone.
+    private static func performSequence(
+        requestId: String,
+        app: String,
+        steps: [HostAppControlSequenceStep]
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        if steps.isEmpty {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: "sequence requires at least one step"
+            )
+        }
+
+        await ensureActive(pid: resolved.pid)
+
+        for (index, step) in steps.enumerated() {
+            do {
+                try await AppKeyboard.press(
+                    pid: resolved.pid,
+                    key: step.key,
+                    modifiers: step.modifiers ?? [],
+                    durationMs: step.durationMs ?? SEQUENCE_DEFAULT_DURATION_MS
+                )
+            } catch {
+                return HostAppControlResultPayload(
+                    requestId: requestId,
+                    state: .running,
+                    executionError: "step \(index) (key=\(step.key)) failed: \(error.localizedDescription)"
+                )
+            }
+
+            // Apply per-step gap (skip after the final step — no follow-up
+            // press to space it from).
+            if index < steps.count - 1 {
+                let gap = step.gapMs ?? SEQUENCE_DEFAULT_GAP_MS
+                if gap > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(gap) * 1_000_000)
+                }
+            }
+        }
+
+        return HostAppControlResultPayload(
+            requestId: requestId,
+            state: .running,
+            executionResult: "sequence: \(steps.count) step(s) (pid=\(resolved.pid))",
+            executionError: nil
+        )
+    }
+
+    // MARK: - type
+
+    private static func performType(
+        requestId: String,
+        app: String,
+        text: String
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        await ensureActive(pid: resolved.pid)
+
+        do {
+            try await AppKeyboard.type(pid: resolved.pid, text: text)
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionResult: "typed \(text.count) char(s) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - click
+
+    private static func performClick(
+        requestId: String,
+        app: String,
+        x: Double,
+        y: Double,
+        button: String?,
+        double: Bool
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        await ensureActive(pid: resolved.pid)
+
+        let capture = await AppWindowCapture.capture(forPid: resolved.pid)
+        guard capture.state == .running, let bounds = capture.bounds else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionError: boundsMissingExecutionError(capture)
+            )
+        }
+
+        // Bounds came through, so a missing PNG is non-fatal: the click can
+        // proceed without a screenshot. Ignore `capture.captureError` here.
+        do {
+            try AppMouse.click(
+                pid: resolved.pid,
+                windowBounds: bounds,
+                x: x,
+                y: y,
+                button: parseButton(button),
+                double: double
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionResult: "clicked at (\(x), \(y)) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - drag
+
+    private static func performDrag(
+        requestId: String,
+        app: String,
+        fromX: Double,
+        fromY: Double,
+        toX: Double,
+        toY: Double,
+        button: String?
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        await ensureActive(pid: resolved.pid)
+
+        let capture = await AppWindowCapture.capture(forPid: resolved.pid)
+        guard capture.state == .running, let bounds = capture.bounds else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionError: boundsMissingExecutionError(capture)
+            )
+        }
+
+        // Bounds came through, so a missing PNG is non-fatal: the drag can
+        // proceed without a screenshot. Ignore `capture.captureError` here.
+        do {
+            try AppMouse.drag(
+                pid: resolved.pid,
+                windowBounds: bounds,
+                fromX: fromX,
+                fromY: fromY,
+                toX: toX,
+                toY: toY,
+                button: parseButton(button)
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionResult: "dragged (\(fromX), \(fromY)) -> (\(toX), \(toY)) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - stop
+
+    /// `stop` does NOT terminate the target app — it just acknowledges the
+    /// session-end signal so the daemon can finalize bookkeeping.
+    private static func performStop(requestId: String) -> HostAppControlResultPayload {
+        return HostAppControlResultPayload(
+            requestId: requestId,
+            state: .running,
+            executionResult: "session stopped",
+            executionError: nil
+        )
+    }
+
+    // MARK: - capture error mapping
+
+    /// Pick an `executionError` value for the bounds-missing branch of click
+    /// and drag. Bounds are required by those tools to translate the
+    /// caller-supplied coordinates into screen space — so when bounds are
+    /// missing we always return a non-nil error.
+    ///
+    /// We prefer `capture.captureError` when present (it tells the user *why*
+    /// we couldn't get bounds — commonly missing Screen Recording permission)
+    /// over a bare state-classification message. Marked `internal` for unit
+    /// testing; not part of the public executor surface.
+    static func boundsMissingExecutionError(_ capture: AppWindowCapture.CaptureResult) -> String {
+        return capture.captureError
+            ?? "Window not visible (state=\(capture.state.rawValue))"
+    }
+
+    // MARK: - PID resolution
+
+    /// Resolves a user-supplied app identifier to a running PID and a display
+    /// name. Tries bundle-ID match first (preferred), then falls back to a
+    /// case-insensitive localized-name match across all running apps.
+    ///
+    /// When multiple processes match the bundle ID or localized name, the
+    /// first match is returned and the count is encoded into the display name
+    /// so callers can surface it in `executionResult`.
+    private static func resolvePid(forApp app: String) -> (pid: pid_t, name: String)? {
+        // Bundle ID (preferred).
+        let bundleMatches = NSRunningApplication.runningApplications(withBundleIdentifier: app)
+        if let first = bundleMatches.first {
+            let pid = first.processIdentifier
+            let name = displayName(for: first, fallback: app)
+            if bundleMatches.count > 1 {
+                return (pid, "\(name) [\(bundleMatches.count) matches]")
+            }
+            return (pid, name)
+        }
+
+        // Localized name (case-insensitive).
+        let lowered = app.lowercased()
+        let nameMatches = NSWorkspace.shared.runningApplications.filter { running in
+            (running.localizedName?.lowercased() == lowered)
+        }
+        if let first = nameMatches.first {
+            let pid = first.processIdentifier
+            let name = displayName(for: first, fallback: app)
+            if nameMatches.count > 1 {
+                return (pid, "\(name) [\(nameMatches.count) matches]")
+            }
+            return (pid, name)
+        }
+
+        return nil
+    }
+
+    private static func displayName(for app: NSRunningApplication, fallback: String) -> String {
+        return app.localizedName ?? app.bundleIdentifier ?? fallback
+    }
+
+    /// Try to find an installed `.app` URL for `app`, treating `app` first as a
+    /// bundle identifier and falling back to a localized name lookup that
+    /// scans common install directories.
+    private static func locateApplicationURL(for app: String) -> URL? {
+        if let bundleURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app) {
+            return bundleURL
+        }
+
+        // Fall back to scanning common application directories by name.
+        let searchDirs = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            NSString("~/Applications").expandingTildeInPath,
+        ]
+        let nameWithSuffix = app.hasSuffix(".app") ? app : "\(app).app"
+        let lowerName = nameWithSuffix.lowercased()
+
+        for dir in searchDirs {
+            let direct = "\(dir)/\(nameWithSuffix)"
+            if FileManager.default.fileExists(atPath: direct) {
+                return URL(fileURLWithPath: direct)
+            }
+            // Case-insensitive match within the directory.
+            if let entries = try? FileManager.default.contentsOfDirectory(atPath: dir),
+               let match = entries.first(where: { $0.lowercased() == lowerName }) {
+                return URL(fileURLWithPath: "\(dir)/\(match)")
+            }
+        }
+        return nil
+    }
+
+    /// Convert a daemon-supplied button string to an `AppMouse.MouseButton`.
+    /// Defaults to `.left` for `nil` or unrecognized input so callers always
+    /// get a valid button without surfacing parse errors.
+    private static func parseButton(_ s: String?) -> AppMouse.MouseButton {
+        guard let s, let parsed = AppMouse.MouseButton(rawValue: s.lowercased()) else {
+            return .left
+        }
+        return parsed
+    }
+}
+#endif

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppKeyboard.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppKeyboard.swift
@@ -1,0 +1,223 @@
+import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
+
+/// Per-process keyboard input helper.
+///
+/// All input is posted via [`CGEvent.postToPid(_:)`](https://developer.apple.com/documentation/coregraphics/cgevent/posttopid(_:))
+/// (the Swift-bridged form of `CGEventPostToPid`) so events are delivered
+/// directly to the target process's event queue without affecting whichever
+/// app currently has system focus. This intentionally differs from
+/// `CGEvent.post(tap:)`, which injects at the system level and would leak
+/// to whatever the user has frontmost.
+enum AppKeyboard {
+    enum Error: LocalizedError {
+        case eventCreationFailed
+        case unknownKey(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .eventCreationFailed: return "Failed to create CGEvent"
+            case .unknownKey(let key): return "Unknown key: \(key)"
+            }
+        }
+    }
+
+    /// Friendly key name → Carbon `kVK_*` virtual key code.
+    static let keyMap: [String: CGKeyCode] = {
+        var map: [String: CGKeyCode] = [
+            "enter": CGKeyCode(kVK_Return),
+            "return": CGKeyCode(kVK_Return),
+            "tab": CGKeyCode(kVK_Tab),
+            "escape": CGKeyCode(kVK_Escape),
+            "space": CGKeyCode(kVK_Space),
+            "backspace": CGKeyCode(kVK_Delete),
+            "delete": CGKeyCode(kVK_Delete),
+            "forwarddelete": CGKeyCode(kVK_ForwardDelete),
+            "up": CGKeyCode(kVK_UpArrow),
+            "down": CGKeyCode(kVK_DownArrow),
+            "left": CGKeyCode(kVK_LeftArrow),
+            "right": CGKeyCode(kVK_RightArrow),
+        ]
+
+        let letters: [(String, Int)] = [
+            ("a", kVK_ANSI_A), ("b", kVK_ANSI_B), ("c", kVK_ANSI_C), ("d", kVK_ANSI_D),
+            ("e", kVK_ANSI_E), ("f", kVK_ANSI_F), ("g", kVK_ANSI_G), ("h", kVK_ANSI_H),
+            ("i", kVK_ANSI_I), ("j", kVK_ANSI_J), ("k", kVK_ANSI_K), ("l", kVK_ANSI_L),
+            ("m", kVK_ANSI_M), ("n", kVK_ANSI_N), ("o", kVK_ANSI_O), ("p", kVK_ANSI_P),
+            ("q", kVK_ANSI_Q), ("r", kVK_ANSI_R), ("s", kVK_ANSI_S), ("t", kVK_ANSI_T),
+            ("u", kVK_ANSI_U), ("v", kVK_ANSI_V), ("w", kVK_ANSI_W), ("x", kVK_ANSI_X),
+            ("y", kVK_ANSI_Y), ("z", kVK_ANSI_Z),
+        ]
+        for (name, code) in letters {
+            map[name] = CGKeyCode(code)
+        }
+
+        let digits: [(String, Int)] = [
+            ("0", kVK_ANSI_0), ("1", kVK_ANSI_1), ("2", kVK_ANSI_2), ("3", kVK_ANSI_3),
+            ("4", kVK_ANSI_4), ("5", kVK_ANSI_5), ("6", kVK_ANSI_6), ("7", kVK_ANSI_7),
+            ("8", kVK_ANSI_8), ("9", kVK_ANSI_9),
+        ]
+        for (name, code) in digits {
+            map[name] = CGKeyCode(code)
+        }
+
+        let functionKeys: [(String, Int)] = [
+            ("f1", kVK_F1), ("f2", kVK_F2), ("f3", kVK_F3), ("f4", kVK_F4),
+            ("f5", kVK_F5), ("f6", kVK_F6), ("f7", kVK_F7), ("f8", kVK_F8),
+            ("f9", kVK_F9), ("f10", kVK_F10), ("f11", kVK_F11), ("f12", kVK_F12),
+        ]
+        for (name, code) in functionKeys {
+            map[name] = CGKeyCode(code)
+        }
+
+        return map
+    }()
+
+    /// Translate friendly modifier names (case-insensitive) to a `CGEventFlags`
+    /// bitmask. Unknown names are silently ignored.
+    static func modifierFlags(_ mods: [String]) -> CGEventFlags {
+        var flags: CGEventFlags = []
+        for raw in mods {
+            switch raw.lowercased() {
+            case "cmd", "command":
+                flags.insert(.maskCommand)
+            case "shift":
+                flags.insert(.maskShift)
+            case "option", "alt":
+                flags.insert(.maskAlternate)
+            case "control", "ctrl":
+                flags.insert(.maskControl)
+            case "fn":
+                flags.insert(.maskSecondaryFn)
+            default:
+                continue
+            }
+        }
+        return flags
+    }
+
+    /// Press a single key (with optional modifiers) for `durationMs` and release.
+    ///
+    /// On `Task` cancellation the key-up is still posted before re-throwing, so
+    /// a cancelled press never leaves the key stuck down.
+    static func press(pid: pid_t, key: String, modifiers: [String], durationMs: Int) async throws {
+        guard let keyCode = keyMap[key.lowercased()] else {
+            throw Error.unknownKey(key)
+        }
+        let flags = modifierFlags(modifiers)
+
+        guard let down = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) else {
+            throw Error.eventCreationFailed
+        }
+        down.flags = flags
+        down.postToPid(pid)
+
+        do {
+            try await Task.sleep(nanoseconds: UInt64(max(0, durationMs)) * 1_000_000)
+        } catch {
+            postKeyUp(pid: pid, keyCode: keyCode, flags: flags)
+            throw error
+        }
+
+        postKeyUp(pid: pid, keyCode: keyCode, flags: flags)
+    }
+
+    /// Hold multiple keys simultaneously for `durationMs`, then release in
+    /// reverse order. Modifier tokens (`cmd`, `shift`, `option`/`alt`,
+    /// `control`/`ctrl`, `fn`) inside `keys` are folded into the event flags
+    /// applied to each non-modifier key, so callers can pass a combined
+    /// shortcut like `["cmd", "shift", "4"]`.
+    ///
+    /// On `Task` cancellation any keys that were successfully pressed are
+    /// released (in reverse order) before re-throwing, so a cancelled combo
+    /// never leaves keys stuck down.
+    static func combo(pid: pid_t, keys: [String], durationMs: Int) async throws {
+        var modifierTokens: [String] = []
+        var keyCodes: [CGKeyCode] = []
+        keyCodes.reserveCapacity(keys.count)
+        for key in keys {
+            let lower = key.lowercased()
+            if isModifierToken(lower) {
+                modifierTokens.append(lower)
+                continue
+            }
+            guard let code = keyMap[lower] else {
+                throw Error.unknownKey(key)
+            }
+            keyCodes.append(code)
+        }
+        let flags = modifierFlags(modifierTokens)
+
+        var pressedCodes: [CGKeyCode] = []
+        pressedCodes.reserveCapacity(keyCodes.count)
+        for code in keyCodes {
+            guard let down = CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: true) else {
+                releaseAll(pid: pid, keyCodes: pressedCodes, flags: flags)
+                throw Error.eventCreationFailed
+            }
+            down.flags = flags
+            down.postToPid(pid)
+            pressedCodes.append(code)
+        }
+
+        do {
+            try await Task.sleep(nanoseconds: UInt64(max(0, durationMs)) * 1_000_000)
+        } catch {
+            releaseAll(pid: pid, keyCodes: pressedCodes, flags: flags)
+            throw error
+        }
+
+        releaseAll(pid: pid, keyCodes: pressedCodes, flags: flags)
+    }
+
+    /// Type a Unicode string by posting per-character key events with
+    /// `keyboardSetUnicodeString`. Uses `virtualKey: 0` because the Unicode
+    /// string carries the actual character — this lets us type emoji and other
+    /// characters that have no virtual-key mapping.
+    static func type(pid: pid_t, text: String) async throws {
+        for character in text {
+            try postUnicode(pid: pid, character: character, keyDown: true)
+            try postUnicode(pid: pid, character: character, keyDown: false)
+            try await Task.sleep(nanoseconds: 5 * 1_000_000)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private static func postKeyUp(pid: pid_t, keyCode: CGKeyCode, flags: CGEventFlags) {
+        guard let up = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
+            return
+        }
+        up.flags = flags
+        up.postToPid(pid)
+    }
+
+    private static func releaseAll(pid: pid_t, keyCodes: [CGKeyCode], flags: CGEventFlags = []) {
+        for code in keyCodes.reversed() {
+            postKeyUp(pid: pid, keyCode: code, flags: flags)
+        }
+    }
+
+    private static func isModifierToken(_ lowercased: String) -> Bool {
+        switch lowercased {
+        case "cmd", "command", "shift", "option", "alt", "control", "ctrl", "fn":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func postUnicode(pid: pid_t, character: Character, keyDown: Bool) throws {
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: keyDown) else {
+            throw Error.eventCreationFailed
+        }
+        let utf16 = Array(String(character).utf16)
+        utf16.withUnsafeBufferPointer { buffer in
+            if let base = buffer.baseAddress {
+                event.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: base)
+            }
+        }
+        event.postToPid(pid)
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppMouse.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppMouse.swift
@@ -1,0 +1,175 @@
+import CoreGraphics
+import Foundation
+
+/// Per-process mouse input helper for the app-control skill.
+///
+/// All events are posted via `CGEvent.postToPid(_:)` (the modern Swift
+/// spelling of `CGEventPostToPid`) so they target the specific host process
+/// rather than the global event tap, keeping the user's real cursor and
+/// other apps unaffected.
+///
+/// Coordinates are window-relative and translated to global at post time
+/// using the current `WindowBounds` reported by the assistant.
+enum AppMouse {
+
+    // MARK: - Errors
+
+    enum AppMouseError: LocalizedError {
+        case eventCreationFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .eventCreationFailed: return "Failed to create CGEvent"
+            }
+        }
+    }
+
+    // MARK: - Mouse buttons
+
+    enum MouseButton: String {
+        case left
+        case right
+        case middle
+    }
+
+    static func cgButton(for button: MouseButton) -> CGMouseButton {
+        switch button {
+        case .left: return .left
+        case .right: return .right
+        case .middle: return .center
+        }
+    }
+
+    private static func downType(for button: MouseButton) -> CGEventType {
+        switch button {
+        case .left: return .leftMouseDown
+        case .right: return .rightMouseDown
+        case .middle: return .otherMouseDown
+        }
+    }
+
+    private static func upType(for button: MouseButton) -> CGEventType {
+        switch button {
+        case .left: return .leftMouseUp
+        case .right: return .rightMouseUp
+        case .middle: return .otherMouseUp
+        }
+    }
+
+    private static func draggedType(for button: MouseButton) -> CGEventType {
+        switch button {
+        case .left: return .leftMouseDragged
+        case .right: return .rightMouseDragged
+        case .middle: return .otherMouseDragged
+        }
+    }
+
+    // MARK: - Pure helpers (unit-tested)
+
+    /// Translates a window-relative point to a global screen coordinate.
+    static func windowRelativeToGlobal(_ point: CGPoint, windowBounds: WindowBounds) -> CGPoint {
+        return CGPoint(x: windowBounds.x + point.x, y: windowBounds.y + point.y)
+    }
+
+    /// Returns `steps` evenly-spaced intermediate points strictly between
+    /// `from` and `to` (exclusive of both endpoints). Returns an empty
+    /// array when `steps <= 0`.
+    static func interpolate(from: CGPoint, to: CGPoint, steps: Int) -> [CGPoint] {
+        guard steps > 0 else { return [] }
+        var points: [CGPoint] = []
+        points.reserveCapacity(steps)
+        let denom = CGFloat(steps + 1)
+        for i in 1...steps {
+            let t = CGFloat(i) / denom
+            points.append(CGPoint(
+                x: from.x + (to.x - from.x) * t,
+                y: from.y + (to.y - from.y) * t
+            ))
+        }
+        return points
+    }
+
+    // MARK: - Click
+
+    /// Posts a synthetic mouse click to the target process.
+    ///
+    /// `x`/`y` are window-relative; they are translated to global coordinates
+    /// using `windowBounds`. When `double` is `true`, two down/up cycles are
+    /// posted with `mouseEventClickState` set to 2 on the second cycle to
+    /// match how macOS native double-click events look.
+    static func click(
+        pid: pid_t,
+        windowBounds: WindowBounds,
+        x: Double,
+        y: Double,
+        button: MouseButton,
+        double: Bool
+    ) throws {
+        let global = windowRelativeToGlobal(CGPoint(x: x, y: y), windowBounds: windowBounds)
+        let cgButton = cgButton(for: button)
+        let down = downType(for: button)
+        let up = upType(for: button)
+
+        try postClick(pid: pid, position: global, downType: down, upType: up, cgButton: cgButton, clickState: 1)
+        if double {
+            try postClick(pid: pid, position: global, downType: down, upType: up, cgButton: cgButton, clickState: 2)
+        }
+    }
+
+    private static func postClick(
+        pid: pid_t,
+        position: CGPoint,
+        downType: CGEventType,
+        upType: CGEventType,
+        cgButton: CGMouseButton,
+        clickState: Int64
+    ) throws {
+        try postMouseEvent(pid: pid, type: downType, position: position, cgButton: cgButton, clickState: clickState)
+        try postMouseEvent(pid: pid, type: upType, position: position, cgButton: cgButton, clickState: clickState)
+    }
+
+    private static func postMouseEvent(
+        pid: pid_t,
+        type: CGEventType,
+        position: CGPoint,
+        cgButton: CGMouseButton,
+        clickState: Int64? = nil
+    ) throws {
+        guard let event = CGEvent(
+            mouseEventSource: nil,
+            mouseType: type,
+            mouseCursorPosition: position,
+            mouseButton: cgButton
+        ) else {
+            throw AppMouseError.eventCreationFailed
+        }
+        if let clickState {
+            event.setIntegerValueField(.mouseEventClickState, value: clickState)
+        }
+        event.postToPid(pid)
+    }
+
+    // MARK: - Drag
+
+    /// Posts a synthetic mouse drag to the target process: mouseDown at
+    /// `from`, 10 interpolated mouseDragged events, then mouseUp at `to`.
+    static func drag(
+        pid: pid_t,
+        windowBounds: WindowBounds,
+        fromX: Double,
+        fromY: Double,
+        toX: Double,
+        toY: Double,
+        button: MouseButton
+    ) throws {
+        let fromGlobal = windowRelativeToGlobal(CGPoint(x: fromX, y: fromY), windowBounds: windowBounds)
+        let toGlobal = windowRelativeToGlobal(CGPoint(x: toX, y: toY), windowBounds: windowBounds)
+        let cgButton = cgButton(for: button)
+
+        try postMouseEvent(pid: pid, type: downType(for: button), position: fromGlobal, cgButton: cgButton)
+        for point in interpolate(from: fromGlobal, to: toGlobal, steps: 10) {
+            try postMouseEvent(pid: pid, type: draggedType(for: button), position: point, cgButton: cgButton)
+        }
+        try postMouseEvent(pid: pid, type: upType(for: button), position: toGlobal, cgButton: cgButton)
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppWindowCapture.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/AppControl/AppWindowCapture.swift
@@ -1,0 +1,250 @@
+#if os(macOS)
+import AppKit
+import CoreGraphics
+import ImageIO
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+import os
+
+private let log = Logger(subsystem: "ai.vellum.mac-helper", category: "AppWindowCapture")
+
+/// Captures the frontmost normal window of a target process by PID.
+///
+/// Returns a `CaptureResult` whose `state` distinguishes:
+///   - `.running`   — the process is alive and an on-screen normal window was captured.
+///   - `.minimized` — the process is alive but no normal layer-0 window is on-screen
+///                    (e.g. minimized to Dock or app is hidden).
+///   - `.missing`   — no running NSRunningApplication has the requested PID.
+///
+/// `WindowBounds` is populated whenever a layer-0 window matched
+/// (`state == .running`). `pngBase64` is populated only when ScreenCaptureKit
+/// also succeeded; on capture failure it stays `nil` and `captureError`
+/// carries the underlying reason (most commonly: Screen Recording permission
+/// is not granted). Callers must not assume "running implies image" — `state`
+/// describes the window, `captureError` describes the screenshot.
+///
+/// Window filtering uses `CGWindowListCopyWindowInfo` (which remains available in
+/// macOS 15) to identify on-screen layer-0 windows owned by the target PID. The
+/// actual pixel capture goes through `SCScreenshotManager` because
+/// `CGWindowListCreateImage` is unavailable in macOS 15.
+enum AppWindowCapture {
+
+    struct CaptureResult: Equatable {
+        let state: HostAppControlState
+        let pngBase64: String?
+        let bounds: WindowBounds?
+        /// Set when ScreenCaptureKit failed even though the window exists. Most
+        /// commonly indicates missing Screen Recording permission. The window
+        /// `state` remains correctly classified (`.running`/`.minimized`/
+        /// `.missing`); this field is an orthogonal signal that *capture* failed.
+        let captureError: String?
+    }
+
+    /// Inner result for the ScreenCaptureKit path. Distinguishes "no PNG, here's
+    /// why" from "no PNG, no error" so callers can surface the failure reason
+    /// without conflating it with the window-state classification.
+    private struct PNGCaptureResult {
+        let pngBase64: String?
+        let error: String?
+    }
+
+    /// Capture the frontmost normal window owned by `pid`. See type docs for state semantics.
+    static func capture(forPid pid: pid_t) async -> CaptureResult {
+        let infoList = (CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[CFString: Any]]) ?? []
+
+        let match = infoList.first { entry in
+            guard let ownerPID = entry[kCGWindowOwnerPID] as? pid_t,
+                  ownerPID == pid else { return false }
+            // Layer 0 is the normal application-window layer; menu bar / dock / overlays sit
+            // on positive layers we explicitly want to skip.
+            guard let layer = entry[kCGWindowLayer] as? Int, layer == 0 else { return false }
+            return true
+        }
+
+        guard let entry = match,
+              let windowNumber = entry[kCGWindowNumber] as? CGWindowID else {
+            // Distinguish a missing process from a running-but-minimized one.
+            let processIsAlive = NSWorkspace.shared.runningApplications
+                .contains(where: { $0.processIdentifier == pid })
+            return CaptureResult(
+                state: processIsAlive ? .minimized : .missing,
+                pngBase64: nil,
+                bounds: nil,
+                captureError: nil
+            )
+        }
+
+        let bounds = parseBounds(entry[kCGWindowBounds])
+        let png = await captureWindowPNG(windowID: windowNumber)
+        return CaptureResult(
+            state: .running,
+            pngBase64: png.pngBase64,
+            bounds: bounds,
+            captureError: png.error
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private static func parseBounds(_ value: Any?) -> WindowBounds? {
+        // kCGWindowBounds is a CFDictionary representation of a CGRect. Cast through
+        // CFDictionary explicitly — `Any as CFDictionary` requires forced conversion.
+        guard let value, CFGetTypeID(value as CFTypeRef) == CFDictionaryGetTypeID() else {
+            return nil
+        }
+        let cfDict = value as! CFDictionary
+        guard let rect = CGRect(dictionaryRepresentation: cfDict) else { return nil }
+        return WindowBounds(
+            x: Double(rect.origin.x),
+            y: Double(rect.origin.y),
+            width: Double(rect.size.width),
+            height: Double(rect.size.height)
+        )
+    }
+
+    /// Capture a single PNG of `windowID` via ScreenCaptureKit. Returns the
+    /// base64 PNG on success, or a human-readable error message describing why
+    /// capture failed. Empirically, missing Screen Recording permission may
+    /// either *throw* (most common, observed in `ScreenCapture.swift`) or
+    /// silently return an empty `SCShareableContent.windows` list on some
+    /// macOS versions — we surface a permission hint in both branches so the
+    /// daemon and the LLM can suggest the right fix.
+    ///
+    /// Two paths, gated by the `VELLUM_APP_CONTROL_USE_DISPLAY_FILTER` env
+    /// var (diagnostic — default off):
+    ///
+    /// - **Default (warmup pattern)** — `SCContentFilter(desktopIndependentWindow:)`
+    ///   with a discardable warmup capture + ~33ms gap before the real capture.
+    ///   This is the historical path. Doesn't hang, but can return stale
+    ///   buffered frames for GPU-rendered apps (emulators) because the
+    ///   per-window filter reads the AppKit/CoreAnimation backing store.
+    ///
+    /// - **Display filter (env-gated)** — `SCContentFilter(display:including:)`,
+    ///   one-shot. Theoretically reads via the display-composite path (fresh
+    ///   GPU pixels) and lets SCK mask down to the window without coordinate
+    ///   math. Empirically hangs for unknown reasons in this codebase
+    ///   (#29389 one-shot + cropped sourceRect, #29445 continuous SCStream
+    ///   both hung at 60s timeout). Re-enabled here behind an env var so we
+    ///   can collect Console logs that pin down which call blocks.
+    ///
+    /// Both paths log every step with elapsed-ms timestamps under the
+    /// `AppWindowCapture` category — filter Console.app for that to see the
+    /// trace. Once we know where the display path hangs we can either fix
+    /// it or close the door on display-filter for good.
+    private static func captureWindowPNG(windowID: CGWindowID) async -> PNGCaptureResult {
+        let useDisplay = ProcessInfo.processInfo.environment[USE_DISPLAY_FILTER_ENV] == "1"
+        let start = Date()
+
+        func elapsed() -> Int { Int(Date().timeIntervalSince(start) * 1000) }
+
+        log.notice("captureWindowPNG: start (windowID=\(windowID, privacy: .public), useDisplay=\(useDisplay, privacy: .public))")
+
+        do {
+            log.notice("captureWindowPNG: requesting SCShareableContent.current (+\(elapsed())ms)")
+            let shareable = try await SCShareableContent.current
+            log.notice("captureWindowPNG: got SCShareableContent (+\(elapsed())ms, windows=\(shareable.windows.count, privacy: .public), displays=\(shareable.displays.count, privacy: .public))")
+
+            guard let scWindow = shareable.windows.first(where: { $0.windowID == windowID }) else {
+                let message = "ScreenCaptureKit could not find window \(windowID) — Screen Recording permission may be required (System Settings > Privacy & Security > Screen & System Audio Recording)"
+                log.warning("captureWindowPNG: window not found in SCShareableContent.windows (+\(elapsed())ms)")
+                return PNGCaptureResult(pngBase64: nil, error: message)
+            }
+            log.notice("captureWindowPNG: matched window \(windowID, privacy: .public) frame=\(NSStringFromRect(scWindow.frame), privacy: .public) (+\(elapsed())ms)")
+
+            let filter: SCContentFilter
+            if useDisplay {
+                let center = CGPoint(x: scWindow.frame.midX, y: scWindow.frame.midY)
+                let display = shareable.displays.first(where: { $0.frame.contains(center) })
+                    ?? shareable.displays.first
+                guard let display else {
+                    log.warning("captureWindowPNG: no display available (+\(elapsed())ms)")
+                    return PNGCaptureResult(
+                        pngBase64: nil,
+                        error: "No display available for capture"
+                    )
+                }
+                log.notice("captureWindowPNG: display path — display id=\(display.displayID, privacy: .public) frame=\(NSStringFromRect(display.frame), privacy: .public) (+\(elapsed())ms)")
+                filter = SCContentFilter(display: display, including: [scWindow])
+                log.notice("captureWindowPNG: built display:including: filter (+\(elapsed())ms)")
+            } else {
+                filter = SCContentFilter(desktopIndependentWindow: scWindow)
+                log.notice("captureWindowPNG: built desktopIndependentWindow filter (+\(elapsed())ms)")
+            }
+
+            let config = SCStreamConfiguration()
+            config.width = max(Int(scWindow.frame.width), 1)
+            config.height = max(Int(scWindow.frame.height), 1)
+            config.pixelFormat = kCVPixelFormatType_32BGRA
+            config.showsCursor = false
+            log.notice("captureWindowPNG: built config \(config.width, privacy: .public)x\(config.height, privacy: .public) (+\(elapsed())ms)")
+
+            if !useDisplay {
+                // Warmup capture — discarded. Forces SCK to invalidate any
+                // stale buffered frame for this window. Errors here are
+                // non-fatal: if the warmup fails, the real capture below
+                // will surface the error.
+                log.notice("captureWindowPNG: warmup capture start (+\(elapsed())ms)")
+                _ = try? await SCScreenshotManager.captureImage(
+                    contentFilter: filter,
+                    configuration: config
+                )
+                log.notice("captureWindowPNG: warmup capture done (+\(elapsed())ms)")
+                try? await Task.sleep(nanoseconds: UInt64(CAPTURE_INTER_SHOT_GAP_MS) * 1_000_000)
+                log.notice("captureWindowPNG: warmup gap elapsed (+\(elapsed())ms)")
+            }
+
+            log.notice("captureWindowPNG: real capture start (+\(elapsed())ms)")
+            let cgImage = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: config
+            )
+            log.notice("captureWindowPNG: real capture done \(cgImage.width, privacy: .public)x\(cgImage.height, privacy: .public) (+\(elapsed())ms)")
+
+            guard let png = encodePNGBase64(cgImage: cgImage) else {
+                log.warning("captureWindowPNG: PNG encode failed (+\(elapsed())ms)")
+                return PNGCaptureResult(pngBase64: nil, error: "Failed to encode captured window as PNG")
+            }
+            log.notice("captureWindowPNG: PNG encoded (\(png.count, privacy: .public) base64 chars) (+\(elapsed())ms)")
+            return PNGCaptureResult(pngBase64: png, error: nil)
+        } catch {
+            log.warning("captureWindowPNG: caught error after \(elapsed())ms: \(error.localizedDescription, privacy: .public)")
+            let message = "Screen capture failed: \(error.localizedDescription) — Screen Recording permission may be required (System Settings > Privacy & Security > Screen & System Audio Recording)"
+            return PNGCaptureResult(pngBase64: nil, error: message)
+        }
+    }
+
+    /// Env var that opts in to the diagnostic `display:including:` filter
+    /// path. Set to `"1"` before launching the macOS app to enable. Default
+    /// behavior (env unset or any other value) is the historical
+    /// warmup-capture pattern.
+    private static let USE_DISPLAY_FILTER_ENV = "VELLUM_APP_CONTROL_USE_DISPLAY_FILTER"
+
+    /// Gap between the warmup capture and the real capture. ~2 frames at
+    /// 60fps — long enough for the SCK pipeline to advance past whatever
+    /// stale frame was cached, short enough that the added observe latency
+    /// is unnoticeable.
+    private static let CAPTURE_INTER_SHOT_GAP_MS: Int = 33
+
+    private static func encodePNGBase64(cgImage: CGImage) -> String? {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            log.warning("AppWindowCapture: CGImageDestinationCreateWithData returned nil")
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            log.warning("AppWindowCapture: CGImageDestinationFinalize failed")
+            return nil
+        }
+        return (data as Data).base64EncodedString()
+    }
+}
+#endif

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/CUWireTypes.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/CUWireTypes.swift
@@ -1,0 +1,269 @@
+import Foundation
+import MacHelperCore
+
+// Helper-local recreations of the daemon wire types for computer-use and
+// app-control results. Field names/shapes mirror the shared MessageTypes.
+
+// MARK: - Computer Use
+
+struct HostCuResultPayload {
+    let requestId: String
+    var axTree: String?
+    var axDiff: String?
+    var screenshot: String?
+    var screenshotWidthPx: Int?
+    var screenshotHeightPx: Int?
+    var screenWidthPt: Int?
+    var screenHeightPt: Int?
+    var executionResult: String?
+    var executionError: String?
+    var secondaryWindows: String?
+
+    init(
+        requestId: String,
+        axTree: String? = nil,
+        axDiff: String? = nil,
+        screenshot: String? = nil,
+        screenshotWidthPx: Int? = nil,
+        screenshotHeightPx: Int? = nil,
+        screenWidthPt: Int? = nil,
+        screenHeightPt: Int? = nil,
+        executionResult: String? = nil,
+        executionError: String? = nil,
+        secondaryWindows: String? = nil
+    ) {
+        self.requestId = requestId
+        self.axTree = axTree
+        self.axDiff = axDiff
+        self.screenshot = screenshot
+        self.screenshotWidthPx = screenshotWidthPx
+        self.screenshotHeightPx = screenshotHeightPx
+        self.screenWidthPt = screenWidthPt
+        self.screenHeightPt = screenHeightPt
+        self.executionResult = executionResult
+        self.executionError = executionError
+        self.secondaryWindows = secondaryWindows
+    }
+
+    func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = ["requestId": requestId]
+        if let axTree { dict["axTree"] = axTree }
+        if let axDiff { dict["axDiff"] = axDiff }
+        if let screenshot { dict["screenshot"] = screenshot }
+        if let screenshotWidthPx { dict["screenshotWidthPx"] = screenshotWidthPx }
+        if let screenshotHeightPx { dict["screenshotHeightPx"] = screenshotHeightPx }
+        if let screenWidthPt { dict["screenWidthPt"] = screenWidthPt }
+        if let screenHeightPt { dict["screenHeightPt"] = screenHeightPt }
+        if let executionResult { dict["executionResult"] = executionResult }
+        if let executionError { dict["executionError"] = executionError }
+        if let secondaryWindows { dict["secondaryWindows"] = secondaryWindows }
+        return dict
+    }
+}
+
+// MARK: - App Control
+
+/// Lifecycle state of the target app at the moment of observation.
+enum HostAppControlState: String {
+    case running
+    case missing
+    case minimized
+}
+
+/// Window bounds in points for the focused window of the target app.
+struct WindowBounds: Equatable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    func toDictionary() -> [String: Any] {
+        ["x": x, "y": y, "width": width, "height": height]
+    }
+}
+
+/// Payload posted back to the daemon with the result of a host app-control action.
+struct HostAppControlResultPayload {
+    let requestId: String
+    let state: HostAppControlState
+    let pngBase64: String?
+    let windowBounds: WindowBounds?
+    let executionResult: String?
+    let executionError: String?
+
+    init(
+        requestId: String,
+        state: HostAppControlState,
+        pngBase64: String? = nil,
+        windowBounds: WindowBounds? = nil,
+        executionResult: String? = nil,
+        executionError: String? = nil
+    ) {
+        self.requestId = requestId
+        self.state = state
+        self.pngBase64 = pngBase64
+        self.windowBounds = windowBounds
+        self.executionResult = executionResult
+        self.executionError = executionError
+    }
+
+    func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "requestId": requestId,
+            "state": state.rawValue,
+        ]
+        if let pngBase64 { dict["pngBase64"] = pngBase64 }
+        if let windowBounds { dict["windowBounds"] = windowBounds.toDictionary() }
+        if let executionResult { dict["executionResult"] = executionResult }
+        if let executionError { dict["executionError"] = executionError }
+        return dict
+    }
+}
+
+/// A single step inside `.sequence`: one key press with optional modifiers,
+/// hold duration, and post-press gap. Decoded from snake_case wire keys.
+struct HostAppControlSequenceStep {
+    let key: String
+    let modifiers: [String]?
+    let durationMs: Int?
+    let gapMs: Int?
+
+    init(
+        key: String,
+        modifiers: [String]? = nil,
+        durationMs: Int? = nil,
+        gapMs: Int? = nil
+    ) {
+        self.key = key
+        self.modifiers = modifiers
+        self.durationMs = durationMs
+        self.gapMs = gapMs
+    }
+
+    static func from(dictionary dict: [String: Any]) throws -> HostAppControlSequenceStep {
+        guard let key = dict["key"] as? String else {
+            throw JsonRpcDispatchError.invalidParams("sequence step requires key")
+        }
+        return HostAppControlSequenceStep(
+            key: key,
+            modifiers: dict["modifiers"] as? [String],
+            durationMs: (dict["duration_ms"] as? NSNumber)?.intValue,
+            gapMs: (dict["gap_ms"] as? NSNumber)?.intValue
+        )
+    }
+}
+
+/// Discriminated-union payload for app-control input. The wire shape is
+/// `{ "tool": "<variant>", ...fields }` for each variant.
+enum HostAppControlInput {
+    case start(app: String, args: [String]?)
+    case observe(app: String, settleMs: Int?)
+    case press(app: String, key: String, modifiers: [String]?, durationMs: Int?)
+    case combo(app: String, keys: [String], durationMs: Int?)
+    case sequence(app: String, steps: [HostAppControlSequenceStep])
+    case type(app: String, text: String)
+    case click(app: String, x: Double, y: Double, button: String?, double: Bool?)
+    case drag(app: String, fromX: Double, fromY: Double, toX: Double, toY: Double, button: String?)
+    case stop
+
+    /// Whether the tool synthesizes input (CGEvent), which silently no-ops
+    /// without Accessibility. Used to gate-and-prompt before executing so a
+    /// first-time user doesn't get a "successful" action that did nothing.
+    var needsAccessibility: Bool {
+        switch self {
+        case .press, .combo, .sequence, .type, .click, .drag:
+            return true
+        case .start, .observe, .stop:
+            return false
+        }
+    }
+
+    static func from(dictionary dict: [String: Any]) throws -> HostAppControlInput {
+        let tool: String
+        if let explicit = dict["tool"] as? String {
+            tool = explicit
+        } else if let toolName = dict["toolName"] as? String {
+            // Derive the variant by stripping the `app_control_` prefix.
+            tool = toolName.hasPrefix("app_control_")
+                ? String(toolName.dropFirst("app_control_".count))
+                : toolName
+        } else {
+            throw JsonRpcDispatchError.invalidParams("app control input requires tool")
+        }
+
+        func requireString(_ key: String) throws -> String {
+            guard let value = dict[key] as? String else {
+                throw JsonRpcDispatchError.invalidParams("app control \(tool) requires \(key)")
+            }
+            return value
+        }
+        func requireDouble(_ key: String) throws -> Double {
+            guard let value = (dict[key] as? NSNumber)?.doubleValue else {
+                throw JsonRpcDispatchError.invalidParams("app control \(tool) requires \(key)")
+            }
+            return value
+        }
+
+        switch tool {
+        case "start":
+            return .start(app: try requireString("app"), args: dict["args"] as? [String])
+        case "observe":
+            return .observe(
+                app: try requireString("app"),
+                settleMs: (dict["settle_ms"] as? NSNumber)?.intValue
+            )
+        case "press":
+            return .press(
+                app: try requireString("app"),
+                key: try requireString("key"),
+                modifiers: dict["modifiers"] as? [String],
+                durationMs: (dict["duration_ms"] as? NSNumber)?.intValue
+            )
+        case "combo":
+            guard let keys = dict["keys"] as? [String] else {
+                throw JsonRpcDispatchError.invalidParams("app control combo requires keys")
+            }
+            return .combo(
+                app: try requireString("app"),
+                keys: keys,
+                durationMs: (dict["duration_ms"] as? NSNumber)?.intValue
+            )
+        case "sequence":
+            guard let rawSteps = dict["steps"] as? [[String: Any]] else {
+                throw JsonRpcDispatchError.invalidParams("app control sequence requires steps")
+            }
+            let steps = try rawSteps.map { try HostAppControlSequenceStep.from(dictionary: $0) }
+            return .sequence(app: try requireString("app"), steps: steps)
+        case "type":
+            return .type(app: try requireString("app"), text: try requireString("text"))
+        case "click":
+            return .click(
+                app: try requireString("app"),
+                x: try requireDouble("x"),
+                y: try requireDouble("y"),
+                button: dict["button"] as? String,
+                double: dict["double"] as? Bool
+            )
+        case "drag":
+            return .drag(
+                app: try requireString("app"),
+                fromX: try requireDouble("from_x"),
+                fromY: try requireDouble("from_y"),
+                toX: try requireDouble("to_x"),
+                toY: try requireDouble("to_y"),
+                button: dict["button"] as? String
+            )
+        case "stop":
+            return .stop
+        default:
+            throw JsonRpcDispatchError.invalidParams("Unknown app control tool: \(tool)")
+        }
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AXTreeDiff.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AXTreeDiff.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// Computes a compact diff between two formatted AX tree snapshots.
+/// Returns a human-readable summary of what changed (elements added, removed, value changes, focus changes).
+enum AXTreeDiff {
+
+    /// Stable identity for matching elements across scans.
+    /// Uses immutable structural properties instead of ephemeral IDs (which reset each
+    /// enumeration). Title is intentionally excluded — it can change in place (e.g. a
+    /// button label updating) and should be detected as a "Changed" entry, not remove+add.
+    struct StableKey: Hashable, Comparable {
+        let role: String
+        let identifier: String?
+        let frameX: Int
+        let frameY: Int
+
+        static func < (lhs: StableKey, rhs: StableKey) -> Bool {
+            if lhs.role != rhs.role { return lhs.role < rhs.role }
+            if lhs.frameX != rhs.frameX { return lhs.frameX < rhs.frameX }
+            return lhs.frameY < rhs.frameY
+        }
+    }
+
+    struct ElementSnapshot: Hashable {
+        let id: Int
+        let role: String
+        let title: String?
+        let value: String?
+        let isFocused: Bool
+        let isEnabled: Bool
+    }
+
+    /// Produce a compact diff summary between two AX tree element lists.
+    /// Returns nil if the trees are identical.
+    ///
+    /// Elements are matched by stable structural identity (role, identifier, frame
+    /// position) rather than ephemeral IDs, which reset each enumeration and shift
+    /// when elements are inserted or removed. Uses multiset matching per key so
+    /// duplicate elements (same structural identity) are individually tracked.
+    static func diff(previous: [AXElement], current: [AXElement]) -> String? {
+        let prevFlat = AccessibilityTreeEnumerator.flattenElements(previous)
+        let currFlat = AccessibilityTreeEnumerator.flattenElements(current)
+        return computeDiff(prevFlat: prevFlat, currFlat: currFlat)
+    }
+
+    /// Diff overload accepting pre-flattened element arrays to avoid redundant traversals.
+    static func diff(previousFlat: [AXElement], currentFlat: [AXElement]) -> String? {
+        return computeDiff(prevFlat: previousFlat, currFlat: currentFlat)
+    }
+
+    private static func computeDiff(prevFlat: [AXElement], currFlat: [AXElement]) -> String? {
+        // Build multimaps so duplicate structural keys are preserved
+        var prevByKey: [StableKey: [ElementSnapshot]] = [:]
+        for el in prevFlat {
+            prevByKey[stableKey(of: el), default: []].append(snapshot(of: el))
+        }
+        var currByKey: [StableKey: [ElementSnapshot]] = [:]
+        for el in currFlat {
+            currByKey[stableKey(of: el), default: []].append(snapshot(of: el))
+        }
+
+        var changes: [String] = []
+        let allKeys = Set(prevByKey.keys).union(currByKey.keys).sorted()
+
+        for key in allKeys {
+            var unmatchedPrev = prevByKey[key] ?? []
+            var unmatchedCurr = currByKey[key] ?? []
+
+            // Remove identical pairs (unchanged elements) using frequency map for O(n)
+            var currCounts: [ElementSnapshot: Int] = [:]
+            for snap in unmatchedCurr {
+                currCounts[snap, default: 0] += 1
+            }
+            unmatchedPrev = unmatchedPrev.filter { snap in
+                if let count = currCounts[snap], count > 0 {
+                    currCounts[snap] = count - 1
+                    return false
+                }
+                return true
+            }
+            // currCounts now holds only unmatched remainder counts
+            var remainderCounts = currCounts
+            unmatchedCurr = unmatchedCurr.filter { snap in
+                if let count = remainderCounts[snap], count > 0 {
+                    remainderCounts[snap] = count - 1
+                    return true
+                }
+                return false
+            }
+
+            // Pair remaining as changes (same structural key, different state)
+            let paired = min(unmatchedPrev.count, unmatchedCurr.count)
+            for i in 0..<paired {
+                let prev = unmatchedPrev[i]
+                let curr = unmatchedCurr[i]
+
+                var elementChanges: [String] = []
+                let label = curr.title ?? curr.role
+
+                if prev.value != curr.value {
+                    let oldVal = prev.value ?? "(empty)"
+                    let newVal = curr.value ?? "(empty)"
+                    let truncOld = oldVal.count > 30 ? String(oldVal.prefix(30)) + "..." : oldVal
+                    let truncNew = newVal.count > 30 ? String(newVal.prefix(30)) + "..." : newVal
+                    elementChanges.append("value: \"\(truncOld)\" → \"\(truncNew)\"")
+                }
+                if prev.isFocused != curr.isFocused {
+                    elementChanges.append(curr.isFocused ? "gained focus" : "lost focus")
+                }
+                if prev.isEnabled != curr.isEnabled {
+                    elementChanges.append(curr.isEnabled ? "enabled" : "disabled")
+                }
+                if prev.title != curr.title {
+                    elementChanges.append("title: \"\(prev.title ?? "(none)")\" → \"\(curr.title ?? "(none)")\"")
+                }
+
+                if !elementChanges.isEmpty {
+                    changes.append("~ Changed: [\(curr.id)] \(label) — \(elementChanges.joined(separator: ", "))")
+                }
+            }
+
+            // Extra in prev = removed
+            for i in paired..<unmatchedPrev.count {
+                let snap = unmatchedPrev[i]
+                let label = snap.title ?? snap.role
+                changes.append("- Removed: [\(snap.id)] \(label)")
+            }
+
+            // Extra in curr = added
+            for i in paired..<unmatchedCurr.count {
+                let snap = unmatchedCurr[i]
+                let label = snap.title ?? snap.role
+                changes.append("+ Added: [\(snap.id)] \(label)")
+            }
+        }
+
+        guard !changes.isEmpty else { return nil }
+
+        // If more than half the elements changed on a non-trivial page, it likely navigated —
+        // the per-element diff is noise. Return a short sentinel instead of nil so the caller
+        // knows a diff was computed (avoiding the full previous-tree fallback in the inference layer).
+        let totalElements = max(prevFlat.count, currFlat.count)
+        if totalElements >= 10 && changes.count > totalElements / 2 {
+            return "CHANGES SINCE LAST ACTION:\nPage navigated — UI changed substantially (\(changes.count) of \(totalElements) elements differ). Refer to the current screen state below."
+        }
+
+        return "CHANGES SINCE LAST ACTION:\n" + changes.joined(separator: "\n")
+    }
+
+    private static func stableKey(of element: AXElement) -> StableKey {
+        StableKey(
+            role: element.role,
+            identifier: element.identifier,
+            frameX: Int(element.frame.origin.x),
+            frameY: Int(element.frame.origin.y)
+        )
+    }
+
+    private static func snapshot(of element: AXElement) -> ElementSnapshot {
+        ElementSnapshot(
+            id: element.id,
+            role: element.role,
+            title: element.title,
+            value: element.value,
+            isFocused: element.isFocused,
+            isEnabled: element.isEnabled
+        )
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AccessibilityTree.swift
@@ -1,0 +1,669 @@
+import ApplicationServices
+import AppKit
+import os
+
+private let log = Logger(subsystem: "ai.vellum.mac-helper", category: "AXTree")
+
+struct AXElement: Identifiable {
+    let id: Int
+    let role: String
+    let title: String?
+    let value: String?
+    let frame: CGRect
+    let isEnabled: Bool
+    let isFocused: Bool
+    let children: [AXElement]
+    let roleDescription: String?
+    let identifier: String?
+    let url: String?
+    let placeholderValue: String?
+}
+
+struct WindowInfo {
+    let elements: [AXElement]
+    let windowTitle: String
+    let appName: String
+}
+
+protocol AccessibilityTreeProviding: Sendable {
+    func enumerateCurrentWindow() async -> (elements: [AXElement], windowTitle: String, appName: String, pid: pid_t)?
+    func enumerateSecondaryWindows(excludingPID: pid_t?, maxWindows: Int) async -> [WindowInfo]
+}
+
+/// Enumerates macOS accessibility trees for the focused window and any
+/// secondary windows of interest. All AX IPC runs off the main thread so a
+/// slow or unresponsive target app cannot stall the caller past the system
+/// AppHang threshold — AX operations are synchronous Mach IPC bound to the
+/// *target* process's run loop, not the caller's, so running them on a
+/// background queue keeps the caller responsive without changing AX semantics.
+///
+/// Thread safety: each caller is expected to create a fresh enumerator and
+/// await calls on it sequentially. Under that invariant, instance state
+/// (`nextId`, `lastTargetPid`, `totalElementsEnumerated`) has no cross-task
+/// contention. Static caches (`_enhancedAXEnabled`, `_lastFocusedPID`) are
+/// shared across enumerators and are guarded by `stateLock`.
+final class AccessibilityTreeEnumerator: AccessibilityTreeProviding, @unchecked Sendable {
+    private var nextId = 1
+    /// PID of the last successfully enumerated target app, used to resolve the
+    /// correct app when our own window is frontmost.
+    private var lastTargetPid: pid_t?
+
+    /// Track total elements enumerated in current call to prevent infinite loops
+    private var totalElementsEnumerated = 0
+    /// Maximum elements to enumerate before bailing out (protects against circular refs)
+    private let maxElementsPerEnumeration = 10000
+
+    /// Per-call timeout (in seconds) for AX API calls to a target app. If the
+    /// target is unresponsive, each `AXUIElement*` call returns
+    /// `kAXErrorCannotComplete` after this duration instead of blocking
+    /// indefinitely. Sized to bound worst-case latency in fallback paths that
+    /// probe multiple apps, while staying generous enough for slow/heavy
+    /// targets (Chrome with many tabs, Electron during GC) where individual
+    /// attribute reads can momentarily take upwards of 1s.
+    private static let axMessagingTimeoutSeconds: Float = 3.0
+
+    static let interactiveRoles: Set<String> = [
+        "AXButton", "AXTextField", "AXTextArea", "AXCheckBox", "AXRadioButton",
+        "AXPopUpButton", "AXComboBox", "AXSlider", "AXLink", "AXMenuItem",
+        "AXMenuButton", "AXIncrementor", "AXDisclosureTriangle", "AXTab",
+        "AXTabGroup", "AXSegmentedControl"
+    ]
+
+    private static let containerRoles: Set<String> = [
+        "AXGroup", "AXScrollArea", "AXSplitGroup", "AXTabGroup", "AXToolbar",
+        "AXTable", "AXOutline", "AXList", "AXBrowser", "AXWebArea", "AXRow",
+        "AXCell", "AXSheet", "AXDrawer",
+        // Web content containers (Chrome, Safari, Electron)
+        "AXSection", "AXForm", "AXLandmarkMain", "AXLandmarkNavigation",
+        "AXLandmarkBanner", "AXLandmarkContentInfo", "AXLandmarkSearch",
+        "AXArticle", "AXDocument", "AXApplication"
+    ]
+
+    /// Guards the shared static caches below. Accessed from the detached tasks
+    /// that run AX enumeration, so every read/write goes through this lock.
+    private static let stateLock = NSLock()
+
+    /// Set of app PIDs where we've already enabled enhanced AX. Guarded by `stateLock`.
+    private nonisolated(unsafe) static var _enhancedAXEnabled: Set<pid_t> = []
+
+    /// Tracks the last non-self focused app PID, written by the live enumerate
+    /// path and read for fast lookup in enumeratePreviousApp(). Guarded by `stateLock`.
+    private nonisolated(unsafe) static var _lastFocusedPID: pid_t?
+
+    /// Atomically insert `pid` into the enhanced-AX cache.
+    /// Returns true if the PID was newly inserted (caller should set the attribute).
+    private static func markEnhancedAXIfNeeded(pid: pid_t) -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _enhancedAXEnabled.insert(pid).inserted
+    }
+
+    private static func setLastFocusedPID(_ pid: pid_t?) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        _lastFocusedPID = pid
+    }
+
+    private static func getLastFocusedPID() -> pid_t? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _lastFocusedPID
+    }
+
+    /// PID of the Electron app that spawned this helper. Computer use observes
+    /// the app *behind* our own UI, and when a CU request is issued from the
+    /// chat the frontmost app is that Electron process — the helper itself is
+    /// LSUIElement/prohibited and never frontmost, so a `Bundle.main` check
+    /// alone never matches. `getppid()` is the host app's PID for the helper's
+    /// lifetime.
+    private static let hostAppPid: pid_t = getppid()
+
+    /// True when `app` is this helper or the Electron host app — neither should
+    /// be observed or controlled by computer use.
+    static func isOwnOrHostApp(_ app: NSRunningApplication) -> Bool {
+        if app.processIdentifier == hostAppPid { return true }
+        if let myId = Bundle.main.bundleIdentifier, app.bundleIdentifier == myId {
+            return true
+        }
+        return false
+    }
+
+    /// PID of the front-most on-screen, layer-0 window not owned by this helper
+    /// or the Electron host — i.e. the app visible behind our UI. `CGWindowList`
+    /// returns windows in front-to-back z-order, so the first match is topmost.
+    static func topmostNonHostWindowPID() -> pid_t? {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard
+            let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID)
+                as? [[String: Any]]
+        else { return nil }
+        let myPID = ProcessInfo.processInfo.processIdentifier
+        let hostPID = getppid()
+        for window in windows {
+            guard
+                let layer = window[kCGWindowLayer as String] as? Int, layer == 0,
+                let ownerPID = window[kCGWindowOwnerPID as String] as? Int
+            else { continue }
+            let pid = pid_t(ownerPID)
+            if pid == myPID || pid == hostPID { continue }
+            return pid
+        }
+        return nil
+    }
+
+    /// Enumerate the focused window of the frontmost non-self app.
+    ///
+    /// Runs the synchronous AX work on a detached task so a slow or
+    /// unresponsive target app cannot block the caller (typically
+    /// `@MainActor`) on Mach IPC.
+    func enumerateCurrentWindow() async -> (elements: [AXElement], windowTitle: String, appName: String, pid: pid_t)? {
+        await Task.detached { [self] in
+            enumerateCurrentWindowSync()
+        }.value
+    }
+
+    private func enumerateCurrentWindowSync() -> (elements: [AXElement], windowTitle: String, appName: String, pid: pid_t)? {
+        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+            log.warning("No frontmost application found")
+            return nil
+        }
+
+        log.debug("Frontmost app: \(frontApp.localizedName ?? "?", privacy: .public) (\(frontApp.bundleIdentifier ?? "no-bundle-id", privacy: .public))")
+
+        // Skip our own helper and the Electron host app — computer use targets
+        // the window behind our UI. Otherwise track the frontmost PID so
+        // enumeratePreviousApp() can reuse it next time we're frontmost.
+        if Self.isOwnOrHostApp(frontApp) {
+            log.info("Skipping own/host app, looking for previous app")
+            return enumeratePreviousAppSync()
+        }
+        Self.setLastFocusedPID(frontApp.processIdentifier)
+
+        let pid = frontApp.processIdentifier
+        let appName = frontApp.localizedName ?? "Unknown"
+        let appElement = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(appElement, Self.axMessagingTimeoutSeconds)
+
+        // Tell apps (especially Chrome, Electron) to expose full web content AX tree.
+        // This is what real assistive technologies do.
+        if Self.markEnhancedAXIfNeeded(pid: pid) {
+            let result = AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+            log.info("Set AXEnhancedUserInterface on \(appName, privacy: .public) (pid \(pid)): \(result == .success ? "success" : "failed (\(result.rawValue))")")
+        }
+
+        var windowValue: CFTypeRef?
+        let windowResult = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue)
+        guard windowResult == .success, let windowRef = windowValue else {
+            log.warning("Failed to get focused window for \(appName, privacy: .public) (pid \(pid)): AXError \(windowResult.rawValue)")
+            if windowResult.rawValue == -25211 {
+                log.error("AX API disabled — Accessibility permission likely not granted for this executable")
+            }
+            return nil
+        }
+        guard CFGetTypeID(windowRef) == AXUIElementGetTypeID() else { return nil }
+        let windowElement = windowRef as! AXUIElement
+
+        let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
+
+        nextId = 1
+        totalElementsEnumerated = 0
+        let elements = enumerateElementSafely(element: windowElement, depth: 0, maxDepth: 25)
+
+        let flat = AccessibilityTreeEnumerator.flattenElements(elements)
+        let interactive = flat.filter { Self.interactiveRoles.contains($0.role) }
+        log.info("Enumerated \(appName, privacy: .public): \(flat.count) total, \(interactive.count) interactive, maxId=\(self.nextId - 1)")
+
+        lastTargetPid = pid
+        return (elements: elements, windowTitle: windowTitle, appName: appName, pid: pid)
+    }
+
+    /// When our own app is focused, find the previously-active app's window
+    /// instead. Prefers the tracked last-focused PID so the agent returns to
+    /// the correct window rather than an arbitrary app from the running-apps
+    /// list, and falls back to probing every regular running app so
+    /// observation remains correct when the tracker is stale (e.g., on
+    /// startup or after a missed workspace activation). Each per-app call
+    /// is individually bounded by `axMessagingTimeoutSeconds`.
+    private func enumeratePreviousAppSync() -> (elements: [AXElement], windowTitle: String, appName: String, pid: pid_t)? {
+        let trackedPID = Self.getLastFocusedPID()
+
+        // Fast path: try the tracked last-focused PID first.
+        if let trackedPID {
+            log.debug("enumeratePreviousApp: trying tracked PID \(trackedPID)")
+            if let result = enumerateAppByPIDSync(trackedPID) {
+                return result
+            }
+            log.debug("enumeratePreviousApp: tracked PID \(trackedPID) failed, falling back to iteration")
+        }
+
+        // z-order fallback: the front-most on-screen window not owned by the
+        // helper or the Electron host is exactly what the screenshot shows, so
+        // the AX tree must describe that same app. This is correct even before
+        // the last-focused PID is tracked (e.g. the first request after startup),
+        // where iterating running apps could otherwise pick an unrelated app and
+        // desync the AX tree from the screenshot.
+        if let topPID = Self.topmostNonHostWindowPID(), topPID != trackedPID,
+           let result = enumerateAppByPIDSync(topPID) {
+            return result
+        }
+
+        let runningApps = NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular && !Self.isOwnOrHostApp($0) && !$0.isTerminated }
+
+        // Try the last-known target app next for deterministic behavior.
+        if let targetPid = lastTargetPid,
+           targetPid != trackedPID,
+           runningApps.contains(where: { $0.processIdentifier == targetPid }),
+           let result = enumerateAppByPIDSync(targetPid) {
+            return result
+        }
+
+        for app in runningApps {
+            let pid = app.processIdentifier
+            if pid == trackedPID { continue } // already tried
+            if pid == lastTargetPid { continue } // already tried
+            if let result = enumerateAppByPIDSync(pid) {
+                return result
+            }
+        }
+        return nil
+    }
+
+    /// Try to enumerate the focused window for a specific PID.
+    /// Returns nil if the app has no focused window or yields no elements.
+    private func enumerateAppByPIDSync(_ pid: pid_t) -> (elements: [AXElement], windowTitle: String, appName: String, pid: pid_t)? {
+        let appElement = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(appElement, Self.axMessagingTimeoutSeconds)
+
+        if Self.markEnhancedAXIfNeeded(pid: pid) {
+            AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+        }
+
+        var windowValue: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue)
+        guard result == .success, let windowRef = windowValue else {
+            let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "Unknown"
+            log.debug("enumerateAppByPID: no focused window for \(appName, privacy: .public) (pid \(pid)): AXError \(result.rawValue)")
+            return nil
+        }
+        guard CFGetTypeID(windowRef) == AXUIElementGetTypeID() else { return nil }
+        let windowElement = windowRef as! AXUIElement
+
+        let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
+        let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "Unknown"
+
+        nextId = 1
+        totalElementsEnumerated = 0
+        let elements = enumerateElementSafely(element: windowElement, depth: 0, maxDepth: 25)
+
+        guard !elements.isEmpty else { return nil }
+        lastTargetPid = pid
+        return (elements: elements, windowTitle: windowTitle, appName: appName, pid: pid)
+    }
+
+    /// Enumerate the focused windows of up to `maxWindows` non-primary apps,
+    /// useful for cross-app observation. Runs off the main thread for the
+    /// same reason as `enumerateCurrentWindow()`.
+    func enumerateSecondaryWindows(excludingPID: pid_t?, maxWindows: Int = 2) async -> [WindowInfo] {
+        await Task.detached { [self] in
+            enumerateSecondaryWindowsSync(excludingPID: excludingPID, maxWindows: maxWindows)
+        }.value
+    }
+
+    private func enumerateSecondaryWindowsSync(excludingPID: pid_t?, maxWindows: Int) -> [WindowInfo] {
+        let runningApps = NSWorkspace.shared.runningApplications
+            .filter { app in
+                app.activationPolicy == .regular
+                    && !app.isTerminated
+                    && !Self.isOwnOrHostApp(app)
+                    && (excludingPID == nil || app.processIdentifier != excludingPID)
+            }
+
+        var results: [WindowInfo] = []
+        for app in runningApps {
+            guard results.count < maxWindows else { break }
+            let pid = app.processIdentifier
+            let appElement = AXUIElementCreateApplication(pid)
+            AXUIElementSetMessagingTimeout(appElement, Self.axMessagingTimeoutSeconds)
+
+            if Self.markEnhancedAXIfNeeded(pid: pid) {
+                AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+            }
+
+            // Get all windows for this app and find the first visible one
+            var windowsRef: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+                  let windows = windowsRef as? [AXUIElement],
+                  !windows.isEmpty else { continue }
+
+            // Find a window that is on the main display (skip external monitors)
+            let mainDisplayBounds = CGDisplayBounds(CGMainDisplayID())
+            guard let visibleWindow = windows.first(where: {
+                let frame = getFrameAttribute($0)
+                return frame.width > 50 && frame.height > 50 && frame.intersects(mainDisplayBounds)
+            }) else { continue }
+
+            let windowTitle = getStringAttribute(visibleWindow, kAXTitleAttribute as CFString) ?? "Untitled"
+            let appName = app.localizedName ?? "Unknown"
+
+            nextId = 1
+            totalElementsEnumerated = 0
+            let elements = enumerateElementSafely(element: visibleWindow, depth: 0, maxDepth: 15) // shallower for secondary
+            guard !elements.isEmpty else { continue }
+
+            results.append(WindowInfo(elements: elements, windowTitle: windowTitle, appName: appName))
+            log.info("Secondary window: \(appName, privacy: .public) — \"\(windowTitle)\"")
+        }
+
+        return results
+    }
+
+    /// Safe wrapper around enumerateElement that prevents infinite loops.
+    /// File save dialogs (especially with Downloads) can have corrupted AX trees or circular references.
+    private func enumerateElementSafely(element: AXUIElement, depth: Int, maxDepth: Int) -> [AXElement] {
+        // Bail out if we've processed too many elements (circular reference protection)
+        guard totalElementsEnumerated < maxElementsPerEnumeration else {
+            log.warning("Hit max element limit (\(self.maxElementsPerEnumeration)) during enumeration — stopping to prevent infinite loop")
+            return []
+        }
+
+        totalElementsEnumerated += 1
+        return enumerateElement(element: element, depth: depth, maxDepth: maxDepth)
+    }
+
+    private func enumerateElement(element: AXUIElement, depth: Int, maxDepth: Int) -> [AXElement] {
+        guard depth < maxDepth else { return [] }
+
+        let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? ""
+        let title = getStringAttribute(element, kAXTitleAttribute as CFString)
+            ?? getStringAttribute(element, kAXDescriptionAttribute as CFString)
+        let value = getValueAttribute(element)
+        let roleDescription = getStringAttribute(element, kAXRoleDescriptionAttribute as CFString)
+        let identifier = getStringAttribute(element, kAXIdentifierAttribute as CFString)
+        let placeholderValue = getStringAttribute(element, kAXPlaceholderValueAttribute as CFString)
+        let isEnabled = getBoolAttribute(element, kAXEnabledAttribute as CFString) ?? true
+        let isFocused = getBoolAttribute(element, kAXFocusedAttribute as CFString) ?? false
+        let frame = getFrameAttribute(element)
+        let url = getStringAttribute(element, "AXURL" as CFString)
+
+        let isInteractive = Self.interactiveRoles.contains(role)
+        let isContainer = Self.containerRoles.contains(role)
+        let hasTextContent = (title != nil && !title!.isEmpty) || (value != nil && !value!.isEmpty)
+        let isStaticText = role == "AXStaticText" || role == "AXHeading"
+
+        // Enumerate children with safety checks
+        var childElements: [AXElement] = []
+        var childrenRef: CFTypeRef?
+
+        if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+           let children = childrenRef as? [AXUIElement] {
+            // Sanity check: if children array is suspiciously large, it might be corrupted
+            // Skip children enumeration but continue processing current element
+            if children.count >= 1000 {
+                log.warning("Element has \(children.count) children — likely corrupted, skipping children enumeration")
+            } else {
+                for (index, child) in children.enumerated() {
+                    // Stop if we've hit the limit mid-enumeration
+                    guard totalElementsEnumerated < maxElementsPerEnumeration else {
+                        log.warning("Hit element limit while enumerating children (\(index)/\(children.count) processed)")
+                        break
+                    }
+
+                    // Recursively enumerate with the safe wrapper
+                    childElements.append(contentsOf: enumerateElementSafely(element: child, depth: depth + 1, maxDepth: maxDepth))
+                }
+            }
+        }
+
+        if isInteractive {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id,
+                role: role,
+                title: title,
+                value: value,
+                frame: frame,
+                isEnabled: isEnabled,
+                isFocused: isFocused,
+                children: [], // Flatten interactive elements
+                roleDescription: roleDescription,
+                identifier: identifier,
+                url: url,
+                placeholderValue: placeholderValue
+            )]
+        }
+
+        if isStaticText && hasTextContent {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id,
+                role: role,
+                title: title,
+                value: value,
+                frame: frame,
+                isEnabled: isEnabled,
+                isFocused: isFocused,
+                children: [],
+                roleDescription: roleDescription,
+                identifier: identifier,
+                url: url,
+                placeholderValue: placeholderValue
+            )]
+        }
+
+        if isContainer && !childElements.isEmpty {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id,
+                role: role,
+                title: title,
+                value: value,
+                frame: frame,
+                isEnabled: isEnabled,
+                isFocused: isFocused,
+                children: childElements,
+                roleDescription: roleDescription,
+                identifier: identifier,
+                url: url,
+                placeholderValue: placeholderValue
+            )]
+        }
+
+        // Skip this element but keep children
+        return childElements
+    }
+
+    // MARK: - AX Attribute Helpers
+
+    private func getStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    private func getBoolAttribute(_ element: AXUIElement, _ attribute: CFString) -> Bool? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return (value as? NSNumber)?.boolValue
+    }
+
+    private func getValueAttribute(_ element: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &value) == .success else { return nil }
+        if let str = value as? String { return str }
+        if let num = value as? NSNumber { return num.stringValue }
+        return nil
+    }
+
+    private func getFrameAttribute(_ element: AXUIElement) -> CGRect {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+
+        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success,
+              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success
+        else { return .zero }
+
+        var point = CGPoint.zero
+        var size = CGSize.zero
+
+        if let posRef = positionValue, CFGetTypeID(posRef) == AXValueGetTypeID() {
+            AXValueGetValue(posRef as! AXValue, .cgPoint, &point)
+        }
+        if let sizeRef = sizeValue, CFGetTypeID(sizeRef) == AXValueGetTypeID() {
+            AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
+        }
+
+        return CGRect(origin: point, size: size)
+    }
+
+    // MARK: - Formatting
+
+    static func formatAXTree(elements: [AXElement], windowTitle: String, appName: String) -> String {
+        var lines: [String] = []
+        lines.append("Window: \"\(windowTitle)\" (\(appName))")
+
+        var interactive: [String] = []
+        var staticTexts: [String] = []
+        var prunedCount = 0
+        collectFormatted(elements: elements, interactive: &interactive, staticTexts: &staticTexts, prunedCount: &prunedCount)
+
+        if !interactive.isEmpty {
+            lines.append("Interactive elements:")
+            for line in interactive {
+                lines.append("  \(line)")
+            }
+            if prunedCount > 0 {
+                lines.append("  (\(prunedCount) unlabeled elements hidden)")
+            }
+        }
+
+        if !staticTexts.isEmpty {
+            lines.append("")
+            lines.append("Visible text:")
+            for text in staticTexts.prefix(30) {
+                lines.append("  \(text)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Roles that represent text inputs — always shown even without a title,
+    /// since the model may need to click/type in them.
+    private static let textInputRoles: Set<String> = [
+        "AXTextField", "AXTextArea", "AXComboBox"
+    ]
+
+    private static func collectFormatted(elements: [AXElement], interactive: inout [String], staticTexts: inout [String], prunedCount: inout Int) {
+        for element in elements {
+            let isInteractiveRole = interactiveRoles.contains(element.role)
+            let isText = element.role == "AXStaticText" || element.role == "AXHeading"
+
+            if isInteractiveRole {
+                // Skip unlabeled non-text elements — the model can't meaningfully target
+                // "button at (431, 56)" without knowing what it does.
+                let hasTitle = element.title != nil && !element.title!.isEmpty
+                let isTextInput = textInputRoles.contains(element.role)
+                let hasPlaceholder = element.placeholderValue != nil && !element.placeholderValue!.isEmpty
+                let hasUrl = element.url != nil && !element.url!.isEmpty
+
+                if !hasTitle && !isTextInput && !element.isFocused && !hasPlaceholder && !hasUrl {
+                    prunedCount += 1
+                    collectFormatted(elements: element.children, interactive: &interactive, staticTexts: &staticTexts, prunedCount: &prunedCount)
+                    continue
+                }
+
+                let cleanedRole = cleanRole(element.role)
+                let centerX = Int(element.frame.midX)
+                let centerY = Int(element.frame.midY)
+                var line = "[\(element.id)] \(cleanedRole)"
+                if let title = element.title, !title.isEmpty {
+                    line += " \"\(title)\""
+                }
+                line += " at (\(centerX), \(centerY))"
+                if element.isFocused { line += " FOCUSED" }
+                if !element.isEnabled { line += " disabled" }
+                if let value = element.value, !value.isEmpty {
+                    let truncated = value.count > 50 ? String(value.prefix(50)) + "..." : value
+                    line += " value: \"\(truncated)\""
+                } else if let placeholder = element.placeholderValue, !placeholder.isEmpty {
+                    line += " placeholder: \"\(placeholder)\""
+                }
+                if let url = element.url, !url.isEmpty {
+                    line += " → \(url)"
+                }
+                interactive.append(line)
+            } else if isText {
+                if let title = element.title, !title.isEmpty {
+                    staticTexts.append(title)
+                } else if let value = element.value, !value.isEmpty {
+                    staticTexts.append(value)
+                }
+            }
+
+            collectFormatted(elements: element.children, interactive: &interactive, staticTexts: &staticTexts, prunedCount: &prunedCount)
+        }
+    }
+
+    private static func cleanRole(_ role: String) -> String {
+        var cleaned = role
+        if cleaned.hasPrefix("AX") {
+            cleaned = String(cleaned.dropFirst(2))
+        }
+        // Split camelCase
+        var result = ""
+        for char in cleaned {
+            if char.isUppercase && !result.isEmpty {
+                result += " "
+            }
+            result += String(char).lowercased()
+        }
+        return result
+    }
+
+    /// Format secondary windows into a compact text representation.
+    /// Uses a condensed format (interactive elements only) to minimize token cost.
+    static func formatSecondaryWindows(_ windows: [WindowInfo]) -> String? {
+        guard !windows.isEmpty else { return nil }
+
+        var lines: [String] = ["OTHER VISIBLE WINDOWS:"]
+        for window in windows {
+            lines.append("")
+            lines.append("  Window: \"\(window.windowTitle)\" (\(window.appName))")
+
+            var interactive: [String] = []
+            var staticTexts: [String] = []
+            var prunedCount = 0
+            collectFormatted(elements: window.elements, interactive: &interactive, staticTexts: &staticTexts, prunedCount: &prunedCount)
+
+            if !interactive.isEmpty {
+                for line in interactive.prefix(15) { // Cap per window to limit tokens
+                    lines.append("    \(line)")
+                }
+                if interactive.count > 15 {
+                    lines.append("    ... and \(interactive.count - 15) more elements")
+                }
+            }
+
+            if !staticTexts.isEmpty {
+                for text in staticTexts.prefix(10) {
+                    lines.append("    \(text)")
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    static func flattenElements(_ elements: [AXElement]) -> [AXElement] {
+        var result: [AXElement] = []
+        for element in elements {
+            result.append(element)
+            result.append(contentsOf: flattenElements(element.children))
+        }
+        return result
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
@@ -1,0 +1,439 @@
+import CoreGraphics
+import AppKit
+import ApplicationServices
+import os
+
+enum ExecutorError: LocalizedError {
+    case eventCreationFailed
+    case missingCoordinates
+    case missingText
+    case missingKey
+    case unknownKey(String)
+    case accessibilityNotGranted
+    case appNotFound(String)
+    case appleScriptError(String)
+    case appleScriptMissingScript
+    case appleScriptTimeout
+    case clipboardMismatch
+
+    var errorDescription: String? {
+        switch self {
+        case .eventCreationFailed: return "Failed to create CGEvent"
+        case .missingCoordinates: return "Action requires x,y coordinates"
+        case .missingText: return "Type action requires text"
+        case .missingKey: return "Key action requires key name"
+        case .unknownKey(let key): return "Unknown key: \(key)"
+        case .accessibilityNotGranted: return "Accessibility permission not granted"
+        case .appNotFound(let name): return "Application not found: \(name)"
+        case .appleScriptError(let msg): return "AppleScript error: \(msg)"
+        case .appleScriptMissingScript: return "run_applescript requires a script"
+        case .appleScriptTimeout: return "AppleScript timed out after 5 seconds"
+        case .clipboardMismatch: return "Clipboard contents changed before paste injection; aborting to prevent wrong text from being typed"
+        }
+    }
+}
+
+private let log = Logger(subsystem: "ai.vellum.mac-helper", category: "ActionExecutor")
+
+final class ActionExecutor {
+    private let eventSource: CGEventSource?
+
+    init() {
+        eventSource = CGEventSource(stateID: .hidSystemState)
+    }
+
+    static func checkAccessibilityPermission(prompt: Bool = false) -> Bool {
+        let promptKey = "AXTrustedCheckOptionPrompt" as CFString
+        let options = [promptKey: prompt] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
+    // MARK: - Mouse Actions
+
+    func click(at point: CGPoint) throws {
+        try mouseMove(to: point)
+        usleep(30_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    func doubleClick(at point: CGPoint) throws {
+        try click(at: point)
+        usleep(100_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseDown.setIntegerValueField(.mouseEventClickState, value: 2)
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseUp.setIntegerValueField(.mouseEventClickState, value: 2)
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    func rightClick(at point: CGPoint) throws {
+        try mouseMove(to: point)
+        usleep(30_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .rightMouseDown, mouseCursorPosition: point, mouseButton: .right) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .rightMouseUp, mouseCursorPosition: point, mouseButton: .right) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    private func mouseMove(to point: CGPoint) throws {
+        guard let moveEvent = CGEvent(mouseEventSource: eventSource, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        moveEvent.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Keyboard Actions
+
+    func typeText(_ text: String) throws {
+        let pasteboard = NSPasteboard.general
+        let previousContents = pasteboard.string(forType: .string)
+
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        // Capture changeCount immediately after our write, before any sleep or
+        // keystroke that frees the thread for other writers. This ensures the
+        // baseline reflects only OUR write, not an intervening writer's.
+        // Reference: https://developer.apple.com/documentation/appkit/nspasteboard/changecount
+        let postWriteChangeCount = pasteboard.changeCount
+
+        // Pre-injection equality check: verify the clipboard now holds exactly
+        // what we queued before issuing the paste keystroke. If another process
+        // wrote to the clipboard between our setString and this read-back, the
+        // paste would inject wrong content — catch that here instead of silently
+        // typing unintended text.
+        let verifiedContents = pasteboard.string(forType: .string)
+        guard verifiedContents == text else {
+            // Another process updated the clipboard between our setString and
+            // this read-back. We don't know what the current state should be, so
+            // restoring previousContents would overwrite that other process's
+            // data. Leave the clipboard as-is and surface a clear error.
+            log.warning("Clipboard read-back mismatch — another process may have modified the pasteboard; skipping injection")
+            throw ExecutorError.clipboardMismatch
+        }
+
+        try keyCombo(keyCode: 9, modifiers: .maskCommand) // Cmd+V
+        usleep(100_000)
+
+        // Restore clipboard after delay, but only if no one else has written
+        // to the pasteboard in the meantime (e.g. the user clicking "Copy").
+        let saved = previousContents
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let pb = NSPasteboard.general
+            guard pb.changeCount == postWriteChangeCount else {
+                // Another writer (e.g. copy button) claimed the pasteboard — skip restore.
+                return
+            }
+            pb.clearContents()
+            if let saved = saved {
+                pb.setString(saved, forType: .string)
+            }
+        }
+    }
+
+    func pressKey(_ keyString: String) throws {
+        let parts = keyString.lowercased().split(separator: "+").map(String.init)
+        var modifiers: CGEventFlags = []
+        var keyName = ""
+
+        for part in parts {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            switch trimmed {
+            case "cmd", "command":
+                modifiers.insert(.maskCommand)
+            case "shift":
+                modifiers.insert(.maskShift)
+            case "option", "alt":
+                modifiers.insert(.maskAlternate)
+            case "ctrl", "control":
+                modifiers.insert(.maskControl)
+            default:
+                keyName = trimmed
+            }
+        }
+
+        guard let keyCode = Self.keyCodeMap[keyName] else {
+            throw ExecutorError.unknownKey(keyName)
+        }
+
+        try keyCombo(keyCode: keyCode, modifiers: modifiers)
+    }
+
+    func keyCombo(keyCode: CGKeyCode, modifiers: CGEventFlags) throws {
+        guard let keyDown = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: true) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        keyDown.flags = modifiers
+        keyDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: false) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        keyUp.flags = modifiers
+        keyUp.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Scroll
+
+    func scroll(at point: CGPoint, direction: String, amount: Int) throws {
+        try mouseMove(to: point)
+        usleep(30_000)
+
+        let multiplier = amount * 5
+        var dy: Int32 = 0
+        var dx: Int32 = 0
+
+        switch direction.lowercased() {
+        case "up": dy = Int32(multiplier)
+        case "down": dy = -Int32(multiplier)
+        case "left": dx = Int32(multiplier)
+        case "right": dx = -Int32(multiplier)
+        default: break
+        }
+
+        guard let scrollEvent = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: 2, wheel1: dy, wheel2: dx, wheel3: 0) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        scrollEvent.post(tap: .cgSessionEventTap)
+    }
+
+    // MARK: - Dispatch
+
+    @discardableResult
+    func execute(_ action: AgentAction) async throws -> String? {
+        switch action.type {
+        case .click:
+            guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
+            try click(at: CGPoint(x: x, y: y))
+        case .doubleClick:
+            guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
+            try doubleClick(at: CGPoint(x: x, y: y))
+        case .rightClick:
+            guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
+            try rightClick(at: CGPoint(x: x, y: y))
+        case .type:
+            guard let text = action.text else { throw ExecutorError.missingText }
+            try typeText(text)
+        case .key:
+            guard let key = action.key else { throw ExecutorError.missingKey }
+            try pressKey(key)
+        case .scroll:
+            let x = action.x ?? 0
+            let y = action.y ?? 0
+            let direction = action.scrollDirection ?? "down"
+            let amount = action.scrollAmount ?? 3
+            try scroll(at: CGPoint(x: x, y: y), direction: direction, amount: amount)
+        case .drag:
+            guard let fromX = action.x, let fromY = action.y else { throw ExecutorError.missingCoordinates }
+            guard let endX = action.toX, let endY = action.toY else { throw ExecutorError.missingCoordinates }
+            try drag(from: CGPoint(x: fromX, y: fromY), to: CGPoint(x: endX, y: endY))
+        case .openApp:
+            guard let appName = action.appName else { throw ExecutorError.appNotFound("(no name)") }
+            try await openApp(name: appName)
+        case .runAppleScript:
+            guard let source = action.script else { throw ExecutorError.appleScriptMissingScript }
+            return try await runAppleScript(source)
+        case .wait:
+            let ms = action.waitDuration ?? 500
+            try await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
+        case .done, .respond:
+            break
+        }
+        return nil
+    }
+
+    // MARK: - AppleScript
+
+    func runAppleScript(_ source: String) async throws -> String? {
+        // Run osascript as a subprocess so we can kill it on timeout and avoid blocking the main thread
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", source]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        // 5-second timeout — terminate the subprocess if it takes too long
+        let timeoutTask = Task {
+            try await Task.sleep(nanoseconds: 5_000_000_000)
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            // Assign the handler before launching: a fast script (e.g.
+            // `return "ok"`) can exit before run() returns, and a handler set
+            // afterward would miss the termination, leaving the continuation
+            // suspended until the helper/proxy timeout.
+            process.terminationHandler = { proc in
+                timeoutTask.cancel()
+
+                let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let errorOutput = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                if proc.terminationReason == .uncaughtSignal {
+                    continuation.resume(throwing: ExecutorError.appleScriptTimeout)
+                } else if proc.terminationStatus != 0 {
+                    let message = errorOutput ?? "Unknown AppleScript error (exit \(proc.terminationStatus))"
+                    continuation.resume(throwing: ExecutorError.appleScriptError(message))
+                } else {
+                    continuation.resume(returning: output)
+                }
+            }
+            do {
+                try process.run()
+            } catch {
+                timeoutTask.cancel()
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    // MARK: - Drag
+
+    func drag(from startPoint: CGPoint, to endPoint: CGPoint) throws {
+        try mouseMove(to: startPoint)
+        usleep(30_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: startPoint, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        // Interpolate drag path for smooth movement
+        let steps = 10
+        for i in 1...steps {
+            let t = CGFloat(i) / CGFloat(steps)
+            let point = CGPoint(
+                x: startPoint.x + (endPoint.x - startPoint.x) * t,
+                y: startPoint.y + (endPoint.y - startPoint.y) * t
+            )
+            guard let dragEvent = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDragged, mouseCursorPosition: point, mouseButton: .left) else {
+                throw ExecutorError.eventCreationFailed
+            }
+            dragEvent.post(tap: .cghidEventTap)
+            usleep(10_000)
+        }
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: endPoint, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Open App
+
+    static let appAliases: [String: String] = [
+        "chrome": "Google Chrome",
+        "vs code": "Visual Studio Code",
+        "vscode": "Visual Studio Code",
+        "edge": "Microsoft Edge",
+        "word": "Microsoft Word",
+        "excel": "Microsoft Excel",
+        "powerpoint": "Microsoft PowerPoint",
+        "outlook": "Microsoft Outlook",
+        "teams": "Microsoft Teams",
+        "iterm": "iTerm",
+    ]
+
+    func openApp(name: String) async throws {
+        let workspace = NSWorkspace.shared
+
+        // 1. Check running apps for exact or case-insensitive match
+        let nameLower = name.lowercased()
+        if let runningApp = workspace.runningApplications.first(where: {
+            $0.localizedName?.lowercased() == nameLower
+        }) {
+            runningApp.activate()
+            try await Task.sleep(nanoseconds: 300_000_000) // 300ms for app to come forward
+            return
+        }
+
+        // 2. Resolve aliases
+        let resolvedName = Self.appAliases[nameLower] ?? name
+
+        // 3. Search common application directories
+        let searchDirs = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            NSString("~/Applications").expandingTildeInPath,
+        ]
+
+        for dir in searchDirs {
+            let appPath = "\(dir)/\(resolvedName).app"
+            let appURL = URL(fileURLWithPath: appPath)
+            if FileManager.default.fileExists(atPath: appPath) {
+                let config = NSWorkspace.OpenConfiguration()
+                config.activates = true
+                try await workspace.openApplication(at: appURL, configuration: config)
+                return
+            }
+        }
+
+        // 4. Try case-insensitive filesystem search in /Applications
+        if let found = try? FileManager.default.contentsOfDirectory(atPath: "/Applications")
+            .first(where: {
+                $0.lowercased() == "\(resolvedName.lowercased()).app"
+            }) {
+            let appURL = URL(fileURLWithPath: "/Applications/\(found)")
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            try await workspace.openApplication(at: appURL, configuration: config)
+            return
+        }
+
+        throw ExecutorError.appNotFound(name)
+    }
+
+    // MARK: - Key Code Map
+
+    static let keyCodeMap: [String: CGKeyCode] = [
+        "a": 0, "b": 11, "c": 8, "d": 2, "e": 14, "f": 3, "g": 5, "h": 4,
+        "i": 34, "j": 38, "k": 40, "l": 37, "m": 46, "n": 45, "o": 31, "p": 35,
+        "q": 12, "r": 15, "s": 1, "t": 17, "u": 32, "v": 9, "w": 13, "x": 7,
+        "y": 16, "z": 6,
+        "0": 29, "1": 18, "2": 19, "3": 20, "4": 21, "5": 23, "6": 22, "7": 26,
+        "8": 28, "9": 25,
+        "enter": 36, "return": 36, "tab": 48, "space": 49, "escape": 53, "esc": 53,
+        "backspace": 51, "delete": 51, "forwarddelete": 117,
+        "up": 126, "down": 125, "left": 123, "right": 124,
+        "home": 115, "end": 119, "pageup": 116, "pagedown": 121,
+        "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
+        "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
+        "-": 27, "=": 24, "[": 33, "]": 30, "\\": 42, ";": 41, "'": 39,
+        ",": 43, ".": 47, "/": 44, "`": 50,
+    ]
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionTypes.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionTypes.swift
@@ -1,0 +1,72 @@
+import Foundation
+import CoreGraphics
+
+enum ActionType: String, Codable {
+    case click
+    case doubleClick = "double_click"
+    case rightClick = "right_click"
+    case type
+    case key
+    case scroll
+    case wait
+    case done
+    case drag
+    case openApp = "open_app"
+    case runAppleScript = "run_applescript"
+    case respond
+}
+
+struct AgentAction: Codable {
+    let type: ActionType
+    var x: CGFloat?
+    var y: CGFloat?
+    var text: String?
+    var key: String?
+    var scrollDirection: String?
+    var scrollAmount: Int?
+    var toX: CGFloat?
+    var toY: CGFloat?
+    var waitDuration: Int?
+    var appName: String?
+    var script: String?
+    var reasoning: String
+    var resolvedFromElementId: Int?
+    var resolvedToElementId: Int?
+    var elementDescription: String?
+
+    init(
+        type: ActionType,
+        reasoning: String,
+        x: CGFloat? = nil,
+        y: CGFloat? = nil,
+        toX: CGFloat? = nil,
+        toY: CGFloat? = nil,
+        text: String? = nil,
+        key: String? = nil,
+        scrollDirection: String? = nil,
+        scrollAmount: Int? = nil,
+        waitDuration: Int? = nil,
+        appName: String? = nil,
+        script: String? = nil,
+        resolvedFromElementId: Int? = nil,
+        resolvedToElementId: Int? = nil,
+        elementDescription: String? = nil
+    ) {
+        self.type = type
+        self.reasoning = reasoning
+        self.x = x
+        self.y = y
+        self.toX = toX
+        self.toY = toY
+        self.text = text
+        self.key = key
+        self.scrollDirection = scrollDirection
+        self.scrollAmount = scrollAmount
+        self.waitDuration = waitDuration
+        self.appName = appName
+        self.script = script
+        self.resolvedFromElementId = resolvedFromElementId
+        self.resolvedToElementId = resolvedToElementId
+        self.elementDescription = elementDescription
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionVerifier.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionVerifier.swift
@@ -1,0 +1,150 @@
+import Foundation
+import CoreGraphics
+
+enum VerifyResult {
+    case allowed
+    case needsConfirmation(String)
+    case blocked(String)
+}
+
+final class ActionVerifier {
+    private var actionHistory: [AgentAction] = []
+    private let maxSteps: Int
+
+    init(maxSteps: Int = 50) {
+        self.maxSteps = maxSteps
+    }
+
+    func verify(_ action: AgentAction) -> VerifyResult {
+        // 1. Step limit
+        if actionHistory.count >= maxSteps {
+            return .blocked("Maximum step limit (\(maxSteps)) reached")
+        }
+
+        // 2. Loop detection — repeating action patterns
+        if detectLoop(including: action) {
+            return .blocked("Agent appears stuck in a repeating action loop")
+        }
+
+        // Note: detecting "sensitive" typed text (passwords/SSNs/cards) is a
+        // user-experience judgement, which AGENTS.md requires be made by the
+        // assistant through the daemon rather than a hardcoded client heuristic
+        // — and in proxy mode a client-side block has no confirmation path, so
+        // it would make legitimate user-directed typing impossible. Left to the
+        // daemon/approval flow.
+
+        // 4. Destructive key combos
+        if action.type == .key, let key = action.key?.lowercased() {
+            let destructiveKeys = ["cmd+q", "command+q", "cmd+w", "command+w",
+                                   "cmd+delete", "command+delete", "cmd+backspace", "command+backspace"]
+            if destructiveKeys.contains(key) {
+                return .needsConfirmation("Key combo '\(key)' could close a window or delete content")
+            }
+        }
+
+        // 5. Form submission (Enter after typing)
+        if action.type == .key, let key = action.key?.lowercased(),
+           (key == "enter" || key == "return"),
+           let lastAction = actionHistory.last, lastAction.type == .type {
+            return .needsConfirmation("Pressing Enter may submit a form")
+        }
+
+        // 6. Forbidden screen region (system menu bar)
+        if let y = action.y, y < 25, action.type == .click || action.type == .doubleClick || action.type == .rightClick {
+            return .blocked("Action targets the system menu bar (y < 25)")
+        }
+
+        // 7. AppleScript safety
+        if action.type == .runAppleScript, let script = action.script {
+            // Normalize whitespace to prevent bypass via "do shell\nscript" etc.
+            let normalized = script.lowercased()
+                .split(omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
+                .joined(separator: " ")
+            let blockedPatterns = [
+                "do shell script", "keychain", "password", "credential",
+                "sudo", "rm -rf", "defaults write", "defaults delete",
+                "osascript", "system events\" to keystroke",
+                "system events' to keystroke"
+            ]
+            for pattern in blockedPatterns {
+                if normalized.contains(pattern) {
+                    return .blocked("AppleScript contains blocked pattern: \(pattern)")
+                }
+            }
+            // A script that passes the blocklist is allowed: the daemon gates
+            // computer-use execution behind its own approval, and proxy mode has
+            // no interactive confirmation path — returning needsConfirmation here
+            // surfaces as a hard BLOCK, making the tool unusable for every safe
+            // script. Fall through to .allowed.
+        }
+
+        // All checks passed
+        actionHistory.append(action)
+        return .allowed
+    }
+
+    // MARK: - Loop Detection
+
+    private static let loopWindowSize = 10
+    private static let coordinateTolerance: CGFloat = 5
+    private static let clickTypes: Set<ActionType> = [.click, .doubleClick, .rightClick]
+
+    /// Detects repeating action patterns using a sliding window.
+    /// Checks for length-1 cycles (3 consecutive identical) and
+    /// length 2-4 cycles (pattern repeats twice) within the last 10 actions.
+    private func detectLoop(including candidate: AgentAction) -> Bool {
+        let historySlice = actionHistory.suffix(Self.loopWindowSize - 1)
+        var window = Array(historySlice)
+        window.append(candidate)
+
+        // Length-1: same action 3 times in a row
+        if window.count >= 3 {
+            let tail = window.suffix(3)
+            let first = tail[tail.startIndex]
+            if tail.dropFirst().allSatisfy({ actionsMatch($0, first) }) {
+                return true
+            }
+        }
+
+        // Length 2-4: pattern repeats at least twice consecutively
+        for cycleLen in 2...4 {
+            let needed = cycleLen * 2
+            guard window.count >= needed else { continue }
+            let end = window.count
+            let patternA = window[(end - needed)..<(end - cycleLen)]
+            let patternB = window[(end - cycleLen)..<end]
+            if zip(patternA, patternB).allSatisfy({ actionsMatch($0, $1) }) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // MARK: - Comparison
+
+    /// Compare two actions for equivalence. Click-type actions use radial
+    /// proximity matching on coordinates (within 5px radius) to catch near-identical clicks.
+    private func actionsMatch(_ a: AgentAction, _ b: AgentAction) -> Bool {
+        guard a.type == b.type && a.text == b.text && a.key == b.key
+              && a.appName == b.appName && a.script == b.script else {
+            return false
+        }
+        if Self.clickTypes.contains(a.type) {
+            return coordinatesMatch(a.x, a.y, b.x, b.y)
+        }
+        return a.x == b.x && a.y == b.y
+    }
+
+    private func coordinatesMatch(_ ax: CGFloat?, _ ay: CGFloat?,
+                                  _ bx: CGFloat?, _ by: CGFloat?) -> Bool {
+        switch (ax, ay, bx, by) {
+        case let (.some(x1), .some(y1), .some(x2), .some(y2)):
+            return hypot(x1 - x2, y1 - y2) <= Self.coordinateTolerance
+        case (.none, .none, .none, .none):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -1,0 +1,468 @@
+import Foundation
+import CoreGraphics
+import AppKit
+import os
+
+private let log = Logger(subsystem: "ai.vellum.mac-helper", category: "HostCu")
+
+// MARK: - Action Runner
+
+/// Encapsulates the full host CU action cycle: map tool -> verify -> execute -> wait -> observe.
+@MainActor
+enum HostCuActionRunner {
+
+    /// Per-session verifier state so safety checks (loop detection, step limits,
+    /// "Enter after typing") accumulate across requests within the same session.
+    private static var verifiers: [String: ActionVerifier] = [:]
+
+    /// Per-session previous AX elements for computing diffs between steps.
+    private static var previousAXElements: [String: [AXElement]] = [:]
+
+    /// Last time each session was touched, for reclaiming state from sessions
+    /// that end without a terminal done/respond (cancelled, or conversation
+    /// closed mid-flight).
+    private static var lastAccess: [String: Date] = [:]
+
+    /// Idle window after which an untouched session's state is reclaimed.
+    private static let sessionTTL: TimeInterval = 600
+
+    /// Remove session state when a session ends.
+    static func clearSession(_ conversationId: String) {
+        verifiers.removeValue(forKey: conversationId)
+        previousAXElements.removeValue(forKey: conversationId)
+        lastAccess.removeValue(forKey: conversationId)
+    }
+
+    /// Evict state for sessions untouched longer than `sessionTTL`, then record
+    /// `conversationId` as just-accessed. Bounds memory for abandoned sessions.
+    private static func touchSession(_ conversationId: String, now: Date = Date()) {
+        for (id, seen) in lastAccess where now.timeIntervalSince(seen) > sessionTTL {
+            verifiers.removeValue(forKey: id)
+            previousAXElements.removeValue(forKey: id)
+            lastAccess.removeValue(forKey: id)
+        }
+        lastAccess[conversationId] = now
+    }
+
+    static func perform(
+        requestId: String,
+        conversationId: String,
+        toolName: String,
+        input: [String: Any],
+        stepNumber: Int,
+        reasoning: String?
+    ) async -> HostCuResultPayload {
+        touchSession(conversationId)
+        let enumerator = AccessibilityTreeEnumerator()
+        let screenCapture = ScreenCapture()
+        let executor = ActionExecutor()
+        let verifier = verifiers[conversationId] ?? {
+            let v = ActionVerifier()
+            verifiers[conversationId] = v
+            return v
+        }()
+
+        // Map tool name + input to an AgentAction
+        let agentAction = mapToAgentAction(toolName: toolName, input: input, reasoning: reasoning)
+
+        // For observe-only requests, skip action execution and just capture state
+        let isObserveOnly = toolName == "computer_use_observe" || toolName == "cu_observe"
+
+        var executionResult: String? = nil
+        var executionError: String? = nil
+
+        if !isObserveOnly {
+            // Ensure Accessibility is granted before any CGEvent input, which
+            // silently fails otherwise. Prompt the user on first miss.
+            if !ActionExecutor.checkAccessibilityPermission(prompt: true) {
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: "Accessibility permission not granted. Grant Vellum access in System Settings > Privacy & Security > Accessibility, then retry.",
+                    stepNumber: stepNumber,
+                    conversationId: conversationId
+                )
+                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+
+            // Resolve element IDs to coordinates if needed
+            guard let resolvedAction = await resolveCoordinatesIfNeeded(for: agentAction, enumerator: enumerator, stepNumber: stepNumber) else {
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: "Could not resolve element coordinates for action",
+                    stepNumber: stepNumber,
+                    conversationId: conversationId
+                )
+                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+
+            // Handle done/respond completion signals — skip execution
+            if resolvedAction.type == .done {
+                clearSession(conversationId)
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: nil,
+                    stepNumber: stepNumber,
+                    conversationId: conversationId
+                )
+                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+
+            if resolvedAction.type == .respond {
+                clearSession(conversationId)
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: nil,
+                    stepNumber: stepNumber,
+                    conversationId: conversationId
+                )
+                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+
+            // VERIFY (local safety check)
+            let verifyResult = verifier.verify(resolvedAction)
+            switch verifyResult {
+            case .allowed:
+                break
+
+            case .needsConfirmation(let reason):
+                log.warning("[\(stepNumber)] Needs confirmation (blocked in proxy): \(reason)")
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: "BLOCKED: \(reason) (confirmation not available in proxy mode)",
+                    stepNumber: stepNumber,
+                    conversationId: conversationId
+                )
+                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+
+            case .blocked(let reason):
+                log.warning("[\(stepNumber)] BLOCKED: \(reason)")
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: "BLOCKED: \(reason)",
+                    stepNumber: stepNumber,
+                    conversationId: conversationId
+                )
+                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+
+            // EXECUTE
+            do {
+                executionResult = try await executor.execute(resolvedAction)
+            } catch {
+                let errorMessage = error.localizedDescription
+                if resolvedAction.type == .runAppleScript {
+                    log.warning("[\(stepNumber)] AppleScript error (non-fatal): \(errorMessage)")
+                }
+                executionError = errorMessage
+            }
+
+            // WAIT — brief delay to let the UI settle after action
+            do {
+                try await Task.sleep(nanoseconds: 300_000_000) // 300ms
+            } catch {
+                log.warning("Post-action delay interrupted: \(error)")
+            }
+        }
+
+        // OBSERVE — capture AX tree, screenshot, etc.
+        let obs = await buildObservation(
+            enumerator: enumerator,
+            screenCapture: screenCapture,
+            executionResult: executionResult,
+            executionError: executionError,
+            stepNumber: stepNumber,
+            conversationId: conversationId
+        )
+
+        return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+    }
+
+    // MARK: - Tool Name Mapping
+
+    /// Maps a tool name + input dictionary to an `AgentAction` for local execution.
+    private static func mapToAgentAction(toolName: String, input: [String: Any], reasoning: String?) -> AgentAction {
+        let type: ActionType = switch toolName {
+        case "computer_use_click", "cu_click": .click
+        case "computer_use_double_click", "cu_double_click": .doubleClick
+        case "computer_use_right_click", "cu_right_click": .rightClick
+        case "computer_use_type_text", "cu_type_text": .type
+        case "computer_use_key", "cu_key": .key
+        case "computer_use_scroll", "cu_scroll": .scroll
+        case "computer_use_wait", "cu_wait": .wait
+        case "computer_use_drag", "cu_drag": .drag
+        case "computer_use_open_app", "cu_open_app": .openApp
+        case "computer_use_run_applescript", "cu_run_applescript": .runAppleScript
+        case "computer_use_done", "cu_done": .done
+        case "computer_use_respond", "cu_respond": .respond
+        default: .done
+        }
+
+        let x = extractCGFloat(from: input, key: "x")
+        let y = extractCGFloat(from: input, key: "y")
+        let toX = extractCGFloat(from: input, key: "toX")
+            ?? extractCGFloat(from: input, key: "to_x")
+        let toY = extractCGFloat(from: input, key: "toY")
+            ?? extractCGFloat(from: input, key: "to_y")
+        let text = input["text"] as? String
+        let key = input["key"] as? String
+        let scrollDirection = input["direction"] as? String
+            ?? input["scrollDirection"] as? String
+            ?? input["scroll_direction"] as? String
+        let scrollAmount = extractInt(from: input, key: "amount")
+            ?? extractInt(from: input, key: "scrollAmount")
+            ?? extractInt(from: input, key: "scroll_amount")
+        let waitDuration = extractInt(from: input, key: "duration_ms")
+            ?? extractInt(from: input, key: "duration")
+            ?? extractInt(from: input, key: "waitDuration")
+            ?? extractInt(from: input, key: "wait_duration")
+        let appName = input["app_name"] as? String
+            ?? input["appName"] as? String
+        let script = input["script"] as? String
+        let elementId = extractInt(from: input, key: "element_id")
+            ?? extractInt(from: input, key: "elementId")
+        let toElementId = extractInt(from: input, key: "to_element_id")
+            ?? extractInt(from: input, key: "toElementId")
+        let elementDescription = input["element_description"] as? String
+            ?? input["elementDescription"] as? String
+
+        return AgentAction(
+            type: type,
+            reasoning: reasoning ?? "",
+            x: x,
+            y: y,
+            toX: toX,
+            toY: toY,
+            text: text,
+            key: key,
+            scrollDirection: scrollDirection,
+            scrollAmount: scrollAmount,
+            waitDuration: waitDuration,
+            appName: appName,
+            script: script,
+            resolvedFromElementId: elementId,
+            resolvedToElementId: toElementId,
+            elementDescription: elementDescription
+        )
+    }
+
+    // MARK: - Coordinate Resolution
+
+    /// Resolve element IDs to screen coordinates when x/y are not provided.
+    private static func resolveCoordinatesIfNeeded(for action: AgentAction, enumerator: AccessibilityTreeProviding, stepNumber: Int) async -> AgentAction? {
+        var resolved = action
+
+        switch resolved.type {
+        case .click, .doubleClick, .rightClick:
+            if resolved.x == nil || resolved.y == nil {
+                guard let sourceId = resolved.resolvedFromElementId else {
+                    log.error("[\(stepNumber)] Action requires either x/y coordinates or element_id")
+                    return nil
+                }
+                guard let center = await elementCenter(for: sourceId, enumerator: enumerator) else {
+                    log.error("[\(stepNumber)] Could not resolve element_id [\(sourceId)]")
+                    return nil
+                }
+                resolved.x = center.x
+                resolved.y = center.y
+            }
+
+        case .scroll:
+            if (resolved.x == nil || resolved.y == nil), let sourceId = resolved.resolvedFromElementId {
+                guard let center = await elementCenter(for: sourceId, enumerator: enumerator) else {
+                    log.error("[\(stepNumber)] Could not resolve element_id [\(sourceId)]")
+                    return nil
+                }
+                resolved.x = center.x
+                resolved.y = center.y
+            }
+
+        case .drag:
+            if resolved.x == nil || resolved.y == nil, let sourceId = resolved.resolvedFromElementId {
+                if let center = await elementCenter(for: sourceId, enumerator: enumerator) {
+                    resolved.x = center.x
+                    resolved.y = center.y
+                }
+            }
+            if resolved.toX == nil || resolved.toY == nil, let targetId = resolved.resolvedToElementId {
+                if let center = await elementCenter(for: targetId, enumerator: enumerator) {
+                    resolved.toX = center.x
+                    resolved.toY = center.y
+                }
+            }
+
+        default:
+            break
+        }
+
+        return resolved
+    }
+
+    /// Find the center point of an AX element by ID in the current window.
+    private static func elementCenter(for elementId: Int, enumerator: AccessibilityTreeProviding) async -> CGPoint? {
+        guard let result = await enumerator.enumerateCurrentWindow() else { return nil }
+        let flat = AccessibilityTreeEnumerator.flattenElements(result.elements)
+        guard let element = flat.first(where: { $0.id == elementId }) else { return nil }
+        let frame = element.frame
+        return CGPoint(x: frame.midX, y: frame.midY)
+    }
+
+    // MARK: - Observation Builder
+
+    /// Internal observation data before packaging into the result payload.
+    private struct ObservationData {
+        let axTree: String?
+        let axDiff: String?
+        let currentElements: [AXElement]?
+        let screenshot: String?
+        let screenshotWidthPx: Int?
+        let screenshotHeightPx: Int?
+        let screenWidthPt: Int?
+        let screenHeightPt: Int?
+        let executionResult: String?
+        let executionError: String?
+        let secondaryWindows: String?
+    }
+
+    /// Capture the current screen state as an observation.
+    private static func buildObservation(
+        enumerator: AccessibilityTreeProviding,
+        screenCapture: ScreenCaptureProviding,
+        executionResult: String?,
+        executionError: String?,
+        stepNumber: Int,
+        conversationId: String
+    ) async -> ObservationData {
+        var axTreeText: String?
+        var axDiffText: String?
+        var currentElements: [AXElement]?
+        var screenshotBase64: String?
+        var screenshotWidthPx: Int?
+        var screenshotHeightPx: Int?
+        var screenWidthPt: Int?
+        var screenHeightPt: Int?
+        var secondaryWindowsText: String?
+
+        if let result = await enumerator.enumerateCurrentWindow() {
+            axTreeText = AccessibilityTreeEnumerator.formatAXTree(
+                elements: result.elements,
+                windowTitle: result.windowTitle,
+                appName: result.appName
+            )
+            let flat = AccessibilityTreeEnumerator.flattenElements(result.elements)
+            currentElements = flat
+            let interactiveCount = flat.filter { AccessibilityTreeEnumerator.interactiveRoles.contains($0.role) }.count
+            log.info("[\(stepNumber)] AX tree: \(result.appName) — \"\(result.windowTitle)\" — \(flat.count) elements (\(interactiveCount) interactive)")
+
+            // Compute AX diff against previous step's elements
+            if let previousFlat = previousAXElements[conversationId] {
+                axDiffText = AXTreeDiff.diff(previousFlat: previousFlat, currentFlat: flat)
+            }
+
+            // Enumerate secondary windows on first step
+            if stepNumber <= 1 {
+                let secondaryWindows = await enumerator.enumerateSecondaryWindows(
+                    excludingPID: result.pid,
+                    maxWindows: 2
+                )
+                secondaryWindowsText = AccessibilityTreeEnumerator.formatSecondaryWindows(secondaryWindows)
+            }
+
+            // Capture screenshot
+            do {
+                let screenshotResult = try await screenCapture.captureScreenWithMetadata(maxWidth: 960, maxHeight: 540)
+                screenshotBase64 = screenshotResult.jpegData.base64EncodedString()
+                if let meta = screenshotResult.metadata {
+                    screenshotWidthPx = meta.screenshotWidthPx
+                    screenshotHeightPx = meta.screenshotHeightPx
+                }
+                let screenSize = screenCapture.screenSize()
+                screenWidthPt = Int(screenSize.width)
+                screenHeightPt = Int(screenSize.height)
+            } catch {
+                log.error("[\(stepNumber)] Screenshot capture failed: \(error)")
+            }
+        } else {
+            // No focused window — try screenshot as fallback
+            log.warning("[\(stepNumber)] No AX tree available — falling back to screenshot")
+            do {
+                let screenshotResult = try await screenCapture.captureScreenWithMetadata(maxWidth: 960, maxHeight: 540)
+                screenshotBase64 = screenshotResult.jpegData.base64EncodedString()
+                if let meta = screenshotResult.metadata {
+                    screenshotWidthPx = meta.screenshotWidthPx
+                    screenshotHeightPx = meta.screenshotHeightPx
+                }
+                let screenSize = screenCapture.screenSize()
+                screenWidthPt = Int(screenSize.width)
+                screenHeightPt = Int(screenSize.height)
+            } catch {
+                log.error("[\(stepNumber)] Screen capture failed: \(error)")
+            }
+        }
+
+        return ObservationData(
+            axTree: axTreeText,
+            axDiff: axDiffText,
+            currentElements: currentElements,
+            screenshot: screenshotBase64,
+            screenshotWidthPx: screenshotWidthPx,
+            screenshotHeightPx: screenshotHeightPx,
+            screenWidthPt: screenWidthPt,
+            screenHeightPt: screenHeightPt,
+            executionResult: executionResult,
+            executionError: executionError,
+            secondaryWindows: secondaryWindowsText
+        )
+    }
+
+    /// Package observation data into a `HostCuResultPayload` and update previous AX state.
+    private static func buildResultPayload(requestId: String, conversationId: String, observation: ObservationData) -> HostCuResultPayload {
+        // Update previous AX elements for next step's diff
+        if let elements = observation.currentElements {
+            previousAXElements[conversationId] = elements
+        }
+
+        return HostCuResultPayload(
+            requestId: requestId,
+            axTree: observation.axTree,
+            axDiff: observation.axDiff,
+            screenshot: observation.screenshot,
+            screenshotWidthPx: observation.screenshotWidthPx,
+            screenshotHeightPx: observation.screenshotHeightPx,
+            screenWidthPt: observation.screenWidthPt,
+            screenHeightPt: observation.screenHeightPt,
+            executionResult: observation.executionResult,
+            executionError: observation.executionError,
+            secondaryWindows: observation.secondaryWindows
+        )
+    }
+
+    // MARK: - Input Helpers
+
+    private static func extractCGFloat(from input: [String: Any], key: String) -> CGFloat? {
+        guard let val = input[key] else { return nil }
+        if let intVal = val as? Int { return CGFloat(intVal) }
+        if let doubleVal = val as? Double { return CGFloat(doubleVal) }
+        if let num = val as? NSNumber { return CGFloat(num.doubleValue) }
+        return nil
+    }
+
+    private static func extractInt(from input: [String: Any], key: String) -> Int? {
+        guard let val = input[key] else { return nil }
+        if let intVal = val as? Int { return intVal }
+        if let doubleVal = val as? Double { return Int(doubleVal) }
+        if let num = val as? NSNumber { return num.intValue }
+        return nil
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ScreenCapture.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ScreenCapture.swift
@@ -1,0 +1,125 @@
+import ScreenCaptureKit
+import AppKit
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+
+enum CaptureError: LocalizedError {
+    case noDisplay
+    case conversionFailed
+    case permissionDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .noDisplay: return "No display found"
+        case .conversionFailed: return "Failed to convert screenshot to JPEG"
+        case .permissionDenied: return "Screen Recording permission denied"
+        }
+    }
+}
+
+struct ScreenCaptureMetadata: Sendable {
+    let screenshotWidthPx: Int
+    let screenshotHeightPx: Int
+    let captureDisplayId: UInt32
+}
+
+struct ScreenCaptureResult: Sendable {
+    let jpegData: Data
+    let metadata: ScreenCaptureMetadata?
+}
+
+protocol ScreenCaptureProviding: Sendable {
+    func captureScreen(maxWidth: Int, maxHeight: Int) async throws -> Data
+    func captureScreenWithMetadata(maxWidth: Int, maxHeight: Int) async throws -> ScreenCaptureResult
+    func screenSize() -> CGSize
+}
+
+extension ScreenCaptureProviding {
+    func captureScreen() async throws -> Data {
+        try await captureScreen(maxWidth: 1280, maxHeight: 720)
+    }
+
+    func captureScreenWithMetadata(maxWidth: Int, maxHeight: Int) async throws -> ScreenCaptureResult {
+        let data = try await captureScreen(maxWidth: maxWidth, maxHeight: maxHeight)
+        return ScreenCaptureResult(jpegData: data, metadata: nil)
+    }
+}
+
+final class ScreenCapture: ScreenCaptureProviding, @unchecked Sendable {
+    func captureScreen(maxWidth: Int = 1280, maxHeight: Int = 720) async throws -> Data {
+        let result = try await captureScreenWithMetadata(maxWidth: maxWidth, maxHeight: maxHeight)
+        return result.jpegData
+    }
+
+    func captureScreenWithMetadata(maxWidth: Int = 1280, maxHeight: Int = 720) async throws -> ScreenCaptureResult {
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.current
+        } catch {
+            throw CaptureError.permissionDenied
+        }
+
+        // Match the main display (CGMainDisplayID) so screenshots align with AX tree coordinates.
+        // content.displays.first is arbitrary and may return an external monitor.
+        let mainDisplayID = CGMainDisplayID()
+        guard let display = content.displays.first(where: { $0.displayID == mainDisplayID })
+                ?? content.displays.first else {
+            throw CaptureError.noDisplay
+        }
+
+        // Exclude this helper's and the Electron host app's windows so the
+        // screenshot shows the app behind our UI — matching the AX tree, which
+        // skips the same processes (AccessibilityTreeEnumerator.isOwnOrHostApp).
+        // Otherwise the model reasons over a screenshot of the chat window while
+        // the AX tree describes the app behind it, and clicks the wrong place.
+        let myPID = ProcessInfo.processInfo.processIdentifier
+        let hostPID = getppid()
+        let excluded = content.windows.filter {
+            guard let pid = $0.owningApplication?.processID else { return false }
+            return pid == myPID || pid == hostPID
+        }
+        let filter = SCContentFilter(display: display, excludingWindows: excluded)
+        let config = SCStreamConfiguration()
+
+        let displayWidth = CGFloat(display.width)
+        let displayHeight = CGFloat(display.height)
+        let scaleX = CGFloat(maxWidth) / displayWidth
+        let scaleY = CGFloat(maxHeight) / displayHeight
+        let scale = min(scaleX, scaleY, 1.0) // Don't upscale
+
+        config.width = Int(displayWidth * scale)
+        config.height = Int(displayHeight * scale)
+        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.showsCursor = true
+
+        let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+
+        // Direct CGImage → JPEG via ImageIO (skips NSImage/TIFF intermediate)
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data as CFMutableData, UTType.jpeg.identifier as CFString, 1, nil) else {
+            throw CaptureError.conversionFailed
+        }
+        let options: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: 0.6]
+        CGImageDestinationAddImage(destination, image, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            throw CaptureError.conversionFailed
+        }
+
+        return ScreenCaptureResult(
+            jpegData: data as Data,
+            metadata: ScreenCaptureMetadata(
+                screenshotWidthPx: image.width,
+                screenshotHeightPx: image.height,
+                captureDisplayId: display.displayID
+            )
+        )
+    }
+
+    /// Returns the main display size in logical points (same coordinate space as AX tree and CGEvent).
+    /// Uses CGDisplayBounds like graphos for consistency.
+    func screenSize() -> CGSize {
+        let bounds = CGDisplayBounds(CGMainDisplayID())
+        return bounds.size
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
@@ -30,5 +30,9 @@
     <string>Vellum uses the microphone to transcribe dictated voice input.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to show your words live while you dictate.</string>
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>Vellum captures the screen so the assistant can see what's on screen and control your computer on your behalf.</string>
+    <key>NSAccessibilityUsageDescription</key>
+    <string>Vellum uses accessibility features to read on-screen elements and control apps when you ask it to use your computer.</string>
 </dict>
 </plist>

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -249,7 +249,111 @@ final class MacHelper: @unchecked Sendable {
     }
 
     private func handleCommand(_ line: String) {
+        // Computer-use and app-control dispatch are async + @MainActor, so they
+        // can't go through the synchronous JsonRpcRouter. Peek at the method and
+        // hand the raw line off to an async dispatcher (which re-parses inside
+        // the Task so no non-Sendable JSON value crosses the isolation boundary).
+        if let data = line.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let method = object["method"] as? String,
+           method == "cu.perform" || method == "appControl.perform" {
+            if method == "cu.perform" {
+                dispatchCuPerform(line: line)
+            } else {
+                dispatchAppControlPerform(line: line)
+            }
+            return
+        }
         writeLine(router.handle(line: line))
+    }
+
+    private func dispatchCuPerform(line: String) {
+        Task { @MainActor in
+            let object = (try? JSONSerialization.jsonObject(with: Data(line.utf8))) as? [String: Any]
+            let id = object?["id"] ?? NSNull()
+            let params = object?["params"] as? [String: Any] ?? [:]
+            guard
+                let requestId = params["requestId"] as? String,
+                let conversationId = params["conversationId"] as? String,
+                let toolName = params["toolName"] as? String
+            else {
+                self.writeResponse(JsonRpcCodec.errorResponse(
+                    id: id,
+                    code: JsonRpcErrorCode.invalidParams,
+                    message: "cu.perform requires requestId, conversationId, toolName"
+                ))
+                return
+            }
+            let input = params["input"] as? [String: Any] ?? [:]
+            let stepNumber = (params["stepNumber"] as? NSNumber)?.intValue ?? 0
+            let reasoning = params["reasoning"] as? String
+            let payload = await HostCuActionRunner.perform(
+                requestId: requestId,
+                conversationId: conversationId,
+                toolName: toolName,
+                input: input,
+                stepNumber: stepNumber,
+                reasoning: reasoning
+            )
+            self.writeResponse(
+                JsonRpcCodec.successResponse(id: id, result: payload.toDictionary())
+            )
+        }
+    }
+
+    private func dispatchAppControlPerform(line: String) {
+        Task { @MainActor in
+            let object = (try? JSONSerialization.jsonObject(with: Data(line.utf8))) as? [String: Any]
+            let id = object?["id"] ?? NSNull()
+            let params = object?["params"] as? [String: Any] ?? [:]
+            guard let requestId = params["requestId"] as? String else {
+                self.writeResponse(JsonRpcCodec.errorResponse(
+                    id: id,
+                    code: JsonRpcErrorCode.invalidParams,
+                    message: "appControl.perform requires requestId"
+                ))
+                return
+            }
+            // The daemon sends `{requestId, conversationId, toolName, input:{...}}`
+            // where `input` already carries the `tool` discriminator. Decode from
+            // that sub-dict, falling back to the top-level params (so a toolName
+            // discriminator can still be derived).
+            let toolDict = params["input"] as? [String: Any] ?? params
+            do {
+                let input = try HostAppControlInput.from(dictionary: toolDict)
+                let payload = await AppControlExecutor.perform(
+                    requestId: requestId,
+                    input: input
+                )
+                self.writeResponse(
+                    JsonRpcCodec.successResponse(id: id, result: payload.toDictionary())
+                )
+            } catch let error as JsonRpcDispatchError {
+                let message: String
+                if case let .invalidParams(reason) = error { message = reason }
+                else if case let .internalError(reason) = error { message = reason }
+                else { message = "Invalid params" }
+                self.writeResponse(JsonRpcCodec.errorResponse(
+                    id: id,
+                    code: JsonRpcErrorCode.invalidParams,
+                    message: message
+                ))
+            } catch {
+                self.writeResponse(JsonRpcCodec.errorResponse(
+                    id: id,
+                    code: JsonRpcErrorCode.internalError,
+                    message: error.localizedDescription
+                ))
+            }
+        }
+    }
+
+    private func writeResponse(_ object: [String: Any]) {
+        do {
+            writeLine(try JsonRpcCodec.encodeLine(object))
+        } catch {
+            log("Failed to encode response: \(error.localizedDescription)")
+        }
     }
 
     /// Start/stop local speech-recognition partials (`dictation.partial`

--- a/clients/macos/src/main/executors/host-app-control-executor.test.ts
+++ b/clients/macos/src/main/executors/host-app-control-executor.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Avoid pulling electron (via shared-cu-helper → mac-helper-path) and the
+// electron-log file backend into the test process.
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: {
+        file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) },
+      },
+    },
+  };
+});
+mock.module("../sidecar/shared-cu-helper", () => ({
+  CU_HELPER_TIMEOUT_MS: 20_000,
+  getSharedCuHelper: () => {
+    throw new Error("shared helper should not be used in tests");
+  },
+}));
+
+import { createHostAppControlExecutor } from "./host-app-control-executor";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makePoster() {
+  const postAppControlResult = mock(async (_payload: unknown) => true);
+  return {
+    poster: { postAppControlResult } as unknown as HostProxyPoster,
+    postAppControlResult,
+  };
+}
+
+function request(overrides: Partial<HostProxySseMessage> = {}): HostProxySseMessage {
+  return {
+    type: "host_app_control_request",
+    requestId: "req-1",
+    conversationId: "conv-1",
+    toolName: "app_control_observe",
+    input: { tool: "observe", app: "com.apple.Safari" },
+    ...overrides,
+  };
+}
+
+describe("hostAppControlExecutor", () => {
+  let lastCall: { method: string; params: unknown } | null;
+
+  beforeEach(() => {
+    lastCall = null;
+  });
+
+  function helperReturning(result: unknown) {
+    return {
+      call: mock(async (method: string, params?: unknown) => {
+        lastCall = { method, params };
+        return result;
+      }),
+    };
+  }
+
+  test("forwards the request to appControl.perform and posts the result", async () => {
+    const helper = helperReturning({
+      state: "running",
+      pngBase64: "PNG",
+      windowBounds: { x: 0, y: 0, width: 800, height: 600 },
+      executionResult: "observed",
+    });
+    const executor = createHostAppControlExecutor({ helper });
+    const { poster, postAppControlResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    await tick();
+
+    expect(lastCall?.method).toBe("appControl.perform");
+    expect(lastCall?.params).toMatchObject({
+      requestId: "req-1",
+      toolName: "app_control_observe",
+      input: { tool: "observe", app: "com.apple.Safari" },
+    });
+    expect(postAppControlResult.mock.calls[0]?.[0]).toMatchObject({
+      requestId: "req-1",
+      state: "running",
+      pngBase64: "PNG",
+      windowBounds: { x: 0, y: 0, width: 800, height: 600 },
+    });
+  });
+
+  test("posts a missing-state error when input is absent", async () => {
+    const helper = helperReturning({});
+    const executor = createHostAppControlExecutor({ helper });
+    const { poster, postAppControlResult } = makePoster();
+
+    executor.handleRequest(request({ input: undefined }), poster);
+    await tick();
+
+    expect(helper.call).not.toHaveBeenCalled();
+    expect(postAppControlResult.mock.calls[0]?.[0]).toMatchObject({
+      requestId: "req-1",
+      state: "missing",
+      executionError: "Missing input",
+    });
+  });
+
+  test("surfaces helper failures as a missing-state error", async () => {
+    const helper = {
+      call: mock(async () => {
+        throw new Error("helper exploded");
+      }),
+    };
+    const executor = createHostAppControlExecutor({ helper });
+    const { poster, postAppControlResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    await tick();
+
+    expect(postAppControlResult.mock.calls[0]?.[0]).toMatchObject({
+      requestId: "req-1",
+      state: "missing",
+      executionError: "helper exploded",
+    });
+  });
+
+  test("drops the result when the request was cancelled", async () => {
+    const helper = helperReturning({ state: "running" });
+    const executor = createHostAppControlExecutor({ helper });
+    const { poster, postAppControlResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    executor.handleCancel(request(), poster);
+    await tick();
+
+    expect(postAppControlResult).not.toHaveBeenCalled();
+  });
+});

--- a/clients/macos/src/main/executors/host-app-control-executor.ts
+++ b/clients/macos/src/main/executors/host-app-control-executor.ts
@@ -1,0 +1,78 @@
+/**
+ * Host app-control executor — proxies a single `host_app_control_request`
+ * (start / observe / press / combo / sequence / type / click / drag / stop) to
+ * the native mac-helper's `appControl.perform` JSON-RPC method, then posts the
+ * result (window state, PNG screenshot, window bounds) back to the daemon.
+ *
+ * App-control input is a discriminated union keyed by a `tool` field that the
+ * daemon injects into `input`; the helper decodes it natively. This executor
+ * only forwards the request and translates the result.
+ */
+
+import { z } from "zod";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import { getSharedCuHelper } from "../sidecar/shared-cu-helper";
+import {
+  HostHelperProxyExecutor,
+  type CuHelperClient,
+  type HostHelperProxyConfig,
+} from "./host-helper-proxy-executor";
+
+export interface HostAppControlExecutorDeps {
+  helper?: CuHelperClient;
+}
+
+const APP_CONTROL_RESULT_SCHEMA = z
+  .object({
+    state: z.enum(["running", "missing", "minimized"]),
+    pngBase64: z.string().optional(),
+    windowBounds: z
+      .object({
+        x: z.number(),
+        y: z.number(),
+        width: z.number(),
+        height: z.number(),
+      })
+      .optional(),
+    executionResult: z.string().optional(),
+    executionError: z.string().optional(),
+  })
+  .passthrough();
+
+function config(deps: HostAppControlExecutorDeps): HostHelperProxyConfig<
+  z.infer<typeof APP_CONTROL_RESULT_SCHEMA>
+> {
+  return {
+    label: "host-app-control-executor",
+    method: "appControl.perform",
+    resolveHelper: deps.helper ? () => deps.helper as CuHelperClient : getSharedCuHelper,
+    schema: APP_CONTROL_RESULT_SCHEMA,
+    buildParams: (message, requestId) => {
+      const input = message.input as Record<string, unknown> | undefined;
+      if (!input) return { error: "Missing input" };
+      return {
+        params: {
+          requestId,
+          conversationId: (message.conversationId as string | undefined) ?? "",
+          ...(typeof message.toolName === "string" ? { toolName: message.toolName } : {}),
+          input,
+        },
+      };
+    },
+    postSuccess: (poster, requestId, result) => {
+      void poster.postAppControlResult({ requestId, ...result });
+    },
+    postError: (poster, requestId, message) => {
+      void poster.postAppControlResult({ requestId, state: "missing", executionError: message });
+    },
+  };
+}
+
+export function createHostAppControlExecutor(
+  deps: HostAppControlExecutorDeps = {},
+): HostProxyExecutor {
+  return new HostHelperProxyExecutor(config(deps));
+}
+
+export const hostAppControlExecutor: HostProxyExecutor = createHostAppControlExecutor();

--- a/clients/macos/src/main/executors/host-cu-executor.test.ts
+++ b/clients/macos/src/main/executors/host-cu-executor.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Avoid pulling electron (via shared-cu-helper → mac-helper-path) and the
+// electron-log file backend into the test process.
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: {
+        file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) },
+      },
+    },
+  };
+});
+mock.module("../sidecar/shared-cu-helper", () => ({
+  CU_HELPER_TIMEOUT_MS: 20_000,
+  getSharedCuHelper: () => {
+    throw new Error("shared helper should not be used in tests");
+  },
+}));
+
+import { createHostCuExecutor } from "./host-cu-executor";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makePoster() {
+  const postCuResult = mock(async (_payload: unknown) => true);
+  return { poster: { postCuResult } as unknown as HostProxyPoster, postCuResult };
+}
+
+function request(overrides: Partial<HostProxySseMessage> = {}): HostProxySseMessage {
+  return {
+    type: "host_cu_request",
+    requestId: "req-1",
+    conversationId: "conv-1",
+    toolName: "computer_use_click",
+    input: { element_id: 3, reasoning: "click it" },
+    stepNumber: 2,
+    reasoning: "click it",
+    ...overrides,
+  };
+}
+
+describe("hostCuExecutor", () => {
+  let lastCall: { method: string; params: unknown } | null;
+
+  beforeEach(() => {
+    lastCall = null;
+  });
+
+  function helperReturning(result: unknown) {
+    return {
+      call: mock(async (method: string, params?: unknown) => {
+        lastCall = { method, params };
+        return result;
+      }),
+    };
+  }
+
+  test("forwards the request to cu.perform and posts the observation", async () => {
+    const helper = helperReturning({
+      axTree: "Window: x",
+      axDiff: "+ Added: [4] button",
+      screenshot: "BASE64",
+      screenshotWidthPx: 960,
+      screenshotHeightPx: 540,
+      screenWidthPt: 1512,
+      screenHeightPt: 982,
+      executionResult: "clicked",
+    });
+    const executor = createHostCuExecutor({ helper });
+    const { poster, postCuResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    await tick();
+
+    expect(lastCall?.method).toBe("cu.perform");
+    expect(lastCall?.params).toMatchObject({
+      requestId: "req-1",
+      conversationId: "conv-1",
+      toolName: "computer_use_click",
+      stepNumber: 2,
+      reasoning: "click it",
+    });
+    expect(postCuResult).toHaveBeenCalledTimes(1);
+    expect(postCuResult.mock.calls[0]?.[0]).toMatchObject({
+      requestId: "req-1",
+      axTree: "Window: x",
+      screenshot: "BASE64",
+      screenshotWidthPx: 960,
+      executionResult: "clicked",
+    });
+  });
+
+  test("posts an error when toolName is missing", async () => {
+    const helper = helperReturning({});
+    const executor = createHostCuExecutor({ helper });
+    const { poster, postCuResult } = makePoster();
+
+    executor.handleRequest(request({ toolName: undefined }), poster);
+    await tick();
+
+    expect(helper.call).not.toHaveBeenCalled();
+    expect(postCuResult.mock.calls[0]?.[0]).toMatchObject({
+      requestId: "req-1",
+      executionError: "Missing toolName",
+    });
+  });
+
+  test("surfaces helper failures as executionError", async () => {
+    const helper = {
+      call: mock(async () => {
+        throw new Error("helper exploded");
+      }),
+    };
+    const executor = createHostCuExecutor({ helper });
+    const { poster, postCuResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    await tick();
+
+    expect(postCuResult.mock.calls[0]?.[0]).toMatchObject({
+      requestId: "req-1",
+      executionError: "helper exploded",
+    });
+  });
+
+  test("drops the result when the request was cancelled", async () => {
+    const helper = helperReturning({ executionResult: "done" });
+    const executor = createHostCuExecutor({ helper });
+    const { poster, postCuResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    executor.handleCancel(request(), poster);
+    await tick();
+
+    expect(postCuResult).not.toHaveBeenCalled();
+  });
+});

--- a/clients/macos/src/main/executors/host-cu-executor.ts
+++ b/clients/macos/src/main/executors/host-cu-executor.ts
@@ -1,0 +1,78 @@
+/**
+ * Host computer-use executor — proxies a single `host_cu_request` action
+ * (click / type / key / scroll / drag / open-app / run-applescript / observe /
+ * wait) to the native mac-helper's `cu.perform` JSON-RPC method, then posts the
+ * resulting observation (AX tree, diff, screenshot, and px/pt screen metadata)
+ * back to the daemon.
+ *
+ * The helper owns the verify → execute → settle → observe cycle natively; this
+ * executor only translates the SSE request into the helper call.
+ */
+
+import { z } from "zod";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import { getSharedCuHelper } from "../sidecar/shared-cu-helper";
+import {
+  HostHelperProxyExecutor,
+  type CuHelperClient,
+  type HostHelperProxyConfig,
+} from "./host-helper-proxy-executor";
+
+export interface HostCuExecutorDeps {
+  helper?: CuHelperClient;
+}
+
+// The helper returns only the observation fields; `requestId` is added when
+// posting. Unknown keys are tolerated so a newer helper can extend the shape.
+const CU_RESULT_SCHEMA = z
+  .object({
+    axTree: z.string().optional(),
+    axDiff: z.string().optional(),
+    screenshot: z.string().optional(),
+    screenshotWidthPx: z.number().optional(),
+    screenshotHeightPx: z.number().optional(),
+    screenWidthPt: z.number().optional(),
+    screenHeightPt: z.number().optional(),
+    executionResult: z.string().optional(),
+    executionError: z.string().optional(),
+    secondaryWindows: z.string().optional(),
+  })
+  .passthrough();
+
+function config(deps: HostCuExecutorDeps): HostHelperProxyConfig<
+  z.infer<typeof CU_RESULT_SCHEMA>
+> {
+  return {
+    label: "host-cu-executor",
+    method: "cu.perform",
+    resolveHelper: deps.helper ? () => deps.helper as CuHelperClient : getSharedCuHelper,
+    schema: CU_RESULT_SCHEMA,
+    buildParams: (message, requestId) => {
+      const toolName = message.toolName as string | undefined;
+      if (!toolName) return { error: "Missing toolName" };
+      return {
+        params: {
+          requestId,
+          conversationId: (message.conversationId as string | undefined) ?? "",
+          toolName,
+          input: (message.input as Record<string, unknown> | undefined) ?? {},
+          stepNumber: (message.stepNumber as number | undefined) ?? 1,
+          ...(typeof message.reasoning === "string" ? { reasoning: message.reasoning } : {}),
+        },
+      };
+    },
+    postSuccess: (poster, requestId, result) => {
+      void poster.postCuResult({ requestId, ...result });
+    },
+    postError: (poster, requestId, message) => {
+      void poster.postCuResult({ requestId, executionError: message });
+    },
+  };
+}
+
+export function createHostCuExecutor(deps: HostCuExecutorDeps = {}): HostProxyExecutor {
+  return new HostHelperProxyExecutor(config(deps));
+}
+
+export const hostCuExecutor: HostProxyExecutor = createHostCuExecutor();

--- a/clients/macos/src/main/executors/host-helper-proxy-executor.ts
+++ b/clients/macos/src/main/executors/host-helper-proxy-executor.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared base for host-proxy executors that forward a single request to the
+ * native mac-helper via one JSON-RPC method and post the parsed result back.
+ *
+ * Both the computer-use (`cu.perform`) and app-control (`appControl.perform`)
+ * executors are the same shape — validate the request, call the helper, parse
+ * the result, post it — differing only in the method name, the params they
+ * build, the result schema, and which `poster.post*Result` they call. This
+ * base captures the common flow, including the cancellation bookkeeping
+ * (TTL-evicted so a cancel that races a completed request never leaks).
+ */
+
+import type { z } from "zod";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import type { MacHelperClient } from "../sidecar/mac-helper";
+import log from "../logger";
+
+/** Subset of the mac-helper client the executors depend on (injectable for tests). */
+export type CuHelperClient = Pick<MacHelperClient, "call">;
+
+const CANCEL_TTL_MS = 30_000;
+
+/** Result of building helper params: the params, or a reason to reject up front. */
+export type BuildParamsResult =
+  | { params: Record<string, unknown> }
+  | { error: string };
+
+export interface HostHelperProxyConfig<T> {
+  /** Short label for logs, e.g. "host-cu". */
+  label: string;
+  /** JSON-RPC method on the helper, e.g. "cu.perform". */
+  method: string;
+  resolveHelper: () => CuHelperClient;
+  /** Schema the helper result is validated against (tolerant of extra keys). */
+  schema: z.ZodType<T>;
+  /**
+   * Build the JSON-RPC params from the request, or return `{ error }` to reject
+   * the request up front (posted via `postError`) without calling the helper.
+   */
+  buildParams: (message: HostProxySseMessage, requestId: string) => BuildParamsResult;
+  /** Post a successful, validated result. */
+  postSuccess: (poster: HostProxyPoster, requestId: string, result: T) => void;
+  /** Post an error result (bad request, helper failure, invalid result). */
+  postError: (poster: HostProxyPoster, requestId: string, message: string) => void;
+}
+
+export class HostHelperProxyExecutor<T> implements HostProxyExecutor {
+  // Requests the daemon cancelled — their late helper result is dropped.
+  // Timestamped so entries from cancels that arrive after completion expire.
+  private readonly cancelledIds = new Map<string, number>();
+
+  constructor(private readonly config: HostHelperProxyConfig<T>) {}
+
+  handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+    const requestId = message.requestId as string | undefined;
+    if (!requestId) {
+      log.warn(`[${this.config.label}] message missing requestId`);
+      return;
+    }
+
+    if (this.consumeCancelled(requestId)) return;
+
+    const built = this.config.buildParams(message, requestId);
+    if ("error" in built) {
+      this.config.postError(poster, requestId, built.error);
+      return;
+    }
+
+    void this.run(requestId, built.params, poster);
+  }
+
+  handleCancel(message: HostProxySseMessage, _poster: HostProxyPoster): void {
+    const requestId = message.requestId as string | undefined;
+    if (requestId) this.markCancelled(requestId);
+  }
+
+  private async run(
+    requestId: string,
+    params: Record<string, unknown>,
+    poster: HostProxyPoster,
+  ): Promise<void> {
+    try {
+      const raw = await this.config.resolveHelper().call(this.config.method, params);
+      if (this.consumeCancelled(requestId)) return;
+
+      const parsed = this.config.schema.safeParse(raw);
+      if (!parsed.success) {
+        this.config.postError(
+          poster,
+          requestId,
+          `mac helper returned invalid ${this.config.method} result`,
+        );
+        return;
+      }
+
+      this.config.postSuccess(poster, requestId, parsed.data);
+    } catch (err) {
+      if (this.consumeCancelled(requestId)) return;
+      this.config.postError(
+        poster,
+        requestId,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  private markCancelled(requestId: string): void {
+    const now = Date.now();
+    this.cancelledIds.set(requestId, now);
+    for (const [id, ts] of this.cancelledIds) {
+      if (now - ts >= CANCEL_TTL_MS) this.cancelledIds.delete(id);
+    }
+  }
+
+  /** Returns true (and clears the flag) when `requestId` was cancelled. */
+  private consumeCancelled(requestId: string): boolean {
+    return this.cancelledIds.delete(requestId);
+  }
+}

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -24,6 +24,9 @@ import { hostFileExecutor } from "./executors/host-file-executor";
 import { hostTransferExecutor } from "./executors/host-transfer-executor";
 import { onLockfileChange, getWatchedLockfile } from "./lockfile-watcher";
 import { HostBrowserExecutor } from "./executors/host-browser-executor";
+import { hostCuExecutor } from "./executors/host-cu-executor";
+import { hostAppControlExecutor } from "./executors/host-app-control-executor";
+import { shutdownSharedCuHelper } from "./sidecar/shared-cu-helper";
 import { getSessionToken } from "./session-token-store";
 import log from "./logger";
 
@@ -390,6 +393,8 @@ export function installHostProxyBridge(
   setExecutor("host_bash", hostBashExecutor);
   setExecutor("host_file", hostFileExecutor);
   setExecutor("host_transfer", hostTransferExecutor);
+  setExecutor("host_cu", hostCuExecutor);
+  setExecutor("host_app_control", hostAppControlExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);
 
   // Seed from any assistants already present in the lockfile
@@ -410,6 +415,9 @@ export function installHostProxyBridge(
     }
     browserExecutor.destroy();
     removeExecutor("host_browser");
+    removeExecutor("host_cu");
+    removeExecutor("host_app_control");
+    shutdownSharedCuHelper();
     resolveCliInvocation = null;
   };
 }

--- a/clients/macos/src/main/hotkey-helper.test.ts
+++ b/clients/macos/src/main/hotkey-helper.test.ts
@@ -105,13 +105,15 @@ const {
   __resetForTesting,
   __setPlatformForTesting,
   __setSupervisorOptionsForTesting,
-  getMacHelperAppPath,
-  getMacHelperPath,
   installHotkeyHelper,
   queryFreshMacHelperPermission,
   requestMacHelperInputMonitoringPermission,
   requestMacHelperSpeechRecognitionPermission,
 } = await import("./hotkey-helper");
+
+const { getMacHelperAppPath, getMacHelperPath } = await import(
+  "./sidecar/mac-helper-path"
+);
 
 const invokeFnPushToTalk = (enable: boolean) =>
   handlers["vellum:helper:hotkey:fnPushToTalk"](

--- a/clients/macos/src/main/hotkey-helper.ts
+++ b/clients/macos/src/main/hotkey-helper.ts
@@ -22,6 +22,10 @@ import {
   type MacHelperClientOptions,
   type MacHelperState,
 } from "./sidecar/mac-helper";
+import {
+  getMacHelperAppPath,
+  getMacHelperPath,
+} from "./sidecar/mac-helper-path";
 
 export type {
   DictationPartialEvent,
@@ -99,22 +103,6 @@ let supervisorOptionsForTesting: Partial<
 
 const getPlatform = (): NodeJS.Platform =>
   platformForTesting ?? process.platform;
-
-export const getMacHelperPath = (): string => {
-  return path.join(
-    getMacHelperAppPath(),
-    "Contents",
-    "MacOS",
-    "vellum-mac-helper",
-  );
-};
-
-export const getMacHelperAppPath = (): string => {
-  if (app.isPackaged) {
-    return path.join(process.resourcesPath, "bin", "vellum-mac-helper.app");
-  }
-  return path.join(app.getAppPath(), "resources", "vellum-mac-helper.app");
-};
 
 const makeClient = (): MacHelperClient =>
   new MacHelperClient({

--- a/clients/macos/src/main/sidecar/mac-helper-path.ts
+++ b/clients/macos/src/main/sidecar/mac-helper-path.ts
@@ -1,0 +1,19 @@
+/**
+ * Resolves the on-disk location of the bundled `vellum-mac-helper.app` and its
+ * executable. Shared by every consumer that spawns the helper (hotkey/dictation
+ * and the host-proxy computer-use executors) so the path logic lives in one
+ * place.
+ */
+
+import { app } from "electron";
+import path from "node:path";
+
+export const getMacHelperAppPath = (): string => {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, "bin", "vellum-mac-helper.app");
+  }
+  return path.join(app.getAppPath(), "resources", "vellum-mac-helper.app");
+};
+
+export const getMacHelperPath = (): string =>
+  path.join(getMacHelperAppPath(), "Contents", "MacOS", "vellum-mac-helper");

--- a/clients/macos/src/main/sidecar/shared-cu-helper.ts
+++ b/clients/macos/src/main/sidecar/shared-cu-helper.ts
@@ -1,0 +1,45 @@
+/**
+ * Lazily-spawned mac-helper instance dedicated to the host-proxy computer-use
+ * and app-control executors.
+ *
+ * This is a separate `MacHelperClient` from the hotkey/dictation client in
+ * `hotkey-helper.ts`: the two drive disjoint JSON-RPC surfaces, and keeping
+ * them apart means a crash in one supervisor circuit never tears down the
+ * other. The underlying process is the same signed binary, so both share the
+ * user's Accessibility / Screen Recording TCC grants. The process is not
+ * spawned until the first `cu.perform` / `appControl.perform` call, so users
+ * who never invoke computer use pay nothing.
+ */
+
+import log from "../logger";
+import { MacHelperClient } from "./mac-helper";
+import { getMacHelperPath } from "./mac-helper-path";
+
+// Computer-use / app-control actions run an accessibility-tree walk, a settle
+// delay, and a screen capture before responding — well past the default 2s
+// request budget. Some inputs legitimately take longer (computer_use_wait,
+// long app_control_sequence, large text typing). Set this just above the
+// daemon's 60s host-proxy request timeout so the daemon's timeout stays
+// authoritative and the client never reports "did not respond" for an action
+// the daemon would still accept; the client timeout only catches a genuinely
+// hung helper.
+export const CU_HELPER_TIMEOUT_MS = 65_000;
+
+let client: MacHelperClient | null = null;
+
+export function getSharedCuHelper(): MacHelperClient {
+  if (!client) {
+    client = new MacHelperClient({
+      name: "mac helper (computer use)",
+      resolveExecutablePath: getMacHelperPath,
+      logger: log,
+      responseTimeoutMs: CU_HELPER_TIMEOUT_MS,
+    });
+  }
+  return client;
+}
+
+export function shutdownSharedCuHelper(): void {
+  client?.shutdown();
+  client = null;
+}


### PR DESCRIPTION
## Summary

Re-introduces the macOS **computer-use** and **app-control** tools on the Electron client. The legacy native Swift app provided these (screenshots, accessibility-tree reading, mouse/keyboard input, app control); when it was replaced by Electron, the client-side execution layer disappeared. The daemon already ships the full `host_cu` / `host_app_control` proxy pipeline and the `macos` interface auto-advertises both capabilities — the only gap was the client execution layer, which this PR fills.

## What changed

**Native `vellum-mac-helper` (Swift)** — ported the legacy CU/app-control logic (recovered from git history) into the standalone helper behind two JSON-RPC methods:
- `cu.perform` — runs the native verify → execute → settle → observe cycle: AccessibilityTree walk + AX diff, ScreenCaptureKit screenshot with px/pt Retina metadata, CGEvent input synthesis (click/double/right, type-via-paste, key combos, scroll, drag), open-app, AppleScript.
- `appControl.perform` — per-process app control (start/observe/press/combo/sequence/type/click/drag/stop) via `CGEvent.postToPid` + per-window ScreenCaptureKit capture.
- Added `ScreenCaptureKit` + `ApplicationServices` frameworks; `main.swift` dispatches these async (the sync JSON-RPC router can't host an `async`/`@MainActor` handler). Kept Swift 6 strict concurrency.
- Prompts for Accessibility on first non-observe action and returns a clear error observation when not granted.

**TypeScript executors** (`clients/macos/src/main/executors/`) — `host-cu-executor.ts` and `host-app-control-executor.ts` share a small `HostHelperProxyExecutor` base: validate the SSE request → call the helper via a dedicated lazily-spawned shared client (`sidecar/shared-cu-helper.ts`) → parse and post via `postCuResult` / `postAppControlResult`. Registered in `host-proxy-router.ts`; cancellation drops late results (TTL-evicted set).

**Supporting** — extracted `sidecar/mac-helper-path.ts`; added `NSScreenCaptureUsageDescription` + `NSAccessibilityUsageDescription` to the helper Info.plist.

## Contract

The TS executors and the Swift helper agree field-for-field: `cu.perform` returns `{ axTree?, axDiff?, screenshot? (base64 JPEG), screenshotWidthPx?/HeightPx?, screenWidthPt?/HeightPt?, executionResult?, executionError?, secondaryWindows? }`; `appControl.perform` returns `{ state: running|missing|minimized, pngBase64?, windowBounds?, executionResult?, executionError? }`. These match exactly what the daemon's `host-cu-result` / `host-app-control-result` routes consume.

## Self-review

Ran the run-plan multi-pass self-review (faithfulness **PASS**). Closed inline: the duplicate-executor slop (shared base), always-nil `userGuidance`, dead ported Swift helpers + dead `AgentAction` presentation layer + `summary`/`defaultMaxSteps`, redundant per-call timeout, comment slop, the TS cancelled-set leak (TTL eviction + pre-flight check, mirroring `host-browser-executor`), and the Swift per-session-state leak (`HostCuActionRunner.touchSession` evicts sessions idle >10 min).

Deferred follow-up: cancellation suppresses the late result but does not **abort** the in-flight action — tracked in **LUM-2563**. (A latent same-session concurrency concern is not triggered today since the daemon serializes CU steps.)

## Verification

- `swift build` (debug + release) + `swift test` (6/6); helper bundle builds and code-signs with the usage strings embedded.
- TypeScript `tsc --noEmit` clean.
- Full isolating test suite **60/60 files pass**, including new executor tests (success / error / missing-input / cancellation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)