### PR TITLE
refactor(gateway): cleanup createGuardianBinding id-resolution reads

### DIFF
--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -90,11 +90,6 @@ export function getExternalAssistantId(): string {
 // Contact operations (via IPC proxy to assistant's DB)
 // ---------------------------------------------------------------------------
 
-interface ExistingChannelRow {
-  id: string;
-  contactId: string;
-}
-
 /**
  * Find the existing guardian contact for the "vellum" channel.
  * Mirrors assistant's `findGuardianForChannel("vellum")`.
@@ -237,10 +232,11 @@ export async function createGuardianBinding(
   const displayName = params.displayName ?? params.externalUserId;
   const verifiedVia = params.verifiedVia ?? "challenge";
 
-  // --- Id resolution (reads the gateway DB; ids feed the dual-write) ---
+  // Resolve ids from the gateway DB; the dual-write keeps both DBs in sync, so
+  // a gateway-resolved id matches the assistant row in normal operation.
   const gwReadDb = getGatewayDb();
 
-  const existingContacts = gwReadDb
+  const existingGuardianContact = gwReadDb
     .select({ id: gwContacts.id })
     .from(gwContacts)
     .where(
@@ -250,10 +246,9 @@ export async function createGuardianBinding(
       ),
     )
     .limit(1)
-    .all();
-  const existingGuardianContactId = existingContacts[0]?.id;
+    .get();
 
-  const claimableChannels = gwReadDb
+  const claimableChannel = gwReadDb
     .select({
       id: gwContactChannels.id,
       contactId: gwContactChannels.contactId,
@@ -267,38 +262,37 @@ export async function createGuardianBinding(
       ),
     )
     .orderBy(
-      sql`CASE WHEN ${gwContactChannels.contactId} = ${existingGuardianContactId ?? ""} THEN 0 ELSE 1 END`,
+      sql`CASE WHEN ${gwContactChannels.contactId} = ${existingGuardianContact?.id ?? ""} THEN 0 ELSE 1 END`,
       sql`CASE ${gwContactChannels.status} WHEN 'active' THEN 0 WHEN 'unverified' THEN 1 ELSE 2 END`,
       desc(gwContactChannels.updatedAt),
     )
     .limit(1)
-    .all() as ExistingChannelRow[];
+    .get();
 
   const contactId =
-    existingContacts[0]?.id ?? claimableChannels[0]?.contactId ?? uuid();
+    existingGuardianContact?.id ?? claimableChannel?.contactId ?? uuid();
 
-  let existingChannels: { id: string }[] = [];
-  if (!claimableChannels[0] && existingContacts[0]) {
-    existingChannels = gwReadDb
-      .select({ id: gwContactChannels.id })
-      .from(gwContactChannels)
-      .where(
-        and(
-          eq(gwContactChannels.contactId, contactId),
-          eq(gwContactChannels.type, params.channel),
-        ),
-      )
-      .limit(1)
-      .all();
-  }
+  const existingChannel =
+    !claimableChannel && existingGuardianContact
+      ? gwReadDb
+          .select({ id: gwContactChannels.id })
+          .from(gwContactChannels)
+          .where(
+            and(
+              eq(gwContactChannels.contactId, contactId),
+              eq(gwContactChannels.type, params.channel),
+            ),
+          )
+          .limit(1)
+          .get()
+      : undefined;
 
-  const channelId =
-    claimableChannels[0]?.id ?? existingChannels[0]?.id ?? uuid();
+  const channelId = claimableChannel?.id ?? existingChannel?.id ?? uuid();
 
   // --- Assistant DB write (primary, via IPC proxy) ---
   await assistantDbExec("BEGIN IMMEDIATE");
   try {
-    if (existingContacts[0] || claimableChannels[0]) {
+    if (existingGuardianContact || claimableChannel) {
       await assistantDbRun(
         `UPDATE contacts
          SET display_name = ?, role = 'guardian', principal_id = ?, updated_at = ?
@@ -313,7 +307,7 @@ export async function createGuardianBinding(
       );
     }
 
-    if (claimableChannels[0] || existingChannels[0]) {
+    if (claimableChannel || existingChannel) {
       // Remove duplicate channels with the same address (defensive).
       await assistantDbRun(
         `DELETE FROM contact_channels


### PR DESCRIPTION
## Summary
- Remove dead ExistingChannelRow type + redundant cast; use .get() for single-row gateway reads to match sibling readers.
- Document the accepted gateway/assistant id-sync assumption; no write-path or transaction changes.

Follow-up cleanup for plan: gateway-bootstrap-binding-reads.md