### PR TITLE
fix(llm-resolver): keep explicit call-site temperature/top_p when a higher profile is silent

### DIFF
--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -1555,6 +1555,84 @@ describe("resolveCallSiteConfig sampling-param provenance (temperature / top_p)"
     expect(resolved.model).toBe("claude-opus-4-7");
     expect(resolved.topP).toBeNull();
   });
+
+  test("forceOverrideProfile: an explicit call-site temperature survives a forced profile silent on sampling", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        active: { verbosity: "low" },
+        sitep: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        forced: { model: "claude-opus-4-7", effort: "high" },
+      },
+      callSites: {
+        memoryExtraction: {
+          profile: "sitep",
+          temperature: 0.7,
+          maxTokens: 1000,
+        },
+      },
+      activeProfile: "active",
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm, {
+      overrideProfile: "forced",
+      forceOverrideProfile: true,
+    });
+    // The forced profile floats to the top for fields it sets.
+    expect(resolved.model).toBe("claude-opus-4-7");
+    expect(resolved.effort).toBe("high");
+    // It is silent on temperature, so the deliberate call-site value survives —
+    // consistent with sibling call-site fields like maxTokens (which flow
+    // through the deep-merge).
+    expect(resolved.temperature).toBe(0.7);
+    expect(resolved.maxTokens).toBe(1000);
+  });
+
+  test("forceOverrideProfile: a forced profile that sets temperature wins over the call-site override", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        sitep: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        forced: { model: "claude-opus-4-7", temperature: 0.1 },
+      },
+      callSites: {
+        memoryExtraction: { profile: "sitep", temperature: 0.7 },
+      },
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm, {
+      overrideProfile: "forced",
+      forceOverrideProfile: true,
+    });
+    // The forced profile explicitly sets temperature, so it floats above the
+    // call-site override.
+    expect(resolved.temperature).toBe(0.1);
+  });
+
+  test("mainAgent: an explicit call-site temperature survives an active profile silent on sampling", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: { active: { model: "claude-sonnet-4-7" } },
+      callSites: { mainAgent: { temperature: 0.5 } },
+      activeProfile: "active",
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm);
+    // The active profile floats above the call-site for mainAgent but is silent
+    // on temperature, so the deliberate call-site value survives.
+    expect(resolved.model).toBe("claude-sonnet-4-7");
+    expect(resolved.temperature).toBe(0.5);
+  });
+
+  test("mainAgent: the active profile's explicit temperature wins over a call-site temperature", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: { active: { model: "claude-sonnet-4-7", temperature: 0.2 } },
+      callSites: { mainAgent: { temperature: 0.5 } },
+      activeProfile: "active",
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm);
+    // For mainAgent the active profile floats above the call-site override, so
+    // its explicit temperature wins.
+    expect(resolved.temperature).toBe(0.2);
+  });
 });
 
 describe("resolveCallSiteConfig — workflowLeaf default", () => {

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -125,11 +125,16 @@ export function resolveCallSiteConfig(
 
   // Effective sampling params, tracked outside the deep-merge for the same
   // reason as `logitBias`: `temperature`/`top_p` are provider-coupled, so only
-  // the winning profile may contribute them. Each profile fully determines the
-  // pair (REPLACE — a profile that omits a param clears what a lower-precedence
-  // profile set), while an explicit call-site override COALESCES on top (see
-  // `appendProfileLayer` / `appendCallSiteLayers`).
-  const samplingRef: SamplingRef = { temperature: undefined, topP: undefined };
+  // the winning profile may contribute them. A profile clears what a lower
+  // PROFILE set where it is silent (so a shadowed profile's sampling can't
+  // leak), while an explicit call-site override is sticky and survives a later
+  // silent profile (see `applyProfileSampling` / `appendCallSiteLayers`).
+  const samplingRef: SamplingRef = {
+    temperature: undefined,
+    topP: undefined,
+    temperatureFromCallSite: false,
+    topPFromCallSite: false,
+  };
 
   const activeFragment = resolveProfileFragment(llm.activeProfile, llm, opts);
   const overrideFragment = resolveProfileFragment(
@@ -224,6 +229,13 @@ type LogitBiasRef = { preset: ProfileEntry["logitBias"] };
 type SamplingRef = {
   temperature: ProfileEntry["temperature"];
   topP: ProfileEntry["topP"];
+  // Provenance of the current pair: `true` when a field came from an explicit
+  // call-site override (deliberate, sticky), `false` when it came from a profile
+  // (clearable by a higher-precedence profile that determines the model). Lets a
+  // silent higher profile clear a lower profile's sampling without discarding a
+  // deliberate call-site override.
+  temperatureFromCallSite: boolean;
+  topPFromCallSite: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -383,6 +395,32 @@ function withImpliedProviderForKnownModel(source: Mergeable): Mergeable {
   };
 }
 
+/**
+ * Fold a profile's sampling into `samplingRef`. A profile determines
+ * provider/model, so its pair supersedes any LOWER PROFILE's: set each field the
+ * profile specifies, and clear a lower profile's value where the profile is
+ * silent. A deliberate call-site override is NOT a profile and outranks a silent
+ * profile — it survives until a profile EXPLICITLY sets the field. (The mirror
+ * COALESCE for call-site overrides lives in `appendCallSiteLayers`.)
+ */
+function applyProfileSampling(
+  samplingRef: SamplingRef,
+  profile: ProfileEntry,
+): void {
+  if (profile.temperature !== undefined) {
+    samplingRef.temperature = profile.temperature;
+    samplingRef.temperatureFromCallSite = false;
+  } else if (!samplingRef.temperatureFromCallSite) {
+    samplingRef.temperature = undefined;
+  }
+  if (profile.topP !== undefined) {
+    samplingRef.topP = profile.topP;
+    samplingRef.topPFromCallSite = false;
+  } else if (!samplingRef.topPFromCallSite) {
+    samplingRef.topP = undefined;
+  }
+}
+
 function appendProfileLayer(
   layers: Mergeable[],
   profile: ProfileEntry | undefined,
@@ -391,11 +429,7 @@ function appendProfileLayer(
 ): void {
   if (profile != null) {
     biasRef.preset = profile.logitBias;
-    // Each profile fully determines the sampling pair: a profile that omits
-    // `temperature`/`topP` clears what a lower-precedence profile set, so the
-    // winning (last-appended) profile is the sole profile source.
-    samplingRef.temperature = profile.temperature;
-    samplingRef.topP = profile.topP;
+    applyProfileSampling(samplingRef, profile);
     layers.push(profileConfigFragment(profile));
   }
 }
@@ -422,24 +456,29 @@ function appendCallSiteLayers(
         );
       }
       biasRef.preset = profileFragment.logitBias;
-      samplingRef.temperature = profileFragment.temperature;
-      samplingRef.topP = profileFragment.topP;
+      applyProfileSampling(samplingRef, profileFragment);
       layers.push(profileConfigFragment(profileFragment));
     }
     // Strip the `profile` discriminator (not a `LLMConfigBase` field) and the
     // sampling params before merging. An explicit call-site `temperature` /
     // `topP` is a deliberate per-site choice, so it COALESCES over the winning
-    // profile's pair (only overriding the fields it sets) — routed through
-    // `samplingRef` so it never inherits a shadowed profile's value via merge.
+    // profile's pair (only overriding the fields it sets) and is marked sticky
+    // so a later silent profile can't clear it — routed through `samplingRef` so
+    // it never inherits a shadowed profile's value via merge.
     const {
       profile: _profile,
       temperature: siteTemperature,
       topP: siteTopP,
       ...siteFragment
     } = site;
-    if (siteTemperature !== undefined)
+    if (siteTemperature !== undefined) {
       samplingRef.temperature = siteTemperature;
-    if (siteTopP !== undefined) samplingRef.topP = siteTopP;
+      samplingRef.temperatureFromCallSite = true;
+    }
+    if (siteTopP !== undefined) {
+      samplingRef.topP = siteTopP;
+      samplingRef.topPFromCallSite = true;
+    }
     layers.push(siteFragment as Mergeable);
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #35823 addressing the Codex P2 review finding. In the `mainAgent` and `forceOverrideProfile` branches a profile is appended *after* the call-site layer, so the `samplingRef` REPLACE-on-silence wiped a deliberate call-site `temperature`/`topP` with `undefined` (and the field was stripped from the merge, so there was no fallback) — dropping it even though sibling call-site fields like `maxTokens`/`speed` survived. This contradicted the resolver's own docstring ("an explicit call-site override still wins").
- **Fix**: track provenance on `samplingRef` (`temperatureFromCallSite`/`topPFromCallSite`). A profile clears only a *lower profile's* sampling where it's silent; an explicit call-site override is sticky and survives a later silent profile, while an explicit profile value still wins. Factored the per-field profile logic into `applyProfileSampling` (shared by `appendProfileLayer` and the site-profile branch of `appendCallSiteLayers`). All existing cross-profile leak prevention is preserved.
- Added regression tests for both the `forceOverrideProfile` case Codex flagged and the `mainAgent` analog, in both directions (silent profile → call-site survives; explicit profile → profile wins).

## Original prompt
Codex left a P2 on #35823: when `forceOverrideProfile` appends a higher-precedence profile that doesn't set `temperature`/`topP`, the new sampling tracking overwrote the call-site override's explicit value with `undefined`, so e.g. a forced profile that only changes `model` dropped a `callSites.X.temperature`. I confirmed it's a real (latent) bug — the same class also affects `mainAgent` — and the ask was to fix it by making the call-site override sticky against a silent higher profile while still letting an explicit profile value win and preserving the cross-profile leak prevention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)