### PR TITLE
docs(anthropic): scope the deprecated-sampler strip to the direct API

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -864,13 +864,20 @@ export class AnthropicProvider implements Provider {
         (restConfig as Record<string, unknown>).model?.toString() ?? this.model;
       const isHaiku = effectiveModel.includes("haiku");
       const supportsEffort = !isHaiku;
-      // opus-4-7 / opus-4-8 reject `temperature` and `top_p` with a 400
-      // "`temperature`/`top_p` is deprecated for this model" — model-wide, not
+      // opus-4-7 / opus-4-8 reject `temperature`, `top_p`, and `top_k` with a
+      // 400 "`<param>` is deprecated for this model" — model-wide, not
       // effort-conditional (verified 2026-06-23). opus-4-6 / sonnet-4-6 /
       // haiku-4-5 still accept them. fable-5 is included conservatively (a
       // frontier model that could not be verified directly but follows the same
       // deprecation direction). Stripping the params here keeps callers that set
       // them (e.g. the memory-v3 L2 selector's `temperature: 0`) from 400ing.
+      //
+      // This dash-form predicate targets the direct Anthropic API. The
+      // OpenRouter delegation reuses this provider with dotted catalog IDs
+      // (`anthropic/claude-opus-4.8`), which it deliberately does not match:
+      // OpenRouter's Messages endpoint accepts these params for the same models
+      // (verified 2026-06-23, 200), so stripping there would alter sampling on a
+      // working path rather than avert a 400.
       const deprecatesSamplingParams =
         /claude-opus-4-[78]\b/.test(effectiveModel) ||
         effectiveModel.startsWith("claude-fable-");


### PR DESCRIPTION
## Summary
- Follow-up to #35820 addressing a Codex P2 on the OpenRouter Anthropic path. Codex correctly observed that `deprecatesSamplingParams` (the dash-form regex `claude-opus-4-[78]`) does **not** match OpenRouter's dotted catalog IDs (`anthropic/claude-opus-4.8` / `:4.7`), which delegate into `AnthropicProvider` via `OpenRouterProvider.sendMessage` — so `temperature`/`top_p`/`top_k` still flow through on that path.
- **But the predicted 400 does not occur.** Verified live (2026-06-23) via the real `OpenRouterProvider`: opus-4.8 / 4.7 / 4.6 each return **200 + a usable `tool_use`** with the full sampler trio on the wire. OpenRouter's Anthropic-compat Messages endpoint absorbs the deprecated params — matching the user-observed "works via OpenRouter, fails Anthropic-direct" split that drove this incident. Stripping there would alter sampling on a *working* path rather than avert a 400, so the predicate is left as-is.
- **Doc-only:** documents the predicate's deliberate direct-API scope (so it isn't re-flagged or "fixed" into a regression), and corrects the upper comment that #35820 left listing only two params (`temperature`/`top_p`) to the full deprecated trio including `top_k`.

## Original prompt
Sidd asked me to look at the Codex review comment on PR #35820 and address it in a follow-up if I agreed. I investigated: Codex's code-path claim is accurate, but its consequence (OpenRouter users hitting the deprecated-`top_k` 400) is empirically false — OpenRouter normalizes the params. So rather than implement Codex's suggested strip (a no-op at best, a silent sampling change at worst), this PR documents why the predicate deliberately scopes to the direct Anthropic API, plus a stale-comment cleanup from #35820.

No behavior change; no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
