### PR TITLE
perf(memory): cut inter-call embed delay to 100ms to speed onboarding

### DIFF
--- a/assistant/src/memory/embedding-gemini.ts
+++ b/assistant/src/memory/embedding-gemini.ts
@@ -40,7 +40,7 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
     this.taskType = options?.taskType;
     this.dimensions = options?.dimensions;
     this.managedBaseUrl = options?.managedBaseUrl;
-    this.interCallDelayMs = options?.interCallDelayMs ?? 5000;
+    this.interCallDelayMs = options?.interCallDelayMs ?? 100;
   }
 
   /** True when requests route through the managed platform proxy. */


### PR DESCRIPTION
## Why

The `GeminiEmbedding` inter-call delay defaulted to **5000ms**. This sleep yields the event loop between sequential embed calls so the daemon stays responsive during large batches — but the comment on it explicitly calls out the **startup skill reseed** as the batch it's protecting.

The problem: a cold-start skill reseed runs 68+ sequential Gemini embeds. At 5s apiece, that's **5+ minutes** of added latency, which is negatively affecting onboarding (the finder lane / skill pinning has nothing to surface until the reseed finishes).

## What

Drop the default `interCallDelayMs` from `5000` → `100`. We still yield to the event loop between every embed call (so HTTP requests, health checks, and cron ticks aren't starved), but the reseed no longer stalls for minutes. 100ms × 67 gaps ≈ 6.7s of yielding instead of ~5.6 minutes.

The value remains injectable via `GeminiEmbeddingOptions.interCallDelayMs`, so callers that need a different cadence are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pv5yg4CXJUXAQuoY4Rm21p)_