### PR TITLE
Ignore runtime SQLite databases in data/db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,11 @@ clients/web/public/skills/
 # Generated at release time by the publish-meta jobs (release.yml)
 meta/package-lock.json
 meta/npm-shrinkwrap.json
+
+# Runtime SQLite databases. These live on the assistant's workspace volume
+# (VELLUM_WORKSPACE_DIR, e.g. /workspace/data/db) and must never be committed.
+# Scoped to data/db/ plus sqlite sidecar files so intentionally-tracked
+# fixture databases elsewhere in the tree are unaffected.
+data/db/
+*.sqlite-wal
+*.sqlite-shm


### PR DESCRIPTION
Closing as unnecessary.

The runtime-generated workspace `.gitignore` (written by `WorkspaceGitService` in `assistant/src/workspace/git-service.ts`, `WORKSPACE_GITIGNORE_RULES`) already covers `/workspace/data/db` — via a `data/db/` directory rule plus `*.db`/`*.sqlite` extension rules (including `-wal`/`-shm`/`-journal` sidecars). Those rules are applied idempotently on every workspace git init, including appending to pre-existing `.gitignore` files.

This PR patched the *repo root* `.gitignore`, which never receives `data/db` SQLite files in normal operation, so it addressed the wrong file.