### PR TITLE
fix(skills): hand gmail-scan cache payload to CLI via --file, not piped stdin

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -270,7 +270,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-04T21:30:07.000Z"
+      "updatedAt": "2026-06-23T21:36:50.000Z"
     },
     {
       "id": "google-calendar",
@@ -644,7 +644,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-22T22:11:12.000Z"
+      "updatedAt": "2026-06-23T08:55:44.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/gmail/scripts/gmail-scan.ts
+++ b/skills/gmail/scripts/gmail-scan.ts
@@ -7,6 +7,10 @@
  *   outreach-scan  — Find senders without prior replies (likely cold outreach)
  */
 
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { parseArgs, optionalArg, printError, ok } from "./lib/common.js";
 import {
   gmailGet,
@@ -69,27 +73,49 @@ interface OutreachSenderAggregation {
  * Store data in the daemon's in-memory cache via `assistant cache set`.
  * Returns the cache key. Keeps large payloads (e.g. thousands of message IDs)
  * out of the LLM conversation context.
+ *
+ * The payload is handed to the CLI via `--file` rather than piped stdin: a
+ * subprocess pipe read-end cannot be reopened by path, so piping is fragile
+ * across runtime environments, and a temp file has no command-line length
+ * limit for the large payloads this writes.
  */
 async function cacheStore(data: unknown): Promise<string> {
-  const proc = Bun.spawn(
-    ["assistant", "cache", "set", "--ttl", "30m", "--json"],
-    { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
-  );
-  proc.stdin.write(JSON.stringify(data));
-  proc.stdin.end();
+  const dir = mkdtempSync(join(tmpdir(), "gmail-scan-cache-"));
+  const payloadPath = join(dir, "payload.json");
+  try {
+    writeFileSync(payloadPath, JSON.stringify(data), "utf-8");
 
-  const stdout = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
+    const proc = Bun.spawn(
+      [
+        "assistant",
+        "cache",
+        "set",
+        "--file",
+        payloadPath,
+        "--ttl",
+        "30m",
+        "--json",
+      ],
+      { stdin: "ignore", stdout: "pipe", stderr: "pipe" },
+    );
 
-  if (exitCode !== 0) {
-    throw new Error(`assistant cache set failed (exit ${exitCode}): ${stdout}`);
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      throw new Error(
+        `assistant cache set failed (exit ${exitCode}): ${stdout}`,
+      );
+    }
+
+    const result = JSON.parse(stdout);
+    if (!result.ok) {
+      throw new Error(`assistant cache set error: ${result.error}`);
+    }
+    return result.key;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
-
-  const result = JSON.parse(stdout);
-  if (!result.ok) {
-    throw new Error(`assistant cache set error: ${result.error}`);
-  }
-  return result.key;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`gmail-scan.ts`'s `cacheStore()` spawned `assistant cache set` with `stdin: "pipe"` and wrote the payload to the child's stdin. The CLI consumed stdin by reopening the pipe read-end by path (`/dev/stdin`), which fails with `ENXIO` in the sandboxed bash environment. So every inbox scan ran ~100s of Gmail fetching, then **died at the cache-write step** — and the model, reading *"Failed to read stdin"*, burned ~8 retries on stdin workarounds before giving up (~20 tool calls / ~10 min, no result).

Write the payload to a temp file and pass `--file` instead. This avoids the fragile pipe entirely and sidesteps command-line length limits for the large payloads (thousands of message IDs) this stores. The temp dir is cleaned up in a `finally` block.

## Relationship to #35838

#35838 is the **root-cause** fix — `cache set` now reads fd 0 directly, repairing the whole class of piped-subprocess callers. This PR is the **belt-and-suspenders** change on the caller side: `--file` is the documented robust input path for large payloads regardless of how the CLI reads stdin. Either PR alone fixes the inbox scan; together they're defense in depth.

## Test

- `bun build` parse check passes; script runs (early-exits cleanly on a bad subcommand).
- The cache-write path needs a live daemon (IPC), so it's exercised by the existing CLI test suite in #35838 rather than re-stubbed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)