### PR TITLE
fix(memory): seed capability needle lane independent of the embedding backend

### DIFF
--- a/assistant/src/memory/v2/__tests__/cli-command-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/cli-command-store.test.ts
@@ -417,28 +417,13 @@ describe("seedV2CliCommandEntries", () => {
     expect(getCliCommandCapability("browser")).not.toBeNull();
   });
 
-  test("treats an empty command set as anomalous: skips prune and preserves the prior cache", async () => {
-    // The Commander tree is always non-empty in production, so an empty
-    // `buildCliProgramTree()` result is a transient anomaly — not a signal to
-    // clear. We neither prune Qdrant (nothing was persisted this run) nor wipe
-    // a previously-populated cache, which would take the needle lane dark.
-    state.commands = [
-      { name: "config", description: "Manage configuration", helpText: "..." },
-    ];
-    state.embedReturn = [[0.1, 0.2, 0.3]];
-
-    await seedV2CliCommandEntries();
-    expect(getCliCommandCapability("config")).not.toBeNull();
-
-    state.upsertCalls.length = 0;
-    state.pruneCalls.length = 0;
+  test("empty command set still calls prune to clear stale rows", async () => {
     state.commands = [];
 
     await seedV2CliCommandEntries();
 
     expect(state.upsertCalls).toHaveLength(0);
-    expect(state.pruneCalls).toHaveLength(0);
-    // The prior cache survives the anomalous empty run.
-    expect(getCliCommandCapability("config")).not.toBeNull();
+    expect(state.pruneCalls).toHaveLength(1);
+    expect(state.pruneCalls[0].activeSuffixes).toEqual([]);
   });
 });

--- a/assistant/src/memory/v2/__tests__/cli-command-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/cli-command-store.test.ts
@@ -371,6 +371,31 @@ describe("seedV2CliCommandEntries", () => {
     ).rejects.toThrow("backend exploded");
   });
 
+  test("populates the cache from the Commander tree on the first seed even when the embedding backend is unavailable (cold-start needle resilience)", async () => {
+    // Cold-start race: the startup seed runs before the managed embedding
+    // credential is provisioned, so the first `embedWithBackend` throws. The
+    // in-memory cache (read by the v3 needle lane and the page index) must
+    // still populate from the local Commander tree so CLI commands are
+    // discoverable from first boot; only the dense Qdrant upsert is deferred.
+    state.commands = [
+      { name: "config", description: "Manage configuration", helpText: "..." },
+    ];
+    state.embedThrows = new Error(
+      'Embedding backend "gemini" is not configured',
+    );
+
+    await expect(seedV2CliCommandEntries()).resolves.toBeUndefined();
+
+    const entry = getCliCommandCapability("config");
+    expect(entry).not.toBeNull();
+    expect(entry?.id).toBe("config");
+    expect(listCliCommandEntries().map((e) => e.id)).toEqual(["config"]);
+
+    // No dense vectors were produced, so the Qdrant write is skipped entirely.
+    expect(state.upsertCalls).toHaveLength(0);
+    expect(state.pruneCalls).toHaveLength(0);
+  });
+
   test("skips stale in-flight seed results when a newer refresh is requested", async () => {
     state.commands = [
       { name: "config", description: "Manage configuration", helpText: "..." },
@@ -392,13 +417,28 @@ describe("seedV2CliCommandEntries", () => {
     expect(getCliCommandCapability("browser")).not.toBeNull();
   });
 
-  test("empty command set still calls prune to clear stale rows", async () => {
+  test("treats an empty command set as anomalous: skips prune and preserves the prior cache", async () => {
+    // The Commander tree is always non-empty in production, so an empty
+    // `buildCliProgramTree()` result is a transient anomaly — not a signal to
+    // clear. We neither prune Qdrant (nothing was persisted this run) nor wipe
+    // a previously-populated cache, which would take the needle lane dark.
+    state.commands = [
+      { name: "config", description: "Manage configuration", helpText: "..." },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2CliCommandEntries();
+    expect(getCliCommandCapability("config")).not.toBeNull();
+
+    state.upsertCalls.length = 0;
+    state.pruneCalls.length = 0;
     state.commands = [];
 
     await seedV2CliCommandEntries();
 
     expect(state.upsertCalls).toHaveLength(0);
-    expect(state.pruneCalls).toHaveLength(1);
-    expect(state.pruneCalls[0].activeSuffixes).toEqual([]);
+    expect(state.pruneCalls).toHaveLength(0);
+    // The prior cache survives the anomalous empty run.
+    expect(getCliCommandCapability("config")).not.toBeNull();
   });
 });

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -619,6 +619,87 @@ Write a local article draft.
     expect(after).toEqual(before);
   });
 
+  test("populates the cache from the local catalog on the first seed even when the embedding backend is unavailable (cold-start needle resilience)", async () => {
+    // Regression: on a brand-new managed assistant the startup seed runs before
+    // the platform provisions the managed embedding credential, so the very
+    // first `embedWithBackend` throws. The in-memory cache (which the v3 needle
+    // lane and the page index read) must still populate from the local catalog
+    // so skills are discoverable from first boot; only the dense Qdrant upsert
+    // is deferred until the backend recovers.
+    const skillA = makeSummary({
+      id: "example-skill-a",
+      displayName: "Skill A",
+    });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    // No prior successful seed — the backend is unconfigured from the start.
+    state.embedThrows = new Error(
+      'Embedding backend "gemini" is not configured',
+    );
+
+    // Best-effort callers (the startup seed) must resolve.
+    await expect(seedV2SkillEntries()).resolves.toBeUndefined();
+
+    // The needle-lane cache is populated despite the dense-embed failure.
+    const entry = getSkillCapability("example-skill-a");
+    expect(entry).not.toBeNull();
+    expect(entry?.id).toBe("example-skill-a");
+    expect(entry?.content).toContain("Skill A");
+    expect(listSkillEntries().map((e) => e.id)).toEqual(["example-skill-a"]);
+
+    // No dense vectors were produced, so the Qdrant write is skipped entirely.
+    expect(state.upsertCalls).toHaveLength(0);
+    expect(state.pruneCalls).toHaveLength(0);
+  });
+
+  test("surfaces the dense-embed failure to throwOnError callers while still populating the needle cache", async () => {
+    // The managed-credential reseed and the operator reembed route pass
+    // `throwOnError` so they learn the dense lane didn't complete and the
+    // retry/maintain machinery backfills it — but the needle cache is fixed
+    // regardless before the error propagates.
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.embedThrows = new Error("backend down");
+
+    await expect(seedV2SkillEntries({ throwOnError: true })).rejects.toThrow(
+      "backend down",
+    );
+
+    expect(getSkillCapability("example-skill-a")).not.toBeNull();
+    expect(state.upsertCalls).toHaveLength(0);
+  });
+
+  test("does not wipe a populated cache when a reseed finds no skills and the catalog is unavailable", async () => {
+    // Regression: an empty enumeration we can't trust (no enabled local skills
+    // AND a failed catalog fetch) must not atomically clear the cache and take
+    // the needle lane dark. Only a genuinely-available, genuinely-empty catalog
+    // clears stale entries.
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.fullCatalog = [
+      { id: "example-skill-a", name: "example-skill-a", description: "A" },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    // First run populates the cache.
+    await seedV2SkillEntries();
+    expect(getSkillCapability("example-skill-a")).not.toBeNull();
+
+    // Second run: no enabled local skills AND the catalog fetch throws — an
+    // unverified-empty enumeration. The prior cache must survive.
+    state.catalog = [];
+    state.resolved = [];
+    state.fullCatalog = [];
+    state.fullCatalogThrows = new Error("catalog fetch failed");
+
+    await seedV2SkillEntries();
+
+    expect(getSkillCapability("example-skill-a")).not.toBeNull();
+    expect(listSkillEntries().map((e) => e.id)).toEqual(["example-skill-a"]);
+  });
+
   test("no enabled skills yields empty cache and no prune when catalog is empty", async () => {
     state.catalog = [];
     state.resolved = [];

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -670,11 +670,10 @@ Write a local article draft.
     expect(state.upsertCalls).toHaveLength(0);
   });
 
-  test("does not wipe a populated cache when a reseed finds no skills and the catalog is unavailable", async () => {
-    // Regression: an empty enumeration we can't trust (no enabled local skills
-    // AND a failed catalog fetch) must not atomically clear the cache and take
-    // the needle lane dark. Only a genuinely-available, genuinely-empty catalog
-    // clears stale entries.
+  test("drops a locally-disabled installed skill even when the catalog is unavailable (local state is authoritative)", async () => {
+    // Regression: the local resolution is authoritative, so a skill that is
+    // still installed but explicitly disabled must NOT be kept alive by remote-
+    // catalog uncertainty — `getSkillCapability` and the page index must drop it.
     const skillA = makeSummary({ id: "example-skill-a" });
     state.catalog = [skillA];
     state.resolved = [{ summary: skillA, state: "enabled" }];
@@ -683,21 +682,21 @@ Write a local article draft.
     ];
     state.embedReturn = [[0.1, 0.2, 0.3]];
 
-    // First run populates the cache.
+    // First run: skillA enabled and cached.
     await seedV2SkillEntries();
     expect(getSkillCapability("example-skill-a")).not.toBeNull();
 
-    // Second run: no enabled local skills AND the catalog fetch throws — an
-    // unverified-empty enumeration. The prior cache must survive.
-    state.catalog = [];
-    state.resolved = [];
+    // Second run: skillA is still locally installed but now disabled; the remote
+    // catalog is unavailable. It stays in `installedIds`, so the carry-forward
+    // must skip it and the cache drops it.
+    state.resolved = [{ summary: skillA, state: "disabled" }];
     state.fullCatalog = [];
     state.fullCatalogThrows = new Error("catalog fetch failed");
 
     await seedV2SkillEntries();
 
-    expect(getSkillCapability("example-skill-a")).not.toBeNull();
-    expect(listSkillEntries().map((e) => e.id)).toEqual(["example-skill-a"]);
+    expect(getSkillCapability("example-skill-a")).toBeNull();
+    expect(listSkillEntries()).toEqual([]);
   });
 
   test("no enabled skills yields empty cache and no prune when catalog is empty", async () => {

--- a/assistant/src/memory/v2/cli-command-store.ts
+++ b/assistant/src/memory/v2/cli-command-store.ts
@@ -226,10 +226,10 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
       nextEntries.set(seed.id, seed);
     }
 
-    // Write Qdrant points and reconcile the collection only when dense vectors
-    // were produced. In the degraded (backend-unavailable) path we skip Qdrant
-    // mutation entirely so we never write half-formed points or prune against a
-    // set we did not persist.
+    // Write the dense+sparse Qdrant points only when dense vectors were
+    // produced. In the degraded (backend-unavailable) path we skip the upsert
+    // so we never write half-formed points; the dense lane backfills on
+    // recovery.
     if (seeds.length > 0 && denseAvailable) {
       const now = Date.now();
       await Promise.all(
@@ -243,11 +243,15 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
           }),
         ),
       );
+    }
 
-      // The CLI tree is always available (no remote catalog), so pruning is
-      // unconditional once we have written the current set. Run the legacy
-      // `kind` backfill once per process so pre-discriminator rows become
-      // prunable.
+    // The CLI tree is always available (no remote catalog), so pruning to clear
+    // stale rows runs whenever we wrote the current set this run OR there was
+    // nothing to embed (empty tree). The cold-start degraded path (commands
+    // present but dense embedding unavailable) skips the prune so we never
+    // reconcile the collection against a set we did not persist. Run the legacy
+    // `kind` backfill once per process so pre-discriminator rows become prunable.
+    if (denseAvailable || seeds.length === 0) {
       const knownIds = new Set(seeds.map((s) => s.id));
       if (!legacyKindBackfillDone) {
         try {
@@ -271,24 +275,11 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
       );
     }
 
-    // Replace the cache — but never clear a populated cache with an empty
-    // enumeration. The Commander tree is always non-empty in practice, so an
-    // empty `nextEntries` means `buildCliProgramTree` returned nothing
-    // (anomalous); keep the prior cache rather than wiping the needle lane.
-    const priorEntries = entries;
-    if (
-      nextEntries.size === 0 &&
-      priorEntries !== null &&
-      priorEntries.size > 0
-    ) {
-      log.warn(
-        { cachedEntries: priorEntries.size },
-        "Refusing to clear cached CLI-command entries on an empty program tree — preserving the prior cache",
-      );
-    } else {
-      entries = nextEntries;
-      invalidatePageIndex();
-    }
+    // Atomically replace the cache from the freshly enumerated commands. Drop
+    // the page-index cache so the next router invocation observes the new
+    // command set.
+    entries = nextEntries;
+    invalidatePageIndex();
 
     // Surface a dense-embed failure to `throwOnError` callers so the existing
     // retry + maintain machinery backfills the dense lane. The in-memory cache

--- a/assistant/src/memory/v2/cli-command-store.ts
+++ b/assistant/src/memory/v2/cli-command-store.ts
@@ -161,22 +161,23 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
       seeds.push({ id: name, description, content });
     }
 
+    // Sparse (BM25/TF) encoding is computed locally; only the dense vectors
+    // require `embedWithBackend`, which is unconfigured during the cold-start
+    // window before a managed-proxy embedding credential is provisioned. A
+    // dense-embed failure is non-fatal to the in-memory cache: the v3 needle
+    // finder lane reads CLI capabilities from `entries` / the page index, NOT
+    // from Qdrant, so the cache is populated from the local Commander tree
+    // regardless of backend state and commands stay discoverable from first
+    // boot. Only the dense Qdrant upsert is skipped; the managed-credential
+    // reseed and the v3 maintain pass backfill the dense vectors on recovery.
     const nextEntries = new Map<string, CliCommandEntry>();
     let denseVectors: number[][] = [];
+    let denseAvailable = false;
+    let denseError: unknown = null;
     let encodeSparse: (
       input: string,
     ) => ReturnType<typeof generateSparseEmbedding> = generateSparseEmbedding;
     if (seeds.length > 0) {
-      const embedded = await embedWithBackend(
-        config,
-        seeds.map((s) => s.content),
-      );
-      denseVectors = await Promise.all(
-        embedded.vectors.map((v) =>
-          applyCorrectionIfCalibrated(v, embedded.provider, embedded.model),
-        ),
-      );
-
       // CLI commands share the concept-page Qdrant collection, so the sparse
       // vector must use the same stemmed BM25 encoding as the concept-page
       // documents. Fall back to the legacy TF encoder only during the cold-
@@ -190,6 +191,24 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
               b: config.memory.v2.bm25_b,
             })
           : generateSparseEmbedding(input);
+      try {
+        const embedded = await embedWithBackend(
+          config,
+          seeds.map((s) => s.content),
+        );
+        denseVectors = await Promise.all(
+          embedded.vectors.map((v) =>
+            applyCorrectionIfCalibrated(v, embedded.provider, embedded.model),
+          ),
+        );
+        denseAvailable = true;
+      } catch (err) {
+        denseError = err;
+        log.warn(
+          { err },
+          "Embedding backend unavailable — seeding CLI-command cache without dense Qdrant vectors; the needle lane surfaces commands from the cache and the dense lane backfills when the backend recovers",
+        );
+      }
     }
 
     if (generation !== requestedSeedGeneration) {
@@ -201,7 +220,17 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
       return;
     }
 
-    if (seeds.length > 0) {
+    // Populate the in-memory cache (and therefore the page index / needle lane)
+    // from the local Commander tree regardless of dense availability.
+    for (const seed of seeds) {
+      nextEntries.set(seed.id, seed);
+    }
+
+    // Write Qdrant points and reconcile the collection only when dense vectors
+    // were produced. In the degraded (backend-unavailable) path we skip Qdrant
+    // mutation entirely so we never write half-formed points or prune against a
+    // set we did not persist.
+    if (seeds.length > 0 && denseAvailable) {
       const now = Date.now();
       await Promise.all(
         seeds.map((seed, i) =>
@@ -214,40 +243,57 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
           }),
         ),
       );
-      for (const seed of seeds) {
-        nextEntries.set(seed.id, seed);
+
+      // The CLI tree is always available (no remote catalog), so pruning is
+      // unconditional once we have written the current set. Run the legacy
+      // `kind` backfill once per process so pre-discriminator rows become
+      // prunable.
+      const knownIds = new Set(seeds.map((s) => s.id));
+      if (!legacyKindBackfillDone) {
+        try {
+          await backfillKindOnPointsWithPrefix(
+            CLI_COMMAND_SLUG_PREFIX,
+            CLI_COMMAND_PAYLOAD_KIND,
+            knownIds,
+          );
+          legacyKindBackfillDone = true;
+        } catch (err) {
+          log.warn(
+            { err },
+            "Failed to backfill kind on legacy CLI-command points — pruning may leave orphans this run",
+          );
+        }
       }
+      await pruneSlugsWithPrefixExcept(
+        CLI_COMMAND_SLUG_PREFIX,
+        seeds.map((s) => s.id),
+        { kind: CLI_COMMAND_PAYLOAD_KIND },
+      );
     }
 
-    // The CLI tree is always available (no remote catalog), so pruning is
-    // unconditional. Run the legacy `kind` backfill once per process so
-    // pre-discriminator rows become prunable.
-    const knownIds = new Set(seeds.map((s) => s.id));
-    if (!legacyKindBackfillDone) {
-      try {
-        await backfillKindOnPointsWithPrefix(
-          CLI_COMMAND_SLUG_PREFIX,
-          CLI_COMMAND_PAYLOAD_KIND,
-          knownIds,
-        );
-        legacyKindBackfillDone = true;
-      } catch (err) {
-        log.warn(
-          { err },
-          "Failed to backfill kind on legacy CLI-command points — pruning may leave orphans this run",
-        );
-      }
+    // Replace the cache — but never clear a populated cache with an empty
+    // enumeration. The Commander tree is always non-empty in practice, so an
+    // empty `nextEntries` means `buildCliProgramTree` returned nothing
+    // (anomalous); keep the prior cache rather than wiping the needle lane.
+    const priorEntries = entries;
+    if (
+      nextEntries.size === 0 &&
+      priorEntries !== null &&
+      priorEntries.size > 0
+    ) {
+      log.warn(
+        { cachedEntries: priorEntries.size },
+        "Refusing to clear cached CLI-command entries on an empty program tree — preserving the prior cache",
+      );
+    } else {
+      entries = nextEntries;
+      invalidatePageIndex();
     }
-    await pruneSlugsWithPrefixExcept(
-      CLI_COMMAND_SLUG_PREFIX,
-      seeds.map((s) => s.id),
-      { kind: CLI_COMMAND_PAYLOAD_KIND },
-    );
 
-    // Atomically replace the cache only after every step above succeeds.
-    entries = nextEntries;
-    invalidatePageIndex();
-    lastSeedError = null;
+    // Surface a dense-embed failure to `throwOnError` callers so the existing
+    // retry + maintain machinery backfills the dense lane. The in-memory cache
+    // is already updated above, so the needle lane is fixed regardless.
+    lastSeedError = denseError;
   } catch (err) {
     lastSeedError = err;
     log.warn({ err }, "Failed to seed v2 CLI-command entries");

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -357,29 +357,14 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
       );
     }
 
-    // Replace the cache — but never clear a populated cache on an unverified-
-    // empty enumeration. When this run produced no entries AND the catalog was
-    // unavailable, we cannot tell "genuinely no skills" from "catalog fetch
-    // failed", so keep the prior cache rather than wiping the needle lane. A
-    // genuinely-empty catalog (catalogAvailable) still clears stale state.
-    const priorEntries = entries;
-    if (
-      nextEntries.size === 0 &&
-      priorEntries !== null &&
-      priorEntries.size > 0 &&
-      !catalogAvailable
-    ) {
-      log.warn(
-        { cachedEntries: priorEntries.size },
-        "Refusing to clear cached skill entries on an unverified-empty enumeration (catalog unavailable) — preserving the prior cache",
-      );
-    } else {
-      // Drop the page-index cache so the next router invocation observes the
-      // freshly seeded skill set (skill entries share the unified concept-page
-      // collection and surface in the same index).
-      entries = nextEntries;
-      invalidatePageIndex();
-    }
+    // Atomically replace the cache from the freshly enumerated skills. The local
+    // resolution (`resolveSkillStates`) is authoritative, so a skill the config
+    // just disabled or removed drops out here even when the remote catalog is
+    // unavailable. Drop the page-index cache so the next router invocation
+    // observes the new skill set (skill entries share the unified concept-page
+    // collection and surface in the same index).
+    entries = nextEntries;
+    invalidatePageIndex();
 
     // Surface a dense-embed failure to `throwOnError` callers (the managed-
     // credential reseed and the operator reembed route) so the existing retry +

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -16,8 +16,11 @@
 //
 // Skill entries are kept in a small in-process cache so the render path can
 // fetch a `SkillEntry` synchronously by id without round-tripping to Qdrant.
-// The cache is replaced atomically at the end of a successful seed run; on
-// error the prior cache stays intact (skills are best-effort).
+// The cache is replaced atomically from the local catalog at the end of a seed
+// run — including when the dense embedding backend is unavailable, in which
+// case only the dense Qdrant write is deferred so the cache (and the v3 needle
+// lane it feeds) still reflects the current skills. An unexpected error in
+// another step leaves the prior cache intact (skills are best-effort).
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
@@ -228,26 +231,26 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
       );
     }
 
-    // Embed all content strings in one batched call when there is anything to
-    // embed. Skipping the call when `seeds` is empty avoids throwing on an
-    // unavailable embedding backend in the all-disabled case, so pruning and
-    // cache replacement still run and clear stale state.
+    // Build the dense + sparse vectors for the Qdrant write. Sparse (BM25/TF)
+    // encoding is computed locally and needs no backend; only the dense vectors
+    // require `embedWithBackend`, which is unconfigured during the cold-start
+    // window before a managed-proxy embedding credential is provisioned.
+    //
+    // A dense-embed failure is non-fatal to the in-memory cache: the v3 needle
+    // finder lane and always-candidate skill pinning read skills from `entries`
+    // / the page index, NOT from Qdrant, so the cache is populated from the
+    // local catalog regardless of backend state and skills stay discoverable
+    // from first boot. Only the dense Qdrant upsert is skipped; the managed-
+    // credential reseed (`maybeReseedCapabilitiesAfterManagedCredential`) and
+    // the v3 maintain pass backfill the dense vectors once the backend recovers.
     const nextEntries = new Map<string, SkillEntry>();
     let denseVectors: number[][] = [];
+    let denseAvailable = false;
+    let denseError: unknown = null;
     let encodeSparse: (
       input: string,
     ) => ReturnType<typeof generateSparseEmbedding> = generateSparseEmbedding;
     if (seeds.length > 0) {
-      const embedded = await embedWithBackend(
-        config,
-        seeds.map((s) => s.content),
-      );
-      denseVectors = await Promise.all(
-        embedded.vectors.map((v) =>
-          applyCorrectionIfCalibrated(v, embedded.provider, embedded.model),
-        ),
-      );
-
       // Skills share the concept-page Qdrant collection, so the sparse vector
       // must use the same stemmed BM25 encoding the concept-page documents
       // carry — otherwise the stemmed BM25 query vectors used by callers (see
@@ -263,6 +266,24 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
               b: config.memory.v2.bm25_b,
             })
           : generateSparseEmbedding(input);
+      try {
+        const embedded = await embedWithBackend(
+          config,
+          seeds.map((s) => s.content),
+        );
+        denseVectors = await Promise.all(
+          embedded.vectors.map((v) =>
+            applyCorrectionIfCalibrated(v, embedded.provider, embedded.model),
+          ),
+        );
+        denseAvailable = true;
+      } catch (err) {
+        denseError = err;
+        log.warn(
+          { err },
+          "Embedding backend unavailable — seeding skill cache without dense Qdrant vectors; the needle lane surfaces skills from the cache and the dense lane backfills when the backend recovers",
+        );
+      }
     }
 
     if (generation !== requestedSeedGeneration) {
@@ -274,7 +295,17 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
       return;
     }
 
-    if (seeds.length > 0) {
+    // Populate the in-memory cache (and therefore the page index / needle lane)
+    // from the local catalog regardless of dense availability.
+    for (const seed of seeds) {
+      nextEntries.set(seed.id, seed);
+    }
+
+    // Write Qdrant points only when dense vectors were produced. In the
+    // degraded (backend-unavailable) path we skip Qdrant mutation entirely —
+    // both the upsert and the prune below — so we never write half-formed
+    // points or reconcile the collection against a set we did not persist.
+    if (seeds.length > 0 && denseAvailable) {
       const now = Date.now();
       await Promise.all(
         seeds.map((seed, i) =>
@@ -287,16 +318,15 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
           }),
         ),
       );
-      for (const seed of seeds) {
-        nextEntries.set(seed.id, seed);
-      }
     }
 
-    // Prune stale skill slugs. When the catalog is unavailable (empty array
-    // from network failure or cold cache), we cannot enumerate which
-    // uninstalled catalog skills should exist, so skip pruning entirely to
-    // avoid aggressively removing previously-seeded catalog skill embeddings.
-    if (catalogAvailable) {
+    // Prune stale skill slugs. Skip when the catalog is unavailable (empty array
+    // from network failure or cold cache — we cannot enumerate which uninstalled
+    // catalog skills should exist) OR when dense vectors were not written this
+    // run (don't reconcile Qdrant against points we did not refresh). The
+    // `seeds.length === 0` branch still prunes under an available catalog so the
+    // all-disabled case clears stale rows.
+    if (catalogAvailable && (denseAvailable || seeds.length === 0)) {
       // Tag legacy skill points missing `payload.kind` before pruning so the
       // kind-scoped prune can see them. Once-per-process; the backfill is
       // idempotent (server-side `is_empty` filter), so a partial failure
@@ -321,19 +351,41 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
         seeds.map((s) => s.id),
         { kind: SKILL_PAYLOAD_KIND },
       );
-    } else {
+    } else if (!catalogAvailable) {
       log.info(
         "Catalog unavailable — skipping skill pruning to preserve prior catalog embeddings",
       );
     }
 
-    // Atomically replace the cache only after every step above succeeds.
-    entries = nextEntries;
-    // Drop the page-index cache so the next router invocation observes the
-    // freshly seeded skill set (skill entries share the unified concept-page
-    // collection and surface in the same index).
-    invalidatePageIndex();
-    lastSeedError = null;
+    // Replace the cache — but never clear a populated cache on an unverified-
+    // empty enumeration. When this run produced no entries AND the catalog was
+    // unavailable, we cannot tell "genuinely no skills" from "catalog fetch
+    // failed", so keep the prior cache rather than wiping the needle lane. A
+    // genuinely-empty catalog (catalogAvailable) still clears stale state.
+    const priorEntries = entries;
+    if (
+      nextEntries.size === 0 &&
+      priorEntries !== null &&
+      priorEntries.size > 0 &&
+      !catalogAvailable
+    ) {
+      log.warn(
+        { cachedEntries: priorEntries.size },
+        "Refusing to clear cached skill entries on an unverified-empty enumeration (catalog unavailable) — preserving the prior cache",
+      );
+    } else {
+      // Drop the page-index cache so the next router invocation observes the
+      // freshly seeded skill set (skill entries share the unified concept-page
+      // collection and surface in the same index).
+      entries = nextEntries;
+      invalidatePageIndex();
+    }
+
+    // Surface a dense-embed failure to `throwOnError` callers (the managed-
+    // credential reseed and the operator reembed route) so the existing retry +
+    // maintain machinery backfills the dense lane. The in-memory cache is
+    // already updated above, so the needle lane is fixed regardless.
+    lastSeedError = denseError;
   } catch (err) {
     lastSeedError = err;
     log.warn({ err }, "Failed to seed v2 skill entries");


### PR DESCRIPTION
## Problem

This is the root cause behind a staging assistant injecting only `cli-commands/*` pages and **no skills** from memory v3, even on exact-name queries like *"tell me about the app builder and document editor skills"* (which surfaced only `cli-commands/skills`, never `skills/app-builder`).

On a brand-new managed assistant the daemon's startup seed runs **before** the platform provisions the managed embedding credential. The first `embedWithBackend` call throws `EmbeddingBackendUnavailableError`, which aborted the *entire* skill/CLI seed before the in-memory cache was populated. Result: `listSkillEntries()` / `listCliCommandEntries()` stay empty → the v3 **needle** finder lane and the page index have no skill/CLI rows to surface until a later credential-triggered reseed.

CLI commands appeared to "work" only because they reseed from the always-available local Commander tree; skills (catalog + embedding dependent) did not recover.

## Fix

**Decouple the in-memory cache (needle lane) from dense-embed success**, in `skill-store.ts` and `cli-command-store.ts`. Sparse (BM25/TF) encoding is local; only the dense Qdrant write needs the backend. A dense-embed failure now:

- populates the cache from the local catalog (so skills/CLI are discoverable from first boot, even mid-credential-gap),
- skips **only** the dense Qdrant upsert + prune (so we never write half-formed points or reconcile against a set we didn't persist),
- is still surfaced to `throwOnError` callers so the existing retry + maintain machinery backfills the dense vectors on recovery.

Cache replacement stays unconditional, so the cache always reflects the current enumeration — a disabled or removed skill drops out (local `resolveSkillStates` is authoritative).

## Scope note

The credential-triggered reseed + v3 maintain enqueue (`maybeReseedCapabilitiesAfterManagedCredential`) **already ships** and covers "re-seed when the credential lands" + "reconcile the dense lane." This PR hardens the seed *itself* so the needle lane survives the cold-start window **without depending on that recovery firing**.

> An earlier revision also added a guard to *preserve* a populated cache on an empty enumeration. Codex correctly flagged that it could keep a locally-disabled skill alive, and the underlying signal is ambiguous (an empty `getCatalog()` can mean genuine-empty / cold-cache / network-failure, and the local catalog legitimately changes between seeds). It was dropped — unconditional replacement is the correct, unambiguous behavior.

## Tests

- New: cache populates from the local catalog on the first seed even when the embedding backend is unavailable (cold-start needle resilience), for both stores.
- New: dense-embed failure is surfaced to `throwOnError` callers while the needle cache is still populated.
- New: a locally-disabled installed skill is dropped even when the catalog fetch fails (local state is authoritative).
- All store + downstream tests pass; `tsc --noEmit`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)