### PR TITLE
[codex] Fix quote reply hover chip surface

### DIFF
--- a/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
@@ -117,10 +117,13 @@ describe("TextSelectionPopover", () => {
       }
 
       const button = await screen.findByRole("button", { name: "Reply" });
+      const popoverContent = document.body.querySelector(
+        '[data-slot="popover-content"]',
+      );
       expect(button.getAttribute("data-slot")).toBe("button");
-      expect(
-        document.body.querySelector('[data-slot="popover-content"]'),
-      ).toBeTruthy();
+      expect(popoverContent).toBeTruthy();
+      expect(popoverContent?.className).not.toContain("bg-transparent");
+      expect(popoverContent?.className).not.toContain("shadow-none");
       expect(screen.queryByRole("button", { name: "Quote & Reply" })).toBeNull();
     } finally {
       restoreAnimationFrame();

--- a/clients/web/src/domains/chat/components/text-selection-popover.tsx
+++ b/clients/web/src/domains/chat/components/text-selection-popover.tsx
@@ -169,14 +169,15 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
         sideOffset={8}
         onOpenAutoFocus={(event) => event.preventDefault()}
         onCloseAutoFocus={(event) => event.preventDefault()}
-        className="rounded-md bg-transparent p-0 shadow-none"
+        className="rounded-lg p-0"
       >
         <Button
-          variant="outlined"
-          size="regular"
+          variant="ghost"
+          size="compact"
           onClick={handleQuoteReply}
-          leftIcon={<MessageSquareQuote />}
-          className="bg-[var(--surface-base)] shadow-md"
+          leftIcon={<MessageSquareQuote className="h-3 w-3" />}
+          tintColor="var(--content-default)"
+          className="rounded-lg px-2.5"
         >
           Reply
         </Button>


### PR DESCRIPTION
## Summary
- Keep the quote-reply hover affordance on the design-system Popover surface instead of overriding it to transparent/no-shadow chrome
- Switch the inner action to a compact ghost design-system Button so the popover reads as one solid chip
- Add a regression assertion that the hover popover does not opt into transparent content or no-shadow styling

## Root cause
The design-system conversion preserved the old chip copy and interaction, but `TextSelectionPopover` overrode `Popover.Content` with `bg-transparent p-0 shadow-none` and used an outlined button. That looked acceptable over empty space, but when dense message text sat behind the hover affordance, the text showed through the transparent surfaces and made the chip look broken.

## Testing
- `cd clients/web && bun test src/domains/chat/components/quote-reply-components.test.tsx --grep "shows a design-system Reply action"`
- `cd clients/web && bun test src/domains/chat/components/quote-reply-components.test.tsx`
- `cd clients/web && bun run lint src/domains/chat/components/text-selection-popover.tsx src/domains/chat/components/quote-reply-components.test.tsx`
- `cd clients/web && bunx tsc --noEmit`