### PR TITLE
refactor(assistant): consolidate reset-drift trust recovery + restore unknown observability

### DIFF
--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -66,6 +66,31 @@ let healDriftReturn = false;
 const healGuardianBindingDriftMock = mock(async () => healDriftReturn);
 mock.module("../runtime/guardian-vellum-migration.js", () => ({
   healGuardianBindingDrift: healGuardianBindingDriftMock,
+  // Mirror the real helper against the mocked gateway/local-mirror state so the
+  // route exercises the shared narrow-drift gate end-to-end.
+  reResolveTrustOnResetDrift: async (
+    incomingPrincipalId: string,
+    sourceChannel: string,
+  ) => {
+    const gatewayPrincipal = mockGuardians
+      ? mockGuardians.find(
+          (g) => g.channelType === "vellum" && g.status === "active",
+        )?.principalId
+      : undefined;
+    const isResetDrift =
+      incomingPrincipalId.startsWith("vellum-principal-") &&
+      typeof gatewayPrincipal === "string" &&
+      gatewayPrincipal.startsWith("vellum-principal-") &&
+      gatewayPrincipal !== incomingPrincipalId;
+    if (!isResetDrift) return null;
+    await healGuardianBindingDriftMock();
+    return {
+      trustClass: localMirrorGuardians.has(incomingPrincipalId)
+        ? "guardian"
+        : "unknown",
+      sourceChannel,
+    };
+  },
 }));
 
 mock.module("../memory/canonical-guardian-store.js", () => ({
@@ -110,10 +135,10 @@ mock.module("../memory/conversation-crud.js", () => ({
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalTrustContext: () => ({
-    trustClass: "guardian",
-    sourceChannel: "vellum",
-  }),
+  findLocalGuardianPrincipalId: async () =>
+    mockGuardians?.find(
+      (g) => g.channelType === "vellum" && g.status === "active",
+    )?.principalId as string | undefined,
 }));
 
 let mockGuardians: Array<Record<string, unknown>> | null = [
@@ -131,8 +156,7 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: (
     list: Array<Record<string, unknown>>,
     channelType: string,
-  ) =>
-    list.find((g) => g.channelType === channelType && g.status === "active"),
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 // The local mirror grants guardian only to principals present in this set;
@@ -606,6 +630,14 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
 
   test("dev-bypass maps the gateway guardian principal to guardian", async () => {
     expect(await trustClassFor("dev-bypass")).toBe("guardian");
+  });
+
+  test("dev-bypass fails closed to unknown on an empty gateway", async () => {
+    // No active gateway binding: dev-bypass must not grant guardian from the
+    // stale local mirror — parity with /v1/surface-actions.
+    mockGuardians = [];
+    localMirrorGuardians = new Set<string>(["test-user"]);
+    expect(await trustClassFor("dev-bypass")).toBe("unknown");
   });
 
   test("fails closed to unknown when the gateway is unreachable", async () => {

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -109,10 +109,15 @@ mock.module("../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => _approvalGenerator,
 }));
 
-// Mock local-actor-identity to return a stable guardian context that uses
-// the same principal as the canonical requests created in tests.
+// Dev-bypass resolves the real guardian principal, then maps it through the
+// local-principal trust mapper. Both are stubbed to the principal the canonical
+// requests in these tests use.
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalTrustContext: () => ({
+  findLocalGuardianPrincipalId: async () => "test-principal-id",
+}));
+
+mock.module("../runtime/local-principal-trust.js", () => ({
+  resolveLocalPrincipalTrustContext: async () => ({
     sourceChannel: "vellum",
     trustClass: "guardian",
     guardianPrincipalId: "test-principal-id",

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -7,6 +7,7 @@
  * assistant-side since it reacts to incoming JWT principals.
  */
 
+import type { ChannelId } from "../channels/types.js";
 import {
   findGuardianForChannel,
   updateContactPrincipalAndChannel,
@@ -15,7 +16,13 @@ import {
   getGuardianDelivery,
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
+import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
+import {
+  resolveTrustContext,
+  withSourceChannel,
+} from "./trust-context-resolver.js";
 
 const log = getLogger("guardian-vellum-migration");
 
@@ -93,4 +100,33 @@ export async function healGuardianBindingDrift(
   );
 
   return true;
+}
+
+/**
+ * Re-resolve trust from the local mirror only for the narrow vellum-principal
+ * reset-drift case; null when it isn't drift (caller keeps the gateway verdict).
+ */
+export async function reResolveTrustOnResetDrift(
+  incomingPrincipalId: string,
+  sourceChannel: ChannelId,
+): Promise<TrustContext | null> {
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  const gatewayPrincipal = guardians
+    ? guardianForChannel(guardians, "vellum")?.principalId
+    : undefined;
+  const isResetDrift =
+    incomingPrincipalId.startsWith("vellum-principal-") &&
+    !!gatewayPrincipal?.startsWith("vellum-principal-") &&
+    gatewayPrincipal !== incomingPrincipalId;
+  if (!isResetDrift) return null;
+  await healGuardianBindingDrift(incomingPrincipalId);
+  return withSourceChannel(
+    sourceChannel,
+    resolveTrustContext({
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      sourceChannel: "vellum",
+      conversationExternalId: "local",
+      actorExternalId: incomingPrincipalId,
+    }),
+  );
 }

--- a/assistant/src/runtime/local-principal-trust.ts
+++ b/assistant/src/runtime/local-principal-trust.ts
@@ -1,14 +1,6 @@
 /**
- * Local-principal trust mapper.
- *
- * Derives a local principal's runtime {@link TrustContext} from the gateway
- * guardian binding instead of the assistant DB. A `vellum` principal is the
- * guardian (owner) or nobody, so "trust of this principal on the vellum
- * channel" reduces to "does `actorPrincipalId` match the gateway guardian's
- * principalId?" — which {@link getGuardianDelivery} answers.
- *
- * The mapper is pure: it does not heal binding drift or read local ACL. The
- * routes own the heal/re-resolve loop and call this mapper.
+ * Derives a local principal's {@link TrustContext} from the gateway guardian
+ * binding. Fails closed to unknown on a missing or null read.
  */
 
 import type { ChannelId } from "../channels/types.js";
@@ -22,11 +14,7 @@ export interface ResolveLocalPrincipalTrustInput {
   conversationExternalId: string;
 }
 
-/**
- * Resolve the trust context for a local principal from the gateway guardian
- * binding. Guardian match → guardian ctx; otherwise → unknown. A null gateway
- * read fails closed to unknown rather than granting guardian on a miss.
- */
+/** Guardian match → guardian ctx; miss or null read → unknown (fail closed). */
 export async function resolveLocalPrincipalTrustContext(
   input: ResolveLocalPrincipalTrustInput,
 ): Promise<TrustContext> {

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -66,8 +66,7 @@ mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: (
     list: Array<Record<string, unknown>>,
     channelType: string,
-  ) =>
-    list.find((g) => g.channelType === channelType && g.status === "active"),
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 mock.module("../../../contacts/contact-store.js", () => ({
@@ -84,6 +83,33 @@ mock.module("../../guardian-vellum-migration.js", () => ({
     healCalls.push(principalId);
     onHeal?.();
     return healResult;
+  },
+  // Mirror the real helper against this file's mocked gateway/local-mirror
+  // state so the route exercises the shared narrow-drift gate end-to-end.
+  reResolveTrustOnResetDrift: async (
+    incomingPrincipalId: string,
+    sourceChannel: string,
+  ) => {
+    const gatewayPrincipal = mockGuardianList
+      ? mockGuardianList.find(
+          (g) => g.channelType === "vellum" && g.status === "active",
+        )?.principalId
+      : undefined;
+    const isResetDrift =
+      incomingPrincipalId.startsWith("vellum-principal-") &&
+      typeof gatewayPrincipal === "string" &&
+      gatewayPrincipal.startsWith("vellum-principal-") &&
+      gatewayPrincipal !== incomingPrincipalId;
+    if (!isResetDrift) return null;
+    healCalls.push(incomingPrincipalId);
+    onHeal?.();
+    return {
+      trustClass:
+        mockGuardianRecord?.contact.principalId === incomingPrincipalId
+          ? "guardian"
+          : "unknown",
+      sourceChannel,
+    };
   },
 }));
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -26,10 +26,6 @@ import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-fl
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../contacts/guardian-delivery-reader.js";
-import {
   mergeConsecutiveAssistantMessages,
   mergeToolResultsIntoAssistantMessages,
 } from "../../conversations/message-consolidation.js";
@@ -72,6 +68,7 @@ import type {
   HostProxyTransportMetadata,
   NonHostProxyTransportMetadata,
 } from "../../daemon/message-types/conversations.js";
+import type { TrustContext } from "../../daemon/trust-context.js";
 import { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import {
   writeOnboardingSidecar,
@@ -125,31 +122,27 @@ import {
 } from "../../util/platform.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { getPersistedSeq } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   type GuardianPendingScope,
   routeGuardianReply,
 } from "../guardian-reply-router.js";
-import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
+import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
 import type {
   ApprovalConversationGenerator,
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
   SendMessageDeps,
 } from "../http-types.js";
-import { resolveLocalTrustContext } from "../local-actor-identity.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   publishConversationListAndMetadataChanged,
   publishConversationMessagesChanged,
 } from "../sync/resource-sync-events.js";
-import {
-  resolveTrustContext,
-  withSourceChannel,
-} from "../trust-context-resolver.js";
+import { withSourceChannel } from "../trust-context-resolver.js";
 import {
   BadRequestError,
   InternalError,
@@ -1453,23 +1446,28 @@ export async function handleSendMessage(
   // gateway guardian binding: a vellum principal is the guardian or nobody.
   if (actorPrincipalId) {
     // Dev bypass (HTTP auth disabled): the synthetic "dev-bypass" principal
-    // won't match any guardian binding. Resolve the real guardian principal
-    // from the gateway binding and map that through instead.
+    // won't match any guardian binding. Resolve the real guardian principal and
+    // map that through, failing closed to unknown on an empty gateway.
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-      const guardianPrincipalId = guardians?.[0]?.principalId;
-      conversation.setTrustContext(
-        guardianPrincipalId
-          ? withSourceChannel(
-              sourceChannel,
-              await resolveLocalPrincipalTrustContext({
-                actorPrincipalId: guardianPrincipalId,
-                sourceChannel: "vellum",
-                conversationExternalId: "local",
-              }),
-            )
-          : await resolveLocalTrustContext(sourceChannel),
-      );
+      const guardianPrincipalId = await findLocalGuardianPrincipalId();
+      let trustCtx: TrustContext = guardianPrincipalId
+        ? withSourceChannel(
+            sourceChannel,
+            await resolveLocalPrincipalTrustContext({
+              actorPrincipalId: guardianPrincipalId,
+              sourceChannel: "vellum",
+              conversationExternalId: "local",
+            }),
+          )
+        : { trustClass: "unknown", sourceChannel };
+      if (guardianPrincipalId && trustCtx.trustClass === "unknown") {
+        const healed = await reResolveTrustOnResetDrift(
+          guardianPrincipalId,
+          sourceChannel,
+        );
+        if (healed) trustCtx = healed;
+      }
+      conversation.setTrustContext(trustCtx);
     } else {
       let trustCtx = withSourceChannel(
         sourceChannel,
@@ -1480,49 +1478,26 @@ export async function handleSendMessage(
         }),
       );
       if (trustCtx.trustClass === "unknown") {
-        const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-        const gatewayPrincipal = guardians
-          ? guardianForChannel(guardians, "vellum")?.principalId
-          : undefined;
-        // Narrow drift only: a DB reset rebound the gateway to a fresh
-        // vellum-principal while the client holds a valid JWT for the old one.
-        // Both are daemon-minted vellum-principal-* ids, so a genuine
-        // revocation or rebind to a real identity fails closed instead of
-        // re-granting from a stale mirror.
-        const isResetDrift =
-          actorPrincipalId.startsWith("vellum-principal-") &&
-          !!gatewayPrincipal?.startsWith("vellum-principal-") &&
-          gatewayPrincipal !== actorPrincipalId;
-        if (isResetDrift) {
-          await healGuardianBindingDrift(actorPrincipalId);
-          trustCtx = withSourceChannel(
-            sourceChannel,
-            resolveTrustContext({
-              assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-              sourceChannel: "vellum",
-              conversationExternalId: "local",
-              actorExternalId: actorPrincipalId,
-            }),
+        const healed = await reResolveTrustOnResetDrift(
+          actorPrincipalId,
+          sourceChannel,
+        );
+        if (healed && healed.trustClass !== "unknown") {
+          trustCtx = healed;
+          log.info(
+            { actorPrincipalId, trustClass: trustCtx.trustClass },
+            "Trust re-resolved from local mirror after gateway returned unknown",
           );
-          if (trustCtx.trustClass === "unknown") {
-            log.warn(
-              {
-                actorPrincipalId,
-                sourceChannel,
-                trustClass: trustCtx.trustClass,
-                principalType,
-              },
-              "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
-            );
-          } else {
-            log.info(
-              {
-                actorPrincipalId,
-                trustClass: trustCtx.trustClass,
-              },
-              "Trust re-resolved from local mirror after gateway returned unknown",
-            );
-          }
+        } else {
+          log.warn(
+            {
+              actorPrincipalId,
+              sourceChannel,
+              trustClass: "unknown",
+              principalType,
+            },
+            "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+          );
         }
       }
       conversation.setTrustContext(trustCtx);

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -11,22 +11,13 @@ import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
-import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
-import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
+import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
 import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
-import {
-  resolveTrustContext,
-  withSourceChannel,
-} from "../trust-context-resolver.js";
 import { parseCallbackData } from "./channel-route-shared.js";
 import {
   BadRequestError,
@@ -77,29 +68,9 @@ async function applyTrustContext(
     conversationExternalId: "local",
   });
   if (trustCtx.trustClass === "unknown") {
-    const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-    const gatewayPrincipal = guardians
-      ? guardianForChannel(guardians, sourceChannel)?.principalId
-      : undefined;
-    // Narrow drift only: a DB reset rebound the gateway to a fresh
-    // vellum-principal while the client holds a valid JWT for the old one. Both
-    // are daemon-minted vellum-principal-* ids, so a genuine revocation or rebind
-    // to a real identity fails closed instead of re-granting from a stale mirror.
-    const isResetDrift =
-      principalId.startsWith("vellum-principal-") &&
-      !!gatewayPrincipal?.startsWith("vellum-principal-") &&
-      gatewayPrincipal !== principalId;
-    if (isResetDrift) {
-      await healGuardianBindingDrift(principalId);
-      trustCtx = withSourceChannel(
-        sourceChannel,
-        resolveTrustContext({
-          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-          sourceChannel,
-          conversationExternalId: "local",
-          actorExternalId: principalId,
-        }),
-      );
+    const healed = await reResolveTrustOnResetDrift(principalId, sourceChannel);
+    if (healed) {
+      trustCtx = healed;
       log.info(
         { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
         "Trust re-resolved from local mirror after gateway reset drift (surface action)",


### PR DESCRIPTION
## Summary
- Extract the narrow vellum-principal reset-drift re-resolution shared by /v1/surface-actions and /v1/messages into reResolveTrustOnResetDrift (next to healGuardianBindingDrift), removing duplicated gate logic.
- Restore the /v1/messages warn when a JWT-verified actor resolves to a terminal unknown (genuine revocation / real-identity rebind / gateway unreachable) — diagnostics were dropped.
- Align the /v1/messages dev-bypass path to fail closed like surface-actions instead of granting guardian from the local mirror on an empty gateway.
- Trim verbose comments to the repo's terse convention.

Part of plan: local-principal-trust-from-binding.md (self-review remediation)