### PR TITLE
test(assistant): cover the reset-drift helper directly, stub it in route tests

### DIFF
--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -62,34 +62,18 @@ mock.module("../runtime/guardian-reply-router.js", () => ({
   routeGuardianReply: routeGuardianReplyMock,
 }));
 
-let healDriftReturn = false;
-const healGuardianBindingDriftMock = mock(async () => healDriftReturn);
+// Stub for the shared reset-drift helper. handleSendMessage only consumes its
+// result (a guardian TrustContext or null) on a first-pass-unknown actor; the
+// gate itself is covered in runtime/__tests__/guardian-vellum-migration.test.ts.
+const reResolveCalls: string[] = [];
+let mockReResolve: { trustClass: string; sourceChannel: string } | null = null;
 mock.module("../runtime/guardian-vellum-migration.js", () => ({
-  healGuardianBindingDrift: healGuardianBindingDriftMock,
-  // Mirror the real helper against the mocked gateway/local-mirror state so the
-  // route exercises the shared narrow-drift gate end-to-end.
   reResolveTrustOnResetDrift: async (
     incomingPrincipalId: string,
-    sourceChannel: string,
+    _sourceChannel: string,
   ) => {
-    const gatewayPrincipal = mockGuardians
-      ? mockGuardians.find(
-          (g) => g.channelType === "vellum" && g.status === "active",
-        )?.principalId
-      : undefined;
-    const isResetDrift =
-      incomingPrincipalId.startsWith("vellum-principal-") &&
-      typeof gatewayPrincipal === "string" &&
-      gatewayPrincipal.startsWith("vellum-principal-") &&
-      gatewayPrincipal !== incomingPrincipalId;
-    if (!isResetDrift) return null;
-    await healGuardianBindingDriftMock();
-    return {
-      trustClass: localMirrorGuardians.has(incomingPrincipalId)
-        ? "guardian"
-        : "unknown",
-      sourceChannel,
-    };
+    reResolveCalls.push(incomingPrincipalId);
+    return mockReResolve;
   },
 }));
 
@@ -159,18 +143,8 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
-// The local mirror grants guardian only to principals present in this set;
-// everyone else resolves unknown. Models the dual-written local mirror that
-// the gateway-first resolve falls back to.
-let localMirrorGuardians = new Set<string>(["test-user"]);
+// handleSendMessage wraps the first-pass resolve with withSourceChannel.
 mock.module("../runtime/trust-context-resolver.js", () => ({
-  resolveTrustContext: (input: { actorExternalId?: string }) => ({
-    trustClass:
-      input.actorExternalId && localMirrorGuardians.has(input.actorExternalId)
-        ? "guardian"
-        : "unknown",
-    sourceChannel: "vellum",
-  }),
   withSourceChannel: (sourceChannel: unknown, ctx: unknown) => ({
     ...(ctx as Record<string, unknown>),
     sourceChannel,
@@ -525,9 +499,8 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
         status: "active",
       },
     ];
-    healDriftReturn = false;
-    localMirrorGuardians = new Set<string>(["test-user"]);
-    healGuardianBindingDriftMock.mockClear();
+    reResolveCalls.length = 0;
+    mockReResolve = null;
   });
 
   function requestAs(principalId: string, sourceChannel = "vellum") {
@@ -578,20 +551,18 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
     return (await trustContextFor(principalId)).trustClass as string;
   }
 
-  test("guardian principal resolves to guardian context", async () => {
+  test("guardian principal resolves to guardian context, helper not called", async () => {
     expect(await trustClassFor("test-user")).toBe("guardian");
+    expect(reResolveCalls).toEqual([]);
   });
 
-  test("non-guardian principal resolves to unknown", async () => {
+  test("non-guardian principal: helper consulted, null result stays unknown", async () => {
+    mockReResolve = null;
     expect(await trustClassFor("vellum-principal-stranger")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+    expect(reResolveCalls).toEqual(["vellum-principal-stranger"]);
   });
 
-  test("re-resolves to guardian from the local mirror after a drift heal", async () => {
-    healDriftReturn = true;
-    // The gateway binding mismatches the JWT throughout — heal repairs the
-    // local mirror, not the gateway. Post-heal trust comes from the local
-    // resolver (resolveTrustContext), not a still-mismatched gateway read.
+  test("reset drift: helper returns guardian → route adopts it", async () => {
     mockGuardians = [
       {
         channelType: "vellum",
@@ -601,18 +572,13 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
         status: "active",
       },
     ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+    mockReResolve = { trustClass: "guardian", sourceChannel: "vellum" };
 
     expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
-    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+    expect(reResolveCalls).toEqual(["vellum-principal-healed"]);
   });
 
-  test("re-resolves to guardian on later drift requests where heal is a no-op", async () => {
-    // Second-request drift window: the gateway binding still mismatches the
-    // JWT, so heal is a no-op and returns false. The local re-resolve must
-    // still run (gated on the gateway returning unknown, not on a heal write)
-    // and keep guardian trust from the already-repaired local mirror.
-    healDriftReturn = false;
+  test("helper returns an unknown-class ctx → trust stays unknown (not adopted)", async () => {
     mockGuardians = [
       {
         channelType: "vellum",
@@ -622,10 +588,9 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
         status: "active",
       },
     ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+    mockReResolve = { trustClass: "unknown", sourceChannel: "vellum" };
 
-    expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
-    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
   });
 
   test("dev-bypass maps the gateway guardian principal to guardian", async () => {
@@ -633,69 +598,11 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
   });
 
   test("dev-bypass fails closed to unknown on an empty gateway", async () => {
-    // No active gateway binding: dev-bypass must not grant guardian from the
-    // stale local mirror — parity with /v1/surface-actions.
+    // No active gateway binding: dev-bypass cannot translate to a real guardian,
+    // and the helper (null) leaves trust unknown — parity with /v1/surface-actions.
     mockGuardians = [];
-    localMirrorGuardians = new Set<string>(["test-user"]);
+    mockReResolve = null;
     expect(await trustClassFor("dev-bypass")).toBe("unknown");
-  });
-
-  test("fails closed to unknown when the gateway is unreachable", async () => {
-    // Gateway read returns null (unreachable) while the local mirror WOULD
-    // grant guardian. The drift fallback must not fall open to the mirror.
-    mockGuardians = null;
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
-  });
-
-  test("fails closed to unknown when the gateway guardian is revoked", async () => {
-    // Empty active guardian list (revoked/rebind in flight) while the local
-    // mirror WOULD grant guardian. No active gateway principal means no
-    // narrow-drift heal — re-granting revoked trust is a security regression.
-    mockGuardians = [];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
-  });
-
-  test("fails closed to unknown when only a non-active guardian remains", async () => {
-    // A revoked binding lingers with status !== "active"; guardianForChannel
-    // skips it, so there is no active gateway principal to drift against.
-    mockGuardians = [
-      {
-        channelType: "vellum",
-        contactId: "guardian-contact",
-        principalId: "vellum-principal-stale",
-        address: "vellum-principal-stale",
-        status: "revoked",
-      },
-    ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
-  });
-
-  test("fails closed to unknown on rebind to a real external identity", async () => {
-    // The gateway's active guardian is a real identity (not a daemon-minted
-    // vellum-principal-*), so a stale vellum-principal JWT must not re-grant
-    // from the mirror — a genuine rebind, not DB-reset drift.
-    mockGuardians = [
-      {
-        channelType: "vellum",
-        contactId: "guardian-contact",
-        principalId: "user@example.com",
-        address: "user@example.com",
-        status: "active",
-      },
-    ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
   });
 
   test("preserves the request body channel on the guardian-match happy path", async () => {

--- a/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the narrow reset-drift trust-recovery helper
+ * `reResolveTrustOnResetDrift`.
+ *
+ * The real helper runs against mocked leaf deps: the gateway guardian read
+ * (`getGuardianDelivery`/`guardianForChannel`), the local-mirror heal
+ * (`findGuardianForChannel`/`updateContactPrincipalAndChannel`, which the real
+ * `healGuardianBindingDrift` drives), and the local trust resolver
+ * (`resolveTrustContext`). Heal invocations are observed via the contact-store
+ * write mock.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardianList,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+// Local mirror the real heal reads/writes. `findGuardianForChannel` returns the
+// stored guardian; `updateContactPrincipalAndChannel` records heal writes.
+let mockLocalGuardian: {
+  contact: { id: string; principalId: string };
+  channel: { id: string };
+} | null = null;
+const healWrites: Array<{ principalId: string }> = [];
+
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => mockLocalGuardian,
+  updateContactPrincipalAndChannel: (
+    _contactId: string,
+    _channelId: string,
+    principalId: string,
+  ) => {
+    healWrites.push({ principalId });
+    return true;
+  },
+}));
+
+// The local trust resolver returns guardian for the actor; the gate threads
+// sourceChannel via the real withSourceChannel wrapper.
+mock.module("../../runtime/trust-context-resolver.js", () => ({
+  resolveTrustContext: (input: { actorExternalId?: string }) => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+    resolvedActor: input.actorExternalId,
+  }),
+  withSourceChannel: (sourceChannel: unknown, ctx: Record<string, unknown>) => ({
+    ...ctx,
+    sourceChannel,
+  }),
+}));
+
+const { reResolveTrustOnResetDrift } = await import(
+  "../guardian-vellum-migration.js"
+);
+
+function gatewayGuardian(principalId: string): Record<string, unknown> {
+  return {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId,
+    address: principalId,
+    status: "active",
+  };
+}
+
+function localGuardian(principalId: string) {
+  return {
+    contact: { id: "contact-1", principalId },
+    channel: { id: "channel-1" },
+  };
+}
+
+describe("reResolveTrustOnResetDrift", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    mockLocalGuardian = null;
+    healWrites.length = 0;
+  });
+
+  test("reset drift: heals and returns the re-resolved guardian ctx", async () => {
+    // Stale local mirror still holds the pre-reset principal; the incoming JWT
+    // carries the old one. Heal repairs the mirror toward the incoming actor.
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-stale");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx?.trustClass).toBe("guardian");
+    expect(healWrites).toEqual([{ principalId: "vellum-principal-old" }]);
+  });
+
+  test("repeat drift where heal no-ops still returns the guardian ctx", async () => {
+    // Local mirror already matches the incoming principal, so heal's write is
+    // skipped, but the gate still passes and the re-resolve yields guardian.
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx?.trustClass).toBe("guardian");
+    expect(healWrites).toEqual([]);
+  });
+
+  test("gateway unreachable (null): returns null, heal not called", async () => {
+    mockGuardianList = null;
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("empty/revoked gateway (no active guardian): returns null, heal not called", async () => {
+    mockGuardianList = [];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("gateway guardian is a real (non vellum-principal-*) id: returns null", async () => {
+    mockGuardianList = [gatewayGuardian("user@example.com")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("incoming principal is not vellum-principal-*: returns null", async () => {
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift("user@example.com", "vellum");
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("threads sourceChannel into the returned ctx", async () => {
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "telegram",
+    );
+
+    expect(ctx?.sourceChannel).toBe("telegram");
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -46,18 +46,14 @@ const rawGetCalls: Array<{ sql: string; params: unknown[] }> = [];
 // Gateway guardian-delivery list (shared by the route's dev-bypass lookup and
 // the local-principal-trust mapper): null = unreachable, [] = no guardian.
 let mockGuardianList: Array<Record<string, unknown>> | null = [];
-// Local-mirror guardian record: dev-bypass reads .contact.principalId; the
-// post-heal local resolver reads .contact and .channel.
-let mockGuardianRecord: {
-  contact: Record<string, unknown>;
-  channel?: Record<string, unknown>;
-} | null = null;
 let httpAuthDisabled = false;
-// Tracks heal invocations; onHeal lets a test repair the local mirror to
-// simulate the post-heal re-resolve matching.
-const healCalls: string[] = [];
-let healResult = false;
-let onHeal: (() => void) | null = null;
+
+// Stub for the shared reset-drift helper. The route under test only consumes
+// its result (a guardian TrustContext or null); the gate itself is covered in
+// runtime/__tests__/guardian-vellum-migration.test.ts. Tests set
+// `mockReResolve` per case and read `reResolveCalls` to assert routing.
+const reResolveCalls: string[] = [];
+let mockReResolve: { trustClass: string; sourceChannel: string } | null = null;
 
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: (_input?: { channelTypes?: string[] }) =>
@@ -70,7 +66,7 @@ mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
 }));
 
 mock.module("../../../contacts/contact-store.js", () => ({
-  findGuardianForChannel: (_channelType: string) => mockGuardianRecord,
+  findGuardianForChannel: (_channelType: string) => null,
   findContactByAddress: () => null,
 }));
 
@@ -79,37 +75,12 @@ mock.module("../../../config/env.js", () => ({
 }));
 
 mock.module("../../guardian-vellum-migration.js", () => ({
-  healGuardianBindingDrift: async (principalId: string) => {
-    healCalls.push(principalId);
-    onHeal?.();
-    return healResult;
-  },
-  // Mirror the real helper against this file's mocked gateway/local-mirror
-  // state so the route exercises the shared narrow-drift gate end-to-end.
   reResolveTrustOnResetDrift: async (
     incomingPrincipalId: string,
-    sourceChannel: string,
+    _sourceChannel: string,
   ) => {
-    const gatewayPrincipal = mockGuardianList
-      ? mockGuardianList.find(
-          (g) => g.channelType === "vellum" && g.status === "active",
-        )?.principalId
-      : undefined;
-    const isResetDrift =
-      incomingPrincipalId.startsWith("vellum-principal-") &&
-      typeof gatewayPrincipal === "string" &&
-      gatewayPrincipal.startsWith("vellum-principal-") &&
-      gatewayPrincipal !== incomingPrincipalId;
-    if (!isResetDrift) return null;
-    healCalls.push(incomingPrincipalId);
-    onHeal?.();
-    return {
-      trustClass:
-        mockGuardianRecord?.contact.principalId === incomingPrincipalId
-          ? "guardian"
-          : "unknown",
-      sourceChannel,
-    };
+    reResolveCalls.push(incomingPrincipalId);
+    return mockReResolve;
   },
 }));
 
@@ -207,11 +178,9 @@ beforeEach(() => {
   getOrCreateCalls.length = 0;
   rawGetCalls.length = 0;
   mockGuardianList = [];
-  mockGuardianRecord = null;
   httpAuthDisabled = false;
-  healCalls.length = 0;
-  healResult = false;
-  onHeal = null;
+  reResolveCalls.length = 0;
+  mockReResolve = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -436,26 +405,13 @@ function guardianDelivery(principalId: string): Record<string, unknown> {
   };
 }
 
-// Local-mirror guardian record as returned by findGuardianForChannel and read
-// by resolveActorTrust. The channel address equals the principal so the local
-// resolver classifies it as guardian on the vellum channel.
-function localGuardianRecord(principalId: string): {
-  contact: Record<string, unknown>;
-  channel: Record<string, unknown>;
-} {
-  return {
-    contact: { principalId, displayName: "Guardian" },
-    channel: {
-      type: "vellum",
-      address: principalId,
-      externalChatId: "guardian-chat",
-      status: "active",
-    },
-  };
+// A guardian TrustContext the stubbed helper hands back on a recovered drift.
+function guardianCtx(): { trustClass: string; sourceChannel: string } {
+  return { trustClass: "guardian", sourceChannel: "vellum" };
 }
 
 describe("triggerSurfaceAction trust context", () => {
-  test("guardian principal → guardian trust context from the gateway binding", async () => {
+  test("guardian principal → guardian from the gateway binding, helper not called", async () => {
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
     const live = makeStub("conv-guardian");
     memoryBySurface = live;
@@ -468,36 +424,29 @@ describe("triggerSurfaceAction trust context", () => {
 
     expect(live.trustContext?.trustClass).toBe("guardian");
     expect(live.trustContext?.sourceChannel).toBe("vellum");
-    expect(healCalls).toEqual([]);
+    // First-pass resolve already granted guardian, so the drift helper is skipped.
+    expect(reResolveCalls).toEqual([]);
   });
 
-  test("unknown principal → unknown trust context", async () => {
+  test("unknown principal: helper consulted, null result stays unknown (fail closed)", async () => {
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    mockReResolve = null;
     const live = makeStub("conv-unknown");
     memoryBySurface = live;
 
     const handler = findHandler("triggerSurfaceAction");
     await handler({
       body: { surfaceId: "surf-u", actionId: "act-u" },
-      headers: { "x-vellum-actor-principal-id": "principal-other" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
     });
 
+    expect(reResolveCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
     expect(live.trustContext?.trustClass).toBe("unknown");
-    // Neither principal is a vellum-principal-*, so the reset-drift gate is
-    // closed and no heal runs.
-    expect(healCalls).toEqual([]);
   });
 
-  test("reset drift: heal repairs the local mirror → guardian from local re-resolve", async () => {
-    // DB-reset signature: the gateway active guardian is a fresh vellum-principal
-    // while the client holds a JWT for the old one. The gateway binding stays
-    // mismatched, so the mapper returns unknown both before and after heal. Heal
-    // repairs the local mirror; the post-heal re-resolve reads it and matches.
+  test("reset drift: helper returns guardian → route adopts it", async () => {
     mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
-    healResult = true;
-    onHeal = () => {
-      mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    };
+    mockReResolve = guardianCtx();
     const live = makeStub("conv-drift");
     memoryBySurface = live;
 
@@ -507,117 +456,11 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
     });
 
-    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
-    // Gateway binding never matched; guardian comes from the local mirror.
-    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
+    expect(reResolveCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
     expect(live.trustContext?.trustClass).toBe("guardian");
   });
 
-  test("reset drift second request: heal no-ops (false) but local mirror already matches → guardian", async () => {
-    // Later requests in the drift window reuse the same stale JWT: the gateway
-    // binding still mismatches, and heal returns false because the local mirror
-    // was already repaired on the first request. The local re-resolve must run
-    // regardless of heal's return and recover guardian trust.
-    mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    healResult = false;
-    const live = makeStub("conv-drift-2");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-d2", actionId: "act-d2" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
-    // Gateway binding never matched; guardian comes from the local mirror even
-    // though no heal write occurred.
-    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
-    expect(live.trustContext?.trustClass).toBe("guardian");
-  });
-
-  test("fail-closed: revoked gateway guardian (empty list) blocks the local fallback → unknown", async () => {
-    // The gateway authoritatively revoked the guardian (no active binding) while
-    // the local mirror WOULD still grant guardian. With no active gateway
-    // principal there is no reset signature, so trust stays unknown (fail closed).
-    mockGuardianList = [];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-revoked");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-rv", actionId: "act-rv" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
-  });
-
-  test("fail-closed: non-active gateway guardian blocks the local fallback → unknown", async () => {
-    // The gateway binding exists but is not active (e.g. pending revocation):
-    // guardianForChannel filters it out, so there is no active reset principal
-    // and the fallback stays closed.
-    mockGuardianList = [
-      { ...guardianDelivery(VELLUM_PRINCIPAL_NEW), status: "revoked" },
-    ];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-inactive");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-ia", actionId: "act-ia" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
-  });
-
-  test("fail-closed: rebind to a real external identity blocks the local fallback → unknown", async () => {
-    // The gateway active guardian principal is a real external id (not a
-    // vellum-principal-*) that differs from the actor — a genuine rebind, not a
-    // DB reset. The fallback must stay closed even though the local mirror would
-    // grant guardian.
-    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-rebind");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-rb", actionId: "act-rb" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
-  });
-
-  test("fail-closed: unreachable gateway (null) blocks the local drift fallback → unknown", async () => {
-    // Gateway unreadable: the mapper fails closed to unknown, and the local
-    // mirror WOULD classify this principal as guardian. The drift fallback must
-    // stay gated off a null read, so trust must remain unknown (fail closed).
-    mockGuardianList = null;
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-fail-closed");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-fc", actionId: "act-fc" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    // No fallback ran: heal is skipped on a null read.
-    expect(healCalls).toEqual([]);
-  });
-
-  test("dev-bypass resolves the real guardian principal from the gateway", async () => {
+  test("dev-bypass resolves the real guardian principal from the gateway, helper not called", async () => {
     httpAuthDisabled = true;
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
     const live = makeStub("conv-dev");
@@ -630,21 +473,18 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     // The synthetic dev-bypass principal is translated to the real guardian,
-    // yielding a guardian trust context without any heal.
+    // yielding a guardian trust context without consulting the drift helper.
     expect(live.trustContext?.trustClass).toBe("guardian");
-    expect(healCalls).toEqual([]);
+    expect(reResolveCalls).toEqual([]);
   });
 
-  test("dev-bypass with an empty gateway and stale local mirror → unknown (fail closed)", async () => {
+  test("dev-bypass with an empty gateway: helper null result → unknown (fail closed)", async () => {
     httpAuthDisabled = true;
+    // The gateway has no active binding, so dev-bypass cannot translate to a
+    // real guardian; the first-pass resolve is unknown and the helper, returning
+    // null, leaves trust unknown.
     mockGuardianList = [];
-    // Local store supplies the guardian principal for dev-bypass, but the gateway
-    // has no active binding. With no active gateway principal there is no reset
-    // signature, so the fallback stays closed and trust is unknown.
-    mockGuardianRecord = {
-      contact: { principalId: GUARDIAN_PRINCIPAL },
-      channel: { type: "vellum", address: "stale-address", status: "active" },
-    };
+    mockReResolve = null;
     const live = makeStub("conv-dev-fallback");
     memoryBySurface = live;
 
@@ -655,7 +495,6 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -71,10 +71,12 @@ async function applyTrustContext(
     const healed = await reResolveTrustOnResetDrift(principalId, sourceChannel);
     if (healed) {
       trustCtx = healed;
-      log.info(
-        { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
-        "Trust re-resolved from local mirror after gateway reset drift (surface action)",
-      );
+      if (healed.trustClass !== "unknown") {
+        log.info(
+          { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
+          "Trust re-resolved from local mirror after gateway reset drift (surface action)",
+        );
+      }
     }
   }
   conversation.setTrustContext(trustCtx);


### PR DESCRIPTION
## Summary
- Add a direct unit test for reResolveTrustOnResetDrift (mocking only its leaf deps), covering drift recovery and the fail-closed cases.
- Replace the route tests' inline reimplementation of the drift predicate with a simple stub, so routes test route behavior and the gate logic is tested once.
- Guard the surface-action re-resolve success log on a non-unknown result, matching /v1/messages.

Part of plan: local-principal-trust-from-binding.md (self-review remediation round 2)