### PR TITLE
fix(subagent): preserve token usage when a subagent is aborted

### DIFF
--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -326,3 +326,68 @@ describe("SubagentManager terminal disposal", () => {
     asInternals(manager).stopSweep();
   });
 });
+
+describe("SubagentManager.abort usage", () => {
+  test("emits the conversation's latest usage on abort, not zeros", () => {
+    const manager = new SubagentManager();
+    const sent: ServerMessage[] = [];
+    const sender = (msg: ServerMessage) => sent.push(msg);
+
+    const subagentId = "sa-abort-usage";
+    // state.usage starts at {0,0,0}; the live (fake) conversation has accrued
+    // usage (makeFakeConversation → {100, 50, 0.005}). Wire `sender` as the
+    // stored parent sender so `setStatus` routes the terminal event through it.
+    injectFakeSubagent(manager, subagentId, makeState(subagentId), sender);
+
+    const aborted = manager.abort(subagentId, sender, undefined, {
+      suppressNotification: true,
+    });
+    expect(aborted).toBe(true);
+
+    const statusMsg = sent.find(
+      (m): m is Extract<ServerMessage, { type: "subagent_status_changed" }> =>
+        m.type === "subagent_status_changed",
+    );
+    expect(statusMsg).toBeDefined();
+    expect(statusMsg!.status).toBe("aborted");
+    // The emitted usage is the conversation's accrued total — NOT the {0,0,0}
+    // init — so the client doesn't flush the token panel to zero on stop.
+    expect(statusMsg!.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      estimatedCost: 0.005,
+    });
+
+    asInternals(manager).stopSweep();
+  });
+
+  test("keeps the last-known state.usage when the conversation was already released", () => {
+    const manager = new SubagentManager();
+    const sent: ServerMessage[] = [];
+    const sender = (msg: ServerMessage) => sent.push(msg);
+
+    const subagentId = "sa-abort-no-conv";
+    // No live conversation (released), but state carries a last-known usage —
+    // the abort must surface that, not overwrite it.
+    const state = makeState(subagentId, {
+      usage: { inputTokens: 320, outputTokens: 80, estimatedCost: 0.004 },
+    });
+    injectFakeSubagent(manager, subagentId, state, sender, null);
+
+    manager.abort(subagentId, sender, undefined, {
+      suppressNotification: true,
+    });
+
+    const statusMsg = sent.find(
+      (m): m is Extract<ServerMessage, { type: "subagent_status_changed" }> =>
+        m.type === "subagent_status_changed",
+    );
+    expect(statusMsg!.usage).toEqual({
+      inputTokens: 320,
+      outputTokens: 80,
+      estimatedCost: 0.004,
+    });
+
+    asInternals(manager).stopSweep();
+  });
+});

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -553,6 +553,15 @@ export class SubagentManager {
       ),
     );
     managed.state.completedAt = Date.now();
+    // Capture the conversation's latest usage before emitting the terminal
+    // status. `subagent_status_changed` ships `state.usage`, and the abort path
+    // (unlike the completion/failure paths, which sync at agent-loop exit) would
+    // otherwise send the {0,0,0} init usage — zeroing the client's token counts
+    // even though those tokens were already spent. `usageStats` accrues per LLM
+    // turn (see conversation-usage.ts), so this is the most recent total.
+    if (managed.conversation) {
+      managed.state.usage = { ...managed.conversation.usageStats };
+    }
     if (parentSendToClient) {
       // Route the status update through the stored parent sender so the
       // owning conversation's UI chip updates, even when the abort comes from a


### PR DESCRIPTION
## Problem

Stopping a running subagent flushed its **Input/Output token counts to zero** in the detail panel, even though those tokens were already spent.

The daemon's abort path emits `subagent_status_changed` carrying `state.usage`, but — unlike the completion and failure paths, which sync `state.usage` from `conversation.usageStats` right before emitting their terminal status — the abort path never refreshed it. So it shipped the `{0, 0, 0}` init usage, and the client overwrote its accumulated tally with zeros.

## Fix

In `SubagentManager.abort()`, capture the conversation's latest usage before `setStatus("aborted")`, mirroring the completion (`manager.ts` ~L470) and failure (~L487) paths:

```ts
if (managed.conversation) {
  managed.state.usage = { ...managed.conversation.usageStats };
}
```

`usageStats` accrues per LLM turn (`conversation-usage.ts`), so this is the most-recent total used up to the abort. The no-live-conversation case (already-released conversation) keeps the last-known `state.usage` rather than overwriting it.

This is the daemon-side complement to the client-side guard already merged in #35660 (which switched the store's terminal-usage merge from `??` to `||` so a stray zero can't clobber the tally). Together: the daemon now sends the authoritative total, and the client won't zero out even if a terminal event ever carries junk.

## Tests

Added two tests to `subagent-disposal.test.ts`:
- abort emits the conversation's accrued usage (`{100, 50, 0.005}`), not `{0,0,0}`
- with no live conversation, abort surfaces the last-known `state.usage` instead of overwriting it

Verified: `bun test src/__tests__/subagent-disposal.test.ts` (11 pass), eslint + prettier clean.

## Risk

🟢 Low — a 9-line addition reusing the exact pattern the completion/failure paths already use; no new control flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)