### PR TITLE
Remove quote reply feature flag

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -199,7 +199,6 @@ export function ChatMainPanel({
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   const assistantName = useAssistantIdentityStore.use.name();
   const chatPullToRefreshEnabled = useClientFeatureFlagStore.use.chatPullToRefreshEnabled();
-  const quoteReplyEnabled = useClientFeatureFlagStore.use.quoteReply();
 
   // -------------------------------------------------------------------------
   // Store reads — per-conversation state
@@ -852,7 +851,7 @@ export function ChatMainPanel({
       />
       {sendErrorModalNode}
       {ruleEditorModalNode}
-      {quoteReplyEnabled && !isChannelReadonly && (
+      {!isChannelReadonly && (
         <>
           <TextSelectionPopover containerRef={transcriptContainerRef} />
           <QuoteReplyBubble onSendNow={handleQuoteReplyNow} />

--- a/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
@@ -12,14 +12,12 @@ import { QuoteReplyBubble } from "@/domains/chat/components/quote-reply-bubble";
 import { StagedQuotesStrip } from "@/domains/chat/components/staged-quotes-strip";
 import { TextSelectionPopover } from "@/domains/chat/components/text-selection-popover";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 function resetQuoteReplyState() {
   useQuoteReplyStore.setState({
     stagedQuotes: [],
     replyBubble: null,
   });
-  useClientFeatureFlagStore.setState({ quoteReply: false });
 }
 
 function installFinePointer() {
@@ -166,7 +164,6 @@ describe("QuoteReplyBubble", () => {
 
 describe("StagedQuotesStrip", () => {
   test("renders staged quote previews with shared card and button primitives", () => {
-    useClientFeatureFlagStore.setState({ quoteReply: true });
     useQuoteReplyStore.setState({
       stagedQuotes: [
         {

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -13,7 +13,6 @@ import {
   type StagedQuote,
   useQuoteReplyStore,
 } from "@/domains/chat/quote-reply-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { Button, Card, Typography } from "@vellumai/design-library";
 
 function truncate(text: string, maxLen: number): string {
@@ -65,10 +64,9 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
 }
 
 export function StagedQuotesStrip() {
-  const quoteReplyEnabled = useClientFeatureFlagStore.use.quoteReply();
   const stagedQuotes = useQuoteReplyStore.use.stagedQuotes();
 
-  if (!quoteReplyEnabled || stagedQuotes.length === 0) {
+  if (stagedQuotes.length === 0) {
     return null;
   }
 

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -10,9 +10,11 @@ import {
   scopeIncludes,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
+const originalWindow = (globalThis as Record<string, unknown>).window;
+
 afterEach(() => {
   resetEnvOverridesCache();
-  delete (globalThis as Record<string, unknown>).window;
+  (globalThis as Record<string, unknown>).window = originalWindow;
 });
 
 describe("feature flag catalog", () => {
@@ -36,6 +38,11 @@ describe("feature flag catalog", () => {
   test("does not expose GA empty-state greetings as a feature flag", () => {
     expect("emptyStateDynamicGreetings" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
     expect("emptyStateDynamicGreetings" in CLIENT_FLAG_DEFAULTS).toBe(false);
+  });
+
+  test("does not expose GA quote reply as a feature flag", () => {
+    expect("quoteReply" in CLIENT_FLAG_DEFAULTS).toBe(false);
+    expect("quoteReply" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
   });
 
   test("exposes web remote ingress as an assistant flag defaulted off", () => {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -425,14 +425,6 @@
       "label": "OS Beta",
       "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
       "defaultEnabled": false
-    },
-    {
-      "id": "quote-reply",
-      "scope": "client",
-      "key": "quote-reply",
-      "label": "Quote & Reply",
-      "description": "Show a Quote & Reply popover when selecting text in assistant messages, allowing users to annotate quoted passages and stage them for inclusion in the next chat message.",
-      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove the client-side quote-reply feature flag from the bundled registry.
- Render quote/reply UI for all writable chat conversations.
- Update focused tests to cover GA behavior and clean test DOM restoration.

## Original prompt
The user asked to remove the feature flag for the Quote & Reply feature because it is ready for GA, then open a PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->