### PR TITLE
[codex] Normalize OpenAI-compatible provider errors

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8408,6 +8408,22 @@ paths:
                                   anyOf:
                                     - type: number
                                     - type: "null"
+                                apiErrorCode:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                apiErrorType:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                apiErrorParam:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                requestId:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
                               additionalProperties: false
                             - type: "null"
                       required:
@@ -15352,6 +15368,22 @@ paths:
                             anyOf:
                               - type: number
                               - type: "null"
+                          apiErrorCode:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          apiErrorType:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          apiErrorParam:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          requestId:
+                            anyOf:
+                              - type: string
+                              - type: "null"
                         additionalProperties: false
                       - type: "null"
                 required:
@@ -17808,6 +17840,22 @@ paths:
                                 retryAfterMs:
                                   anyOf:
                                     - type: number
+                                    - type: "null"
+                                apiErrorCode:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                apiErrorType:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                apiErrorParam:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                requestId:
+                                  anyOf:
+                                    - type: string
                                     - type: "null"
                               additionalProperties: false
                             - type: "null"

--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -1877,7 +1877,7 @@ describe("normalizeLlmContextPayloads", () => {
       expect(normalized.summary?.provider).toBe("openai");
     });
 
-    test("carries statusCode 0 and retryAfterMs through", () => {
+    test("carries statusCode 0, retryAfterMs, and upstream metadata through", () => {
       const normalized = normalizeLlmContextPayloads({
         createdAt: 1_742_400_000_000,
         requestPayload: null,
@@ -1888,6 +1888,10 @@ describe("normalizeLlmContextPayloads", () => {
             provider: "anthropic",
             statusCode: 0,
             retryAfterMs: 1500,
+            apiErrorCode: "rate_limit_error",
+            apiErrorType: "overloaded_error",
+            apiErrorParam: "model",
+            requestId: "req_abc123",
           },
         },
       });
@@ -1898,6 +1902,10 @@ describe("normalizeLlmContextPayloads", () => {
         provider: "anthropic",
         statusCode: 0,
         retryAfterMs: 1500,
+        apiErrorCode: "rate_limit_error",
+        apiErrorType: "overloaded_error",
+        apiErrorParam: "model",
+        requestId: "req_abc123",
       });
     });
 

--- a/assistant/src/__tests__/llm-request-log-error-payload.test.ts
+++ b/assistant/src/__tests__/llm-request-log-error-payload.test.ts
@@ -12,6 +12,7 @@
  *
  * Coverage:
  *  - `ProviderError` with full metadata (provider, statusCode, retryAfterMs).
+ *  - `ProviderError` with upstream provider error metadata.
  *  - `ProviderError` without optional metadata.
  *  - Non-provider `AssistantError` (carries `code` but not provider fields).
  *  - Plain `Error` (degrades to `{name, message}`).
@@ -25,18 +26,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { buildProviderErrorResponsePayload } from "../memory/llm-request-log-store.js";
-import {
-  AssistantError,
-  ErrorCode,
-  ProviderError,
-} from "../util/errors.js";
+import { AssistantError, ErrorCode, ProviderError } from "../util/errors.js";
 
 function persisted(err: Error): { error: Record<string, unknown> } {
   // Round-trip through JSON to assert on the actual stored shape, not the
   // in-memory object reference.
-  return JSON.parse(
-    JSON.stringify(buildProviderErrorResponsePayload(err)),
-  );
+  return JSON.parse(JSON.stringify(buildProviderErrorResponsePayload(err)));
 }
 
 describe("buildProviderErrorResponsePayload", () => {
@@ -56,6 +51,34 @@ describe("buildProviderErrorResponsePayload", () => {
         provider: "anthropic",
         statusCode: 429,
         retryAfterMs: 1500,
+      },
+    });
+  });
+
+  test("ProviderError serializes upstream provider error metadata when present", () => {
+    const err = new ProviderError(
+      "OpenAI API error (401): Invalid API key provided",
+      "openai",
+      401,
+      {
+        apiErrorCode: "invalid_api_key",
+        apiErrorType: "invalid_request_error",
+        apiErrorParam: "api_key",
+        requestId: "req_abc123",
+      },
+    );
+    const got = persisted(err);
+    expect(got).toEqual({
+      error: {
+        name: "ProviderError",
+        message: "OpenAI API error (401): Invalid API key provided",
+        code: ErrorCode.PROVIDER_ERROR,
+        provider: "openai",
+        statusCode: 401,
+        apiErrorCode: "invalid_api_key",
+        apiErrorType: "invalid_request_error",
+        apiErrorParam: "api_key",
+        requestId: "req_abc123",
       },
     });
   });

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -62,6 +62,13 @@ function userMsg(text: string): Message {
   return { role: "user", content: [{ type: "text", text }] };
 }
 
+function expectOpenAIConstructorOptions(
+  expected: Record<string, unknown>,
+): void {
+  expect(lastConstructorOptions).toEqual(expect.objectContaining(expected));
+  expect(typeof lastConstructorOptions?.fetch).toBe("function");
+}
+
 // Simulate OpenAI.APIError
 class FakeAPIError extends Error {
   status: number;
@@ -309,7 +316,7 @@ describe("OpenAIProvider", () => {
     });
 
     expect(compatible.name).toBe("ollama");
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "sk-local",
       baseURL: "http://127.0.0.1:11434/v1",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -322,7 +329,7 @@ describe("OpenAIProvider", () => {
       delete process.env.OLLAMA_BASE_URL;
       const ollama = new OllamaProvider("llama3.2");
       expect(ollama.name).toBe("ollama");
-      expect(lastConstructorOptions).toEqual({
+      expectOpenAIConstructorOptions({
         apiKey: "ollama",
         baseURL: "http://127.0.0.1:11434/v1",
         timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -342,7 +349,7 @@ describe("OpenAIProvider", () => {
       process.env.OLLAMA_BASE_URL = "   ";
       const ollama = new OllamaProvider("llama3.2");
       expect(ollama.name).toBe("ollama");
-      expect(lastConstructorOptions).toEqual({
+      expectOpenAIConstructorOptions({
         apiKey: "ollama",
         baseURL: "http://127.0.0.1:11434/v1",
         timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1260,7 +1267,7 @@ describe("custom baseURL initialization", () => {
     });
 
     expect(managed.name).toBe("openai");
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "ast-key-123",
       baseURL: "https://platform.example.com/v1/runtime-proxy/openai",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1270,7 +1277,7 @@ describe("custom baseURL initialization", () => {
   test("OpenAIProvider without baseURL calls provider directly", () => {
     new OpenAIProvider("sk-user-key", "gpt-4o");
 
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "sk-user-key",
       baseURL: undefined,
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1282,7 +1289,7 @@ describe("custom baseURL initialization", () => {
       streamTimeoutMs: 300_000,
     });
 
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "sk-user-key",
       baseURL: undefined,
       timeout: 360_000,
@@ -1299,7 +1306,7 @@ describe("custom baseURL initialization", () => {
     );
 
     expect(managed.name).toBe("fireworks");
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "ast-key-123",
       baseURL: "https://platform.example.com/v1/runtime-proxy/fireworks",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1312,7 +1319,7 @@ describe("custom baseURL initialization", () => {
       "accounts/fireworks/models/llama-v3p1-70b-instruct",
     );
 
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "fw-user-key",
       baseURL: "https://api.fireworks.ai/inference/v1",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1325,7 +1332,7 @@ describe("custom baseURL initialization", () => {
     });
 
     expect(managed.name).toBe("openrouter");
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "ast-key-123",
       baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1335,7 +1342,7 @@ describe("custom baseURL initialization", () => {
   test("OpenRouterProvider without custom baseURL uses default OpenRouter URL", () => {
     new OpenRouterProvider("or-user-key", "openai/gpt-4o");
 
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "or-user-key",
       baseURL: "https://openrouter.ai/api/v1",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1348,7 +1355,7 @@ describe("custom baseURL initialization", () => {
     });
 
     expect(managed.name).toBe("minimax");
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "ast-key-123",
       baseURL: "https://platform.example.com/v1/runtime-proxy/minimax",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -1358,7 +1365,7 @@ describe("custom baseURL initialization", () => {
   test("MinimaxProvider without custom baseURL uses default MiniMax URL", () => {
     new MinimaxProvider("mm-user-key", "MiniMax-M2.7");
 
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "mm-user-key",
       baseURL: "https://api.minimax.io/v1",
       timeout: DEFAULT_SDK_TIMEOUT_MS,

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -24,6 +24,13 @@ let lastConstructorOptions: Record<string, unknown> | null = null;
 let shouldThrow: Error | null = null;
 const DEFAULT_SDK_TIMEOUT_MS = 1_860_000;
 
+function expectOpenAIConstructorOptions(
+  expected: Record<string, unknown>,
+): void {
+  expect(lastConstructorOptions).toEqual(expect.objectContaining(expected));
+  expect(typeof lastConstructorOptions?.fetch).toBe("function");
+}
+
 // Simulate OpenAI.APIError
 class FakeAPIError extends Error {
   status: number;
@@ -218,7 +225,7 @@ describe("OpenAIResponsesProvider", () => {
       providerLabel: "Managed OpenAI",
     });
 
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "sk-custom",
       baseURL: "https://proxy.example.com/v1",
       timeout: DEFAULT_SDK_TIMEOUT_MS,
@@ -230,7 +237,7 @@ describe("OpenAIResponsesProvider", () => {
       streamTimeoutMs: 300_000,
     });
 
-    expect(lastConstructorOptions).toEqual({
+    expectOpenAIConstructorOptions({
       apiKey: "sk-custom",
       baseURL: undefined,
       timeout: 360_000,

--- a/assistant/src/api/responses/llm-request-log-entry.ts
+++ b/assistant/src/api/responses/llm-request-log-entry.ts
@@ -87,6 +87,10 @@ export const LLMCallErrorSchema = z.object({
   provider: z.string().nullish(),
   statusCode: z.number().nullish(),
   retryAfterMs: z.number().nullish(),
+  apiErrorCode: z.string().nullish(),
+  apiErrorType: z.string().nullish(),
+  apiErrorParam: z.string().nullish(),
+  requestId: z.string().nullish(),
 });
 
 export type LLMCallError = z.infer<typeof LLMCallErrorSchema>;

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -111,6 +111,18 @@ export function buildProviderErrorResponsePayload(err: Error): {
     if (err.retryAfterMs !== undefined) {
       payload.retryAfterMs = err.retryAfterMs;
     }
+    if (err.apiErrorCode !== undefined) {
+      payload.apiErrorCode = err.apiErrorCode;
+    }
+    if (err.apiErrorType !== undefined) {
+      payload.apiErrorType = err.apiErrorType;
+    }
+    if (err.apiErrorParam !== undefined) {
+      payload.apiErrorParam = err.apiErrorParam;
+    }
+    if (err.requestId !== undefined) {
+      payload.requestId = err.requestId;
+    }
   } else if (err instanceof AssistantError) {
     payload.code = err.code;
   }

--- a/assistant/src/providers/openai/__tests__/api-error-detail.test.ts
+++ b/assistant/src/providers/openai/__tests__/api-error-detail.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import OpenAI from "openai";
+import type OpenAI from "openai";
 
-import { extractApiErrorDetail } from "../chat-completions-provider.js";
+import {
+  extractApiErrorDetail,
+  formatNormalizedOpenAIAPIError,
+  normalizeOpenAIAPIError,
+} from "../api-error-normalization.js";
 
 /**
  * Construct a real `OpenAI.APIError` so production code paths that use
@@ -12,20 +16,65 @@ function buildApiError(
   status: number,
   body: unknown,
   headers?: Headers,
+  message?: string,
 ): InstanceType<typeof OpenAI.APIError> {
-  return new OpenAI.APIError(
+  return {
     status,
-    body as Record<string, unknown>,
-    undefined,
-    headers ?? new Headers(),
-  );
+    message:
+      message ??
+      (body === undefined
+        ? `${status} status code (no body)`
+        : `${status} ${JSON.stringify(body)}`),
+    headers: headers ?? new Headers(),
+    error: body,
+  } as unknown as InstanceType<typeof OpenAI.APIError>;
 }
 
-describe("extractApiErrorDetail", () => {
-  test("serializes a structured body so logs show the upstream error", () => {
-    // This is the canonical OpenRouter shape that motivated the helper:
-    // the SDK's `error.message` collapses to "400 Provider returned error"
-    // and the real detail lives nested under `error.metadata.raw`.
+describe("normalizeOpenAIAPIError", () => {
+  test("surfaces Django detail bodies captured before the SDK drops them", () => {
+    const err = buildApiError(400, undefined);
+    const normalized = normalizeOpenAIAPIError(
+      err,
+      JSON.stringify({
+        detail:
+          "Model 'MiniMaxAI/MiniMax-M3' is not yet supported on the Vellum hosted service.",
+      }),
+    );
+
+    expect(normalized.message).toBe(
+      "Model 'MiniMaxAI/MiniMax-M3' is not yet supported on the Vellum hosted service.",
+    );
+    expect(formatNormalizedOpenAIAPIError("Together AI", 400, normalized)).toBe(
+      "Together AI API error (400): Model 'MiniMaxAI/MiniMax-M3' is not yet supported on the Vellum hosted service.",
+    );
+  });
+
+  test("normalizes OpenAI-shaped errors with provider metadata", () => {
+    const err = buildApiError(401, undefined);
+    const normalized = normalizeOpenAIAPIError(
+      err,
+      JSON.stringify({
+        error: {
+          message: "Invalid API key provided",
+          code: "invalid_api_key",
+          type: "invalid_request_error",
+          param: "api_key",
+        },
+      }),
+    );
+
+    expect(normalized).toMatchObject({
+      message: "Invalid API key provided",
+      apiErrorCode: "invalid_api_key",
+      apiErrorType: "invalid_request_error",
+      apiErrorParam: "api_key",
+    });
+    expect(formatNormalizedOpenAIAPIError("OpenAI", 401, normalized)).toContain(
+      "code=invalid_api_key; type=invalid_request_error; param=api_key",
+    );
+  });
+
+  test("promotes OpenRouter downstream raw metadata over the wrapper message", () => {
     const err = buildApiError(400, {
       error: {
         code: 400,
@@ -36,85 +85,60 @@ describe("extractApiErrorDetail", () => {
         },
       },
     });
-    const { detail, requestId } = extractApiErrorDetail(err);
-    expect(detail).toContain("Provider returned error");
-    expect(detail).toContain("tool_use_id must reference a prior tool_use");
-    expect(detail).toContain("Anthropic");
-    expect(requestId).toBeUndefined();
+    const normalized = normalizeOpenAIAPIError(err);
+
+    expect(normalized.message).toBe(
+      "messages.4: tool_use_id must reference a prior tool_use block",
+    );
+    expect(normalized.detail).toBe("provider=Anthropic");
+    expect(normalized.apiErrorCode).toBe("400");
+  });
+
+  test("uses a plain-text raw body when JSON parsing fails", () => {
+    const err = buildApiError(502, undefined);
+    const normalized = normalizeOpenAIAPIError(err, "upstream timeout");
+    expect(normalized.message).toBe("upstream timeout");
   });
 
   test("surfaces the upstream request id when present in headers", () => {
     const headers = new Headers({ "x-request-id": "req_abc123" });
-    const err = buildApiError(
-      400,
-      { error: { message: "Provider returned error" } },
-      headers,
+    const err = buildApiError(400, undefined, headers);
+    const normalized = normalizeOpenAIAPIError(
+      err,
+      JSON.stringify({ detail: "bad request" }),
     );
-    const { requestId } = extractApiErrorDetail(err);
-    expect(requestId).toBe("req_abc123");
-  });
-
-  test("falls back to x-openrouter-request-id when x-request-id is absent", () => {
-    const headers = new Headers({
-      "x-openrouter-request-id": "gen-or-xyz",
-    });
-    const err = buildApiError(
-      400,
-      { error: { message: "Provider returned error" } },
-      headers,
+    expect(normalized.requestId).toBe("req_abc123");
+    expect(formatNormalizedOpenAIAPIError("OpenAI", 400, normalized)).toContain(
+      "request_id=req_abc123",
     );
-    const { requestId } = extractApiErrorDetail(err);
-    expect(requestId).toBe("gen-or-xyz");
   });
+});
 
+describe("extractApiErrorDetail", () => {
   test("returns empty detail when the body is missing", () => {
-    // The SDK constructs an APIError even when the upstream response had
-    // no JSON body (e.g. network-layer 5xx). The helper must degrade
-    // gracefully rather than emit `undefined` or `null` strings.
     const err = buildApiError(500, undefined);
     const { detail, requestId } = extractApiErrorDetail(err);
     expect(detail).toBe("");
     expect(requestId).toBeUndefined();
   });
 
-  test("returns empty detail when the body serializes to an empty object", () => {
-    // `{}` carries zero signal and just adds noise to log lines.
-    const err = buildApiError(429, {});
-    const { detail } = extractApiErrorDetail(err);
-    expect(detail).toBe("");
+  test("returns distinct normalized detail for legacy callers", () => {
+    const err = buildApiError(400, undefined);
+    const { detail } = extractApiErrorDetail(
+      err,
+      JSON.stringify({ detail: "managed proxy rejected model" }),
+    );
+    expect(detail).toBe("managed proxy rejected model");
   });
 
-  test("truncates very long bodies with an ellipsis", () => {
+  test("truncates very long normalized details with an ellipsis", () => {
     const huge = "X".repeat(5000);
-    const err = buildApiError(400, { error: { message: huge } });
-    const { detail } = extractApiErrorDetail(err);
-    // Cap is 2000 chars; the helper appends a single-char ellipsis when truncating.
+    const err = buildApiError(400, undefined);
+    const { detail } = extractApiErrorDetail(
+      err,
+      JSON.stringify({ detail: huge }),
+    );
     expect(detail.length).toBeLessThanOrEqual(2001);
     expect(detail.endsWith("…")).toBe(true);
-  });
-
-  test("preserves string bodies verbatim (no double-encoding)", () => {
-    // Some providers return a non-JSON body (HTML error page, plain text).
-    // The SDK stores it on `error.error` as a string in that case.
-    const err = buildApiError(502, "upstream timeout");
-    const { detail } = extractApiErrorDetail(err);
-    expect(detail).toBe("upstream timeout");
-  });
-
-  test("returns empty detail when JSON.stringify throws (cyclic body)", () => {
-    // Pathological body — should not propagate the TypeError to callers.
-    // OpenAI's `APIError` constructor itself JSON.stringifies the body to
-    // build its own `.message`, so we can't get to this branch via the SDK
-    // constructor; build a structural stand-in instead.
-    const cyclic: Record<string, unknown> = {};
-    cyclic.self = cyclic;
-    const stub = {
-      status: 400,
-      message: "synthetic",
-      headers: new Headers(),
-      error: cyclic,
-    } as unknown as InstanceType<typeof OpenAI.APIError>;
-    const { detail } = extractApiErrorDetail(stub);
-    expect(detail).toBe("");
   });
 });

--- a/assistant/src/providers/openai/api-error-normalization.ts
+++ b/assistant/src/providers/openai/api-error-normalization.ts
@@ -1,0 +1,290 @@
+import OpenAI from "openai";
+
+export interface NormalizedOpenAIAPIError {
+  message: string;
+  detail?: string;
+  requestId?: string;
+  apiErrorCode?: string;
+  apiErrorType?: string;
+  apiErrorParam?: string;
+}
+
+interface ErrorBodyDetails {
+  message?: string;
+  detail?: string;
+  apiErrorCode?: string;
+  apiErrorType?: string;
+  apiErrorParam?: string;
+}
+
+const MAX_API_ERROR_DETAIL_CHARS = 2000;
+const REQUEST_ID_HEADERS = [
+  "x-request-id",
+  "x-openrouter-request-id",
+  "openai-request-id",
+  "x-amzn-requestid",
+] as const;
+
+export async function readOpenAIRawErrorBody(
+  response: Response,
+): Promise<string | undefined> {
+  if (response.ok) return undefined;
+  try {
+    return await response.clone().text();
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeOpenAIAPIError(
+  error: InstanceType<typeof OpenAI.APIError>,
+  rawBody?: string,
+): NormalizedOpenAIAPIError {
+  const rawDetails = parseRawErrorBody(rawBody);
+  const sdkDetails = extractErrorBodyDetails(
+    (error as { error?: unknown }).error,
+  );
+  const message =
+    rawDetails?.message ??
+    sdkDetails?.message ??
+    stripLeadingStatus(error.message ?? "", error.status) ??
+    "Request failed";
+  const detail = firstDistinctDetail(
+    message,
+    rawDetails?.detail,
+    sdkDetails?.detail,
+  );
+  const requestId = readHeader(error.headers, REQUEST_ID_HEADERS);
+  return {
+    message,
+    ...(detail !== undefined ? { detail } : {}),
+    ...mergeApiMetadata(error, rawDetails, sdkDetails),
+    ...(requestId !== undefined ? { requestId } : {}),
+  };
+}
+
+export function formatNormalizedOpenAIAPIError(
+  providerLabel: string,
+  status: number | undefined,
+  normalized: NormalizedOpenAIAPIError,
+): string {
+  const statusLabel =
+    typeof status === "number" ? String(status) : "unknown status";
+  const extras = [
+    normalized.detail,
+    normalized.apiErrorCode ? `code=${normalized.apiErrorCode}` : undefined,
+    normalized.apiErrorType ? `type=${normalized.apiErrorType}` : undefined,
+    normalized.apiErrorParam ? `param=${normalized.apiErrorParam}` : undefined,
+    normalized.requestId ? `request_id=${normalized.requestId}` : undefined,
+  ].filter((value): value is string => Boolean(value));
+  const suffix = extras.length > 0 ? ` [${extras.join("; ")}]` : "";
+  return `${providerLabel} API error (${statusLabel}): ${normalized.message}${suffix}`;
+}
+
+/**
+ * Exported for tests and for older call sites that only need a serialized
+ * detail string plus request id.
+ */
+export function extractApiErrorDetail(
+  error: InstanceType<typeof OpenAI.APIError>,
+  rawBody?: string,
+): { detail: string; requestId: string | undefined } {
+  const normalized = normalizeOpenAIAPIError(error, rawBody);
+  const detail = firstDistinctDetail(
+    stripLeadingStatus(error.message ?? "", error.status) ?? "",
+    normalized.message,
+    normalized.detail,
+  );
+  return { detail: detail ?? "", requestId: normalized.requestId };
+}
+
+function parseRawErrorBody(
+  rawBody: string | undefined,
+): ErrorBodyDetails | undefined {
+  const trimmed = rawBody?.trim();
+  if (!trimmed) return undefined;
+  try {
+    return extractErrorBodyDetails(JSON.parse(trimmed));
+  } catch {
+    return { message: truncateDetail(trimmed) };
+  }
+}
+
+function extractErrorBodyDetails(body: unknown): ErrorBodyDetails | undefined {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === "string") {
+    const message = truncateDetail(body.trim());
+    return message ? { message } : undefined;
+  }
+  const record = asRecord(body);
+  if (!record) return undefined;
+
+  const wrappedError = record.error;
+  if (typeof wrappedError === "string") {
+    const details: ErrorBodyDetails = { message: truncateDetail(wrappedError) };
+    addApiMetadata(details, record);
+    return details;
+  }
+  const wrappedRecord = asRecord(wrappedError);
+  if (wrappedRecord) {
+    const nested = extractErrorRecordDetails(wrappedRecord);
+    addApiMetadata(nested, record);
+    return nested;
+  }
+
+  return extractErrorRecordDetails(record);
+}
+
+function extractErrorRecordDetails(
+  record: Record<string, unknown>,
+): ErrorBodyDetails {
+  const detail = stringProp(record, "detail");
+  const message = stringProp(record, "message") ?? detail;
+  const metadata = asRecord(record.metadata);
+  const raw = stringProp(metadata, "raw");
+  const providerName = stringProp(metadata, "provider_name");
+  const normalizedMessage =
+    raw && message && isGenericProviderErrorMessage(message)
+      ? raw
+      : (message ?? raw);
+  const metadataDetails = [
+    raw && raw !== normalizedMessage ? raw : undefined,
+    providerName ? `provider=${providerName}` : undefined,
+  ].filter((value): value is string => Boolean(value));
+  const metadataDetail =
+    metadataDetails.length > 0 ? metadataDetails.join("; ") : undefined;
+
+  const details: ErrorBodyDetails = {};
+  if (normalizedMessage) {
+    details.message = truncateDetail(normalizedMessage);
+  }
+  if (metadataDetail) {
+    details.detail = truncateDetail(metadataDetail);
+  }
+  addApiMetadata(details, record);
+  return details;
+}
+
+function mergeApiMetadata(
+  error: InstanceType<typeof OpenAI.APIError>,
+  rawDetails: ErrorBodyDetails | undefined,
+  sdkDetails: ErrorBodyDetails | undefined,
+): Pick<
+  NormalizedOpenAIAPIError,
+  "apiErrorCode" | "apiErrorType" | "apiErrorParam"
+> {
+  const metadata: Pick<
+    NormalizedOpenAIAPIError,
+    "apiErrorCode" | "apiErrorType" | "apiErrorParam"
+  > = {};
+  const apiErrorCode =
+    rawDetails?.apiErrorCode ??
+    sdkDetails?.apiErrorCode ??
+    scalarString((error as { code?: unknown }).code);
+  const apiErrorType =
+    rawDetails?.apiErrorType ??
+    sdkDetails?.apiErrorType ??
+    scalarString((error as { type?: unknown }).type);
+  const apiErrorParam =
+    rawDetails?.apiErrorParam ??
+    sdkDetails?.apiErrorParam ??
+    scalarString((error as { param?: unknown }).param);
+  if (apiErrorCode !== undefined) metadata.apiErrorCode = apiErrorCode;
+  if (apiErrorType !== undefined) metadata.apiErrorType = apiErrorType;
+  if (apiErrorParam !== undefined) metadata.apiErrorParam = apiErrorParam;
+  return metadata;
+}
+
+function addApiMetadata(
+  details: ErrorBodyDetails,
+  record: Record<string, unknown>,
+): void {
+  if (details.apiErrorCode === undefined) {
+    const code = scalarString(record.code);
+    if (code !== undefined) details.apiErrorCode = code;
+  }
+  if (details.apiErrorType === undefined) {
+    const type = scalarString(record.type);
+    if (type !== undefined) details.apiErrorType = type;
+  }
+  if (details.apiErrorParam === undefined) {
+    const param = scalarString(record.param);
+    if (param !== undefined) details.apiErrorParam = param;
+  }
+}
+
+function firstDistinctDetail(
+  message: string,
+  ...details: Array<string | undefined>
+): string | undefined {
+  for (const detail of details) {
+    if (!detail) continue;
+    const trimmed = truncateDetail(detail.trim());
+    if (trimmed && trimmed !== message) return trimmed;
+  }
+  return undefined;
+}
+
+function stripLeadingStatus(
+  message: string,
+  status: number | undefined,
+): string | undefined {
+  const trimmed = message.trim();
+  if (!trimmed) return undefined;
+  if (typeof status !== "number") return trimmed;
+  return trimmed.replace(new RegExp(`^${status}\\s+`), "").trim() || trimmed;
+}
+
+function truncateDetail(detail: string): string {
+  return detail.length > MAX_API_ERROR_DETAIL_CHARS
+    ? `${detail.slice(0, MAX_API_ERROR_DETAIL_CHARS)}…`
+    : detail;
+}
+
+function isGenericProviderErrorMessage(message: string): boolean {
+  return /^provider returned error$/i.test(message.trim());
+}
+
+function stringProp(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  if (!record) return undefined;
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function scalarString(value: unknown): string | undefined {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readHeader(
+  headers: unknown,
+  names: readonly string[],
+): string | undefined {
+  if (!headers) return undefined;
+  const getter =
+    typeof (headers as { get?: unknown }).get === "function"
+      ? (headers as { get(name: string): string | null }).get.bind(headers)
+      : undefined;
+  for (const name of names) {
+    let value: string | null | undefined;
+    if (getter) {
+      value = getter(name);
+    } else if (typeof headers === "object") {
+      const record = headers as Record<string, unknown>;
+      const raw = record[name] ?? record[name.toLowerCase()];
+      value = typeof raw === "string" ? raw : undefined;
+    }
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -23,6 +23,12 @@ import {
   wrapUnparseableToolArgs,
 } from "../unparseable-tool-args.js";
 import {
+  extractApiErrorDetail,
+  formatNormalizedOpenAIAPIError,
+  normalizeOpenAIAPIError,
+  readOpenAIRawErrorBody,
+} from "./api-error-normalization.js";
+import {
   coerceObjectParamsToJsonString,
   decodeCoercedObjectArgs,
 } from "./coerce-object-args.js";
@@ -43,6 +49,7 @@ import {
  */
 export function detectOpenAICompatibleContextOverflow(
   error: InstanceType<typeof OpenAI.APIError>,
+  extraMessage?: string,
 ): { actualTokens?: number; maxTokens?: number } | null {
   // OpenAI-compatible providers use 400 (most) or 413 (rarer payload-too-large).
   const status = error.status;
@@ -53,7 +60,7 @@ export function detectOpenAICompatibleContextOverflow(
     /context_length_exceeded|context_window_exceeded|input_too_long|prompt_too_long/i.test(
       code,
     );
-  const message = error.message ?? "";
+  const message = `${error.message ?? ""} ${extraMessage ?? ""}`;
   const messageMatches =
     /context.?length.?exceeded|context.?window.?exceeded|prompt.?is.?too.?long|prompt_too_long|input.?too.?long|too.?many.?(?:input.?)?tokens|maximum.?context/i.test(
       message,
@@ -63,52 +70,7 @@ export function detectOpenAICompatibleContextOverflow(
   return extractOverflowTokensFromMessage(message);
 }
 
-/**
- * Build the human-readable error string surfaced from an
- * `OpenAI.APIError`. The SDK's `error.message` is typically a one-line
- * summary like `"400 Provider returned error"` — useless when the
- * upstream is OpenRouter (which wraps the real downstream error on
- * `error.error.metadata.raw`) or any provider that returns nested
- * structured details.
- *
- * Returns `{ detail, requestId }` where `detail` includes the JSON body
- * (truncated) and `requestId` is the upstream correlation header when
- * present. Callers fold these into the thrown `ProviderError` so log
- * lines actually identify the failure without re-running the request.
- *
- * Exported for tests.
- */
-export function extractApiErrorDetail(
-  error: InstanceType<typeof OpenAI.APIError>,
-): { detail: string; requestId: string | undefined } {
-  const body = (error as { error?: unknown }).error;
-  let detail = "";
-  if (body !== undefined && body !== null) {
-    try {
-      const serialized = typeof body === "string" ? body : JSON.stringify(body);
-      if (serialized && serialized !== "{}") {
-        detail =
-          serialized.length > MAX_API_ERROR_DETAIL_CHARS
-            ? `${serialized.slice(0, MAX_API_ERROR_DETAIL_CHARS)}…`
-            : serialized;
-      }
-    } catch {
-      // Body had a cycle or threw on toJSON — fall through with empty detail.
-    }
-  }
-  const requestId = readHeader(error.headers, [
-    "x-request-id",
-    "x-openrouter-request-id",
-    "openai-request-id",
-    "x-amzn-requestid",
-  ]);
-  return { detail, requestId };
-}
-
-/** Cap on the inline-rendered body to keep log lines readable while still
- *  surfacing the meaningful upstream payload. Tuned to comfortably hold
- *  OpenRouter's `error.metadata.raw` strings, which are typically <1KB. */
-const MAX_API_ERROR_DETAIL_CHARS = 2000;
+export { extractApiErrorDetail };
 
 const VISION_NOT_SUPPORTED_PATTERNS = [
   /no endpoints found that support image input/i,
@@ -121,8 +83,9 @@ const VISION_NOT_SUPPORTED_PATTERNS = [
 
 export function detectVisionNotSupported(
   error: InstanceType<typeof OpenAI.APIError>,
+  extraMessage?: string,
 ): boolean {
-  const haystack = `${error.message} ${JSON.stringify((error as { error?: unknown }).error ?? "")}`;
+  const haystack = `${error.message} ${extraMessage ?? ""} ${JSON.stringify((error as { error?: unknown }).error ?? "")}`;
   return VISION_NOT_SUPPORTED_PATTERNS.some((re) => re.test(haystack));
 }
 
@@ -145,34 +108,6 @@ export function detectVisionNotSupported(
  * `isPlaceholderSentinelText`.
  */
 export const EMPTY_ASSISTANT_TURN_PLACEHOLDER = PLACEHOLDER_EMPTY_TURN.slice(1);
-
-/**
- * Read the first matching header from an SDK error's headers object,
- * tolerating both Map-like (`Headers.get()`) and plain-object shapes.
- * Mirrors the shape-tolerance already in `extractRetryAfterMs`.
- */
-function readHeader(
-  headers: unknown,
-  names: readonly string[],
-): string | undefined {
-  if (!headers) return undefined;
-  const getter =
-    typeof (headers as { get?: unknown }).get === "function"
-      ? (headers as { get(name: string): string | null }).get.bind(headers)
-      : undefined;
-  for (const name of names) {
-    let value: string | null | undefined;
-    if (getter) {
-      value = getter(name);
-    } else if (typeof headers === "object") {
-      const record = headers as Record<string, unknown>;
-      const raw = record[name] ?? record[name.toLowerCase()];
-      value = typeof raw === "string" ? raw : undefined;
-    }
-    if (typeof value === "string" && value.length > 0) return value;
-  }
-  return undefined;
-}
 
 export interface OpenAIChatCompletionsProviderOptions {
   baseURL?: string;
@@ -326,6 +261,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     | undefined;
   private backfillEmptyAssistantContent: boolean;
   private coerceObjectArgsToJsonString: boolean;
+  private lastRawErrorBody: string | undefined;
 
   constructor(
     apiKey: string,
@@ -342,6 +278,11 @@ export class OpenAIChatCompletionsProvider implements Provider {
       apiKey,
       baseURL: options.baseURL,
       timeout: sdkTimeoutMs,
+      fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+        const response = await globalThis.fetch(url, init);
+        this.lastRawErrorBody = await readOpenAIRawErrorBody(response);
+        return response;
+      },
     });
     this.model = model;
     this.extraCreateParams = options.extraCreateParams ?? {};
@@ -371,6 +312,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
+    this.lastRawErrorBody = undefined;
 
     // Per-tool keys whose object schemas were rewritten to JSON strings for the
     // wire, to be decoded back on the response. Empty unless
@@ -763,11 +705,19 @@ export class OpenAIChatCompletionsProvider implements Provider {
           ? signal.reason
           : undefined;
       if (error instanceof OpenAI.APIError) {
-        const { detail, requestId } = extractApiErrorDetail(error);
-        const detailSuffix = detail ? ` ${detail}` : "";
-        const requestIdSuffix = requestId ? ` [request_id=${requestId}]` : "";
-        const formattedMessage = `${this.providerLabel} API error (${error.status}): ${error.message}${detailSuffix}${requestIdSuffix}`;
-        const overflow = detectOpenAICompatibleContextOverflow(error);
+        const normalized = normalizeOpenAIAPIError(
+          error,
+          this.consumeRawErrorBody(),
+        );
+        const formattedMessage = formatNormalizedOpenAIAPIError(
+          this.providerLabel,
+          error.status,
+          normalized,
+        );
+        const overflow = detectOpenAICompatibleContextOverflow(
+          error,
+          normalized.message,
+        );
         if (overflow) {
           throw new ContextOverflowError(formattedMessage, this.name, {
             actualTokens: overflow.actualTokens,
@@ -776,7 +726,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
             cause: error,
           });
         }
-        if (detectVisionNotSupported(error)) {
+        if (detectVisionNotSupported(error, normalized.message)) {
           const model = modelOverride ?? this.model;
           throw new ProviderError(
             `This model (${model}) doesn't support image input. Remove the image or switch to a vision-capable model.`,
@@ -789,10 +739,21 @@ export class OpenAIChatCompletionsProvider implements Provider {
         const errorOptions: {
           retryAfterMs?: number;
           abortReason?: unknown;
+          apiErrorCode?: string;
+          apiErrorType?: string;
+          apiErrorParam?: string;
+          requestId?: string;
         } = {};
         if (retryAfterMs !== undefined)
           errorOptions.retryAfterMs = retryAfterMs;
         if (abortReason) errorOptions.abortReason = abortReason;
+        if (normalized.apiErrorCode)
+          errorOptions.apiErrorCode = normalized.apiErrorCode;
+        if (normalized.apiErrorType)
+          errorOptions.apiErrorType = normalized.apiErrorType;
+        if (normalized.apiErrorParam)
+          errorOptions.apiErrorParam = normalized.apiErrorParam;
+        if (normalized.requestId) errorOptions.requestId = normalized.requestId;
         throw new ProviderError(
           formattedMessage,
           this.name,
@@ -809,6 +770,12 @@ export class OpenAIChatCompletionsProvider implements Provider {
         abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
+  }
+
+  private consumeRawErrorBody(): string | undefined {
+    const body = this.lastRawErrorBody;
+    this.lastRawErrorBody = undefined;
+    return body;
   }
 
   /**

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -16,6 +16,11 @@ import type {
 } from "../types.js";
 import { ContextOverflowError } from "../types.js";
 import { wrapUnparseableToolArgs } from "../unparseable-tool-args.js";
+import {
+  formatNormalizedOpenAIAPIError,
+  normalizeOpenAIAPIError,
+  readOpenAIRawErrorBody,
+} from "./api-error-normalization.js";
 import { detectOpenAICompatibleContextOverflow } from "./chat-completions-provider.js";
 
 const log = getLogger("openai-responses");
@@ -148,7 +153,7 @@ export class OpenAIResponsesProvider implements Provider {
   private streamTimeoutMs: number;
   private useNativeWebSearch: boolean;
   private codexSubscription: boolean;
-  private lastCodexErrorBody: string | undefined;
+  private lastRawErrorBody: string | undefined;
 
   constructor(
     apiKey: string,
@@ -168,27 +173,21 @@ export class OpenAIResponsesProvider implements Provider {
         ? "https://chatgpt.com/backend-api/codex"
         : options.baseURL,
       timeout: sdkTimeoutMs,
-      ...(this.codexSubscription
-        ? {
-            fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
-              const res = await globalThis.fetch(url, init);
-              if (!res.ok) {
-                const body = await res.text();
-                this.lastCodexErrorBody = body;
-                log.warn(
-                  { status: res.status, body, url: String(url) },
-                  "Codex endpoint raw error response",
-                );
-                return new Response(body, {
-                  status: res.status,
-                  statusText: res.statusText,
-                  headers: res.headers,
-                });
-              }
-              return res;
+      fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+        const res = await globalThis.fetch(url, init);
+        this.lastRawErrorBody = await readOpenAIRawErrorBody(res);
+        if (!res.ok && this.codexSubscription) {
+          log.warn(
+            {
+              status: res.status,
+              body: this.lastRawErrorBody,
+              url: String(url),
             },
-          }
-        : {}),
+            "Codex endpoint raw error response",
+          );
+        }
+        return res;
+      },
     });
     this.model = model;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
@@ -207,6 +206,7 @@ export class OpenAIResponsesProvider implements Provider {
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
+    this.lastRawErrorBody = undefined;
 
     try {
       const input = this.toResponsesInput(messages);
@@ -510,43 +510,48 @@ export class OpenAIResponsesProvider implements Provider {
           ? signal.reason
           : undefined;
       if (error instanceof OpenAI.APIError) {
-        const overflow = detectOpenAICompatibleContextOverflow(error);
+        const normalized = normalizeOpenAIAPIError(
+          error,
+          this.consumeRawErrorBody(),
+        );
+        const formattedMessage = formatNormalizedOpenAIAPIError(
+          this.providerLabel,
+          error.status,
+          normalized,
+        );
+        const overflow = detectOpenAICompatibleContextOverflow(
+          error,
+          normalized.message,
+        );
         if (overflow) {
-          throw new ContextOverflowError(
-            `${this.providerLabel} API error (${error.status}): ${error.message}`,
-            this.name,
-            {
-              actualTokens: overflow.actualTokens,
-              maxTokens: overflow.maxTokens,
-              statusCode: error.status,
-              cause: error,
-            },
-          );
+          throw new ContextOverflowError(formattedMessage, this.name, {
+            actualTokens: overflow.actualTokens,
+            maxTokens: overflow.maxTokens,
+            statusCode: error.status,
+            cause: error,
+          });
         }
         const retryAfterMs = extractRetryAfterMs(error.headers);
         const errorOptions: {
           retryAfterMs?: number;
           abortReason?: unknown;
+          apiErrorCode?: string;
+          apiErrorType?: string;
+          apiErrorParam?: string;
+          requestId?: string;
         } = {};
         if (retryAfterMs !== undefined)
           errorOptions.retryAfterMs = retryAfterMs;
         if (abortReason) errorOptions.abortReason = abortReason;
-        let errorDetail = error.message;
-        if (this.lastCodexErrorBody) {
-          try {
-            const parsed = JSON.parse(this.lastCodexErrorBody);
-            if (parsed.detail) errorDetail = parsed.detail;
-          } catch {
-            errorDetail = this.lastCodexErrorBody.slice(0, 200);
-          }
-          this.lastCodexErrorBody = undefined;
-        }
-        const extras = [error.code, error.type, error.param]
-          .filter(Boolean)
-          .join(", ");
-        const extraSuffix = extras ? ` [${extras}]` : "";
+        if (normalized.apiErrorCode)
+          errorOptions.apiErrorCode = normalized.apiErrorCode;
+        if (normalized.apiErrorType)
+          errorOptions.apiErrorType = normalized.apiErrorType;
+        if (normalized.apiErrorParam)
+          errorOptions.apiErrorParam = normalized.apiErrorParam;
+        if (normalized.requestId) errorOptions.requestId = normalized.requestId;
         throw new ProviderError(
-          `${this.providerLabel} API error (${error.status}): ${errorDetail}${extraSuffix}`,
+          formattedMessage,
           this.name,
           error.status,
           Object.keys(errorOptions).length > 0 ? errorOptions : undefined,
@@ -561,6 +566,12 @@ export class OpenAIResponsesProvider implements Provider {
         abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
+  }
+
+  private consumeRawErrorBody(): string | undefined {
+    const body = this.lastRawErrorBody;
+    this.lastRawErrorBody = undefined;
+    return body;
   }
 
   /**

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -54,6 +54,10 @@ export interface LlmContextError {
   provider?: string;
   statusCode?: number;
   retryAfterMs?: number;
+  apiErrorCode?: string;
+  apiErrorType?: string;
+  apiErrorParam?: string;
+  requestId?: string;
 }
 
 export interface LlmContextNormalizationResult {
@@ -121,6 +125,14 @@ function normalizeProviderErrorPayload(
   if (statusCode !== undefined) normalized.statusCode = statusCode;
   const retryAfterMs = asNumber(error.retryAfterMs);
   if (retryAfterMs !== undefined) normalized.retryAfterMs = retryAfterMs;
+  const apiErrorCode = asString(error.apiErrorCode);
+  if (apiErrorCode !== undefined) normalized.apiErrorCode = apiErrorCode;
+  const apiErrorType = asString(error.apiErrorType);
+  if (apiErrorType !== undefined) normalized.apiErrorType = apiErrorType;
+  const apiErrorParam = asString(error.apiErrorParam);
+  if (apiErrorParam !== undefined) normalized.apiErrorParam = apiErrorParam;
+  const requestId = asString(error.requestId);
+  if (requestId !== undefined) normalized.requestId = requestId;
   return normalized;
 }
 

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -102,6 +102,10 @@ export class AssistantError extends VellumError {
 export class ProviderError extends AssistantError {
   /** Delay (in ms) suggested by the server's Retry-After header, if present. */
   public readonly retryAfterMs?: number;
+  public readonly apiErrorCode?: string;
+  public readonly apiErrorType?: string;
+  public readonly apiErrorParam?: string;
+  public readonly requestId?: string;
   /**
    * Tagged daemon-owned abort reason carried over from the AbortSignal that
    * triggered this error. Untyped here to avoid a daemon→util import cycle;
@@ -114,11 +118,23 @@ export class ProviderError extends AssistantError {
     message: string,
     public readonly provider: string,
     public readonly statusCode?: number,
-    options?: { cause?: unknown; retryAfterMs?: number; abortReason?: unknown },
+    options?: {
+      cause?: unknown;
+      retryAfterMs?: number;
+      abortReason?: unknown;
+      apiErrorCode?: string;
+      apiErrorType?: string;
+      apiErrorParam?: string;
+      requestId?: string;
+    },
   ) {
     super(message, ErrorCode.PROVIDER_ERROR, options);
     this.name = "ProviderError";
     this.retryAfterMs = options?.retryAfterMs;
+    this.apiErrorCode = options?.apiErrorCode;
+    this.apiErrorType = options?.apiErrorType;
+    this.apiErrorParam = options?.apiErrorParam;
+    this.requestId = options?.requestId;
     this.abortReason = options?.abortReason;
   }
 }

--- a/clients/web/src/domains/chat/inspector/components/llm-call-error-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/llm-call-error-card.tsx
@@ -79,6 +79,22 @@ function buildErrorChips(error: LLMCallError): ErrorChipModel[] {
   if (code) {
     chips.push({ label: "Code", value: code });
   }
+  const apiErrorCode = error.apiErrorCode?.trim();
+  if (apiErrorCode) {
+    chips.push({ label: "Upstream code", value: apiErrorCode });
+  }
+  const apiErrorType = error.apiErrorType?.trim();
+  if (apiErrorType) {
+    chips.push({ label: "Upstream type", value: apiErrorType });
+  }
+  const apiErrorParam = error.apiErrorParam?.trim();
+  if (apiErrorParam) {
+    chips.push({ label: "Upstream param", value: apiErrorParam });
+  }
+  const requestId = error.requestId?.trim();
+  if (requestId) {
+    chips.push({ label: "Request ID", value: requestId });
+  }
   return chips;
 }
 

--- a/clients/web/src/domains/chat/inspector/components/tabs/response-tab.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/response-tab.test.tsx
@@ -41,6 +41,10 @@ describe("ResponseTab — failed calls", () => {
           code: "PROVIDER_ERROR",
           provider: "fireworks",
           statusCode: 400,
+          apiErrorCode: "model_not_supported",
+          apiErrorType: "invalid_request_error",
+          apiErrorParam: "model",
+          requestId: "req_abc123",
         },
       }),
     );
@@ -52,6 +56,9 @@ describe("ResponseTab — failed calls", () => {
     expect(html).toContain("400");
     expect(html).toContain("ProviderError");
     expect(html).toContain("PROVIDER_ERROR");
+    expect(html).toContain("model_not_supported");
+    expect(html).toContain("invalid_request_error");
+    expect(html).toContain("req_abc123");
     // The generic fallback must not appear when the call failed.
     expect(html).not.toContain("Section rendering unavailable");
   });


### PR DESCRIPTION
## Summary
- Capture and normalize raw OpenAI-compatible non-2xx response bodies before the SDK drops Django detail payloads.
- Thread normalized upstream error metadata through ProviderError, request logs, API schema, and the web inspector.
- Regenerate OpenAPI contracts for the expanded log error payload.

## Why
Managed runtime proxy errors can be Django {"detail": "..."} payloads, while the OpenAI SDK reads error.message and renders missing messages as "(no body)". This keeps the proxy error body intact on the assistant side.

## Validation
- assistant: bun test src/providers/openai/__tests__/api-error-detail.test.ts src/__tests__/openai-provider.test.ts src/__tests__/openai-responses-provider.test.ts src/__tests__/llm-request-log-error-payload.test.ts src/__tests__/llm-context-normalization.test.ts
- clients/web: bun test src/domains/chat/inspector/components/tabs/response-tab.test.tsx src/domains/chat/inspector/components/tabs/overview-tab.test.tsx src/domains/chat/inspector/components/call-rail.test.ts
- assistant: bunx tsc --noEmit
- clients/web: bunx tsc --noEmit
- assistant: bun run lint
- clients/web: bun run lint
- git diff --check

Note: clients/web lint still reports existing warnings unrelated to these changes.