### PR TITLE
Local-principal trust context from the gateway guardian binding (Combo 11 prereq)

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -104,6 +104,18 @@ mock.module("../runtime/trust-context-resolver.js", () => ({
   }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-contact",
+      principalId: "test-user",
+      address: "test-user",
+      status: "active",
+    },
+  ],
+}));
+
 import type { AuthContext } from "../runtime/auth/types.js";
 import { handleSendMessage } from "../runtime/routes/conversation-routes.js";
 import { callHandler } from "./helpers/call-route-handler.js";

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -190,6 +190,18 @@ mock.module("../runtime/trust-context-resolver.js", () => ({
   }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-contact",
+      principalId: "test-user",
+      address: "test-user",
+      status: "active",
+    },
+  ],
+}));
+
 const ipcCallMock = mock(
   async (): Promise<Record<string, unknown> | undefined> => ({ ok: true }),
 );

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -62,34 +62,18 @@ mock.module("../runtime/guardian-reply-router.js", () => ({
   routeGuardianReply: routeGuardianReplyMock,
 }));
 
-let healDriftReturn = false;
-const healGuardianBindingDriftMock = mock(async () => healDriftReturn);
+// Stub for the shared reset-drift helper. handleSendMessage only consumes its
+// result (a guardian TrustContext or null) on a first-pass-unknown actor; the
+// gate itself is covered in runtime/__tests__/guardian-vellum-migration.test.ts.
+const reResolveCalls: string[] = [];
+let mockReResolve: { trustClass: string; sourceChannel: string } | null = null;
 mock.module("../runtime/guardian-vellum-migration.js", () => ({
-  healGuardianBindingDrift: healGuardianBindingDriftMock,
-  // Mirror the real helper against the mocked gateway/local-mirror state so the
-  // route exercises the shared narrow-drift gate end-to-end.
   reResolveTrustOnResetDrift: async (
     incomingPrincipalId: string,
-    sourceChannel: string,
+    _sourceChannel: string,
   ) => {
-    const gatewayPrincipal = mockGuardians
-      ? mockGuardians.find(
-          (g) => g.channelType === "vellum" && g.status === "active",
-        )?.principalId
-      : undefined;
-    const isResetDrift =
-      incomingPrincipalId.startsWith("vellum-principal-") &&
-      typeof gatewayPrincipal === "string" &&
-      gatewayPrincipal.startsWith("vellum-principal-") &&
-      gatewayPrincipal !== incomingPrincipalId;
-    if (!isResetDrift) return null;
-    await healGuardianBindingDriftMock();
-    return {
-      trustClass: localMirrorGuardians.has(incomingPrincipalId)
-        ? "guardian"
-        : "unknown",
-      sourceChannel,
-    };
+    reResolveCalls.push(incomingPrincipalId);
+    return mockReResolve;
   },
 }));
 
@@ -159,18 +143,8 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
-// The local mirror grants guardian only to principals present in this set;
-// everyone else resolves unknown. Models the dual-written local mirror that
-// the gateway-first resolve falls back to.
-let localMirrorGuardians = new Set<string>(["test-user"]);
+// handleSendMessage wraps the first-pass resolve with withSourceChannel.
 mock.module("../runtime/trust-context-resolver.js", () => ({
-  resolveTrustContext: (input: { actorExternalId?: string }) => ({
-    trustClass:
-      input.actorExternalId && localMirrorGuardians.has(input.actorExternalId)
-        ? "guardian"
-        : "unknown",
-    sourceChannel: "vellum",
-  }),
   withSourceChannel: (sourceChannel: unknown, ctx: unknown) => ({
     ...(ctx as Record<string, unknown>),
     sourceChannel,
@@ -525,9 +499,8 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
         status: "active",
       },
     ];
-    healDriftReturn = false;
-    localMirrorGuardians = new Set<string>(["test-user"]);
-    healGuardianBindingDriftMock.mockClear();
+    reResolveCalls.length = 0;
+    mockReResolve = null;
   });
 
   function requestAs(principalId: string, sourceChannel = "vellum") {
@@ -578,20 +551,18 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
     return (await trustContextFor(principalId)).trustClass as string;
   }
 
-  test("guardian principal resolves to guardian context", async () => {
+  test("guardian principal resolves to guardian context, helper not called", async () => {
     expect(await trustClassFor("test-user")).toBe("guardian");
+    expect(reResolveCalls).toEqual([]);
   });
 
-  test("non-guardian principal resolves to unknown", async () => {
+  test("non-guardian principal: helper consulted, null result stays unknown", async () => {
+    mockReResolve = null;
     expect(await trustClassFor("vellum-principal-stranger")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+    expect(reResolveCalls).toEqual(["vellum-principal-stranger"]);
   });
 
-  test("re-resolves to guardian from the local mirror after a drift heal", async () => {
-    healDriftReturn = true;
-    // The gateway binding mismatches the JWT throughout — heal repairs the
-    // local mirror, not the gateway. Post-heal trust comes from the local
-    // resolver (resolveTrustContext), not a still-mismatched gateway read.
+  test("reset drift: helper returns guardian → route adopts it", async () => {
     mockGuardians = [
       {
         channelType: "vellum",
@@ -601,18 +572,13 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
         status: "active",
       },
     ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+    mockReResolve = { trustClass: "guardian", sourceChannel: "vellum" };
 
     expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
-    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+    expect(reResolveCalls).toEqual(["vellum-principal-healed"]);
   });
 
-  test("re-resolves to guardian on later drift requests where heal is a no-op", async () => {
-    // Second-request drift window: the gateway binding still mismatches the
-    // JWT, so heal is a no-op and returns false. The local re-resolve must
-    // still run (gated on the gateway returning unknown, not on a heal write)
-    // and keep guardian trust from the already-repaired local mirror.
-    healDriftReturn = false;
+  test("helper returns an unknown-class ctx → trust stays unknown (not adopted)", async () => {
     mockGuardians = [
       {
         channelType: "vellum",
@@ -622,10 +588,9 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
         status: "active",
       },
     ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+    mockReResolve = { trustClass: "unknown", sourceChannel: "vellum" };
 
-    expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
-    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
   });
 
   test("dev-bypass maps the gateway guardian principal to guardian", async () => {
@@ -633,69 +598,11 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
   });
 
   test("dev-bypass fails closed to unknown on an empty gateway", async () => {
-    // No active gateway binding: dev-bypass must not grant guardian from the
-    // stale local mirror — parity with /v1/surface-actions.
+    // No active gateway binding: dev-bypass cannot translate to a real guardian,
+    // and the helper (null) leaves trust unknown — parity with /v1/surface-actions.
     mockGuardians = [];
-    localMirrorGuardians = new Set<string>(["test-user"]);
+    mockReResolve = null;
     expect(await trustClassFor("dev-bypass")).toBe("unknown");
-  });
-
-  test("fails closed to unknown when the gateway is unreachable", async () => {
-    // Gateway read returns null (unreachable) while the local mirror WOULD
-    // grant guardian. The drift fallback must not fall open to the mirror.
-    mockGuardians = null;
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
-  });
-
-  test("fails closed to unknown when the gateway guardian is revoked", async () => {
-    // Empty active guardian list (revoked/rebind in flight) while the local
-    // mirror WOULD grant guardian. No active gateway principal means no
-    // narrow-drift heal — re-granting revoked trust is a security regression.
-    mockGuardians = [];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
-  });
-
-  test("fails closed to unknown when only a non-active guardian remains", async () => {
-    // A revoked binding lingers with status !== "active"; guardianForChannel
-    // skips it, so there is no active gateway principal to drift against.
-    mockGuardians = [
-      {
-        channelType: "vellum",
-        contactId: "guardian-contact",
-        principalId: "vellum-principal-stale",
-        address: "vellum-principal-stale",
-        status: "revoked",
-      },
-    ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
-  });
-
-  test("fails closed to unknown on rebind to a real external identity", async () => {
-    // The gateway's active guardian is a real identity (not a daemon-minted
-    // vellum-principal-*), so a stale vellum-principal JWT must not re-grant
-    // from the mirror — a genuine rebind, not DB-reset drift.
-    mockGuardians = [
-      {
-        channelType: "vellum",
-        contactId: "guardian-contact",
-        principalId: "user@example.com",
-        address: "user@example.com",
-        status: "active",
-      },
-    ];
-    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
-
-    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
-    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
   });
 
   test("preserves the request body channel on the guardian-match happy path", async () => {

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -66,6 +66,31 @@ let healDriftReturn = false;
 const healGuardianBindingDriftMock = mock(async () => healDriftReturn);
 mock.module("../runtime/guardian-vellum-migration.js", () => ({
   healGuardianBindingDrift: healGuardianBindingDriftMock,
+  // Mirror the real helper against the mocked gateway/local-mirror state so the
+  // route exercises the shared narrow-drift gate end-to-end.
+  reResolveTrustOnResetDrift: async (
+    incomingPrincipalId: string,
+    sourceChannel: string,
+  ) => {
+    const gatewayPrincipal = mockGuardians
+      ? mockGuardians.find(
+          (g) => g.channelType === "vellum" && g.status === "active",
+        )?.principalId
+      : undefined;
+    const isResetDrift =
+      incomingPrincipalId.startsWith("vellum-principal-") &&
+      typeof gatewayPrincipal === "string" &&
+      gatewayPrincipal.startsWith("vellum-principal-") &&
+      gatewayPrincipal !== incomingPrincipalId;
+    if (!isResetDrift) return null;
+    await healGuardianBindingDriftMock();
+    return {
+      trustClass: localMirrorGuardians.has(incomingPrincipalId)
+        ? "guardian"
+        : "unknown",
+      sourceChannel,
+    };
+  },
 }));
 
 mock.module("../memory/canonical-guardian-store.js", () => ({
@@ -110,10 +135,10 @@ mock.module("../memory/conversation-crud.js", () => ({
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalTrustContext: () => ({
-    trustClass: "guardian",
-    sourceChannel: "vellum",
-  }),
+  findLocalGuardianPrincipalId: async () =>
+    mockGuardians?.find(
+      (g) => g.channelType === "vellum" && g.status === "active",
+    )?.principalId as string | undefined,
 }));
 
 let mockGuardians: Array<Record<string, unknown>> | null = [
@@ -131,8 +156,7 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: (
     list: Array<Record<string, unknown>>,
     channelType: string,
-  ) =>
-    list.find((g) => g.channelType === channelType && g.status === "active"),
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 // The local mirror grants guardian only to principals present in this set;
@@ -606,6 +630,14 @@ describe("HTTP POST /v1/messages trust context from the gateway binding", () => 
 
   test("dev-bypass maps the gateway guardian principal to guardian", async () => {
     expect(await trustClassFor("dev-bypass")).toBe("guardian");
+  });
+
+  test("dev-bypass fails closed to unknown on an empty gateway", async () => {
+    // No active gateway binding: dev-bypass must not grant guardian from the
+    // stale local mirror — parity with /v1/surface-actions.
+    mockGuardians = [];
+    localMirrorGuardians = new Set<string>(["test-user"]);
+    expect(await trustClassFor("dev-bypass")).toBe("unknown");
   });
 
   test("fails closed to unknown when the gateway is unreachable", async () => {

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -62,6 +62,12 @@ mock.module("../runtime/guardian-reply-router.js", () => ({
   routeGuardianReply: routeGuardianReplyMock,
 }));
 
+let healDriftReturn = false;
+const healGuardianBindingDriftMock = mock(async () => healDriftReturn);
+mock.module("../runtime/guardian-vellum-migration.js", () => ({
+  healGuardianBindingDrift: healGuardianBindingDriftMock,
+}));
+
 mock.module("../memory/canonical-guardian-store.js", () => ({
   createCanonicalGuardianRequest: () => ({
     id: "canonical-id",
@@ -110,9 +116,35 @@ mock.module("../runtime/local-actor-identity.js", () => ({
   }),
 }));
 
+let mockGuardians: Array<Record<string, unknown>> | null = [
+  {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId: "test-user",
+    address: "test-user",
+    status: "active",
+  },
+];
+
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardians,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+// The local mirror grants guardian only to principals present in this set;
+// everyone else resolves unknown. Models the dual-written local mirror that
+// the gateway-first resolve falls back to.
+let localMirrorGuardians = new Set<string>(["test-user"]);
 mock.module("../runtime/trust-context-resolver.js", () => ({
-  resolveTrustContext: () => ({
-    trustClass: "guardian",
+  resolveTrustContext: (input: { actorExternalId?: string }) => ({
+    trustClass:
+      input.actorExternalId && localMirrorGuardians.has(input.actorExternalId)
+        ? "guardian"
+        : "unknown",
     sourceChannel: "vellum",
   }),
   withSourceChannel: (sourceChannel: unknown, ctx: unknown) => ({
@@ -452,5 +484,191 @@ describe("HTTP POST /v1/messages clientTimezone transport metadata", () => {
     });
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// TRUST CONTEXT — derived from the gateway guardian binding
+// ============================================================================
+describe("HTTP POST /v1/messages trust context from the gateway binding", () => {
+  beforeEach(() => {
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "test-user",
+        address: "test-user",
+        status: "active",
+      },
+    ];
+    healDriftReturn = false;
+    localMirrorGuardians = new Set<string>(["test-user"]);
+    healGuardianBindingDriftMock.mockClear();
+  });
+
+  function requestAs(principalId: string, sourceChannel = "vellum") {
+    return new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-vellum-actor-principal-id": principalId,
+        "x-vellum-principal-type": "actor",
+      },
+      body: JSON.stringify({
+        conversationKey: "trust-test-key",
+        content: "hi",
+        sourceChannel,
+        interface: "macos",
+      }),
+    });
+  }
+
+  async function trustContextFor(
+    principalId: string,
+    sourceChannel = "vellum",
+  ): Promise<Record<string, unknown>> {
+    let captured: Record<string, unknown> | undefined;
+    const conversation = makeConversation({
+      setTrustContext: (ctx: Record<string, unknown>) => {
+        captured = ctx;
+      },
+    });
+    const res = await callHandler(
+      (args) =>
+        handleSendMessage(args, {
+          sendMessageDeps: {
+            getOrCreateConversation: async () => conversation,
+            assistantEventHub: { publish: async () => {} } as any,
+            resolveAttachments: () => [],
+          },
+        }),
+      requestAs(principalId, sourceChannel),
+      undefined,
+      202,
+    );
+    expect(res.status).toBe(202);
+    return captured ?? {};
+  }
+
+  async function trustClassFor(principalId: string): Promise<string> {
+    return (await trustContextFor(principalId)).trustClass as string;
+  }
+
+  test("guardian principal resolves to guardian context", async () => {
+    expect(await trustClassFor("test-user")).toBe("guardian");
+  });
+
+  test("non-guardian principal resolves to unknown", async () => {
+    expect(await trustClassFor("vellum-principal-stranger")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("re-resolves to guardian from the local mirror after a drift heal", async () => {
+    healDriftReturn = true;
+    // The gateway binding mismatches the JWT throughout — heal repairs the
+    // local mirror, not the gateway. Post-heal trust comes from the local
+    // resolver (resolveTrustContext), not a still-mismatched gateway read.
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "vellum-principal-stale",
+        address: "vellum-principal-stale",
+        status: "active",
+      },
+    ];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
+    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-resolves to guardian on later drift requests where heal is a no-op", async () => {
+    // Second-request drift window: the gateway binding still mismatches the
+    // JWT, so heal is a no-op and returns false. The local re-resolve must
+    // still run (gated on the gateway returning unknown, not on a heal write)
+    // and keep guardian trust from the already-repaired local mirror.
+    healDriftReturn = false;
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "vellum-principal-stale",
+        address: "vellum-principal-stale",
+        status: "active",
+      },
+    ];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("guardian");
+    expect(healGuardianBindingDriftMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dev-bypass maps the gateway guardian principal to guardian", async () => {
+    expect(await trustClassFor("dev-bypass")).toBe("guardian");
+  });
+
+  test("fails closed to unknown when the gateway is unreachable", async () => {
+    // Gateway read returns null (unreachable) while the local mirror WOULD
+    // grant guardian. The drift fallback must not fall open to the mirror.
+    mockGuardians = null;
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed to unknown when the gateway guardian is revoked", async () => {
+    // Empty active guardian list (revoked/rebind in flight) while the local
+    // mirror WOULD grant guardian. No active gateway principal means no
+    // narrow-drift heal — re-granting revoked trust is a security regression.
+    mockGuardians = [];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed to unknown when only a non-active guardian remains", async () => {
+    // A revoked binding lingers with status !== "active"; guardianForChannel
+    // skips it, so there is no active gateway principal to drift against.
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "vellum-principal-stale",
+        address: "vellum-principal-stale",
+        status: "revoked",
+      },
+    ];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed to unknown on rebind to a real external identity", async () => {
+    // The gateway's active guardian is a real identity (not a daemon-minted
+    // vellum-principal-*), so a stale vellum-principal JWT must not re-grant
+    // from the mirror — a genuine rebind, not DB-reset drift.
+    mockGuardians = [
+      {
+        channelType: "vellum",
+        contactId: "guardian-contact",
+        principalId: "user@example.com",
+        address: "user@example.com",
+        status: "active",
+      },
+    ];
+    localMirrorGuardians = new Set<string>(["vellum-principal-healed"]);
+
+    expect(await trustClassFor("vellum-principal-healed")).toBe("unknown");
+    expect(healGuardianBindingDriftMock).not.toHaveBeenCalled();
+  });
+
+  test("preserves the request body channel on the guardian-match happy path", async () => {
+    const ctx = await trustContextFor("test-user", "telegram");
+    expect(ctx.trustClass).toBe("guardian");
+    expect(ctx.sourceChannel).toBe("telegram");
   });
 });

--- a/assistant/src/__tests__/secret-ingress-http.test.ts
+++ b/assistant/src/__tests__/secret-ingress-http.test.ts
@@ -127,6 +127,18 @@ mock.module("../runtime/trust-context-resolver.js", () => ({
   }),
 }));
 
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [
+    {
+      channelType: "vellum",
+      contactId: "guardian-contact",
+      principalId: "test-user",
+      address: "test-user",
+      status: "active",
+    },
+  ],
+}));
+
 mock.module("../runtime/guardian-reply-router.js", () => ({
   routeGuardianReply: async () => ({
     consumed: false,

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -109,22 +109,38 @@ mock.module("../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => _approvalGenerator,
 }));
 
-// Dev-bypass resolves the real guardian principal, then maps it through the
-// local-principal trust mapper. Both are stubbed to the principal the canonical
-// requests in these tests use.
+// Dev-bypass resolves the real guardian principal, then runs the real
+// local-principal trust mapper against the gateway delivery read.
 mock.module("../runtime/local-actor-identity.js", () => ({
   findLocalGuardianPrincipalId: async () => "test-principal-id",
 }));
 
-mock.module("../runtime/local-principal-trust.js", () => ({
-  resolveLocalPrincipalTrustContext: async () => ({
-    sourceChannel: "vellum",
-    trustClass: "guardian",
-    guardianPrincipalId: "test-principal-id",
-    guardianExternalUserId: "test-principal-id",
-  }),
+// Mock the IPC transport rather than local-principal-trust.js so the sibling
+// resolver unit test (which mocks guardian-delivery-reader, not ipcCall) isn't
+// shadowed when both files run in one Bun process. resolve_guardian_delivery
+// returns a single active vellum guardian whose principal matches the
+// dev-bypass-resolved id; any other method throws so unexpected IPC surfaces.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCall: async (method: string) => {
+    if (method === "resolve_guardian_delivery") {
+      return {
+        guardians: [
+          {
+            channelType: "vellum",
+            contactId: "test-contact-id",
+            principalId: "test-principal-id",
+            address: "test-principal-id",
+            externalChatId: "test-principal-id",
+            status: "active",
+          },
+        ],
+      };
+    }
+    throw new Error(`Unexpected ipcCall in test: ${method}`);
+  },
 }));
 
+import { __resetGuardianDeliveryCacheForTest } from "../contacts/guardian-delivery-reader.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
@@ -348,6 +364,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
     pendingInteractions.clear();
+    __resetGuardianDeliveryCacheForTest();
 
     createGuardianBinding({
       channel: "vellum",

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -109,10 +109,15 @@ mock.module("../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => _approvalGenerator,
 }));
 
-// Mock local-actor-identity to return a stable guardian context that uses
-// the same principal as the canonical requests created in tests.
+// Dev-bypass resolves the real guardian principal, then maps it through the
+// local-principal trust mapper. Both are stubbed to the principal the canonical
+// requests in these tests use.
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalTrustContext: () => ({
+  findLocalGuardianPrincipalId: async () => "test-principal-id",
+}));
+
+mock.module("../runtime/local-principal-trust.js", () => ({
+  resolveLocalPrincipalTrustContext: async () => ({
     sourceChannel: "vellum",
     trustClass: "guardian",
     guardianPrincipalId: "test-principal-id",

--- a/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the narrow reset-drift trust-recovery helper
+ * `reResolveTrustOnResetDrift`.
+ *
+ * The real helper runs against mocked leaf deps: the gateway guardian read
+ * (`getGuardianDelivery`/`guardianForChannel`), the local-mirror heal
+ * (`findGuardianForChannel`/`updateContactPrincipalAndChannel`, which the real
+ * `healGuardianBindingDrift` drives), and the local trust resolver
+ * (`resolveTrustContext`). Heal invocations are observed via the contact-store
+ * write mock.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => mockGuardianList,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+// Local mirror the real heal reads/writes. `findGuardianForChannel` returns the
+// stored guardian; `updateContactPrincipalAndChannel` records heal writes.
+let mockLocalGuardian: {
+  contact: { id: string; principalId: string };
+  channel: { id: string };
+} | null = null;
+const healWrites: Array<{ principalId: string }> = [];
+
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => mockLocalGuardian,
+  updateContactPrincipalAndChannel: (
+    _contactId: string,
+    _channelId: string,
+    principalId: string,
+  ) => {
+    healWrites.push({ principalId });
+    return true;
+  },
+}));
+
+// The local trust resolver returns guardian for the actor; the gate threads
+// sourceChannel via the real withSourceChannel wrapper.
+mock.module("../../runtime/trust-context-resolver.js", () => ({
+  resolveTrustContext: (input: { actorExternalId?: string }) => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+    resolvedActor: input.actorExternalId,
+  }),
+  withSourceChannel: (sourceChannel: unknown, ctx: Record<string, unknown>) => ({
+    ...ctx,
+    sourceChannel,
+  }),
+}));
+
+const { reResolveTrustOnResetDrift } = await import(
+  "../guardian-vellum-migration.js"
+);
+
+function gatewayGuardian(principalId: string): Record<string, unknown> {
+  return {
+    channelType: "vellum",
+    contactId: "guardian-contact",
+    principalId,
+    address: principalId,
+    status: "active",
+  };
+}
+
+function localGuardian(principalId: string) {
+  return {
+    contact: { id: "contact-1", principalId },
+    channel: { id: "channel-1" },
+  };
+}
+
+describe("reResolveTrustOnResetDrift", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    mockLocalGuardian = null;
+    healWrites.length = 0;
+  });
+
+  test("reset drift: heals and returns the re-resolved guardian ctx", async () => {
+    // Stale local mirror still holds the pre-reset principal; the incoming JWT
+    // carries the old one. Heal repairs the mirror toward the incoming actor.
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-stale");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx?.trustClass).toBe("guardian");
+    expect(healWrites).toEqual([{ principalId: "vellum-principal-old" }]);
+  });
+
+  test("repeat drift where heal no-ops still returns the guardian ctx", async () => {
+    // Local mirror already matches the incoming principal, so heal's write is
+    // skipped, but the gate still passes and the re-resolve yields guardian.
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx?.trustClass).toBe("guardian");
+    expect(healWrites).toEqual([]);
+  });
+
+  test("gateway unreachable (null): returns null, heal not called", async () => {
+    mockGuardianList = null;
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("empty/revoked gateway (no active guardian): returns null, heal not called", async () => {
+    mockGuardianList = [];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("gateway guardian is a real (non vellum-principal-*) id: returns null", async () => {
+    mockGuardianList = [gatewayGuardian("user@example.com")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "vellum",
+    );
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("incoming principal is not vellum-principal-*: returns null", async () => {
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift("user@example.com", "vellum");
+
+    expect(ctx).toBeNull();
+    expect(healWrites).toEqual([]);
+  });
+
+  test("threads sourceChannel into the returned ctx", async () => {
+    mockGuardianList = [gatewayGuardian("vellum-principal-new")];
+    mockLocalGuardian = localGuardian("vellum-principal-old");
+
+    const ctx = await reResolveTrustOnResetDrift(
+      "vellum-principal-old",
+      "telegram",
+    );
+
+    expect(ctx?.sourceChannel).toBe("telegram");
+  });
+});

--- a/assistant/src/runtime/__tests__/local-principal-trust.test.ts
+++ b/assistant/src/runtime/__tests__/local-principal-trust.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ChannelId } from "../../channels/types.js";
+
+// Gateway guardian-delivery list: null = couldn't determine (gateway
+// unreachable), [] = authoritatively no guardian, one active entry = bound.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: (_input?: { channelTypes?: string[] }) =>
+    Promise.resolve(mockGuardianList),
+}));
+
+// Local-resolver guardian binding, used to construct the expected guardian
+// TrustContext via the existing resolver and prove equivalence.
+let mockGuardianRecord: {
+  contact: Record<string, unknown>;
+  channel: Record<string, unknown>;
+} | null = null;
+
+mock.module("../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (_channelType: string) => mockGuardianRecord,
+  findContactByAddress: (_channelType: string, _address: string) => null,
+}));
+
+const { resolveLocalPrincipalTrustContext } = await import(
+  "../local-principal-trust.js"
+);
+const { resolveActorTrust, toTrustContext } = await import(
+  "../actor-trust-resolver.js"
+);
+
+const SOURCE_CHANNEL: ChannelId = "vellum";
+const CONVERSATION_ID = "conv-1";
+const GUARDIAN_PRINCIPAL_ID = "principal-guardian";
+const GUARDIAN_ADDRESS = "guardian-address";
+const GUARDIAN_CHAT_ID = "guardian-chat";
+
+describe("resolveLocalPrincipalTrustContext", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    mockGuardianRecord = null;
+  });
+
+  test("principal matching the gateway guardian → guardian ctx", async () => {
+    mockGuardianList = [
+      {
+        channelType: "vellum",
+        contactId: "contact-1",
+        principalId: GUARDIAN_PRINCIPAL_ID,
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    ];
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_PRINCIPAL_ID,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("guardian");
+    expect(ctx.guardianPrincipalId).toBe(GUARDIAN_PRINCIPAL_ID);
+    expect(ctx.guardianExternalUserId).toBe(GUARDIAN_ADDRESS);
+    expect(ctx.guardianChatId).toBe(GUARDIAN_CHAT_ID);
+    expect(ctx.requesterExternalUserId).toBe(GUARDIAN_PRINCIPAL_ID);
+    expect(ctx.requesterChatId).toBe(CONVERSATION_ID);
+    expect(ctx.sourceChannel).toBe(SOURCE_CHANNEL);
+  });
+
+  test("guardian ctx is equivalent to the prior toTrustContext output", async () => {
+    // The actor IS the guardian: its principal id is the guardian binding's
+    // address (vellum canonicalization is pass-through) so the local resolver
+    // classifies it guardian and we can compare the two outputs directly.
+    mockGuardianList = [
+      {
+        channelType: "vellum",
+        contactId: "contact-1",
+        principalId: GUARDIAN_ADDRESS,
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    ];
+    mockGuardianRecord = {
+      contact: { id: "contact-1", principalId: GUARDIAN_ADDRESS },
+      channel: {
+        type: "vellum",
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    };
+
+    const expected = toTrustContext(
+      resolveActorTrust({
+        assistantId: "assistant-1",
+        sourceChannel: SOURCE_CHANNEL,
+        conversationExternalId: CONVERSATION_ID,
+        actorExternalId: GUARDIAN_ADDRESS,
+      }),
+      CONVERSATION_ID,
+    );
+
+    const actual = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_ADDRESS,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(actual).toEqual(expected);
+  });
+
+  test("non-matching principal → unknown ctx", async () => {
+    mockGuardianList = [
+      {
+        channelType: "vellum",
+        contactId: "contact-1",
+        principalId: GUARDIAN_PRINCIPAL_ID,
+        address: GUARDIAN_ADDRESS,
+        externalChatId: GUARDIAN_CHAT_ID,
+        status: "active",
+      },
+    ];
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: "principal-other",
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("unknown");
+    expect(ctx.requesterExternalUserId).toBe("principal-other");
+    expect(ctx.requesterChatId).toBe(CONVERSATION_ID);
+    expect(ctx.sourceChannel).toBe(SOURCE_CHANNEL);
+    expect(ctx.guardianPrincipalId).toBeUndefined();
+  });
+
+  test("empty guardian list → unknown ctx", async () => {
+    mockGuardianList = [];
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_PRINCIPAL_ID,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("unknown");
+  });
+
+  test("null guardian list (gateway unreachable) → unknown (fail closed)", async () => {
+    mockGuardianList = null;
+
+    const ctx = await resolveLocalPrincipalTrustContext({
+      actorPrincipalId: GUARDIAN_PRINCIPAL_ID,
+      sourceChannel: SOURCE_CHANNEL,
+      conversationExternalId: CONVERSATION_ID,
+    });
+
+    expect(ctx.trustClass).toBe("unknown");
+    expect(ctx.requesterExternalUserId).toBe(GUARDIAN_PRINCIPAL_ID);
+  });
+});

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -7,6 +7,7 @@
  * assistant-side since it reacts to incoming JWT principals.
  */
 
+import type { ChannelId } from "../channels/types.js";
 import {
   findGuardianForChannel,
   updateContactPrincipalAndChannel,
@@ -15,7 +16,13 @@ import {
   getGuardianDelivery,
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
+import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
+import {
+  resolveTrustContext,
+  withSourceChannel,
+} from "./trust-context-resolver.js";
 
 const log = getLogger("guardian-vellum-migration");
 
@@ -93,4 +100,33 @@ export async function healGuardianBindingDrift(
   );
 
   return true;
+}
+
+/**
+ * Re-resolve trust from the local mirror only for the narrow vellum-principal
+ * reset-drift case; null when it isn't drift (caller keeps the gateway verdict).
+ */
+export async function reResolveTrustOnResetDrift(
+  incomingPrincipalId: string,
+  sourceChannel: ChannelId,
+): Promise<TrustContext | null> {
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  const gatewayPrincipal = guardians
+    ? guardianForChannel(guardians, "vellum")?.principalId
+    : undefined;
+  const isResetDrift =
+    incomingPrincipalId.startsWith("vellum-principal-") &&
+    !!gatewayPrincipal?.startsWith("vellum-principal-") &&
+    gatewayPrincipal !== incomingPrincipalId;
+  if (!isResetDrift) return null;
+  await healGuardianBindingDrift(incomingPrincipalId);
+  return withSourceChannel(
+    sourceChannel,
+    resolveTrustContext({
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      sourceChannel: "vellum",
+      conversationExternalId: "local",
+      actorExternalId: incomingPrincipalId,
+    }),
+  );
 }

--- a/assistant/src/runtime/local-principal-trust.ts
+++ b/assistant/src/runtime/local-principal-trust.ts
@@ -1,0 +1,64 @@
+/**
+ * Local-principal trust mapper.
+ *
+ * Derives a local principal's runtime {@link TrustContext} from the gateway
+ * guardian binding instead of the assistant DB. A `vellum` principal is the
+ * guardian (owner) or nobody, so "trust of this principal on the vellum
+ * channel" reduces to "does `actorPrincipalId` match the gateway guardian's
+ * principalId?" — which {@link getGuardianDelivery} answers.
+ *
+ * The mapper is pure: it does not heal binding drift or read local ACL. The
+ * routes own the heal/re-resolve loop and call this mapper.
+ */
+
+import type { ChannelId } from "../channels/types.js";
+import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
+
+export interface ResolveLocalPrincipalTrustInput {
+  actorPrincipalId: string;
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+}
+
+/**
+ * Resolve the trust context for a local principal from the gateway guardian
+ * binding. Guardian match → guardian ctx; otherwise → unknown. A null gateway
+ * read fails closed to unknown rather than granting guardian on a miss.
+ */
+export async function resolveLocalPrincipalTrustContext(
+  input: ResolveLocalPrincipalTrustInput,
+): Promise<TrustContext> {
+  const unknownContext: TrustContext = {
+    sourceChannel: input.sourceChannel,
+    trustClass: "unknown",
+    requesterExternalUserId: input.actorPrincipalId,
+    requesterChatId: input.conversationExternalId,
+  };
+
+  // Fail closed: a null read means the gateway is unreachable — never grant
+  // guardian on a miss.
+  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+  if (!guardians) return unknownContext;
+
+  const guardian = guardians.find(
+    (g) => g.principalId === input.actorPrincipalId,
+  );
+  if (!guardian) return unknownContext;
+
+  return {
+    sourceChannel: input.sourceChannel,
+    trustClass: "guardian",
+    guardianChatId: guardian.externalChatId ?? input.conversationExternalId,
+    guardianExternalUserId:
+      canonicalizeInboundIdentity(input.sourceChannel, guardian.address) ??
+      undefined,
+    guardianPrincipalId: guardian.principalId ?? undefined,
+    // Mirror toTrustContext: with no username the requester identifier is the
+    // canonical sender id, which for a vellum principal is actorPrincipalId.
+    requesterIdentifier: input.actorPrincipalId,
+    requesterExternalUserId: input.actorPrincipalId,
+    requesterChatId: input.conversationExternalId,
+  };
+}

--- a/assistant/src/runtime/local-principal-trust.ts
+++ b/assistant/src/runtime/local-principal-trust.ts
@@ -1,14 +1,6 @@
 /**
- * Local-principal trust mapper.
- *
- * Derives a local principal's runtime {@link TrustContext} from the gateway
- * guardian binding instead of the assistant DB. A `vellum` principal is the
- * guardian (owner) or nobody, so "trust of this principal on the vellum
- * channel" reduces to "does `actorPrincipalId` match the gateway guardian's
- * principalId?" — which {@link getGuardianDelivery} answers.
- *
- * The mapper is pure: it does not heal binding drift or read local ACL. The
- * routes own the heal/re-resolve loop and call this mapper.
+ * Derives a local principal's {@link TrustContext} from the gateway guardian
+ * binding. Fails closed to unknown on a missing or null read.
  */
 
 import type { ChannelId } from "../channels/types.js";
@@ -22,11 +14,7 @@ export interface ResolveLocalPrincipalTrustInput {
   conversationExternalId: string;
 }
 
-/**
- * Resolve the trust context for a local principal from the gateway guardian
- * binding. Guardian match → guardian ctx; otherwise → unknown. A null gateway
- * read fails closed to unknown rather than granting guardian on a miss.
- */
+/** Guardian match → guardian ctx; miss or null read → unknown (fail closed). */
 export async function resolveLocalPrincipalTrustContext(
   input: ResolveLocalPrincipalTrustInput,
 ): Promise<TrustContext> {

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -25,6 +25,7 @@ interface StubConversation {
   handleSurfaceActionThrows?: Error;
   handleSurfaceUndoCalled?: boolean;
   handleSurfaceUndoThrows?: Error;
+  trustContext?: { trustClass: string; sourceChannel: string };
   surfaceActionCalls: Array<{
     surfaceId: string;
     actionId: string;
@@ -41,6 +42,50 @@ const findConvCalls: string[] = [];
 const findBySurfaceCalls: string[] = [];
 const getOrCreateCalls: string[] = [];
 const rawGetCalls: Array<{ sql: string; params: unknown[] }> = [];
+
+// Gateway guardian-delivery list (shared by the route's dev-bypass lookup and
+// the local-principal-trust mapper): null = unreachable, [] = no guardian.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+// Local-mirror guardian record: dev-bypass reads .contact.principalId; the
+// post-heal local resolver reads .contact and .channel.
+let mockGuardianRecord: {
+  contact: Record<string, unknown>;
+  channel?: Record<string, unknown>;
+} | null = null;
+let httpAuthDisabled = false;
+// Tracks heal invocations; onHeal lets a test repair the local mirror to
+// simulate the post-heal re-resolve matching.
+const healCalls: string[] = [];
+let healResult = false;
+let onHeal: (() => void) | null = null;
+
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: (_input?: { channelTypes?: string[] }) =>
+    Promise.resolve(mockGuardianList),
+  peekCachedGuardianDelivery: () => mockGuardianList ?? undefined,
+  guardianForChannel: (
+    list: Array<Record<string, unknown>>,
+    channelType: string,
+  ) =>
+    list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: (_channelType: string) => mockGuardianRecord,
+  findContactByAddress: () => null,
+}));
+
+mock.module("../../../config/env.js", () => ({
+  isHttpAuthDisabled: () => httpAuthDisabled,
+}));
+
+mock.module("../../guardian-vellum-migration.js", () => ({
+  healGuardianBindingDrift: async (principalId: string) => {
+    healCalls.push(principalId);
+    onHeal?.();
+    return healResult;
+  },
+}));
 
 mock.module("../../../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => {
@@ -115,6 +160,9 @@ function makeStub(id: string): StubConversation {
       stub.handleSurfaceUndoCalled = true;
       if (stub.handleSurfaceUndoThrows) throw stub.handleSurfaceUndoThrows;
     },
+    setTrustContext: (ctx: { trustClass: string; sourceChannel: string }) => {
+      stub.trustContext = ctx;
+    },
   });
   return stub;
 }
@@ -132,6 +180,12 @@ beforeEach(() => {
   findBySurfaceCalls.length = 0;
   getOrCreateCalls.length = 0;
   rawGetCalls.length = 0;
+  mockGuardianList = [];
+  mockGuardianRecord = null;
+  httpAuthDisabled = false;
+  healCalls.length = 0;
+  healResult = false;
+  onHeal = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -332,6 +386,250 @@ describe("triggerSurfaceAction handler", () => {
     // BadRequestError is a RouteError — verify the error message bubbled.
     expect(caught).toBeDefined();
     expect((caught as Error).message).toContain("surface already completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust context resolution
+// ---------------------------------------------------------------------------
+
+const GUARDIAN_PRINCIPAL = "principal-guardian";
+// Daemon-minted vellum-principal-* ids: the DB-reset drift signature. The
+// gateway rebinds to a fresh id while the client still holds a JWT for the old.
+const VELLUM_PRINCIPAL_OLD = "vellum-principal-old";
+const VELLUM_PRINCIPAL_NEW = "vellum-principal-new";
+
+function guardianDelivery(principalId: string): Record<string, unknown> {
+  return {
+    channelType: "vellum",
+    contactId: "contact-1",
+    principalId,
+    address: "guardian-address",
+    externalChatId: "guardian-chat",
+    status: "active",
+  };
+}
+
+// Local-mirror guardian record as returned by findGuardianForChannel and read
+// by resolveActorTrust. The channel address equals the principal so the local
+// resolver classifies it as guardian on the vellum channel.
+function localGuardianRecord(principalId: string): {
+  contact: Record<string, unknown>;
+  channel: Record<string, unknown>;
+} {
+  return {
+    contact: { principalId, displayName: "Guardian" },
+    channel: {
+      type: "vellum",
+      address: principalId,
+      externalChatId: "guardian-chat",
+      status: "active",
+    },
+  };
+}
+
+describe("triggerSurfaceAction trust context", () => {
+  test("guardian principal → guardian trust context from the gateway binding", async () => {
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-guardian");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-g", actionId: "act-g" },
+      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(live.trustContext?.sourceChannel).toBe("vellum");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("unknown principal → unknown trust context", async () => {
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-unknown");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-u", actionId: "act-u" },
+      headers: { "x-vellum-actor-principal-id": "principal-other" },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    // Neither principal is a vellum-principal-*, so the reset-drift gate is
+    // closed and no heal runs.
+    expect(healCalls).toEqual([]);
+  });
+
+  test("reset drift: heal repairs the local mirror → guardian from local re-resolve", async () => {
+    // DB-reset signature: the gateway active guardian is a fresh vellum-principal
+    // while the client holds a JWT for the old one. The gateway binding stays
+    // mismatched, so the mapper returns unknown both before and after heal. Heal
+    // repairs the local mirror; the post-heal re-resolve reads it and matches.
+    mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
+    healResult = true;
+    onHeal = () => {
+      mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    };
+    const live = makeStub("conv-drift");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-d", actionId: "act-d" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
+    // Gateway binding never matched; guardian comes from the local mirror.
+    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
+    expect(live.trustContext?.trustClass).toBe("guardian");
+  });
+
+  test("reset drift second request: heal no-ops (false) but local mirror already matches → guardian", async () => {
+    // Later requests in the drift window reuse the same stale JWT: the gateway
+    // binding still mismatches, and heal returns false because the local mirror
+    // was already repaired on the first request. The local re-resolve must run
+    // regardless of heal's return and recover guardian trust.
+    mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    healResult = false;
+    const live = makeStub("conv-drift-2");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-d2", actionId: "act-d2" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
+    // Gateway binding never matched; guardian comes from the local mirror even
+    // though no heal write occurred.
+    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
+    expect(live.trustContext?.trustClass).toBe("guardian");
+  });
+
+  test("fail-closed: revoked gateway guardian (empty list) blocks the local fallback → unknown", async () => {
+    // The gateway authoritatively revoked the guardian (no active binding) while
+    // the local mirror WOULD still grant guardian. With no active gateway
+    // principal there is no reset signature, so trust stays unknown (fail closed).
+    mockGuardianList = [];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    const live = makeStub("conv-revoked");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-rv", actionId: "act-rv" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("fail-closed: non-active gateway guardian blocks the local fallback → unknown", async () => {
+    // The gateway binding exists but is not active (e.g. pending revocation):
+    // guardianForChannel filters it out, so there is no active reset principal
+    // and the fallback stays closed.
+    mockGuardianList = [
+      { ...guardianDelivery(VELLUM_PRINCIPAL_NEW), status: "revoked" },
+    ];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    const live = makeStub("conv-inactive");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-ia", actionId: "act-ia" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("fail-closed: rebind to a real external identity blocks the local fallback → unknown", async () => {
+    // The gateway active guardian principal is a real external id (not a
+    // vellum-principal-*) that differs from the actor — a genuine rebind, not a
+    // DB reset. The fallback must stay closed even though the local mirror would
+    // grant guardian.
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    const live = makeStub("conv-rebind");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-rb", actionId: "act-rb" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("fail-closed: unreachable gateway (null) blocks the local drift fallback → unknown", async () => {
+    // Gateway unreadable: the mapper fails closed to unknown, and the local
+    // mirror WOULD classify this principal as guardian. The drift fallback must
+    // stay gated off a null read, so trust must remain unknown (fail closed).
+    mockGuardianList = null;
+    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
+    const live = makeStub("conv-fail-closed");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-fc", actionId: "act-fc" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    // No fallback ran: heal is skipped on a null read.
+    expect(healCalls).toEqual([]);
+  });
+
+  test("dev-bypass resolves the real guardian principal from the gateway", async () => {
+    httpAuthDisabled = true;
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-dev");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-dev", actionId: "act-dev" },
+      headers: { "x-vellum-actor-principal-id": "dev-bypass" },
+    });
+
+    // The synthetic dev-bypass principal is translated to the real guardian,
+    // yielding a guardian trust context without any heal.
+    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(healCalls).toEqual([]);
+  });
+
+  test("dev-bypass with an empty gateway and stale local mirror → unknown (fail closed)", async () => {
+    httpAuthDisabled = true;
+    mockGuardianList = [];
+    // Local store supplies the guardian principal for dev-bypass, but the gateway
+    // has no active binding. With no active gateway principal there is no reset
+    // signature, so the fallback stays closed and trust is unknown.
+    mockGuardianRecord = {
+      contact: { principalId: GUARDIAN_PRINCIPAL },
+      channel: { type: "vellum", address: "stale-address", status: "active" },
+    };
+    const live = makeStub("conv-dev-fallback");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-devf", actionId: "act-devf" },
+      headers: { "x-vellum-actor-principal-id": "dev-bypass" },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(healCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -66,8 +66,7 @@ mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: (
     list: Array<Record<string, unknown>>,
     channelType: string,
-  ) =>
-    list.find((g) => g.channelType === channelType && g.status === "active"),
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 mock.module("../../../contacts/contact-store.js", () => ({
@@ -84,6 +83,33 @@ mock.module("../../guardian-vellum-migration.js", () => ({
     healCalls.push(principalId);
     onHeal?.();
     return healResult;
+  },
+  // Mirror the real helper against this file's mocked gateway/local-mirror
+  // state so the route exercises the shared narrow-drift gate end-to-end.
+  reResolveTrustOnResetDrift: async (
+    incomingPrincipalId: string,
+    sourceChannel: string,
+  ) => {
+    const gatewayPrincipal = mockGuardianList
+      ? mockGuardianList.find(
+          (g) => g.channelType === "vellum" && g.status === "active",
+        )?.principalId
+      : undefined;
+    const isResetDrift =
+      incomingPrincipalId.startsWith("vellum-principal-") &&
+      typeof gatewayPrincipal === "string" &&
+      gatewayPrincipal.startsWith("vellum-principal-") &&
+      gatewayPrincipal !== incomingPrincipalId;
+    if (!isResetDrift) return null;
+    healCalls.push(incomingPrincipalId);
+    onHeal?.();
+    return {
+      trustClass:
+        mockGuardianRecord?.contact.principalId === incomingPrincipalId
+          ? "guardian"
+          : "unknown",
+      sourceChannel,
+    };
   },
 }));
 

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -46,18 +46,14 @@ const rawGetCalls: Array<{ sql: string; params: unknown[] }> = [];
 // Gateway guardian-delivery list (shared by the route's dev-bypass lookup and
 // the local-principal-trust mapper): null = unreachable, [] = no guardian.
 let mockGuardianList: Array<Record<string, unknown>> | null = [];
-// Local-mirror guardian record: dev-bypass reads .contact.principalId; the
-// post-heal local resolver reads .contact and .channel.
-let mockGuardianRecord: {
-  contact: Record<string, unknown>;
-  channel?: Record<string, unknown>;
-} | null = null;
 let httpAuthDisabled = false;
-// Tracks heal invocations; onHeal lets a test repair the local mirror to
-// simulate the post-heal re-resolve matching.
-const healCalls: string[] = [];
-let healResult = false;
-let onHeal: (() => void) | null = null;
+
+// Stub for the shared reset-drift helper. The route under test only consumes
+// its result (a guardian TrustContext or null); the gate itself is covered in
+// runtime/__tests__/guardian-vellum-migration.test.ts. Tests set
+// `mockReResolve` per case and read `reResolveCalls` to assert routing.
+const reResolveCalls: string[] = [];
+let mockReResolve: { trustClass: string; sourceChannel: string } | null = null;
 
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: (_input?: { channelTypes?: string[] }) =>
@@ -70,7 +66,7 @@ mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
 }));
 
 mock.module("../../../contacts/contact-store.js", () => ({
-  findGuardianForChannel: (_channelType: string) => mockGuardianRecord,
+  findGuardianForChannel: (_channelType: string) => null,
   findContactByAddress: () => null,
 }));
 
@@ -79,37 +75,12 @@ mock.module("../../../config/env.js", () => ({
 }));
 
 mock.module("../../guardian-vellum-migration.js", () => ({
-  healGuardianBindingDrift: async (principalId: string) => {
-    healCalls.push(principalId);
-    onHeal?.();
-    return healResult;
-  },
-  // Mirror the real helper against this file's mocked gateway/local-mirror
-  // state so the route exercises the shared narrow-drift gate end-to-end.
   reResolveTrustOnResetDrift: async (
     incomingPrincipalId: string,
-    sourceChannel: string,
+    _sourceChannel: string,
   ) => {
-    const gatewayPrincipal = mockGuardianList
-      ? mockGuardianList.find(
-          (g) => g.channelType === "vellum" && g.status === "active",
-        )?.principalId
-      : undefined;
-    const isResetDrift =
-      incomingPrincipalId.startsWith("vellum-principal-") &&
-      typeof gatewayPrincipal === "string" &&
-      gatewayPrincipal.startsWith("vellum-principal-") &&
-      gatewayPrincipal !== incomingPrincipalId;
-    if (!isResetDrift) return null;
-    healCalls.push(incomingPrincipalId);
-    onHeal?.();
-    return {
-      trustClass:
-        mockGuardianRecord?.contact.principalId === incomingPrincipalId
-          ? "guardian"
-          : "unknown",
-      sourceChannel,
-    };
+    reResolveCalls.push(incomingPrincipalId);
+    return mockReResolve;
   },
 }));
 
@@ -207,11 +178,9 @@ beforeEach(() => {
   getOrCreateCalls.length = 0;
   rawGetCalls.length = 0;
   mockGuardianList = [];
-  mockGuardianRecord = null;
   httpAuthDisabled = false;
-  healCalls.length = 0;
-  healResult = false;
-  onHeal = null;
+  reResolveCalls.length = 0;
+  mockReResolve = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -436,26 +405,13 @@ function guardianDelivery(principalId: string): Record<string, unknown> {
   };
 }
 
-// Local-mirror guardian record as returned by findGuardianForChannel and read
-// by resolveActorTrust. The channel address equals the principal so the local
-// resolver classifies it as guardian on the vellum channel.
-function localGuardianRecord(principalId: string): {
-  contact: Record<string, unknown>;
-  channel: Record<string, unknown>;
-} {
-  return {
-    contact: { principalId, displayName: "Guardian" },
-    channel: {
-      type: "vellum",
-      address: principalId,
-      externalChatId: "guardian-chat",
-      status: "active",
-    },
-  };
+// A guardian TrustContext the stubbed helper hands back on a recovered drift.
+function guardianCtx(): { trustClass: string; sourceChannel: string } {
+  return { trustClass: "guardian", sourceChannel: "vellum" };
 }
 
 describe("triggerSurfaceAction trust context", () => {
-  test("guardian principal → guardian trust context from the gateway binding", async () => {
+  test("guardian principal → guardian from the gateway binding, helper not called", async () => {
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
     const live = makeStub("conv-guardian");
     memoryBySurface = live;
@@ -468,36 +424,29 @@ describe("triggerSurfaceAction trust context", () => {
 
     expect(live.trustContext?.trustClass).toBe("guardian");
     expect(live.trustContext?.sourceChannel).toBe("vellum");
-    expect(healCalls).toEqual([]);
+    // First-pass resolve already granted guardian, so the drift helper is skipped.
+    expect(reResolveCalls).toEqual([]);
   });
 
-  test("unknown principal → unknown trust context", async () => {
+  test("unknown principal: helper consulted, null result stays unknown (fail closed)", async () => {
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    mockReResolve = null;
     const live = makeStub("conv-unknown");
     memoryBySurface = live;
 
     const handler = findHandler("triggerSurfaceAction");
     await handler({
       body: { surfaceId: "surf-u", actionId: "act-u" },
-      headers: { "x-vellum-actor-principal-id": "principal-other" },
+      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
     });
 
+    expect(reResolveCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
     expect(live.trustContext?.trustClass).toBe("unknown");
-    // Neither principal is a vellum-principal-*, so the reset-drift gate is
-    // closed and no heal runs.
-    expect(healCalls).toEqual([]);
   });
 
-  test("reset drift: heal repairs the local mirror → guardian from local re-resolve", async () => {
-    // DB-reset signature: the gateway active guardian is a fresh vellum-principal
-    // while the client holds a JWT for the old one. The gateway binding stays
-    // mismatched, so the mapper returns unknown both before and after heal. Heal
-    // repairs the local mirror; the post-heal re-resolve reads it and matches.
+  test("reset drift: helper returns guardian → route adopts it", async () => {
     mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
-    healResult = true;
-    onHeal = () => {
-      mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    };
+    mockReResolve = guardianCtx();
     const live = makeStub("conv-drift");
     memoryBySurface = live;
 
@@ -507,117 +456,11 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
     });
 
-    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
-    // Gateway binding never matched; guardian comes from the local mirror.
-    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
+    expect(reResolveCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
     expect(live.trustContext?.trustClass).toBe("guardian");
   });
 
-  test("reset drift second request: heal no-ops (false) but local mirror already matches → guardian", async () => {
-    // Later requests in the drift window reuse the same stale JWT: the gateway
-    // binding still mismatches, and heal returns false because the local mirror
-    // was already repaired on the first request. The local re-resolve must run
-    // regardless of heal's return and recover guardian trust.
-    mockGuardianList = [guardianDelivery(VELLUM_PRINCIPAL_NEW)];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    healResult = false;
-    const live = makeStub("conv-drift-2");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-d2", actionId: "act-d2" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(healCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
-    // Gateway binding never matched; guardian comes from the local mirror even
-    // though no heal write occurred.
-    expect(mockGuardianList).toEqual([guardianDelivery(VELLUM_PRINCIPAL_NEW)]);
-    expect(live.trustContext?.trustClass).toBe("guardian");
-  });
-
-  test("fail-closed: revoked gateway guardian (empty list) blocks the local fallback → unknown", async () => {
-    // The gateway authoritatively revoked the guardian (no active binding) while
-    // the local mirror WOULD still grant guardian. With no active gateway
-    // principal there is no reset signature, so trust stays unknown (fail closed).
-    mockGuardianList = [];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-revoked");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-rv", actionId: "act-rv" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
-  });
-
-  test("fail-closed: non-active gateway guardian blocks the local fallback → unknown", async () => {
-    // The gateway binding exists but is not active (e.g. pending revocation):
-    // guardianForChannel filters it out, so there is no active reset principal
-    // and the fallback stays closed.
-    mockGuardianList = [
-      { ...guardianDelivery(VELLUM_PRINCIPAL_NEW), status: "revoked" },
-    ];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-inactive");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-ia", actionId: "act-ia" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
-  });
-
-  test("fail-closed: rebind to a real external identity blocks the local fallback → unknown", async () => {
-    // The gateway active guardian principal is a real external id (not a
-    // vellum-principal-*) that differs from the actor — a genuine rebind, not a
-    // DB reset. The fallback must stay closed even though the local mirror would
-    // grant guardian.
-    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-rebind");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-rb", actionId: "act-rb" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
-  });
-
-  test("fail-closed: unreachable gateway (null) blocks the local drift fallback → unknown", async () => {
-    // Gateway unreadable: the mapper fails closed to unknown, and the local
-    // mirror WOULD classify this principal as guardian. The drift fallback must
-    // stay gated off a null read, so trust must remain unknown (fail closed).
-    mockGuardianList = null;
-    mockGuardianRecord = localGuardianRecord(VELLUM_PRINCIPAL_OLD);
-    const live = makeStub("conv-fail-closed");
-    memoryBySurface = live;
-
-    const handler = findHandler("triggerSurfaceAction");
-    await handler({
-      body: { surfaceId: "surf-fc", actionId: "act-fc" },
-      headers: { "x-vellum-actor-principal-id": VELLUM_PRINCIPAL_OLD },
-    });
-
-    expect(live.trustContext?.trustClass).toBe("unknown");
-    // No fallback ran: heal is skipped on a null read.
-    expect(healCalls).toEqual([]);
-  });
-
-  test("dev-bypass resolves the real guardian principal from the gateway", async () => {
+  test("dev-bypass resolves the real guardian principal from the gateway, helper not called", async () => {
     httpAuthDisabled = true;
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
     const live = makeStub("conv-dev");
@@ -630,21 +473,18 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     // The synthetic dev-bypass principal is translated to the real guardian,
-    // yielding a guardian trust context without any heal.
+    // yielding a guardian trust context without consulting the drift helper.
     expect(live.trustContext?.trustClass).toBe("guardian");
-    expect(healCalls).toEqual([]);
+    expect(reResolveCalls).toEqual([]);
   });
 
-  test("dev-bypass with an empty gateway and stale local mirror → unknown (fail closed)", async () => {
+  test("dev-bypass with an empty gateway: helper null result → unknown (fail closed)", async () => {
     httpAuthDisabled = true;
+    // The gateway has no active binding, so dev-bypass cannot translate to a
+    // real guardian; the first-pass resolve is unknown and the helper, returning
+    // null, leaves trust unknown.
     mockGuardianList = [];
-    // Local store supplies the guardian principal for dev-bypass, but the gateway
-    // has no active binding. With no active gateway principal there is no reset
-    // signature, so the fallback stays closed and trust is unknown.
-    mockGuardianRecord = {
-      contact: { principalId: GUARDIAN_PRINCIPAL },
-      channel: { type: "vellum", address: "stale-address", status: "active" },
-    };
+    mockReResolve = null;
     const live = makeStub("conv-dev-fallback");
     memoryBySurface = live;
 
@@ -655,7 +495,6 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     expect(live.trustContext?.trustClass).toBe("unknown");
-    expect(healCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -26,10 +26,6 @@ import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-fl
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../contacts/guardian-delivery-reader.js";
-import {
   mergeConsecutiveAssistantMessages,
   mergeToolResultsIntoAssistantMessages,
 } from "../../conversations/message-consolidation.js";
@@ -72,6 +68,7 @@ import type {
   HostProxyTransportMetadata,
   NonHostProxyTransportMetadata,
 } from "../../daemon/message-types/conversations.js";
+import type { TrustContext } from "../../daemon/trust-context.js";
 import { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import {
   writeOnboardingSidecar,
@@ -125,31 +122,27 @@ import {
 } from "../../util/platform.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { getPersistedSeq } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   type GuardianPendingScope,
   routeGuardianReply,
 } from "../guardian-reply-router.js";
-import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
+import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
 import type {
   ApprovalConversationGenerator,
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
   SendMessageDeps,
 } from "../http-types.js";
-import { resolveLocalTrustContext } from "../local-actor-identity.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   publishConversationListAndMetadataChanged,
   publishConversationMessagesChanged,
 } from "../sync/resource-sync-events.js";
-import {
-  resolveTrustContext,
-  withSourceChannel,
-} from "../trust-context-resolver.js";
+import { withSourceChannel } from "../trust-context-resolver.js";
 import {
   BadRequestError,
   InternalError,
@@ -1453,23 +1446,28 @@ export async function handleSendMessage(
   // gateway guardian binding: a vellum principal is the guardian or nobody.
   if (actorPrincipalId) {
     // Dev bypass (HTTP auth disabled): the synthetic "dev-bypass" principal
-    // won't match any guardian binding. Resolve the real guardian principal
-    // from the gateway binding and map that through instead.
+    // won't match any guardian binding. Resolve the real guardian principal and
+    // map that through, failing closed to unknown on an empty gateway.
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-      const guardianPrincipalId = guardians?.[0]?.principalId;
-      conversation.setTrustContext(
-        guardianPrincipalId
-          ? withSourceChannel(
-              sourceChannel,
-              await resolveLocalPrincipalTrustContext({
-                actorPrincipalId: guardianPrincipalId,
-                sourceChannel: "vellum",
-                conversationExternalId: "local",
-              }),
-            )
-          : await resolveLocalTrustContext(sourceChannel),
-      );
+      const guardianPrincipalId = await findLocalGuardianPrincipalId();
+      let trustCtx: TrustContext = guardianPrincipalId
+        ? withSourceChannel(
+            sourceChannel,
+            await resolveLocalPrincipalTrustContext({
+              actorPrincipalId: guardianPrincipalId,
+              sourceChannel: "vellum",
+              conversationExternalId: "local",
+            }),
+          )
+        : { trustClass: "unknown", sourceChannel };
+      if (guardianPrincipalId && trustCtx.trustClass === "unknown") {
+        const healed = await reResolveTrustOnResetDrift(
+          guardianPrincipalId,
+          sourceChannel,
+        );
+        if (healed) trustCtx = healed;
+      }
+      conversation.setTrustContext(trustCtx);
     } else {
       let trustCtx = withSourceChannel(
         sourceChannel,
@@ -1480,49 +1478,26 @@ export async function handleSendMessage(
         }),
       );
       if (trustCtx.trustClass === "unknown") {
-        const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-        const gatewayPrincipal = guardians
-          ? guardianForChannel(guardians, "vellum")?.principalId
-          : undefined;
-        // Narrow drift only: a DB reset rebound the gateway to a fresh
-        // vellum-principal while the client holds a valid JWT for the old one.
-        // Both are daemon-minted vellum-principal-* ids, so a genuine
-        // revocation or rebind to a real identity fails closed instead of
-        // re-granting from a stale mirror.
-        const isResetDrift =
-          actorPrincipalId.startsWith("vellum-principal-") &&
-          !!gatewayPrincipal?.startsWith("vellum-principal-") &&
-          gatewayPrincipal !== actorPrincipalId;
-        if (isResetDrift) {
-          await healGuardianBindingDrift(actorPrincipalId);
-          trustCtx = withSourceChannel(
-            sourceChannel,
-            resolveTrustContext({
-              assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-              sourceChannel: "vellum",
-              conversationExternalId: "local",
-              actorExternalId: actorPrincipalId,
-            }),
+        const healed = await reResolveTrustOnResetDrift(
+          actorPrincipalId,
+          sourceChannel,
+        );
+        if (healed && healed.trustClass !== "unknown") {
+          trustCtx = healed;
+          log.info(
+            { actorPrincipalId, trustClass: trustCtx.trustClass },
+            "Trust re-resolved from local mirror after gateway returned unknown",
           );
-          if (trustCtx.trustClass === "unknown") {
-            log.warn(
-              {
-                actorPrincipalId,
-                sourceChannel,
-                trustClass: trustCtx.trustClass,
-                principalType,
-              },
-              "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
-            );
-          } else {
-            log.info(
-              {
-                actorPrincipalId,
-                trustClass: trustCtx.trustClass,
-              },
-              "Trust re-resolved from local mirror after gateway returned unknown",
-            );
-          }
+        } else {
+          log.warn(
+            {
+              actorPrincipalId,
+              sourceChannel,
+              trustClass: "unknown",
+              principalType,
+            },
+            "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+          );
         }
       }
       conversation.setTrustContext(trustCtx);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -26,6 +26,10 @@ import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-fl
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../contacts/guardian-delivery-reader.js";
+import {
   mergeConsecutiveAssistantMessages,
   mergeToolResultsIntoAssistantMessages,
 } from "../../conversations/message-consolidation.js";
@@ -136,6 +140,7 @@ import type {
   SendMessageDeps,
 } from "../http-types.js";
 import { resolveLocalTrustContext } from "../local-actor-identity.js";
+import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   publishConversationListAndMetadataChanged,
@@ -1444,58 +1449,83 @@ export async function handleSendMessage(
     conversation.setOnboardingContext(body.onboarding!);
   }
 
-  // Resolve guardian context from the AuthContext's actorPrincipalId.
-  // The JWT-verified principal is used as the sender identity through
-  // the same trust resolution pipeline that channel ingress uses.
+  // Resolve guardian context from the AuthContext's actorPrincipalId via the
+  // gateway guardian binding: a vellum principal is the guardian or nobody.
   if (actorPrincipalId) {
     // Dev bypass (HTTP auth disabled): the synthetic "dev-bypass" principal
-    // won't match any guardian binding. Resolve from the local guardian
-    // binding instead, which produces the correct guardian trust context.
+    // won't match any guardian binding. Resolve the real guardian principal
+    // from the gateway binding and map that through instead.
     if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
+      const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+      const guardianPrincipalId = guardians?.[0]?.principalId;
       conversation.setTrustContext(
-        await resolveLocalTrustContext(sourceChannel),
+        guardianPrincipalId
+          ? withSourceChannel(
+              sourceChannel,
+              await resolveLocalPrincipalTrustContext({
+                actorPrincipalId: guardianPrincipalId,
+                sourceChannel: "vellum",
+                conversationExternalId: "local",
+              }),
+            )
+          : await resolveLocalTrustContext(sourceChannel),
       );
     } else {
-      const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-      let trustCtx = resolveTrustContext({
-        assistantId,
-        sourceChannel: "vellum",
-        conversationExternalId: "local",
-        actorExternalId: actorPrincipalId,
-      });
+      let trustCtx = withSourceChannel(
+        sourceChannel,
+        await resolveLocalPrincipalTrustContext({
+          actorPrincipalId,
+          sourceChannel: "vellum",
+          conversationExternalId: "local",
+        }),
+      );
       if (trustCtx.trustClass === "unknown") {
-        // Attempt to heal guardian binding drift: after a DB reset the
-        // guardian binding gets a new vellum-principal-* UUID while the
-        // client still holds a valid JWT with the old one. The signing
-        // key survives the reset, so the JWT is authentic — just stale.
-        const healed = await healGuardianBindingDrift(actorPrincipalId);
-        if (healed) {
-          trustCtx = resolveTrustContext({
-            assistantId,
-            sourceChannel: "vellum",
-            conversationExternalId: "local",
-            actorExternalId: actorPrincipalId,
-          });
-          log.info(
-            {
-              actorPrincipalId: actorPrincipalId,
-              trustClass: trustCtx.trustClass,
-            },
-            "Trust re-resolved after guardian binding drift heal",
+        const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+        const gatewayPrincipal = guardians
+          ? guardianForChannel(guardians, "vellum")?.principalId
+          : undefined;
+        // Narrow drift only: a DB reset rebound the gateway to a fresh
+        // vellum-principal while the client holds a valid JWT for the old one.
+        // Both are daemon-minted vellum-principal-* ids, so a genuine
+        // revocation or rebind to a real identity fails closed instead of
+        // re-granting from a stale mirror.
+        const isResetDrift =
+          actorPrincipalId.startsWith("vellum-principal-") &&
+          !!gatewayPrincipal?.startsWith("vellum-principal-") &&
+          gatewayPrincipal !== actorPrincipalId;
+        if (isResetDrift) {
+          await healGuardianBindingDrift(actorPrincipalId);
+          trustCtx = withSourceChannel(
+            sourceChannel,
+            resolveTrustContext({
+              assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+              sourceChannel: "vellum",
+              conversationExternalId: "local",
+              actorExternalId: actorPrincipalId,
+            }),
           );
-        } else {
-          log.warn(
-            {
-              actorPrincipalId: actorPrincipalId,
-              sourceChannel,
-              trustClass: trustCtx.trustClass,
-              principalType: principalType,
-            },
-            "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
-          );
+          if (trustCtx.trustClass === "unknown") {
+            log.warn(
+              {
+                actorPrincipalId,
+                sourceChannel,
+                trustClass: trustCtx.trustClass,
+                principalType,
+              },
+              "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+            );
+          } else {
+            log.info(
+              {
+                actorPrincipalId,
+                trustClass: trustCtx.trustClass,
+              },
+              "Trust re-resolved from local mirror after gateway returned unknown",
+            );
+          }
         }
       }
-      conversation.setTrustContext(withSourceChannel(sourceChannel, trustCtx));
+      conversation.setTrustContext(trustCtx);
     }
   } else {
     // Service principals (svc_gateway) or tokens without an actor ID

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -71,10 +71,12 @@ async function applyTrustContext(
     const healed = await reResolveTrustOnResetDrift(principalId, sourceChannel);
     if (healed) {
       trustCtx = healed;
-      log.info(
-        { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
-        "Trust re-resolved from local mirror after gateway reset drift (surface action)",
-      );
+      if (healed.trustClass !== "unknown") {
+        log.info(
+          { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
+          "Trust re-resolved from local mirror after gateway reset drift (surface action)",
+        );
+      }
     }
   }
   conversation.setTrustContext(trustCtx);

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -9,16 +9,20 @@
  */
 import { z } from "zod";
 
-import type { ChannelId } from "../../channels/types.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import {
+  getGuardianDelivery,
+  guardianForChannel,
+} from "../../contacts/guardian-delivery-reader.js";
+import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
-import type { TrustClass } from "../actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
-import { resolveLocalTrustContext } from "../local-actor-identity.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
+import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import {
   resolveTrustContext,
   withSourceChannel,
@@ -40,17 +44,13 @@ const log = getLogger("surface-action-routes");
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve trust context from the actor principal ID and set it on the
- * conversation, following the same pattern as POST /v1/messages. This ensures
- * surface actions inherit the correct trust class (guardian vs trusted_contact)
- * rather than defaulting to unknown.
+ * Resolve trust context for the actor principal from the gateway guardian
+ * binding and set it on the conversation. A vellum principal is the guardian or
+ * nobody, so the mapper yields guardian or unknown.
  */
 async function applyTrustContext(
   conversation: {
-    setTrustContext?(ctx: {
-      trustClass: TrustClass;
-      sourceChannel: ChannelId;
-    }): void;
+    setTrustContext?(ctx: TrustContext): void;
   },
   actorPrincipalId: string | undefined,
 ): Promise<void> {
@@ -58,42 +58,55 @@ async function applyTrustContext(
 
   const sourceChannel = "vellum";
 
-  if (actorPrincipalId) {
-    if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-      conversation.setTrustContext(
-        await resolveLocalTrustContext(sourceChannel),
-      );
-    } else {
-      const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-      let trustCtx = resolveTrustContext({
-        assistantId,
-        sourceChannel,
-        conversationExternalId: "local",
-        actorExternalId: actorPrincipalId,
-      });
-      if (trustCtx.trustClass === "unknown") {
-        const healed = await healGuardianBindingDrift(actorPrincipalId);
-        if (healed) {
-          trustCtx = resolveTrustContext({
-            assistantId,
-            sourceChannel,
-            conversationExternalId: "local",
-            actorExternalId: actorPrincipalId,
-          });
-          log.info(
-            {
-              actorPrincipalId,
-              trustClass: trustCtx.trustClass,
-            },
-            "Trust re-resolved after guardian binding drift heal (surface action)",
-          );
-        }
-      }
-      conversation.setTrustContext(withSourceChannel(sourceChannel, trustCtx));
-    }
-  } else {
+  if (!actorPrincipalId) {
     conversation.setTrustContext({ trustClass: "guardian", sourceChannel });
+    return;
   }
+
+  // Dev-bypass injects a synthetic principal that won't match the real
+  // guardian binding, so resolve the actual guardian principalId (gateway
+  // first, local store fallback) before mapping trust.
+  let principalId = actorPrincipalId;
+  if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
+    principalId = (await findLocalGuardianPrincipalId()) ?? actorPrincipalId;
+  }
+
+  let trustCtx = await resolveLocalPrincipalTrustContext({
+    actorPrincipalId: principalId,
+    sourceChannel,
+    conversationExternalId: "local",
+  });
+  if (trustCtx.trustClass === "unknown") {
+    const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
+    const gatewayPrincipal = guardians
+      ? guardianForChannel(guardians, sourceChannel)?.principalId
+      : undefined;
+    // Narrow drift only: a DB reset rebound the gateway to a fresh
+    // vellum-principal while the client holds a valid JWT for the old one. Both
+    // are daemon-minted vellum-principal-* ids, so a genuine revocation or rebind
+    // to a real identity fails closed instead of re-granting from a stale mirror.
+    const isResetDrift =
+      principalId.startsWith("vellum-principal-") &&
+      !!gatewayPrincipal?.startsWith("vellum-principal-") &&
+      gatewayPrincipal !== principalId;
+    if (isResetDrift) {
+      await healGuardianBindingDrift(principalId);
+      trustCtx = withSourceChannel(
+        sourceChannel,
+        resolveTrustContext({
+          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+          sourceChannel,
+          conversationExternalId: "local",
+          actorExternalId: principalId,
+        }),
+      );
+      log.info(
+        { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
+        "Trust re-resolved from local mirror after gateway reset drift (surface action)",
+      );
+    }
+  }
+  conversation.setTrustContext(trustCtx);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -11,22 +11,13 @@ import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
-import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
-import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
+import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
 import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
-import {
-  resolveTrustContext,
-  withSourceChannel,
-} from "../trust-context-resolver.js";
 import { parseCallbackData } from "./channel-route-shared.js";
 import {
   BadRequestError,
@@ -77,29 +68,9 @@ async function applyTrustContext(
     conversationExternalId: "local",
   });
   if (trustCtx.trustClass === "unknown") {
-    const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-    const gatewayPrincipal = guardians
-      ? guardianForChannel(guardians, sourceChannel)?.principalId
-      : undefined;
-    // Narrow drift only: a DB reset rebound the gateway to a fresh
-    // vellum-principal while the client holds a valid JWT for the old one. Both
-    // are daemon-minted vellum-principal-* ids, so a genuine revocation or rebind
-    // to a real identity fails closed instead of re-granting from a stale mirror.
-    const isResetDrift =
-      principalId.startsWith("vellum-principal-") &&
-      !!gatewayPrincipal?.startsWith("vellum-principal-") &&
-      gatewayPrincipal !== principalId;
-    if (isResetDrift) {
-      await healGuardianBindingDrift(principalId);
-      trustCtx = withSourceChannel(
-        sourceChannel,
-        resolveTrustContext({
-          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-          sourceChannel,
-          conversationExternalId: "local",
-          actorExternalId: principalId,
-        }),
-      );
+    const healed = await reResolveTrustOnResetDrift(principalId, sourceChannel);
+    if (healed) {
+      trustCtx = healed;
       log.info(
         { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
         "Trust re-resolved from local mirror after gateway reset drift (surface action)",


### PR DESCRIPTION
## Summary
Moves the OWNER/guardian-principal trust resolution on `/v1/surface-actions` and `/v1/messages` off the local `resolveTrustContext` + `findGuardianForChannel` ACL reads and onto the gateway guardian binding (via the `getGuardianDelivery` reader from #35806). This is the actor-trust (non-inbound-verdict) read-side prerequisite for Combo 11 — getting the owner-principal ACL read off the assistant DB.

- **New mapper** `resolveLocalPrincipalTrustContext` (`assistant/src/runtime/local-principal-trust.ts`): derives a local principal's `TrustContext` from the gateway guardian binding — guardian-match → guardian ctx, else unknown, fail-closed on a null (unreachable) gateway read. Proven equivalent to the prior `toTrustContext` output.
- **Both routes** now resolve trust from the binding; the happy path wraps with `withSourceChannel` to preserve the request body channel.
- **Drift recovery** (DB-reset: gateway rebound to a fresh `vellum-principal-*` while the client holds a valid JWT for the old one) is preserved via a shared `reResolveTrustOnResetDrift` helper, gated to the **narrow** case: both the gateway's active vellum guardian principal AND the incoming JWT principal are daemon-minted `vellum-principal-*` ids that differ. Genuine revocation, rebind to a real identity, and gateway-unreachable all **fail closed** to `unknown`.
- `healGuardianBindingDrift` (local write-path reconciliation) is intentionally unchanged — its write is a Combo 11 concern. The transitional local-mirror fallback is removed in Combo 11.

## Self-review result
PASS across all four passes (external feedback, plan faithfulness, repo integration, slop/reuse) after 2 remediation rounds.

## PRs merged into the feature branch
- #35812: map a local principal to a TrustContext via the gateway guardian binding
- #35821: surface-action trust context from the gateway guardian binding
- #35824: /v1/messages trust context from the gateway guardian binding

### Fix / remediation PRs
- #35845: consolidate reset-drift recovery into a shared helper; restore /v1/messages unknown warn; align dev-bypass fail-closed
- #35846: unit-test the helper directly; stub it in route tests; guard surface-action success log

Part of plan: local-principal-trust-from-binding.md