### PR TITLE
fix(cli): unref stdin in confirmAction so destructive commands don't hang

### DIFF
--- a/cli/src/lib/confirm-action.ts
+++ b/cli/src/lib/confirm-action.ts
@@ -18,6 +18,9 @@ export function canPromptForConfirmation(): boolean {
  * Show `prompt` and resolve true on Enter, false on Esc/q/Ctrl-C. Restores the
  * prior stdin raw/paused state on exit. Caller must gate on
  * {@link canPromptForConfirmation} first.
+ *
+ * `unref()`s stdin on cleanup so the resumed handle doesn't keep the process
+ * alive after the prompt resolves.
  */
 export async function confirmAction(prompt: string): Promise<boolean> {
   const stdin = process.stdin;
@@ -36,6 +39,7 @@ export async function confirmAction(prompt: string): Promise<boolean> {
       if (wasPaused) {
         stdin.pause();
       }
+      stdin.unref?.();
       stdout.write("\n");
     };
 


### PR DESCRIPTION
`confirmAction` resumes stdin to read a keypress but only re-paused it conditionally, so the handle stayed referenced and `retire`/`unpair`/`devices` hung after their work completed (notably under bun). Add `process.stdin.unref()` in cleanup — it releases the event-loop hold without touching the raw/paused state the helper already restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)