### PR TITLE
fix(skills): strip misplaced `activity` from resolved skill_execute input

### DIFF
--- a/assistant/src/__tests__/skill-execute-input.test.ts
+++ b/assistant/src/__tests__/skill-execute-input.test.ts
@@ -69,6 +69,46 @@ describe("resolveSkillExecuteInput", () => {
     expect(result).toEqual({ prompt: "the real prompt" });
   });
 
+  test("strips a misplaced activity nested inside input", () => {
+    // The exact shape from the MiniMax app_refresh failure: the harness
+    // `activity` label nested inside `input` alongside the real parameters,
+    // where it would otherwise trip app_refresh's strict unknown-parameter
+    // validation ("Unknown parameter \"activity\"").
+    const result = resolveSkillExecuteInput({
+      tool: "app_refresh",
+      input: {
+        app_id: "3133005b-caf6-4173-ab3b-d072776f19fd",
+        change_summary: "feat: add calculator logic and styles",
+        activity: "Compiling the calculator",
+      },
+    });
+    expect(result).toEqual({
+      app_id: "3133005b-caf6-4173-ab3b-d072776f19fd",
+      change_summary: "feat: add calculator logic and styles",
+    });
+  });
+
+  test("strips a misplaced activity from a JSON-encoded input string", () => {
+    const result = resolveSkillExecuteInput({
+      tool: "app_refresh",
+      input: '{"app_id":"abc","change_summary":"x","activity":"Compiling"}',
+    });
+    expect(result).toEqual({ app_id: "abc", change_summary: "x" });
+  });
+
+  test("falls through to sibling rescue when input holds only activity", () => {
+    // input nested nothing but the harness `activity`; the real parameters sit
+    // at the top level. Stripping activity empties the nested object so sibling
+    // rescue can recover the real call.
+    const result = resolveSkillExecuteInput({
+      tool: "app_refresh",
+      input: { activity: "Compiling the calculator" },
+      app_id: "abc",
+      change_summary: "x",
+    });
+    expect(result).toEqual({ app_id: "abc", change_summary: "x" });
+  });
+
   test("returns empty object when no parameters are present anywhere", () => {
     const result = resolveSkillExecuteInput({
       tool: "media_generate_image",

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -11,6 +11,27 @@ import type {
 const SKILL_EXECUTE_ENVELOPE_KEYS = new Set(["tool", "input", "activity"]);
 
 /**
+ * Harness keys that may surface inside a resolved inner-input object but never
+ * name an inner-tool parameter. `activity` is the progress label carried on the
+ * `skill_execute` envelope; weak models sometimes nest it inside `input` (or a
+ * JSON-encoded `input` string) rather than alongside `tool`, where it then
+ * trips the inner tool's strict unknown-parameter validation. `tool`/`input`
+ * are structural and could legitimately name an inner param, so only `activity`
+ * is stripped.
+ */
+const RESERVED_INNER_KEYS = ["activity"] as const;
+
+/** Drop reserved harness keys from a resolved inner-input object. */
+function stripReservedInnerKeys(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!RESERVED_INNER_KEYS.some((key) => key in input)) return input;
+  const scrubbed = { ...input };
+  for (const key of RESERVED_INNER_KEYS) delete scrubbed[key];
+  return scrubbed;
+}
+
+/**
  * Recover a `skill_execute` envelope that the provider layer wrapped under the
  * `_raw` unparseable marker.
  *
@@ -62,6 +83,10 @@ export function recoverSkillExecuteEnvelope(
  *    — e.g. the full Markdown body as `input` instead of `{ "content": "..." }`.
  *    Rescued only when `innerSchema` has exactly one required string field, so
  *    the mapping is unambiguous.
+ *
+ * Reserved harness keys (see {@link RESERVED_INNER_KEYS}) are stripped from the
+ * resolved object so a misplaced `activity` cannot trip the inner tool's strict
+ * unknown-parameter validation.
  */
 export function resolveSkillExecuteInput(
   envelope: Record<string, unknown>,
@@ -70,10 +95,11 @@ export function resolveSkillExecuteInput(
   const raw = envelope.input;
 
   if (raw != null && typeof raw === "object" && !Array.isArray(raw)) {
-    const obj = raw as Record<string, unknown>;
-    // A populated object is the well-formed case. An empty object falls
-    // through to sibling rescue: the model may have nested nothing yet placed
-    // the real parameters at the top level.
+    const obj = stripReservedInnerKeys(raw as Record<string, unknown>);
+    // A populated object is the well-formed case. An object that is empty (or
+    // empty once reserved harness keys are dropped) falls through to sibling
+    // rescue: the model may have nested nothing yet placed the real parameters
+    // at the top level.
     if (Object.keys(obj).length > 0) return obj;
   } else if (typeof raw === "string" && raw.trim()) {
     try {
@@ -83,7 +109,8 @@ export function resolveSkillExecuteInput(
         typeof parsed === "object" &&
         !Array.isArray(parsed)
       ) {
-        return parsed as Record<string, unknown>;
+        const obj = stripReservedInnerKeys(parsed as Record<string, unknown>);
+        if (Object.keys(obj).length > 0) return obj;
       }
     } catch {
       // Not JSON. A weak model may have placed the inner tool's sole required


### PR DESCRIPTION
## Problem

A recent QA pass found app-builder/calculator builds intermittently failing on the **balanced** profile (MiniMax-M3). Comparing working vs. failing feedback bundles showed identical code, LLM config, provider endpoint, sampling params, and core system prompt across runs — the difference was **MiniMax's nondeterministic tool-call serialization**, not the environment.

One concrete, recurring failure: the model nests the harness `activity` label **inside** `skill_execute`'s `input` rather than alongside `tool`. The resolver passed it straight through to the inner tool, where strict unknown-parameter validation rejected it:

```
Invalid input for tool "app_refresh": Unknown parameter "activity". Supported: "app_id", "change_summary".
```

This fired twice on the failing `app_refresh` calls before the model recovered, producing visible errors and thrash.

## Fix

`resolveSkillExecuteInput` now drops reserved harness keys (`activity`) from the resolved inner-input object, on both the nested-object and JSON-encoded-string paths. Stripping happens **before** the emptiness check, so an `input` holding only `activity` falls through to the existing sibling rescue. Only `activity` is stripped — `tool`/`input` are structural and could legitimately name an inner param.

This is the cache-safe residue of the reverted #35477: it's pure **server-side input normalization**, so the tool list the model sees is unchanged and **prompt caching is unaffected** (the reason #35477 was reverted via #35487).

## Scope

- ✅ Fixes the `app_refresh`/`app_update`-style `Unknown parameter "activity"` rejection class, deterministically, for any weak model.
- ❌ Does **not** address the separate `app_create` `source_files` object-collapse — that's partially lossy and already degrades gracefully via the existing scaffold + `file_write` fallback. (Tracked as a possible follow-up "Tier 2".)

## Tests

3 new cases in `skill-execute-input.test.ts` reproducing the exact transcript shapes (nested `activity` in object input, in JSON-string input, and activity-only input falling through to sibling rescue). Full file: 24 pass. `tsc --noEmit` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)