### PR TITLE
Inbox triage: accept caller-chosen start stage + pin admin-copilot inbox-archive fix

### DIFF
--- a/assistant/src/__tests__/skill-execute-input.test.ts
+++ b/assistant/src/__tests__/skill-execute-input.test.ts
@@ -69,6 +69,46 @@ describe("resolveSkillExecuteInput", () => {
     expect(result).toEqual({ prompt: "the real prompt" });
   });
 
+  test("strips a misplaced activity nested inside input", () => {
+    // The exact shape from the MiniMax app_refresh failure: the harness
+    // `activity` label nested inside `input` alongside the real parameters,
+    // where it would otherwise trip app_refresh's strict unknown-parameter
+    // validation ("Unknown parameter \"activity\"").
+    const result = resolveSkillExecuteInput({
+      tool: "app_refresh",
+      input: {
+        app_id: "3133005b-caf6-4173-ab3b-d072776f19fd",
+        change_summary: "feat: add calculator logic and styles",
+        activity: "Compiling the calculator",
+      },
+    });
+    expect(result).toEqual({
+      app_id: "3133005b-caf6-4173-ab3b-d072776f19fd",
+      change_summary: "feat: add calculator logic and styles",
+    });
+  });
+
+  test("strips a misplaced activity from a JSON-encoded input string", () => {
+    const result = resolveSkillExecuteInput({
+      tool: "app_refresh",
+      input: '{"app_id":"abc","change_summary":"x","activity":"Compiling"}',
+    });
+    expect(result).toEqual({ app_id: "abc", change_summary: "x" });
+  });
+
+  test("falls through to sibling rescue when input holds only activity", () => {
+    // input nested nothing but the harness `activity`; the real parameters sit
+    // at the top level. Stripping activity empties the nested object so sibling
+    // rescue can recover the real call.
+    const result = resolveSkillExecuteInput({
+      tool: "app_refresh",
+      input: { activity: "Compiling the calculator" },
+      app_id: "abc",
+      change_summary: "x",
+    });
+    expect(result).toEqual({ app_id: "abc", change_summary: "x" });
+  });
+
   test("returns empty object when no parameters are present anywhere", () => {
     const result = resolveSkillExecuteInput({
       tool: "media_generate_image",

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -11,6 +11,27 @@ import type {
 const SKILL_EXECUTE_ENVELOPE_KEYS = new Set(["tool", "input", "activity"]);
 
 /**
+ * Harness keys that may surface inside a resolved inner-input object but never
+ * name an inner-tool parameter. `activity` is the progress label carried on the
+ * `skill_execute` envelope; weak models sometimes nest it inside `input` (or a
+ * JSON-encoded `input` string) rather than alongside `tool`, where it then
+ * trips the inner tool's strict unknown-parameter validation. `tool`/`input`
+ * are structural and could legitimately name an inner param, so only `activity`
+ * is stripped.
+ */
+const RESERVED_INNER_KEYS = ["activity"] as const;
+
+/** Drop reserved harness keys from a resolved inner-input object. */
+function stripReservedInnerKeys(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!RESERVED_INNER_KEYS.some((key) => key in input)) return input;
+  const scrubbed = { ...input };
+  for (const key of RESERVED_INNER_KEYS) delete scrubbed[key];
+  return scrubbed;
+}
+
+/**
  * Recover a `skill_execute` envelope that the provider layer wrapped under the
  * `_raw` unparseable marker.
  *
@@ -62,6 +83,10 @@ export function recoverSkillExecuteEnvelope(
  *    — e.g. the full Markdown body as `input` instead of `{ "content": "..." }`.
  *    Rescued only when `innerSchema` has exactly one required string field, so
  *    the mapping is unambiguous.
+ *
+ * Reserved harness keys (see {@link RESERVED_INNER_KEYS}) are stripped from the
+ * resolved object so a misplaced `activity` cannot trip the inner tool's strict
+ * unknown-parameter validation.
  */
 export function resolveSkillExecuteInput(
   envelope: Record<string, unknown>,
@@ -70,10 +95,11 @@ export function resolveSkillExecuteInput(
   const raw = envelope.input;
 
   if (raw != null && typeof raw === "object" && !Array.isArray(raw)) {
-    const obj = raw as Record<string, unknown>;
-    // A populated object is the well-formed case. An empty object falls
-    // through to sibling rescue: the model may have nested nothing yet placed
-    // the real parameters at the top level.
+    const obj = stripReservedInnerKeys(raw as Record<string, unknown>);
+    // A populated object is the well-formed case. An object that is empty (or
+    // empty once reserved harness keys are dropped) falls through to sibling
+    // rescue: the model may have nested nothing yet placed the real parameters
+    // at the top level.
     if (Object.keys(obj).length > 0) return obj;
   } else if (typeof raw === "string" && raw.trim()) {
     try {
@@ -83,7 +109,8 @@ export function resolveSkillExecuteInput(
         typeof parsed === "object" &&
         !Array.isArray(parsed)
       ) {
-        return parsed as Record<string, unknown>;
+        const obj = stripReservedInnerKeys(parsed as Record<string, unknown>);
+        if (Object.keys(obj).length > 0) return obj;
       }
     } catch {
       // Not JSON. A weak model may have placed the inner tool's sole required

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -94,7 +94,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/admin-copilot",
-        "ref": "287276f2dd36608f660851858cea14c85e1785d1"
+        "ref": "0e8686928ceac20ca1988787f5a4f9f460abe44e"
       },
       "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
       "category": "productivity",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -270,7 +270,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-23T21:36:50.000Z"
+      "updatedAt": "2026-06-23T21:50:11.000Z"
     },
     {
       "id": "google-calendar",
@@ -378,7 +378,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-06-23T23:31:20.000Z"
     },
     {
       "id": "influencer",

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -54,7 +54,7 @@ Before anything else, explain what the user is opting into. Be direct:
 
 > "Here's what inbox management does: on a schedule you choose (e.g. every few hours on weekdays), I'll scan your inbox and take action based on a trust level you control.
 >
-> **Stage 0 (where everyone starts):** I watch but don't touch. I'll tell you what I _would_ archive, show you draft replies I wrote, and flag urgent items — but I won't move or delete anything. This lasts until you explicitly tell me to graduate.
+> **Stage 0 (the default starting point):** I watch but don't touch. I'll tell you what I _would_ archive, show you draft replies I wrote, and flag urgent items — but I won't move or delete anything. This lasts until you explicitly tell me to graduate.
 >
 > **Stage 1 (you opt in):** I silently archive obvious noise — calendar responses, no-reply senders, newsletters. Everything else is still flagged for your review.
 >
@@ -66,7 +66,12 @@ Wait for explicit confirmation before proceeding. If the user hesitates or asks 
 
 ### 1. Stage
 
-Start at **Stage 0**. Store via `gmail-prefs.ts --action set-management-config --stage 0`.
+Default to **Stage 0** (flag-only). When the user — directly or via a caller like
+`admin-copilot` setup — has made an explicit, informed choice to start higher,
+honor it: **Stage 1** (silent archive of known-safe categories only) or **Stage 2**
+(also cold outreach by judgment). Do not infer a higher stage from enthusiasm;
+require an explicit choice made after the §0 consent framing for that stage. Store
+the chosen stage via `gmail-prefs.ts --action set-management-config --stage <0|1|2>`.
 
 ### 2. Safe-list
 


### PR DESCRIPTION
Companion to **vellum-ai/admin-copilot#1**. Together they fix "inbox triage never actually archives anything."

## Background

A copilot set up with "Digest + inbox triage" produced `"would archive N"` summaries forever and never moved an email. Root cause was two defaults, not a capability gap (`gmail-archive.ts` removes the `INBOX` label fine):

1. The digest deferred *approved* archives to "the next scheduled run."
2. `inbox-management` hard-defaulted to Stage 0 (flag-only) and `admin-copilot-setup` hardcoded it with *"never jump"* — so nothing archived until an explicit `"graduate me"`.

The admin-copilot PR fixes (1) and the setup side of (2). This PR is the `inbox-management` side.

## Changes

- **`skills/inbox-management/SKILL.md`** — Setup §1 no longer says *"Start at Stage 0"* unconditionally. It defaults to Stage 0 but honors a caller-chosen higher start (Stage 1 = known-safe noise only; Stage 2 = + cold outreach) when the user has made an explicit, informed choice after the §0 consent framing. The "graduate me" ladder for moving up *after* setup is unchanged.
- **`plugins/marketplace.json`** — pins `admin-copilot` to `0e86869` (the inbox-archive commit). ⚠️ If admin-copilot#1 is squash-merged, this ref must be repinned to the merge commit before this lands.
- **`skills/catalog.json`** — regenerated for the SKILL.md change. Also picks up a stale `gmail` `updatedAt` that #35839 left behind (it landed without a catalog regen); the catalog gate recomputes from git, so this correction is required to stay green.

## Review focus

Safety invariants preserved: nothing above Stage 0 without explicit informed consent, safe-list cross-checked before every archive, drafts never auto-sent. The marketplace repin is the one thing to watch — flagging it as **medium risk** so it's repinned to the real merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)