### PR TITLE
inbox-management: accept a caller-chosen starting stage

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -270,7 +270,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-23T21:36:50.000Z"
+      "updatedAt": "2026-06-23T21:50:11.000Z"
     },
     {
       "id": "google-calendar",
@@ -378,7 +378,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-06-23T23:31:20.000Z"
     },
     {
       "id": "influencer",

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -54,7 +54,7 @@ Before anything else, explain what the user is opting into. Be direct:
 
 > "Here's what inbox management does: on a schedule you choose (e.g. every few hours on weekdays), I'll scan your inbox and take action based on a trust level you control.
 >
-> **Stage 0 (where everyone starts):** I watch but don't touch. I'll tell you what I _would_ archive, show you draft replies I wrote, and flag urgent items — but I won't move or delete anything. This lasts until you explicitly tell me to graduate.
+> **Stage 0 (the default starting point):** I watch but don't touch. I'll tell you what I _would_ archive, show you draft replies I wrote, and flag urgent items — but I won't move or delete anything. This lasts until you explicitly tell me to graduate.
 >
 > **Stage 1 (you opt in):** I silently archive obvious noise — calendar responses, no-reply senders, newsletters. Everything else is still flagged for your review.
 >
@@ -66,7 +66,12 @@ Wait for explicit confirmation before proceeding. If the user hesitates or asks 
 
 ### 1. Stage
 
-Start at **Stage 0**. Store via `gmail-prefs.ts --action set-management-config --stage 0`.
+Default to **Stage 0** (flag-only). When the user — directly or via a caller like
+`admin-copilot` setup — has made an explicit, informed choice to start higher,
+honor it: **Stage 1** (silent archive of known-safe categories only) or **Stage 2**
+(also cold outreach by judgment). Do not infer a higher stage from enthusiasm;
+require an explicit choice made after the §0 consent framing for that stage. Store
+the chosen stage via `gmail-prefs.ts --action set-management-config --stage <0|1|2>`.
 
 ### 2. Safe-list
 


### PR DESCRIPTION
Companion to **vellum-ai/admin-copilot#1** (merged). Split out of #35856 so it lands independently.

## Change

`inbox-management` setup §1 previously said *"Start at Stage 0"* unconditionally, so it always began flag-only and archived nothing until an explicit `"graduate me"`. Now it defaults to Stage 0 but honors a caller-chosen higher start (Stage 1 = known-safe noise only; Stage 2 = + cold outreach) when the user has made an explicit, informed choice after the §0 consent framing. The post-setup "graduate me" ladder is unchanged.

This is what makes the merged admin-copilot setup change coherent: setup now maps `flag-only`→0 / `standard`→1 / `autonomous`→2 and passes the chosen stage here.

`skills/catalog.json` is regenerated for the SKILL.md change; it also corrects a stale `gmail` `updatedAt` that #35839 left behind (catalog gate recomputes from git).

## Safety

Nothing above Stage 0 without explicit informed consent; safe-list cross-checked before every archive; drafts never auto-sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)