### PR TITLE
Pin admin-copilot to inbox-archive fix

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -94,7 +94,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/admin-copilot",
-        "ref": "287276f2dd36608f660851858cea14c85e1785d1"
+        "ref": "3f9a29433ecad421086e879641c0f2558f463beb"
       },
       "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
       "category": "productivity",


### PR DESCRIPTION
Bumps the `admin-copilot` marketplace pin to **vellum-ai/admin-copilot@3f9a294** (merged in admin-copilot#1), so the inbox-triage fix reaches users.

That commit:
- makes the digest **archive an approved batch immediately** on the user's go-ahead (via `inbox-management`'s `gmail-archive.ts`) instead of deferring to the next scheduled run, and
- lets setup pick a starting stage instead of hardcoding flag-only.

Pairs with the `inbox-management` SKILL change (separate PR). Split out of #35856 so the pin can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)