### PR TITLE
chore(plugins): bump admin-copilot pin to fail-fast fix

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -94,7 +94,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/admin-copilot",
-        "ref": "287276f2dd36608f660851858cea14c85e1785d1"
+        "ref": "e2b9b1e6486178def5fecf69c1131f6fcb9909ae"
       },
       "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
       "category": "productivity",


### PR DESCRIPTION
Promotes the `admin-copilot` marketplace pin from `287276f` → `e2b9b1e`.

## Why

The catalog serves each plugin at its **SHA-pinned** commit in `plugins/marketplace.json`, not the plugin repo's `main` HEAD. So the fail-fast fix merged in vellum-ai/admin-copilot#2 doesn't reach users until this pin moves.

## What `e2b9b1e` ships

Fail-fast guardrails across all three admin-copilot skills so a weak open model (MiniMax) can't dead-end into a multi-minute filesystem-exploration loop when `admin_copilot_prefs` isn't loaded:
- **setup** — name `set_prefs` as the only write path; if the tool is absent, tell the user to restart + re-run, create enabled schedules with defaults, stop.
- **admin-digest** — default to in-app delivery, skip the competitor section, note prefs unavailable, continue.
- **competitor-brief** — report and stop (no usable fallback; never fabricate).

Context: a MiniMax-M3 dogfood where setup Step 2 ran ~26 tool calls / ~4 min before giving up. The deeper activation/staleness cause (plugin installed-but-dormant in the live registry) is tracked in #35855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)