### PR TITLE
chore(plugins): bump admin-copilot pin to proactive chief-of-staff updates

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -94,7 +94,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/admin-copilot",
-        "ref": "e2b9b1e6486178def5fecf69c1131f6fcb9909ae"
+        "ref": "3d375a31c910448e45723487d18358b78bf3ddb0"
       },
       "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
       "category": "productivity",


### PR DESCRIPTION
Bumps the `admin-copilot` marketplace pin `e2b9b1e` → `3d375a3` to ship three merged improvements. The catalog serves the pinned commit (not the plugin repo's main HEAD), so this bump is required for users to receive them.

- **vellum-ai/admin-copilot#3** — calendar prep proposes reversible chief-of-staff moves (focus-block holds, conflict resolution, agenda drafts, recurring-meeting declines) under a shared "autonomy scales with reversibility" principle.
- **vellum-ai/admin-copilot#4** — material competitor findings carry draft-only suggested actions (heads-up drafts, deeper passes), never transmitted.
- **vellum-ai/admin-copilot#5** — inbox graduation is earned from remembered approval patterns (`remember`/`recall`) instead of a manual "graduate me", with the consent gate preserved.

No-email constraint preserved throughout — every outbound stays a draft a human sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)