### PR TITLE
test(gateway/slack): pin DM defaultAssistantId fallback for block_actions (LUM-2414)

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -215,6 +215,71 @@ describe("normalizeSlackBlockActions", () => {
 
     expect(result).toBeNull();
   });
+
+  // LUM-2414: a guardian's Block Kit button click (Approve/Reject on an
+  // access-request card) arrives on their DM channel (D...). When that channel
+  // isn't in the routing table the normalizer must fall back to the default
+  // assistant rather than silently dropping the click — mirroring the fallback
+  // in normalizeSlackDirectMessage, normalizeSlackReaction, and the message
+  // edit/delete normalizers.
+  it("falls back to the default assistant for an unrouted DM channel", () => {
+    const config = makeConfig({
+      defaultAssistantId: "default-ast",
+      unmappedPolicy: "reject",
+    });
+    const payload = makeBlockActionsPayload({ channelId: "D999" });
+    const result = normalizeSlackBlockActions(
+      payload,
+      "env-dm-fallback",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.channel).toBe("D999");
+    expect(result!.routing.assistantId).toBe("default-ast");
+    expect(result!.routing.routeSource).toBe("default");
+  });
+
+  it("uses explicit routing for a DM channel that is in the routing table", () => {
+    // The DM fallback only fires when routing rejects; an explicit
+    // conversation_id route for the DM channel must still win.
+    const config = makeConfig({
+      defaultAssistantId: "default-ast",
+      unmappedPolicy: "reject",
+      routingEntries: [
+        { type: "conversation_id", key: "D789", assistantId: "explicit-ast" },
+      ],
+    });
+    const payload = makeBlockActionsPayload({ channelId: "D789" });
+    const result = normalizeSlackBlockActions(
+      payload,
+      "env-dm-explicit",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.routing.assistantId).toBe("explicit-ast");
+    expect(result!.routing.routeSource).toBe("conversation_id");
+  });
+
+  it("returns null for an unrouted non-DM channel even when a default assistant exists", () => {
+    // Non-DM channels keep strict routing: the DM-only fallback must not leak
+    // into public channels, so a rejected route stays dropped even though
+    // defaultAssistantId is set. (The "returns null when routing rejects" case
+    // above uses defaultAssistantId: undefined and so can't pin this guard.)
+    const config = makeConfig({
+      defaultAssistantId: "default-ast",
+      unmappedPolicy: "reject",
+    });
+    const payload = makeBlockActionsPayload({ channelId: "C456" });
+    const result = normalizeSlackBlockActions(
+      payload,
+      "env-non-dm-reject",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
 });
 
 describe("normalizeSlackReactionAdded", () => {


### PR DESCRIPTION
## LUM-2414 — Slack Block Kit buttons silently drop when guardian DM channel isn't in the routing table

**Linear:** https://linear.app/vellum/issue/LUM-2414

### TL;DR — the code fix already shipped; this PR closes the missing-test gap

While tracing the bug I found the runtime fix is **already present** in `normalizeSlackBlockActions` (`gateway/src/slack/normalize.ts`). It falls back to `config.defaultAssistantId` for unrouted DM channels, gated by `isSlackDmChannel(channelId)`:

```ts
let routing = resolveAssistant(config, channelId, userId);
if (isRejection(routing) && config.defaultAssistantId && isSlackDmChannel(channelId)) {
  routing = { assistantId: config.defaultAssistantId, routeSource: "default" as const };
}
if (isRejection(routing)) return null;
```

**The PRs that already fixed it** (traced via `git blame` + the merged-commit patches):

- **#34678** — _Surface-based access request card with functional Approve/Reject buttons_ (merged 2026-06-13, LUM-2380/2390/2397). This is the PR that **introduced the DM `defaultAssistantId` fallback** in `normalizeSlackBlockActions`, in the *same* PR that made the buttons functional — originally as `channelId.startsWith("D")`. The comment it shipped is the LUM-2414 symptom verbatim: _"button clicks on guardian notifications sent as DMs are silently dropped."_
- **#35331** — _unify DM classification so thread-replies aren't dropped_ (merged 2026-06-18, Closes LUM-2485). This **hardened** the fallback to the canonical `isSlackDmChannel(channelId)` classifier (`channel_type === "im"` OR `D`-prefix) — more robust than the raw prefix the ticket proposed, and the form on `main` today.

So I did **not** re-apply the fix.

### What was actually missing: the regression test

The ticket's acceptance criteria explicitly require a unit test for the DM-fallback, and that test did **not** exist for `normalizeSlackBlockActions`. Its sibling normalizers (`normalizeSlackReaction`, `normalizeSlackMessageDelete`) each have a DM-fallback test, but block_actions did not. The only rejection test used `defaultAssistantId: undefined`, so it never exercised the fallback branch *or* the non-DM guard — a future refactor could silently delete the fallback and CI would stay green.

This PR adds three tests in `gateway/src/slack/normalize.test.ts` covering the acceptance criteria exactly:

- **unrouted DM channel (`D...`) → falls back to `defaultAssistantId`** (asserts `routeSource: "default"`)
- **DM channel with an explicit `conversation_id` route → explicit route wins** (fallback only fires on rejection)
- **unrouted non-DM channel with a default set → still returns `null`** — the guard the existing suite couldn't pin, since it used `defaultAssistantId: undefined`

### Verification

- I temporarily stripped the DM-fallback from the implementation and confirmed the first test **fails** (`Received: null`), then restored it — so the test genuinely pins the fix rather than passing vacuously.
- `bun test src/slack/normalize.test.ts` → **78 pass / 0 fail**.
- `tsc --noEmit`, `prettier --check`, and `eslint` are clean for the changed file.

### Scope

Test-only change. Respected the ticket's out-of-scope list: no change to `resolveAssistant`, no change to non-DM rejection semantics, no change to the access-request card or approval-decision logic.

> [!NOTE]
> The runtime fix is already in `main` (**#34678** introduced it, **#35331** hardened it), so the net diff here is the test file only. If LUM-2414 is tracked as "needs a code change," that change already shipped — this is the regression test that pins it, and the ticket can likely be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016k9WTAmG8Xy4n6hpqw15jd