### PR TITLE
perf(subagent): stop re-projecting the timeline on token and status updates

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -37,7 +37,7 @@ import { WebFetchDetailView } from "@/domains/chat/components/web-fetch/web-fetc
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
 import {
     buildSubagentStepDetails,
-    computeSubagentCardData,
+    computeSubagentSteps,
 } from "@/domains/chat/hooks/use-subagent-card-data";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
@@ -103,8 +103,16 @@ export function SubagentDetailPanel({
   // three separate times in the JSX below.
   const traits = useMemo(() => subagentTraits(entry.subagentId), [entry.subagentId]);
   // The panel re-renders when `entry` changes via the store subscription in
-  // chat-content-layout.tsx, so memoizing on `entry` keeps the steps fresh.
-  const cardData = useMemo(() => computeSubagentCardData(entry), [entry]);
+  // chat-content-layout.tsx. The store bumps `entry` identity on every
+  // token/status/usage update but keeps `entry.events` reference-stable, so the
+  // heavy O(n) timeline walk is keyed on `entry.events` — it re-runs only when
+  // the event list actually changes, not on every status/usage tick. The panel
+  // renders its own header from `entry` directly, so it needs only the projected
+  // `steps` (not the carousel meta `computeSubagentCardData` derives).
+  const { steps } = useMemo(
+    () => computeSubagentSteps(entry.events),
+    [entry.events],
+  );
 
   // `toolCallId`-keyed map of nested tool-detail payloads, used to swap the
   // panel body to a tool's input/output when its timeline pill is clicked —
@@ -117,7 +125,10 @@ export function SubagentDetailPanel({
   // `mapDetailEvents` carries through); thinking/text steps key on the source
   // event id and carry the full, un-truncated reasoning. Steps with no entry
   // here render as non-clickable pills — a graceful fallback, not an error.
-  const stepDetails = useMemo(() => buildSubagentStepDetails(entry), [entry]);
+  const stepDetails = useMemo(
+    () => buildSubagentStepDetails(entry.events),
+    [entry.events],
+  );
 
   // Which step's detail (if any) is shown nested inside this panel — the key
   // into `stepDetails` (a tool call or a thinking segment), or `null` to show
@@ -408,20 +419,20 @@ export function SubagentDetailPanel({
                * subagent's same-positioned phase.
                */}
               {/*
-               * Gate the empty state on the RAW `entry.events`, not on
-               * `cardData.steps`. `computeSubagentCardData` can intentionally
+               * Gate the empty state on the RAW `entry.events`, not on the
+               * projected `steps`. `computeSubagentSteps` can intentionally
                * DROP events (e.g. a `tool_result` with no preceding in-flight
-               * `tool_call`), so `entry.events` can be non-empty while
-               * `cardData.steps` is empty. Gating on steps would show a false
-               * "No events yet" AND — because `entry.events.length !== 0` — the
-               * detail-refetch effect above wouldn't fire to recover. When the
-               * store has events we render the timeline (which returns null for
-               * zero steps, an acceptable no-op).
+               * `tool_call`), so `entry.events` can be non-empty while `steps`
+               * is empty. Gating on steps would show a false "No events yet"
+               * AND — because `entry.events.length !== 0` — the detail-refetch
+               * effect above wouldn't fire to recover. When the store has events
+               * we render the timeline (which returns null for zero steps, an
+               * acceptable no-op).
                */}
               {entry.events.length > 0 ? (
                 <SubagentPhaseTimeline
                   key={entry.subagentId}
-                  steps={cardData.steps}
+                  steps={steps}
                   expandedKeys={expandedSectionKeys}
                   onExpandedKeysChange={setExpandedSectionKeys}
                   onStepDetailClick={(key) => {

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -824,7 +824,7 @@ describe("computeSubagentCardData — web tools match main-chat group labels", (
       ],
     });
     const step = computeSubagentCardData(entry).steps[0]!;
-    const details = buildSubagentStepDetails(entry);
+    const details = buildSubagentStepDetails(entry.events);
     if (step.kind === "thinking") {
       expect(step.detailKey).toBe("tu-wf");
       expect(details.has(step.detailKey!)).toBe(true);
@@ -1255,7 +1255,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("tu-1")!;
@@ -1274,7 +1274,7 @@ describe("buildSubagentStepDetails", () => {
     const details = buildSubagentStepDetails(
       makeEntry({
         events: [makeEvent({ type: "text", content }, 0)],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("te-0")!;
@@ -1315,7 +1315,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("tu-ws")!;
@@ -1349,7 +1349,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-ws")!;
     expect(payload.kind).toBe("web_search");
@@ -1360,7 +1360,7 @@ describe("buildSubagentStepDetails", () => {
     const details = buildSubagentStepDetails(
       makeEntry({
         events: [makeEvent({ type: "text", content: "   \n  " }, 0)],
-      }),
+      }).events,
     );
     expect(details.size).toBe(0);
   });
@@ -1383,7 +1383,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.get("tu-1")!.result).toBe("fallback output");
   });
@@ -1414,7 +1414,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1440,7 +1440,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1472,7 +1472,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-ws")!;
     expect(payload).toBeDefined();
@@ -1496,7 +1496,7 @@ describe("buildSubagentStepDetails", () => {
             0,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("tu-1")!;
@@ -1510,7 +1510,7 @@ describe("buildSubagentStepDetails", () => {
     const details = buildSubagentStepDetails(
       makeEntry({
         events: [makeEvent({ type: "tool_call", toolName: "bash" })],
-      }),
+      }).events,
     );
     expect(details.size).toBe(0);
   });
@@ -1548,7 +1548,7 @@ describe("buildSubagentStepDetails", () => {
             2,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(2);
     const a = details.get("tu-A")!;
@@ -1580,7 +1580,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1609,7 +1609,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1635,7 +1635,7 @@ describe("buildSubagentStepDetails", () => {
             timestamp: NOW,
           }),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("completed");
@@ -1747,4 +1747,112 @@ describe("computeSubagentSteps / applyTimelineEvent reproduce computeSubagentCar
       expect(steps).toEqual(computeSubagentSteps(events).steps);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Heavy-projection memoization keyed on `entry.events` (PR 2)
+//
+// The panel keys its two heavy O(n) walks (`computeSubagentSteps` and
+// `buildSubagentStepDetails`) on `entry.events`, not `entry`. The store bumps
+// `entry` identity on every token/status/usage update while keeping
+// `entry.events` reference-stable, so a memo on `[entry.events]` skips the walk
+// when only the status/usage changed — and re-runs when the event list itself
+// changes. These tests pin that contract: a `[entry.events]`-keyed memo is the
+// correct dependency.
+// ---------------------------------------------------------------------------
+
+describe("heavy projections are memoizable on entry.events (PR 2)", () => {
+  // Minimal stand-in for React's `useMemo`: recompute only when the dependency
+  // reference changes. Mirrors the panel's `useMemo(..., [entry.events])`.
+  function memoizeByDep<Dep, Result>(compute: (dep: Dep) => Result) {
+    let lastDep: Dep | undefined;
+    let lastResult: Result;
+    let calls = 0;
+    return {
+      run(dep: Dep): Result {
+        if (calls === 0 || dep !== lastDep) {
+          calls += 1;
+          lastDep = dep;
+          lastResult = compute(dep);
+        }
+        return lastResult;
+      },
+      get calls() {
+        return calls;
+      },
+    };
+  }
+
+  const events: SubagentTimelineEvent[] = [
+    makeEvent({ type: "text", content: "Investigating" }, 0),
+    makeEvent(
+      { type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls" },
+      1,
+    ),
+    makeEvent(
+      { type: "tool_result", toolName: "bash", toolUseId: "tu-1", result: "ok" },
+      2,
+    ),
+  ];
+
+  test("computeSubagentSteps memoized on entry.events skips the walk across a token/status update", () => {
+    // A token/status/usage update bumps `entry` identity but leaves
+    // `entry.events` reference-stable — the same array instance.
+    const entryA = makeEntry({ status: "running", events });
+    const entryB = makeEntry({
+      status: "completed",
+      // Same `events` reference — only the surrounding entry changed.
+      events: entryA.events,
+      outputTokens: 42,
+    });
+    expect(entryA).not.toBe(entryB);
+    expect(entryB.events).toBe(entryA.events);
+
+    const memo = memoizeByDep((evts: SubagentTimelineEvent[]) =>
+      computeSubagentSteps(evts),
+    );
+    const first = memo.run(entryA.events);
+    const second = memo.run(entryB.events);
+    // No recompute: the stable `events` reference is the only dependency.
+    expect(memo.calls).toBe(1);
+    expect(second).toBe(first);
+    // And the cached result is still correct.
+    expect(first.steps).toEqual(computeSubagentSteps(events).steps);
+  });
+
+  test("computeSubagentSteps memoized on entry.events re-runs when the event list changes", () => {
+    const entryA = makeEntry({ events });
+    // A new event appended → a new array reference (the store replaces it).
+    const entryB = makeEntry({
+      events: [...events, makeEvent({ type: "text", content: "done" }, 3)],
+    });
+    expect(entryB.events).not.toBe(entryA.events);
+
+    const memo = memoizeByDep((evts: SubagentTimelineEvent[]) =>
+      computeSubagentSteps(evts),
+    );
+    memo.run(entryA.events);
+    const after = memo.run(entryB.events);
+    expect(memo.calls).toBe(2);
+    expect(after.steps).toEqual(computeSubagentSteps(entryB.events).steps);
+  });
+
+  test("buildSubagentStepDetails memoized on entry.events skips the walk across a token/status update", () => {
+    const entryA = makeEntry({ status: "running", events });
+    const entryB = makeEntry({
+      status: "completed",
+      events: entryA.events,
+      inputTokens: 100,
+    });
+    expect(entryB.events).toBe(entryA.events);
+
+    const memo = memoizeByDep((evts: SubagentTimelineEvent[]) =>
+      buildSubagentStepDetails(evts),
+    );
+    const first = memo.run(entryA.events);
+    const second = memo.run(entryB.events);
+    expect(memo.calls).toBe(1);
+    expect(second).toBe(first);
+    expect(first.get("tu-1")?.status).toBe("completed");
+  });
 });

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -495,6 +495,12 @@ export function computeSubagentSteps(events: SubagentTimelineEvent[]): {
 /**
  * Pure projection of (entry) → card props. Split from the hook so tests
  * can drive it without instantiating the Zustand store.
+ *
+ * The heavy O(n) timeline walk is isolated in `computeSubagentSteps` so callers
+ * that re-render on every status/usage tick — like `subagent-detail-panel.tsx`,
+ * which renders its own header from `entry` and consumes only `steps` — can
+ * memoize the walk on `entry.events` (reference-stable across those ticks)
+ * rather than re-running it here on every `entry` identity bump.
  */
 export function computeSubagentCardData(
   entry: SubagentEntry,
@@ -659,7 +665,7 @@ export function useSubagentCardData(
  *    the parsed result sources, keyed by `toolUseId` (matching the `detailKey`
  *    `computeSubagentCardData` stamps on the search step).
  *
- * Walks `entry.events` in order, tracking in-flight tool payloads and resolving
+ * Walks `events` in order, tracking in-flight tool payloads and resolving
  * `tool_result` / `error` follow-ups against them with `matchInFlightTool` —
  * the same precedence `computeSubagentCardData` uses, so the two stay aligned.
  * Risk fields (`riskLevel`/`riskReason`) are omitted — subagent timeline events
@@ -799,14 +805,14 @@ export function applyDetailEvent(
 }
 
 export function buildSubagentStepDetails(
-  entry: SubagentEntry,
+  events: SubagentTimelineEvent[],
 ): Map<string, ToolDetailPayload> {
   const payloads: ToolDetailPayload[] = [];
   // Parallel array: start timestamp + running flag per payload, used for
   // matching follow-ups and duration calc. Indexed by `payloads` position.
   const meta: Array<{ startTs: number; running: boolean }> = [];
 
-  for (const event of entry.events) applyDetailEvent(payloads, meta, event);
+  for (const event of events) applyDetailEvent(payloads, meta, event);
 
   // Every payload (including a failed web_search) is kept and keyed by its tool
   // id. The timeline's `web_search_error` step carries the same id as its


### PR DESCRIPTION
## Summary
- Key computeSubagentSteps + buildSubagentStepDetails on entry.events (reference-stable across token/status updates) instead of entry identity.
- Narrow buildSubagentStepDetails to (events). The panel renders its own header from entry and consumes only steps, so the carousel meta is no longer projected there.

Part of plan: subagent-panel-incremental-projection.md (PR 2 of 5)