### PR TITLE
perf(subagent): incrementally project the timeline instead of full replay

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -35,10 +35,8 @@ import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
 import { WebFetchDetailView } from "@/domains/chat/components/web-fetch/web-fetch-detail-view";
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
-import {
-    buildSubagentStepDetails,
-    computeSubagentSteps,
-} from "@/domains/chat/hooks/use-subagent-card-data";
+import { buildSubagentStepDetails } from "@/domains/chat/hooks/use-subagent-card-data";
+import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -104,15 +102,13 @@ export function SubagentDetailPanel({
   const traits = useMemo(() => subagentTraits(entry.subagentId), [entry.subagentId]);
   // The panel re-renders when `entry` changes via the store subscription in
   // chat-content-layout.tsx. The store bumps `entry` identity on every
-  // token/status/usage update but keeps `entry.events` reference-stable, so the
-  // heavy O(n) timeline walk is keyed on `entry.events` — it re-runs only when
-  // the event list actually changes, not on every status/usage tick. The panel
-  // renders its own header from `entry` directly, so it needs only the projected
-  // `steps` (not the carousel meta `computeSubagentCardData` derives).
-  const { steps } = useMemo(
-    () => computeSubagentSteps(entry.events),
-    [entry.events],
-  );
+  // token/status/usage update but keeps `entry.events` reference-stable. Rather
+  // than rebuild the whole timeline on each tick, `useSubagentSteps` replays
+  // only the events that changed since the last render (append / text-coalesce),
+  // and preserves the `steps` array identity when nothing visible changed so the
+  // timeline below can bail. The panel renders its own header from `entry`
+  // directly, so it needs only the projected `steps`.
+  const { steps } = useSubagentSteps(entry.events);
 
   // `toolCallId`-keyed map of nested tool-detail payloads, used to swap the
   // panel body to a tool's input/output when its timeline pill is clicked —

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -28,13 +28,14 @@
  *   step so the body doesn't show a stale loader.
  */
 
-import { useMemo } from "react";
+import { useRef } from "react";
 
 import {
   useSubagentStore,
   type SubagentEntry,
   type SubagentTimelineEvent,
 } from "@/domains/chat/subagent-store";
+import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
 import type { SubagentStatus } from "@vellumai/assistant-api";
 import { deriveStepLabelFromName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
@@ -58,6 +59,13 @@ export type { ToolCallCardData, ToolCallCardStep };
 // ---------------------------------------------------------------------------
 
 const TEXT_PREVIEW_MAX = 160;
+
+/**
+ * Shared frozen empty events array for the spawn-race window (no entry yet).
+ * A stable reference keeps the projector's identity check happy so the hook
+ * doesn't churn while waiting for the `subagent_spawned` event.
+ */
+const EMPTY_EVENTS: SubagentTimelineEvent[] = [];
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -505,8 +513,21 @@ export function computeSubagentSteps(events: SubagentTimelineEvent[]): {
 export function computeSubagentCardData(
   entry: SubagentEntry,
 ): ToolCallCardData {
-  const { steps, toolMeta } = computeSubagentSteps(entry.events);
+  return deriveSubagentCardData(entry, computeSubagentSteps(entry.events));
+}
 
+/**
+ * The cheap O(1) tail of `computeSubagentCardData`: given an entry and an
+ * already-projected `{ steps, toolMeta }`, derive the carousel meta (state,
+ * current-step title/info, step count) and assemble the card props. Split out so
+ * `useSubagentCardData` can feed it the incremental projector's output instead
+ * of re-walking the timeline. Reads only the last step, so it's safe to run on
+ * every render.
+ */
+export function deriveSubagentCardData(
+  entry: SubagentEntry,
+  { steps, toolMeta }: { steps: ToolCallCardStep[]; toolMeta: Array<ToolMeta | undefined> },
+): ToolCallCardData {
   const state = deriveCardState(entry.status);
   const { currentStepTitle, currentStepInfo } = deriveCurrentStep(
     entry,
@@ -644,10 +665,42 @@ export function useSubagentCardData(
   subagentId: string,
 ): ToolCallCardData | null {
   const entry = useSubagentStore((state) => state.byId[subagentId]);
-  return useMemo(() => {
-    if (!entry) return null;
-    return computeSubagentCardData(entry);
-  }, [entry]);
+  // Project incrementally (must run unconditionally — `useSubagentSteps` holds
+  // a ref). In the spawn-race window there's no entry yet, so feed the stable
+  // empty array; the `null` return below preserves the existing contract.
+  const projected = useSubagentSteps(entry?.events ?? EMPTY_EVENTS);
+
+  const lastRef = useRef<ToolCallCardData | null>(null);
+
+  // Intentional render-phase ref usage: `lastRef` caches the last projected
+  // card so we can preserve its identity across renders that produce an equal
+  // result (so the inline card's `React.memo` bails). Same pattern as
+  // `useSubagentSteps` / `use-event-stream.ts`.
+  /* eslint-disable react-hooks/refs -- per-instance card-identity cache (see above) */
+  if (!entry) {
+    lastRef.current = null;
+    return null;
+  }
+
+  const next = deriveSubagentCardData(entry, projected);
+  const last = lastRef.current;
+  // Preserve `cardData` identity when the projected steps and the cheap meta
+  // scalars are all unchanged, so the inline card's `React.memo` / shell bails.
+  // `toolMeta`/`carouselItems` aren't read downstream; comparing `steps`
+  // identity (stable across no-op deltas) plus the derived scalars is sufficient.
+  if (
+    last != null &&
+    last.steps === next.steps &&
+    last.state === next.state &&
+    last.currentStepTitle === next.currentStepTitle &&
+    last.currentStepInfo === next.currentStepInfo &&
+    last.stepCount === next.stepCount
+  ) {
+    return last;
+  }
+  lastRef.current = next;
+  return next;
+  /* eslint-enable react-hooks/refs */
 }
 
 /**

--- a/clients/web/src/domains/chat/subagent-step-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Tests for the incremental step projector (`createIncrementalStepProjection`).
+ *
+ * The core safety net is the **no-drift property test**: it drives the projector
+ * one store-mutation at a time (append vs text-coalesce mutate-last, exactly as
+ * `subagent-store.receiveEvent` does) and asserts the incremental output always
+ * deep-equals a full `computeSubagentSteps` rebuild — so the O(Δ) replay can
+ * never diverge from the O(n) source of truth.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { createIncrementalStepProjection } from "@/domains/chat/subagent-step-projection";
+import {
+  applyTimelineEvent,
+  computeSubagentSteps,
+  type ToolCallCardStep,
+  type ToolMeta,
+} from "@/domains/chat/hooks/use-subagent-card-data";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+const NOW = 1700000000000;
+
+let eventSeq = 0;
+function nextEventId(): string {
+  return `te-${eventSeq++}`;
+}
+
+function makeEvent(
+  overrides: Partial<SubagentTimelineEvent> & {
+    type: SubagentTimelineEvent["type"];
+  },
+  ts: number = NOW,
+): SubagentTimelineEvent {
+  return {
+    id: nextEventId(),
+    content: "",
+    timestamp: ts,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
+// incremental array shapes so the projector is fed precisely what it sees live.
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a fresh event to the events array, returning a NEW array (every prior
+ * element shared by reference). Models the store's "Append-1" shape.
+ */
+function appendEvent(
+  events: SubagentTimelineEvent[],
+  event: SubagentTimelineEvent,
+): SubagentTimelineEvent[] {
+  return [...events, event];
+}
+
+/**
+ * Grow the trailing text event's content by `delta`, returning a NEW array with
+ * only the last element replaced (same `id`, longer `content`) — the store's
+ * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
+ * event when the tail isn't text (matching `receiveEvent`).
+ */
+function coalesceText(
+  events: SubagentTimelineEvent[],
+  delta: string,
+  ts: number,
+): SubagentTimelineEvent[] {
+  const last = events[events.length - 1];
+  if (last && last.type === "text") {
+    const updated = [...events];
+    updated[updated.length - 1] = {
+      ...last,
+      content: last.content + delta,
+    };
+    return updated;
+  }
+  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
+}
+
+// ---------------------------------------------------------------------------
+// Per-diff-class unit tests
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalStepProjection — per-diff-class", () => {
+  test("first call / empty cache builds via full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    const events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "Investigating" }),
+    ];
+    expect(p.project(events)).toEqual(computeSubagentSteps(events));
+  });
+
+  test("identity: same array reference returns the cached result unchanged", () => {
+    const p = createIncrementalStepProjection();
+    const events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "hi" }),
+    ];
+    const first = p.project(events);
+    const second = p.project(events);
+    // The projector returns the cached ARRAY references unchanged on identity
+    // (the `useSubagentSteps` hook layers wrapper-object stability on top).
+    expect(second.steps).toBe(first.steps);
+    expect(second.toolMeta).toBe(first.toolMeta);
+  });
+
+  test("append-1 text: new tail thinking step", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "first" }),
+    ];
+    p.project(events);
+    events = appendEvent(events, makeEvent({ type: "text", content: "second" }));
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    expect(out.steps).toHaveLength(2);
+  });
+
+  test("append-1 tool_call: new in-flight tool step", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "thinking" }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls" }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const last = out.steps[out.steps.length - 1]!;
+    expect(last.kind).toBe("tool");
+    if (last.kind === "tool") expect(last.status).toBe("running");
+  });
+
+  test("append-1 tool_result closes an EARLIER in-flight tool (not the tail)", () => {
+    const p = createIncrementalStepProjection();
+    // tool_call, then a trailing text event, then the tool_result lands — so the
+    // result must close the tool at an earlier index, exercising the
+    // append-MOSTLY path through the real reducer.
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls", timestamp: NOW }),
+      makeEvent({ type: "text", content: "waiting" }, NOW + 100),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-1", content: "ok", timestamp: NOW + 2500 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const toolStep = out.steps.find((s) => s.kind === "tool")!;
+    expect(toolStep.kind).toBe("tool");
+    if (toolStep.kind === "tool") expect(toolStep.status).toBe("completed");
+  });
+
+  test("append-1 error closes in-flight tool + appends a tool_error step", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "rm -rf /", timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "error", content: "permission denied", timestamp: NOW + 500 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const toolStep = out.steps.find((s) => s.kind === "tool")!;
+    if (toolStep.kind === "tool") expect(toolStep.status).toBe("error");
+    expect(out.steps[out.steps.length - 1]!.kind).toBe("tool_error");
+  });
+
+  test("mutate-last under the 160-char clamp: new tail identity, content grows", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "short" }),
+    ];
+    const first = p.project(events);
+    const firstTail = first.steps[0]!;
+    // Grow the text but stay well under 160 chars.
+    events = coalesceText(events, " more text", events[0]!.timestamp);
+    const second = p.project(events);
+    expect(second).toEqual(computeSubagentSteps(events));
+    // A new tail step (preview changed), so the array is a fresh reference.
+    expect(second.steps).not.toBe(first.steps);
+    const secondTail = second.steps[0]!;
+    if (firstTail.kind === "thinking" && secondTail.kind === "thinking") {
+      expect(secondTail.text.length).toBeGreaterThan(firstTail.text.length);
+    }
+  });
+
+  test("mutate-last PAST the clamp: tail identity preserved (same steps reference)", () => {
+    const p = createIncrementalStepProjection();
+    // Seed with content already well past 160 chars so the preview is clamped.
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "y".repeat(300) }),
+    ];
+    const a = p.project(events);
+    // Append more identical chars — the clamped 160-char preview is unchanged.
+    events = coalesceText(events, "y".repeat(50), events[0]!.timestamp);
+    const b = p.project(events);
+    expect(b.steps).toBe(a.steps);
+    expect(b.toolMeta).toBe(a.toolMeta);
+    // Still correct vs the full rebuild.
+    expect(b.steps).toEqual(computeSubagentSteps(events).steps);
+  });
+
+  test("mutate-last that grows past the clamp from under it: still deep-equals rebuild", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "z".repeat(100) }),
+    ];
+    p.project(events);
+    events = coalesceText(events, "z".repeat(200), events[0]!.timestamp);
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+  });
+
+  test("full-replace (history hydration) falls back to a full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    p.project([makeEvent({ type: "text", content: "live" })]);
+    // A wholesale swap — entirely new array, no shared prefix.
+    const hydrated: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "hydrated-1" }),
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "h-1", content: "echo" }),
+    ];
+    const out = p.project(hydrated);
+    expect(out).toEqual(computeSubagentSteps(hydrated));
+  });
+
+  test("subagent switch (totally different array) falls back to a full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    p.project([
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-a", input: { query: "a" } }),
+    ]);
+    const other: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "different subagent" }),
+      makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: "wf-b", input: { url: "https://x.dev" } }),
+    ];
+    const out = p.project(other);
+    expect(out).toEqual(computeSubagentSteps(other));
+  });
+
+  test("truncation (shorter array) falls back to a full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    const full: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "a" }),
+      makeEvent({ type: "text", content: "b" }),
+    ];
+    p.project(full);
+    const truncated = full.slice(0, 1);
+    const out = p.project(truncated);
+    expect(out).toEqual(computeSubagentSteps(truncated));
+  });
+
+  test("parallel same-name tool calls: result closes the correct match index", () => {
+    const p = createIncrementalStepProjection();
+    // Two concurrent bash calls; the result for tu-2 must close the SECOND, not
+    // the first — exercises `findMatchingInFlightToolIndex` through the append.
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls", timestamp: NOW }),
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-2", content: "pwd", timestamp: NOW + 100 }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-2", content: "/home", timestamp: NOW + 1500 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const toolSteps = out.steps.filter((s) => s.kind === "tool");
+    // First still running, second completed.
+    if (toolSteps[0]!.kind === "tool") expect(toolSteps[0]!.status).toBe("running");
+    if (toolSteps[1]!.kind === "tool") expect(toolSteps[1]!.status).toBe("completed");
+  });
+
+  test("web_search result flips the placeholder to 'Searched the web'", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-1", input: { query: "vellum" }, timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "web_search", toolUseId: "ws-1", result: "Vellum\nhttps://vellum.ai", timestamp: NOW + 900 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const search = out.steps[0]!;
+    if (search.kind === "web_search") expect(search.title).toBe("Searched the web");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic event-stream generator (tiny LCG; no Math.random).
+// ---------------------------------------------------------------------------
+
+/** Numerical Recipes LCG — deterministic, seedable. */
+function makeRng(seed: number) {
+  let state = (seed >>> 0) || 1;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+type Mutation =
+  | { kind: "append"; event: SubagentTimelineEvent }
+  | { kind: "coalesce"; delta: string };
+
+/**
+ * Generate a deterministic sequence of store mutations: text deltas (coalesced
+ * when consecutive), tool calls, their results/errors, and web_search/web_fetch
+ * — covering every reducer branch. Tracks open tool ids so results/errors close
+ * real in-flight calls.
+ */
+function generateStream(seed: number, n: number): Mutation[] {
+  const rng = makeRng(seed);
+  const mutations: Mutation[] = [];
+  const openTools: Array<{ id: string; toolName: string }> = [];
+  let lastWasText = false;
+  let ts = NOW;
+
+  for (let i = 0; i < n; i++) {
+    ts += 1 + Math.floor(rng() * 50);
+    const roll = rng();
+
+    // Bias toward text + appends so coalescing fires often.
+    if (roll < 0.45) {
+      const delta = "w".repeat(1 + Math.floor(rng() * 40));
+      if (lastWasText) {
+        mutations.push({ kind: "coalesce", delta });
+      } else {
+        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
+        lastWasText = true;
+      }
+      continue;
+    }
+
+    lastWasText = false;
+
+    if (roll < 0.7) {
+      // Open a tool call (regular / web_search / web_fetch).
+      const toolRoll = rng();
+      const id = `t-${seed}-${i}`;
+      if (toolRoll < 0.2) {
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
+        });
+        openTools.push({ id, toolName: "web_search" });
+      } else if (toolRoll < 0.35) {
+        // web_fetch has no follow-up — a thinking step, no open tracking.
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
+        });
+      } else {
+        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
+        });
+        openTools.push({ id, toolName });
+      }
+      continue;
+    }
+
+    if (roll < 0.9 && openTools.length > 0) {
+      // Close an open tool with a result (maybe an error result).
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      const isError = rng() < 0.25;
+      mutations.push({
+        kind: "append",
+        event: makeEvent(
+          {
+            type: "tool_result",
+            toolName: open.toolName,
+            toolUseId: open.id,
+            isError,
+            result: isError ? "boom" : `result-${i}`,
+            content: `result-${i}`,
+          },
+          ts,
+        ),
+      });
+      continue;
+    }
+
+    if (openTools.length > 0) {
+      // Close an open tool with a raw error event.
+      const idx = Math.floor(rng() * openTools.length);
+      openTools.splice(idx, 1);
+      mutations.push({
+        kind: "append",
+        event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+      });
+      continue;
+    }
+
+    // Nothing open — emit a standalone error row.
+    mutations.push({
+      kind: "append",
+      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+    });
+  }
+
+  return mutations;
+}
+
+function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+): SubagentTimelineEvent[] {
+  return m.kind === "append"
+    ? appendEvent(events, m.event)
+    : coalesceText(events, m.delta, NOW);
+}
+
+// ---------------------------------------------------------------------------
+// No-drift property test — the core safety net.
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalStepProjection — no-drift property", () => {
+  const seeds = [1, 7, 42, 1337, 99999];
+  for (const seed of seeds) {
+    test(`seed ${seed}: incremental deep-equals full rebuild after every mutation (N=300)`, () => {
+      const projector = createIncrementalStepProjection();
+      const mutations = generateStream(seed, 300);
+      let events: SubagentTimelineEvent[] = [];
+      // Prime with the empty array.
+      projector.project(events);
+
+      for (let i = 0; i < mutations.length; i++) {
+        events = applyMutation(events, mutations[i]!);
+        const incremental = projector.project(events);
+        const full = computeSubagentSteps(events);
+        expect(incremental.steps).toEqual(full.steps);
+        expect(incremental.toolMeta).toEqual(full.toolMeta);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Incremental-work guard — reducer invocations must be ~O(N), not O(N²).
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalStepProjection — incremental-work guard", () => {
+  function countReducerCalls(n: number): { calls: number; toolResults: number } {
+    let calls = 0;
+    const counting = (
+      steps: ToolCallCardStep[],
+      toolMeta: Array<ToolMeta | undefined>,
+      event: SubagentTimelineEvent,
+    ) => {
+      calls++;
+      applyTimelineEvent(steps, toolMeta, event);
+    };
+    const projector = createIncrementalStepProjection(counting);
+    const mutations = generateStream(2024, n);
+    const toolResults = mutations.filter(
+      (m) => m.kind === "append" && (m.event.type === "tool_result" || m.event.type === "error"),
+    ).length;
+
+    let events: SubagentTimelineEvent[] = [];
+    projector.project(events);
+    for (const m of mutations) {
+      events = applyMutation(events, m);
+      projector.project(events);
+    }
+    return { calls, toolResults };
+  }
+
+  for (const n of [50, 150, 300]) {
+    test(`N=${n}: reducer invocations are ~linear (≤ N + small constant), not O(N²)`, () => {
+      const { calls } = countReducerCalls(n);
+      // Each store mutation replays at most ONE event through the reducer
+      // (append-1 → 1 call; mutate-last → exactly 1 re-derive call). So the
+      // total is bounded by the number of mutations, far below N² for large N.
+      expect(calls).toBeLessThanOrEqual(n);
+      // Sanity: O(N²) would be ~N*N/2; assert we're nowhere near it.
+      expect(calls).toBeLessThan((n * n) / 4);
+    });
+  }
+
+  test("reducer call count grows linearly across N ∈ {50,150,300}", () => {
+    const c50 = countReducerCalls(50).calls;
+    const c150 = countReducerCalls(150).calls;
+    const c300 = countReducerCalls(300).calls;
+    // Linear growth: tripling N roughly triples the work (within a small band).
+    // Quadratic growth would make c300/c50 ≈ 36, not ≈ 6.
+    expect(c300 / Math.max(c50, 1)).toBeLessThan(12);
+    expect(c150).toBeGreaterThan(c50);
+    expect(c300).toBeGreaterThan(c150);
+  });
+});

--- a/clients/web/src/domains/chat/subagent-step-projection.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.ts
@@ -1,0 +1,207 @@
+/**
+ * Incremental step projection for a subagent's timeline.
+ *
+ * Background — the store mutates `entry.events` in exactly three shapes
+ * (verified in `subagent-store.ts` `receiveEvent` / `loadDetail`):
+ *
+ *  1. **Append-1** — a new `tool_call` / `tool_result` / `error` / first `text`
+ *     event lands → `events: [...existing.events, ev]`. A new array, but every
+ *     prior element keeps its reference and exactly one element is appended at
+ *     the tail.
+ *  2. **Mutate-last** — consecutive `assistant_text_delta`s coalesce → the array
+ *     is copied (`[...existing.events]`) with only the **last** element replaced
+ *     by `{ ...lastEvent, content: lastEvent.content + delta }`. Same length,
+ *     same element references except the last, the last keeps the **same `id`**,
+ *     and its `content` only grows. Always a `text` event.
+ *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
+ *     subagent switch).
+ *
+ * `computeSubagentSteps(events)` is O(n) and the panel previously re-ran it on
+ * every streamed event → O(n²) over a run. This projector replays only the
+ * events that changed since the last call, folding them through the **same**
+ * `applyTimelineEvent` reducer the full rebuild uses — so the incremental and
+ * full paths can never drift. Any diff that doesn't fit the append / mutate-last
+ * shapes (full-replace, truncation, reorder, or a violated assumption) falls
+ * back to a full O(n) `computeSubagentSteps` rebuild, which is always correct.
+ *
+ * Note: a `tool_result` / `error` event closes an in-flight tool by writing at
+ * an *earlier* step's match index, so projection is append-MOSTLY, not
+ * append-only — which is exactly why we reuse the real reducer instead of a
+ * naive "push one step."
+ */
+
+import { useRef } from "react";
+
+import {
+  applyTimelineEvent,
+  computeSubagentSteps,
+  type ToolCallCardStep,
+  type ToolMeta,
+} from "@/domains/chat/hooks/use-subagent-card-data";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+export interface ProjectedSteps {
+  steps: ToolCallCardStep[];
+  toolMeta: Array<ToolMeta | undefined>;
+}
+
+/**
+ * Structural equality for two timeline steps. The steps are flat objects (only
+ * `results` carries a nested array), so a shallow JSON compare is both correct
+ * and cheap — used only on the single re-derived tail step in the mutate-last
+ * path to decide whether the array identity can be preserved.
+ */
+function stepsEqual(a: ToolCallCardStep, b: ToolCallCardStep): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** The per-event reducer signature shared by the full and incremental paths. */
+type TimelineReducer = (
+  steps: ToolCallCardStep[],
+  toolMeta: Array<ToolMeta | undefined>,
+  event: SubagentTimelineEvent,
+) => void;
+
+/**
+ * Create a stateful incremental projector. `project(events)` returns the
+ * `{ steps, toolMeta }` for `events`, replaying only the diff vs the previous
+ * call through `applyTimelineEvent`. The returned arrays are cached; identical
+ * inputs (or no-op text deltas past the preview clamp) return the cached arrays
+ * by reference so downstream memo / `React.memo` consumers can bail.
+ *
+ * One projector instance owns one cache slot — hold it per component instance
+ * (see `useSubagentSteps`), never module-global, so the panel and N inline
+ * cards don't thrash a single slot.
+ *
+ * `reducer` defaults to the real `applyTimelineEvent`; it's a seam for the
+ * incremental-work guard test to count reducer invocations without mocking.
+ */
+export function createIncrementalStepProjection(
+  reducer: TimelineReducer = applyTimelineEvent,
+) {
+  let prevEvents: SubagentTimelineEvent[] | null = null;
+  let steps: ToolCallCardStep[] = [];
+  let toolMeta: Array<ToolMeta | undefined> = [];
+
+  function fullBuild(events: SubagentTimelineEvent[]): ProjectedSteps {
+    const built = computeSubagentSteps(events);
+    prevEvents = events;
+    steps = built.steps;
+    toolMeta = built.toolMeta;
+    return { steps, toolMeta };
+  }
+
+  function project(events: SubagentTimelineEvent[]): ProjectedSteps {
+    // Identity — also covers PR2's events-stable status/usage updates.
+    if (events === prevEvents) return { steps, toolMeta };
+
+    // First call / empty cache.
+    if (prevEvents == null) return fullBuild(events);
+
+    const prevLen = prevEvents.length;
+    const len = events.length;
+
+    // Append: same prefix, one-or-more new events at the tail. The O(1)
+    // boundary checks (first + last-of-prev still share their references)
+    // distinguish a genuine append from a full-replace whose new array happens
+    // to be longer.
+    if (
+      len > prevLen &&
+      (prevLen === 0 ||
+        (events[0] === prevEvents[0] &&
+          events[prevLen - 1] === prevEvents[prevLen - 1]))
+    ) {
+      const stepsClone = steps.slice();
+      const toolMetaClone = toolMeta.slice();
+      for (let i = prevLen; i < len; i++) {
+        reducer(stepsClone, toolMetaClone, events[i]!);
+      }
+      prevEvents = events;
+      steps = stepsClone;
+      toolMeta = toolMetaClone;
+      return { steps, toolMeta };
+    }
+
+    // Mutate-last: text-delta coalescing. Same length, only the last element
+    // replaced (same `id`, longer `content`), every earlier element shared.
+    if (
+      len === prevLen &&
+      len >= 1 &&
+      events[len - 1] !== prevEvents[len - 1] &&
+      events[len - 1]!.id === prevEvents[len - 1]!.id &&
+      (len === 1 || events[len - 2] === prevEvents[len - 2])
+    ) {
+      const stepsClone = steps.slice();
+      const toolMetaClone = toolMeta.slice();
+
+      // A text event contributes 0 or 1 trailing thinking step and never
+      // mutates earlier steps, so popping the keyed tail (if present) and
+      // re-deriving from the grown content reproduces the full rebuild exactly.
+      const tail = stepsClone[stepsClone.length - 1];
+      let poppedStep: ToolCallCardStep | undefined;
+      if (tail && tail.kind === "thinking" && tail.detailKey === events[len - 1]!.id) {
+        poppedStep = tail;
+        stepsClone.pop();
+        toolMetaClone.pop();
+      }
+
+      reducer(stepsClone, toolMetaClone, events[len - 1]!);
+
+      prevEvents = events;
+      const newTail = stepsClone[stepsClone.length - 1];
+      // Identity preservation — once the collapsed preview passes the 160-char
+      // clamp, further deltas don't change the rendered step. Keep the previous
+      // `steps` reference so memo / `React.memo` consumers bail. (toolMeta is
+      // re-derived identically too; reuse the prior reference for the same win.)
+      if (poppedStep && newTail && stepsEqual(poppedStep, newTail)) {
+        return { steps, toolMeta };
+      }
+      steps = stepsClone;
+      toolMeta = toolMetaClone;
+      return { steps, toolMeta };
+    }
+
+    // Fallback — full-replace / truncation / reorder / violated assumption.
+    return fullBuild(events);
+  }
+
+  return { project };
+}
+
+/**
+ * Hook wrapper: holds an incremental projector per component instance (in a
+ * `useRef`, tied to the component's lifecycle — never a module-global cache, so
+ * the panel and N inline cards don't share/thrash one slot). Returns the
+ * projector output, stabilizing the wrapper object's identity when both arrays
+ * are unchanged so callers that compare the `{ steps, toolMeta }` object also
+ * bail.
+ */
+export function useSubagentSteps(
+  events: SubagentTimelineEvent[],
+): ProjectedSteps {
+  const projectorRef = useRef<ReturnType<
+    typeof createIncrementalStepProjection
+  > | null>(null);
+  const lastRef = useRef<ProjectedSteps | null>(null);
+
+  // Intentional render-phase ref usage: the projector is a per-instance
+  // mutable cache (like `useMemo` but with custom diff-aware equality), so its
+  // identity must be stable across renders and `project(events)` must run on
+  // every render to fold in new events. Reading `.current` here is the whole
+  // point — the same lazy-init + cache pattern `use-event-stream.ts` uses.
+  /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
+  if (projectorRef.current == null) {
+    projectorRef.current = createIncrementalStepProjection();
+  }
+  const next = projectorRef.current.project(events);
+  const last = lastRef.current;
+  // Stabilize the wrapper object's identity when both arrays are unchanged so
+  // callers comparing the `{ steps, toolMeta }` object (not just the arrays)
+  // also bail.
+  if (last != null && last.steps === next.steps && last.toolMeta === next.toolMeta) {
+    return last;
+  }
+  lastRef.current = next;
+  return next;
+  /* eslint-enable react-hooks/refs */
+}


### PR DESCRIPTION
## Summary
- Add createIncrementalStepProjection + useSubagentSteps: replay only changed events (append-1 / mutate-last text coalescing) through the shared applyTimelineEvent reducer, with an O(n) full-rebuild fallback.
- Preserve steps identity when a text delta past the 160-char clamp doesn't change the preview, so the timeline skips re-render.
- No-drift property test asserts incremental output always deep-equals a full rebuild across 300-event streams; work-count guard asserts O(N) not O(N^2).

Part of plan: subagent-panel-incremental-projection.md (PR 3 of 5)