### PR TITLE
perf(subagent): incrementally build the nested detail map

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -35,8 +35,8 @@ import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
 import { WebFetchDetailView } from "@/domains/chat/components/web-fetch/web-fetch-detail-view";
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
-import { buildSubagentStepDetails } from "@/domains/chat/hooks/use-subagent-card-data";
 import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
+import { useSubagentStepDetails } from "@/domains/chat/subagent-detail-projection";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -121,10 +121,13 @@ export function SubagentDetailPanel({
   // `mapDetailEvents` carries through); thinking/text steps key on the source
   // event id and carry the full, un-truncated reasoning. Steps with no entry
   // here render as non-clickable pills — a graceful fallback, not an error.
-  const stepDetails = useMemo(
-    () => buildSubagentStepDetails(entry.events),
-    [entry.events],
-  );
+  //
+  // Built incrementally (mirrors `useSubagentSteps`): the projector replays only
+  // the events that changed since the last render through the shared
+  // `applyDetailEvent` reducer, with an O(n) full-rebuild fallback. This map is
+  // read lazily (only on pill click), so the win is avoiding the O(n) re-walk
+  // per streamed event, not re-render avoidance.
+  const stepDetails = useSubagentStepDetails(entry.events);
 
   // Which step's detail (if any) is shown nested inside this panel — the key
   // into `stepDetails` (a tool call or a thinking segment), or `null` to show

--- a/clients/web/src/domains/chat/subagent-detail-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.test.ts
@@ -275,6 +275,63 @@ describe("createIncrementalDetailProjection — per-diff-class", () => {
     expect(search?.searchResults?.length).toBeGreaterThan(0);
   });
 
+  test("cross-subagent id collision (detail-1 reused) is NOT misclassified as mutate-last", () => {
+    // `mapDetailEvents` restarts event ids at `detail-1` for EACH subagent. When
+    // the panel is reused across a subagent switch and both subagents have
+    // exactly ONE event, the last ids collide on `detail-1`. The previous (tool)
+    // entry must NOT survive into subagent B's map — only id equality would have
+    // let it through; the text-coalescing content-shape guards force a full
+    // rebuild instead.
+    const p = createIncrementalDetailProjection();
+    // Subagent A: a single tool_call (web payload) keyed by toolUseId.
+    const subagentA: SubagentTimelineEvent[] = [
+      {
+        id: "detail-1",
+        type: "tool_call",
+        content: "ls",
+        toolName: "bash",
+        toolUseId: "tu-a",
+        timestamp: NOW,
+      },
+    ];
+    p.project(subagentA);
+    // Subagent B: a single text event — SAME id `detail-1`, different object.
+    const subagentB: SubagentTimelineEvent[] = [
+      { id: "detail-1", type: "text", content: "B is thinking", timestamp: NOW },
+    ];
+    const map = p.project(subagentB);
+    // Must deep-equal a full rebuild of B — no stale tool entry from A.
+    expectMapsEqual(map, buildSubagentStepDetails(subagentB));
+    expect(map.has("tu-a")).toBe(false);
+  });
+
+  test("genuine text coalescing (same id, text→text, content extends) still takes the incremental path", () => {
+    // The positive case: the work-count seam proves the incremental mutate-last
+    // path is taken (exactly ONE reducer call to re-derive the grown tail), and
+    // the result still deep-equals a full rebuild.
+    let calls = 0;
+    const counting = (
+      payloads: ToolDetailPayload[],
+      meta: Array<{ startTs: number; running: boolean }>,
+      event: SubagentTimelineEvent,
+    ) => {
+      calls++;
+      applyDetailEvent(payloads, meta, event);
+    };
+    const p = createIncrementalDetailProjection(counting);
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "Investig" }),
+    ];
+    p.project(events);
+    const callsAfterFirst = calls;
+    events = coalesceText(events, "ating the bug", events[0]!.timestamp);
+    const map = p.project(events);
+    // Incremental path: exactly one more reducer call (re-derive the grown tail),
+    // not a full re-walk of every event.
+    expect(calls - callsAfterFirst).toBe(1);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+  });
+
   test("tool_call with an empty id is skipped (not keyed/clickable)", () => {
     const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [

--- a/clients/web/src/domains/chat/subagent-detail-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Tests for the incremental detail-map projector
+ * (`createIncrementalDetailProjection`).
+ *
+ * The core safety net is the **no-drift property test**: it drives the projector
+ * one store-mutation at a time (append vs text-coalesce mutate-last, exactly as
+ * `subagent-store.receiveEvent` does) and asserts the incremental `Map` always
+ * deep-equals a full `buildSubagentStepDetails` rebuild — so the O(Δ) replay can
+ * never diverge from the O(n) source of truth, including failed web_search
+ * payloads keyed by `toolUseId` and thinking payloads keyed by event id.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { createIncrementalDetailProjection } from "@/domains/chat/subagent-detail-projection";
+import {
+  applyDetailEvent,
+  buildSubagentStepDetails,
+} from "@/domains/chat/hooks/use-subagent-card-data";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+const NOW = 1700000000000;
+
+let eventSeq = 0;
+function nextEventId(): string {
+  return `de-${eventSeq++}`;
+}
+
+function makeEvent(
+  overrides: Partial<SubagentTimelineEvent> & {
+    type: SubagentTimelineEvent["type"];
+  },
+  ts: number = NOW,
+): SubagentTimelineEvent {
+  return {
+    id: nextEventId(),
+    content: "",
+    timestamp: ts,
+    ...overrides,
+  };
+}
+
+/**
+ * Stable, order-independent serialization of a detail map for deep comparison:
+ * sort by key, then compare key→payload pairs. (`Map` equality in bun's `toEqual`
+ * is order-sensitive on insertion; the incremental and full paths build the same
+ * payloads but we compare the canonical content, not insertion order.)
+ */
+function mapToSortedEntries(
+  map: Map<string, ToolDetailPayload>,
+): Array<[string, ToolDetailPayload]> {
+  return [...map.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+function expectMapsEqual(
+  incremental: Map<string, ToolDetailPayload>,
+  full: Map<string, ToolDetailPayload>,
+): void {
+  expect(mapToSortedEntries(incremental)).toEqual(mapToSortedEntries(full));
+}
+
+// ---------------------------------------------------------------------------
+// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
+// incremental array shapes so the projector is fed precisely what it sees live.
+// ---------------------------------------------------------------------------
+
+/** Append a fresh event, returning a NEW array (prior elements shared). */
+function appendEvent(
+  events: SubagentTimelineEvent[],
+  event: SubagentTimelineEvent,
+): SubagentTimelineEvent[] {
+  return [...events, event];
+}
+
+/**
+ * Grow the trailing text event's content by `delta`, returning a NEW array with
+ * only the last element replaced (same `id`, longer `content`) — the store's
+ * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
+ * event when the tail isn't text (matching `receiveEvent`).
+ */
+function coalesceText(
+  events: SubagentTimelineEvent[],
+  delta: string,
+  ts: number,
+): SubagentTimelineEvent[] {
+  const last = events[events.length - 1];
+  if (last && last.type === "text") {
+    const updated = [...events];
+    updated[updated.length - 1] = {
+      ...last,
+      content: last.content + delta,
+    };
+    return updated;
+  }
+  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
+}
+
+// ---------------------------------------------------------------------------
+// Per-diff-class unit tests
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalDetailProjection — per-diff-class", () => {
+  test("first call / empty cache builds via full rebuild", () => {
+    const p = createIncrementalDetailProjection();
+    const events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "Investigating" }),
+    ];
+    expectMapsEqual(p.project(events), buildSubagentStepDetails(events));
+  });
+
+  test("identity: same array reference returns the cached Map by reference", () => {
+    const p = createIncrementalDetailProjection();
+    const events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "hi" }),
+    ];
+    const first = p.project(events);
+    const second = p.project(events);
+    expect(second).toBe(first);
+  });
+
+  test("thinking payload is keyed by the source event id", () => {
+    const p = createIncrementalDetailProjection();
+    const textEv = makeEvent({ type: "text", content: "deep reasoning here" });
+    const events = [textEv];
+    const map = p.project(events);
+    const payload = map.get(textEv.id);
+    expect(payload?.kind).toBe("thinking");
+    expect(payload?.toolCallId).toBe(textEv.id);
+    expect(payload?.thinkingText).toBe("deep reasoning here");
+  });
+
+  test("append-1 text: new thinking payload keyed by event id", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "first" }),
+    ];
+    p.project(events);
+    const second = makeEvent({ type: "text", content: "second" });
+    events = appendEvent(events, second);
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get(second.id)?.thinkingText).toBe("second");
+  });
+
+  test("append-1 tool_call: new in-flight tool payload keyed by toolUseId", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "thinking" }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls" }),
+    );
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get("tu-1")?.status).toBe("running");
+  });
+
+  test("append-1 tool_result closes an earlier in-flight tool (full untruncated result)", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls", timestamp: NOW }),
+      makeEvent({ type: "text", content: "waiting" }, NOW + 100),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-1", result: "file-a\nfile-b", timestamp: NOW + 2500 }),
+    );
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get("tu-1")?.status).toBe("completed");
+    expect(map.get("tu-1")?.result).toBe("file-a\nfile-b");
+  });
+
+  test("append-1 error closes in-flight tool as error", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "rm -rf /", timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "error", toolName: "bash", toolUseId: "tu-1", content: "permission denied", result: "permission denied", isError: true, timestamp: NOW + 500 }),
+    );
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get("tu-1")?.status).toBe("error");
+  });
+
+  test("mutate-last thinking payload grows with the full untruncated content", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "short" }),
+    ];
+    const first = p.project(events);
+    const id = events[0]!.id;
+    expect(first.get(id)?.thinkingText).toBe("short");
+    // Grow past 160 chars — unlike steps, the thinking payload carries the FULL
+    // content, so it keeps changing every delta (no clamp shortcut).
+    const tail = "x".repeat(300);
+    events = coalesceText(events, tail, events[0]!.timestamp);
+    const second = p.project(events);
+    expectMapsEqual(second, buildSubagentStepDetails(events));
+    expect(second.get(id)?.thinkingText).toBe("short" + tail);
+  });
+
+  test("full-replace (history hydration) falls back to a full rebuild", () => {
+    const p = createIncrementalDetailProjection();
+    p.project([makeEvent({ type: "text", content: "live" })]);
+    const hydrated: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "hydrated-1" }),
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "h-1", content: "echo" }),
+    ];
+    expectMapsEqual(p.project(hydrated), buildSubagentStepDetails(hydrated));
+  });
+
+  test("subagent switch (totally different array) falls back to a full rebuild", () => {
+    const p = createIncrementalDetailProjection();
+    p.project([
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-a", input: { query: "a" } }),
+    ]);
+    const other: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "different subagent" }),
+      makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: "wf-b", input: { url: "https://x.dev" } }),
+    ];
+    expectMapsEqual(p.project(other), buildSubagentStepDetails(other));
+  });
+
+  test("truncation (shorter array) falls back to a full rebuild", () => {
+    const p = createIncrementalDetailProjection();
+    const full: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "a" }),
+      makeEvent({ type: "text", content: "b" }),
+    ];
+    p.project(full);
+    const truncated = full.slice(0, 1);
+    expectMapsEqual(p.project(truncated), buildSubagentStepDetails(truncated));
+  });
+
+  test("failed web_search payload is keyed by toolUseId and carries the full error", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-1", input: { query: "vellum" }, timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "web_search", toolUseId: "ws-1", isError: true, result: "upstream 503 backend overloaded", content: "search failed", timestamp: NOW + 900 }),
+    );
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    const failed = map.get("ws-1");
+    expect(failed?.kind).toBe("web_search");
+    expect(failed?.status).toBe("error");
+    expect(failed?.result).toBe("upstream 503 backend overloaded");
+  });
+
+  test("successful web_search payload flips to completed with parsed sources", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-2", input: { query: "vellum" }, timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "web_search", toolUseId: "ws-2", result: "Vellum\nhttps://vellum.ai", timestamp: NOW + 900 }),
+    );
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    const search = map.get("ws-2");
+    expect(search?.status).toBe("completed");
+    expect(search?.searchResults?.length).toBeGreaterThan(0);
+  });
+
+  test("tool_call with an empty id is skipped (not keyed/clickable)", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "thinking" }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_call", toolName: "bash", content: "ls" }),
+    );
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.has("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic event-stream generator (tiny LCG; no Math.random).
+// ---------------------------------------------------------------------------
+
+/** Numerical Recipes LCG — deterministic, seedable. */
+function makeRng(seed: number) {
+  let state = (seed >>> 0) || 1;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+type Mutation =
+  | { kind: "append"; event: SubagentTimelineEvent }
+  | { kind: "coalesce"; delta: string };
+
+/**
+ * Generate a deterministic sequence of store mutations: text deltas (coalesced
+ * when consecutive), tool calls, their results/errors, and web_search/web_fetch
+ * — covering every reducer branch. Tracks open tool ids so results/errors close
+ * real in-flight calls.
+ */
+function generateStream(seed: number, n: number): Mutation[] {
+  const rng = makeRng(seed);
+  const mutations: Mutation[] = [];
+  const openTools: Array<{ id: string; toolName: string }> = [];
+  let lastWasText = false;
+  let ts = NOW;
+
+  for (let i = 0; i < n; i++) {
+    ts += 1 + Math.floor(rng() * 50);
+    const roll = rng();
+
+    // Bias toward text + appends so coalescing fires often.
+    if (roll < 0.45) {
+      const delta = "w".repeat(1 + Math.floor(rng() * 40));
+      if (lastWasText) {
+        mutations.push({ kind: "coalesce", delta });
+      } else {
+        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
+        lastWasText = true;
+      }
+      continue;
+    }
+
+    lastWasText = false;
+
+    if (roll < 0.7) {
+      // Open a tool call (regular / web_search / web_fetch).
+      const toolRoll = rng();
+      const id = `t-${seed}-${i}`;
+      if (toolRoll < 0.2) {
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
+        });
+        openTools.push({ id, toolName: "web_search" });
+      } else if (toolRoll < 0.35) {
+        // web_fetch has no follow-up — keyed by id, no open tracking.
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
+        });
+      } else {
+        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
+        });
+        openTools.push({ id, toolName });
+      }
+      continue;
+    }
+
+    if (roll < 0.9 && openTools.length > 0) {
+      // Close an open tool with a result (maybe an error result).
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      const isError = rng() < 0.25;
+      mutations.push({
+        kind: "append",
+        event: makeEvent(
+          {
+            type: "tool_result",
+            toolName: open.toolName,
+            toolUseId: open.id,
+            isError,
+            result: isError ? "boom" : `result-${i}`,
+            content: `result-${i}`,
+          },
+          ts,
+        ),
+      });
+      continue;
+    }
+
+    if (openTools.length > 0) {
+      // Close an open tool with a raw error event.
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      mutations.push({
+        kind: "append",
+        event: makeEvent({ type: "error", toolName: open.toolName, toolUseId: open.id, isError: true, result: `err-${i}`, content: `err-${i}` }, ts),
+      });
+      continue;
+    }
+
+    // Nothing open — emit a standalone error row.
+    mutations.push({
+      kind: "append",
+      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+    });
+  }
+
+  return mutations;
+}
+
+function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+): SubagentTimelineEvent[] {
+  return m.kind === "append"
+    ? appendEvent(events, m.event)
+    : coalesceText(events, m.delta, NOW);
+}
+
+// ---------------------------------------------------------------------------
+// No-drift property test — the core safety net.
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalDetailProjection — no-drift property", () => {
+  const seeds = [1, 7, 42, 1337, 99999];
+  for (const seed of seeds) {
+    test(`seed ${seed}: incremental Map deep-equals full rebuild after every mutation (N=300)`, () => {
+      const projector = createIncrementalDetailProjection();
+      const mutations = generateStream(seed, 300);
+      let events: SubagentTimelineEvent[] = [];
+      // Prime with the empty array.
+      projector.project(events);
+
+      for (let i = 0; i < mutations.length; i++) {
+        events = applyMutation(events, mutations[i]!);
+        const incremental = projector.project(events);
+        const full = buildSubagentStepDetails(events);
+        expectMapsEqual(incremental, full);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Incremental-work guard — reducer invocations must be ~O(N), not O(N²).
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalDetailProjection — incremental-work guard", () => {
+  function countReducerCalls(n: number): number {
+    let calls = 0;
+    const counting = (
+      payloads: ToolDetailPayload[],
+      meta: Array<{ startTs: number; running: boolean }>,
+      event: SubagentTimelineEvent,
+    ) => {
+      calls++;
+      applyDetailEvent(payloads, meta, event);
+    };
+    const projector = createIncrementalDetailProjection(counting);
+    const mutations = generateStream(2024, n);
+
+    let events: SubagentTimelineEvent[] = [];
+    projector.project(events);
+    for (const m of mutations) {
+      events = applyMutation(events, m);
+      projector.project(events);
+    }
+    return calls;
+  }
+
+  for (const n of [50, 150, 300]) {
+    test(`N=${n}: reducer invocations are ~linear (≤ N), not O(N²)`, () => {
+      const calls = countReducerCalls(n);
+      // Each store mutation replays at most ONE event through the reducer
+      // (append-1 → 1 call; mutate-last → exactly 1 re-derive call). So the
+      // total is bounded by the number of mutations, far below N² for large N.
+      expect(calls).toBeLessThanOrEqual(n);
+      // Sanity: O(N²) would be ~N*N/2; assert we're nowhere near it.
+      expect(calls).toBeLessThan((n * n) / 4);
+    });
+  }
+
+  test("reducer call count grows linearly across N ∈ {50,150,300}", () => {
+    const c50 = countReducerCalls(50);
+    const c150 = countReducerCalls(150);
+    const c300 = countReducerCalls(300);
+    // Linear growth: tripling N roughly triples the work (within a small band).
+    // Quadratic growth would make c300/c50 ≈ 36, not ≈ 6.
+    expect(c300 / Math.max(c50, 1)).toBeLessThan(12);
+    expect(c150).toBeGreaterThan(c50);
+    expect(c300).toBeGreaterThan(c150);
+  });
+});

--- a/clients/web/src/domains/chat/subagent-detail-projection.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.ts
@@ -1,0 +1,203 @@
+/**
+ * Incremental nested-detail projection for a subagent's timeline.
+ *
+ * The detail-map counterpart to `subagent-step-projection.ts`: the same store
+ * mutates `entry.events` in exactly three shapes (verified in
+ * `subagent-store.ts` `receiveEvent` / `loadDetail`):
+ *
+ *  1. **Append-1** — a new `tool_call` / `tool_result` / `error` / first `text`
+ *     event lands → `events: [...existing.events, ev]`. Every prior element
+ *     keeps its reference; exactly one element is appended at the tail.
+ *  2. **Mutate-last** — consecutive `assistant_text_delta`s coalesce → the array
+ *     is copied with only the **last** element replaced by
+ *     `{ ...lastEvent, content: lastEvent.content + delta }`. Same length, same
+ *     element references except the last, same `id` on the last, growing
+ *     `content`. Always a `text` event.
+ *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
+ *     subagent switch).
+ *
+ * `buildSubagentStepDetails(events)` is O(n) and the panel previously re-ran it
+ * on every streamed event → O(n²) over a run. This projector replays only the
+ * events that changed since the last call, folding them through the **same**
+ * `applyDetailEvent` reducer the full rebuild uses — so the incremental and full
+ * paths can never drift. Any diff that doesn't fit the append / mutate-last
+ * shapes (full-replace, truncation, reorder, or a violated assumption) falls
+ * back to a full O(n) `buildSubagentStepDetails` rebuild, which is always
+ * correct.
+ *
+ * NOTE — unlike the step projection, this map is consumed **lazily**: the panel
+ * only reads from it when a timeline pill is clicked. Its churn therefore never
+ * drives a render on its own, so there is no identity-preservation shortcut to
+ * be had here (and the mutate-last `thinkingText` carries the FULL untruncated
+ * content, which changes on every delta anyway). The win is purely avoiding the
+ * O(n) re-walk per streamed event — replaying only the changed events — not
+ * re-render avoidance.
+ */
+
+import { useRef } from "react";
+
+import { applyDetailEvent } from "@/domains/chat/hooks/use-subagent-card-data";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+/** Per-payload metadata tracked in parallel with `payloads` (indexed by position). */
+type DetailMeta = { startTs: number; running: boolean };
+
+/** The per-event reducer signature shared by the full and incremental paths. */
+type DetailReducer = (
+  payloads: ToolDetailPayload[],
+  meta: DetailMeta[],
+  event: SubagentTimelineEvent,
+) => void;
+
+/** Build the keyed `Map` from the payload array exactly as `buildSubagentStepDetails` does. */
+function payloadsToMap(
+  payloads: ToolDetailPayload[],
+): Map<string, ToolDetailPayload> {
+  return new Map(payloads.map((payload) => [payload.toolCallId, payload]));
+}
+
+/**
+ * Create a stateful incremental detail projector. `project(events)` returns the
+ * `toolCallId`-keyed `Map<string, ToolDetailPayload>` for `events`, replaying
+ * only the diff vs the previous call through `applyDetailEvent`. The payload
+ * array, parallel meta array, and resulting `Map` are cached; identical inputs
+ * return the cached `Map` by reference.
+ *
+ * One projector instance owns one cache slot — hold it per component instance
+ * (see `useSubagentStepDetails`), never module-global, so the panel and any
+ * other consumer don't thrash a single slot.
+ *
+ * `reducer` defaults to the real `applyDetailEvent`; it's a seam for the
+ * incremental-work guard test to count reducer invocations without mocking.
+ */
+export function createIncrementalDetailProjection(
+  reducer: DetailReducer = applyDetailEvent,
+) {
+  let prevEvents: SubagentTimelineEvent[] | null = null;
+  let payloads: ToolDetailPayload[] = [];
+  let meta: DetailMeta[] = [];
+  let map: Map<string, ToolDetailPayload> = new Map();
+
+  function fullBuild(
+    events: SubagentTimelineEvent[],
+  ): Map<string, ToolDetailPayload> {
+    // Re-run the reducer ourselves (rather than calling `buildSubagentStepDetails`)
+    // so the cached `payloads`/`meta` stay in sync for the next incremental diff.
+    const builtPayloads: ToolDetailPayload[] = [];
+    const builtMeta: DetailMeta[] = [];
+    for (const event of events) reducer(builtPayloads, builtMeta, event);
+
+    prevEvents = events;
+    payloads = builtPayloads;
+    meta = builtMeta;
+    map = payloadsToMap(payloads);
+    return map;
+  }
+
+  function project(
+    events: SubagentTimelineEvent[],
+  ): Map<string, ToolDetailPayload> {
+    // Identity — also covers events-stable status/usage updates.
+    if (events === prevEvents) return map;
+
+    // First call / empty cache.
+    if (prevEvents == null) return fullBuild(events);
+
+    const prevLen = prevEvents.length;
+    const len = events.length;
+
+    // Append: same prefix, one-or-more new events at the tail. The O(1)
+    // boundary checks (first + last-of-prev still share their references)
+    // distinguish a genuine append from a full-replace whose new array happens
+    // to be longer.
+    if (
+      len > prevLen &&
+      (prevLen === 0 ||
+        (events[0] === prevEvents[0] &&
+          events[prevLen - 1] === prevEvents[prevLen - 1]))
+    ) {
+      const payloadsClone = payloads.slice();
+      const metaClone = meta.slice();
+      for (let i = prevLen; i < len; i++) {
+        reducer(payloadsClone, metaClone, events[i]!);
+      }
+      prevEvents = events;
+      payloads = payloadsClone;
+      meta = metaClone;
+      // The Map build is O(n) but pointer-cheap — the expensive per-event
+      // parsing (parseWebSearchResultText, deriveStepLabelFromName) already ran
+      // only for the appended events inside the reducer above.
+      map = payloadsToMap(payloads);
+      return map;
+    }
+
+    // Mutate-last: text-delta coalescing. Same length, only the last element
+    // replaced (same `id`, longer `content`), every earlier element shared.
+    if (
+      len === prevLen &&
+      len >= 1 &&
+      events[len - 1] !== prevEvents[len - 1] &&
+      events[len - 1]!.id === prevEvents[len - 1]!.id &&
+      (len === 1 || events[len - 2] === prevEvents[len - 2])
+    ) {
+      const payloadsClone = payloads.slice();
+      const metaClone = meta.slice();
+
+      // A text event contributes 0 or 1 trailing `thinking` payload (keyed by
+      // the event id) and never mutates earlier payloads, so popping the keyed
+      // tail (if present) and re-applying the grown event reproduces the full
+      // rebuild exactly. Unlike the step projection there is NO tail-identity
+      // shortcut: `thinkingText` carries the full untruncated content, so the
+      // payload changes on every delta — but the replay is still O(Δ).
+      const tail = payloadsClone[payloadsClone.length - 1];
+      if (
+        tail &&
+        tail.kind === "thinking" &&
+        tail.toolCallId === events[len - 1]!.id
+      ) {
+        payloadsClone.pop();
+        metaClone.pop();
+      }
+
+      reducer(payloadsClone, metaClone, events[len - 1]!);
+
+      prevEvents = events;
+      payloads = payloadsClone;
+      meta = metaClone;
+      map = payloadsToMap(payloads);
+      return map;
+    }
+
+    // Fallback — full-replace / truncation / reorder / violated assumption.
+    return fullBuild(events);
+  }
+
+  return { project };
+}
+
+/**
+ * Hook wrapper: holds an incremental detail projector per component instance (in
+ * a `useRef`, tied to the component's lifecycle — never a module-global cache,
+ * so independent panels don't share/thrash one slot). Returns the projected
+ * `toolCallId`-keyed `Map`.
+ */
+export function useSubagentStepDetails(
+  events: SubagentTimelineEvent[],
+): Map<string, ToolDetailPayload> {
+  const projectorRef = useRef<ReturnType<
+    typeof createIncrementalDetailProjection
+  > | null>(null);
+
+  // Intentional render-phase ref usage: the projector is a per-instance mutable
+  // cache (like `useMemo` but with custom diff-aware equality), so its identity
+  // must be stable across renders and `project(events)` must run on every render
+  // to fold in new events. Reading `.current` here is the whole point — the same
+  // lazy-init + cache pattern `useSubagentSteps` / `use-event-stream.ts` use.
+  /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
+  if (projectorRef.current == null) {
+    projectorRef.current = createIncrementalDetailProjection();
+  }
+  return projectorRef.current.project(events);
+  /* eslint-enable react-hooks/refs */
+}

--- a/clients/web/src/domains/chat/subagent-detail-projection.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.ts
@@ -12,7 +12,14 @@
  *     is copied with only the **last** element replaced by
  *     `{ ...lastEvent, content: lastEvent.content + delta }`. Same length, same
  *     element references except the last, same `id` on the last, growing
- *     `content`. Always a `text` event.
+ *     `content`. Always a `text` event. We classify this shape by the
+ *     text-coalescing CONTENT shape — both last events `type: "text"` and the
+ *     new content strictly EXTENDS the old (`startsWith` + non-shrinking length)
+ *     — not just last-id equality. `mapDetailEvents` restarts ids at `detail-1`
+ *     per subagent, so two different subagents whose detail arrays each have one
+ *     event collide on `id === "detail-1"`; matching only by id would misclassify
+ *     a subagent switch as mutate-last and leave a stale tool entry that a full
+ *     rebuild drops (then a stale pill could open the previous subagent's detail).
  *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
  *     subagent switch).
  *
@@ -133,12 +140,24 @@ export function createIncrementalDetailProjection(
     }
 
     // Mutate-last: text-delta coalescing. Same length, only the last element
-    // replaced (same `id`, longer `content`), every earlier element shared.
+    // replaced, every earlier element shared. We require the genuine
+    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
+    // equality: both last events must be `type: "text"` and the new content must
+    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
+    // alone is insufficient because `mapDetailEvents` restarts event ids at
+    // `detail-1` per subagent — a single-event subagent switch collides on
+    // `id === "detail-1"` and would be misclassified, surviving a stale tool
+    // entry. The type + content-extension guards reject that collision (different
+    // type, or content that isn't a strict extension → Fallback full rebuild).
     if (
       len === prevLen &&
       len >= 1 &&
       events[len - 1] !== prevEvents[len - 1] &&
       events[len - 1]!.id === prevEvents[len - 1]!.id &&
+      prevEvents[len - 1]!.type === "text" &&
+      events[len - 1]!.type === "text" &&
+      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
+      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
       (len === 1 || events[len - 2] === prevEvents[len - 2])
     ) {
       const payloadsClone = payloads.slice();

--- a/clients/web/src/domains/chat/subagent-step-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.test.ts
@@ -276,6 +276,63 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
     if (toolSteps[1]!.kind === "tool") expect(toolSteps[1]!.status).toBe("completed");
   });
 
+  test("cross-subagent id collision (detail-1 reused) is NOT misclassified as mutate-last", () => {
+    // `mapDetailEvents` restarts event ids at `detail-1` for EACH subagent. When
+    // the panel is reused across a subagent switch and both subagents have
+    // exactly ONE event, the last ids collide on `detail-1`. The previous (tool)
+    // step must NOT survive into subagent B's steps — only id equality would have
+    // let it through; the text-coalescing content-shape guards force a full
+    // rebuild instead.
+    const p = createIncrementalStepProjection();
+    // Subagent A: a single tool_call (web payload).
+    const subagentA: SubagentTimelineEvent[] = [
+      {
+        id: "detail-1",
+        type: "tool_call",
+        content: "ls",
+        toolName: "bash",
+        toolUseId: "tu-a",
+        timestamp: NOW,
+      },
+    ];
+    p.project(subagentA);
+    // Subagent B: a single text event — SAME id `detail-1`, different object.
+    const subagentB: SubagentTimelineEvent[] = [
+      { id: "detail-1", type: "text", content: "B is thinking", timestamp: NOW },
+    ];
+    const out = p.project(subagentB);
+    // Must deep-equal a full rebuild of B — no stale tool step from A.
+    expect(out).toEqual(computeSubagentSteps(subagentB));
+    expect(out.steps.some((s) => s.kind === "tool")).toBe(false);
+  });
+
+  test("genuine text coalescing (same id, text→text, content extends) still takes the incremental path", () => {
+    // The positive case: the work-count seam proves the incremental mutate-last
+    // path is taken (exactly ONE reducer call to re-derive the grown tail), and
+    // the result still deep-equals a full rebuild.
+    let calls = 0;
+    const counting = (
+      steps: ToolCallCardStep[],
+      toolMeta: Array<ToolMeta | undefined>,
+      event: SubagentTimelineEvent,
+    ) => {
+      calls++;
+      applyTimelineEvent(steps, toolMeta, event);
+    };
+    const p = createIncrementalStepProjection(counting);
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "Investig" }),
+    ];
+    p.project(events);
+    const callsAfterFirst = calls;
+    events = coalesceText(events, "ating the bug", events[0]!.timestamp);
+    const out = p.project(events);
+    // Incremental path: exactly one more reducer call (re-derive the grown tail),
+    // not a full re-walk of every event.
+    expect(calls - callsAfterFirst).toBe(1);
+    expect(out).toEqual(computeSubagentSteps(events));
+  });
+
   test("web_search result flips the placeholder to 'Searched the web'", () => {
     const p = createIncrementalStepProjection();
     let events: SubagentTimelineEvent[] = [

--- a/clients/web/src/domains/chat/subagent-step-projection.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.ts
@@ -12,7 +12,15 @@
  *     is copied (`[...existing.events]`) with only the **last** element replaced
  *     by `{ ...lastEvent, content: lastEvent.content + delta }`. Same length,
  *     same element references except the last, the last keeps the **same `id`**,
- *     and its `content` only grows. Always a `text` event.
+ *     and its `content` only grows. Always a `text` event. We classify this shape
+ *     by the text-coalescing CONTENT shape — both last events `type: "text"` and
+ *     the new content strictly EXTENDS the old (`startsWith` + non-shrinking
+ *     length) — not just last-id equality. `mapDetailEvents` restarts ids at
+ *     `detail-1` per subagent, so two different subagents whose detail arrays each
+ *     have one event collide on `id === "detail-1"`; matching only by id would
+ *     misclassify a subagent switch as mutate-last and leave a stale step that a
+ *     full rebuild drops (then a stale pill/key could open the previous
+ *     subagent's detail).
  *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
  *     subagent switch).
  *
@@ -123,12 +131,24 @@ export function createIncrementalStepProjection(
     }
 
     // Mutate-last: text-delta coalescing. Same length, only the last element
-    // replaced (same `id`, longer `content`), every earlier element shared.
+    // replaced, every earlier element shared. We require the genuine
+    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
+    // equality: both last events must be `type: "text"` and the new content must
+    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
+    // alone is insufficient because `mapDetailEvents` restarts event ids at
+    // `detail-1` per subagent — a single-event subagent switch collides on
+    // `id === "detail-1"` and would be misclassified, surviving a stale step. The
+    // type + content-extension guards reject that collision (different type, or
+    // content that isn't a strict extension → Fallback full rebuild).
     if (
       len === prevLen &&
       len >= 1 &&
       events[len - 1] !== prevEvents[len - 1] &&
       events[len - 1]!.id === prevEvents[len - 1]!.id &&
+      prevEvents[len - 1]!.type === "text" &&
+      events[len - 1]!.type === "text" &&
+      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
+      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
       (len === 1 || events[len - 2] === prevEvents[len - 2])
     ) {
       const stepsClone = steps.slice();


### PR DESCRIPTION
## Summary
- Add createIncrementalDetailProjection + useSubagentStepDetails: replay only changed events through the shared applyDetailEvent reducer, with an O(n) full-rebuild fallback.
- No-drift property test asserts the incremental detail Map always deep-equals a full rebuild across 300-event streams.

Part of plan: subagent-panel-incremental-projection.md (PR 4 of 5)