### PR TITLE
fix(macos): make WindowInfo and AXElement Sendable

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AccessibilityTree.swift
@@ -4,7 +4,7 @@ import os
 
 private let log = Logger(subsystem: "ai.vellum.mac-helper", category: "AXTree")
 
-struct AXElement: Identifiable {
+struct AXElement: Identifiable, Sendable {
     let id: Int
     let role: String
     let title: String?
@@ -19,7 +19,7 @@ struct AXElement: Identifiable {
     let placeholderValue: String?
 }
 
-struct WindowInfo {
+struct WindowInfo: Sendable {
     let elements: [AXElement]
     let windowTitle: String
     let appName: String


### PR DESCRIPTION
## Problem

The Electron build is failing on `main` during the mac-helper Swift compile:

```
AccessibilityTree.swift:310:11: error: type 'WindowInfo' does not conform to the 'Sendable' protocol
```

`enumerateSecondaryWindows` runs its work in a `Task.detached` and returns `[WindowInfo]` across that concurrency boundary, but `WindowInfo` (and its element type `AXElement`) lack `Sendable` conformance.

## Fix

Both `WindowInfo` and `AXElement` are value types composed entirely of `Sendable` members (`Int`, `String?`, `CGRect`, `Bool`, nested `[AXElement]`), so add explicit `Sendable` conformance. Verified with `swift build` — compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)