### PR TITLE
perf(subagent): memoize phase rows and stabilize timeline callbacks

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -137,6 +137,20 @@ export function SubagentDetailPanel({
     null,
   );
 
+  // Read `stepDetails` through a ref so the click handler below can stay
+  // identity-stable across `entry.events` changes. `stepDetails` is rebuilt
+  // (new Map identity) on most streamed events, so closing over it directly
+  // would change the handler identity every tick — which, passed down to the
+  // now-memoized `SubagentPhaseRow`s, would re-render every row on each event.
+  // The ref is assigned during render (not in an effect) so the handler always
+  // sees the latest map without listing it as a dependency.
+  const stepDetailsRef = useRef(stepDetails);
+  // eslint-disable-next-line react-hooks/refs -- render-phase sync so the stable handler below reads the latest map
+  stepDetailsRef.current = stepDetails;
+  const handleStepDetailClick = useCallback((key: string) => {
+    if (stepDetailsRef.current.has(key)) setSelectedDetailKey(key);
+  }, []);
+
   // Which timeline groups are expanded. Lifted out of `SubagentPhaseTimeline`
   // so the expansion survives the timeline unmounting while a nested tool
   // detail is shown — returning via "Back" restores the same open group. Reset
@@ -434,9 +448,7 @@ export function SubagentDetailPanel({
                   steps={steps}
                   expandedKeys={expandedSectionKeys}
                   onExpandedKeysChange={setExpandedSectionKeys}
-                  onStepDetailClick={(key) => {
-                    if (stepDetails.has(key)) setSelectedDetailKey(key);
-                  }}
+                  onStepDetailClick={handleStepDetailClick}
                   // Keeps the last phase's node pulsing while the subagent is
                   // still active but its last phase has settled.
                   isRunning={isRunning}

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -9,10 +9,13 @@
  * for 1); and contiguous same-phase collapsing into a single row.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+import { useState } from "react";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
+import * as phaseGroupedStepList from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 
@@ -739,9 +742,13 @@ describe("SubagentPhaseTimeline — controlled expand state", () => {
   // When `expandedKeys`/`onExpandedKeysChange` are supplied the parent owns the
   // expansion (so it can outlive an unmount): the component renders from the
   // prop and reports toggles instead of self-managing, and does not expand
-  // until the parent feeds the new set back.
+  // until the parent feeds the new set back. `onExpandedKeysChange` receives a
+  // functional updater (the `setState`-style contract that keeps the internal
+  // `toggle` callback stable), so the next set is derived by applying it to the
+  // previous one.
   test("renders expansion from `expandedKeys` and reports toggles to the parent", () => {
-    const onExpandedKeysChange = mock((_next: Set<string>) => {});
+    const onExpandedKeysChange =
+      mock((_updater: (prev: Set<string>) => Set<string>) => {});
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", "tc-a"),
       bash("pwd", "completed", "2s", "tc-b"),
@@ -758,14 +765,15 @@ describe("SubagentPhaseTimeline — controlled expand state", () => {
     // Controlled + collapsed: no pills yet.
     expect(queryAllByTestId("phase-step-pill").length).toBe(0);
 
-    // Clicking the header reports the next set but does NOT self-expand.
+    // Clicking the header reports an updater but does NOT self-expand.
     fireEvent.click(getByTestId("subagent-phase-header"));
     expect(onExpandedKeysChange).toHaveBeenCalledTimes(1);
-    const nextKeys = onExpandedKeysChange.mock.calls[0]![0];
+    const updater = onExpandedKeysChange.mock.calls[0]![0];
+    const nextKeys = updater(new Set());
     expect(nextKeys.size).toBe(1);
     expect(queryAllByTestId("phase-step-pill").length).toBe(0);
 
-    // Feeding the reported set back expands the section.
+    // Feeding the derived set back expands the section.
     rerender(
       <SubagentPhaseTimeline
         steps={steps}
@@ -774,5 +782,80 @@ describe("SubagentPhaseTimeline — controlled expand state", () => {
       />,
     );
     expect(queryAllByTestId("phase-step-pill").length).toBe(2);
+  });
+});
+
+describe("SubagentPhaseTimeline — row render isolation", () => {
+  // `SubagentPhaseRow` is `React.memo`-wrapped, and both the `toggle` callback
+  // and the parent's stable `onExpandedKeysChange` setter keep every prop a row
+  // receives reference-stable across an expand/collapse and across a no-op
+  // parent re-render. We count actual row renders by spying on
+  // `phaseHeaderStatus`, which each row calls exactly once at the top of its
+  // render — so the spy's call count is precisely the number of rows whose
+  // render function ran. `spyOn` + `mockRestore` is local to this test (it does
+  // NOT use `mock.module`), so it leaves no cross-file pollution.
+  function toolStep(id: string): ToolCallCardStep {
+    return bash(id, "completed", "1s", `tc-${id}`);
+  }
+
+  // Five phases: tool / thinking / tool / thinking / tool — each step kind
+  // change opens a new phase, so this yields five independent rows.
+  const FIVE_PHASE_STEPS: ToolCallCardStep[] = [
+    toolStep("a"),
+    thinking("t1"),
+    toolStep("b"),
+    thinking("t2"),
+    toolStep("c"),
+  ];
+
+  test("toggling one phase re-renders only that row; a no-op parent re-render re-renders zero rows", () => {
+    const renderSpy = spyOn(phaseGroupedStepList, "phaseHeaderStatus");
+    try {
+      // Harness owns the expanded state via a stable `setState` setter (the
+      // contract the real panel uses) and exposes a `forceRerender` that bumps
+      // unrelated state without touching the stable `steps` array — modelling a
+      // parent re-render driven by an `entry` identity bump that didn't change
+      // the projected steps.
+      let forceRerender: () => void = () => {};
+      function Harness() {
+        const [expanded, setExpanded] = useState<Set<string>>(new Set());
+        const [, setTick] = useState(0);
+        forceRerender = () => setTick((n) => n + 1);
+        return (
+          <SubagentPhaseTimeline
+            steps={FIVE_PHASE_STEPS}
+            expandedKeys={expanded}
+            onExpandedKeysChange={setExpanded}
+          />
+        );
+      }
+
+      const { getAllByTestId } = render(<Harness />);
+
+      // Mount renders every row once.
+      const rows = getAllByTestId("subagent-phase-header");
+      expect(rows.length).toBe(5);
+      expect(renderSpy.mock.calls.length).toBe(5);
+
+      // Toggling one phase open re-renders ONLY that row (the memoized siblings
+      // bail because `section`, `onToggle`, and `onStepDetailClick` are all
+      // reference-stable).
+      renderSpy.mockClear();
+      fireEvent.click(rows[0]!);
+      expect(renderSpy.mock.calls.length).toBe(1);
+
+      // Toggling it back also re-renders only that one row.
+      renderSpy.mockClear();
+      fireEvent.click(rows[0]!);
+      expect(renderSpy.mock.calls.length).toBe(1);
+
+      // A parent re-render that leaves `steps` (and thus the memoized `sections`
+      // array) reference-stable re-renders ZERO rows.
+      renderSpy.mockClear();
+      forceRerender();
+      expect(renderSpy.mock.calls.length).toBe(0);
+    } finally {
+      renderSpy.mockRestore();
+    }
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -14,7 +14,7 @@
  */
 
 import { Brain, Globe } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
 
@@ -149,7 +149,15 @@ export function SubagentPhaseTimeline({
    * manages the state internally.
    */
   expandedKeys?: Set<string>;
-  onExpandedKeysChange?: (next: Set<string>) => void;
+  /**
+   * Controlled-expansion setter. Takes a functional updater so the parent can
+   * pass a stable `setState`-style setter (React's
+   * `Dispatch<SetStateAction<Set<string>>>` satisfies this). Receiving a stable
+   * identity here lets `toggle` below stay `useCallback`-stable across
+   * expand/collapse, which keeps the memoized rows from all re-rendering on a
+   * single toggle.
+   */
+  onExpandedKeysChange?: (updater: (prev: Set<string>) => Set<string>) => void;
   /**
    * Whether the owning subagent is still active. When `true`, the LAST phase's
    * node keeps pulsing (a `ThreeDotIndicator`) even after its own steps settle,
@@ -169,23 +177,26 @@ export function SubagentPhaseTimeline({
     new Set(),
   );
   const expanded = expandedKeys ?? internalExpanded;
+  // Both branches toggle via a functional updater, so `toggle` never closes over
+  // the current `expanded` set — its identity stays stable across expand/collapse
+  // (the parent passes a stable `setState`-style `onExpandedKeysChange`). A
+  // stable `toggle` is what lets the memoized `SubagentPhaseRow`s bail on a
+  // single toggle instead of all re-rendering.
   const toggle = useCallback(
     (key: string) => {
-      if (onExpandedKeysChange) {
-        const next = new Set(expanded);
-        if (next.has(key)) next.delete(key);
-        else next.add(key);
-        onExpandedKeysChange(next);
-        return;
-      }
-      setInternalExpanded((prev) => {
+      const update = (prev: Set<string>): Set<string> => {
         const next = new Set(prev);
         if (next.has(key)) next.delete(key);
         else next.add(key);
         return next;
-      });
+      };
+      if (onExpandedKeysChange) {
+        onExpandedKeysChange(update);
+        return;
+      }
+      setInternalExpanded(update);
     },
-    [expanded, onExpandedKeysChange],
+    [onExpandedKeysChange],
   );
 
   // Memoized so the O(n) grouping + fresh section allocations don't re-run on
@@ -219,7 +230,13 @@ export function SubagentPhaseTimeline({
   );
 }
 
-function SubagentPhaseRow({
+// Memoized so a single expand/collapse re-renders only the toggled row and a
+// no-op parent re-render re-renders none. The bail relies on every prop being
+// reference-stable on those re-renders: `section` (from the stable `sections`
+// `useMemo`) and the `onToggle` / `onStepDetailClick` callbacks. A genuine
+// `steps` change re-runs `groupStepsByPhase`, producing fresh `section` objects
+// that correctly bust the memo for the rows that changed.
+const SubagentPhaseRow = memo(function SubagentPhaseRow({
   section,
   isLast,
   isActiveTail,
@@ -589,4 +606,4 @@ function SubagentPhaseRow({
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
- React.memo SubagentPhaseRow; stabilize the toggle (functional-updater contract) and the panel's onStepDetailClick (useCallback + ref).
- Expand/collapse now re-renders only the toggled row; a no-op parent re-render re-renders no rows.

Part of plan: subagent-panel-incremental-projection.md (PR 5 of 5)