### PR TITLE
fix(plugins): restore image-fallback + memory-v3 selector state lost in v0.10.1 merge

### DIFF
--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -33,8 +33,10 @@ const fakeProvider = {
 // Mock @vellumai/plugin-api — only the runtime handles the plugin imports.
 // `extractAllText` stays real (imported from the relative path, not plugin-api).
 mock.module("@vellumai/plugin-api", () => ({
-  doesSupportVision: (profile: ModelProfileInfo) =>
-    visionProfiles.has(profile.key),
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModels.has(arg)
+      : visionProfiles.has(arg.key),
   getModelProfiles: () => mockProfiles,
   getConfiguredProvider: async () => (providerResolves ? fakeProvider : null),
 }));
@@ -358,9 +360,10 @@ describe("image-fallback post-tool-use hook", () => {
     );
   });
 
-  test("is a no-op when the active model supports vision", async () => {
-    visionProfiles = new Set(["text-only"]); // active profile supports vision
+  test("is a no-op when the model that ran supports vision", async () => {
+    visionModels = new Set(["vision-model"]);
     const ctx = makeToolCtx({
+      model: "vision-model",
       toolResponse: toolResult([imageBlock("shot1")]),
     });
     await postToolUse(ctx);
@@ -409,5 +412,30 @@ describe("image-fallback post-tool-use hook", () => {
     await postToolUse(ctx);
     const text = (ctx.toolResponse.contentBlocks![0] as { text: string }).text;
     expect(text).not.toContain("saved to");
+  });
+
+  test("is a no-op when contentBlocks carry no image", async () => {
+    const textBlock = { type: "text" as const, text: "just text" };
+    const ctx = makeToolCtx({ toolResponse: toolResult([textBlock]) });
+    await postToolUse(ctx);
+    expect(ctx.toolResponse.contentBlocks![0]).toEqual(textBlock);
+  });
+
+  test("gates on ctx.model, not the workspace active profile", async () => {
+    // The active profile is vision-capable, but the model that actually ran
+    // (ctx.model) is text-only — the model that ran must win, so the image is
+    // captioned.
+    mockProfiles = [
+      profile("vision-active", { isActive: true }),
+      profile("vision-profile", {}),
+    ];
+    visionProfiles = new Set(["vision-active", "vision-profile"]);
+    visionModels = new Set<string>(); // "text-only-model" is text-only
+    const ctx = makeToolCtx({
+      model: "text-only-model",
+      toolResponse: toolResult([imageBlock("shot1")]),
+    });
+    await postToolUse(ctx);
+    expect(ctx.toolResponse.contentBlocks![0].type).toBe("text");
   });
 });

--- a/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
@@ -1,5 +1,5 @@
 /**
- * Default `post-tool-use` hook: when the active model is text-only, captions
+ * Default `post-tool-use` hook: when the turn's model is text-only, captions
  * the image blocks a tool returns (e.g. a `browser_screenshot`) and
  * substitutes the caption as a text block so the result stays sendable to a
  * provider that would otherwise reject the raw image.
@@ -9,15 +9,14 @@
  * rather than the top-level message content the `user-prompt-submit` hook
  * handles. Both share {@link captionImageBlocks}.
  *
- * The active model is resolved from the workspace's active profile — the
- * post-tool-use context carries the running model, and the active profile is
- * what the loop is executing this turn. If that profile supports vision, the
- * hook is a no-op and the image reaches the model untouched.
+ * Capability is read straight off `ctx.model` — the provider-reported model id
+ * for the turn that issued this tool call — so the decision tracks the model
+ * that actually ran, including a text-only override. The substitution is in
+ * place, so the persisted/displayed tool result carries the caption too.
  */
 
 import {
   doesSupportVision,
-  getModelProfiles,
   type PluginHookFn,
   type PostToolUseContext,
 } from "@vellumai/plugin-api";
@@ -26,13 +25,13 @@ import { captionImageBlocks } from "../src/caption-blocks.js";
 import { findVisionProfile } from "../src/vision-caption.js";
 
 const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+  // Cheapest gate first: bail unless the tool actually returned an image,
+  // before touching the model catalog or resolving a vision profile.
   const blocks = ctx.toolResponse.contentBlocks;
-  if (blocks == null || blocks.length === 0) return;
+  if (blocks == null || !blocks.some((b) => b.type === "image")) return;
 
-  // If the active model already supports vision, leave the image in place.
-  const activeProfile = getModelProfiles().find((p) => p.isActive);
-  if (activeProfile == null) return;
-  if (doesSupportVision(activeProfile)) return;
+  // If the model that ran already supports vision, leave the image in place.
+  if (doesSupportVision(ctx.model)) return;
 
   // Find a vision-capable profile for captioning.
   const visionProfileKey = findVisionProfile();

--- a/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
@@ -14,7 +14,7 @@
  * 2. Finds a vision-capable profile for captioning via `findVisionProfile`.
  *    If none exists, images are replaced with a fail-open placeholder so the
  *    model at least knows an image was present.
- * 3. Replaces each `ImageContent` block with a `[Image …]` text caption via
+ * 3. Replaces each image block with a `[Image …]` text caption via
  *    {@link captionImageBlocks} (which also persists the original and caches
  *    captions across turns).
  *
@@ -23,13 +23,14 @@
  */
 
 import {
-  doesSupportVision,
-  getModelProfiles,
   type PluginHookFn,
   type UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
-import { captionImageBlocks } from "../src/caption-blocks.js";
+import {
+  captionImageBlocks,
+  needsImageFallback,
+} from "../src/caption-blocks.js";
 import { findVisionProfile } from "../src/vision-caption.js";
 
 const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -1,30 +1,61 @@
 /**
  * Shared image→text substitution for the image-fallback plugin's hooks.
  *
- * Two hooks replace `image` content blocks with a text caption when the active
+ * Two hooks replace `image` content blocks with a text caption when the turn's
  * model can't process images: `user-prompt-submit` handles user-attached
  * images, and `post-tool-use` handles images a tool returns (e.g. a browser
- * screenshot). This module holds the per-block substitution they share —
- * persist the original image to a known location, caption it via a
- * vision-capable profile, and swap in a `[Image …]` text block.
+ * screenshot). This module holds what they share — deciding whether a profile
+ * needs the fallback ({@link needsImageFallback}) and the per-block
+ * substitution ({@link captionImageBlocks}): persist the original image to a
+ * known location, caption it via a vision-capable profile, and swap in a
+ * `[Image …]` text block.
  *
- * The caption text states up front that the active model can't view images and
- * the image was auto-described to text, so the model treats the block as a
- * derived description rather than a verbatim transcript.
+ * The substitution mutates the blocks in place, so the caption replaces the
+ * image everywhere the block is referenced (the provider-bound history and the
+ * persisted/displayed copy alike) — a text-only turn does not keep the raw
+ * image around.
+ *
+ * The caption text states up front that the model can't view images and the
+ * image was auto-described to text, so the model treats the block as a derived
+ * description rather than a verbatim transcript.
  *
  * Fail-open is the dominant error mode: a captioning failure leaves a
  * placeholder text block rather than the raw image (which a text-only provider
  * would reject) or nothing (which would lose information).
  */
 
-import type {
-  ContentBlock,
-  ImageContent,
-  PluginLogger,
+import {
+  type ContentBlock,
+  doesSupportVision,
+  getModelProfiles,
+  type ImageContent,
+  type PluginLogger,
 } from "@vellumai/plugin-api";
 
 import { persistImage } from "./image-persist.js";
 import { captionImage } from "./vision-caption.js";
+
+/**
+ * Whether the profile a turn runs needs image→text fallback (i.e. it can't
+ * process images itself).
+ *
+ * Used by `user-prompt-submit`, whose context carries the profile key rather
+ * than the resolved model id: prefer the turn's `modelProfileKey` — which
+ * carries a text-only override even when the workspace's active profile is
+ * vision-capable — and fall back to the active profile only when the key is
+ * `null` (profile unchanged since the last notified turn). Returns `false` when
+ * no profile resolves or the resolved model already supports vision, in which
+ * case the image reaches the model untouched.
+ */
+export function needsImageFallback(modelProfileKey: string | null): boolean {
+  const profiles = getModelProfiles();
+  const activeProfile =
+    modelProfileKey != null
+      ? profiles.find((p) => p.key === modelProfileKey)
+      : profiles.find((p) => p.isActive);
+  if (activeProfile == null) return false;
+  return !doesSupportVision(activeProfile);
+}
 
 /**
  * Replace every `image` block in `blocks` (in place) with a text caption so a

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -429,7 +429,7 @@ export async function selectPool(
     try {
       response = await provider.sendMessage([userMsg], {
         tools: [SELECT_PAGES_TOOL],
-        systemPrompt: SYSTEM_PROMPT,
+        systemPrompt,
         config: {
           callSite: MEMORY_V3_SELECT_CALL_SITE,
           tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },


### PR DESCRIPTION
## Summary
- Fixes 3 lint failures on `main` (`no-unused-vars`) that are symptoms of a botched v0.10.1 release merge, not stray imports.
- The `Release v0.10.1` commit (`918934128b`) is a single-parent commit that overwrote main's tree and partially reverted two already-merged PRs: #35761 (image-fallback) and #35807 (memory-v3 configurable selector prompt). It reverted `caption-blocks.ts`, `post-tool-use.ts`, and the image-fallback test while leaving `user-prompt-submit.ts` in the newer shape — so it called the now-deleted `needsImageFallback()` and left `doesSupportVision`/`getModelProfiles` imported-but-unused. Separately it reverted `pool-select.ts`'s `sendMessage` call to `systemPrompt: SYSTEM_PROMPT`, silently dropping the `selectorPrompt` override threaded in by `orchestrate.ts` and leaving the `systemPrompt` param unused.
- Per guidance to prefer the state on main prior to the v0.10.1 merge: the four image-fallback files are restored verbatim to the pre-merge tree (the complete, consistent #35761 refactor, with matching tests), and `pool-select.ts` is re-pointed at its `systemPrompt` parameter (one-token change, matching #35807). Lint passes; 44 plugin tests pass.

## Original prompt
CI on `main` was red with three `@typescript-eslint/no-unused-vars` errors in `image-fallback/hooks/user-prompt-submit.ts` (`doesSupportVision`, `getModelProfiles`) and `memory-v3-shadow/pool-select.ts` (`systemPrompt`). The ask was to fix the failures, preferring the changes that were on main before the v0.10.1 release branch was merged where a choice was needed. Investigation showed the errors were collateral from the v0.10.1 release commit partially reverting two merged PRs, so the fix restores the pre-merge state rather than just deleting the unused symbols.