### PR TITLE
fix(web-login): use header-only auth for /v1 proxy to avoid CSRF rejection

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -895,14 +895,27 @@ async function runWebInterface(
       headers.delete("Origin");
       headers.delete("Referer");
 
-      // Authenticate with the loopback session token the SPA registered. The
-      // platform expects it both as the Django session cookie and as
-      // X-Session-Token (for DRF views that accept header-based auth). Only
+      // The DRF API authenticates by header (X-Session-Token); the allauth /
+      // accounts session endpoints need the Django session cookie.
+      const isApiRequest = pathname.startsWith("/v1/");
+
+      // Authenticate with the loopback session token the SPA registered. Only
       // same-origin SPA traffic gets the credential — never a cross-site caller.
       const sessionToken = isSameOriginRequest(req)
         ? currentPlatformToken()
         : null;
-      if (sessionToken) {
+      if (isApiRequest) {
+        // Header-only auth for the DRF API. Sending a `sessionid` cookie would
+        // engage Django's SessionAuthentication, which enforces CSRF — and the
+        // proxy strips Origin/Referer above, so the CSRF Referer check would
+        // reject every unsafe (POST/PUT/PATCH) request. Drop any browser cookie
+        // (localhost jar) so it can't re-engage that path.
+        headers.delete("Cookie");
+        if (sessionToken) {
+          headers.set("X-Session-Token", sessionToken);
+        }
+      } else if (sessionToken) {
+        // allauth / accounts: the platform expects the Django session cookie.
         headers.set(
           "Cookie",
           `sessionid=${sessionToken}; __Secure-sessionid=${sessionToken}`,

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -24,24 +24,39 @@ function isPlatformMode(raw: string | undefined): boolean {
 
 /**
  * Proxy configure hook (local mode) that authenticates upstream requests with
- * the loopback platform session token the SPA registered, as the Django session
- * cookie. No browser cookie is involved.
+ * the loopback platform session token the SPA registered. No browser cookie is
+ * involved.
+ *
+ * The DRF API (`/v1`) authenticates by header (X-Session-Token); sending a
+ * `sessionid` cookie would engage Django's SessionAuthentication, which enforces
+ * CSRF and rejects unsafe (POST/PUT/PATCH) requests when the proxy can't supply
+ * a matching Origin/Referer. The allauth / accounts session endpoints need the
+ * Django session cookie instead.
  */
-function injectPlatformToken(proxy: {
-  on: (event: string, cb: (...args: unknown[]) => void) => void;
-}): void {
-  proxy.on("proxyReq", (...args: unknown[]) => {
-    const proxyReq = args[0] as http.ClientRequest;
-    const req = args[1] as http.IncomingMessage;
-    if (!isSameOriginProxyRequest(req)) return;
-    const token = getDevPlatformToken();
-    if (token) {
-      proxyReq.setHeader(
-        "Cookie",
-        `sessionid=${token}; __Secure-sessionid=${token}`,
-      );
-    }
-  });
+function injectPlatformToken(apiMode: boolean) {
+  return (proxy: {
+    on: (event: string, cb: (...args: unknown[]) => void) => void;
+  }): void => {
+    proxy.on("proxyReq", (...args: unknown[]) => {
+      const proxyReq = args[0] as http.ClientRequest;
+      const req = args[1] as http.IncomingMessage;
+      if (!isSameOriginProxyRequest(req)) return;
+      const token = getDevPlatformToken();
+      if (apiMode) {
+        // Header-only auth; drop any browser cookie so it can't re-engage the
+        // session-cookie (CSRF-enforcing) path.
+        proxyReq.removeHeader("Cookie");
+        if (token) proxyReq.setHeader("X-Session-Token", token);
+        return;
+      }
+      if (token) {
+        proxyReq.setHeader(
+          "Cookie",
+          `sessionid=${token}; __Secure-sessionid=${token}`,
+        );
+      }
+    });
+  };
 }
 
 // Reference: https://vite.dev/config/#using-environment-variables-in-config
@@ -150,17 +165,17 @@ export default defineConfig(({ mode }) => {
               "/v1": {
                 target: apiProxyTarget,
                 changeOrigin: true,
-                configure: injectPlatformToken,
+                configure: injectPlatformToken(true),
               },
               "/_allauth": {
                 target: apiProxyTarget,
                 changeOrigin: true,
-                configure: injectPlatformToken,
+                configure: injectPlatformToken(false),
               },
               "/accounts": {
                 target: apiProxyTarget,
                 changeOrigin: true,
-                configure: injectPlatformToken,
+                configure: injectPlatformToken(false),
               },
             }),
         "/auth": { target: gatewayProxyTarget, changeOrigin: true },

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -46,6 +46,9 @@ function injectPlatformToken(apiMode: boolean) {
         // Header-only auth; drop any browser cookie so it can't re-engage the
         // session-cookie (CSRF-enforcing) path.
         proxyReq.removeHeader("Cookie");
+        // Server-side proxy injection of the loopback token, not browser auth —
+        // the centralized interceptor can't reach this Node proxy hook.
+        // eslint-disable-next-line no-restricted-syntax
         if (token) proxyReq.setHeader("X-Session-Token", token);
         return;
       }


### PR DESCRIPTION
## Summary
- The `vellum client --interface web` proxy authenticated `/v1` API requests with **both** a `sessionid` cookie and `X-Session-Token`. The cookie engages Django's `SessionAuthentication`, which enforces CSRF. Because the proxy strips `Origin`/`Referer` before forwarding to the production HTTPS backend, Django's CSRF Referer check rejected every unsafe (POST/PUT/PATCH) request with `CSRF Failed: Referer checking failed - no Referer.` (GET worked because CSRF only applies to unsafe methods.)
- Authenticate the DRF API (`/v1`) by header only (`X-Session-Token`) and drop any inbound browser cookie so it can't re-engage the session-cookie/CSRF path. This matches how the rest of the CLI already talks to `/v1`.
- Keep the Django session cookie for `/_allauth` and `/accounts`, which rely on it. Applied the same split to both the Bun proxy (`cli/src/commands/client.ts`) and the Vite dev proxy (`clients/web/vite.config.ts`).

## Original prompt
After #35725 enabled `vellum client --interface web` login, POST/PUT/PATCH requests to a production assistant (e.g. sending a message) returned `403 CSRF Failed: Referer checking failed - no Referer.` We root-caused it to the proxy sending the session token as a Django `sessionid` cookie (which triggers CSRF enforcement) while also stripping `Origin`/`Referer`. The fix (option 1) is to use header-only `X-Session-Token` auth for the `/v1` API and keep the cookie only for the allauth/accounts session endpoints.