### PR TITLE
feat(trust): introduce verdict-owned member ACL type

### DIFF
--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -14,6 +14,7 @@ import {
   resolvedMemberFromVerdict,
   trustContextFromVerdict,
   verdictHasMemberIdentity,
+  verdictMemberFromVerdict,
   verdictMemberUnresolvable,
 } from "../trust-verdict-consumer.js";
 
@@ -604,6 +605,84 @@ describe("resolvedMemberFromVerdict", () => {
       expect(member!.channel.status).toBe(status);
       expect(member!.channel.policy).toBe("deny");
     }
+  });
+});
+
+describe("verdictMemberFromVerdict", () => {
+  test("active member verdict yields the narrow ACL view", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "active",
+      policy: "allow",
+      verifiedAt: 1700000000,
+      memberDisplayName: "Dora",
+    } satisfies TrustVerdict;
+
+    expect(verdictMemberFromVerdict(verdict)).toEqual({
+      contactId: "contact-1",
+      channelId: "channel-1",
+      status: "active",
+      policy: "allow",
+      verifiedAt: 1700000000,
+      displayName: "Dora",
+    });
+  });
+
+  test("blocked member verdict surfaces status/policy verbatim, null defaults", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-3",
+      contactId: "contact-3",
+      channelId: "channel-3",
+      status: "blocked",
+      policy: "deny",
+    } satisfies TrustVerdict;
+
+    expect(verdictMemberFromVerdict(verdict)).toEqual({
+      contactId: "contact-3",
+      channelId: "channel-3",
+      status: "blocked",
+      policy: "deny",
+      verifiedAt: null,
+      displayName: null,
+    });
+  });
+
+  test("memberless verdict (no contactId/channelId) returns null", () => {
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "unknown",
+        canonicalSenderId: "u-2",
+      } satisfies TrustVerdict),
+    ).toBeNull();
+  });
+
+  test("invalid enum (unknown status/policy) returns null (fail-closed)", () => {
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-7",
+        contactId: "contact-7",
+        channelId: "channel-7",
+        status: "quarantined",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toBeNull();
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-6",
+        contactId: "contact-6",
+        channelId: "channel-6",
+        status: "active",
+        policy: "bogus",
+      } satisfies TrustVerdict),
+    ).toBeNull();
   });
 });
 

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -152,6 +152,44 @@ function isChannelPolicy(value: string): value is ChannelPolicy {
 }
 
 /**
+ * The ACL fields a gateway verdict carries for a resolved member, decoupled
+ * from the schema-derived {@link ContactChannel}.
+ */
+export interface VerdictMember {
+  contactId: string;
+  channelId: string;
+  status: ChannelStatus;
+  policy: ChannelPolicy;
+  verifiedAt: number | null;
+  displayName: string | null;
+}
+
+/**
+ * Extract the narrow {@link VerdictMember} ACL view from a gateway verdict.
+ *
+ * Mirrors {@link resolvedMemberFromVerdict}'s guards (contactId/channelId
+ * present + known status/policy enums), failing closed to null otherwise.
+ */
+export function verdictMemberFromVerdict(
+  verdict: TrustVerdict,
+): VerdictMember | null {
+  if (!verdict.contactId || !verdict.channelId) return null;
+  if (!verdict.status || !verdict.policy) return null;
+  if (!isChannelStatus(verdict.status) || !isChannelPolicy(verdict.policy)) {
+    return null;
+  }
+
+  return {
+    contactId: verdict.contactId,
+    channelId: verdict.channelId,
+    status: verdict.status,
+    policy: verdict.policy,
+    verifiedAt: verdict.verifiedAt ?? null,
+    displayName: verdict.memberDisplayName ?? null,
+  };
+}
+
+/**
  * Build a synthetic {@link ResolvedMember} from a gateway verdict.
  *
  * ACL + identity only; info fields are placeholders, re-joined locally by


### PR DESCRIPTION
## Summary
- Add VerdictMember type + verdictMemberFromVerdict() owning ACL fields from the gateway verdict, decoupling consumers from the schema-derived ContactChannel.

Part of plan: combo11-phase-a-read-decoupling.md (PR 1 of 11)