### PR TITLE
fix(a2a): derive a2a channel readiness without the status column

### DIFF
--- a/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
@@ -129,4 +129,29 @@ describe("redeemA2AInvite", () => {
     const result = redeemA2AInvite({ sender: SENDER });
     expect(result.success).toBe(true);
   });
+
+  test("activeConnections counts a2a channel existence, not status", () => {
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+
+    expect(getA2AConfig().activeConnections).toBe(1);
+
+    // Readiness is existence-based: a non-active stored status still counts.
+    const sqlite = getSqlite();
+    sqlite.run("UPDATE contact_channels SET status = 'unverified'");
+    invalidateConfigCache();
+    expect(getA2AConfig().activeConnections).toBe(1);
+  });
+
+  test("already-connected guard fires regardless of stored channel status", () => {
+    const first = redeemA2AInvite({ sender: SENDER });
+    expect(first.success).toBe(true);
+
+    const sqlite = getSqlite();
+    sqlite.run("UPDATE contact_channels SET status = 'revoked'");
+
+    const second = redeemA2AInvite({ sender: SENDER });
+    expect(second.alreadyConnected).toBe(true);
+    expect(second.contactId).toBe(first.contactId);
+  });
 });

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -96,13 +96,11 @@ export function getA2AConfig(): A2AConfigResult {
   const config = getConfig();
   const enabled = config.a2a?.enabled ?? false;
 
+  // a2a is peer binding outside the human-trust ACL model — the gateway has no
+  // canonical a2a channel status, so channel existence is the readiness signal.
   const contacts = searchContacts({ channelType: "a2a" });
   const activeConnections = contacts.reduce((count, c) => {
-    return (
-      count +
-      c.channels.filter((ch) => ch.type === "a2a" && ch.status === "active")
-        .length
-    );
+    return count + c.channels.filter((ch) => ch.type === "a2a").length;
   }, 0);
 
   return { success: true, enabled, activeConnections };
@@ -270,12 +268,9 @@ export function redeemA2AInvite(params: {
     setA2AConfig();
   }
 
-  // 2. Check for existing active contact with this sender
+  // 2. Check for existing contact with this sender (a2a binding existence)
   const existing = findContactByAddress("a2a", params.sender.assistantId);
-  if (
-    existing &&
-    existing.channels.some((ch) => ch.type === "a2a" && ch.status === "active")
-  ) {
+  if (existing && existing.channels.some((ch) => ch.type === "a2a")) {
     return { success: true, alreadyConnected: true, contactId: existing.id };
   }
 
@@ -373,10 +368,7 @@ export async function acceptA2AInvite(params: {
   // 2. Short-circuit if already connected — avoids a network round-trip
   //    and consuming a token on the sender side.
   const existing = findContactByAddress("a2a", params.senderAssistantId);
-  if (
-    existing &&
-    existing.channels.some((ch) => ch.type === "a2a" && ch.status === "active")
-  ) {
+  if (existing && existing.channels.some((ch) => ch.type === "a2a")) {
     return { success: true, alreadyConnected: true, contactId: existing.id };
   }
 


### PR DESCRIPTION
## Summary
- a2a config readiness gates on a2a channel existence (peer binding, outside the human-trust ACL model) instead of the assistant-DB status column.

Part of plan: combo11-phase-a-read-decoupling.md (PR 6 of 11)