### PR TITLE
fix(routes): resolve dev-bypass principal via gateway identity

### DIFF
--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -14,7 +14,6 @@
 import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import {
   type CanonicalGuardianRequest,
   listPendingRequestsByConversationScope,
@@ -23,6 +22,7 @@ import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import type { GuardianDecisionPrompt } from "../guardian-decision-types.js";
 import { buildOneTimeDecisionActions } from "../guardian-decision-types.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -73,16 +73,15 @@ async function handleGuardianActionDecision({
   // Resolve the actor's guardian principal ID. The HTTP adapter injects it
   // from the AuthContext via the x-vellum-actor-principal-id header.
   // For dev bypass (HTTP auth disabled) the synthetic "dev-bypass" principal
-  // won't match the real guardian binding, so fall back to the local guardian
-  // binding to avoid identity_mismatch.
+  // won't match the real guardian binding, so resolve the local guardian
+  // principal to avoid identity_mismatch.
   let guardianPrincipalId: string | undefined =
     headers["x-vellum-actor-principal-id"] ?? undefined;
   if (
     isHttpAuthDisabled() &&
     headers["x-vellum-actor-principal-id"] === "dev-bypass"
   ) {
-    const binding = findGuardianForChannel("vellum");
-    guardianPrincipalId = binding?.contact.principalId ?? undefined;
+    guardianPrincipalId = (await findLocalGuardianPrincipalId()) ?? undefined;
   }
 
   const result = await processGuardianDecision({

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -10,7 +10,6 @@
 import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -117,16 +116,15 @@ async function handleSurfaceAction({
   const aprDecision = parseCallbackData(actionId, "vellum");
   if (aprDecision) {
     // Resolve the actor's guardian principal ID. In dev mode the synthetic
-    // "dev-bypass" principal won't match the real guardian binding, so fall
-    // back to the local guardian binding — mirrors guardian-action-routes.ts.
+    // "dev-bypass" principal won't match the real guardian binding, so resolve
+    // the local guardian principal — mirrors guardian-action-routes.ts.
     let guardianPrincipalId: string | undefined =
       headers?.["x-vellum-actor-principal-id"] ?? undefined;
     if (
       isHttpAuthDisabled() &&
       headers?.["x-vellum-actor-principal-id"] === "dev-bypass"
     ) {
-      const binding = findGuardianForChannel("vellum");
-      guardianPrincipalId = binding?.contact.principalId ?? undefined;
+      guardianPrincipalId = (await findLocalGuardianPrincipalId()) ?? undefined;
     }
 
     const result = await processGuardianDecision({


### PR DESCRIPTION
## Summary
- guardian-action-routes + surface-action-routes dev-bypass fallback resolves the principal via findLocalGuardianPrincipalId() (gateway-first) instead of findGuardianForChannel's assistant-DB principalId.

Part of plan: combo11-phase-a-read-decoupling.md (PR 10 of 11)