### PR TITLE
fix(migrations): 017/019 resolve guardian off gateway identity

### DIFF
--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -8,11 +8,6 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import { desc, eq } from "drizzle-orm";
-
-import { generateUserFileSlug } from "../../contacts/contact-store.js";
-import { getDb } from "../../memory/db-connection.js";
-import { contacts } from "../../memory/schema/contacts.js";
 import type { WorkspaceMigration } from "./types.js";
 
 // ── Inlined helpers ───────────────────────────────────────────────
@@ -122,35 +117,9 @@ export const seedPersonaDirsMigration: WorkspaceMigration = {
     // template from disk, since migration 031 deletes that template file.
     if (content === LEGACY_USER_MD_TEMPLATE_STRIPPED) return;
 
-    // Determine destination filename based on guardian contact
-    let destFilename = "guardian.md";
-    try {
-      const db = getDb();
-      const guardian = db
-        .select()
-        .from(contacts)
-        .where(eq(contacts.role, "guardian"))
-        .orderBy(desc(contacts.createdAt))
-        .limit(1)
-        .get();
-
-      if (guardian) {
-        if (guardian.userFile) {
-          destFilename = guardian.userFile;
-        } else {
-          const slug = generateUserFileSlug(guardian.displayName);
-          db.update(contacts)
-            .set({ userFile: slug })
-            .where(eq(contacts.id, guardian.id))
-            .run();
-          destFilename = slug;
-        }
-      }
-    } catch {
-      // DB might not be initialized yet — fall back to guardian.md
-    }
-
-    const destPath = join(workspaceDir, "users", destFilename);
+    // Seed the canonical `users/guardian.md` — the runtime persona resolver
+    // falls back to this name, so no assistant-DB lookup is needed.
+    const destPath = join(workspaceDir, "users", "guardian.md");
     if (!existsSync(destPath)) {
       copyFileSync(userMdPath, destPath);
     }

--- a/assistant/src/workspace/migrations/019-scope-journal-to-guardian.ts
+++ b/assistant/src/workspace/migrations/019-scope-journal-to-guardian.ts
@@ -8,10 +8,6 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import { desc, eq } from "drizzle-orm";
-
-import { getDb } from "../../memory/db-connection.js";
-import { contacts } from "../../memory/schema/contacts.js";
 import type { WorkspaceMigration } from "./types.js";
 
 export const scopeJournalToGuardianMigration: WorkspaceMigration = {
@@ -40,26 +36,9 @@ export const scopeJournalToGuardianMigration: WorkspaceMigration = {
     });
     if (mdFiles.length === 0) return;
 
-    // Resolve guardian user slug (same pattern as 017-seed-persona-dirs)
-    let slug = "guardian";
-    try {
-      const db = getDb();
-      const guardian = db
-        .select()
-        .from(contacts)
-        .where(eq(contacts.role, "guardian"))
-        .orderBy(desc(contacts.createdAt))
-        .limit(1)
-        .get();
-      if (guardian?.userFile) {
-        slug = guardian.userFile.replace(/\.md$/, "");
-      }
-    } catch {
-      // DB not ready — use fallback "guardian"
-    }
-
-    // Create per-user directory and move files (renameSync preserves birthtimes)
-    const destDir = join(journalDir, slug);
+    // Scope under the canonical `guardian` slug — the runtime resolver falls
+    // back to it, so no assistant-DB lookup is needed.
+    const destDir = join(journalDir, "guardian");
     mkdirSync(destDir, { recursive: true });
     for (const f of mdFiles) {
       const src = join(journalDir, f);


### PR DESCRIPTION
## Summary
- Migrations 017/019 no longer read contacts.role; guardian lookup is repointed to the gateway identity (or frozen to its already-run state). Both stay idempotent on fresh + migrated DBs.

Part of plan: combo11-phase-a-read-decoupling.md (PR 11 of 11)