### PR TITLE
fix(contacts-api): serve role/status/stats from the gateway relay only

### DIFF
--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -3,8 +3,9 @@
  *
  * handleListContacts (non-search) and handleGetContact relay to the gateway
  * via `ipcCallPersistent`. On the happy path they serve gateway-sourced data
- * and do NOT read the assistant DB. On IPC failure they fall back to the
- * assistant-DB read and log a warning. getContact still 404s for unknown ids.
+ * and do NOT read the assistant DB. On IPC failure they FAIL CLOSED — the relay
+ * error propagates rather than falling back to the assistant DB. getContact
+ * surfaces a clean gateway not-found as a 404.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -213,16 +214,15 @@ describe("handleListContacts relay", () => {
     expect(result.contacts[0].displayName).toBe("Your Guardian");
   });
 
-  test("falls back to the assistant DB on IPC failure", async () => {
+  test("fails closed on IPC failure (no assistant-DB fallback)", async () => {
     ipcStub = () => {
       throw new Error("gateway down");
     };
 
-    const result = await handleListContacts({});
+    await expect(handleListContacts({})).rejects.toThrow("gateway down");
 
     expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
-    expect(localCalls).toContain("listContacts");
-    expect(result.contacts[0].id).toBe("local-1");
+    expect(localCalls).toEqual([]);
   });
 
   test("search params stay daemon-native and log the boundary note", async () => {
@@ -384,26 +384,24 @@ describe("handleGetContact relay", () => {
     expect(localCalls).toEqual([]);
   });
 
-  test("falls back to the assistant DB on IPC transport failure", async () => {
+  test("fails closed on IPC transport failure (no assistant-DB fallback)", async () => {
     ipcStub = () => {
       throw new Error("gateway down");
     };
 
-    const result = await handleGetContact("gw-1");
+    await expect(handleGetContact("gw-1")).rejects.toThrow("gateway down");
 
     expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
-    expect(localCalls).toContain("getContact");
-    expect(result.contact.id).toBe("gw-1");
+    expect(localCalls).toEqual([]);
   });
 
-  test("fallback path still 404s for unknown ids", async () => {
-    ipcStub = () => {
-      throw new Error("gateway down");
-    };
+  test("clean gateway not-found surfaces as a 404 for unknown ids", async () => {
+    ipcStub = () => null;
 
     await expect(handleGetContact("missing")).rejects.toThrow(
       'Contact "missing" not found',
     );
-    expect(localCalls).toContain("getContact");
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
+    expect(localCalls).toEqual([]);
   });
 });

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the contacts read API.
+ *
+ * `handleListContacts`, `handleGetContact`, and the `search_contacts`
+ * no-filter case relay to the gateway rich read (`contacts_list_rich` /
+ * `contacts_get_rich`), which is the source of truth for the ACL fields
+ * (`role`/`status`/`policy`/`verifiedAt`/`interactionCount`/`lastInteraction`).
+ * These tests assert the serialized response shape is gateway-sourced and
+ * unchanged for the web client, that no read path falls back to the assistant
+ * DB, and that a relay failure fails closed (surfaces an error) instead of
+ * reading local ACL.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+let ipcCalls: { method: string; params?: Record<string, unknown> }[] = [];
+let ipcResult: unknown = {};
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if any read path falls back to the assistant DB for ACL
+// fields. The relay read paths must source role/status/stats from the gateway.
+const actualContactStore = await import("../../../contacts/contact-store.js");
+
+const contactStoreReadGuard = mock(() => {
+  throw new Error(
+    "assistant contact-store read must not happen on the gateway relay path",
+  );
+});
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  getContact: contactStoreReadGuard,
+  listContacts: contactStoreReadGuard,
+  getAssistantContactMetadata: contactStoreReadGuard,
+}));
+
+const { handleListContacts, handleGetContact, ROUTES } = await import(
+  "../contact-routes.js"
+);
+
+const gatewayChannel = {
+  id: "ch_1",
+  contactId: "ct_1",
+  type: "sms",
+  address: "+15550100",
+  isPrimary: true,
+  externalUserId: null,
+  status: "active",
+  policy: "allow",
+  verifiedAt: 1700,
+  verifiedVia: "invite",
+  lastSeenAt: 1800,
+  interactionCount: 7,
+  lastInteraction: 1900,
+  revokedReason: null,
+  blockedReason: null,
+};
+
+const gatewayContact = {
+  id: "ct_1",
+  displayName: "Alice",
+  role: "member",
+  notes: "a note",
+  contactType: "human",
+  lastInteraction: 1900,
+  interactionCount: 7,
+  createdAt: 1000,
+  updatedAt: 1500,
+  channels: [gatewayChannel],
+};
+
+describe("contacts read API relays from the gateway", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = {};
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    contactStoreReadGuard.mockClear();
+  });
+
+  test("list relays to contacts_list_rich and serializes the gateway ACL fields", async () => {
+    ipcResult = { ok: true, contacts: [gatewayContact] };
+
+    const result = await handleListContacts({ limit: "50" });
+
+    expect(ipcCalls).toEqual([
+      { method: "contacts_list_rich", params: { limit: 50 } },
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.contacts).toHaveLength(1);
+
+    const [contact] = result.contacts;
+    // ACL fields are gateway-sourced and reach the web client unchanged.
+    expect(contact.role).toBe("member");
+    expect(contact.interactionCount).toBe(7);
+    expect(contact.lastInteraction).toBe(1900);
+    const channel = contact.channels[0] as Record<string, unknown>;
+    expect(channel.status).toBe("active");
+    expect(channel.policy).toBe("allow");
+    expect(channel.verifiedAt).toBe(1700);
+    expect(channel.interactionCount).toBe(7);
+    expect(channel.lastInteraction).toBe(1900);
+    // Channel compat echoes address into externalUserId for older clients.
+    expect(channel.externalUserId).toBe("+15550100");
+
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("list forwards the role filter to the gateway", async () => {
+    ipcResult = { ok: true, contacts: [] };
+
+    await handleListContacts({ limit: "10", role: "guardian" });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "contacts_list_rich",
+        params: { limit: 10, role: "guardian" },
+      },
+    ]);
+  });
+
+  test("list fails closed when the gateway relay is unavailable", async () => {
+    ipcError = new IpcCallError("gateway down", {
+      statusCode: 503,
+      errorCode: "UNAVAILABLE",
+    });
+
+    await expect(handleListContacts({ limit: "50" })).rejects.toMatchObject({
+      message: "gateway down",
+      statusCode: 503,
+    });
+    // No assistant-DB fallback read.
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("get relays to contacts_get_rich and serializes the gateway ACL fields", async () => {
+    ipcResult = { ok: true, contact: gatewayContact };
+
+    const result = await handleGetContact("ct_1");
+
+    expect(ipcCalls).toEqual([
+      { method: "contacts_get_rich", params: { contactId: "ct_1" } },
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.contact.role).toBe("member");
+    expect(result.contact.interactionCount).toBe(7);
+    const channel = result.contact.channels[0] as Record<string, unknown>;
+    expect(channel.status).toBe("active");
+    expect(channel.externalUserId).toBe("+15550100");
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("get surfaces a clean gateway not-found as a 404", async () => {
+    ipcResult = { ok: true };
+
+    await expect(handleGetContact("missing")).rejects.toMatchObject({
+      statusCode: 404,
+    });
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("get fails closed on a relay failure (no assistant-DB fallback)", async () => {
+    ipcError = new IpcCallError("gateway down", {
+      statusCode: 503,
+      errorCode: "UNAVAILABLE",
+    });
+
+    await expect(handleGetContact("ct_1")).rejects.toMatchObject({
+      message: "gateway down",
+      statusCode: 503,
+    });
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("search no-filter relays to the gateway list read", async () => {
+    ipcResult = { ok: true, contacts: [gatewayContact] };
+
+    const route = ROUTES.find((r) => r.operationId === "search_contacts");
+    expect(route).toBeDefined();
+
+    const contacts = (await route!.handler({ body: {} })) as Array<{
+      role: string;
+      interactionCount: number;
+      channels: { status: string }[];
+    }>;
+
+    expect(ipcCalls).toEqual([
+      { method: "contacts_list_rich", params: { limit: 50 } },
+    ]);
+    expect(contacts[0].role).toBe("member");
+    expect(contacts[0].interactionCount).toBe(7);
+    expect(contacts[0].channels[0].status).toBe("active");
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -17,8 +17,6 @@ import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import {
-  getAssistantContactMetadata,
-  getContact,
   listContacts,
   mergeContacts,
   searchContacts,
@@ -139,9 +137,10 @@ const contactSchema = z.object({
 
 /**
  * Relay a non-search contact list read to the gateway (source of truth for ACL
- * fields), falling back to the assistant DB on IPC failure. Shared by the GET
- * `contacts` list and the `search_contacts` no-filter case so both serve
- * gateway-sourced data consistently.
+ * fields). Shared by the GET `contacts` list and the `search_contacts`
+ * no-filter case so both serve gateway-sourced data consistently. Fail-closed:
+ * a relay failure surfaces as an error rather than reading ACL from the
+ * assistant DB.
  */
 async function relayListContacts(
   limit: number,
@@ -158,15 +157,7 @@ async function relayListContacts(
       contacts: contacts.map(prepareContactResponse),
     };
   } catch (err) {
-    log.warn(
-      { err },
-      "relayListContacts: gateway relay failed; falling back to assistant DB",
-    );
-    const contacts = listContacts(limit, role);
-    return {
-      ok: true,
-      contacts: contacts.map(prepareContactResponse),
-    };
+    rethrowGatewayError(err);
   }
 }
 
@@ -240,25 +231,10 @@ export async function handleGetContact(contactId: string) {
       assistantMetadata: assistantMetadata ?? undefined,
     };
   } catch (err) {
-    // A clean not-found is a real 404 — don't fall back or mask it.
+    // A clean not-found is a real 404. Any other relay failure fails closed
+    // rather than reading ACL from the assistant DB.
     if (err instanceof NotFoundError) throw err;
-    log.warn(
-      { err, contactId },
-      "handleGetContact: gateway relay failed; falling back to assistant DB",
-    );
-    const contact = getContact(contactId);
-    if (!contact) {
-      throw new NotFoundError(`Contact "${contactId}" not found`);
-    }
-    const assistantMeta =
-      contact.contactType === "assistant"
-        ? getAssistantContactMetadata(contact.id)
-        : undefined;
-    return {
-      ok: true,
-      contact: prepareContactResponse(contact),
-      assistantMetadata: assistantMeta ?? undefined,
-    };
+    rethrowGatewayError(err);
   }
 }
 


### PR DESCRIPTION
## Summary
- Contacts list/get/search always source role/status/policy/verifiedAt/stats from the gateway rich relay; remove the assistant-DB ACL fallback (fail-closed if relay unavailable). INFO fields stay locally joined.

Part of plan: combo11-phase-a-read-decoupling.md (PR 3 of 11)