### PR TITLE
fix(daemon): gate channel revoke/verify on gateway delivery state

### DIFF
--- a/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+import type { ContactChannel } from "../../../contacts/types.js";
+
+let mockGuardians: GuardianDelivery[] | null = null;
+let mockBinding: { guardianExternalUserId: string; guardianDeliveryChatId: string } | null = null;
+let mockContactChannel: { channel: ContactChannel } | null = null;
+let mockChannel: ContactChannel | null = null;
+let ipcCalls: Array<{ method: string; payload: unknown }> = [];
+
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async (input?: { channelTypes?: string[] }) => {
+    if (mockGuardians == null) return null;
+    if (!input?.channelTypes) return mockGuardians;
+    return mockGuardians.filter((g) =>
+      input.channelTypes!.includes(g.channelType),
+    );
+  },
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findContactChannel: () => mockContactChannel,
+  findGuardianForChannel: () => null,
+  getChannelById: () => mockChannel,
+  getContact: () => ({ id: "contact-1", displayName: "Pat" }),
+}));
+
+mock.module("../../../contacts/contact-events.js", () => ({
+  emitContactChange: () => {},
+  onContactChange: () => {},
+}));
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (method: string, payload: unknown) => {
+    ipcCalls.push({ method, payload });
+    return {
+      ok: true,
+      didWrite: true,
+      channel: {
+        id: "ch-1",
+        contactId: "contact-1",
+        type: "telegram",
+        address: "user-123",
+        status: "revoked",
+        revokedReason: "guardian_binding_revoked",
+      },
+    };
+  },
+  ipcCall: async () => null,
+}));
+
+mock.module("../../../runtime/channel-verification-service.js", () => ({
+  getGuardianBinding: () => mockBinding,
+  revokeBinding: () => true,
+  revokePendingSessions: () => {},
+  createOutboundSession: () => ({
+    sessionId: "sess",
+    secret: "code",
+    expiresAt: Date.now() + 1000,
+  }),
+  countRecentSendsToDestination: () => 0,
+  isGuardianBoundForChannel: async () => false,
+  updateSessionDelivery: () => {},
+}));
+
+mock.module("../../../runtime/verification-outbound-actions.js", () => ({
+  cancelOutbound: () => {},
+  deliverVerificationEmail: () => {},
+  deliverVerificationSlack: () => {},
+  deliverVerificationTelegram: () => {},
+  DESTINATION_RATE_WINDOW_MS: 1000,
+  MAX_SENDS_PER_DESTINATION_WINDOW: 5,
+  normalizeTelegramDestination: (d: string) => d,
+  resendOutbound: () => ({}),
+  startOutbound: async () => ({}),
+}));
+
+import {
+  revokeVerificationForChannel,
+  verifyTrustedContact,
+} from "../config-channels.js";
+
+function channel(overrides: Partial<ContactChannel> = {}): ContactChannel {
+  return {
+    id: "ch-1",
+    contactId: "contact-1",
+    type: "telegram",
+    address: "user-123",
+    isPrimary: true,
+    externalChatId: "chat-123",
+    // DB columns are intentionally a terminal state to prove the gates ignore
+    // them and read from the gateway delivery instead.
+    status: "revoked",
+    policy: {} as ContactChannel["policy"],
+    verifiedAt: null,
+    verifiedVia: null,
+    inviteId: null,
+    revokedReason: null,
+    blockedReason: null,
+    lastSeenAt: null,
+    interactionCount: 0,
+    lastInteraction: null,
+    updatedAt: null,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+function delivery(overrides: Partial<GuardianDelivery> = {}): GuardianDelivery {
+  return {
+    channelType: "telegram",
+    contactId: "contact-1",
+    address: "user-123",
+    externalChatId: "chat-123",
+    status: "active",
+    verifiedAt: 1700000000,
+    ...overrides,
+  };
+}
+
+describe("revokeVerificationForChannel", () => {
+  beforeEach(() => {
+    mockGuardians = null;
+    mockBinding = { guardianExternalUserId: "user-123", guardianDeliveryChatId: "chat-123" };
+    mockContactChannel = { channel: channel() };
+    ipcCalls = [];
+  });
+
+  test("relays mark_channel_revoked when the gateway delivery is live", async () => {
+    mockGuardians = [delivery({ status: "active" })];
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).toContain("mark_channel_revoked");
+  });
+
+  test("skips a redundant revoke when the gateway delivery is already revoked", async () => {
+    // Local DB status is the live "active" here, but the gateway (SoT) says
+    // revoked — the gate must follow the gateway and not relay.
+    mockContactChannel = { channel: channel({ status: "active" }) };
+    mockGuardians = [delivery({ status: "revoked" })];
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).not.toContain("mark_channel_revoked");
+  });
+
+  test("skips the relay when the gateway has no delivery for the channel", async () => {
+    mockGuardians = [];
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).not.toContain("mark_channel_revoked");
+  });
+
+  test("skips the relay when the gateway is unreachable", async () => {
+    mockGuardians = null;
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).not.toContain("mark_channel_revoked");
+  });
+});
+
+describe("verifyTrustedContact already-verified gate", () => {
+  beforeEach(() => {
+    mockGuardians = null;
+    mockChannel = channel();
+  });
+
+  test("short-circuits when the gateway delivery is active and verified", async () => {
+    mockGuardians = [delivery({ status: "active", verifiedAt: 1700000000 })];
+    const result = await verifyTrustedContact("ch-1", "assistant-1");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("already_verified");
+  });
+
+  test("does not short-circuit when the gateway delivery has no verifiedAt", async () => {
+    // DB column says verified, but the gateway delivery is unverified — proceed.
+    mockChannel = channel({ status: "active", verifiedAt: 1700000000 });
+    mockGuardians = [delivery({ status: "active", verifiedAt: null })];
+    const result = await verifyTrustedContact("ch-1", "assistant-1");
+    expect(result.error).not.toBe("already_verified");
+  });
+
+  test("does not short-circuit when the gateway has no delivery", async () => {
+    mockGuardians = [];
+    const result = await verifyTrustedContact("ch-1", "assistant-1");
+    expect(result.error).not.toBe("already_verified");
+  });
+});

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
 import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { startVerificationCall } from "../../calls/call-domain.js";
@@ -11,7 +12,8 @@ import {
   getChannelById,
   getContact,
 } from "../../contacts/contact-store.js";
-import type { ChannelStatus } from "../../contacts/types.js";
+import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
+import type { ContactChannel } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { getBindingByChannelChat } from "../../memory/external-conversation-store.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
@@ -75,6 +77,29 @@ export function getReadinessService(): ChannelReadinessService {
     _readinessService = createReadinessService();
   }
   return _readinessService;
+}
+
+// ---------------------------------------------------------------------------
+// Gateway delivery lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the gateway-owned delivery (ACL source of truth) for a contact
+ * channel, matching on type and either address or externalChatId. Returns
+ * `undefined` when the gateway is unreachable or has no binding for it.
+ */
+async function deliveryForChannel(
+  channel: Pick<ContactChannel, "type" | "address" | "externalChatId">,
+): Promise<GuardianDelivery | undefined> {
+  const guardians = await getGuardianDelivery({ channelTypes: [channel.type] });
+  if (!guardians) return undefined;
+  return guardians.find(
+    (g) =>
+      g.channelType === channel.type &&
+      ((channel.address && g.address === channel.address) ||
+        (channel.externalChatId != null &&
+          g.externalChatId === channel.externalChatId)),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -206,13 +231,16 @@ export async function revokeVerificationForChannel(
 
   // Relay the ACL downgrade to the gateway (source of truth). The gateway's
   // mark_channel_revoked enforces the guardian guard and dual-writes the
-  // contact-channel status back to the assistant DB.
+  // contact-channel status back to the assistant DB. Gate on the gateway
+  // delivery's live status, not the assistant DB column, so a redundant revoke
+  // is still skipped for an already-revoked binding.
   if (contactResult) {
-    const channelStatus: ChannelStatus = contactResult.channel.status;
+    const delivery = await deliveryForChannel(contactResult.channel);
+    const deliveryStatus = delivery?.status;
     if (
-      channelStatus === "active" ||
-      channelStatus === "pending" ||
-      channelStatus === "unverified"
+      deliveryStatus === "active" ||
+      deliveryStatus === "pending" ||
+      deliveryStatus === "unverified"
     ) {
       const result = await ipcCallPersistent("mark_channel_revoked", {
         contactChannelId: contactResult.channel.id,
@@ -294,7 +322,10 @@ export async function verifyTrustedContact(
     };
   }
 
-  if (channel.status === "active" && channel.verifiedAt != null) {
+  // Already-verified short-circuit derived from the gateway delivery (ACL SoT)
+  // rather than the assistant DB status/verifiedAt columns.
+  const delivery = await deliveryForChannel(channel);
+  if (delivery?.status === "active" && delivery.verifiedAt != null) {
     return {
       success: false,
       error: "already_verified",

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -10,6 +10,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 
 type IpcCall = { method: string; params?: Record<string, unknown> };
@@ -73,14 +74,36 @@ mock.module("../../channel-verification-service.js", () => ({
   getGuardianBinding: mock(() => guardianBinding),
 }));
 
-// Contact-store lookup that resolves the guardian's channel to downgrade.
-let contactChannel: { id: string; status: string } | null = null;
+// Contact-store lookup that resolves the guardian's channel to downgrade. The
+// channel carries the type/address/externalChatId the gateway delivery is
+// matched against (see deliveryForChannel).
+let contactChannel: {
+  id: string;
+  status: string;
+  type: string;
+  address: string;
+  externalChatId: string;
+} | null = null;
 const actualContactStore = await import("../../../contacts/contact-store.js");
 mock.module("../../../contacts/contact-store.js", () => ({
   ...actualContactStore,
   findContactChannel: mock(() =>
     contactChannel ? { channel: contactChannel, contact: { id: "c1" } } : null,
   ),
+}));
+
+// Gateway delivery (ACL source of truth). The revoke gate relays only when the
+// matching delivery is live (active/pending/unverified); already-revoked or a
+// missing delivery short-circuits the relay.
+let guardianDeliveries: GuardianDelivery[] | null = null;
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: mock(async (input?: { channelTypes?: string[] }) => {
+    if (guardianDeliveries == null) return null;
+    if (!input?.channelTypes) return guardianDeliveries;
+    return guardianDeliveries.filter((g) =>
+      input.channelTypes!.includes(g.channelType),
+    );
+  }),
 }));
 
 // Guard: the contact-channel ACL write moves to the gateway relay and must
@@ -122,7 +145,24 @@ describe("verification revoke relay", () => {
       guardianExternalUserId: "guardian-user",
       guardianDeliveryChatId: "chat-1",
     };
-    contactChannel = { id: "ch1", status: "active" };
+    contactChannel = {
+      id: "ch1",
+      status: "active",
+      type: "telegram",
+      address: "guardian-user",
+      externalChatId: "chat-1",
+    };
+    // Gateway delivery is live by default, so the revoke relay fires.
+    guardianDeliveries = [
+      {
+        channelType: "telegram",
+        contactId: "c1",
+        address: "guardian-user",
+        externalChatId: "chat-1",
+        status: "active",
+        verifiedAt: 1700000000,
+      },
+    ];
     ipcCallPersistentMock.mockClear();
     cancelOutboundMock.mockClear();
     revokePendingSessionsMock.mockClear();
@@ -263,8 +303,19 @@ describe("verification revoke relay", () => {
     expect(result.bound).toBe(false);
   });
 
-  test("skips the relay when the resolved channel is already revoked", async () => {
-    contactChannel = { id: "ch1", status: "revoked" };
+  test("skips the relay when the gateway delivery is already revoked", async () => {
+    // The gateway (source of truth) already shows the channel revoked, so the
+    // redundant relay is skipped even though session/binding teardown runs.
+    guardianDeliveries = [
+      {
+        channelType: "telegram",
+        contactId: "c1",
+        address: "guardian-user",
+        externalChatId: "chat-1",
+        status: "revoked",
+        verifiedAt: 1700000000,
+      },
+    ];
 
     await revokeHandler({ body: { channel: "telegram" } });
 


### PR DESCRIPTION
## Summary
- config-channels revoke + re-verify gates derive channel status/verifiedAt from the gateway delivery instead of the assistant-DB ACL columns; relay behavior unchanged for the same gateway state.

Part of plan: combo11-phase-a-read-decoupling.md (PR 5 of 11)