### PR TITLE
refactor(subagent): share projection diff-classification and test fixtures

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -34,16 +34,17 @@ mock.module("@/domains/chat/components/subagent-phase-timeline", () => ({
   }: {
     onStepDetailClick?: (detailKey: string) => void;
     expandedKeys?: Set<string>;
-    onExpandedKeysChange?: (next: Set<string>) => void;
+    onExpandedKeysChange?: (updater: (prev: Set<string>) => Set<string>) => void;
   }) => (
     <div data-testid="timeline">
       {/* Surfaces the controlled expand state so a test can assert the panel
-          preserves it across the detail view swap. */}
+          preserves it across the detail view swap. The real timeline drives the
+          functional-updater form, so the stub exercises the same contract. */}
       <button
         type="button"
         data-testid="timeline-expand"
         onClick={() =>
-          onExpandedKeysChange?.(new Set(expandedKeys).add("grp-1"))
+          onExpandedKeysChange?.((prev) => new Set(prev).add("grp-1"))
         }
       >
         {expandedKeys?.has("grp-1") ? "group-open" : "group-closed"}

--- a/clients/web/src/domains/chat/subagent-detail-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.test.ts
@@ -17,28 +17,48 @@ import {
   applyDetailEvent,
   buildSubagentStepDetails,
 } from "@/domains/chat/hooks/use-subagent-card-data";
+import {
+  NOW,
+  appendEvent,
+  applyMutation as applyMutationShared,
+  coalesceText as coalesceTextShared,
+  createMakeEvent,
+  generateStream as generateStreamShared,
+  type Mutation,
+} from "@/domains/chat/subagent-projection-test-fixtures";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
-
-const NOW = 1700000000000;
 
 let eventSeq = 0;
 function nextEventId(): string {
   return `de-${eventSeq++}`;
 }
 
-function makeEvent(
-  overrides: Partial<SubagentTimelineEvent> & {
-    type: SubagentTimelineEvent["type"];
-  },
-  ts: number = NOW,
-): SubagentTimelineEvent {
-  return {
-    id: nextEventId(),
-    content: "",
-    timestamp: ts,
-    ...overrides,
-  };
+const makeEvent = createMakeEvent(nextEventId);
+
+// Bind the shared simulator/generator to this suite's `makeEvent`. The detail
+// suite attaches tool metadata to `error` events that CLOSE an in-flight tool
+// (`errorEventsCarryToolMeta`) so the failed-tool payload is keyed by
+// `toolUseId` and carries the error — its one divergence from the step suite.
+function coalesceText(
+  events: SubagentTimelineEvent[],
+  delta: string,
+  ts: number,
+): SubagentTimelineEvent[] {
+  return coalesceTextShared(events, delta, ts, makeEvent);
+}
+
+function generateStream(seed: number, n: number): Mutation[] {
+  return generateStreamShared(seed, n, makeEvent, {
+    errorEventsCarryToolMeta: true,
+  });
+}
+
+function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+): SubagentTimelineEvent[] {
+  return applyMutationShared(events, m, makeEvent);
 }
 
 /**
@@ -58,42 +78,6 @@ function expectMapsEqual(
   full: Map<string, ToolDetailPayload>,
 ): void {
   expect(mapToSortedEntries(incremental)).toEqual(mapToSortedEntries(full));
-}
-
-// ---------------------------------------------------------------------------
-// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
-// incremental array shapes so the projector is fed precisely what it sees live.
-// ---------------------------------------------------------------------------
-
-/** Append a fresh event, returning a NEW array (prior elements shared). */
-function appendEvent(
-  events: SubagentTimelineEvent[],
-  event: SubagentTimelineEvent,
-): SubagentTimelineEvent[] {
-  return [...events, event];
-}
-
-/**
- * Grow the trailing text event's content by `delta`, returning a NEW array with
- * only the last element replaced (same `id`, longer `content`) — the store's
- * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
- * event when the tail isn't text (matching `receiveEvent`).
- */
-function coalesceText(
-  events: SubagentTimelineEvent[],
-  delta: string,
-  ts: number,
-): SubagentTimelineEvent[] {
-  const last = events[events.length - 1];
-  if (last && last.type === "text") {
-    const updated = [...events];
-    updated[updated.length - 1] = {
-      ...last,
-      content: last.content + delta,
-    };
-    return updated;
-  }
-  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
 }
 
 // ---------------------------------------------------------------------------
@@ -347,133 +331,6 @@ describe("createIncrementalDetailProjection — per-diff-class", () => {
     expect(map.has("")).toBe(false);
   });
 });
-
-// ---------------------------------------------------------------------------
-// Deterministic event-stream generator (tiny LCG; no Math.random).
-// ---------------------------------------------------------------------------
-
-/** Numerical Recipes LCG — deterministic, seedable. */
-function makeRng(seed: number) {
-  let state = (seed >>> 0) || 1;
-  return () => {
-    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
-    return state / 0xffffffff;
-  };
-}
-
-type Mutation =
-  | { kind: "append"; event: SubagentTimelineEvent }
-  | { kind: "coalesce"; delta: string };
-
-/**
- * Generate a deterministic sequence of store mutations: text deltas (coalesced
- * when consecutive), tool calls, their results/errors, and web_search/web_fetch
- * — covering every reducer branch. Tracks open tool ids so results/errors close
- * real in-flight calls.
- */
-function generateStream(seed: number, n: number): Mutation[] {
-  const rng = makeRng(seed);
-  const mutations: Mutation[] = [];
-  const openTools: Array<{ id: string; toolName: string }> = [];
-  let lastWasText = false;
-  let ts = NOW;
-
-  for (let i = 0; i < n; i++) {
-    ts += 1 + Math.floor(rng() * 50);
-    const roll = rng();
-
-    // Bias toward text + appends so coalescing fires often.
-    if (roll < 0.45) {
-      const delta = "w".repeat(1 + Math.floor(rng() * 40));
-      if (lastWasText) {
-        mutations.push({ kind: "coalesce", delta });
-      } else {
-        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
-        lastWasText = true;
-      }
-      continue;
-    }
-
-    lastWasText = false;
-
-    if (roll < 0.7) {
-      // Open a tool call (regular / web_search / web_fetch).
-      const toolRoll = rng();
-      const id = `t-${seed}-${i}`;
-      if (toolRoll < 0.2) {
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
-        });
-        openTools.push({ id, toolName: "web_search" });
-      } else if (toolRoll < 0.35) {
-        // web_fetch has no follow-up — keyed by id, no open tracking.
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
-        });
-      } else {
-        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
-        });
-        openTools.push({ id, toolName });
-      }
-      continue;
-    }
-
-    if (roll < 0.9 && openTools.length > 0) {
-      // Close an open tool with a result (maybe an error result).
-      const idx = Math.floor(rng() * openTools.length);
-      const open = openTools.splice(idx, 1)[0]!;
-      const isError = rng() < 0.25;
-      mutations.push({
-        kind: "append",
-        event: makeEvent(
-          {
-            type: "tool_result",
-            toolName: open.toolName,
-            toolUseId: open.id,
-            isError,
-            result: isError ? "boom" : `result-${i}`,
-            content: `result-${i}`,
-          },
-          ts,
-        ),
-      });
-      continue;
-    }
-
-    if (openTools.length > 0) {
-      // Close an open tool with a raw error event.
-      const idx = Math.floor(rng() * openTools.length);
-      const open = openTools.splice(idx, 1)[0]!;
-      mutations.push({
-        kind: "append",
-        event: makeEvent({ type: "error", toolName: open.toolName, toolUseId: open.id, isError: true, result: `err-${i}`, content: `err-${i}` }, ts),
-      });
-      continue;
-    }
-
-    // Nothing open — emit a standalone error row.
-    mutations.push({
-      kind: "append",
-      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
-    });
-  }
-
-  return mutations;
-}
-
-function applyMutation(
-  events: SubagentTimelineEvent[],
-  m: Mutation,
-): SubagentTimelineEvent[] {
-  return m.kind === "append"
-    ? appendEvent(events, m.event)
-    : coalesceText(events, m.delta, NOW);
-}
 
 // ---------------------------------------------------------------------------
 // No-drift property test — the core safety net.

--- a/clients/web/src/domains/chat/subagent-detail-projection.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.ts
@@ -44,6 +44,7 @@
 import { useRef } from "react";
 
 import { applyDetailEvent } from "@/domains/chat/hooks/use-subagent-card-data";
+import { classifyEventsDiff } from "@/domains/chat/subagent-projection-diff";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
@@ -105,91 +106,74 @@ export function createIncrementalDetailProjection(
   function project(
     events: SubagentTimelineEvent[],
   ): Map<string, ToolDetailPayload> {
-    // Identity — also covers events-stable status/usage updates.
-    if (events === prevEvents) return map;
+    // The diff classification (including the subtle cross-subagent `detail-1`
+    // id-collision guard) is shared with the step projector — see
+    // `subagent-projection-diff.ts`.
+    const diff = classifyEventsDiff(prevEvents, events);
 
-    // First call / empty cache.
-    if (prevEvents == null) return fullBuild(events);
+    switch (diff.kind) {
+      // Identity — also covers events-stable status/usage updates.
+      case "identity":
+        return map;
 
-    const prevLen = prevEvents.length;
-    const len = events.length;
+      // First call / empty cache.
+      case "first":
+        return fullBuild(events);
 
-    // Append: same prefix, one-or-more new events at the tail. The O(1)
-    // boundary checks (first + last-of-prev still share their references)
-    // distinguish a genuine append from a full-replace whose new array happens
-    // to be longer.
-    if (
-      len > prevLen &&
-      (prevLen === 0 ||
-        (events[0] === prevEvents[0] &&
-          events[prevLen - 1] === prevEvents[prevLen - 1]))
-    ) {
-      const payloadsClone = payloads.slice();
-      const metaClone = meta.slice();
-      for (let i = prevLen; i < len; i++) {
-        reducer(payloadsClone, metaClone, events[i]!);
-      }
-      prevEvents = events;
-      payloads = payloadsClone;
-      meta = metaClone;
-      // The Map build is O(n) but pointer-cheap — the expensive per-event
-      // parsing (parseWebSearchResultText, deriveStepLabelFromName) already ran
-      // only for the appended events inside the reducer above.
-      map = payloadsToMap(payloads);
-      return map;
-    }
-
-    // Mutate-last: text-delta coalescing. Same length, only the last element
-    // replaced, every earlier element shared. We require the genuine
-    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
-    // equality: both last events must be `type: "text"` and the new content must
-    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
-    // alone is insufficient because `mapDetailEvents` restarts event ids at
-    // `detail-1` per subagent — a single-event subagent switch collides on
-    // `id === "detail-1"` and would be misclassified, surviving a stale tool
-    // entry. The type + content-extension guards reject that collision (different
-    // type, or content that isn't a strict extension → Fallback full rebuild).
-    if (
-      len === prevLen &&
-      len >= 1 &&
-      events[len - 1] !== prevEvents[len - 1] &&
-      events[len - 1]!.id === prevEvents[len - 1]!.id &&
-      prevEvents[len - 1]!.type === "text" &&
-      events[len - 1]!.type === "text" &&
-      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
-      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
-      (len === 1 || events[len - 2] === prevEvents[len - 2])
-    ) {
-      const payloadsClone = payloads.slice();
-      const metaClone = meta.slice();
-
-      // A text event contributes 0 or 1 trailing `thinking` payload (keyed by
-      // the event id) and never mutates earlier payloads, so popping the keyed
-      // tail (if present) and re-applying the grown event reproduces the full
-      // rebuild exactly. Unlike the step projection there is NO tail-identity
-      // shortcut: `thinkingText` carries the full untruncated content, so the
-      // payload changes on every delta — but the replay is still O(Δ).
-      const tail = payloadsClone[payloadsClone.length - 1];
-      if (
-        tail &&
-        tail.kind === "thinking" &&
-        tail.toolCallId === events[len - 1]!.id
-      ) {
-        payloadsClone.pop();
-        metaClone.pop();
+      // Append: same prefix, one-or-more new events at the tail. Replay only
+      // the appended events through the reducer.
+      case "append": {
+        const len = events.length;
+        const payloadsClone = payloads.slice();
+        const metaClone = meta.slice();
+        for (let i = diff.from; i < len; i++) {
+          reducer(payloadsClone, metaClone, events[i]!);
+        }
+        prevEvents = events;
+        payloads = payloadsClone;
+        meta = metaClone;
+        // The Map build is O(n) but pointer-cheap — the expensive per-event
+        // parsing (parseWebSearchResultText, deriveStepLabelFromName) already ran
+        // only for the appended events inside the reducer above.
+        map = payloadsToMap(payloads);
+        return map;
       }
 
-      reducer(payloadsClone, metaClone, events[len - 1]!);
+      // Mutate-last: text-delta coalescing. Re-apply only the grown tail.
+      case "mutate-last": {
+        const len = events.length;
+        const payloadsClone = payloads.slice();
+        const metaClone = meta.slice();
 
-      prevEvents = events;
-      payloads = payloadsClone;
-      meta = metaClone;
-      map = payloadsToMap(payloads);
-      return map;
+        // A text event contributes 0 or 1 trailing `thinking` payload (keyed by
+        // the event id) and never mutates earlier payloads, so popping the keyed
+        // tail (if present) and re-applying the grown event reproduces the full
+        // rebuild exactly. Unlike the step projection there is NO tail-identity
+        // shortcut: `thinkingText` carries the full untruncated content, so the
+        // payload changes on every delta — but the replay is still O(Δ).
+        const tail = payloadsClone[payloadsClone.length - 1];
+        if (
+          tail &&
+          tail.kind === "thinking" &&
+          tail.toolCallId === events[len - 1]!.id
+        ) {
+          payloadsClone.pop();
+          metaClone.pop();
+        }
+
+        reducer(payloadsClone, metaClone, events[len - 1]!);
+
+        prevEvents = events;
+        payloads = payloadsClone;
+        meta = metaClone;
+        map = payloadsToMap(payloads);
+        return map;
+      }
+
+      // Fallback — full-replace / truncation / reorder / violated assumption.
+      case "fallback":
+        return fullBuild(events);
     }
-
-    // Fallback — full-replace / truncation / reorder / violated assumption.
-    return fullBuild(events);
   }
 
   return { project };

--- a/clients/web/src/domains/chat/subagent-projection-diff.test.ts
+++ b/clients/web/src/domains/chat/subagent-projection-diff.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the shared diff classifier (`classifyEventsDiff`) extracted from the
+ * two incremental subagent projectors. Each `kind` is covered, including the two
+ * cases that MUST fall back to a full rebuild: the cross-subagent `detail-1`
+ * id-collision (single-event subagent switch that would be misclassified as
+ * mutate-last by id alone) and a full-replace. The projectors' own no-drift
+ * property tests are the end-to-end safety net; these pin the classifier itself.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { classifyEventsDiff } from "@/domains/chat/subagent-projection-diff";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+const NOW = 1700000000000;
+
+let seq = 0;
+function textEvent(content: string): SubagentTimelineEvent {
+  return { id: `e-${seq++}`, type: "text", content, timestamp: NOW };
+}
+function toolCallEvent(toolUseId: string): SubagentTimelineEvent {
+  return {
+    id: `e-${seq++}`,
+    type: "tool_call",
+    content: "ls",
+    toolName: "bash",
+    toolUseId,
+    timestamp: NOW,
+  };
+}
+
+describe("classifyEventsDiff", () => {
+  test("identity: same array reference", () => {
+    const events = [textEvent("hi")];
+    expect(classifyEventsDiff(events, events)).toEqual({ kind: "identity" });
+  });
+
+  test("first: no previous array (null cache)", () => {
+    const events = [textEvent("hi")];
+    expect(classifyEventsDiff(null, events)).toEqual({ kind: "first" });
+  });
+
+  test("first: from an empty cache, a non-empty array is still a first build when prev is null", () => {
+    expect(classifyEventsDiff(null, [])).toEqual({ kind: "first" });
+  });
+
+  test("append: same prefix, one new event at the tail — `from` is prevEvents.length", () => {
+    const a = textEvent("first");
+    const prev = [a];
+    const events = [a, textEvent("second")];
+    expect(classifyEventsDiff(prev, events)).toEqual({ kind: "append", from: 1 });
+  });
+
+  test("append: multiple new events at the tail", () => {
+    const a = textEvent("a");
+    const b = toolCallEvent("tu-1");
+    const prev = [a, b];
+    const events = [a, b, textEvent("c"), toolCallEvent("tu-2")];
+    expect(classifyEventsDiff(prev, events)).toEqual({ kind: "append", from: 2 });
+  });
+
+  test("append: growing from an empty previous array", () => {
+    const events = [textEvent("a")];
+    expect(classifyEventsDiff([], events)).toEqual({ kind: "append", from: 0 });
+  });
+
+  test("append rejected when the shared-prefix boundary references differ → fallback", () => {
+    // Longer array, but `events[0]` is a different object (no shared prefix):
+    // a full-replace whose new array merely happens to be longer.
+    const prev = [textEvent("a")];
+    const events = [textEvent("a"), textEvent("b")];
+    expect(classifyEventsDiff(prev, events)).toEqual({ kind: "fallback" });
+  });
+
+  test("mutate-last: genuine text coalescing (same id, text→text, strict content extension)", () => {
+    const a = textEvent("Investig");
+    const prev = [a];
+    // Same id, longer content that strictly extends the old — the store's
+    // text-delta coalescing shape.
+    const grown: SubagentTimelineEvent = { ...a, content: "Investigating" };
+    expect(classifyEventsDiff(prev, [grown])).toEqual({ kind: "mutate-last" });
+  });
+
+  test("mutate-last: coalescing with a shared earlier prefix", () => {
+    const head = toolCallEvent("tu-1");
+    const a = textEvent("Inv");
+    const prev = [head, a];
+    const grown: SubagentTimelineEvent = { ...a, content: "Investigating" };
+    expect(classifyEventsDiff(prev, [head, grown])).toEqual({
+      kind: "mutate-last",
+    });
+  });
+
+  test("fallback: cross-subagent detail-1 id collision is NOT mutate-last", () => {
+    // `mapDetailEvents` restarts ids at `detail-1` per subagent. Two
+    // single-event subagents collide on `id === "detail-1"`, but the last events
+    // differ in type/content, so the content-shape guards force a fallback (a
+    // full rebuild), NOT a mutate-last that would carry a stale entry over.
+    const subagentA: SubagentTimelineEvent[] = [
+      {
+        id: "detail-1",
+        type: "tool_call",
+        content: "ls",
+        toolName: "bash",
+        toolUseId: "tu-a",
+        timestamp: NOW,
+      },
+    ];
+    const subagentB: SubagentTimelineEvent[] = [
+      { id: "detail-1", type: "text", content: "B is thinking", timestamp: NOW },
+    ];
+    expect(classifyEventsDiff(subagentA, subagentB)).toEqual({
+      kind: "fallback",
+    });
+  });
+
+  test("fallback: same id + same length but content shrinks (not a strict extension)", () => {
+    const a = textEvent("Investigating");
+    const prev = [a];
+    const shrunk: SubagentTimelineEvent = { ...a, content: "Inv" };
+    expect(classifyEventsDiff(prev, [shrunk])).toEqual({ kind: "fallback" });
+  });
+
+  test("fallback: full-replace (wholesale array swap, no shared prefix)", () => {
+    const prev = [textEvent("live")];
+    const hydrated = [textEvent("hydrated-1"), toolCallEvent("h-1")];
+    expect(classifyEventsDiff(prev, hydrated)).toEqual({ kind: "fallback" });
+  });
+
+  test("fallback: truncation (shorter array)", () => {
+    const a = textEvent("a");
+    const b = textEvent("b");
+    const prev = [a, b];
+    expect(classifyEventsDiff(prev, [a])).toEqual({ kind: "fallback" });
+  });
+});

--- a/clients/web/src/domains/chat/subagent-projection-diff.ts
+++ b/clients/web/src/domains/chat/subagent-projection-diff.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared diff classification for the two incremental subagent projectors
+ * (`subagent-step-projection.ts` and `subagent-detail-projection.ts`).
+ *
+ * Both projectors face the IDENTICAL problem: classify the diff between the
+ * previous `events` array and the new one into one of the store's known
+ * mutation shapes, then replay only the changed events through their own
+ * reducer. The classification guards are subtle (especially the cross-subagent
+ * `detail-1` id-collision guard), so they live here ONCE — extracting them
+ * prevents the two copies from drifting apart.
+ *
+ * Background — the store mutates `entry.events` in exactly three shapes
+ * (verified in `subagent-store.ts` `receiveEvent` / `loadDetail`):
+ *
+ *  1. **Append-1** — a new `tool_call` / `tool_result` / `error` / first `text`
+ *     event lands → `events: [...existing.events, ev]`. A new array, but every
+ *     prior element keeps its reference and exactly one element is appended at
+ *     the tail.
+ *  2. **Mutate-last** — consecutive `assistant_text_delta`s coalesce → the array
+ *     is copied (`[...existing.events]`) with only the **last** element replaced
+ *     by `{ ...lastEvent, content: lastEvent.content + delta }`. Same length,
+ *     same element references except the last, the last keeps the **same `id`**,
+ *     and its `content` only grows. Always a `text` event. We classify this shape
+ *     by the text-coalescing CONTENT shape — both last events `type: "text"` and
+ *     the new content strictly EXTENDS the old (`startsWith` + non-shrinking
+ *     length) — not just last-id equality. `mapDetailEvents` restarts ids at
+ *     `detail-1` per subagent, so two different subagents whose detail arrays each
+ *     have one event collide on `id === "detail-1"`; matching only by id would
+ *     misclassify a subagent switch as mutate-last and leave a stale step/entry
+ *     that a full rebuild drops (then a stale pill/key could open the previous
+ *     subagent's detail).
+ *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
+ *     subagent switch).
+ *
+ * Any diff that doesn't fit the append / mutate-last shapes (full-replace,
+ * truncation, reorder, or a violated assumption) is classified `fallback`, which
+ * the projectors handle with a full O(n) rebuild that is always correct.
+ */
+
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+/**
+ * The classification of a diff between `prevEvents` and `events`.
+ *
+ * - `identity` — same array reference; nothing changed.
+ * - `first` — no previous array (first call / empty cache); build from scratch.
+ * - `append` — same prefix, one-or-more new events at the tail. `from` is the
+ *   index to start replaying the appended events (i.e. `prevEvents.length`).
+ * - `mutate-last` — text-delta coalescing: same length, only the last element
+ *   replaced by a strict content extension, every earlier element shared.
+ * - `fallback` — full-replace / truncation / reorder / violated assumption.
+ */
+export type EventsDiff =
+  | { kind: "identity" }
+  | { kind: "first" }
+  | { kind: "append"; from: number }
+  | { kind: "mutate-last" }
+  | { kind: "fallback" };
+
+/**
+ * Classify the diff between the previous `events` array and the new one into one
+ * of the store's known mutation shapes. Pure and O(1) — only reference and
+ * tail-content checks, no walk of the arrays.
+ */
+export function classifyEventsDiff(
+  prevEvents: SubagentTimelineEvent[] | null,
+  events: SubagentTimelineEvent[],
+): EventsDiff {
+  // Identity — also covers PR2's events-stable status/usage updates.
+  if (events === prevEvents) return { kind: "identity" };
+
+  // First call / empty cache.
+  if (prevEvents == null) return { kind: "first" };
+
+  const prevLen = prevEvents.length;
+  const len = events.length;
+
+  // Append: same prefix, one-or-more new events at the tail. The O(1)
+  // boundary checks (first + last-of-prev still share their references)
+  // distinguish a genuine append from a full-replace whose new array happens
+  // to be longer.
+  if (
+    len > prevLen &&
+    (prevLen === 0 ||
+      (events[0] === prevEvents[0] &&
+        events[prevLen - 1] === prevEvents[prevLen - 1]))
+  ) {
+    return { kind: "append", from: prevLen };
+  }
+
+  // Mutate-last: text-delta coalescing. Same length, only the last element
+  // replaced, every earlier element shared. We require the genuine
+  // text-coalescing CONTENT shape the store actually produces, NOT just last-id
+  // equality: both last events must be `type: "text"` and the new content must
+  // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
+  // alone is insufficient because `mapDetailEvents` restarts event ids at
+  // `detail-1` per subagent — a single-event subagent switch collides on
+  // `id === "detail-1"` and would be misclassified, surviving a stale step/entry.
+  // The type + content-extension guards reject that collision (different type, or
+  // content that isn't a strict extension → Fallback full rebuild).
+  if (
+    len === prevLen &&
+    len >= 1 &&
+    events[len - 1] !== prevEvents[len - 1] &&
+    events[len - 1]!.id === prevEvents[len - 1]!.id &&
+    prevEvents[len - 1]!.type === "text" &&
+    events[len - 1]!.type === "text" &&
+    events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
+    events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
+    (len === 1 || events[len - 2] === prevEvents[len - 2])
+  ) {
+    return { kind: "mutate-last" };
+  }
+
+  // Fallback — full-replace / truncation / reorder / violated assumption.
+  return { kind: "fallback" };
+}

--- a/clients/web/src/domains/chat/subagent-projection-test-fixtures.ts
+++ b/clients/web/src/domains/chat/subagent-projection-test-fixtures.ts
@@ -1,0 +1,236 @@
+/**
+ * Shared test fixtures for the two incremental subagent projector test files
+ * (`subagent-step-projection.test.ts` and `subagent-detail-projection.test.ts`).
+ *
+ * Both files drive their projector with the SAME deterministic store-mutation
+ * stream — a seedable LCG event generator plus an append/coalesce simulator that
+ * mirrors `subagent-store.receiveEvent`'s two incremental array shapes — so the
+ * generator lives here ONCE to keep the two suites in lockstep.
+ *
+ * The ONE genuine divergence between the two suites is parameterized: when an
+ * `error` event closes an in-flight tool, the detail suite attaches the tool's
+ * `toolName` / `toolUseId` / `isError` / `result` metadata (so the failed-tool
+ * payload is keyed and carries the error), while the step suite emits a bare
+ * error row. Pass `errorEventsCarryToolMeta` to `generateStream` to select.
+ */
+
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+export const NOW = 1700000000000;
+
+/** Numerical Recipes LCG — deterministic, seedable; no `Math.random`. */
+export function makeRng(seed: number): () => number {
+  let state = (seed >>> 0) || 1;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event factory. Each test file supplies its own `nextEventId` so the two
+// suites keep independent, file-local id sequences (`te-*` vs `de-*`).
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `makeEvent(overrides, ts?)` factory backed by `nextEventId`. Each test
+ * file calls this once with its own id generator so ids don't collide or couple
+ * across suites.
+ */
+export function createMakeEvent(
+  nextEventId: () => string,
+): (
+  overrides: Partial<SubagentTimelineEvent> & {
+    type: SubagentTimelineEvent["type"];
+  },
+  ts?: number,
+) => SubagentTimelineEvent {
+  return (overrides, ts = NOW) => ({
+    id: nextEventId(),
+    content: "",
+    timestamp: ts,
+    ...overrides,
+  });
+}
+
+type MakeEvent = ReturnType<typeof createMakeEvent>;
+
+// ---------------------------------------------------------------------------
+// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
+// incremental array shapes so the projector is fed precisely what it sees live.
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a fresh event to the events array, returning a NEW array (every prior
+ * element shared by reference). Models the store's "Append-1" shape.
+ */
+export function appendEvent(
+  events: SubagentTimelineEvent[],
+  event: SubagentTimelineEvent,
+): SubagentTimelineEvent[] {
+  return [...events, event];
+}
+
+/**
+ * Grow the trailing text event's content by `delta`, returning a NEW array with
+ * only the last element replaced (same `id`, longer `content`) — the store's
+ * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
+ * event when the tail isn't text (matching `receiveEvent`).
+ */
+export function coalesceText(
+  events: SubagentTimelineEvent[],
+  delta: string,
+  ts: number,
+  makeEvent: MakeEvent,
+): SubagentTimelineEvent[] {
+  const last = events[events.length - 1];
+  if (last && last.type === "text") {
+    const updated = [...events];
+    updated[updated.length - 1] = {
+      ...last,
+      content: last.content + delta,
+    };
+    return updated;
+  }
+  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic event-stream generator (tiny LCG; no Math.random).
+// ---------------------------------------------------------------------------
+
+export type Mutation =
+  | { kind: "append"; event: SubagentTimelineEvent }
+  | { kind: "coalesce"; delta: string };
+
+export interface GenerateStreamOptions {
+  /**
+   * When an `error` event closes an in-flight tool, attach the tool's
+   * `toolName` / `toolUseId` / `isError` / `result` metadata. The detail suite
+   * needs this so the failed-tool payload is keyed by `toolUseId` and carries
+   * the error; the step suite emits a bare error row instead. Defaults to
+   * `false`.
+   */
+  errorEventsCarryToolMeta?: boolean;
+}
+
+/**
+ * Generate a deterministic sequence of store mutations: text deltas (coalesced
+ * when consecutive), tool calls, their results/errors, and web_search/web_fetch
+ * — covering every reducer branch. Tracks open tool ids so results/errors close
+ * real in-flight calls.
+ */
+export function generateStream(
+  seed: number,
+  n: number,
+  makeEvent: MakeEvent,
+  { errorEventsCarryToolMeta = false }: GenerateStreamOptions = {},
+): Mutation[] {
+  const rng = makeRng(seed);
+  const mutations: Mutation[] = [];
+  const openTools: Array<{ id: string; toolName: string }> = [];
+  let lastWasText = false;
+  let ts = NOW;
+
+  for (let i = 0; i < n; i++) {
+    ts += 1 + Math.floor(rng() * 50);
+    const roll = rng();
+
+    // Bias toward text + appends so coalescing fires often.
+    if (roll < 0.45) {
+      const delta = "w".repeat(1 + Math.floor(rng() * 40));
+      if (lastWasText) {
+        mutations.push({ kind: "coalesce", delta });
+      } else {
+        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
+        lastWasText = true;
+      }
+      continue;
+    }
+
+    lastWasText = false;
+
+    if (roll < 0.7) {
+      // Open a tool call (regular / web_search / web_fetch).
+      const toolRoll = rng();
+      const id = `t-${seed}-${i}`;
+      if (toolRoll < 0.2) {
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
+        });
+        openTools.push({ id, toolName: "web_search" });
+      } else if (toolRoll < 0.35) {
+        // web_fetch has no follow-up — a thinking step, no open tracking.
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
+        });
+      } else {
+        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
+        });
+        openTools.push({ id, toolName });
+      }
+      continue;
+    }
+
+    if (roll < 0.9 && openTools.length > 0) {
+      // Close an open tool with a result (maybe an error result).
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      const isError = rng() < 0.25;
+      mutations.push({
+        kind: "append",
+        event: makeEvent(
+          {
+            type: "tool_result",
+            toolName: open.toolName,
+            toolUseId: open.id,
+            isError,
+            result: isError ? "boom" : `result-${i}`,
+            content: `result-${i}`,
+          },
+          ts,
+        ),
+      });
+      continue;
+    }
+
+    if (openTools.length > 0) {
+      // Close an open tool with a raw error event. The detail suite keys the
+      // failed-tool payload off the closed tool's metadata; the step suite
+      // emits a bare error row.
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      mutations.push({
+        kind: "append",
+        event: errorEventsCarryToolMeta
+          ? makeEvent({ type: "error", toolName: open.toolName, toolUseId: open.id, isError: true, result: `err-${i}`, content: `err-${i}` }, ts)
+          : makeEvent({ type: "error", content: `err-${i}` }, ts),
+      });
+      continue;
+    }
+
+    // Nothing open — emit a standalone error row.
+    mutations.push({
+      kind: "append",
+      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+    });
+  }
+
+  return mutations;
+}
+
+/** Apply one generated mutation to the events array (append or text coalesce). */
+export function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+  makeEvent: MakeEvent,
+): SubagentTimelineEvent[] {
+  return m.kind === "append"
+    ? appendEvent(events, m.event)
+    : coalesceText(events, m.delta, NOW, makeEvent);
+}

--- a/clients/web/src/domains/chat/subagent-step-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.test.ts
@@ -17,66 +17,44 @@ import {
   type ToolCallCardStep,
   type ToolMeta,
 } from "@/domains/chat/hooks/use-subagent-card-data";
+import {
+  NOW,
+  appendEvent,
+  applyMutation as applyMutationShared,
+  coalesceText as coalesceTextShared,
+  createMakeEvent,
+  generateStream as generateStreamShared,
+  type Mutation,
+} from "@/domains/chat/subagent-projection-test-fixtures";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
-
-const NOW = 1700000000000;
 
 let eventSeq = 0;
 function nextEventId(): string {
   return `te-${eventSeq++}`;
 }
 
-function makeEvent(
-  overrides: Partial<SubagentTimelineEvent> & {
-    type: SubagentTimelineEvent["type"];
-  },
-  ts: number = NOW,
-): SubagentTimelineEvent {
-  return {
-    id: nextEventId(),
-    content: "",
-    timestamp: ts,
-    ...overrides,
-  };
-}
+const makeEvent = createMakeEvent(nextEventId);
 
-// ---------------------------------------------------------------------------
-// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
-// incremental array shapes so the projector is fed precisely what it sees live.
-// ---------------------------------------------------------------------------
-
-/**
- * Append a fresh event to the events array, returning a NEW array (every prior
- * element shared by reference). Models the store's "Append-1" shape.
- */
-function appendEvent(
-  events: SubagentTimelineEvent[],
-  event: SubagentTimelineEvent,
-): SubagentTimelineEvent[] {
-  return [...events, event];
-}
-
-/**
- * Grow the trailing text event's content by `delta`, returning a NEW array with
- * only the last element replaced (same `id`, longer `content`) — the store's
- * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
- * event when the tail isn't text (matching `receiveEvent`).
- */
+// Bind the shared simulator/generator to this suite's `makeEvent` so each test
+// file keeps its own id sequence. The step suite emits BARE error rows when an
+// error closes a tool (no tool metadata) — the default `generateStream` shape.
 function coalesceText(
   events: SubagentTimelineEvent[],
   delta: string,
   ts: number,
 ): SubagentTimelineEvent[] {
-  const last = events[events.length - 1];
-  if (last && last.type === "text") {
-    const updated = [...events];
-    updated[updated.length - 1] = {
-      ...last,
-      content: last.content + delta,
-    };
-    return updated;
-  }
-  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
+  return coalesceTextShared(events, delta, ts, makeEvent);
+}
+
+function generateStream(seed: number, n: number): Mutation[] {
+  return generateStreamShared(seed, n, makeEvent);
+}
+
+function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+): SubagentTimelineEvent[] {
+  return applyMutationShared(events, m, makeEvent);
 }
 
 // ---------------------------------------------------------------------------
@@ -349,133 +327,6 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
     if (search.kind === "web_search") expect(search.title).toBe("Searched the web");
   });
 });
-
-// ---------------------------------------------------------------------------
-// Deterministic event-stream generator (tiny LCG; no Math.random).
-// ---------------------------------------------------------------------------
-
-/** Numerical Recipes LCG — deterministic, seedable. */
-function makeRng(seed: number) {
-  let state = (seed >>> 0) || 1;
-  return () => {
-    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
-    return state / 0xffffffff;
-  };
-}
-
-type Mutation =
-  | { kind: "append"; event: SubagentTimelineEvent }
-  | { kind: "coalesce"; delta: string };
-
-/**
- * Generate a deterministic sequence of store mutations: text deltas (coalesced
- * when consecutive), tool calls, their results/errors, and web_search/web_fetch
- * — covering every reducer branch. Tracks open tool ids so results/errors close
- * real in-flight calls.
- */
-function generateStream(seed: number, n: number): Mutation[] {
-  const rng = makeRng(seed);
-  const mutations: Mutation[] = [];
-  const openTools: Array<{ id: string; toolName: string }> = [];
-  let lastWasText = false;
-  let ts = NOW;
-
-  for (let i = 0; i < n; i++) {
-    ts += 1 + Math.floor(rng() * 50);
-    const roll = rng();
-
-    // Bias toward text + appends so coalescing fires often.
-    if (roll < 0.45) {
-      const delta = "w".repeat(1 + Math.floor(rng() * 40));
-      if (lastWasText) {
-        mutations.push({ kind: "coalesce", delta });
-      } else {
-        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
-        lastWasText = true;
-      }
-      continue;
-    }
-
-    lastWasText = false;
-
-    if (roll < 0.7) {
-      // Open a tool call (regular / web_search / web_fetch).
-      const toolRoll = rng();
-      const id = `t-${seed}-${i}`;
-      if (toolRoll < 0.2) {
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
-        });
-        openTools.push({ id, toolName: "web_search" });
-      } else if (toolRoll < 0.35) {
-        // web_fetch has no follow-up — a thinking step, no open tracking.
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
-        });
-      } else {
-        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
-        });
-        openTools.push({ id, toolName });
-      }
-      continue;
-    }
-
-    if (roll < 0.9 && openTools.length > 0) {
-      // Close an open tool with a result (maybe an error result).
-      const idx = Math.floor(rng() * openTools.length);
-      const open = openTools.splice(idx, 1)[0]!;
-      const isError = rng() < 0.25;
-      mutations.push({
-        kind: "append",
-        event: makeEvent(
-          {
-            type: "tool_result",
-            toolName: open.toolName,
-            toolUseId: open.id,
-            isError,
-            result: isError ? "boom" : `result-${i}`,
-            content: `result-${i}`,
-          },
-          ts,
-        ),
-      });
-      continue;
-    }
-
-    if (openTools.length > 0) {
-      // Close an open tool with a raw error event.
-      const idx = Math.floor(rng() * openTools.length);
-      openTools.splice(idx, 1);
-      mutations.push({
-        kind: "append",
-        event: makeEvent({ type: "error", content: `err-${i}` }, ts),
-      });
-      continue;
-    }
-
-    // Nothing open — emit a standalone error row.
-    mutations.push({
-      kind: "append",
-      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
-    });
-  }
-
-  return mutations;
-}
-
-function applyMutation(
-  events: SubagentTimelineEvent[],
-  m: Mutation,
-): SubagentTimelineEvent[] {
-  return m.kind === "append"
-    ? appendEvent(events, m.event)
-    : coalesceText(events, m.delta, NOW);
-}
 
 // ---------------------------------------------------------------------------
 // No-drift property test — the core safety net.

--- a/clients/web/src/domains/chat/subagent-step-projection.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.ts
@@ -46,6 +46,7 @@ import {
   type ToolCallCardStep,
   type ToolMeta,
 } from "@/domains/chat/hooks/use-subagent-card-data";
+import { classifyEventsDiff } from "@/domains/chat/subagent-projection-diff";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 
 export interface ProjectedSteps {
@@ -100,89 +101,72 @@ export function createIncrementalStepProjection(
   }
 
   function project(events: SubagentTimelineEvent[]): ProjectedSteps {
-    // Identity — also covers PR2's events-stable status/usage updates.
-    if (events === prevEvents) return { steps, toolMeta };
+    // The diff classification (including the subtle cross-subagent `detail-1`
+    // id-collision guard) is shared with the detail projector — see
+    // `subagent-projection-diff.ts`.
+    const diff = classifyEventsDiff(prevEvents, events);
 
-    // First call / empty cache.
-    if (prevEvents == null) return fullBuild(events);
+    switch (diff.kind) {
+      // Identity — also covers PR2's events-stable status/usage updates.
+      case "identity":
+        return { steps, toolMeta };
 
-    const prevLen = prevEvents.length;
-    const len = events.length;
+      // First call / empty cache.
+      case "first":
+        return fullBuild(events);
 
-    // Append: same prefix, one-or-more new events at the tail. The O(1)
-    // boundary checks (first + last-of-prev still share their references)
-    // distinguish a genuine append from a full-replace whose new array happens
-    // to be longer.
-    if (
-      len > prevLen &&
-      (prevLen === 0 ||
-        (events[0] === prevEvents[0] &&
-          events[prevLen - 1] === prevEvents[prevLen - 1]))
-    ) {
-      const stepsClone = steps.slice();
-      const toolMetaClone = toolMeta.slice();
-      for (let i = prevLen; i < len; i++) {
-        reducer(stepsClone, toolMetaClone, events[i]!);
-      }
-      prevEvents = events;
-      steps = stepsClone;
-      toolMeta = toolMetaClone;
-      return { steps, toolMeta };
-    }
-
-    // Mutate-last: text-delta coalescing. Same length, only the last element
-    // replaced, every earlier element shared. We require the genuine
-    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
-    // equality: both last events must be `type: "text"` and the new content must
-    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
-    // alone is insufficient because `mapDetailEvents` restarts event ids at
-    // `detail-1` per subagent — a single-event subagent switch collides on
-    // `id === "detail-1"` and would be misclassified, surviving a stale step. The
-    // type + content-extension guards reject that collision (different type, or
-    // content that isn't a strict extension → Fallback full rebuild).
-    if (
-      len === prevLen &&
-      len >= 1 &&
-      events[len - 1] !== prevEvents[len - 1] &&
-      events[len - 1]!.id === prevEvents[len - 1]!.id &&
-      prevEvents[len - 1]!.type === "text" &&
-      events[len - 1]!.type === "text" &&
-      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
-      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
-      (len === 1 || events[len - 2] === prevEvents[len - 2])
-    ) {
-      const stepsClone = steps.slice();
-      const toolMetaClone = toolMeta.slice();
-
-      // A text event contributes 0 or 1 trailing thinking step and never
-      // mutates earlier steps, so popping the keyed tail (if present) and
-      // re-deriving from the grown content reproduces the full rebuild exactly.
-      const tail = stepsClone[stepsClone.length - 1];
-      let poppedStep: ToolCallCardStep | undefined;
-      if (tail && tail.kind === "thinking" && tail.detailKey === events[len - 1]!.id) {
-        poppedStep = tail;
-        stepsClone.pop();
-        toolMetaClone.pop();
-      }
-
-      reducer(stepsClone, toolMetaClone, events[len - 1]!);
-
-      prevEvents = events;
-      const newTail = stepsClone[stepsClone.length - 1];
-      // Identity preservation — once the collapsed preview passes the 160-char
-      // clamp, further deltas don't change the rendered step. Keep the previous
-      // `steps` reference so memo / `React.memo` consumers bail. (toolMeta is
-      // re-derived identically too; reuse the prior reference for the same win.)
-      if (poppedStep && newTail && stepsEqual(poppedStep, newTail)) {
+      // Append: same prefix, one-or-more new events at the tail. Replay only
+      // the appended events through the reducer.
+      case "append": {
+        const len = events.length;
+        const stepsClone = steps.slice();
+        const toolMetaClone = toolMeta.slice();
+        for (let i = diff.from; i < len; i++) {
+          reducer(stepsClone, toolMetaClone, events[i]!);
+        }
+        prevEvents = events;
+        steps = stepsClone;
+        toolMeta = toolMetaClone;
         return { steps, toolMeta };
       }
-      steps = stepsClone;
-      toolMeta = toolMetaClone;
-      return { steps, toolMeta };
-    }
 
-    // Fallback — full-replace / truncation / reorder / violated assumption.
-    return fullBuild(events);
+      // Mutate-last: text-delta coalescing. Re-derive only the grown tail.
+      case "mutate-last": {
+        const len = events.length;
+        const stepsClone = steps.slice();
+        const toolMetaClone = toolMeta.slice();
+
+        // A text event contributes 0 or 1 trailing thinking step and never
+        // mutates earlier steps, so popping the keyed tail (if present) and
+        // re-deriving from the grown content reproduces the full rebuild exactly.
+        const tail = stepsClone[stepsClone.length - 1];
+        let poppedStep: ToolCallCardStep | undefined;
+        if (tail && tail.kind === "thinking" && tail.detailKey === events[len - 1]!.id) {
+          poppedStep = tail;
+          stepsClone.pop();
+          toolMetaClone.pop();
+        }
+
+        reducer(stepsClone, toolMetaClone, events[len - 1]!);
+
+        prevEvents = events;
+        const newTail = stepsClone[stepsClone.length - 1];
+        // Identity preservation — once the collapsed preview passes the 160-char
+        // clamp, further deltas don't change the rendered step. Keep the previous
+        // `steps` reference so memo / `React.memo` consumers bail. (toolMeta is
+        // re-derived identically too; reuse the prior reference for the same win.)
+        if (poppedStep && newTail && stepsEqual(poppedStep, newTail)) {
+          return { steps, toolMeta };
+        }
+        steps = stepsClone;
+        toolMeta = toolMetaClone;
+        return { steps, toolMeta };
+      }
+
+      // Fallback — full-replace / truncation / reorder / violated assumption.
+      case "fallback":
+        return fullBuild(events);
+    }
   }
 
   return { project };


### PR DESCRIPTION
## Summary
Remediation from plan self-review (slop/reuse + integration passes):
- Extract classifyEventsDiff into a shared module so both incremental projectors share one (drift-proof) diff classifier.
- Extract the shared LCG stream-generator/simulator test fixtures used by both projection test files.
- Fix the stale functional-updater mock prop type in subagent-detail-panel.test.tsx.
No behavior change; no-drift property tests + work-count guards still green.

Part of plan: subagent-panel-incremental-projection.md (review remediation)