### PR TITLE
perf(subagent): incremental projection + granular memoization for the detail panel

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -34,16 +34,17 @@ mock.module("@/domains/chat/components/subagent-phase-timeline", () => ({
   }: {
     onStepDetailClick?: (detailKey: string) => void;
     expandedKeys?: Set<string>;
-    onExpandedKeysChange?: (next: Set<string>) => void;
+    onExpandedKeysChange?: (updater: (prev: Set<string>) => Set<string>) => void;
   }) => (
     <div data-testid="timeline">
       {/* Surfaces the controlled expand state so a test can assert the panel
-          preserves it across the detail view swap. */}
+          preserves it across the detail view swap. The real timeline drives the
+          functional-updater form, so the stub exercises the same contract. */}
       <button
         type="button"
         data-testid="timeline-expand"
         onClick={() =>
-          onExpandedKeysChange?.(new Set(expandedKeys).add("grp-1"))
+          onExpandedKeysChange?.((prev) => new Set(prev).add("grp-1"))
         }
       >
         {expandedKeys?.has("grp-1") ? "group-open" : "group-closed"}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -37,7 +37,7 @@ import { WebFetchDetailView } from "@/domains/chat/components/web-fetch/web-fetc
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
 import {
     buildSubagentStepDetails,
-    computeSubagentCardData,
+    computeSubagentSteps,
 } from "@/domains/chat/hooks/use-subagent-card-data";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
@@ -103,8 +103,16 @@ export function SubagentDetailPanel({
   // three separate times in the JSX below.
   const traits = useMemo(() => subagentTraits(entry.subagentId), [entry.subagentId]);
   // The panel re-renders when `entry` changes via the store subscription in
-  // chat-content-layout.tsx, so memoizing on `entry` keeps the steps fresh.
-  const cardData = useMemo(() => computeSubagentCardData(entry), [entry]);
+  // chat-content-layout.tsx. The store bumps `entry` identity on every
+  // token/status/usage update but keeps `entry.events` reference-stable, so the
+  // heavy O(n) timeline walk is keyed on `entry.events` — it re-runs only when
+  // the event list actually changes, not on every status/usage tick. The panel
+  // renders its own header from `entry` directly, so it needs only the projected
+  // `steps` (not the carousel meta `computeSubagentCardData` derives).
+  const { steps } = useMemo(
+    () => computeSubagentSteps(entry.events),
+    [entry.events],
+  );
 
   // `toolCallId`-keyed map of nested tool-detail payloads, used to swap the
   // panel body to a tool's input/output when its timeline pill is clicked —
@@ -117,7 +125,10 @@ export function SubagentDetailPanel({
   // `mapDetailEvents` carries through); thinking/text steps key on the source
   // event id and carry the full, un-truncated reasoning. Steps with no entry
   // here render as non-clickable pills — a graceful fallback, not an error.
-  const stepDetails = useMemo(() => buildSubagentStepDetails(entry), [entry]);
+  const stepDetails = useMemo(
+    () => buildSubagentStepDetails(entry.events),
+    [entry.events],
+  );
 
   // Which step's detail (if any) is shown nested inside this panel — the key
   // into `stepDetails` (a tool call or a thinking segment), or `null` to show
@@ -408,20 +419,20 @@ export function SubagentDetailPanel({
                * subagent's same-positioned phase.
                */}
               {/*
-               * Gate the empty state on the RAW `entry.events`, not on
-               * `cardData.steps`. `computeSubagentCardData` can intentionally
+               * Gate the empty state on the RAW `entry.events`, not on the
+               * projected `steps`. `computeSubagentSteps` can intentionally
                * DROP events (e.g. a `tool_result` with no preceding in-flight
-               * `tool_call`), so `entry.events` can be non-empty while
-               * `cardData.steps` is empty. Gating on steps would show a false
-               * "No events yet" AND — because `entry.events.length !== 0` — the
-               * detail-refetch effect above wouldn't fire to recover. When the
-               * store has events we render the timeline (which returns null for
-               * zero steps, an acceptable no-op).
+               * `tool_call`), so `entry.events` can be non-empty while `steps`
+               * is empty. Gating on steps would show a false "No events yet"
+               * AND — because `entry.events.length !== 0` — the detail-refetch
+               * effect above wouldn't fire to recover. When the store has events
+               * we render the timeline (which returns null for zero steps, an
+               * acceptable no-op).
                */}
               {entry.events.length > 0 ? (
                 <SubagentPhaseTimeline
                   key={entry.subagentId}
-                  steps={cardData.steps}
+                  steps={steps}
                   expandedKeys={expandedSectionKeys}
                   onExpandedKeysChange={setExpandedSectionKeys}
                   onStepDetailClick={(key) => {

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -35,8 +35,8 @@ import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
 import { WebFetchDetailView } from "@/domains/chat/components/web-fetch/web-fetch-detail-view";
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
-import { buildSubagentStepDetails } from "@/domains/chat/hooks/use-subagent-card-data";
 import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
+import { useSubagentStepDetails } from "@/domains/chat/subagent-detail-projection";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -121,10 +121,13 @@ export function SubagentDetailPanel({
   // `mapDetailEvents` carries through); thinking/text steps key on the source
   // event id and carry the full, un-truncated reasoning. Steps with no entry
   // here render as non-clickable pills — a graceful fallback, not an error.
-  const stepDetails = useMemo(
-    () => buildSubagentStepDetails(entry.events),
-    [entry.events],
-  );
+  //
+  // Built incrementally (mirrors `useSubagentSteps`): the projector replays only
+  // the events that changed since the last render through the shared
+  // `applyDetailEvent` reducer, with an O(n) full-rebuild fallback. This map is
+  // read lazily (only on pill click), so the win is avoiding the O(n) re-walk
+  // per streamed event, not re-render avoidance.
+  const stepDetails = useSubagentStepDetails(entry.events);
 
   // Which step's detail (if any) is shown nested inside this panel — the key
   // into `stepDetails` (a tool call or a thinking segment), or `null` to show

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -35,10 +35,8 @@ import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
 import { WebFetchDetailView } from "@/domains/chat/components/web-fetch/web-fetch-detail-view";
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
-import {
-    buildSubagentStepDetails,
-    computeSubagentSteps,
-} from "@/domains/chat/hooks/use-subagent-card-data";
+import { buildSubagentStepDetails } from "@/domains/chat/hooks/use-subagent-card-data";
+import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -104,15 +102,13 @@ export function SubagentDetailPanel({
   const traits = useMemo(() => subagentTraits(entry.subagentId), [entry.subagentId]);
   // The panel re-renders when `entry` changes via the store subscription in
   // chat-content-layout.tsx. The store bumps `entry` identity on every
-  // token/status/usage update but keeps `entry.events` reference-stable, so the
-  // heavy O(n) timeline walk is keyed on `entry.events` — it re-runs only when
-  // the event list actually changes, not on every status/usage tick. The panel
-  // renders its own header from `entry` directly, so it needs only the projected
-  // `steps` (not the carousel meta `computeSubagentCardData` derives).
-  const { steps } = useMemo(
-    () => computeSubagentSteps(entry.events),
-    [entry.events],
-  );
+  // token/status/usage update but keeps `entry.events` reference-stable. Rather
+  // than rebuild the whole timeline on each tick, `useSubagentSteps` replays
+  // only the events that changed since the last render (append / text-coalesce),
+  // and preserves the `steps` array identity when nothing visible changed so the
+  // timeline below can bail. The panel renders its own header from `entry`
+  // directly, so it needs only the projected `steps`.
+  const { steps } = useSubagentSteps(entry.events);
 
   // `toolCallId`-keyed map of nested tool-detail payloads, used to swap the
   // panel body to a tool's input/output when its timeline pill is clicked —

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -137,6 +137,20 @@ export function SubagentDetailPanel({
     null,
   );
 
+  // Read `stepDetails` through a ref so the click handler below can stay
+  // identity-stable across `entry.events` changes. `stepDetails` is rebuilt
+  // (new Map identity) on most streamed events, so closing over it directly
+  // would change the handler identity every tick — which, passed down to the
+  // now-memoized `SubagentPhaseRow`s, would re-render every row on each event.
+  // The ref is assigned during render (not in an effect) so the handler always
+  // sees the latest map without listing it as a dependency.
+  const stepDetailsRef = useRef(stepDetails);
+  // eslint-disable-next-line react-hooks/refs -- render-phase sync so the stable handler below reads the latest map
+  stepDetailsRef.current = stepDetails;
+  const handleStepDetailClick = useCallback((key: string) => {
+    if (stepDetailsRef.current.has(key)) setSelectedDetailKey(key);
+  }, []);
+
   // Which timeline groups are expanded. Lifted out of `SubagentPhaseTimeline`
   // so the expansion survives the timeline unmounting while a nested tool
   // detail is shown — returning via "Back" restores the same open group. Reset
@@ -434,9 +448,7 @@ export function SubagentDetailPanel({
                   steps={steps}
                   expandedKeys={expandedSectionKeys}
                   onExpandedKeysChange={setExpandedSectionKeys}
-                  onStepDetailClick={(key) => {
-                    if (stepDetails.has(key)) setSelectedDetailKey(key);
-                  }}
+                  onStepDetailClick={handleStepDetailClick}
                   // Keeps the last phase's node pulsing while the subagent is
                   // still active but its last phase has settled.
                   isRunning={isRunning}

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -9,10 +9,13 @@
  * for 1); and contiguous same-phase collapsing into a single row.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+import { useState } from "react";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
+import * as phaseGroupedStepList from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 
@@ -739,9 +742,13 @@ describe("SubagentPhaseTimeline — controlled expand state", () => {
   // When `expandedKeys`/`onExpandedKeysChange` are supplied the parent owns the
   // expansion (so it can outlive an unmount): the component renders from the
   // prop and reports toggles instead of self-managing, and does not expand
-  // until the parent feeds the new set back.
+  // until the parent feeds the new set back. `onExpandedKeysChange` receives a
+  // functional updater (the `setState`-style contract that keeps the internal
+  // `toggle` callback stable), so the next set is derived by applying it to the
+  // previous one.
   test("renders expansion from `expandedKeys` and reports toggles to the parent", () => {
-    const onExpandedKeysChange = mock((_next: Set<string>) => {});
+    const onExpandedKeysChange =
+      mock((_updater: (prev: Set<string>) => Set<string>) => {});
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", "tc-a"),
       bash("pwd", "completed", "2s", "tc-b"),
@@ -758,14 +765,15 @@ describe("SubagentPhaseTimeline — controlled expand state", () => {
     // Controlled + collapsed: no pills yet.
     expect(queryAllByTestId("phase-step-pill").length).toBe(0);
 
-    // Clicking the header reports the next set but does NOT self-expand.
+    // Clicking the header reports an updater but does NOT self-expand.
     fireEvent.click(getByTestId("subagent-phase-header"));
     expect(onExpandedKeysChange).toHaveBeenCalledTimes(1);
-    const nextKeys = onExpandedKeysChange.mock.calls[0]![0];
+    const updater = onExpandedKeysChange.mock.calls[0]![0];
+    const nextKeys = updater(new Set());
     expect(nextKeys.size).toBe(1);
     expect(queryAllByTestId("phase-step-pill").length).toBe(0);
 
-    // Feeding the reported set back expands the section.
+    // Feeding the derived set back expands the section.
     rerender(
       <SubagentPhaseTimeline
         steps={steps}
@@ -774,5 +782,80 @@ describe("SubagentPhaseTimeline — controlled expand state", () => {
       />,
     );
     expect(queryAllByTestId("phase-step-pill").length).toBe(2);
+  });
+});
+
+describe("SubagentPhaseTimeline — row render isolation", () => {
+  // `SubagentPhaseRow` is `React.memo`-wrapped, and both the `toggle` callback
+  // and the parent's stable `onExpandedKeysChange` setter keep every prop a row
+  // receives reference-stable across an expand/collapse and across a no-op
+  // parent re-render. We count actual row renders by spying on
+  // `phaseHeaderStatus`, which each row calls exactly once at the top of its
+  // render — so the spy's call count is precisely the number of rows whose
+  // render function ran. `spyOn` + `mockRestore` is local to this test (it does
+  // NOT use `mock.module`), so it leaves no cross-file pollution.
+  function toolStep(id: string): ToolCallCardStep {
+    return bash(id, "completed", "1s", `tc-${id}`);
+  }
+
+  // Five phases: tool / thinking / tool / thinking / tool — each step kind
+  // change opens a new phase, so this yields five independent rows.
+  const FIVE_PHASE_STEPS: ToolCallCardStep[] = [
+    toolStep("a"),
+    thinking("t1"),
+    toolStep("b"),
+    thinking("t2"),
+    toolStep("c"),
+  ];
+
+  test("toggling one phase re-renders only that row; a no-op parent re-render re-renders zero rows", () => {
+    const renderSpy = spyOn(phaseGroupedStepList, "phaseHeaderStatus");
+    try {
+      // Harness owns the expanded state via a stable `setState` setter (the
+      // contract the real panel uses) and exposes a `forceRerender` that bumps
+      // unrelated state without touching the stable `steps` array — modelling a
+      // parent re-render driven by an `entry` identity bump that didn't change
+      // the projected steps.
+      let forceRerender: () => void = () => {};
+      function Harness() {
+        const [expanded, setExpanded] = useState<Set<string>>(new Set());
+        const [, setTick] = useState(0);
+        forceRerender = () => setTick((n) => n + 1);
+        return (
+          <SubagentPhaseTimeline
+            steps={FIVE_PHASE_STEPS}
+            expandedKeys={expanded}
+            onExpandedKeysChange={setExpanded}
+          />
+        );
+      }
+
+      const { getAllByTestId } = render(<Harness />);
+
+      // Mount renders every row once.
+      const rows = getAllByTestId("subagent-phase-header");
+      expect(rows.length).toBe(5);
+      expect(renderSpy.mock.calls.length).toBe(5);
+
+      // Toggling one phase open re-renders ONLY that row (the memoized siblings
+      // bail because `section`, `onToggle`, and `onStepDetailClick` are all
+      // reference-stable).
+      renderSpy.mockClear();
+      fireEvent.click(rows[0]!);
+      expect(renderSpy.mock.calls.length).toBe(1);
+
+      // Toggling it back also re-renders only that one row.
+      renderSpy.mockClear();
+      fireEvent.click(rows[0]!);
+      expect(renderSpy.mock.calls.length).toBe(1);
+
+      // A parent re-render that leaves `steps` (and thus the memoized `sections`
+      // array) reference-stable re-renders ZERO rows.
+      renderSpy.mockClear();
+      forceRerender();
+      expect(renderSpy.mock.calls.length).toBe(0);
+    } finally {
+      renderSpy.mockRestore();
+    }
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -14,7 +14,7 @@
  */
 
 import { Brain, Globe } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
 
@@ -149,7 +149,15 @@ export function SubagentPhaseTimeline({
    * manages the state internally.
    */
   expandedKeys?: Set<string>;
-  onExpandedKeysChange?: (next: Set<string>) => void;
+  /**
+   * Controlled-expansion setter. Takes a functional updater so the parent can
+   * pass a stable `setState`-style setter (React's
+   * `Dispatch<SetStateAction<Set<string>>>` satisfies this). Receiving a stable
+   * identity here lets `toggle` below stay `useCallback`-stable across
+   * expand/collapse, which keeps the memoized rows from all re-rendering on a
+   * single toggle.
+   */
+  onExpandedKeysChange?: (updater: (prev: Set<string>) => Set<string>) => void;
   /**
    * Whether the owning subagent is still active. When `true`, the LAST phase's
    * node keeps pulsing (a `ThreeDotIndicator`) even after its own steps settle,
@@ -169,23 +177,26 @@ export function SubagentPhaseTimeline({
     new Set(),
   );
   const expanded = expandedKeys ?? internalExpanded;
+  // Both branches toggle via a functional updater, so `toggle` never closes over
+  // the current `expanded` set — its identity stays stable across expand/collapse
+  // (the parent passes a stable `setState`-style `onExpandedKeysChange`). A
+  // stable `toggle` is what lets the memoized `SubagentPhaseRow`s bail on a
+  // single toggle instead of all re-rendering.
   const toggle = useCallback(
     (key: string) => {
-      if (onExpandedKeysChange) {
-        const next = new Set(expanded);
-        if (next.has(key)) next.delete(key);
-        else next.add(key);
-        onExpandedKeysChange(next);
-        return;
-      }
-      setInternalExpanded((prev) => {
+      const update = (prev: Set<string>): Set<string> => {
         const next = new Set(prev);
         if (next.has(key)) next.delete(key);
         else next.add(key);
         return next;
-      });
+      };
+      if (onExpandedKeysChange) {
+        onExpandedKeysChange(update);
+        return;
+      }
+      setInternalExpanded(update);
     },
-    [expanded, onExpandedKeysChange],
+    [onExpandedKeysChange],
   );
 
   // Memoized so the O(n) grouping + fresh section allocations don't re-run on
@@ -219,7 +230,13 @@ export function SubagentPhaseTimeline({
   );
 }
 
-function SubagentPhaseRow({
+// Memoized so a single expand/collapse re-renders only the toggled row and a
+// no-op parent re-render re-renders none. The bail relies on every prop being
+// reference-stable on those re-renders: `section` (from the stable `sections`
+// `useMemo`) and the `onToggle` / `onStepDetailClick` callbacks. A genuine
+// `steps` change re-runs `groupStepsByPhase`, producing fresh `section` objects
+// that correctly bust the memo for the rows that changed.
+const SubagentPhaseRow = memo(function SubagentPhaseRow({
   section,
   isLast,
   isActiveTail,
@@ -589,4 +606,4 @@ function SubagentPhaseRow({
       )}
     </div>
   );
-}
+});

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -824,7 +824,7 @@ describe("computeSubagentCardData — web tools match main-chat group labels", (
       ],
     });
     const step = computeSubagentCardData(entry).steps[0]!;
-    const details = buildSubagentStepDetails(entry);
+    const details = buildSubagentStepDetails(entry.events);
     if (step.kind === "thinking") {
       expect(step.detailKey).toBe("tu-wf");
       expect(details.has(step.detailKey!)).toBe(true);
@@ -1255,7 +1255,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("tu-1")!;
@@ -1274,7 +1274,7 @@ describe("buildSubagentStepDetails", () => {
     const details = buildSubagentStepDetails(
       makeEntry({
         events: [makeEvent({ type: "text", content }, 0)],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("te-0")!;
@@ -1315,7 +1315,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("tu-ws")!;
@@ -1349,7 +1349,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-ws")!;
     expect(payload.kind).toBe("web_search");
@@ -1360,7 +1360,7 @@ describe("buildSubagentStepDetails", () => {
     const details = buildSubagentStepDetails(
       makeEntry({
         events: [makeEvent({ type: "text", content: "   \n  " }, 0)],
-      }),
+      }).events,
     );
     expect(details.size).toBe(0);
   });
@@ -1383,7 +1383,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.get("tu-1")!.result).toBe("fallback output");
   });
@@ -1414,7 +1414,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1440,7 +1440,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1472,7 +1472,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-ws")!;
     expect(payload).toBeDefined();
@@ -1496,7 +1496,7 @@ describe("buildSubagentStepDetails", () => {
             0,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(1);
     const payload = details.get("tu-1")!;
@@ -1510,7 +1510,7 @@ describe("buildSubagentStepDetails", () => {
     const details = buildSubagentStepDetails(
       makeEntry({
         events: [makeEvent({ type: "tool_call", toolName: "bash" })],
-      }),
+      }).events,
     );
     expect(details.size).toBe(0);
   });
@@ -1548,7 +1548,7 @@ describe("buildSubagentStepDetails", () => {
             2,
           ),
         ],
-      }),
+      }).events,
     );
     expect(details.size).toBe(2);
     const a = details.get("tu-A")!;
@@ -1580,7 +1580,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1609,7 +1609,7 @@ describe("buildSubagentStepDetails", () => {
             1,
           ),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("error");
@@ -1635,7 +1635,7 @@ describe("buildSubagentStepDetails", () => {
             timestamp: NOW,
           }),
         ],
-      }),
+      }).events,
     );
     const payload = details.get("tu-1")!;
     expect(payload.status).toBe("completed");
@@ -1747,4 +1747,112 @@ describe("computeSubagentSteps / applyTimelineEvent reproduce computeSubagentCar
       expect(steps).toEqual(computeSubagentSteps(events).steps);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Heavy-projection memoization keyed on `entry.events` (PR 2)
+//
+// The panel keys its two heavy O(n) walks (`computeSubagentSteps` and
+// `buildSubagentStepDetails`) on `entry.events`, not `entry`. The store bumps
+// `entry` identity on every token/status/usage update while keeping
+// `entry.events` reference-stable, so a memo on `[entry.events]` skips the walk
+// when only the status/usage changed — and re-runs when the event list itself
+// changes. These tests pin that contract: a `[entry.events]`-keyed memo is the
+// correct dependency.
+// ---------------------------------------------------------------------------
+
+describe("heavy projections are memoizable on entry.events (PR 2)", () => {
+  // Minimal stand-in for React's `useMemo`: recompute only when the dependency
+  // reference changes. Mirrors the panel's `useMemo(..., [entry.events])`.
+  function memoizeByDep<Dep, Result>(compute: (dep: Dep) => Result) {
+    let lastDep: Dep | undefined;
+    let lastResult: Result;
+    let calls = 0;
+    return {
+      run(dep: Dep): Result {
+        if (calls === 0 || dep !== lastDep) {
+          calls += 1;
+          lastDep = dep;
+          lastResult = compute(dep);
+        }
+        return lastResult;
+      },
+      get calls() {
+        return calls;
+      },
+    };
+  }
+
+  const events: SubagentTimelineEvent[] = [
+    makeEvent({ type: "text", content: "Investigating" }, 0),
+    makeEvent(
+      { type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls" },
+      1,
+    ),
+    makeEvent(
+      { type: "tool_result", toolName: "bash", toolUseId: "tu-1", result: "ok" },
+      2,
+    ),
+  ];
+
+  test("computeSubagentSteps memoized on entry.events skips the walk across a token/status update", () => {
+    // A token/status/usage update bumps `entry` identity but leaves
+    // `entry.events` reference-stable — the same array instance.
+    const entryA = makeEntry({ status: "running", events });
+    const entryB = makeEntry({
+      status: "completed",
+      // Same `events` reference — only the surrounding entry changed.
+      events: entryA.events,
+      outputTokens: 42,
+    });
+    expect(entryA).not.toBe(entryB);
+    expect(entryB.events).toBe(entryA.events);
+
+    const memo = memoizeByDep((evts: SubagentTimelineEvent[]) =>
+      computeSubagentSteps(evts),
+    );
+    const first = memo.run(entryA.events);
+    const second = memo.run(entryB.events);
+    // No recompute: the stable `events` reference is the only dependency.
+    expect(memo.calls).toBe(1);
+    expect(second).toBe(first);
+    // And the cached result is still correct.
+    expect(first.steps).toEqual(computeSubagentSteps(events).steps);
+  });
+
+  test("computeSubagentSteps memoized on entry.events re-runs when the event list changes", () => {
+    const entryA = makeEntry({ events });
+    // A new event appended → a new array reference (the store replaces it).
+    const entryB = makeEntry({
+      events: [...events, makeEvent({ type: "text", content: "done" }, 3)],
+    });
+    expect(entryB.events).not.toBe(entryA.events);
+
+    const memo = memoizeByDep((evts: SubagentTimelineEvent[]) =>
+      computeSubagentSteps(evts),
+    );
+    memo.run(entryA.events);
+    const after = memo.run(entryB.events);
+    expect(memo.calls).toBe(2);
+    expect(after.steps).toEqual(computeSubagentSteps(entryB.events).steps);
+  });
+
+  test("buildSubagentStepDetails memoized on entry.events skips the walk across a token/status update", () => {
+    const entryA = makeEntry({ status: "running", events });
+    const entryB = makeEntry({
+      status: "completed",
+      events: entryA.events,
+      inputTokens: 100,
+    });
+    expect(entryB.events).toBe(entryA.events);
+
+    const memo = memoizeByDep((evts: SubagentTimelineEvent[]) =>
+      buildSubagentStepDetails(evts),
+    );
+    const first = memo.run(entryA.events);
+    const second = memo.run(entryB.events);
+    expect(memo.calls).toBe(1);
+    expect(second).toBe(first);
+    expect(first.get("tu-1")?.status).toBe("completed");
+  });
 });

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -1644,9 +1644,9 @@ describe("buildSubagentStepDetails", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Reducer extraction (PR 1) — applyTimelineEvent / computeSubagentSteps must
-// reproduce the same `steps` the full projection produces, so the later
-// incremental-replay path can't drift from `computeSubagentCardData`.
+// `applyTimelineEvent` / `computeSubagentSteps` must reproduce the same `steps`
+// the full projection produces, so the incremental-replay path can't drift from
+// `computeSubagentCardData`.
 // ---------------------------------------------------------------------------
 
 describe("computeSubagentSteps / applyTimelineEvent reproduce computeSubagentCardData", () => {
@@ -1750,20 +1750,22 @@ describe("computeSubagentSteps / applyTimelineEvent reproduce computeSubagentCar
 });
 
 // ---------------------------------------------------------------------------
-// Heavy-projection memoization keyed on `entry.events` (PR 2)
+// Heavy projections recompute only when `entry.events` changes
 //
 // The panel keys its two heavy O(n) walks (`computeSubagentSteps` and
 // `buildSubagentStepDetails`) on `entry.events`, not `entry`. The store bumps
 // `entry` identity on every token/status/usage update while keeping
-// `entry.events` reference-stable, so a memo on `[entry.events]` skips the walk
-// when only the status/usage changed — and re-runs when the event list itself
-// changes. These tests pin that contract: a `[entry.events]`-keyed memo is the
-// correct dependency.
+// `entry.events` reference-stable, so projecting from `entry.events` skips the
+// walk when only the status/usage changed — and re-runs when the event list
+// itself changes. These tests pin that contract: projection is keyed on the
+// `entry.events` reference.
 // ---------------------------------------------------------------------------
 
-describe("heavy projections are memoizable on entry.events (PR 2)", () => {
-  // Minimal stand-in for React's `useMemo`: recompute only when the dependency
-  // reference changes. Mirrors the panel's `useMemo(..., [entry.events])`.
+describe("heavy projections are memoizable on entry.events", () => {
+  // Minimal stand-in for dependency-keyed memoization: recompute only when the
+  // dependency reference changes. Mirrors how the projection hooks
+  // (`useSubagentSteps` / `useSubagentStepDetails`) recompute only when the
+  // `entry.events` reference changes.
   function memoizeByDep<Dep, Result>(compute: (dep: Dep) => Result) {
     let lastDep: Dep | undefined;
     let lastResult: Result;

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -8,9 +8,13 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  applyTimelineEvent,
   buildSubagentStepDetails,
   computeSubagentCardData,
+  computeSubagentSteps,
   mapToolEventToStep,
+  type ToolCallCardStep,
+  type ToolMeta,
 } from "@/domains/chat/hooks/use-subagent-card-data";
 import {
   groupStepsByPhase,
@@ -1637,4 +1641,110 @@ describe("buildSubagentStepDetails", () => {
     expect(payload.status).toBe("completed");
     expect(payload.durationLabel).toBe("");
   });
+});
+
+// ---------------------------------------------------------------------------
+// Reducer extraction (PR 1) — applyTimelineEvent / computeSubagentSteps must
+// reproduce the same `steps` the full projection produces, so the later
+// incremental-replay path can't drift from `computeSubagentCardData`.
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentSteps / applyTimelineEvent reproduce computeSubagentCardData", () => {
+  const fixtures: Array<{ name: string; events: SubagentTimelineEvent[] }> = [
+    {
+      name: "text + bash tool_call → tool_result",
+      events: [
+        makeEvent({ type: "text", content: "Investigating" }, 0),
+        makeEvent(
+          {
+            type: "tool_call",
+            toolName: "bash",
+            toolUseId: "tu-1",
+            content: "ls -la",
+            timestamp: NOW,
+          },
+          1,
+        ),
+        makeEvent(
+          {
+            type: "tool_result",
+            toolName: "bash",
+            toolUseId: "tu-1",
+            content: "ok",
+            timestamp: NOW + 2500,
+          },
+          2,
+        ),
+      ],
+    },
+    {
+      name: "web_search → result + web_fetch thinking step",
+      events: [
+        makeEvent(
+          {
+            type: "tool_call",
+            toolName: "web_search",
+            toolUseId: "ws-1",
+            input: { query: "vellum docs" },
+            timestamp: NOW,
+          },
+          0,
+        ),
+        makeEvent(
+          {
+            type: "tool_result",
+            toolName: "web_search",
+            toolUseId: "ws-1",
+            result: "Vellum\nhttps://vellum.ai",
+            timestamp: NOW + 1000,
+          },
+          1,
+        ),
+        makeEvent(
+          {
+            type: "tool_call",
+            toolName: "web_fetch",
+            toolUseId: "wf-1",
+            input: { url: "https://vellum.ai/docs" },
+            timestamp: NOW + 1100,
+          },
+          2,
+        ),
+      ],
+    },
+    {
+      name: "in-flight tool closed by an error event",
+      events: [
+        makeEvent(
+          {
+            type: "tool_call",
+            toolName: "bash",
+            toolUseId: "tu-2",
+            content: "rm -rf /",
+            timestamp: NOW,
+          },
+          0,
+        ),
+        makeEvent(
+          { type: "error", content: "permission denied", timestamp: NOW + 500 },
+          1,
+        ),
+      ],
+    },
+  ];
+
+  for (const { name, events } of fixtures) {
+    test(`${name}: computeSubagentSteps matches the card projection`, () => {
+      const expected = computeSubagentCardData(makeEntry({ events })).steps;
+      const { steps } = computeSubagentSteps(events);
+      expect(steps).toEqual(expected);
+    });
+
+    test(`${name}: applyTimelineEvent folded by hand matches computeSubagentSteps`, () => {
+      const steps: ToolCallCardStep[] = [];
+      const toolMeta: Array<ToolMeta | undefined> = [];
+      for (const event of events) applyTimelineEvent(steps, toolMeta, event);
+      expect(steps).toEqual(computeSubagentSteps(events).steps);
+    });
+  }
 });

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -71,7 +71,7 @@ const TEXT_PREVIEW_MAX = 160;
  * `web_search` steps, whose step shape carries no id field. `undefined` for
  * steps with no follow-up (thinking, tool_error).
  */
-type ToolMeta = { startTs: number; toolName: string; toolUseId?: string };
+export type ToolMeta = { startTs: number; toolName: string; toolUseId?: string };
 
 /** Trim newlines + collapse whitespace, then clamp to TEXT_PREVIEW_MAX. */
 function trimTextPreview(input: string): string {
@@ -321,157 +321,185 @@ function deriveCardState(status: SubagentStatus): ToolCallCardData["state"] {
 // ---------------------------------------------------------------------------
 
 /**
- * Pure projection of (entry) → card props. Split from the hook so tests
- * can drive it without instantiating the Zustand store.
+ * Pure per-event reducer for the timeline projection: mutates the parallel
+ * `(steps, toolMeta)` arrays in place exactly as a single iteration of
+ * `computeSubagentSteps`'s loop. The shared step-folding logic so an
+ * incremental replay can't drift from the full rebuild. No-op for unhandled
+ * event types.
  */
-export function computeSubagentCardData(
-  entry: SubagentEntry,
-): ToolCallCardData {
+export function applyTimelineEvent(
+  steps: ToolCallCardStep[],
+  toolMeta: Array<ToolMeta | undefined>,
+  event: SubagentTimelineEvent,
+): void {
+  if (event.type === "text") {
+    const text = trimTextPreview(event.content);
+    // Skip empty text events — they'd render as a blank thinking step.
+    if (text.length === 0) return;
+    // `detailKey` (the source event id) lets the timeline pill open the full,
+    // un-truncated reasoning via `buildSubagentStepDetails` — the pill itself
+    // only carries the collapsed `text` preview.
+    steps.push({ kind: "thinking", durationLabel: "", text, detailKey: event.id });
+    toolMeta.push(undefined);
+    return;
+  }
+
+  if (event.type === "tool_call") {
+    const toolName = event.toolName ?? "";
+    // Route web tools to the dedicated step kinds so their phase labels match
+    // main chat ("Searching the web" / "Thinking") instead of the generic
+    // "Working" bucket the tool path produces. Mirrors the main-chat split in
+    // `tool-call-card-utils` (`buildWebSearchStep` / `buildWebFetchStep`).
+    if (WEB_TOOL_NAMES.has(toolName)) {
+      if (toolName === "web_fetch") {
+        // `web_fetch` renders as a "Reading <domain>" thinking step — no
+        // follow-up tracking needed (the domain is known at call time, and a
+        // thinking step is neutral for phase status).
+        steps.push({
+          kind: "thinking",
+          durationLabel: "",
+          text: webFetchReadingText(event),
+          // Key the step to its tool id so the timeline pill opens the nested
+          // web_fetch detail (source card + extracted content) — matching the
+          // `toolUseId`-keyed payload `buildSubagentStepDetails` emits, the
+          // same way the `web_search` branch below keys its pill.
+          detailKey: event.toolUseId,
+        });
+        toolMeta.push(undefined);
+      } else {
+        // `web_search` — placeholder until its result lands; the matched
+        // `tool_result` flips the title tense + fills in results (see below).
+        // `query` (raw input, else the `content` summary which is the query
+        // for web_search) labels the step so unclamped multi-search groups
+        // stay distinct in the timeline; it survives the `...target` spread on
+        // completion.
+        const query =
+          event.input && typeof event.input.query === "string"
+            ? event.input.query
+            : event.content || undefined;
+        steps.push({
+          kind: "web_search",
+          query,
+          title: "Searching the web",
+          durationLabel: "",
+          linkCount: 0,
+          results: [],
+          // The originating tool id keys this search's nested detail so the
+          // timeline can render it as a clickable pill (query + sources) —
+          // matches the key `buildSubagentStepDetails` emits. Survives the
+          // `...target` spread on completion alongside `query`.
+          detailKey: event.toolUseId,
+        });
+        toolMeta.push({
+          startTs: event.timestamp,
+          toolName,
+          toolUseId: event.toolUseId,
+        });
+      }
+      return;
+    }
+    steps.push(mapToolEventToStep(event));
+    toolMeta.push({ startTs: event.timestamp, toolName });
+    return;
+  }
+
+  if (event.type === "tool_result") {
+    const matchIndex = findMatchingInFlightToolIndex(steps, toolMeta, event);
+    if (matchIndex === -1) return;
+    const target = steps[matchIndex]!;
+    const start = toolMeta[matchIndex]?.startTs;
+    const durationLabel = durationLabelBetween(start, event.timestamp);
+    // `web_search` signals completion via title tense (not a `status` field):
+    // success flips "Searching" → "Searched"; an error becomes a
+    // `web_search_error` step (both still group under "Searching the web").
+    if (target.kind === "web_search") {
+      if (event.isError) {
+        steps[matchIndex] = webSearchErrorStep(durationLabel, event);
+        return;
+      }
+      // Parse the result text (Title\nURL pairs) into link chips — the same
+      // fallback main chat uses on reload, since the subagent timeline carries
+      // the raw result text but not the structured `activityMetadata`. No
+      // clamp: the detail panel has room to show every source inline, so all
+      // results go in `results` and `overflowResults` stays empty.
+      const results = parseWebSearchResultText(event.result ?? event.content);
+      steps[matchIndex] = {
+        ...target,
+        title: "Searched the web",
+        // Backfill the query from the result's metadata. The originating
+        // `tool_call` carried empty input live (Anthropic resolves web_search
+        // input only at completion), so `target.query` is usually undefined
+        // until this result lands `searchQuery`. The history/detail path
+        // already has it on the call, hence the `target.query ||` precedence.
+        query: target.query || event.searchQuery,
+        durationLabel,
+        linkCount: results.length,
+        results,
+      };
+      return;
+    }
+    if (target.kind !== "tool") return;
+    steps[matchIndex] = {
+      ...target,
+      status: event.isError ? "error" : "completed",
+      durationLabel,
+    };
+    return;
+  }
+
+  if (event.type === "error") {
+    // Close the matching in-flight tool step (if any) as `error` before
+    // appending the `tool_error` row. Same matching precedence as
+    // `tool_result` — see `findMatchingInFlightToolIndex` — so parallel
+    // calls to the same tool close the correct step.
+    const matchIndex = findMatchingInFlightToolIndex(steps, toolMeta, event);
+    if (matchIndex !== -1) {
+      const target = steps[matchIndex]!;
+      if (target.kind === "tool") {
+        steps[matchIndex] = { ...target, status: "error" };
+      } else if (target.kind === "web_search") {
+        steps[matchIndex] = webSearchErrorStep(
+          durationLabelBetween(toolMeta[matchIndex]?.startTs, event.timestamp),
+          event,
+        );
+      }
+    }
+    const message = trimTextPreview(event.content) || "Subagent error";
+    steps.push({ kind: "tool_error", message });
+    toolMeta.push(undefined);
+    return;
+  }
+}
+
+/**
+ * Build the `(steps, toolMeta)` parallel arrays for a subagent's full event
+ * list by folding `applyTimelineEvent` over each event. The single source of
+ * truth for the timeline projection's step state, consumed by
+ * `computeSubagentCardData`.
+ */
+export function computeSubagentSteps(events: SubagentTimelineEvent[]): {
+  steps: ToolCallCardStep[];
+  toolMeta: Array<ToolMeta | undefined>;
+} {
   const steps: ToolCallCardStep[] = [];
   // Parallel array tracking per-step metadata not carried on the shared step
   // shapes (see `ToolMeta`). Indexed by `steps` position; `undefined` for
   // entries with no follow-up (thinking, tool_error, web_fetch).
   const toolMeta: Array<ToolMeta | undefined> = [];
 
-  for (const event of entry.events) {
-    if (event.type === "text") {
-      const text = trimTextPreview(event.content);
-      // Skip empty text events — they'd render as a blank thinking step.
-      if (text.length === 0) continue;
-      // `detailKey` (the source event id) lets the timeline pill open the full,
-      // un-truncated reasoning via `buildSubagentStepDetails` — the pill itself
-      // only carries the collapsed `text` preview.
-      steps.push({ kind: "thinking", durationLabel: "", text, detailKey: event.id });
-      toolMeta.push(undefined);
-      continue;
-    }
+  for (const event of events) applyTimelineEvent(steps, toolMeta, event);
 
-    if (event.type === "tool_call") {
-      const toolName = event.toolName ?? "";
-      // Route web tools to the dedicated step kinds so their phase labels match
-      // main chat ("Searching the web" / "Thinking") instead of the generic
-      // "Working" bucket the tool path produces. Mirrors the main-chat split in
-      // `tool-call-card-utils` (`buildWebSearchStep` / `buildWebFetchStep`).
-      if (WEB_TOOL_NAMES.has(toolName)) {
-        if (toolName === "web_fetch") {
-          // `web_fetch` renders as a "Reading <domain>" thinking step — no
-          // follow-up tracking needed (the domain is known at call time, and a
-          // thinking step is neutral for phase status).
-          steps.push({
-            kind: "thinking",
-            durationLabel: "",
-            text: webFetchReadingText(event),
-            // Key the step to its tool id so the timeline pill opens the nested
-            // web_fetch detail (source card + extracted content) — matching the
-            // `toolUseId`-keyed payload `buildSubagentStepDetails` emits, the
-            // same way the `web_search` branch below keys its pill.
-            detailKey: event.toolUseId,
-          });
-          toolMeta.push(undefined);
-        } else {
-          // `web_search` — placeholder until its result lands; the matched
-          // `tool_result` flips the title tense + fills in results (see below).
-          // `query` (raw input, else the `content` summary which is the query
-          // for web_search) labels the step so unclamped multi-search groups
-          // stay distinct in the timeline; it survives the `...target` spread on
-          // completion.
-          const query =
-            event.input && typeof event.input.query === "string"
-              ? event.input.query
-              : event.content || undefined;
-          steps.push({
-            kind: "web_search",
-            query,
-            title: "Searching the web",
-            durationLabel: "",
-            linkCount: 0,
-            results: [],
-            // The originating tool id keys this search's nested detail so the
-            // timeline can render it as a clickable pill (query + sources) —
-            // matches the key `buildSubagentStepDetails` emits. Survives the
-            // `...target` spread on completion alongside `query`.
-            detailKey: event.toolUseId,
-          });
-          toolMeta.push({
-            startTs: event.timestamp,
-            toolName,
-            toolUseId: event.toolUseId,
-          });
-        }
-        continue;
-      }
-      steps.push(mapToolEventToStep(event));
-      toolMeta.push({ startTs: event.timestamp, toolName });
-      continue;
-    }
+  return { steps, toolMeta };
+}
 
-    if (event.type === "tool_result") {
-      const matchIndex = findMatchingInFlightToolIndex(steps, toolMeta, event);
-      if (matchIndex === -1) continue;
-      const target = steps[matchIndex]!;
-      const start = toolMeta[matchIndex]?.startTs;
-      const durationLabel = durationLabelBetween(start, event.timestamp);
-      // `web_search` signals completion via title tense (not a `status` field):
-      // success flips "Searching" → "Searched"; an error becomes a
-      // `web_search_error` step (both still group under "Searching the web").
-      if (target.kind === "web_search") {
-        if (event.isError) {
-          steps[matchIndex] = webSearchErrorStep(durationLabel, event);
-          continue;
-        }
-        // Parse the result text (Title\nURL pairs) into link chips — the same
-        // fallback main chat uses on reload, since the subagent timeline carries
-        // the raw result text but not the structured `activityMetadata`. No
-        // clamp: the detail panel has room to show every source inline, so all
-        // results go in `results` and `overflowResults` stays empty.
-        const results = parseWebSearchResultText(event.result ?? event.content);
-        steps[matchIndex] = {
-          ...target,
-          title: "Searched the web",
-          // Backfill the query from the result's metadata. The originating
-          // `tool_call` carried empty input live (Anthropic resolves web_search
-          // input only at completion), so `target.query` is usually undefined
-          // until this result lands `searchQuery`. The history/detail path
-          // already has it on the call, hence the `target.query ||` precedence.
-          query: target.query || event.searchQuery,
-          durationLabel,
-          linkCount: results.length,
-          results,
-        };
-        continue;
-      }
-      if (target.kind !== "tool") continue;
-      steps[matchIndex] = {
-        ...target,
-        status: event.isError ? "error" : "completed",
-        durationLabel,
-      };
-      continue;
-    }
-
-    if (event.type === "error") {
-      // Close the matching in-flight tool step (if any) as `error` before
-      // appending the `tool_error` row. Same matching precedence as
-      // `tool_result` — see `findMatchingInFlightToolIndex` — so parallel
-      // calls to the same tool close the correct step.
-      const matchIndex = findMatchingInFlightToolIndex(steps, toolMeta, event);
-      if (matchIndex !== -1) {
-        const target = steps[matchIndex]!;
-        if (target.kind === "tool") {
-          steps[matchIndex] = { ...target, status: "error" };
-        } else if (target.kind === "web_search") {
-          steps[matchIndex] = webSearchErrorStep(
-            durationLabelBetween(toolMeta[matchIndex]?.startTs, event.timestamp),
-            event,
-          );
-        }
-      }
-      const message = trimTextPreview(event.content) || "Subagent error";
-      steps.push({ kind: "tool_error", message });
-      toolMeta.push(undefined);
-      continue;
-    }
-  }
+/**
+ * Pure projection of (entry) → card props. Split from the hook so tests
+ * can drive it without instantiating the Zustand store.
+ */
+export function computeSubagentCardData(
+  entry: SubagentEntry,
+): ToolCallCardData {
+  const { steps, toolMeta } = computeSubagentSteps(entry.events);
 
   const state = deriveCardState(entry.status);
   const { currentStepTitle, currentStepInfo } = deriveCurrentStep(
@@ -637,6 +665,139 @@ export function useSubagentCardData(
  * Risk fields (`riskLevel`/`riskReason`) are omitted — subagent timeline events
  * don't carry them.
  */
+/**
+ * Pure per-event reducer for the detail-map projection: mutates the parallel
+ * `(payloads, meta)` arrays in place exactly as a single iteration of
+ * `buildSubagentStepDetails`'s loop. The detail-map counterpart to
+ * `applyTimelineEvent` so an incremental replay folds through the same logic.
+ * No-op for unhandled event types.
+ */
+export function applyDetailEvent(
+  payloads: ToolDetailPayload[],
+  meta: Array<{ startTs: number; running: boolean }>,
+  event: SubagentTimelineEvent,
+): void {
+  // Text events become clickable "thinking" pills. Carry the FULL content
+  // (the timeline pill shows only a collapsed preview) and key by the event
+  // id to match the step's `detailKey`. Skip whitespace-only text exactly as
+  // `computeSubagentCardData` does so steps and payloads stay aligned.
+  if (event.type === "text") {
+    if ((event.content ?? "").trim().length === 0) return;
+    payloads.push({
+      toolCallId: event.id,
+      toolName: "",
+      title: "Thought",
+      activity: "",
+      input: {},
+      status: "completed",
+      durationLabel: "",
+      kind: "thinking",
+      thinkingText: event.content,
+    });
+    meta.push({ startTs: event.timestamp, running: false });
+    return;
+  }
+
+  if (event.type === "tool_call") {
+    const toolCallId = event.toolUseId ?? "";
+    // Skip calls without an id — they can't be keyed or clicked.
+    if (!toolCallId) return;
+    const toolName = event.toolName ?? "";
+    // Web search → a dedicated detail payload carrying the query and (once the
+    // result lands) the parsed source list, rendered as favicon chips rather
+    // than the raw technical-details body. Mirrors the `web_search` step the
+    // timeline projection builds, keyed by the same `toolUseId`.
+    if (toolName === "web_search") {
+      const query =
+        event.input && typeof event.input.query === "string"
+          ? event.input.query
+          : event.content || undefined;
+      payloads.push({
+        toolCallId,
+        toolName,
+        title: "Searched the web",
+        activity: "",
+        input: event.input ?? {},
+        status: "running",
+        durationLabel: "",
+        kind: "web_search",
+        searchQuery: query,
+        searchResults: [],
+      });
+      meta.push({ startTs: event.timestamp, running: true });
+      return;
+    }
+    const labelInput =
+      event.input ?? reconstructInputBag(toolName, event.content ?? "");
+    const label = deriveStepLabelFromName(toolName, labelInput);
+    payloads.push({
+      toolCallId,
+      toolName,
+      title: label.title,
+      activity: label.activity,
+      input: event.input ?? {},
+      status: "running",
+      durationLabel: "",
+      kind: "tool",
+    });
+    meta.push({ startTs: event.timestamp, running: true });
+    return;
+  }
+
+  // A follow-up carrying a result. A FAILED tool result is mapped to a raw
+  // `error`-typed event (see `mapInnerEventType`) yet still carries its
+  // `result` + `isError`, so we resolve both `tool_result` and `error`
+  // against the in-flight list regardless of the mapped type.
+  if (event.type === "tool_result" || event.type === "error") {
+    const matchIndex = matchInFlightTool(
+      payloads.map((payload, i) => ({
+        toolCallId: payload.toolCallId,
+        toolName: payload.toolName,
+        running: meta[i]!.running,
+      })),
+      event,
+    );
+    if (matchIndex === -1) return;
+    const target = payloads[matchIndex]!;
+    const start = meta[matchIndex]!.startTs;
+    // Shared with `computeSubagentCardData` so the non-positive-delta
+    // suppression (synthetic equal-timestamp history events → "") can't drift
+    // between the two projections.
+    const durationLabel = durationLabelBetween(start, event.timestamp);
+    // Web search → parse the raw result text into the same source chips the
+    // timeline renders; everything else keeps the raw `result` for the
+    // technical-details body.
+    payloads[matchIndex] =
+      target.kind === "web_search"
+        ? {
+            ...target,
+            status: event.isError ? "error" : "completed",
+            durationLabel,
+            // Backfill the query from the result metadata for the nested
+            // detail view — the call-time `searchQuery` is empty live (see
+            // the timeline projection's matching backfill).
+            searchQuery: target.searchQuery || event.searchQuery,
+            searchResults: event.isError
+              ? []
+              : parseWebSearchResultText(event.result ?? event.content),
+            // On failure, keep the full provider/backend error so the nested
+            // detail can show it untruncated — the timeline chip only carries
+            // a `trimTextPreview` snippet. Parity with how a failed tool keeps
+            // its full `result`.
+            result: event.isError
+              ? (event.result ?? event.content)
+              : undefined,
+          }
+        : {
+            ...target,
+            result: event.result ?? event.content,
+            status: event.isError ? "error" : "completed",
+            durationLabel,
+          };
+    meta[matchIndex]!.running = false;
+  }
+}
+
 export function buildSubagentStepDetails(
   entry: SubagentEntry,
 ): Map<string, ToolDetailPayload> {
@@ -645,127 +806,7 @@ export function buildSubagentStepDetails(
   // matching follow-ups and duration calc. Indexed by `payloads` position.
   const meta: Array<{ startTs: number; running: boolean }> = [];
 
-  for (const event of entry.events) {
-    // Text events become clickable "thinking" pills. Carry the FULL content
-    // (the timeline pill shows only a collapsed preview) and key by the event
-    // id to match the step's `detailKey`. Skip whitespace-only text exactly as
-    // `computeSubagentCardData` does so steps and payloads stay aligned.
-    if (event.type === "text") {
-      if ((event.content ?? "").trim().length === 0) continue;
-      payloads.push({
-        toolCallId: event.id,
-        toolName: "",
-        title: "Thought",
-        activity: "",
-        input: {},
-        status: "completed",
-        durationLabel: "",
-        kind: "thinking",
-        thinkingText: event.content,
-      });
-      meta.push({ startTs: event.timestamp, running: false });
-      continue;
-    }
-
-    if (event.type === "tool_call") {
-      const toolCallId = event.toolUseId ?? "";
-      // Skip calls without an id — they can't be keyed or clicked.
-      if (!toolCallId) continue;
-      const toolName = event.toolName ?? "";
-      // Web search → a dedicated detail payload carrying the query and (once the
-      // result lands) the parsed source list, rendered as favicon chips rather
-      // than the raw technical-details body. Mirrors the `web_search` step the
-      // timeline projection builds, keyed by the same `toolUseId`.
-      if (toolName === "web_search") {
-        const query =
-          event.input && typeof event.input.query === "string"
-            ? event.input.query
-            : event.content || undefined;
-        payloads.push({
-          toolCallId,
-          toolName,
-          title: "Searched the web",
-          activity: "",
-          input: event.input ?? {},
-          status: "running",
-          durationLabel: "",
-          kind: "web_search",
-          searchQuery: query,
-          searchResults: [],
-        });
-        meta.push({ startTs: event.timestamp, running: true });
-        continue;
-      }
-      const labelInput =
-        event.input ?? reconstructInputBag(toolName, event.content ?? "");
-      const label = deriveStepLabelFromName(toolName, labelInput);
-      payloads.push({
-        toolCallId,
-        toolName,
-        title: label.title,
-        activity: label.activity,
-        input: event.input ?? {},
-        status: "running",
-        durationLabel: "",
-        kind: "tool",
-      });
-      meta.push({ startTs: event.timestamp, running: true });
-      continue;
-    }
-
-    // A follow-up carrying a result. A FAILED tool result is mapped to a raw
-    // `error`-typed event (see `mapInnerEventType`) yet still carries its
-    // `result` + `isError`, so we resolve both `tool_result` and `error`
-    // against the in-flight list regardless of the mapped type.
-    if (event.type === "tool_result" || event.type === "error") {
-      const matchIndex = matchInFlightTool(
-        payloads.map((payload, i) => ({
-          toolCallId: payload.toolCallId,
-          toolName: payload.toolName,
-          running: meta[i]!.running,
-        })),
-        event,
-      );
-      if (matchIndex === -1) continue;
-      const target = payloads[matchIndex]!;
-      const start = meta[matchIndex]!.startTs;
-      // Shared with `computeSubagentCardData` so the non-positive-delta
-      // suppression (synthetic equal-timestamp history events → "") can't drift
-      // between the two projections.
-      const durationLabel = durationLabelBetween(start, event.timestamp);
-      // Web search → parse the raw result text into the same source chips the
-      // timeline renders; everything else keeps the raw `result` for the
-      // technical-details body.
-      payloads[matchIndex] =
-        target.kind === "web_search"
-          ? {
-              ...target,
-              status: event.isError ? "error" : "completed",
-              durationLabel,
-              // Backfill the query from the result metadata for the nested
-              // detail view — the call-time `searchQuery` is empty live (see
-              // the timeline projection's matching backfill).
-              searchQuery: target.searchQuery || event.searchQuery,
-              searchResults: event.isError
-                ? []
-                : parseWebSearchResultText(event.result ?? event.content),
-              // On failure, keep the full provider/backend error so the nested
-              // detail can show it untruncated — the timeline chip only carries
-              // a `trimTextPreview` snippet. Parity with how a failed tool keeps
-              // its full `result`.
-              result: event.isError
-                ? (event.result ?? event.content)
-                : undefined,
-            }
-          : {
-              ...target,
-              result: event.result ?? event.content,
-              status: event.isError ? "error" : "completed",
-              durationLabel,
-            };
-      meta[matchIndex]!.running = false;
-    }
-  }
+  for (const event of entry.events) applyDetailEvent(payloads, meta, event);
 
   // Every payload (including a failed web_search) is kept and keyed by its tool
   // id. The timeline's `web_search_error` step carries the same id as its

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -495,6 +495,12 @@ export function computeSubagentSteps(events: SubagentTimelineEvent[]): {
 /**
  * Pure projection of (entry) → card props. Split from the hook so tests
  * can drive it without instantiating the Zustand store.
+ *
+ * The heavy O(n) timeline walk is isolated in `computeSubagentSteps` so callers
+ * that re-render on every status/usage tick — like `subagent-detail-panel.tsx`,
+ * which renders its own header from `entry` and consumes only `steps` — can
+ * memoize the walk on `entry.events` (reference-stable across those ticks)
+ * rather than re-running it here on every `entry` identity bump.
  */
 export function computeSubagentCardData(
   entry: SubagentEntry,
@@ -659,7 +665,7 @@ export function useSubagentCardData(
  *    the parsed result sources, keyed by `toolUseId` (matching the `detailKey`
  *    `computeSubagentCardData` stamps on the search step).
  *
- * Walks `entry.events` in order, tracking in-flight tool payloads and resolving
+ * Walks `events` in order, tracking in-flight tool payloads and resolving
  * `tool_result` / `error` follow-ups against them with `matchInFlightTool` —
  * the same precedence `computeSubagentCardData` uses, so the two stay aligned.
  * Risk fields (`riskLevel`/`riskReason`) are omitted — subagent timeline events
@@ -799,14 +805,14 @@ export function applyDetailEvent(
 }
 
 export function buildSubagentStepDetails(
-  entry: SubagentEntry,
+  events: SubagentTimelineEvent[],
 ): Map<string, ToolDetailPayload> {
   const payloads: ToolDetailPayload[] = [];
   // Parallel array: start timestamp + running flag per payload, used for
   // matching follow-ups and duration calc. Indexed by `payloads` position.
   const meta: Array<{ startTs: number; running: boolean }> = [];
 
-  for (const event of entry.events) applyDetailEvent(payloads, meta, event);
+  for (const event of events) applyDetailEvent(payloads, meta, event);
 
   // Every payload (including a failed web_search) is kept and keyed by its tool
   // id. The timeline's `web_search_error` step carries the same id as its

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -28,13 +28,14 @@
  *   step so the body doesn't show a stale loader.
  */
 
-import { useMemo } from "react";
+import { useRef } from "react";
 
 import {
   useSubagentStore,
   type SubagentEntry,
   type SubagentTimelineEvent,
 } from "@/domains/chat/subagent-store";
+import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
 import type { SubagentStatus } from "@vellumai/assistant-api";
 import { deriveStepLabelFromName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
@@ -58,6 +59,13 @@ export type { ToolCallCardData, ToolCallCardStep };
 // ---------------------------------------------------------------------------
 
 const TEXT_PREVIEW_MAX = 160;
+
+/**
+ * Shared frozen empty events array for the spawn-race window (no entry yet).
+ * A stable reference keeps the projector's identity check happy so the hook
+ * doesn't churn while waiting for the `subagent_spawned` event.
+ */
+const EMPTY_EVENTS: SubagentTimelineEvent[] = [];
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -505,8 +513,21 @@ export function computeSubagentSteps(events: SubagentTimelineEvent[]): {
 export function computeSubagentCardData(
   entry: SubagentEntry,
 ): ToolCallCardData {
-  const { steps, toolMeta } = computeSubagentSteps(entry.events);
+  return deriveSubagentCardData(entry, computeSubagentSteps(entry.events));
+}
 
+/**
+ * The cheap O(1) tail of `computeSubagentCardData`: given an entry and an
+ * already-projected `{ steps, toolMeta }`, derive the carousel meta (state,
+ * current-step title/info, step count) and assemble the card props. Split out so
+ * `useSubagentCardData` can feed it the incremental projector's output instead
+ * of re-walking the timeline. Reads only the last step, so it's safe to run on
+ * every render.
+ */
+export function deriveSubagentCardData(
+  entry: SubagentEntry,
+  { steps, toolMeta }: { steps: ToolCallCardStep[]; toolMeta: Array<ToolMeta | undefined> },
+): ToolCallCardData {
   const state = deriveCardState(entry.status);
   const { currentStepTitle, currentStepInfo } = deriveCurrentStep(
     entry,
@@ -644,10 +665,42 @@ export function useSubagentCardData(
   subagentId: string,
 ): ToolCallCardData | null {
   const entry = useSubagentStore((state) => state.byId[subagentId]);
-  return useMemo(() => {
-    if (!entry) return null;
-    return computeSubagentCardData(entry);
-  }, [entry]);
+  // Project incrementally (must run unconditionally — `useSubagentSteps` holds
+  // a ref). In the spawn-race window there's no entry yet, so feed the stable
+  // empty array; the `null` return below preserves the existing contract.
+  const projected = useSubagentSteps(entry?.events ?? EMPTY_EVENTS);
+
+  const lastRef = useRef<ToolCallCardData | null>(null);
+
+  // Intentional render-phase ref usage: `lastRef` caches the last projected
+  // card so we can preserve its identity across renders that produce an equal
+  // result (so the inline card's `React.memo` bails). Same pattern as
+  // `useSubagentSteps` / `use-event-stream.ts`.
+  /* eslint-disable react-hooks/refs -- per-instance card-identity cache (see above) */
+  if (!entry) {
+    lastRef.current = null;
+    return null;
+  }
+
+  const next = deriveSubagentCardData(entry, projected);
+  const last = lastRef.current;
+  // Preserve `cardData` identity when the projected steps and the cheap meta
+  // scalars are all unchanged, so the inline card's `React.memo` / shell bails.
+  // `toolMeta`/`carouselItems` aren't read downstream; comparing `steps`
+  // identity (stable across no-op deltas) plus the derived scalars is sufficient.
+  if (
+    last != null &&
+    last.steps === next.steps &&
+    last.state === next.state &&
+    last.currentStepTitle === next.currentStepTitle &&
+    last.currentStepInfo === next.currentStepInfo &&
+    last.stepCount === next.stepCount
+  ) {
+    return last;
+  }
+  lastRef.current = next;
+  return next;
+  /* eslint-enable react-hooks/refs */
 }
 
 /**

--- a/clients/web/src/domains/chat/subagent-detail-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.test.ts
@@ -1,29 +1,30 @@
 /**
- * Tests for the incremental step projector (`createIncrementalStepProjection`).
+ * Tests for the incremental detail-map projector
+ * (`createIncrementalDetailProjection`).
  *
  * The core safety net is the **no-drift property test**: it drives the projector
  * one store-mutation at a time (append vs text-coalesce mutate-last, exactly as
- * `subagent-store.receiveEvent` does) and asserts the incremental output always
- * deep-equals a full `computeSubagentSteps` rebuild — so the O(Δ) replay can
- * never diverge from the O(n) source of truth.
+ * `subagent-store.receiveEvent` does) and asserts the incremental `Map` always
+ * deep-equals a full `buildSubagentStepDetails` rebuild — so the O(Δ) replay can
+ * never diverge from the O(n) source of truth, including failed web_search
+ * payloads keyed by `toolUseId` and thinking payloads keyed by event id.
  */
 
 import { describe, expect, test } from "bun:test";
 
-import { createIncrementalStepProjection } from "@/domains/chat/subagent-step-projection";
+import { createIncrementalDetailProjection } from "@/domains/chat/subagent-detail-projection";
 import {
-  applyTimelineEvent,
-  computeSubagentSteps,
-  type ToolCallCardStep,
-  type ToolMeta,
+  applyDetailEvent,
+  buildSubagentStepDetails,
 } from "@/domains/chat/hooks/use-subagent-card-data";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 const NOW = 1700000000000;
 
 let eventSeq = 0;
 function nextEventId(): string {
-  return `te-${eventSeq++}`;
+  return `de-${eventSeq++}`;
 }
 
 function makeEvent(
@@ -40,15 +41,31 @@ function makeEvent(
   };
 }
 
+/**
+ * Stable, order-independent serialization of a detail map for deep comparison:
+ * sort by key, then compare key→payload pairs. (`Map` equality in bun's `toEqual`
+ * is order-sensitive on insertion; the incremental and full paths build the same
+ * payloads but we compare the canonical content, not insertion order.)
+ */
+function mapToSortedEntries(
+  map: Map<string, ToolDetailPayload>,
+): Array<[string, ToolDetailPayload]> {
+  return [...map.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+function expectMapsEqual(
+  incremental: Map<string, ToolDetailPayload>,
+  full: Map<string, ToolDetailPayload>,
+): void {
+  expect(mapToSortedEntries(incremental)).toEqual(mapToSortedEntries(full));
+}
+
 // ---------------------------------------------------------------------------
 // Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
 // incremental array shapes so the projector is fed precisely what it sees live.
 // ---------------------------------------------------------------------------
 
-/**
- * Append a fresh event to the events array, returning a NEW array (every prior
- * element shared by reference). Models the store's "Append-1" shape.
- */
+/** Append a fresh event, returning a NEW array (prior elements shared). */
 function appendEvent(
   events: SubagentTimelineEvent[],
   event: SubagentTimelineEvent,
@@ -83,42 +100,51 @@ function coalesceText(
 // Per-diff-class unit tests
 // ---------------------------------------------------------------------------
 
-describe("createIncrementalStepProjection — per-diff-class", () => {
+describe("createIncrementalDetailProjection — per-diff-class", () => {
   test("first call / empty cache builds via full rebuild", () => {
-    const p = createIncrementalStepProjection();
+    const p = createIncrementalDetailProjection();
     const events: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "Investigating" }),
     ];
-    expect(p.project(events)).toEqual(computeSubagentSteps(events));
+    expectMapsEqual(p.project(events), buildSubagentStepDetails(events));
   });
 
-  test("identity: same array reference returns the cached result unchanged", () => {
-    const p = createIncrementalStepProjection();
+  test("identity: same array reference returns the cached Map by reference", () => {
+    const p = createIncrementalDetailProjection();
     const events: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "hi" }),
     ];
     const first = p.project(events);
     const second = p.project(events);
-    // The projector returns the cached ARRAY references unchanged on identity
-    // (the `useSubagentSteps` hook layers wrapper-object stability on top).
-    expect(second.steps).toBe(first.steps);
-    expect(second.toolMeta).toBe(first.toolMeta);
+    expect(second).toBe(first);
   });
 
-  test("append-1 text: new tail thinking step", () => {
-    const p = createIncrementalStepProjection();
+  test("thinking payload is keyed by the source event id", () => {
+    const p = createIncrementalDetailProjection();
+    const textEv = makeEvent({ type: "text", content: "deep reasoning here" });
+    const events = [textEv];
+    const map = p.project(events);
+    const payload = map.get(textEv.id);
+    expect(payload?.kind).toBe("thinking");
+    expect(payload?.toolCallId).toBe(textEv.id);
+    expect(payload?.thinkingText).toBe("deep reasoning here");
+  });
+
+  test("append-1 text: new thinking payload keyed by event id", () => {
+    const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "first" }),
     ];
     p.project(events);
-    events = appendEvent(events, makeEvent({ type: "text", content: "second" }));
-    const out = p.project(events);
-    expect(out).toEqual(computeSubagentSteps(events));
-    expect(out.steps).toHaveLength(2);
+    const second = makeEvent({ type: "text", content: "second" });
+    events = appendEvent(events, second);
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get(second.id)?.thinkingText).toBe("second");
   });
 
-  test("append-1 tool_call: new in-flight tool step", () => {
-    const p = createIncrementalStepProjection();
+  test("append-1 tool_call: new in-flight tool payload keyed by toolUseId", () => {
+    const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "thinking" }),
     ];
@@ -127,18 +153,13 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
       events,
       makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls" }),
     );
-    const out = p.project(events);
-    expect(out).toEqual(computeSubagentSteps(events));
-    const last = out.steps[out.steps.length - 1]!;
-    expect(last.kind).toBe("tool");
-    if (last.kind === "tool") expect(last.status).toBe("running");
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get("tu-1")?.status).toBe("running");
   });
 
-  test("append-1 tool_result closes an EARLIER in-flight tool (not the tail)", () => {
-    const p = createIncrementalStepProjection();
-    // tool_call, then a trailing text event, then the tool_result lands — so the
-    // result must close the tool at an earlier index, exercising the
-    // append-MOSTLY path through the real reducer.
+  test("append-1 tool_result closes an earlier in-flight tool (full untruncated result)", () => {
+    const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [
       makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls", timestamp: NOW }),
       makeEvent({ type: "text", content: "waiting" }, NOW + 100),
@@ -146,92 +167,58 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
     p.project(events);
     events = appendEvent(
       events,
-      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-1", content: "ok", timestamp: NOW + 2500 }),
+      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-1", result: "file-a\nfile-b", timestamp: NOW + 2500 }),
     );
-    const out = p.project(events);
-    expect(out).toEqual(computeSubagentSteps(events));
-    const toolStep = out.steps.find((s) => s.kind === "tool")!;
-    expect(toolStep.kind).toBe("tool");
-    if (toolStep.kind === "tool") expect(toolStep.status).toBe("completed");
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get("tu-1")?.status).toBe("completed");
+    expect(map.get("tu-1")?.result).toBe("file-a\nfile-b");
   });
 
-  test("append-1 error closes in-flight tool + appends a tool_error step", () => {
-    const p = createIncrementalStepProjection();
+  test("append-1 error closes in-flight tool as error", () => {
+    const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [
       makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "rm -rf /", timestamp: NOW }),
     ];
     p.project(events);
     events = appendEvent(
       events,
-      makeEvent({ type: "error", content: "permission denied", timestamp: NOW + 500 }),
+      makeEvent({ type: "error", toolName: "bash", toolUseId: "tu-1", content: "permission denied", result: "permission denied", isError: true, timestamp: NOW + 500 }),
     );
-    const out = p.project(events);
-    expect(out).toEqual(computeSubagentSteps(events));
-    const toolStep = out.steps.find((s) => s.kind === "tool")!;
-    if (toolStep.kind === "tool") expect(toolStep.status).toBe("error");
-    expect(out.steps[out.steps.length - 1]!.kind).toBe("tool_error");
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.get("tu-1")?.status).toBe("error");
   });
 
-  test("mutate-last under the 160-char clamp: new tail identity, content grows", () => {
-    const p = createIncrementalStepProjection();
+  test("mutate-last thinking payload grows with the full untruncated content", () => {
+    const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "short" }),
     ];
     const first = p.project(events);
-    const firstTail = first.steps[0]!;
-    // Grow the text but stay well under 160 chars.
-    events = coalesceText(events, " more text", events[0]!.timestamp);
+    const id = events[0]!.id;
+    expect(first.get(id)?.thinkingText).toBe("short");
+    // Grow past 160 chars — unlike steps, the thinking payload carries the FULL
+    // content, so it keeps changing every delta (no clamp shortcut).
+    const tail = "x".repeat(300);
+    events = coalesceText(events, tail, events[0]!.timestamp);
     const second = p.project(events);
-    expect(second).toEqual(computeSubagentSteps(events));
-    // A new tail step (preview changed), so the array is a fresh reference.
-    expect(second.steps).not.toBe(first.steps);
-    const secondTail = second.steps[0]!;
-    if (firstTail.kind === "thinking" && secondTail.kind === "thinking") {
-      expect(secondTail.text.length).toBeGreaterThan(firstTail.text.length);
-    }
-  });
-
-  test("mutate-last PAST the clamp: tail identity preserved (same steps reference)", () => {
-    const p = createIncrementalStepProjection();
-    // Seed with content already well past 160 chars so the preview is clamped.
-    let events: SubagentTimelineEvent[] = [
-      makeEvent({ type: "text", content: "y".repeat(300) }),
-    ];
-    const a = p.project(events);
-    // Append more identical chars — the clamped 160-char preview is unchanged.
-    events = coalesceText(events, "y".repeat(50), events[0]!.timestamp);
-    const b = p.project(events);
-    expect(b.steps).toBe(a.steps);
-    expect(b.toolMeta).toBe(a.toolMeta);
-    // Still correct vs the full rebuild.
-    expect(b.steps).toEqual(computeSubagentSteps(events).steps);
-  });
-
-  test("mutate-last that grows past the clamp from under it: still deep-equals rebuild", () => {
-    const p = createIncrementalStepProjection();
-    let events: SubagentTimelineEvent[] = [
-      makeEvent({ type: "text", content: "z".repeat(100) }),
-    ];
-    p.project(events);
-    events = coalesceText(events, "z".repeat(200), events[0]!.timestamp);
-    const out = p.project(events);
-    expect(out).toEqual(computeSubagentSteps(events));
+    expectMapsEqual(second, buildSubagentStepDetails(events));
+    expect(second.get(id)?.thinkingText).toBe("short" + tail);
   });
 
   test("full-replace (history hydration) falls back to a full rebuild", () => {
-    const p = createIncrementalStepProjection();
+    const p = createIncrementalDetailProjection();
     p.project([makeEvent({ type: "text", content: "live" })]);
-    // A wholesale swap — entirely new array, no shared prefix.
     const hydrated: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "hydrated-1" }),
       makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "h-1", content: "echo" }),
     ];
-    const out = p.project(hydrated);
-    expect(out).toEqual(computeSubagentSteps(hydrated));
+    expectMapsEqual(p.project(hydrated), buildSubagentStepDetails(hydrated));
   });
 
   test("subagent switch (totally different array) falls back to a full rebuild", () => {
-    const p = createIncrementalStepProjection();
+    const p = createIncrementalDetailProjection();
     p.project([
       makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-a", input: { query: "a" } }),
     ]);
@@ -239,52 +226,64 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
       makeEvent({ type: "text", content: "different subagent" }),
       makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: "wf-b", input: { url: "https://x.dev" } }),
     ];
-    const out = p.project(other);
-    expect(out).toEqual(computeSubagentSteps(other));
+    expectMapsEqual(p.project(other), buildSubagentStepDetails(other));
   });
 
   test("truncation (shorter array) falls back to a full rebuild", () => {
-    const p = createIncrementalStepProjection();
+    const p = createIncrementalDetailProjection();
     const full: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "a" }),
       makeEvent({ type: "text", content: "b" }),
     ];
     p.project(full);
     const truncated = full.slice(0, 1);
-    const out = p.project(truncated);
-    expect(out).toEqual(computeSubagentSteps(truncated));
+    expectMapsEqual(p.project(truncated), buildSubagentStepDetails(truncated));
   });
 
-  test("parallel same-name tool calls: result closes the correct match index", () => {
-    const p = createIncrementalStepProjection();
-    // Two concurrent bash calls; the result for tu-2 must close the SECOND, not
-    // the first — exercises `findMatchingInFlightToolIndex` through the append.
+  test("failed web_search payload is keyed by toolUseId and carries the full error", () => {
+    const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [
-      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls", timestamp: NOW }),
-      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-2", content: "pwd", timestamp: NOW + 100 }),
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-1", input: { query: "vellum" }, timestamp: NOW }),
     ];
     p.project(events);
     events = appendEvent(
       events,
-      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-2", content: "/home", timestamp: NOW + 1500 }),
+      makeEvent({ type: "tool_result", toolName: "web_search", toolUseId: "ws-1", isError: true, result: "upstream 503 backend overloaded", content: "search failed", timestamp: NOW + 900 }),
     );
-    const out = p.project(events);
-    expect(out).toEqual(computeSubagentSteps(events));
-    const toolSteps = out.steps.filter((s) => s.kind === "tool");
-    // First still running, second completed.
-    if (toolSteps[0]!.kind === "tool") expect(toolSteps[0]!.status).toBe("running");
-    if (toolSteps[1]!.kind === "tool") expect(toolSteps[1]!.status).toBe("completed");
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    const failed = map.get("ws-1");
+    expect(failed?.kind).toBe("web_search");
+    expect(failed?.status).toBe("error");
+    expect(failed?.result).toBe("upstream 503 backend overloaded");
+  });
+
+  test("successful web_search payload flips to completed with parsed sources", () => {
+    const p = createIncrementalDetailProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-2", input: { query: "vellum" }, timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "web_search", toolUseId: "ws-2", result: "Vellum\nhttps://vellum.ai", timestamp: NOW + 900 }),
+    );
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    const search = map.get("ws-2");
+    expect(search?.status).toBe("completed");
+    expect(search?.searchResults?.length).toBeGreaterThan(0);
   });
 
   test("cross-subagent id collision (detail-1 reused) is NOT misclassified as mutate-last", () => {
     // `mapDetailEvents` restarts event ids at `detail-1` for EACH subagent. When
     // the panel is reused across a subagent switch and both subagents have
     // exactly ONE event, the last ids collide on `detail-1`. The previous (tool)
-    // step must NOT survive into subagent B's steps — only id equality would have
+    // entry must NOT survive into subagent B's map — only id equality would have
     // let it through; the text-coalescing content-shape guards force a full
     // rebuild instead.
-    const p = createIncrementalStepProjection();
-    // Subagent A: a single tool_call (web payload).
+    const p = createIncrementalDetailProjection();
+    // Subagent A: a single tool_call (web payload) keyed by toolUseId.
     const subagentA: SubagentTimelineEvent[] = [
       {
         id: "detail-1",
@@ -300,10 +299,10 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
     const subagentB: SubagentTimelineEvent[] = [
       { id: "detail-1", type: "text", content: "B is thinking", timestamp: NOW },
     ];
-    const out = p.project(subagentB);
-    // Must deep-equal a full rebuild of B — no stale tool step from A.
-    expect(out).toEqual(computeSubagentSteps(subagentB));
-    expect(out.steps.some((s) => s.kind === "tool")).toBe(false);
+    const map = p.project(subagentB);
+    // Must deep-equal a full rebuild of B — no stale tool entry from A.
+    expectMapsEqual(map, buildSubagentStepDetails(subagentB));
+    expect(map.has("tu-a")).toBe(false);
   });
 
   test("genuine text coalescing (same id, text→text, content extends) still takes the incremental path", () => {
@@ -312,41 +311,40 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
     // the result still deep-equals a full rebuild.
     let calls = 0;
     const counting = (
-      steps: ToolCallCardStep[],
-      toolMeta: Array<ToolMeta | undefined>,
+      payloads: ToolDetailPayload[],
+      meta: Array<{ startTs: number; running: boolean }>,
       event: SubagentTimelineEvent,
     ) => {
       calls++;
-      applyTimelineEvent(steps, toolMeta, event);
+      applyDetailEvent(payloads, meta, event);
     };
-    const p = createIncrementalStepProjection(counting);
+    const p = createIncrementalDetailProjection(counting);
     let events: SubagentTimelineEvent[] = [
       makeEvent({ type: "text", content: "Investig" }),
     ];
     p.project(events);
     const callsAfterFirst = calls;
     events = coalesceText(events, "ating the bug", events[0]!.timestamp);
-    const out = p.project(events);
+    const map = p.project(events);
     // Incremental path: exactly one more reducer call (re-derive the grown tail),
     // not a full re-walk of every event.
     expect(calls - callsAfterFirst).toBe(1);
-    expect(out).toEqual(computeSubagentSteps(events));
+    expectMapsEqual(map, buildSubagentStepDetails(events));
   });
 
-  test("web_search result flips the placeholder to 'Searched the web'", () => {
-    const p = createIncrementalStepProjection();
+  test("tool_call with an empty id is skipped (not keyed/clickable)", () => {
+    const p = createIncrementalDetailProjection();
     let events: SubagentTimelineEvent[] = [
-      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-1", input: { query: "vellum" }, timestamp: NOW }),
+      makeEvent({ type: "text", content: "thinking" }),
     ];
     p.project(events);
     events = appendEvent(
       events,
-      makeEvent({ type: "tool_result", toolName: "web_search", toolUseId: "ws-1", result: "Vellum\nhttps://vellum.ai", timestamp: NOW + 900 }),
+      makeEvent({ type: "tool_call", toolName: "bash", content: "ls" }),
     );
-    const out = p.project(events);
-    expect(out).toEqual(computeSubagentSteps(events));
-    const search = out.steps[0]!;
-    if (search.kind === "web_search") expect(search.title).toBe("Searched the web");
+    const map = p.project(events);
+    expectMapsEqual(map, buildSubagentStepDetails(events));
+    expect(map.has("")).toBe(false);
   });
 });
 
@@ -409,7 +407,7 @@ function generateStream(seed: number, n: number): Mutation[] {
         });
         openTools.push({ id, toolName: "web_search" });
       } else if (toolRoll < 0.35) {
-        // web_fetch has no follow-up — a thinking step, no open tracking.
+        // web_fetch has no follow-up — keyed by id, no open tracking.
         mutations.push({
           kind: "append",
           event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
@@ -450,10 +448,10 @@ function generateStream(seed: number, n: number): Mutation[] {
     if (openTools.length > 0) {
       // Close an open tool with a raw error event.
       const idx = Math.floor(rng() * openTools.length);
-      openTools.splice(idx, 1);
+      const open = openTools.splice(idx, 1)[0]!;
       mutations.push({
         kind: "append",
-        event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+        event: makeEvent({ type: "error", toolName: open.toolName, toolUseId: open.id, isError: true, result: `err-${i}`, content: `err-${i}` }, ts),
       });
       continue;
     }
@@ -481,11 +479,11 @@ function applyMutation(
 // No-drift property test — the core safety net.
 // ---------------------------------------------------------------------------
 
-describe("createIncrementalStepProjection — no-drift property", () => {
+describe("createIncrementalDetailProjection — no-drift property", () => {
   const seeds = [1, 7, 42, 1337, 99999];
   for (const seed of seeds) {
-    test(`seed ${seed}: incremental deep-equals full rebuild after every mutation (N=300)`, () => {
-      const projector = createIncrementalStepProjection();
+    test(`seed ${seed}: incremental Map deep-equals full rebuild after every mutation (N=300)`, () => {
+      const projector = createIncrementalDetailProjection();
       const mutations = generateStream(seed, 300);
       let events: SubagentTimelineEvent[] = [];
       // Prime with the empty array.
@@ -494,9 +492,8 @@ describe("createIncrementalStepProjection — no-drift property", () => {
       for (let i = 0; i < mutations.length; i++) {
         events = applyMutation(events, mutations[i]!);
         const incremental = projector.project(events);
-        const full = computeSubagentSteps(events);
-        expect(incremental.steps).toEqual(full.steps);
-        expect(incremental.toolMeta).toEqual(full.toolMeta);
+        const full = buildSubagentStepDetails(events);
+        expectMapsEqual(incremental, full);
       }
     });
   }
@@ -506,22 +503,19 @@ describe("createIncrementalStepProjection — no-drift property", () => {
 // Incremental-work guard — reducer invocations must be ~O(N), not O(N²).
 // ---------------------------------------------------------------------------
 
-describe("createIncrementalStepProjection — incremental-work guard", () => {
-  function countReducerCalls(n: number): { calls: number; toolResults: number } {
+describe("createIncrementalDetailProjection — incremental-work guard", () => {
+  function countReducerCalls(n: number): number {
     let calls = 0;
     const counting = (
-      steps: ToolCallCardStep[],
-      toolMeta: Array<ToolMeta | undefined>,
+      payloads: ToolDetailPayload[],
+      meta: Array<{ startTs: number; running: boolean }>,
       event: SubagentTimelineEvent,
     ) => {
       calls++;
-      applyTimelineEvent(steps, toolMeta, event);
+      applyDetailEvent(payloads, meta, event);
     };
-    const projector = createIncrementalStepProjection(counting);
+    const projector = createIncrementalDetailProjection(counting);
     const mutations = generateStream(2024, n);
-    const toolResults = mutations.filter(
-      (m) => m.kind === "append" && (m.event.type === "tool_result" || m.event.type === "error"),
-    ).length;
 
     let events: SubagentTimelineEvent[] = [];
     projector.project(events);
@@ -529,12 +523,12 @@ describe("createIncrementalStepProjection — incremental-work guard", () => {
       events = applyMutation(events, m);
       projector.project(events);
     }
-    return { calls, toolResults };
+    return calls;
   }
 
   for (const n of [50, 150, 300]) {
-    test(`N=${n}: reducer invocations are ~linear (≤ N + small constant), not O(N²)`, () => {
-      const { calls } = countReducerCalls(n);
+    test(`N=${n}: reducer invocations are ~linear (≤ N), not O(N²)`, () => {
+      const calls = countReducerCalls(n);
       // Each store mutation replays at most ONE event through the reducer
       // (append-1 → 1 call; mutate-last → exactly 1 re-derive call). So the
       // total is bounded by the number of mutations, far below N² for large N.
@@ -545,9 +539,9 @@ describe("createIncrementalStepProjection — incremental-work guard", () => {
   }
 
   test("reducer call count grows linearly across N ∈ {50,150,300}", () => {
-    const c50 = countReducerCalls(50).calls;
-    const c150 = countReducerCalls(150).calls;
-    const c300 = countReducerCalls(300).calls;
+    const c50 = countReducerCalls(50);
+    const c150 = countReducerCalls(150);
+    const c300 = countReducerCalls(300);
     // Linear growth: tripling N roughly triples the work (within a small band).
     // Quadratic growth would make c300/c50 ≈ 36, not ≈ 6.
     expect(c300 / Math.max(c50, 1)).toBeLessThan(12);

--- a/clients/web/src/domains/chat/subagent-detail-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.test.ts
@@ -17,28 +17,48 @@ import {
   applyDetailEvent,
   buildSubagentStepDetails,
 } from "@/domains/chat/hooks/use-subagent-card-data";
+import {
+  NOW,
+  appendEvent,
+  applyMutation as applyMutationShared,
+  coalesceText as coalesceTextShared,
+  createMakeEvent,
+  generateStream as generateStreamShared,
+  type Mutation,
+} from "@/domains/chat/subagent-projection-test-fixtures";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
-
-const NOW = 1700000000000;
 
 let eventSeq = 0;
 function nextEventId(): string {
   return `de-${eventSeq++}`;
 }
 
-function makeEvent(
-  overrides: Partial<SubagentTimelineEvent> & {
-    type: SubagentTimelineEvent["type"];
-  },
-  ts: number = NOW,
-): SubagentTimelineEvent {
-  return {
-    id: nextEventId(),
-    content: "",
-    timestamp: ts,
-    ...overrides,
-  };
+const makeEvent = createMakeEvent(nextEventId);
+
+// Bind the shared simulator/generator to this suite's `makeEvent`. The detail
+// suite attaches tool metadata to `error` events that CLOSE an in-flight tool
+// (`errorEventsCarryToolMeta`) so the failed-tool payload is keyed by
+// `toolUseId` and carries the error — its one divergence from the step suite.
+function coalesceText(
+  events: SubagentTimelineEvent[],
+  delta: string,
+  ts: number,
+): SubagentTimelineEvent[] {
+  return coalesceTextShared(events, delta, ts, makeEvent);
+}
+
+function generateStream(seed: number, n: number): Mutation[] {
+  return generateStreamShared(seed, n, makeEvent, {
+    errorEventsCarryToolMeta: true,
+  });
+}
+
+function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+): SubagentTimelineEvent[] {
+  return applyMutationShared(events, m, makeEvent);
 }
 
 /**
@@ -58,42 +78,6 @@ function expectMapsEqual(
   full: Map<string, ToolDetailPayload>,
 ): void {
   expect(mapToSortedEntries(incremental)).toEqual(mapToSortedEntries(full));
-}
-
-// ---------------------------------------------------------------------------
-// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
-// incremental array shapes so the projector is fed precisely what it sees live.
-// ---------------------------------------------------------------------------
-
-/** Append a fresh event, returning a NEW array (prior elements shared). */
-function appendEvent(
-  events: SubagentTimelineEvent[],
-  event: SubagentTimelineEvent,
-): SubagentTimelineEvent[] {
-  return [...events, event];
-}
-
-/**
- * Grow the trailing text event's content by `delta`, returning a NEW array with
- * only the last element replaced (same `id`, longer `content`) — the store's
- * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
- * event when the tail isn't text (matching `receiveEvent`).
- */
-function coalesceText(
-  events: SubagentTimelineEvent[],
-  delta: string,
-  ts: number,
-): SubagentTimelineEvent[] {
-  const last = events[events.length - 1];
-  if (last && last.type === "text") {
-    const updated = [...events];
-    updated[updated.length - 1] = {
-      ...last,
-      content: last.content + delta,
-    };
-    return updated;
-  }
-  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
 }
 
 // ---------------------------------------------------------------------------
@@ -347,133 +331,6 @@ describe("createIncrementalDetailProjection — per-diff-class", () => {
     expect(map.has("")).toBe(false);
   });
 });
-
-// ---------------------------------------------------------------------------
-// Deterministic event-stream generator (tiny LCG; no Math.random).
-// ---------------------------------------------------------------------------
-
-/** Numerical Recipes LCG — deterministic, seedable. */
-function makeRng(seed: number) {
-  let state = (seed >>> 0) || 1;
-  return () => {
-    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
-    return state / 0xffffffff;
-  };
-}
-
-type Mutation =
-  | { kind: "append"; event: SubagentTimelineEvent }
-  | { kind: "coalesce"; delta: string };
-
-/**
- * Generate a deterministic sequence of store mutations: text deltas (coalesced
- * when consecutive), tool calls, their results/errors, and web_search/web_fetch
- * — covering every reducer branch. Tracks open tool ids so results/errors close
- * real in-flight calls.
- */
-function generateStream(seed: number, n: number): Mutation[] {
-  const rng = makeRng(seed);
-  const mutations: Mutation[] = [];
-  const openTools: Array<{ id: string; toolName: string }> = [];
-  let lastWasText = false;
-  let ts = NOW;
-
-  for (let i = 0; i < n; i++) {
-    ts += 1 + Math.floor(rng() * 50);
-    const roll = rng();
-
-    // Bias toward text + appends so coalescing fires often.
-    if (roll < 0.45) {
-      const delta = "w".repeat(1 + Math.floor(rng() * 40));
-      if (lastWasText) {
-        mutations.push({ kind: "coalesce", delta });
-      } else {
-        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
-        lastWasText = true;
-      }
-      continue;
-    }
-
-    lastWasText = false;
-
-    if (roll < 0.7) {
-      // Open a tool call (regular / web_search / web_fetch).
-      const toolRoll = rng();
-      const id = `t-${seed}-${i}`;
-      if (toolRoll < 0.2) {
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
-        });
-        openTools.push({ id, toolName: "web_search" });
-      } else if (toolRoll < 0.35) {
-        // web_fetch has no follow-up — keyed by id, no open tracking.
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
-        });
-      } else {
-        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
-        });
-        openTools.push({ id, toolName });
-      }
-      continue;
-    }
-
-    if (roll < 0.9 && openTools.length > 0) {
-      // Close an open tool with a result (maybe an error result).
-      const idx = Math.floor(rng() * openTools.length);
-      const open = openTools.splice(idx, 1)[0]!;
-      const isError = rng() < 0.25;
-      mutations.push({
-        kind: "append",
-        event: makeEvent(
-          {
-            type: "tool_result",
-            toolName: open.toolName,
-            toolUseId: open.id,
-            isError,
-            result: isError ? "boom" : `result-${i}`,
-            content: `result-${i}`,
-          },
-          ts,
-        ),
-      });
-      continue;
-    }
-
-    if (openTools.length > 0) {
-      // Close an open tool with a raw error event.
-      const idx = Math.floor(rng() * openTools.length);
-      const open = openTools.splice(idx, 1)[0]!;
-      mutations.push({
-        kind: "append",
-        event: makeEvent({ type: "error", toolName: open.toolName, toolUseId: open.id, isError: true, result: `err-${i}`, content: `err-${i}` }, ts),
-      });
-      continue;
-    }
-
-    // Nothing open — emit a standalone error row.
-    mutations.push({
-      kind: "append",
-      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
-    });
-  }
-
-  return mutations;
-}
-
-function applyMutation(
-  events: SubagentTimelineEvent[],
-  m: Mutation,
-): SubagentTimelineEvent[] {
-  return m.kind === "append"
-    ? appendEvent(events, m.event)
-    : coalesceText(events, m.delta, NOW);
-}
 
 // ---------------------------------------------------------------------------
 // No-drift property test — the core safety net.

--- a/clients/web/src/domains/chat/subagent-detail-projection.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.ts
@@ -1,0 +1,222 @@
+/**
+ * Incremental nested-detail projection for a subagent's timeline.
+ *
+ * The detail-map counterpart to `subagent-step-projection.ts`: the same store
+ * mutates `entry.events` in exactly three shapes (verified in
+ * `subagent-store.ts` `receiveEvent` / `loadDetail`):
+ *
+ *  1. **Append-1** — a new `tool_call` / `tool_result` / `error` / first `text`
+ *     event lands → `events: [...existing.events, ev]`. Every prior element
+ *     keeps its reference; exactly one element is appended at the tail.
+ *  2. **Mutate-last** — consecutive `assistant_text_delta`s coalesce → the array
+ *     is copied with only the **last** element replaced by
+ *     `{ ...lastEvent, content: lastEvent.content + delta }`. Same length, same
+ *     element references except the last, same `id` on the last, growing
+ *     `content`. Always a `text` event. We classify this shape by the
+ *     text-coalescing CONTENT shape — both last events `type: "text"` and the
+ *     new content strictly EXTENDS the old (`startsWith` + non-shrinking length)
+ *     — not just last-id equality. `mapDetailEvents` restarts ids at `detail-1`
+ *     per subagent, so two different subagents whose detail arrays each have one
+ *     event collide on `id === "detail-1"`; matching only by id would misclassify
+ *     a subagent switch as mutate-last and leave a stale tool entry that a full
+ *     rebuild drops (then a stale pill could open the previous subagent's detail).
+ *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
+ *     subagent switch).
+ *
+ * `buildSubagentStepDetails(events)` is O(n) and the panel previously re-ran it
+ * on every streamed event → O(n²) over a run. This projector replays only the
+ * events that changed since the last call, folding them through the **same**
+ * `applyDetailEvent` reducer the full rebuild uses — so the incremental and full
+ * paths can never drift. Any diff that doesn't fit the append / mutate-last
+ * shapes (full-replace, truncation, reorder, or a violated assumption) falls
+ * back to a full O(n) `buildSubagentStepDetails` rebuild, which is always
+ * correct.
+ *
+ * NOTE — unlike the step projection, this map is consumed **lazily**: the panel
+ * only reads from it when a timeline pill is clicked. Its churn therefore never
+ * drives a render on its own, so there is no identity-preservation shortcut to
+ * be had here (and the mutate-last `thinkingText` carries the FULL untruncated
+ * content, which changes on every delta anyway). The win is purely avoiding the
+ * O(n) re-walk per streamed event — replaying only the changed events — not
+ * re-render avoidance.
+ */
+
+import { useRef } from "react";
+
+import { applyDetailEvent } from "@/domains/chat/hooks/use-subagent-card-data";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+/** Per-payload metadata tracked in parallel with `payloads` (indexed by position). */
+type DetailMeta = { startTs: number; running: boolean };
+
+/** The per-event reducer signature shared by the full and incremental paths. */
+type DetailReducer = (
+  payloads: ToolDetailPayload[],
+  meta: DetailMeta[],
+  event: SubagentTimelineEvent,
+) => void;
+
+/** Build the keyed `Map` from the payload array exactly as `buildSubagentStepDetails` does. */
+function payloadsToMap(
+  payloads: ToolDetailPayload[],
+): Map<string, ToolDetailPayload> {
+  return new Map(payloads.map((payload) => [payload.toolCallId, payload]));
+}
+
+/**
+ * Create a stateful incremental detail projector. `project(events)` returns the
+ * `toolCallId`-keyed `Map<string, ToolDetailPayload>` for `events`, replaying
+ * only the diff vs the previous call through `applyDetailEvent`. The payload
+ * array, parallel meta array, and resulting `Map` are cached; identical inputs
+ * return the cached `Map` by reference.
+ *
+ * One projector instance owns one cache slot — hold it per component instance
+ * (see `useSubagentStepDetails`), never module-global, so the panel and any
+ * other consumer don't thrash a single slot.
+ *
+ * `reducer` defaults to the real `applyDetailEvent`; it's a seam for the
+ * incremental-work guard test to count reducer invocations without mocking.
+ */
+export function createIncrementalDetailProjection(
+  reducer: DetailReducer = applyDetailEvent,
+) {
+  let prevEvents: SubagentTimelineEvent[] | null = null;
+  let payloads: ToolDetailPayload[] = [];
+  let meta: DetailMeta[] = [];
+  let map: Map<string, ToolDetailPayload> = new Map();
+
+  function fullBuild(
+    events: SubagentTimelineEvent[],
+  ): Map<string, ToolDetailPayload> {
+    // Re-run the reducer ourselves (rather than calling `buildSubagentStepDetails`)
+    // so the cached `payloads`/`meta` stay in sync for the next incremental diff.
+    const builtPayloads: ToolDetailPayload[] = [];
+    const builtMeta: DetailMeta[] = [];
+    for (const event of events) reducer(builtPayloads, builtMeta, event);
+
+    prevEvents = events;
+    payloads = builtPayloads;
+    meta = builtMeta;
+    map = payloadsToMap(payloads);
+    return map;
+  }
+
+  function project(
+    events: SubagentTimelineEvent[],
+  ): Map<string, ToolDetailPayload> {
+    // Identity — also covers events-stable status/usage updates.
+    if (events === prevEvents) return map;
+
+    // First call / empty cache.
+    if (prevEvents == null) return fullBuild(events);
+
+    const prevLen = prevEvents.length;
+    const len = events.length;
+
+    // Append: same prefix, one-or-more new events at the tail. The O(1)
+    // boundary checks (first + last-of-prev still share their references)
+    // distinguish a genuine append from a full-replace whose new array happens
+    // to be longer.
+    if (
+      len > prevLen &&
+      (prevLen === 0 ||
+        (events[0] === prevEvents[0] &&
+          events[prevLen - 1] === prevEvents[prevLen - 1]))
+    ) {
+      const payloadsClone = payloads.slice();
+      const metaClone = meta.slice();
+      for (let i = prevLen; i < len; i++) {
+        reducer(payloadsClone, metaClone, events[i]!);
+      }
+      prevEvents = events;
+      payloads = payloadsClone;
+      meta = metaClone;
+      // The Map build is O(n) but pointer-cheap — the expensive per-event
+      // parsing (parseWebSearchResultText, deriveStepLabelFromName) already ran
+      // only for the appended events inside the reducer above.
+      map = payloadsToMap(payloads);
+      return map;
+    }
+
+    // Mutate-last: text-delta coalescing. Same length, only the last element
+    // replaced, every earlier element shared. We require the genuine
+    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
+    // equality: both last events must be `type: "text"` and the new content must
+    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
+    // alone is insufficient because `mapDetailEvents` restarts event ids at
+    // `detail-1` per subagent — a single-event subagent switch collides on
+    // `id === "detail-1"` and would be misclassified, surviving a stale tool
+    // entry. The type + content-extension guards reject that collision (different
+    // type, or content that isn't a strict extension → Fallback full rebuild).
+    if (
+      len === prevLen &&
+      len >= 1 &&
+      events[len - 1] !== prevEvents[len - 1] &&
+      events[len - 1]!.id === prevEvents[len - 1]!.id &&
+      prevEvents[len - 1]!.type === "text" &&
+      events[len - 1]!.type === "text" &&
+      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
+      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
+      (len === 1 || events[len - 2] === prevEvents[len - 2])
+    ) {
+      const payloadsClone = payloads.slice();
+      const metaClone = meta.slice();
+
+      // A text event contributes 0 or 1 trailing `thinking` payload (keyed by
+      // the event id) and never mutates earlier payloads, so popping the keyed
+      // tail (if present) and re-applying the grown event reproduces the full
+      // rebuild exactly. Unlike the step projection there is NO tail-identity
+      // shortcut: `thinkingText` carries the full untruncated content, so the
+      // payload changes on every delta — but the replay is still O(Δ).
+      const tail = payloadsClone[payloadsClone.length - 1];
+      if (
+        tail &&
+        tail.kind === "thinking" &&
+        tail.toolCallId === events[len - 1]!.id
+      ) {
+        payloadsClone.pop();
+        metaClone.pop();
+      }
+
+      reducer(payloadsClone, metaClone, events[len - 1]!);
+
+      prevEvents = events;
+      payloads = payloadsClone;
+      meta = metaClone;
+      map = payloadsToMap(payloads);
+      return map;
+    }
+
+    // Fallback — full-replace / truncation / reorder / violated assumption.
+    return fullBuild(events);
+  }
+
+  return { project };
+}
+
+/**
+ * Hook wrapper: holds an incremental detail projector per component instance (in
+ * a `useRef`, tied to the component's lifecycle — never a module-global cache,
+ * so independent panels don't share/thrash one slot). Returns the projected
+ * `toolCallId`-keyed `Map`.
+ */
+export function useSubagentStepDetails(
+  events: SubagentTimelineEvent[],
+): Map<string, ToolDetailPayload> {
+  const projectorRef = useRef<ReturnType<
+    typeof createIncrementalDetailProjection
+  > | null>(null);
+
+  // Intentional render-phase ref usage: the projector is a per-instance mutable
+  // cache (like `useMemo` but with custom diff-aware equality), so its identity
+  // must be stable across renders and `project(events)` must run on every render
+  // to fold in new events. Reading `.current` here is the whole point — the same
+  // lazy-init + cache pattern `useSubagentSteps` / `use-event-stream.ts` use.
+  /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
+  if (projectorRef.current == null) {
+    projectorRef.current = createIncrementalDetailProjection();
+  }
+  return projectorRef.current.project(events);
+  /* eslint-enable react-hooks/refs */
+}

--- a/clients/web/src/domains/chat/subagent-detail-projection.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.ts
@@ -44,6 +44,7 @@
 import { useRef } from "react";
 
 import { applyDetailEvent } from "@/domains/chat/hooks/use-subagent-card-data";
+import { classifyEventsDiff } from "@/domains/chat/subagent-projection-diff";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
@@ -105,91 +106,74 @@ export function createIncrementalDetailProjection(
   function project(
     events: SubagentTimelineEvent[],
   ): Map<string, ToolDetailPayload> {
-    // Identity — also covers events-stable status/usage updates.
-    if (events === prevEvents) return map;
+    // The diff classification (including the subtle cross-subagent `detail-1`
+    // id-collision guard) is shared with the step projector — see
+    // `subagent-projection-diff.ts`.
+    const diff = classifyEventsDiff(prevEvents, events);
 
-    // First call / empty cache.
-    if (prevEvents == null) return fullBuild(events);
+    switch (diff.kind) {
+      // Identity — also covers events-stable status/usage updates.
+      case "identity":
+        return map;
 
-    const prevLen = prevEvents.length;
-    const len = events.length;
+      // First call / empty cache.
+      case "first":
+        return fullBuild(events);
 
-    // Append: same prefix, one-or-more new events at the tail. The O(1)
-    // boundary checks (first + last-of-prev still share their references)
-    // distinguish a genuine append from a full-replace whose new array happens
-    // to be longer.
-    if (
-      len > prevLen &&
-      (prevLen === 0 ||
-        (events[0] === prevEvents[0] &&
-          events[prevLen - 1] === prevEvents[prevLen - 1]))
-    ) {
-      const payloadsClone = payloads.slice();
-      const metaClone = meta.slice();
-      for (let i = prevLen; i < len; i++) {
-        reducer(payloadsClone, metaClone, events[i]!);
-      }
-      prevEvents = events;
-      payloads = payloadsClone;
-      meta = metaClone;
-      // The Map build is O(n) but pointer-cheap — the expensive per-event
-      // parsing (parseWebSearchResultText, deriveStepLabelFromName) already ran
-      // only for the appended events inside the reducer above.
-      map = payloadsToMap(payloads);
-      return map;
-    }
-
-    // Mutate-last: text-delta coalescing. Same length, only the last element
-    // replaced, every earlier element shared. We require the genuine
-    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
-    // equality: both last events must be `type: "text"` and the new content must
-    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
-    // alone is insufficient because `mapDetailEvents` restarts event ids at
-    // `detail-1` per subagent — a single-event subagent switch collides on
-    // `id === "detail-1"` and would be misclassified, surviving a stale tool
-    // entry. The type + content-extension guards reject that collision (different
-    // type, or content that isn't a strict extension → Fallback full rebuild).
-    if (
-      len === prevLen &&
-      len >= 1 &&
-      events[len - 1] !== prevEvents[len - 1] &&
-      events[len - 1]!.id === prevEvents[len - 1]!.id &&
-      prevEvents[len - 1]!.type === "text" &&
-      events[len - 1]!.type === "text" &&
-      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
-      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
-      (len === 1 || events[len - 2] === prevEvents[len - 2])
-    ) {
-      const payloadsClone = payloads.slice();
-      const metaClone = meta.slice();
-
-      // A text event contributes 0 or 1 trailing `thinking` payload (keyed by
-      // the event id) and never mutates earlier payloads, so popping the keyed
-      // tail (if present) and re-applying the grown event reproduces the full
-      // rebuild exactly. Unlike the step projection there is NO tail-identity
-      // shortcut: `thinkingText` carries the full untruncated content, so the
-      // payload changes on every delta — but the replay is still O(Δ).
-      const tail = payloadsClone[payloadsClone.length - 1];
-      if (
-        tail &&
-        tail.kind === "thinking" &&
-        tail.toolCallId === events[len - 1]!.id
-      ) {
-        payloadsClone.pop();
-        metaClone.pop();
+      // Append: same prefix, one-or-more new events at the tail. Replay only
+      // the appended events through the reducer.
+      case "append": {
+        const len = events.length;
+        const payloadsClone = payloads.slice();
+        const metaClone = meta.slice();
+        for (let i = diff.from; i < len; i++) {
+          reducer(payloadsClone, metaClone, events[i]!);
+        }
+        prevEvents = events;
+        payloads = payloadsClone;
+        meta = metaClone;
+        // The Map build is O(n) but pointer-cheap — the expensive per-event
+        // parsing (parseWebSearchResultText, deriveStepLabelFromName) already ran
+        // only for the appended events inside the reducer above.
+        map = payloadsToMap(payloads);
+        return map;
       }
 
-      reducer(payloadsClone, metaClone, events[len - 1]!);
+      // Mutate-last: text-delta coalescing. Re-apply only the grown tail.
+      case "mutate-last": {
+        const len = events.length;
+        const payloadsClone = payloads.slice();
+        const metaClone = meta.slice();
 
-      prevEvents = events;
-      payloads = payloadsClone;
-      meta = metaClone;
-      map = payloadsToMap(payloads);
-      return map;
+        // A text event contributes 0 or 1 trailing `thinking` payload (keyed by
+        // the event id) and never mutates earlier payloads, so popping the keyed
+        // tail (if present) and re-applying the grown event reproduces the full
+        // rebuild exactly. Unlike the step projection there is NO tail-identity
+        // shortcut: `thinkingText` carries the full untruncated content, so the
+        // payload changes on every delta — but the replay is still O(Δ).
+        const tail = payloadsClone[payloadsClone.length - 1];
+        if (
+          tail &&
+          tail.kind === "thinking" &&
+          tail.toolCallId === events[len - 1]!.id
+        ) {
+          payloadsClone.pop();
+          metaClone.pop();
+        }
+
+        reducer(payloadsClone, metaClone, events[len - 1]!);
+
+        prevEvents = events;
+        payloads = payloadsClone;
+        meta = metaClone;
+        map = payloadsToMap(payloads);
+        return map;
+      }
+
+      // Fallback — full-replace / truncation / reorder / violated assumption.
+      case "fallback":
+        return fullBuild(events);
     }
-
-    // Fallback — full-replace / truncation / reorder / violated assumption.
-    return fullBuild(events);
   }
 
   return { project };

--- a/clients/web/src/domains/chat/subagent-detail-projection.ts
+++ b/clients/web/src/domains/chat/subagent-detail-projection.ts
@@ -23,8 +23,8 @@
  *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
  *     subagent switch).
  *
- * `buildSubagentStepDetails(events)` is O(n) and the panel previously re-ran it
- * on every streamed event → O(n²) over a run. This projector replays only the
+ * `buildSubagentStepDetails(events)` is O(n); running it on every streamed event
+ * would be O(n²) over a run. This projector replays only the
  * events that changed since the last call, folding them through the **same**
  * `applyDetailEvent` reducer the full rebuild uses — so the incremental and full
  * paths can never drift. Any diff that doesn't fit the append / mutate-last

--- a/clients/web/src/domains/chat/subagent-projection-diff.test.ts
+++ b/clients/web/src/domains/chat/subagent-projection-diff.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the shared diff classifier (`classifyEventsDiff`) extracted from the
+ * two incremental subagent projectors. Each `kind` is covered, including the two
+ * cases that MUST fall back to a full rebuild: the cross-subagent `detail-1`
+ * id-collision (single-event subagent switch that would be misclassified as
+ * mutate-last by id alone) and a full-replace. The projectors' own no-drift
+ * property tests are the end-to-end safety net; these pin the classifier itself.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { classifyEventsDiff } from "@/domains/chat/subagent-projection-diff";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+const NOW = 1700000000000;
+
+let seq = 0;
+function textEvent(content: string): SubagentTimelineEvent {
+  return { id: `e-${seq++}`, type: "text", content, timestamp: NOW };
+}
+function toolCallEvent(toolUseId: string): SubagentTimelineEvent {
+  return {
+    id: `e-${seq++}`,
+    type: "tool_call",
+    content: "ls",
+    toolName: "bash",
+    toolUseId,
+    timestamp: NOW,
+  };
+}
+
+describe("classifyEventsDiff", () => {
+  test("identity: same array reference", () => {
+    const events = [textEvent("hi")];
+    expect(classifyEventsDiff(events, events)).toEqual({ kind: "identity" });
+  });
+
+  test("first: no previous array (null cache)", () => {
+    const events = [textEvent("hi")];
+    expect(classifyEventsDiff(null, events)).toEqual({ kind: "first" });
+  });
+
+  test("first: from an empty cache, a non-empty array is still a first build when prev is null", () => {
+    expect(classifyEventsDiff(null, [])).toEqual({ kind: "first" });
+  });
+
+  test("append: same prefix, one new event at the tail — `from` is prevEvents.length", () => {
+    const a = textEvent("first");
+    const prev = [a];
+    const events = [a, textEvent("second")];
+    expect(classifyEventsDiff(prev, events)).toEqual({ kind: "append", from: 1 });
+  });
+
+  test("append: multiple new events at the tail", () => {
+    const a = textEvent("a");
+    const b = toolCallEvent("tu-1");
+    const prev = [a, b];
+    const events = [a, b, textEvent("c"), toolCallEvent("tu-2")];
+    expect(classifyEventsDiff(prev, events)).toEqual({ kind: "append", from: 2 });
+  });
+
+  test("append: growing from an empty previous array", () => {
+    const events = [textEvent("a")];
+    expect(classifyEventsDiff([], events)).toEqual({ kind: "append", from: 0 });
+  });
+
+  test("append rejected when the shared-prefix boundary references differ → fallback", () => {
+    // Longer array, but `events[0]` is a different object (no shared prefix):
+    // a full-replace whose new array merely happens to be longer.
+    const prev = [textEvent("a")];
+    const events = [textEvent("a"), textEvent("b")];
+    expect(classifyEventsDiff(prev, events)).toEqual({ kind: "fallback" });
+  });
+
+  test("mutate-last: genuine text coalescing (same id, text→text, strict content extension)", () => {
+    const a = textEvent("Investig");
+    const prev = [a];
+    // Same id, longer content that strictly extends the old — the store's
+    // text-delta coalescing shape.
+    const grown: SubagentTimelineEvent = { ...a, content: "Investigating" };
+    expect(classifyEventsDiff(prev, [grown])).toEqual({ kind: "mutate-last" });
+  });
+
+  test("mutate-last: coalescing with a shared earlier prefix", () => {
+    const head = toolCallEvent("tu-1");
+    const a = textEvent("Inv");
+    const prev = [head, a];
+    const grown: SubagentTimelineEvent = { ...a, content: "Investigating" };
+    expect(classifyEventsDiff(prev, [head, grown])).toEqual({
+      kind: "mutate-last",
+    });
+  });
+
+  test("fallback: cross-subagent detail-1 id collision is NOT mutate-last", () => {
+    // `mapDetailEvents` restarts ids at `detail-1` per subagent. Two
+    // single-event subagents collide on `id === "detail-1"`, but the last events
+    // differ in type/content, so the content-shape guards force a fallback (a
+    // full rebuild), NOT a mutate-last that would carry a stale entry over.
+    const subagentA: SubagentTimelineEvent[] = [
+      {
+        id: "detail-1",
+        type: "tool_call",
+        content: "ls",
+        toolName: "bash",
+        toolUseId: "tu-a",
+        timestamp: NOW,
+      },
+    ];
+    const subagentB: SubagentTimelineEvent[] = [
+      { id: "detail-1", type: "text", content: "B is thinking", timestamp: NOW },
+    ];
+    expect(classifyEventsDiff(subagentA, subagentB)).toEqual({
+      kind: "fallback",
+    });
+  });
+
+  test("fallback: same id + same length but content shrinks (not a strict extension)", () => {
+    const a = textEvent("Investigating");
+    const prev = [a];
+    const shrunk: SubagentTimelineEvent = { ...a, content: "Inv" };
+    expect(classifyEventsDiff(prev, [shrunk])).toEqual({ kind: "fallback" });
+  });
+
+  test("fallback: full-replace (wholesale array swap, no shared prefix)", () => {
+    const prev = [textEvent("live")];
+    const hydrated = [textEvent("hydrated-1"), toolCallEvent("h-1")];
+    expect(classifyEventsDiff(prev, hydrated)).toEqual({ kind: "fallback" });
+  });
+
+  test("fallback: truncation (shorter array)", () => {
+    const a = textEvent("a");
+    const b = textEvent("b");
+    const prev = [a, b];
+    expect(classifyEventsDiff(prev, [a])).toEqual({ kind: "fallback" });
+  });
+});

--- a/clients/web/src/domains/chat/subagent-projection-diff.ts
+++ b/clients/web/src/domains/chat/subagent-projection-diff.ts
@@ -66,7 +66,8 @@ export function classifyEventsDiff(
   prevEvents: SubagentTimelineEvent[] | null,
   events: SubagentTimelineEvent[],
 ): EventsDiff {
-  // Identity — also covers PR2's events-stable status/usage updates.
+  // Identity — also covers events-stable status/usage updates (the entry object
+  // changes but its events array reference does not).
   if (events === prevEvents) return { kind: "identity" };
 
   // First call / empty cache.

--- a/clients/web/src/domains/chat/subagent-projection-diff.ts
+++ b/clients/web/src/domains/chat/subagent-projection-diff.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared diff classification for the two incremental subagent projectors
+ * (`subagent-step-projection.ts` and `subagent-detail-projection.ts`).
+ *
+ * Both projectors face the IDENTICAL problem: classify the diff between the
+ * previous `events` array and the new one into one of the store's known
+ * mutation shapes, then replay only the changed events through their own
+ * reducer. The classification guards are subtle (especially the cross-subagent
+ * `detail-1` id-collision guard), so they live here ONCE — extracting them
+ * prevents the two copies from drifting apart.
+ *
+ * Background — the store mutates `entry.events` in exactly three shapes
+ * (verified in `subagent-store.ts` `receiveEvent` / `loadDetail`):
+ *
+ *  1. **Append-1** — a new `tool_call` / `tool_result` / `error` / first `text`
+ *     event lands → `events: [...existing.events, ev]`. A new array, but every
+ *     prior element keeps its reference and exactly one element is appended at
+ *     the tail.
+ *  2. **Mutate-last** — consecutive `assistant_text_delta`s coalesce → the array
+ *     is copied (`[...existing.events]`) with only the **last** element replaced
+ *     by `{ ...lastEvent, content: lastEvent.content + delta }`. Same length,
+ *     same element references except the last, the last keeps the **same `id`**,
+ *     and its `content` only grows. Always a `text` event. We classify this shape
+ *     by the text-coalescing CONTENT shape — both last events `type: "text"` and
+ *     the new content strictly EXTENDS the old (`startsWith` + non-shrinking
+ *     length) — not just last-id equality. `mapDetailEvents` restarts ids at
+ *     `detail-1` per subagent, so two different subagents whose detail arrays each
+ *     have one event collide on `id === "detail-1"`; matching only by id would
+ *     misclassify a subagent switch as mutate-last and leave a stale step/entry
+ *     that a full rebuild drops (then a stale pill/key could open the previous
+ *     subagent's detail).
+ *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
+ *     subagent switch).
+ *
+ * Any diff that doesn't fit the append / mutate-last shapes (full-replace,
+ * truncation, reorder, or a violated assumption) is classified `fallback`, which
+ * the projectors handle with a full O(n) rebuild that is always correct.
+ */
+
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+/**
+ * The classification of a diff between `prevEvents` and `events`.
+ *
+ * - `identity` — same array reference; nothing changed.
+ * - `first` — no previous array (first call / empty cache); build from scratch.
+ * - `append` — same prefix, one-or-more new events at the tail. `from` is the
+ *   index to start replaying the appended events (i.e. `prevEvents.length`).
+ * - `mutate-last` — text-delta coalescing: same length, only the last element
+ *   replaced by a strict content extension, every earlier element shared.
+ * - `fallback` — full-replace / truncation / reorder / violated assumption.
+ */
+export type EventsDiff =
+  | { kind: "identity" }
+  | { kind: "first" }
+  | { kind: "append"; from: number }
+  | { kind: "mutate-last" }
+  | { kind: "fallback" };
+
+/**
+ * Classify the diff between the previous `events` array and the new one into one
+ * of the store's known mutation shapes. Pure and O(1) — only reference and
+ * tail-content checks, no walk of the arrays.
+ */
+export function classifyEventsDiff(
+  prevEvents: SubagentTimelineEvent[] | null,
+  events: SubagentTimelineEvent[],
+): EventsDiff {
+  // Identity — also covers PR2's events-stable status/usage updates.
+  if (events === prevEvents) return { kind: "identity" };
+
+  // First call / empty cache.
+  if (prevEvents == null) return { kind: "first" };
+
+  const prevLen = prevEvents.length;
+  const len = events.length;
+
+  // Append: same prefix, one-or-more new events at the tail. The O(1)
+  // boundary checks (first + last-of-prev still share their references)
+  // distinguish a genuine append from a full-replace whose new array happens
+  // to be longer.
+  if (
+    len > prevLen &&
+    (prevLen === 0 ||
+      (events[0] === prevEvents[0] &&
+        events[prevLen - 1] === prevEvents[prevLen - 1]))
+  ) {
+    return { kind: "append", from: prevLen };
+  }
+
+  // Mutate-last: text-delta coalescing. Same length, only the last element
+  // replaced, every earlier element shared. We require the genuine
+  // text-coalescing CONTENT shape the store actually produces, NOT just last-id
+  // equality: both last events must be `type: "text"` and the new content must
+  // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
+  // alone is insufficient because `mapDetailEvents` restarts event ids at
+  // `detail-1` per subagent — a single-event subagent switch collides on
+  // `id === "detail-1"` and would be misclassified, surviving a stale step/entry.
+  // The type + content-extension guards reject that collision (different type, or
+  // content that isn't a strict extension → Fallback full rebuild).
+  if (
+    len === prevLen &&
+    len >= 1 &&
+    events[len - 1] !== prevEvents[len - 1] &&
+    events[len - 1]!.id === prevEvents[len - 1]!.id &&
+    prevEvents[len - 1]!.type === "text" &&
+    events[len - 1]!.type === "text" &&
+    events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
+    events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
+    (len === 1 || events[len - 2] === prevEvents[len - 2])
+  ) {
+    return { kind: "mutate-last" };
+  }
+
+  // Fallback — full-replace / truncation / reorder / violated assumption.
+  return { kind: "fallback" };
+}

--- a/clients/web/src/domains/chat/subagent-projection-test-fixtures.ts
+++ b/clients/web/src/domains/chat/subagent-projection-test-fixtures.ts
@@ -1,0 +1,236 @@
+/**
+ * Shared test fixtures for the two incremental subagent projector test files
+ * (`subagent-step-projection.test.ts` and `subagent-detail-projection.test.ts`).
+ *
+ * Both files drive their projector with the SAME deterministic store-mutation
+ * stream — a seedable LCG event generator plus an append/coalesce simulator that
+ * mirrors `subagent-store.receiveEvent`'s two incremental array shapes — so the
+ * generator lives here ONCE to keep the two suites in lockstep.
+ *
+ * The ONE genuine divergence between the two suites is parameterized: when an
+ * `error` event closes an in-flight tool, the detail suite attaches the tool's
+ * `toolName` / `toolUseId` / `isError` / `result` metadata (so the failed-tool
+ * payload is keyed and carries the error), while the step suite emits a bare
+ * error row. Pass `errorEventsCarryToolMeta` to `generateStream` to select.
+ */
+
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+export const NOW = 1700000000000;
+
+/** Numerical Recipes LCG — deterministic, seedable; no `Math.random`. */
+export function makeRng(seed: number): () => number {
+  let state = (seed >>> 0) || 1;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event factory. Each test file supplies its own `nextEventId` so the two
+// suites keep independent, file-local id sequences (`te-*` vs `de-*`).
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `makeEvent(overrides, ts?)` factory backed by `nextEventId`. Each test
+ * file calls this once with its own id generator so ids don't collide or couple
+ * across suites.
+ */
+export function createMakeEvent(
+  nextEventId: () => string,
+): (
+  overrides: Partial<SubagentTimelineEvent> & {
+    type: SubagentTimelineEvent["type"];
+  },
+  ts?: number,
+) => SubagentTimelineEvent {
+  return (overrides, ts = NOW) => ({
+    id: nextEventId(),
+    content: "",
+    timestamp: ts,
+    ...overrides,
+  });
+}
+
+type MakeEvent = ReturnType<typeof createMakeEvent>;
+
+// ---------------------------------------------------------------------------
+// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
+// incremental array shapes so the projector is fed precisely what it sees live.
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a fresh event to the events array, returning a NEW array (every prior
+ * element shared by reference). Models the store's "Append-1" shape.
+ */
+export function appendEvent(
+  events: SubagentTimelineEvent[],
+  event: SubagentTimelineEvent,
+): SubagentTimelineEvent[] {
+  return [...events, event];
+}
+
+/**
+ * Grow the trailing text event's content by `delta`, returning a NEW array with
+ * only the last element replaced (same `id`, longer `content`) — the store's
+ * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
+ * event when the tail isn't text (matching `receiveEvent`).
+ */
+export function coalesceText(
+  events: SubagentTimelineEvent[],
+  delta: string,
+  ts: number,
+  makeEvent: MakeEvent,
+): SubagentTimelineEvent[] {
+  const last = events[events.length - 1];
+  if (last && last.type === "text") {
+    const updated = [...events];
+    updated[updated.length - 1] = {
+      ...last,
+      content: last.content + delta,
+    };
+    return updated;
+  }
+  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic event-stream generator (tiny LCG; no Math.random).
+// ---------------------------------------------------------------------------
+
+export type Mutation =
+  | { kind: "append"; event: SubagentTimelineEvent }
+  | { kind: "coalesce"; delta: string };
+
+export interface GenerateStreamOptions {
+  /**
+   * When an `error` event closes an in-flight tool, attach the tool's
+   * `toolName` / `toolUseId` / `isError` / `result` metadata. The detail suite
+   * needs this so the failed-tool payload is keyed by `toolUseId` and carries
+   * the error; the step suite emits a bare error row instead. Defaults to
+   * `false`.
+   */
+  errorEventsCarryToolMeta?: boolean;
+}
+
+/**
+ * Generate a deterministic sequence of store mutations: text deltas (coalesced
+ * when consecutive), tool calls, their results/errors, and web_search/web_fetch
+ * — covering every reducer branch. Tracks open tool ids so results/errors close
+ * real in-flight calls.
+ */
+export function generateStream(
+  seed: number,
+  n: number,
+  makeEvent: MakeEvent,
+  { errorEventsCarryToolMeta = false }: GenerateStreamOptions = {},
+): Mutation[] {
+  const rng = makeRng(seed);
+  const mutations: Mutation[] = [];
+  const openTools: Array<{ id: string; toolName: string }> = [];
+  let lastWasText = false;
+  let ts = NOW;
+
+  for (let i = 0; i < n; i++) {
+    ts += 1 + Math.floor(rng() * 50);
+    const roll = rng();
+
+    // Bias toward text + appends so coalescing fires often.
+    if (roll < 0.45) {
+      const delta = "w".repeat(1 + Math.floor(rng() * 40));
+      if (lastWasText) {
+        mutations.push({ kind: "coalesce", delta });
+      } else {
+        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
+        lastWasText = true;
+      }
+      continue;
+    }
+
+    lastWasText = false;
+
+    if (roll < 0.7) {
+      // Open a tool call (regular / web_search / web_fetch).
+      const toolRoll = rng();
+      const id = `t-${seed}-${i}`;
+      if (toolRoll < 0.2) {
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
+        });
+        openTools.push({ id, toolName: "web_search" });
+      } else if (toolRoll < 0.35) {
+        // web_fetch has no follow-up — a thinking step, no open tracking.
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
+        });
+      } else {
+        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
+        });
+        openTools.push({ id, toolName });
+      }
+      continue;
+    }
+
+    if (roll < 0.9 && openTools.length > 0) {
+      // Close an open tool with a result (maybe an error result).
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      const isError = rng() < 0.25;
+      mutations.push({
+        kind: "append",
+        event: makeEvent(
+          {
+            type: "tool_result",
+            toolName: open.toolName,
+            toolUseId: open.id,
+            isError,
+            result: isError ? "boom" : `result-${i}`,
+            content: `result-${i}`,
+          },
+          ts,
+        ),
+      });
+      continue;
+    }
+
+    if (openTools.length > 0) {
+      // Close an open tool with a raw error event. The detail suite keys the
+      // failed-tool payload off the closed tool's metadata; the step suite
+      // emits a bare error row.
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      mutations.push({
+        kind: "append",
+        event: errorEventsCarryToolMeta
+          ? makeEvent({ type: "error", toolName: open.toolName, toolUseId: open.id, isError: true, result: `err-${i}`, content: `err-${i}` }, ts)
+          : makeEvent({ type: "error", content: `err-${i}` }, ts),
+      });
+      continue;
+    }
+
+    // Nothing open — emit a standalone error row.
+    mutations.push({
+      kind: "append",
+      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+    });
+  }
+
+  return mutations;
+}
+
+/** Apply one generated mutation to the events array (append or text coalesce). */
+export function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+  makeEvent: MakeEvent,
+): SubagentTimelineEvent[] {
+  return m.kind === "append"
+    ? appendEvent(events, m.event)
+    : coalesceText(events, m.delta, NOW, makeEvent);
+}

--- a/clients/web/src/domains/chat/subagent-step-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Tests for the incremental step projector (`createIncrementalStepProjection`).
+ *
+ * The core safety net is the **no-drift property test**: it drives the projector
+ * one store-mutation at a time (append vs text-coalesce mutate-last, exactly as
+ * `subagent-store.receiveEvent` does) and asserts the incremental output always
+ * deep-equals a full `computeSubagentSteps` rebuild — so the O(Δ) replay can
+ * never diverge from the O(n) source of truth.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { createIncrementalStepProjection } from "@/domains/chat/subagent-step-projection";
+import {
+  applyTimelineEvent,
+  computeSubagentSteps,
+  type ToolCallCardStep,
+  type ToolMeta,
+} from "@/domains/chat/hooks/use-subagent-card-data";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+const NOW = 1700000000000;
+
+let eventSeq = 0;
+function nextEventId(): string {
+  return `te-${eventSeq++}`;
+}
+
+function makeEvent(
+  overrides: Partial<SubagentTimelineEvent> & {
+    type: SubagentTimelineEvent["type"];
+  },
+  ts: number = NOW,
+): SubagentTimelineEvent {
+  return {
+    id: nextEventId(),
+    content: "",
+    timestamp: ts,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
+// incremental array shapes so the projector is fed precisely what it sees live.
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a fresh event to the events array, returning a NEW array (every prior
+ * element shared by reference). Models the store's "Append-1" shape.
+ */
+function appendEvent(
+  events: SubagentTimelineEvent[],
+  event: SubagentTimelineEvent,
+): SubagentTimelineEvent[] {
+  return [...events, event];
+}
+
+/**
+ * Grow the trailing text event's content by `delta`, returning a NEW array with
+ * only the last element replaced (same `id`, longer `content`) — the store's
+ * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
+ * event when the tail isn't text (matching `receiveEvent`).
+ */
+function coalesceText(
+  events: SubagentTimelineEvent[],
+  delta: string,
+  ts: number,
+): SubagentTimelineEvent[] {
+  const last = events[events.length - 1];
+  if (last && last.type === "text") {
+    const updated = [...events];
+    updated[updated.length - 1] = {
+      ...last,
+      content: last.content + delta,
+    };
+    return updated;
+  }
+  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
+}
+
+// ---------------------------------------------------------------------------
+// Per-diff-class unit tests
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalStepProjection — per-diff-class", () => {
+  test("first call / empty cache builds via full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    const events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "Investigating" }),
+    ];
+    expect(p.project(events)).toEqual(computeSubagentSteps(events));
+  });
+
+  test("identity: same array reference returns the cached result unchanged", () => {
+    const p = createIncrementalStepProjection();
+    const events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "hi" }),
+    ];
+    const first = p.project(events);
+    const second = p.project(events);
+    // The projector returns the cached ARRAY references unchanged on identity
+    // (the `useSubagentSteps` hook layers wrapper-object stability on top).
+    expect(second.steps).toBe(first.steps);
+    expect(second.toolMeta).toBe(first.toolMeta);
+  });
+
+  test("append-1 text: new tail thinking step", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "first" }),
+    ];
+    p.project(events);
+    events = appendEvent(events, makeEvent({ type: "text", content: "second" }));
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    expect(out.steps).toHaveLength(2);
+  });
+
+  test("append-1 tool_call: new in-flight tool step", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "thinking" }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls" }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const last = out.steps[out.steps.length - 1]!;
+    expect(last.kind).toBe("tool");
+    if (last.kind === "tool") expect(last.status).toBe("running");
+  });
+
+  test("append-1 tool_result closes an EARLIER in-flight tool (not the tail)", () => {
+    const p = createIncrementalStepProjection();
+    // tool_call, then a trailing text event, then the tool_result lands — so the
+    // result must close the tool at an earlier index, exercising the
+    // append-MOSTLY path through the real reducer.
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls", timestamp: NOW }),
+      makeEvent({ type: "text", content: "waiting" }, NOW + 100),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-1", content: "ok", timestamp: NOW + 2500 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const toolStep = out.steps.find((s) => s.kind === "tool")!;
+    expect(toolStep.kind).toBe("tool");
+    if (toolStep.kind === "tool") expect(toolStep.status).toBe("completed");
+  });
+
+  test("append-1 error closes in-flight tool + appends a tool_error step", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "rm -rf /", timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "error", content: "permission denied", timestamp: NOW + 500 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const toolStep = out.steps.find((s) => s.kind === "tool")!;
+    if (toolStep.kind === "tool") expect(toolStep.status).toBe("error");
+    expect(out.steps[out.steps.length - 1]!.kind).toBe("tool_error");
+  });
+
+  test("mutate-last under the 160-char clamp: new tail identity, content grows", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "short" }),
+    ];
+    const first = p.project(events);
+    const firstTail = first.steps[0]!;
+    // Grow the text but stay well under 160 chars.
+    events = coalesceText(events, " more text", events[0]!.timestamp);
+    const second = p.project(events);
+    expect(second).toEqual(computeSubagentSteps(events));
+    // A new tail step (preview changed), so the array is a fresh reference.
+    expect(second.steps).not.toBe(first.steps);
+    const secondTail = second.steps[0]!;
+    if (firstTail.kind === "thinking" && secondTail.kind === "thinking") {
+      expect(secondTail.text.length).toBeGreaterThan(firstTail.text.length);
+    }
+  });
+
+  test("mutate-last PAST the clamp: tail identity preserved (same steps reference)", () => {
+    const p = createIncrementalStepProjection();
+    // Seed with content already well past 160 chars so the preview is clamped.
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "y".repeat(300) }),
+    ];
+    const a = p.project(events);
+    // Append more identical chars — the clamped 160-char preview is unchanged.
+    events = coalesceText(events, "y".repeat(50), events[0]!.timestamp);
+    const b = p.project(events);
+    expect(b.steps).toBe(a.steps);
+    expect(b.toolMeta).toBe(a.toolMeta);
+    // Still correct vs the full rebuild.
+    expect(b.steps).toEqual(computeSubagentSteps(events).steps);
+  });
+
+  test("mutate-last that grows past the clamp from under it: still deep-equals rebuild", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "z".repeat(100) }),
+    ];
+    p.project(events);
+    events = coalesceText(events, "z".repeat(200), events[0]!.timestamp);
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+  });
+
+  test("full-replace (history hydration) falls back to a full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    p.project([makeEvent({ type: "text", content: "live" })]);
+    // A wholesale swap — entirely new array, no shared prefix.
+    const hydrated: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "hydrated-1" }),
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "h-1", content: "echo" }),
+    ];
+    const out = p.project(hydrated);
+    expect(out).toEqual(computeSubagentSteps(hydrated));
+  });
+
+  test("subagent switch (totally different array) falls back to a full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    p.project([
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-a", input: { query: "a" } }),
+    ]);
+    const other: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "different subagent" }),
+      makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: "wf-b", input: { url: "https://x.dev" } }),
+    ];
+    const out = p.project(other);
+    expect(out).toEqual(computeSubagentSteps(other));
+  });
+
+  test("truncation (shorter array) falls back to a full rebuild", () => {
+    const p = createIncrementalStepProjection();
+    const full: SubagentTimelineEvent[] = [
+      makeEvent({ type: "text", content: "a" }),
+      makeEvent({ type: "text", content: "b" }),
+    ];
+    p.project(full);
+    const truncated = full.slice(0, 1);
+    const out = p.project(truncated);
+    expect(out).toEqual(computeSubagentSteps(truncated));
+  });
+
+  test("parallel same-name tool calls: result closes the correct match index", () => {
+    const p = createIncrementalStepProjection();
+    // Two concurrent bash calls; the result for tu-2 must close the SECOND, not
+    // the first — exercises `findMatchingInFlightToolIndex` through the append.
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-1", content: "ls", timestamp: NOW }),
+      makeEvent({ type: "tool_call", toolName: "bash", toolUseId: "tu-2", content: "pwd", timestamp: NOW + 100 }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "bash", toolUseId: "tu-2", content: "/home", timestamp: NOW + 1500 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const toolSteps = out.steps.filter((s) => s.kind === "tool");
+    // First still running, second completed.
+    if (toolSteps[0]!.kind === "tool") expect(toolSteps[0]!.status).toBe("running");
+    if (toolSteps[1]!.kind === "tool") expect(toolSteps[1]!.status).toBe("completed");
+  });
+
+  test("web_search result flips the placeholder to 'Searched the web'", () => {
+    const p = createIncrementalStepProjection();
+    let events: SubagentTimelineEvent[] = [
+      makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: "ws-1", input: { query: "vellum" }, timestamp: NOW }),
+    ];
+    p.project(events);
+    events = appendEvent(
+      events,
+      makeEvent({ type: "tool_result", toolName: "web_search", toolUseId: "ws-1", result: "Vellum\nhttps://vellum.ai", timestamp: NOW + 900 }),
+    );
+    const out = p.project(events);
+    expect(out).toEqual(computeSubagentSteps(events));
+    const search = out.steps[0]!;
+    if (search.kind === "web_search") expect(search.title).toBe("Searched the web");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic event-stream generator (tiny LCG; no Math.random).
+// ---------------------------------------------------------------------------
+
+/** Numerical Recipes LCG — deterministic, seedable. */
+function makeRng(seed: number) {
+  let state = (seed >>> 0) || 1;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+type Mutation =
+  | { kind: "append"; event: SubagentTimelineEvent }
+  | { kind: "coalesce"; delta: string };
+
+/**
+ * Generate a deterministic sequence of store mutations: text deltas (coalesced
+ * when consecutive), tool calls, their results/errors, and web_search/web_fetch
+ * — covering every reducer branch. Tracks open tool ids so results/errors close
+ * real in-flight calls.
+ */
+function generateStream(seed: number, n: number): Mutation[] {
+  const rng = makeRng(seed);
+  const mutations: Mutation[] = [];
+  const openTools: Array<{ id: string; toolName: string }> = [];
+  let lastWasText = false;
+  let ts = NOW;
+
+  for (let i = 0; i < n; i++) {
+    ts += 1 + Math.floor(rng() * 50);
+    const roll = rng();
+
+    // Bias toward text + appends so coalescing fires often.
+    if (roll < 0.45) {
+      const delta = "w".repeat(1 + Math.floor(rng() * 40));
+      if (lastWasText) {
+        mutations.push({ kind: "coalesce", delta });
+      } else {
+        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
+        lastWasText = true;
+      }
+      continue;
+    }
+
+    lastWasText = false;
+
+    if (roll < 0.7) {
+      // Open a tool call (regular / web_search / web_fetch).
+      const toolRoll = rng();
+      const id = `t-${seed}-${i}`;
+      if (toolRoll < 0.2) {
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
+        });
+        openTools.push({ id, toolName: "web_search" });
+      } else if (toolRoll < 0.35) {
+        // web_fetch has no follow-up — a thinking step, no open tracking.
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
+        });
+      } else {
+        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
+        mutations.push({
+          kind: "append",
+          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
+        });
+        openTools.push({ id, toolName });
+      }
+      continue;
+    }
+
+    if (roll < 0.9 && openTools.length > 0) {
+      // Close an open tool with a result (maybe an error result).
+      const idx = Math.floor(rng() * openTools.length);
+      const open = openTools.splice(idx, 1)[0]!;
+      const isError = rng() < 0.25;
+      mutations.push({
+        kind: "append",
+        event: makeEvent(
+          {
+            type: "tool_result",
+            toolName: open.toolName,
+            toolUseId: open.id,
+            isError,
+            result: isError ? "boom" : `result-${i}`,
+            content: `result-${i}`,
+          },
+          ts,
+        ),
+      });
+      continue;
+    }
+
+    if (openTools.length > 0) {
+      // Close an open tool with a raw error event.
+      const idx = Math.floor(rng() * openTools.length);
+      openTools.splice(idx, 1);
+      mutations.push({
+        kind: "append",
+        event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+      });
+      continue;
+    }
+
+    // Nothing open — emit a standalone error row.
+    mutations.push({
+      kind: "append",
+      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
+    });
+  }
+
+  return mutations;
+}
+
+function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+): SubagentTimelineEvent[] {
+  return m.kind === "append"
+    ? appendEvent(events, m.event)
+    : coalesceText(events, m.delta, NOW);
+}
+
+// ---------------------------------------------------------------------------
+// No-drift property test — the core safety net.
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalStepProjection — no-drift property", () => {
+  const seeds = [1, 7, 42, 1337, 99999];
+  for (const seed of seeds) {
+    test(`seed ${seed}: incremental deep-equals full rebuild after every mutation (N=300)`, () => {
+      const projector = createIncrementalStepProjection();
+      const mutations = generateStream(seed, 300);
+      let events: SubagentTimelineEvent[] = [];
+      // Prime with the empty array.
+      projector.project(events);
+
+      for (let i = 0; i < mutations.length; i++) {
+        events = applyMutation(events, mutations[i]!);
+        const incremental = projector.project(events);
+        const full = computeSubagentSteps(events);
+        expect(incremental.steps).toEqual(full.steps);
+        expect(incremental.toolMeta).toEqual(full.toolMeta);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Incremental-work guard — reducer invocations must be ~O(N), not O(N²).
+// ---------------------------------------------------------------------------
+
+describe("createIncrementalStepProjection — incremental-work guard", () => {
+  function countReducerCalls(n: number): { calls: number; toolResults: number } {
+    let calls = 0;
+    const counting = (
+      steps: ToolCallCardStep[],
+      toolMeta: Array<ToolMeta | undefined>,
+      event: SubagentTimelineEvent,
+    ) => {
+      calls++;
+      applyTimelineEvent(steps, toolMeta, event);
+    };
+    const projector = createIncrementalStepProjection(counting);
+    const mutations = generateStream(2024, n);
+    const toolResults = mutations.filter(
+      (m) => m.kind === "append" && (m.event.type === "tool_result" || m.event.type === "error"),
+    ).length;
+
+    let events: SubagentTimelineEvent[] = [];
+    projector.project(events);
+    for (const m of mutations) {
+      events = applyMutation(events, m);
+      projector.project(events);
+    }
+    return { calls, toolResults };
+  }
+
+  for (const n of [50, 150, 300]) {
+    test(`N=${n}: reducer invocations are ~linear (≤ N + small constant), not O(N²)`, () => {
+      const { calls } = countReducerCalls(n);
+      // Each store mutation replays at most ONE event through the reducer
+      // (append-1 → 1 call; mutate-last → exactly 1 re-derive call). So the
+      // total is bounded by the number of mutations, far below N² for large N.
+      expect(calls).toBeLessThanOrEqual(n);
+      // Sanity: O(N²) would be ~N*N/2; assert we're nowhere near it.
+      expect(calls).toBeLessThan((n * n) / 4);
+    });
+  }
+
+  test("reducer call count grows linearly across N ∈ {50,150,300}", () => {
+    const c50 = countReducerCalls(50).calls;
+    const c150 = countReducerCalls(150).calls;
+    const c300 = countReducerCalls(300).calls;
+    // Linear growth: tripling N roughly triples the work (within a small band).
+    // Quadratic growth would make c300/c50 ≈ 36, not ≈ 6.
+    expect(c300 / Math.max(c50, 1)).toBeLessThan(12);
+    expect(c150).toBeGreaterThan(c50);
+    expect(c300).toBeGreaterThan(c150);
+  });
+});

--- a/clients/web/src/domains/chat/subagent-step-projection.test.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.test.ts
@@ -17,66 +17,44 @@ import {
   type ToolCallCardStep,
   type ToolMeta,
 } from "@/domains/chat/hooks/use-subagent-card-data";
+import {
+  NOW,
+  appendEvent,
+  applyMutation as applyMutationShared,
+  coalesceText as coalesceTextShared,
+  createMakeEvent,
+  generateStream as generateStreamShared,
+  type Mutation,
+} from "@/domains/chat/subagent-projection-test-fixtures";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
-
-const NOW = 1700000000000;
 
 let eventSeq = 0;
 function nextEventId(): string {
   return `te-${eventSeq++}`;
 }
 
-function makeEvent(
-  overrides: Partial<SubagentTimelineEvent> & {
-    type: SubagentTimelineEvent["type"];
-  },
-  ts: number = NOW,
-): SubagentTimelineEvent {
-  return {
-    id: nextEventId(),
-    content: "",
-    timestamp: ts,
-    ...overrides,
-  };
-}
+const makeEvent = createMakeEvent(nextEventId);
 
-// ---------------------------------------------------------------------------
-// Store-mutation simulator — mirrors `subagent-store.receiveEvent`'s two
-// incremental array shapes so the projector is fed precisely what it sees live.
-// ---------------------------------------------------------------------------
-
-/**
- * Append a fresh event to the events array, returning a NEW array (every prior
- * element shared by reference). Models the store's "Append-1" shape.
- */
-function appendEvent(
-  events: SubagentTimelineEvent[],
-  event: SubagentTimelineEvent,
-): SubagentTimelineEvent[] {
-  return [...events, event];
-}
-
-/**
- * Grow the trailing text event's content by `delta`, returning a NEW array with
- * only the last element replaced (same `id`, longer `content`) — the store's
- * "Mutate-last" text-coalescing shape. Falls back to appending a fresh text
- * event when the tail isn't text (matching `receiveEvent`).
- */
+// Bind the shared simulator/generator to this suite's `makeEvent` so each test
+// file keeps its own id sequence. The step suite emits BARE error rows when an
+// error closes a tool (no tool metadata) — the default `generateStream` shape.
 function coalesceText(
   events: SubagentTimelineEvent[],
   delta: string,
   ts: number,
 ): SubagentTimelineEvent[] {
-  const last = events[events.length - 1];
-  if (last && last.type === "text") {
-    const updated = [...events];
-    updated[updated.length - 1] = {
-      ...last,
-      content: last.content + delta,
-    };
-    return updated;
-  }
-  return appendEvent(events, makeEvent({ type: "text", content: delta }, ts));
+  return coalesceTextShared(events, delta, ts, makeEvent);
+}
+
+function generateStream(seed: number, n: number): Mutation[] {
+  return generateStreamShared(seed, n, makeEvent);
+}
+
+function applyMutation(
+  events: SubagentTimelineEvent[],
+  m: Mutation,
+): SubagentTimelineEvent[] {
+  return applyMutationShared(events, m, makeEvent);
 }
 
 // ---------------------------------------------------------------------------
@@ -349,133 +327,6 @@ describe("createIncrementalStepProjection — per-diff-class", () => {
     if (search.kind === "web_search") expect(search.title).toBe("Searched the web");
   });
 });
-
-// ---------------------------------------------------------------------------
-// Deterministic event-stream generator (tiny LCG; no Math.random).
-// ---------------------------------------------------------------------------
-
-/** Numerical Recipes LCG — deterministic, seedable. */
-function makeRng(seed: number) {
-  let state = (seed >>> 0) || 1;
-  return () => {
-    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
-    return state / 0xffffffff;
-  };
-}
-
-type Mutation =
-  | { kind: "append"; event: SubagentTimelineEvent }
-  | { kind: "coalesce"; delta: string };
-
-/**
- * Generate a deterministic sequence of store mutations: text deltas (coalesced
- * when consecutive), tool calls, their results/errors, and web_search/web_fetch
- * — covering every reducer branch. Tracks open tool ids so results/errors close
- * real in-flight calls.
- */
-function generateStream(seed: number, n: number): Mutation[] {
-  const rng = makeRng(seed);
-  const mutations: Mutation[] = [];
-  const openTools: Array<{ id: string; toolName: string }> = [];
-  let lastWasText = false;
-  let ts = NOW;
-
-  for (let i = 0; i < n; i++) {
-    ts += 1 + Math.floor(rng() * 50);
-    const roll = rng();
-
-    // Bias toward text + appends so coalescing fires often.
-    if (roll < 0.45) {
-      const delta = "w".repeat(1 + Math.floor(rng() * 40));
-      if (lastWasText) {
-        mutations.push({ kind: "coalesce", delta });
-      } else {
-        mutations.push({ kind: "append", event: makeEvent({ type: "text", content: delta }, ts) });
-        lastWasText = true;
-      }
-      continue;
-    }
-
-    lastWasText = false;
-
-    if (roll < 0.7) {
-      // Open a tool call (regular / web_search / web_fetch).
-      const toolRoll = rng();
-      const id = `t-${seed}-${i}`;
-      if (toolRoll < 0.2) {
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_search", toolUseId: id, input: { query: `q${i}` } }, ts),
-        });
-        openTools.push({ id, toolName: "web_search" });
-      } else if (toolRoll < 0.35) {
-        // web_fetch has no follow-up — a thinking step, no open tracking.
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName: "web_fetch", toolUseId: id, input: { url: `https://ex${i}.dev` } }, ts),
-        });
-      } else {
-        const toolName = toolRoll < 0.6 ? "bash" : "str_replace_editor";
-        mutations.push({
-          kind: "append",
-          event: makeEvent({ type: "tool_call", toolName, toolUseId: id, content: `cmd-${i}` }, ts),
-        });
-        openTools.push({ id, toolName });
-      }
-      continue;
-    }
-
-    if (roll < 0.9 && openTools.length > 0) {
-      // Close an open tool with a result (maybe an error result).
-      const idx = Math.floor(rng() * openTools.length);
-      const open = openTools.splice(idx, 1)[0]!;
-      const isError = rng() < 0.25;
-      mutations.push({
-        kind: "append",
-        event: makeEvent(
-          {
-            type: "tool_result",
-            toolName: open.toolName,
-            toolUseId: open.id,
-            isError,
-            result: isError ? "boom" : `result-${i}`,
-            content: `result-${i}`,
-          },
-          ts,
-        ),
-      });
-      continue;
-    }
-
-    if (openTools.length > 0) {
-      // Close an open tool with a raw error event.
-      const idx = Math.floor(rng() * openTools.length);
-      openTools.splice(idx, 1);
-      mutations.push({
-        kind: "append",
-        event: makeEvent({ type: "error", content: `err-${i}` }, ts),
-      });
-      continue;
-    }
-
-    // Nothing open — emit a standalone error row.
-    mutations.push({
-      kind: "append",
-      event: makeEvent({ type: "error", content: `err-${i}` }, ts),
-    });
-  }
-
-  return mutations;
-}
-
-function applyMutation(
-  events: SubagentTimelineEvent[],
-  m: Mutation,
-): SubagentTimelineEvent[] {
-  return m.kind === "append"
-    ? appendEvent(events, m.event)
-    : coalesceText(events, m.delta, NOW);
-}
 
 // ---------------------------------------------------------------------------
 // No-drift property test — the core safety net.

--- a/clients/web/src/domains/chat/subagent-step-projection.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.ts
@@ -46,6 +46,7 @@ import {
   type ToolCallCardStep,
   type ToolMeta,
 } from "@/domains/chat/hooks/use-subagent-card-data";
+import { classifyEventsDiff } from "@/domains/chat/subagent-projection-diff";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 
 export interface ProjectedSteps {
@@ -100,89 +101,72 @@ export function createIncrementalStepProjection(
   }
 
   function project(events: SubagentTimelineEvent[]): ProjectedSteps {
-    // Identity — also covers PR2's events-stable status/usage updates.
-    if (events === prevEvents) return { steps, toolMeta };
+    // The diff classification (including the subtle cross-subagent `detail-1`
+    // id-collision guard) is shared with the detail projector — see
+    // `subagent-projection-diff.ts`.
+    const diff = classifyEventsDiff(prevEvents, events);
 
-    // First call / empty cache.
-    if (prevEvents == null) return fullBuild(events);
+    switch (diff.kind) {
+      // Identity — also covers PR2's events-stable status/usage updates.
+      case "identity":
+        return { steps, toolMeta };
 
-    const prevLen = prevEvents.length;
-    const len = events.length;
+      // First call / empty cache.
+      case "first":
+        return fullBuild(events);
 
-    // Append: same prefix, one-or-more new events at the tail. The O(1)
-    // boundary checks (first + last-of-prev still share their references)
-    // distinguish a genuine append from a full-replace whose new array happens
-    // to be longer.
-    if (
-      len > prevLen &&
-      (prevLen === 0 ||
-        (events[0] === prevEvents[0] &&
-          events[prevLen - 1] === prevEvents[prevLen - 1]))
-    ) {
-      const stepsClone = steps.slice();
-      const toolMetaClone = toolMeta.slice();
-      for (let i = prevLen; i < len; i++) {
-        reducer(stepsClone, toolMetaClone, events[i]!);
-      }
-      prevEvents = events;
-      steps = stepsClone;
-      toolMeta = toolMetaClone;
-      return { steps, toolMeta };
-    }
-
-    // Mutate-last: text-delta coalescing. Same length, only the last element
-    // replaced, every earlier element shared. We require the genuine
-    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
-    // equality: both last events must be `type: "text"` and the new content must
-    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
-    // alone is insufficient because `mapDetailEvents` restarts event ids at
-    // `detail-1` per subagent — a single-event subagent switch collides on
-    // `id === "detail-1"` and would be misclassified, surviving a stale step. The
-    // type + content-extension guards reject that collision (different type, or
-    // content that isn't a strict extension → Fallback full rebuild).
-    if (
-      len === prevLen &&
-      len >= 1 &&
-      events[len - 1] !== prevEvents[len - 1] &&
-      events[len - 1]!.id === prevEvents[len - 1]!.id &&
-      prevEvents[len - 1]!.type === "text" &&
-      events[len - 1]!.type === "text" &&
-      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
-      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
-      (len === 1 || events[len - 2] === prevEvents[len - 2])
-    ) {
-      const stepsClone = steps.slice();
-      const toolMetaClone = toolMeta.slice();
-
-      // A text event contributes 0 or 1 trailing thinking step and never
-      // mutates earlier steps, so popping the keyed tail (if present) and
-      // re-deriving from the grown content reproduces the full rebuild exactly.
-      const tail = stepsClone[stepsClone.length - 1];
-      let poppedStep: ToolCallCardStep | undefined;
-      if (tail && tail.kind === "thinking" && tail.detailKey === events[len - 1]!.id) {
-        poppedStep = tail;
-        stepsClone.pop();
-        toolMetaClone.pop();
-      }
-
-      reducer(stepsClone, toolMetaClone, events[len - 1]!);
-
-      prevEvents = events;
-      const newTail = stepsClone[stepsClone.length - 1];
-      // Identity preservation — once the collapsed preview passes the 160-char
-      // clamp, further deltas don't change the rendered step. Keep the previous
-      // `steps` reference so memo / `React.memo` consumers bail. (toolMeta is
-      // re-derived identically too; reuse the prior reference for the same win.)
-      if (poppedStep && newTail && stepsEqual(poppedStep, newTail)) {
+      // Append: same prefix, one-or-more new events at the tail. Replay only
+      // the appended events through the reducer.
+      case "append": {
+        const len = events.length;
+        const stepsClone = steps.slice();
+        const toolMetaClone = toolMeta.slice();
+        for (let i = diff.from; i < len; i++) {
+          reducer(stepsClone, toolMetaClone, events[i]!);
+        }
+        prevEvents = events;
+        steps = stepsClone;
+        toolMeta = toolMetaClone;
         return { steps, toolMeta };
       }
-      steps = stepsClone;
-      toolMeta = toolMetaClone;
-      return { steps, toolMeta };
-    }
 
-    // Fallback — full-replace / truncation / reorder / violated assumption.
-    return fullBuild(events);
+      // Mutate-last: text-delta coalescing. Re-derive only the grown tail.
+      case "mutate-last": {
+        const len = events.length;
+        const stepsClone = steps.slice();
+        const toolMetaClone = toolMeta.slice();
+
+        // A text event contributes 0 or 1 trailing thinking step and never
+        // mutates earlier steps, so popping the keyed tail (if present) and
+        // re-deriving from the grown content reproduces the full rebuild exactly.
+        const tail = stepsClone[stepsClone.length - 1];
+        let poppedStep: ToolCallCardStep | undefined;
+        if (tail && tail.kind === "thinking" && tail.detailKey === events[len - 1]!.id) {
+          poppedStep = tail;
+          stepsClone.pop();
+          toolMetaClone.pop();
+        }
+
+        reducer(stepsClone, toolMetaClone, events[len - 1]!);
+
+        prevEvents = events;
+        const newTail = stepsClone[stepsClone.length - 1];
+        // Identity preservation — once the collapsed preview passes the 160-char
+        // clamp, further deltas don't change the rendered step. Keep the previous
+        // `steps` reference so memo / `React.memo` consumers bail. (toolMeta is
+        // re-derived identically too; reuse the prior reference for the same win.)
+        if (poppedStep && newTail && stepsEqual(poppedStep, newTail)) {
+          return { steps, toolMeta };
+        }
+        steps = stepsClone;
+        toolMeta = toolMetaClone;
+        return { steps, toolMeta };
+      }
+
+      // Fallback — full-replace / truncation / reorder / violated assumption.
+      case "fallback":
+        return fullBuild(events);
+    }
   }
 
   return { project };

--- a/clients/web/src/domains/chat/subagent-step-projection.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.ts
@@ -1,0 +1,207 @@
+/**
+ * Incremental step projection for a subagent's timeline.
+ *
+ * Background — the store mutates `entry.events` in exactly three shapes
+ * (verified in `subagent-store.ts` `receiveEvent` / `loadDetail`):
+ *
+ *  1. **Append-1** — a new `tool_call` / `tool_result` / `error` / first `text`
+ *     event lands → `events: [...existing.events, ev]`. A new array, but every
+ *     prior element keeps its reference and exactly one element is appended at
+ *     the tail.
+ *  2. **Mutate-last** — consecutive `assistant_text_delta`s coalesce → the array
+ *     is copied (`[...existing.events]`) with only the **last** element replaced
+ *     by `{ ...lastEvent, content: lastEvent.content + delta }`. Same length,
+ *     same element references except the last, the last keeps the **same `id`**,
+ *     and its `content` only grows. Always a `text` event.
+ *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
+ *     subagent switch).
+ *
+ * `computeSubagentSteps(events)` is O(n) and the panel previously re-ran it on
+ * every streamed event → O(n²) over a run. This projector replays only the
+ * events that changed since the last call, folding them through the **same**
+ * `applyTimelineEvent` reducer the full rebuild uses — so the incremental and
+ * full paths can never drift. Any diff that doesn't fit the append / mutate-last
+ * shapes (full-replace, truncation, reorder, or a violated assumption) falls
+ * back to a full O(n) `computeSubagentSteps` rebuild, which is always correct.
+ *
+ * Note: a `tool_result` / `error` event closes an in-flight tool by writing at
+ * an *earlier* step's match index, so projection is append-MOSTLY, not
+ * append-only — which is exactly why we reuse the real reducer instead of a
+ * naive "push one step."
+ */
+
+import { useRef } from "react";
+
+import {
+  applyTimelineEvent,
+  computeSubagentSteps,
+  type ToolCallCardStep,
+  type ToolMeta,
+} from "@/domains/chat/hooks/use-subagent-card-data";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+export interface ProjectedSteps {
+  steps: ToolCallCardStep[];
+  toolMeta: Array<ToolMeta | undefined>;
+}
+
+/**
+ * Structural equality for two timeline steps. The steps are flat objects (only
+ * `results` carries a nested array), so a shallow JSON compare is both correct
+ * and cheap — used only on the single re-derived tail step in the mutate-last
+ * path to decide whether the array identity can be preserved.
+ */
+function stepsEqual(a: ToolCallCardStep, b: ToolCallCardStep): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** The per-event reducer signature shared by the full and incremental paths. */
+type TimelineReducer = (
+  steps: ToolCallCardStep[],
+  toolMeta: Array<ToolMeta | undefined>,
+  event: SubagentTimelineEvent,
+) => void;
+
+/**
+ * Create a stateful incremental projector. `project(events)` returns the
+ * `{ steps, toolMeta }` for `events`, replaying only the diff vs the previous
+ * call through `applyTimelineEvent`. The returned arrays are cached; identical
+ * inputs (or no-op text deltas past the preview clamp) return the cached arrays
+ * by reference so downstream memo / `React.memo` consumers can bail.
+ *
+ * One projector instance owns one cache slot — hold it per component instance
+ * (see `useSubagentSteps`), never module-global, so the panel and N inline
+ * cards don't thrash a single slot.
+ *
+ * `reducer` defaults to the real `applyTimelineEvent`; it's a seam for the
+ * incremental-work guard test to count reducer invocations without mocking.
+ */
+export function createIncrementalStepProjection(
+  reducer: TimelineReducer = applyTimelineEvent,
+) {
+  let prevEvents: SubagentTimelineEvent[] | null = null;
+  let steps: ToolCallCardStep[] = [];
+  let toolMeta: Array<ToolMeta | undefined> = [];
+
+  function fullBuild(events: SubagentTimelineEvent[]): ProjectedSteps {
+    const built = computeSubagentSteps(events);
+    prevEvents = events;
+    steps = built.steps;
+    toolMeta = built.toolMeta;
+    return { steps, toolMeta };
+  }
+
+  function project(events: SubagentTimelineEvent[]): ProjectedSteps {
+    // Identity — also covers PR2's events-stable status/usage updates.
+    if (events === prevEvents) return { steps, toolMeta };
+
+    // First call / empty cache.
+    if (prevEvents == null) return fullBuild(events);
+
+    const prevLen = prevEvents.length;
+    const len = events.length;
+
+    // Append: same prefix, one-or-more new events at the tail. The O(1)
+    // boundary checks (first + last-of-prev still share their references)
+    // distinguish a genuine append from a full-replace whose new array happens
+    // to be longer.
+    if (
+      len > prevLen &&
+      (prevLen === 0 ||
+        (events[0] === prevEvents[0] &&
+          events[prevLen - 1] === prevEvents[prevLen - 1]))
+    ) {
+      const stepsClone = steps.slice();
+      const toolMetaClone = toolMeta.slice();
+      for (let i = prevLen; i < len; i++) {
+        reducer(stepsClone, toolMetaClone, events[i]!);
+      }
+      prevEvents = events;
+      steps = stepsClone;
+      toolMeta = toolMetaClone;
+      return { steps, toolMeta };
+    }
+
+    // Mutate-last: text-delta coalescing. Same length, only the last element
+    // replaced (same `id`, longer `content`), every earlier element shared.
+    if (
+      len === prevLen &&
+      len >= 1 &&
+      events[len - 1] !== prevEvents[len - 1] &&
+      events[len - 1]!.id === prevEvents[len - 1]!.id &&
+      (len === 1 || events[len - 2] === prevEvents[len - 2])
+    ) {
+      const stepsClone = steps.slice();
+      const toolMetaClone = toolMeta.slice();
+
+      // A text event contributes 0 or 1 trailing thinking step and never
+      // mutates earlier steps, so popping the keyed tail (if present) and
+      // re-deriving from the grown content reproduces the full rebuild exactly.
+      const tail = stepsClone[stepsClone.length - 1];
+      let poppedStep: ToolCallCardStep | undefined;
+      if (tail && tail.kind === "thinking" && tail.detailKey === events[len - 1]!.id) {
+        poppedStep = tail;
+        stepsClone.pop();
+        toolMetaClone.pop();
+      }
+
+      reducer(stepsClone, toolMetaClone, events[len - 1]!);
+
+      prevEvents = events;
+      const newTail = stepsClone[stepsClone.length - 1];
+      // Identity preservation — once the collapsed preview passes the 160-char
+      // clamp, further deltas don't change the rendered step. Keep the previous
+      // `steps` reference so memo / `React.memo` consumers bail. (toolMeta is
+      // re-derived identically too; reuse the prior reference for the same win.)
+      if (poppedStep && newTail && stepsEqual(poppedStep, newTail)) {
+        return { steps, toolMeta };
+      }
+      steps = stepsClone;
+      toolMeta = toolMetaClone;
+      return { steps, toolMeta };
+    }
+
+    // Fallback — full-replace / truncation / reorder / violated assumption.
+    return fullBuild(events);
+  }
+
+  return { project };
+}
+
+/**
+ * Hook wrapper: holds an incremental projector per component instance (in a
+ * `useRef`, tied to the component's lifecycle — never a module-global cache, so
+ * the panel and N inline cards don't share/thrash one slot). Returns the
+ * projector output, stabilizing the wrapper object's identity when both arrays
+ * are unchanged so callers that compare the `{ steps, toolMeta }` object also
+ * bail.
+ */
+export function useSubagentSteps(
+  events: SubagentTimelineEvent[],
+): ProjectedSteps {
+  const projectorRef = useRef<ReturnType<
+    typeof createIncrementalStepProjection
+  > | null>(null);
+  const lastRef = useRef<ProjectedSteps | null>(null);
+
+  // Intentional render-phase ref usage: the projector is a per-instance
+  // mutable cache (like `useMemo` but with custom diff-aware equality), so its
+  // identity must be stable across renders and `project(events)` must run on
+  // every render to fold in new events. Reading `.current` here is the whole
+  // point — the same lazy-init + cache pattern `use-event-stream.ts` uses.
+  /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
+  if (projectorRef.current == null) {
+    projectorRef.current = createIncrementalStepProjection();
+  }
+  const next = projectorRef.current.project(events);
+  const last = lastRef.current;
+  // Stabilize the wrapper object's identity when both arrays are unchanged so
+  // callers comparing the `{ steps, toolMeta }` object (not just the arrays)
+  // also bail.
+  if (last != null && last.steps === next.steps && last.toolMeta === next.toolMeta) {
+    return last;
+  }
+  lastRef.current = next;
+  return next;
+  /* eslint-enable react-hooks/refs */
+}

--- a/clients/web/src/domains/chat/subagent-step-projection.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.ts
@@ -24,8 +24,8 @@
  *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
  *     subagent switch).
  *
- * `computeSubagentSteps(events)` is O(n) and the panel previously re-ran it on
- * every streamed event → O(n²) over a run. This projector replays only the
+ * `computeSubagentSteps(events)` is O(n); running it on every streamed event
+ * would be O(n²) over a run. This projector replays only the
  * events that changed since the last call, folding them through the **same**
  * `applyTimelineEvent` reducer the full rebuild uses — so the incremental and
  * full paths can never drift. Any diff that doesn't fit the append / mutate-last
@@ -107,7 +107,7 @@ export function createIncrementalStepProjection(
     const diff = classifyEventsDiff(prevEvents, events);
 
     switch (diff.kind) {
-      // Identity — also covers PR2's events-stable status/usage updates.
+      // Identity — also covers events-stable status/usage updates.
       case "identity":
         return { steps, toolMeta };
 

--- a/clients/web/src/domains/chat/subagent-step-projection.ts
+++ b/clients/web/src/domains/chat/subagent-step-projection.ts
@@ -12,7 +12,15 @@
  *     is copied (`[...existing.events]`) with only the **last** element replaced
  *     by `{ ...lastEvent, content: lastEvent.content + delta }`. Same length,
  *     same element references except the last, the last keeps the **same `id`**,
- *     and its `content` only grows. Always a `text` event.
+ *     and its `content` only grows. Always a `text` event. We classify this shape
+ *     by the text-coalescing CONTENT shape — both last events `type: "text"` and
+ *     the new content strictly EXTENDS the old (`startsWith` + non-shrinking
+ *     length) — not just last-id equality. `mapDetailEvents` restarts ids at
+ *     `detail-1` per subagent, so two different subagents whose detail arrays each
+ *     have one event collide on `id === "detail-1"`; matching only by id would
+ *     misclassify a subagent switch as mutate-last and leave a stale step that a
+ *     full rebuild drops (then a stale pill/key could open the previous
+ *     subagent's detail).
  *  3. **Full-replace** — `loadDetail` swaps the whole array (history hydration /
  *     subagent switch).
  *
@@ -123,12 +131,24 @@ export function createIncrementalStepProjection(
     }
 
     // Mutate-last: text-delta coalescing. Same length, only the last element
-    // replaced (same `id`, longer `content`), every earlier element shared.
+    // replaced, every earlier element shared. We require the genuine
+    // text-coalescing CONTENT shape the store actually produces, NOT just last-id
+    // equality: both last events must be `type: "text"` and the new content must
+    // strictly EXTEND the old (`content: lastEvent.content + delta`). Id equality
+    // alone is insufficient because `mapDetailEvents` restarts event ids at
+    // `detail-1` per subagent — a single-event subagent switch collides on
+    // `id === "detail-1"` and would be misclassified, surviving a stale step. The
+    // type + content-extension guards reject that collision (different type, or
+    // content that isn't a strict extension → Fallback full rebuild).
     if (
       len === prevLen &&
       len >= 1 &&
       events[len - 1] !== prevEvents[len - 1] &&
       events[len - 1]!.id === prevEvents[len - 1]!.id &&
+      prevEvents[len - 1]!.type === "text" &&
+      events[len - 1]!.type === "text" &&
+      events[len - 1]!.content.length >= prevEvents[len - 1]!.content.length &&
+      events[len - 1]!.content.startsWith(prevEvents[len - 1]!.content) &&
       (len === 1 || events[len - 2] === prevEvents[len - 2])
     ) {
       const stepsClone = steps.slice();


### PR DESCRIPTION
## Summary
Eliminates the O(n²) per-event re-projection in the Sub-agent Detail panel and the entry-identity memo-busting cascade. The panel now replays only the events that changed since the last render (append-1 / text-coalescing mutate-last) through a shared per-event reducer, keys the heavy projections on `entry.events` (reference-stable across token/status updates), and memoizes the phase rows behind stable callbacks.

Net effect: streaming a subagent no longer re-walks the whole timeline per token; a no-op delta past the 160-char preview clamp skips re-render entirely; token/status ticks do zero projection work; expanding a phase re-renders only that row.

## PRs merged into this feature branch
- #35865 — extract per-event reducers behind the projection functions (no behavior change)
- #35866 — key heavy projections on `entry.events`, not `entry`
- #35868 — incremental step projection (O(n²)→O(Δ)) with no-drift property test
- #35869 — incremental nested detail-map projection (includes a Codex-flagged correctness fix: mutate-last now requires the genuine text-coalescing shape, preventing cross-subagent `detail-1` id collisions)
- #35871 — `React.memo` phase rows + stable timeline callbacks
- #35880 — review remediation: shared `classifyEventsDiff` + shared test fixtures + mock prop-type fix

## Correctness guarantees
- **No-drift property tests** (both projectors, 5 seeds × 300-event streams): the incremental output always deep-equals a full rebuild after every store mutation.
- **Work-count guards**: reducer invocations grow ~linearly in N (≈6× from N=50→300), not quadratically.
- **Render-isolation test**: toggling one phase re-renders 1 row; a no-op parent re-render re-renders 0 rows.
- Shared full-rebuild fallback covers history hydration / subagent switch / any unrecognized diff shape.

## Self-review result
4 fresh-eyes passes: external-feedback PASS, plan-faithfulness PASS, repo-integration PASS, slop/reuse GAPS (2 DRY findings) → fixed in #35880 → re-review PASS.

Part of plan: subagent-panel-incremental-projection.md