### PR TITLE
fix(verification): synthesize guardian binding from gateway delivery

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -94,9 +94,19 @@ const resolveGuardianList = async (input?: { channelTypes?: string[] }) => {
   return channels
     .map((channelType) => {
       const found = findGuardianForChannel(channelType);
-      return found ? { channelType, status: "active" } : null;
+      if (!found) return null;
+      return {
+        channelType,
+        contactId: found.contact.id,
+        principalId: found.contact.principalId ?? null,
+        displayName: found.contact.displayName ?? null,
+        address: found.channel.address,
+        externalChatId: found.channel.externalChatId ?? null,
+        status: "active",
+        verifiedAt: found.channel.verifiedAt ?? null,
+      };
     })
-    .filter((g): g is { channelType: string; status: string } => g !== null);
+    .filter((g) => g !== null);
 };
 
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
@@ -345,12 +355,12 @@ describe("guardian service challenge validation", () => {
     }
   });
 
-  test("validateAndConsumeVerification does not create a guardian binding (caller responsibility)", () => {
+  test("validateAndConsumeVerification does not create a guardian binding (caller responsibility)", async () => {
     const { secret } = createInboundVerificationSession("telegram");
 
     validateAndConsumeVerification("telegram", secret, "user-42", "chat-42");
 
-    const binding = getGuardianBinding("asst-1", "telegram");
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).toBeNull();
   });
 
@@ -422,7 +432,7 @@ describe("guardian service challenge validation", () => {
     expect(result2.success).toBe(false);
   });
 
-  test("validateAndConsumeVerification succeeds with voice channel", () => {
+  test("validateAndConsumeVerification succeeds with voice channel", async () => {
     const { secret } = createInboundVerificationSession("phone");
 
     const result = validateAndConsumeVerification(
@@ -439,7 +449,7 @@ describe("guardian service challenge validation", () => {
 
     // validateAndConsumeVerification no longer creates bindings — that is
     // now handled by the gateway's verification intercepts.
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).toBeNull();
   });
 
@@ -475,7 +485,7 @@ describe("guardian service challenge validation", () => {
     expect(telegramResult.success).toBe(true);
   });
 
-  test("validateAndConsumeVerification succeeds even with existing binding (conflict check is caller responsibility)", () => {
+  test("validateAndConsumeVerification succeeds even with existing binding (conflict check is caller responsibility)", async () => {
     // Create initial guardian binding
     createGuardianBinding({
       channel: "telegram",
@@ -484,7 +494,7 @@ describe("guardian service challenge validation", () => {
       guardianDeliveryChatId: "old-chat",
     });
 
-    const oldBinding = getGuardianBinding("asst-1", "telegram");
+    const oldBinding = await getGuardianBinding("asst-1", "telegram");
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe("old-user");
 
@@ -499,7 +509,7 @@ describe("guardian service challenge validation", () => {
     // Challenge validation succeeds — the caller decides how to handle binding conflicts
     expect(result.success).toBe(true);
 
-    const binding = getGuardianBinding("asst-1", "telegram");
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).not.toBeNull();
     expect(binding!.guardianExternalUserId).toBe("old-user");
   });
@@ -514,7 +524,7 @@ describe("guardian identity check", () => {
     resetTables();
   });
 
-  test("isGuardian returns true for matching user", () => {
+  test("isGuardian returns true for matching user", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -522,10 +532,10 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(true);
+    expect(await isGuardian("asst-1", "telegram", "user-42")).toBe(true);
   });
 
-  test("isGuardian returns false for non-matching user", () => {
+  test("isGuardian returns false for non-matching user", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -533,14 +543,14 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    expect(isGuardian("asst-1", "telegram", "user-99")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "user-99")).toBe(false);
   });
 
-  test("isGuardian returns false when no binding exists", () => {
-    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(false);
+  test("isGuardian returns false when no binding exists", async () => {
+    expect(await isGuardian("asst-1", "telegram", "user-42")).toBe(false);
   });
 
-  test("isGuardian returns false after binding is revoked", () => {
+  test("isGuardian returns false after binding is revoked", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -550,10 +560,10 @@ describe("guardian identity check", () => {
 
     serviceRevokeBinding("asst-1", "telegram");
 
-    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "user-42")).toBe(false);
   });
 
-  test("getGuardianBinding returns the active binding", () => {
+  test("getGuardianBinding returns the active binding", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -561,17 +571,17 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    const binding = getGuardianBinding("asst-1", "telegram");
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).not.toBeNull();
     expect(binding!.guardianExternalUserId).toBe("user-42");
   });
 
-  test("getGuardianBinding returns null when no binding exists", () => {
-    const binding = getGuardianBinding("asst-1", "telegram");
+  test("getGuardianBinding returns null when no binding exists", async () => {
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).toBeNull();
   });
 
-  test("isGuardian works for voice channel", () => {
+  test("isGuardian works for voice channel", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "phone-user-1",
@@ -579,13 +589,13 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    expect(isGuardian("asst-1", "phone", "phone-user-1")).toBe(true);
-    expect(isGuardian("asst-1", "phone", "phone-user-2")).toBe(false);
+    expect(await isGuardian("asst-1", "phone", "phone-user-1")).toBe(true);
+    expect(await isGuardian("asst-1", "phone", "phone-user-2")).toBe(false);
     // Telegram guardian should not match voice channel
-    expect(isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
   });
 
-  test("serviceRevokeBinding revokes the active binding", () => {
+  test("serviceRevokeBinding revokes the active binding", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -595,7 +605,7 @@ describe("guardian identity check", () => {
 
     const result = serviceRevokeBinding("asst-1", "telegram");
     expect(result).toBe(true);
-    expect(getGuardianBinding("asst-1", "telegram")).toBeNull();
+    expect(await getGuardianBinding("asst-1", "telegram")).toBeNull();
   });
 });
 
@@ -886,7 +896,7 @@ describe("channel-scoped guardian resolution", () => {
     resetTables();
   });
 
-  test("isGuardian resolves independently per channel", () => {
+  test("isGuardian resolves independently per channel", async () => {
     // Create guardian binding on telegram
     createGuardianBinding({
       channel: "telegram",
@@ -903,15 +913,15 @@ describe("channel-scoped guardian resolution", () => {
     });
 
     // user-alpha is guardian for telegram but not voice
-    expect(isGuardian("self", "telegram", "user-alpha")).toBe(true);
-    expect(isGuardian("self", "phone", "user-alpha")).toBe(false);
+    expect(await isGuardian("self", "telegram", "user-alpha")).toBe(true);
+    expect(await isGuardian("self", "phone", "user-alpha")).toBe(false);
 
     // user-beta is guardian for voice but not telegram
-    expect(isGuardian("self", "phone", "user-beta")).toBe(true);
-    expect(isGuardian("self", "telegram", "user-beta")).toBe(false);
+    expect(await isGuardian("self", "phone", "user-beta")).toBe(true);
+    expect(await isGuardian("self", "telegram", "user-beta")).toBe(false);
   });
 
-  test("getGuardianBinding returns different bindings for different channels", () => {
+  test("getGuardianBinding returns different bindings for different channels", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-alpha",
@@ -925,8 +935,8 @@ describe("channel-scoped guardian resolution", () => {
       guardianDeliveryChatId: "chat-beta",
     });
 
-    const bindingTelegram = getGuardianBinding("self", "telegram");
-    const bindingVoice = getGuardianBinding("self", "phone");
+    const bindingTelegram = await getGuardianBinding("self", "telegram");
+    const bindingVoice = await getGuardianBinding("self", "phone");
 
     expect(bindingTelegram).not.toBeNull();
     expect(bindingVoice).not.toBeNull();
@@ -934,7 +944,7 @@ describe("channel-scoped guardian resolution", () => {
     expect(bindingVoice!.guardianExternalUserId).toBe("user-beta");
   });
 
-  test("revoking binding for one channel does not affect another", () => {
+  test("revoking binding for one channel does not affect another", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-alpha",
@@ -950,11 +960,11 @@ describe("channel-scoped guardian resolution", () => {
 
     serviceRevokeBinding("self", "telegram");
 
-    expect(getGuardianBinding("self", "telegram")).toBeNull();
-    expect(getGuardianBinding("self", "phone")).not.toBeNull();
+    expect(await getGuardianBinding("self", "telegram")).toBeNull();
+    expect(await getGuardianBinding("self", "phone")).not.toBeNull();
   });
 
-  test("validateAndConsumeVerification scoped to channel", () => {
+  test("validateAndConsumeVerification scoped to channel", async () => {
     // Create challenge on telegram
     const { secret: secretTelegram } =
       createInboundVerificationSession("telegram");
@@ -987,8 +997,8 @@ describe("channel-scoped guardian resolution", () => {
     );
     expect(resultVoice.success).toBe(true);
 
-    const bindingTelegram = getGuardianBinding("self", "telegram");
-    const bindingVoice = getGuardianBinding("self", "phone");
+    const bindingTelegram = await getGuardianBinding("self", "telegram");
+    const bindingVoice = await getGuardianBinding("self", "phone");
     expect(bindingTelegram).toBeNull();
     expect(bindingVoice).toBeNull();
   });
@@ -1303,7 +1313,7 @@ describe("voice guardian challenge validation", () => {
     }
   });
 
-  test("validateAndConsumeVerification does not create a guardian binding for voice (caller responsibility)", () => {
+  test("validateAndConsumeVerification does not create a guardian binding for voice (caller responsibility)", async () => {
     const { secret } = createInboundVerificationSession("phone");
 
     validateAndConsumeVerification(
@@ -1313,7 +1323,7 @@ describe("voice guardian challenge validation", () => {
       "voice-chat-1",
     );
 
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).toBeNull();
   });
 
@@ -1387,7 +1397,7 @@ describe("voice guardian challenge validation", () => {
     expect(result2.success).toBe(false);
   });
 
-  test("validateAndConsumeVerification succeeds even with existing voice binding (conflict check is caller responsibility)", () => {
+  test("validateAndConsumeVerification succeeds even with existing voice binding (conflict check is caller responsibility)", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "old-voice-user",
@@ -1395,7 +1405,7 @@ describe("voice guardian challenge validation", () => {
       guardianDeliveryChatId: "old-voice-chat",
     });
 
-    const oldBinding = getGuardianBinding("asst-1", "phone");
+    const oldBinding = await getGuardianBinding("asst-1", "phone");
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe("old-voice-user");
 
@@ -1411,7 +1421,7 @@ describe("voice guardian challenge validation", () => {
     expect(result.success).toBe(true);
 
     // The original binding is untouched (no side effects)
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).not.toBeNull();
     expect(binding!.guardianExternalUserId).toBe("old-voice-user");
   });
@@ -1426,7 +1436,7 @@ describe("voice guardian identity and revocation", () => {
     resetTables();
   });
 
-  test("isGuardian works for voice channel", () => {
+  test("isGuardian works for voice channel", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1434,13 +1444,13 @@ describe("voice guardian identity and revocation", () => {
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    expect(isGuardian("asst-1", "phone", "voice-user-1")).toBe(true);
-    expect(isGuardian("asst-1", "phone", "voice-user-2")).toBe(false);
+    expect(await isGuardian("asst-1", "phone", "voice-user-1")).toBe(true);
+    expect(await isGuardian("asst-1", "phone", "voice-user-2")).toBe(false);
     // Voice guardian should not match telegram channel
-    expect(isGuardian("asst-1", "telegram", "voice-user-1")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "voice-user-1")).toBe(false);
   });
 
-  test("getGuardianBinding returns voice binding", () => {
+  test("getGuardianBinding returns voice binding", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1448,13 +1458,13 @@ describe("voice guardian identity and revocation", () => {
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).not.toBeNull();
     expect(binding!.channel).toBe("phone");
     expect(binding!.guardianExternalUserId).toBe("voice-user-1");
   });
 
-  test("revokeBinding clears active voice guardian binding", () => {
+  test("revokeBinding clears active voice guardian binding", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1464,10 +1474,10 @@ describe("voice guardian identity and revocation", () => {
 
     const result = serviceRevokeBinding("asst-1", "phone");
     expect(result).toBe(true);
-    expect(getGuardianBinding("asst-1", "phone")).toBeNull();
+    expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
   });
 
-  test("revokeBinding for voice does not affect telegram binding", () => {
+  test("revokeBinding for voice does not affect telegram binding", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1483,8 +1493,8 @@ describe("voice guardian identity and revocation", () => {
 
     serviceRevokeBinding("asst-1", "phone");
 
-    expect(getGuardianBinding("asst-1", "phone")).toBeNull();
-    expect(getGuardianBinding("asst-1", "telegram")).not.toBeNull();
+    expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
+    expect(await getGuardianBinding("asst-1", "telegram")).not.toBeNull();
   });
 });
 
@@ -1742,7 +1752,7 @@ describe("HTTP handler voice guardian verification", () => {
     expect(resp!.bound).toBe(false);
 
     // Verify binding is actually revoked
-    expect(getGuardianBinding("self", "phone")).toBeNull();
+    expect(await getGuardianBinding("self", "phone")).toBeNull();
   });
 
   test("revoke for voice does not affect telegram binding", async () => {
@@ -1768,8 +1778,8 @@ describe("HTTP handler voice guardian verification", () => {
 
     await handleChannelVerificationSession(msg);
 
-    expect(getGuardianBinding("self", "phone")).toBeNull();
-    expect(getGuardianBinding("self", "telegram")).not.toBeNull();
+    expect(await getGuardianBinding("self", "phone")).toBeNull();
+    expect(await getGuardianBinding("self", "telegram")).not.toBeNull();
   });
 });
 

--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -135,11 +135,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     mockOnConversationCreatedCallbacks.length = 0;
   });
 
-  test("emits guardian.question for trusted-contact sessions", () => {
+  test("emits guardian.question for trusted-contact sessions", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -160,7 +160,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(payload.requesterIdentifier).toBe("@requester");
   });
 
-  test("skips guardian actor sessions (self-approve)", () => {
+  test("skips guardian actor sessions (self-approve)", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext: TrustContext = {
       sourceChannel: "telegram",
@@ -168,7 +168,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
       guardianExternalUserId: "guardian-1",
     };
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -182,14 +182,14 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("skips unknown actor sessions", () => {
+  test("skips unknown actor sessions", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
     };
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -203,13 +203,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("skips when guardian identity is missing", () => {
+  test("skips when guardian identity is missing", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext({
       guardianExternalUserId: undefined,
     });
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -223,13 +223,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("skips when no guardian binding exists for channel", () => {
+  test("skips when no guardian binding exists for channel", async () => {
     const canonicalRequest = makeCanonicalRequest({ sourceChannel: "phone" });
     const trustContext = makeTrustedContactContext({
       sourceChannel: "phone",
     });
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -243,11 +243,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("sets correct attention hints for urgency", () => {
+  test("sets correct attention hints for urgency", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -261,11 +261,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(hints.visibleInSourceNow).toBe(false);
   });
 
-  test("uses dedupe key scoped to canonical request ID", () => {
+  test("uses dedupe key scoped to canonical request ID", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -277,11 +277,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     );
   });
 
-  test("creates vellum delivery row via onConversationCreated callback", () => {
+  test("creates vellum delivery row via onConversationCreated callback", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -298,18 +298,20 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     });
 
     const deliveries = listCanonicalGuardianDeliveries(canonicalRequest.id);
-    expect(deliveries).toHaveLength(1);
-    expect(deliveries[0].destinationChannel).toBe("vellum");
-    expect(deliveries[0].destinationConversationId).toBe(
+    const vellumDelivery = deliveries.find(
+      (d) => d.destinationChannel === "vellum",
+    );
+    expect(vellumDelivery).toBeDefined();
+    expect(vellumDelivery?.destinationConversationId).toBe(
       "guardian-conversation-1",
     );
   });
 
-  test("uses custom assistantId when provided", () => {
+  test("uses custom assistantId when provided", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -324,13 +326,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("does not pass assistantId to notification signal", () => {
+  test("does not pass assistantId to notification signal", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
     // assistantId is used internally for guardian binding lookup but is no
     // longer forwarded to the notification signal after the assistantId removal refactor.
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -340,13 +342,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals[0].assistantId).toBeUndefined();
   });
 
-  test("includes requesterChatId as null when not provided", () => {
+  test("includes requesterChatId as null when not provided", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext({
       requesterChatId: undefined,
     });
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -357,7 +359,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(payload.requesterChatId).toBeNull();
   });
 
-  test("skips when binding guardian identity does not match canonical request guardian", () => {
+  test("skips when binding guardian identity does not match canonical request guardian", async () => {
     // Create a canonical request where guardianExternalUserId differs from the
     // binding's guardianExternalUserId ('guardian-1' in the mock).
     const canonicalRequest = makeCanonicalRequest({
@@ -365,7 +367,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     });
     const trustContext = makeTrustedContactContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -379,7 +381,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("does not skip when canonical request guardian identity is null", () => {
+  test("does not skip when canonical request guardian identity is null", async () => {
     // When guardianExternalUserId is null on the canonical request (e.g. desktop
     // flow), the identity check should be skipped and the bridge should proceed.
     const canonicalRequest = makeCanonicalRequest({
@@ -387,7 +389,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     });
     const trustContext = makeTrustedContactContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -1735,7 +1735,7 @@ describe("relay-server", () => {
     // Guardian binding is NOT created by the assistant — the gateway owns
     // binding creation for inbound voice verification. The assistant only
     // transitions to connected state and starts the normal call flow.
-    const binding = getGuardianBinding("self", "phone");
+    const binding = await getGuardianBinding("self", "phone");
     expect(binding).toBeNull();
 
     // Orchestrator greeting should have fired
@@ -1806,7 +1806,7 @@ describe("relay-server", () => {
     expect(relay.getConnectionState()).toBe("connected");
 
     // Binding is NOT created by the assistant — gateway owns this.
-    const binding = getGuardianBinding("self", "phone");
+    const binding = await getGuardianBinding("self", "phone");
     expect(binding).toBeNull();
 
     // Greeting should have started
@@ -2327,6 +2327,9 @@ describe("relay-server", () => {
     for (const digit of secret) {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
+
+    // Let the fire-and-forget verification result handler flush
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     // Verification should have succeeded
     expect(relay.isVerificationSessionActive()).toBe(false);
@@ -4777,7 +4780,7 @@ describe("relay-server", () => {
     expect(relay.getConnectionState()).toBe("connected");
 
     // Guardian binding is NOT created by the assistant — gateway owns this.
-    const binding = getGuardianBinding("self", "phone");
+    const binding = await getGuardianBinding("self", "phone");
     expect(binding).toBeNull();
 
     // Normal greeting should fire (from mockSendMessage), not the handoff copy

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -335,7 +335,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
     };
   });
 
-  test("trusted-contact confirmation_request emits guardian.question and creates delivery records", () => {
+  test("trusted-contact confirmation_request emits guardian.question and creates delivery records", async () => {
     const canonicalRequest = createCanonicalGuardianRequest({
       id: `req-bridge-${Date.now()}`,
       kind: "tool_approval",
@@ -352,7 +352,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
 
     const trustContext = makeTrustedContactTrustContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-bridge-1",
@@ -371,7 +371,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
     expect(payload.requesterIdentifier).toBe("@requester");
   });
 
-  test("bridge + tool_grant_request both use guardian.question for unified routing", () => {
+  test("bridge + tool_grant_request both use guardian.question for unified routing", async () => {
     // The confirmation_request bridge and tool_grant_request helper both
     // use 'guardian.question' as the notification signal, ensuring consistent
     // guardian routing regardless of the approval path.
@@ -391,7 +391,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
 
     const trustContext = makeTrustedContactTrustContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-unified-1",
@@ -432,7 +432,7 @@ describe("(c) no-binding flow: trusted contact fails fast without guardian bindi
     expect(state.promptWaitingAllowed).toBe(false);
   });
 
-  test("bridge skips when no guardian binding exists for channel", () => {
+  test("bridge skips when no guardian binding exists for channel", async () => {
     const canonicalRequest = createCanonicalGuardianRequest({
       id: `req-nobinding-${Date.now()}`,
       kind: "tool_approval",
@@ -449,7 +449,7 @@ describe("(c) no-binding flow: trusted contact fails fast without guardian bindi
 
     const trustContext = makeTrustedContactTrustContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-nobinding",
@@ -543,7 +543,7 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
     expect(resolveRoutingState(withoutRoute).canBeInteractive).toBe(false);
   });
 
-  test("bridge skips unknown actor sessions entirely", () => {
+  test("bridge skips unknown actor sessions entirely", async () => {
     const canonicalRequest = createCanonicalGuardianRequest({
       id: `req-unknown-${Date.now()}`,
       kind: "tool_approval",
@@ -563,7 +563,7 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
       trustClass: "unknown",
     };
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-unknown",
@@ -965,7 +965,7 @@ describe("cross-milestone integration checks", () => {
     );
   });
 
-  test("M2+M4: bridge and tool_grant_request target the same guardian identity", () => {
+  test("M2+M4: bridge and tool_grant_request target the same guardian identity", async () => {
     // Both the confirmation_request bridge (M2) and tool grant request escalation (M4)
     // use the guardian binding's guardianExternalUserId to route notifications.
     // Verify this consistency:
@@ -986,7 +986,7 @@ describe("cross-milestone integration checks", () => {
 
     const trustContext = makeTrustedContactTrustContext();
 
-    const bridgeResult = bridgeConfirmationRequestToGuardian({
+    const bridgeResult = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-consistency",

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -267,9 +267,9 @@ type CreateInboundVoiceSessionResult = {
  * returned without creating a duplicate. This handles Twilio webhook
  * replays gracefully.
  */
-export function createInboundVoiceSession(
+export async function createInboundVoiceSession(
   input: CreateInboundVoiceSessionInput,
-): CreateInboundVoiceSessionResult {
+): Promise<CreateInboundVoiceSessionResult> {
   const {
     callSid,
     fromNumber,
@@ -312,7 +312,7 @@ export function createInboundVoiceSession(
   updateCallSession(session.id, { providerCallSid: callSid });
   session.providerCallSid = callSid;
 
-  const callerIsGuardian = isGuardian(assistantId, "phone", fromNumber);
+  const callerIsGuardian = await isGuardian(assistantId, "phone", fromNumber);
   const metadataHints: string[] = [
     callerIsGuardian
       ? "Caller is the guardian"

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1164,7 +1164,7 @@ export class RelayConnection {
     const assistantId = this.verificationAssistantId;
     const fromNumber = this.verificationFromNumber;
 
-    const result = attemptVerificationCode({
+    const result = await attemptVerificationCode({
       verificationAssistantId: assistantId,
       verificationFromNumber: fromNumber,
       enteredCode,

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -112,9 +112,9 @@ type VerificationCallResult =
  * so the caller can apply side-effects (state mutations, TTS, session
  * updates) without this function needing access to the relay connection.
  */
-export function attemptVerificationCode(
+export async function attemptVerificationCode(
   params: VerificationCallParams,
-): VerificationCallResult {
+): Promise<VerificationCallResult> {
   const {
     verificationAssistantId,
     verificationFromNumber,
@@ -142,7 +142,7 @@ export function attemptVerificationCode(
     let canonicalPrincipal: string | undefined;
 
     if (result.verificationType === "guardian") {
-      const existingBinding = getGuardianBinding(
+      const existingBinding = await getGuardianBinding(
         verificationAssistantId,
         "phone",
       );
@@ -155,7 +155,7 @@ export function attemptVerificationCode(
         };
       } else {
         // Resolve canonical principal from the vellum channel binding
-        const vellumBinding = getGuardianBinding(
+        const vellumBinding = await getGuardianBinding(
           verificationAssistantId,
           "vellum",
         );

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -299,7 +299,7 @@ async function processVoiceWebhook(
       "Inbound voice webhook — creating/reusing session",
     );
 
-    const { session } = createInboundVoiceSession({
+    const { session } = await createInboundVoiceSession({
       callSid,
       fromNumber: callerFrom,
       toNumber: callerTo,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -115,13 +115,13 @@ export async function createInboundChallenge(
   };
 }
 
-export function getVerificationStatus(
+export async function getVerificationStatus(
   channel?: ChannelId,
-): ChannelVerificationSessionResult {
+): Promise<ChannelVerificationSessionResult> {
   const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? "telegram";
 
-  const binding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
+  const binding = await getGuardianBinding(resolvedAssistantId, resolvedChannel);
 
   // Read the contact directly to get displayName — getGuardianBinding is a
   // compatibility shim that doesn't carry metadataJson.
@@ -189,7 +189,10 @@ export async function revokeVerificationForChannel(
 
   // Capture binding before revoking so we can downgrade the guardian's
   // channel — without this, the guardian would still pass the ACL check.
-  const bindingBeforeRevoke = getGuardianBinding(assistantId, resolvedChannel);
+  const bindingBeforeRevoke = await getGuardianBinding(
+    assistantId,
+    resolvedChannel,
+  );
   if (!bindingBeforeRevoke) {
     return {
       success: true,
@@ -590,7 +593,7 @@ export async function handleChannelVerificationSession(
         });
       }
     } else if (msg.action === "status") {
-      const result = getVerificationStatus(channel);
+      const result = await getVerificationStatus(channel);
       broadcastMessage({
         type: "channel_verification_session_response",
         ...result,

--- a/assistant/src/runtime/__tests__/channel-verification-service.test.ts
+++ b/assistant/src/runtime/__tests__/channel-verification-service.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Gateway guardian-delivery list drives both getGuardianBinding and isGuardian:
+// null = couldn't determine, [] = authoritative unbound, one active entry =
+// bound. Tests set this to mirror the gateway-owned ACL state.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+const cachedCalls: Array<{ channelTypes?: string[] } | undefined> = [];
+
+const resolveList = (input?: { channelTypes?: string[] }) => {
+  cachedCalls.push(input);
+  return Promise.resolve(mockGuardianList);
+};
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: resolveList,
+  getGuardianDeliveryFresh: resolveList,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+const { getGuardianBinding, isGuardian } = await import(
+  "../channel-verification-service.js"
+);
+
+const TELEGRAM_DELIVERY = {
+  channelType: "telegram",
+  contactId: "contact-1",
+  principalId: "principal-1",
+  displayName: "Guardian",
+  address: "guardian-handle",
+  externalChatId: "chat-1",
+  status: "active",
+  verifiedAt: 1700,
+};
+
+describe("getGuardianBinding", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    cachedCalls.length = 0;
+  });
+
+  test("filters delivery by the requested channel type", async () => {
+    await getGuardianBinding("asst-1", "telegram");
+    expect(cachedCalls).toEqual([{ channelTypes: ["telegram"] }]);
+  });
+
+  test("returns null when no guardian is bound", async () => {
+    mockGuardianList = [];
+    expect(await getGuardianBinding("asst-1", "telegram")).toBeNull();
+  });
+
+  test("returns null when the gateway is unreachable", async () => {
+    mockGuardianList = null;
+    expect(await getGuardianBinding("asst-1", "telegram")).toBeNull();
+  });
+
+  test("synthesizes the binding from the gateway delivery", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+
+    const binding = await getGuardianBinding("asst-1", "telegram");
+
+    expect(binding).not.toBeNull();
+    expect(binding?.assistantId).toBe("asst-1");
+    expect(binding?.channel).toBe("telegram");
+    expect(binding?.id).toBe("contact-1");
+    expect(binding?.guardianPrincipalId).toBe("principal-1");
+    expect(binding?.guardianExternalUserId).toBe("guardian-handle");
+    expect(binding?.guardianDeliveryChatId).toBe("chat-1");
+    expect(binding?.verifiedAt).toBe(1700);
+    expect(binding?.status).toBe("active");
+    expect(binding?.verifiedVia).toBe("verified");
+  });
+
+  test("falls back to empty strings for absent optional delivery fields", async () => {
+    mockGuardianList = [
+      {
+        channelType: "telegram",
+        contactId: "contact-2",
+        address: "addr",
+        status: "active",
+      },
+    ];
+
+    const binding = await getGuardianBinding("asst-1", "telegram");
+
+    expect(binding?.guardianPrincipalId).toBe("");
+    expect(binding?.guardianDeliveryChatId).toBe("");
+    expect(binding?.verifiedAt).toBe(0);
+  });
+
+  test("ignores deliveries for a different channel", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
+  });
+});
+
+describe("isGuardian", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    cachedCalls.length = 0;
+  });
+
+  test("returns true when the address matches the gateway guardian", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await isGuardian("asst-1", "telegram", "guardian-handle")).toBe(true);
+  });
+
+  test("compares case-insensitively", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await isGuardian("asst-1", "telegram", "GUARDIAN-HANDLE")).toBe(true);
+  });
+
+  test("returns false for a non-matching address", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await isGuardian("asst-1", "telegram", "someone-else")).toBe(false);
+  });
+
+  test("returns false when no guardian is bound", async () => {
+    mockGuardianList = [];
+    expect(await isGuardian("asst-1", "telegram", "guardian-handle")).toBe(
+      false,
+    );
+  });
+
+  test("returns false when the gateway is unreachable", async () => {
+    mockGuardianList = null;
+    expect(await isGuardian("asst-1", "telegram", "guardian-handle")).toBe(
+      false,
+    );
+  });
+});

--- a/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
+++ b/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
@@ -7,11 +7,13 @@ let mockGuardianList: Array<Record<string, unknown>> | null = [];
 const freshCalls: Array<{ channelTypes?: string[] } | undefined> = [];
 
 mock.module("../../contacts/guardian-delivery-reader.js", () => ({
-  // Existence guard must read fresh (uncached) — only this variant is stubbed.
+  // Existence guard reads fresh (uncached); the binding/identity reads use the
+  // cached variant. The service imports both, so both must be stubbed.
   getGuardianDeliveryFresh: (input?: { channelTypes?: string[] }) => {
     freshCalls.push(input);
     return Promise.resolve(mockGuardianList);
   },
+  getGuardianDelivery: () => Promise.resolve(mockGuardianList),
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -749,7 +749,7 @@ async function createCanonicalRequestForConfirmation(
     });
 
     if (trustContext && conversation) {
-      bridgeConfirmationRequestToGuardian({
+      await bridgeConfirmationRequestToGuardian({
         canonicalRequest,
         trustContext,
         conversationId,

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -9,9 +9,9 @@
 import { createHash, randomBytes } from "crypto";
 import { v4 as uuid } from "uuid";
 
-import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { revokeGuardianBinding } from "../contacts/contacts-write.js";
 import {
+  getGuardianDelivery,
   getGuardianDeliveryFresh,
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
@@ -323,33 +323,35 @@ export function validateAndConsumeVerification(
 
 /**
  * Look up the active guardian binding for a given assistant and channel.
- * Reads from the contacts table via findGuardianForChannel and
- * synthesizes a GuardianBinding-shaped object.
- * Returns null when no contacts match.
+ * Reads the gateway-owned GuardianDelivery and synthesizes a
+ * GuardianBinding-shaped object. Returns null when no guardian is bound or
+ * the gateway is unreachable.
  */
-export function getGuardianBinding(
+export async function getGuardianBinding(
   assistantId: string,
   channel: string,
-): GuardianBinding | null {
-  const result = findGuardianForChannel(channel);
-  if (result) {
-    return {
-      id: result.channel.id,
-      assistantId,
-      channel,
-      guardianExternalUserId: result.channel.address,
-      guardianDeliveryChatId: result.channel.externalChatId ?? "",
-      guardianPrincipalId: result.contact.principalId ?? "",
-      status: "active" as const,
-      verifiedAt: result.channel.verifiedAt ?? 0,
-      verifiedVia: result.channel.verifiedVia ?? "",
-      metadataJson: null,
-      createdAt: result.channel.createdAt,
-      updatedAt: result.channel.updatedAt ?? result.channel.createdAt,
-    };
-  }
+): Promise<GuardianBinding | null> {
+  const list = await getGuardianDelivery({ channelTypes: [channel] });
+  const delivery = list ? guardianForChannel(list, channel) : undefined;
+  if (!delivery) return null;
 
-  return null;
+  const now = Date.now();
+  return {
+    id: delivery.contactId,
+    assistantId,
+    channel,
+    guardianExternalUserId: delivery.address,
+    guardianDeliveryChatId: delivery.externalChatId ?? "",
+    guardianPrincipalId: delivery.principalId ?? "",
+    status: "active" as const,
+    verifiedAt: delivery.verifiedAt ?? 0,
+    // verifiedVia is not carried on the delivery contract; a bound guardian
+    // is verified by definition.
+    verifiedVia: "verified",
+    metadataJson: null,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 /**
@@ -376,17 +378,16 @@ export async function isGuardianBoundForChannel(
  * Check whether the given external user is the active guardian for
  * the specified assistant and channel.
  */
-export function isGuardian(
+export async function isGuardian(
   assistantId: string,
   channel: string,
   address: string,
-): boolean {
-  const result = findGuardianForChannel(channel);
-  if (result) {
-    return result.channel.address.toLowerCase() === address.toLowerCase();
-  }
+): Promise<boolean> {
+  const list = await getGuardianDelivery({ channelTypes: [channel] });
+  const delivery = list ? guardianForChannel(list, channel) : undefined;
+  if (!delivery) return false;
 
-  return false;
+  return delivery.address.toLowerCase() === address.toLowerCase();
 }
 
 /**

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -70,9 +70,9 @@ export type BridgeConfirmationRequestResult =
  *
  * Fire-and-forget safe: notification emission errors are logged but not propagated.
  */
-export function bridgeConfirmationRequestToGuardian(
+export async function bridgeConfirmationRequestToGuardian(
   params: BridgeConfirmationRequestParams,
-): BridgeConfirmationRequestResult {
+): Promise<BridgeConfirmationRequestResult> {
   const {
     canonicalRequest,
     trustContext,
@@ -100,7 +100,7 @@ export function bridgeConfirmationRequestToGuardian(
   }
 
   const sourceChannel = trustContext.sourceChannel;
-  const binding = getGuardianBinding(assistantId, sourceChannel);
+  const binding = await getGuardianBinding(assistantId, sourceChannel);
   if (!binding) {
     log.debug(
       { sourceChannel, assistantId },

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -192,12 +192,12 @@ export async function handleCreateVerificationSession({
 /**
  * GET /v1/channel-verification-sessions/status
  */
-function handleGetVerificationStatus({
+async function handleGetVerificationStatus({
   queryParams = {},
   body = {},
 }: RouteHandlerArgs) {
   const channel = (queryParams.channel ?? (body as Record<string, unknown>).channel) as ChannelId | undefined;
-  return getVerificationStatus(channel);
+  return await getVerificationStatus(channel);
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -935,7 +935,7 @@ export async function handleChannelInbound({
   }
 
   // ── Ingress escalation ──
-  const escalationResponse = handleEscalationIntercept({
+  const escalationResponse = await handleEscalationIntercept({
     resolvedMember,
     canonicalAssistantId,
     sourceChannel,

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -49,9 +49,9 @@ export interface EscalationInterceptParams {
  * Returns a Response if the escalation was handled (the pipeline should
  * short-circuit), or null to continue the pipeline.
  */
-export function handleEscalationIntercept(
+export async function handleEscalationIntercept(
   params: EscalationInterceptParams,
-): Record<string, unknown> | null {
+): Promise<Record<string, unknown> | null> {
   const {
     resolvedMember,
     canonicalAssistantId,
@@ -76,7 +76,7 @@ export function handleEscalationIntercept(
     return null;
   }
 
-  const binding = getGuardianBinding(canonicalAssistantId, sourceChannel);
+  const binding = await getGuardianBinding(canonicalAssistantId, sourceChannel);
   if (!binding) {
     // Fail-closed: can't escalate without a guardian to route to
     log.info(

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -59,9 +59,9 @@ export type ToolGrantRequestResult =
  * Returns a result indicating whether a new request was created, an existing
  * one was deduped, or the escalation failed (no binding, missing identity).
  */
-export function createOrReuseToolGrantRequest(
+export async function createOrReuseToolGrantRequest(
   params: ToolGrantRequestParams,
-): ToolGrantRequestResult {
+): Promise<ToolGrantRequestResult> {
   const {
     assistantId,
     sourceChannel,
@@ -78,7 +78,7 @@ export function createOrReuseToolGrantRequest(
     return { failed: true, reason: "missing_identity" };
   }
 
-  const binding = getGuardianBinding(assistantId, sourceChannel);
+  const binding = await getGuardianBinding(assistantId, sourceChannel);
   if (!binding) {
     log.debug(
       { sourceChannel, assistantId },

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -224,7 +224,7 @@ export async function startOutbound(
       originConversationId,
     );
   } else if (channel === "phone") {
-    return startOutboundVoice(
+    return await startOutboundVoice(
       params.destination,
       assistantId,
       channel,
@@ -232,7 +232,7 @@ export async function startOutbound(
       originConversationId,
     );
   } else if (channel === "slack") {
-    return startOutboundSlack(
+    return await startOutboundSlack(
       params.destination,
       assistantId,
       channel,
@@ -240,7 +240,7 @@ export async function startOutbound(
       originConversationId,
     );
   } else if (channel === "email") {
-    return startOutboundEmail(
+    return await startOutboundEmail(
       params.destination,
       assistantId,
       channel,
@@ -274,7 +274,7 @@ async function startOutboundTelegram(
     };
   }
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,
@@ -394,13 +394,13 @@ async function startOutboundTelegram(
   };
 }
 
-function startOutboundVoice(
+async function startOutboundVoice(
   rawDestination: string | undefined,
   assistantId: string,
   channel: ChannelId,
   rebind?: boolean,
   originConversationId?: string,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   if (!rawDestination) {
     return {
       success: false,
@@ -422,7 +422,7 @@ function startOutboundVoice(
     };
   }
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,
@@ -591,13 +591,13 @@ export function deliverVerificationEmail(
   })();
 }
 
-function startOutboundSlack(
+async function startOutboundSlack(
   destination: string | undefined,
   assistantId: string,
   channel: ChannelId,
   rebind?: boolean,
   originConversationId?: string,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   if (!destination) {
     return {
       success: false,
@@ -607,7 +607,7 @@ function startOutboundSlack(
     };
   }
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,
@@ -669,13 +669,13 @@ function startOutboundSlack(
   };
 }
 
-function startOutboundEmail(
+async function startOutboundEmail(
   destination: string | undefined,
   assistantId: string,
   channel: ChannelId,
   rebind?: boolean,
   originConversationId?: string,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   if (!destination) {
     return {
       success: false,
@@ -688,7 +688,7 @@ function startOutboundEmail(
 
   const normalizedEmail = destination.trim().toLowerCase();
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -553,7 +553,7 @@ export class ToolApprovalHandler {
         const inputDigest =
           deferredConsumeParams?.inputDigest ??
           computeToolApprovalDigest(name, input);
-        const escalation = createOrReuseToolGrantRequest({
+        const escalation = await createOrReuseToolGrantRequest({
           assistantId: context.assistantId,
           sourceChannel: context.executionChannel as ChannelId,
           conversationId: context.conversationId,


### PR DESCRIPTION
## Summary
- getGuardianBinding/isGuardian derive principalId/verifiedAt and guardian address from the gateway GuardianDelivery instead of findGuardianForChannel's assistant-DB ACL columns.

Part of plan: combo11-phase-a-read-decoupling.md (PR 4 of 11)