### PR TITLE
fix(disk-pressure): never warn/lock while >2GiB free space remains

### DIFF
--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -38,6 +38,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 
 const {
   DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT,
+  DISK_PRESSURE_MIN_FREE_FLOOR_MB,
   DISK_PRESSURE_OVERRIDE_CONFIRMATION,
   DISK_PRESSURE_THRESHOLD_PERCENT,
   DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT,
@@ -341,5 +342,45 @@ describe("disk pressure guard", () => {
     // A drop below even the warning-clear threshold is a genuine recovery.
     setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT - 1);
     expect(evaluateDiskPressureNow().state).toBe("ok");
+  });
+
+  test("stays ok at a critical usage percentage while ample free space remains", () => {
+    // 99% used of a large volume still leaves gigabytes free — above the floor.
+    const totalMb = 1_000_000;
+    const usedMb = Math.round(totalMb * 0.99); // freeMb ~= 10_000 MiB
+    setDiskUsage(usedMb, totalMb);
+    expect(diskSample!.freeMb).toBeGreaterThanOrEqual(
+      DISK_PRESSURE_MIN_FREE_FLOOR_MB,
+    );
+
+    const status = evaluateDiskPressureNow();
+
+    expect(status.state).toBe("ok");
+    expect(status.locked).toBe(false);
+    expect(status.effectivelyLocked).toBe(false);
+  });
+
+  test("stays ok at a warning usage percentage while ample free space remains", () => {
+    const totalMb = 1_000_000;
+    const usedMb = Math.round(totalMb * 0.85); // 85% used, freeMb ~= 150_000 MiB
+    setDiskUsage(usedMb, totalMb);
+
+    const status = evaluateDiskPressureNow();
+
+    expect(status.state).toBe("ok");
+  });
+
+  test("locks at a critical usage percentage once free space drops below the floor", () => {
+    // High percentage AND little absolute headroom: floor does not apply.
+    const totalMb = 100_000;
+    const freeMb = DISK_PRESSURE_MIN_FREE_FLOOR_MB - 1;
+    setDiskUsage(totalMb - freeMb, totalMb);
+    expect(diskSample!.freeMb).toBeLessThan(DISK_PRESSURE_MIN_FREE_FLOOR_MB);
+
+    const status = evaluateDiskPressureNow();
+
+    expect(status.state).toBe("critical");
+    expect(status.locked).toBe(true);
+    expect(status.effectivelyLocked).toBe(true);
   });
 });

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -24,6 +24,12 @@ export const DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT = 90;
 // clears the warning state, which discards the banner's (state-scoped) dismissal
 // so it re-appears the moment usage ticks back up.
 export const DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT = 77;
+// Absolute free-space floor (MiB). Regardless of usage percentage, never enter
+// the warning or critical state while at least this much space remains free. A
+// high usage percentage on a large disk can still leave many gigabytes
+// available, where locking is pointless. Small volumes (where a high percentage
+// genuinely means near-full) drop below the floor and remain protected.
+export const DISK_PRESSURE_MIN_FREE_FLOOR_MB = 2048;
 export const DISK_PRESSURE_CHECK_INTERVAL_MS = 60_000;
 export const DISK_PRESSURE_OVERRIDE_CONFIRMATION = "I understand the risks";
 export const DISK_PRESSURE_BLOCKED_CAPABILITIES = [
@@ -219,7 +225,10 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
   const criticalThreshold = state.status.locked
     ? DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT
     : DISK_PRESSURE_THRESHOLD_PERCENT;
-  const isCritical = usagePercent >= criticalThreshold;
+  // Absolute free-space floor overrides the percentage thresholds: while ample
+  // space remains free, report "ok" no matter how full the volume is by percent.
+  const hasAmpleFreeSpace = usageInfo.freeMb >= DISK_PRESSURE_MIN_FREE_FLOOR_MB;
+  const isCritical = !hasAmpleFreeSpace && usagePercent >= criticalThreshold;
   // Mirror the critical deadband for the warning band: once in an active
   // pressure state (warning or critical), hold warning until usage clears the
   // lower warning-clear threshold. Treating "critical" as active here matters
@@ -235,7 +244,8 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
   const warningThreshold = inActivePressureState
     ? DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT
     : DISK_PRESSURE_WARNING_THRESHOLD_PERCENT;
-  const isWarning = !isCritical && usagePercent >= warningThreshold;
+  const isWarning =
+    !hasAmpleFreeSpace && !isCritical && usagePercent >= warningThreshold;
   const lastCheckedAt = new Date().toISOString();
 
   if (!isCritical && !isWarning) {


### PR DESCRIPTION
## Summary
- Add an absolute free-space floor (`DISK_PRESSURE_MIN_FREE_FLOOR_MB = 2048`, i.e. 2 GiB) to the disk-pressure guard. While at least this much space is free, `evaluateDiskPressureNow()` reports `"ok"` regardless of usage percentage — gating both the warning (80%) and critical (95%) thresholds.
- This suppresses the in-chat banner, the lock/cleanup mode, the `<disk_pressure_warning>` injection, and background-work gating in cases where there is ample absolute headroom (e.g. a near-full small workspace on a large host disk), while small/constrained volumes still drop below the floor and stay protected.
- Adds guard tests: stays `ok` at 99% usage with ample free space, stays `ok` at warning-level usage with ample free space, and still locks at critical usage once free space dips below the floor.

## Original prompt
While self-hosting the assistant locally, disk-pressure mode kept engaging even though plenty of space was free. We first explored a deployment-specific gate (platform-only), but decided that was the wrong axis — the right fix is a percentage-independent floor: don't bother warning/locking when more than 2 GiB is available, regardless of usage percentage. Earlier experimental hacks (a policy-level disable flag and a `getIsPlatform()` startup gate) were reverted in favor of this single change in the guard's threshold evaluation.