### PR TITLE
refactor(inbound): ACL gates consume verdict-owned member type

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -680,7 +680,7 @@ export async function handleChannelInbound({
       canonicalAssistantId,
       assistantId,
       content,
-      channelId: resolvedMember?.channel.id,
+      channelId: resolvedMember?.channelId,
     });
   }
 
@@ -761,7 +761,7 @@ export async function handleChannelInbound({
       : enforceAdmissionPolicy({
           sourceChannel,
           trustClass: trustCtx.trustClass,
-          memberStatus: resolvedMember?.channel.status,
+          memberStatus: resolvedMember?.status,
           policy: admissionPolicyFromGateway,
         });
   if (!admissionResult.admitted) {
@@ -811,7 +811,7 @@ export async function handleChannelInbound({
         ...(resolvedMember
           ? {
               previousMemberStatus: channelStatusToMemberStatus(
-                resolvedMember.channel.status,
+                resolvedMember.status,
               ),
             }
           : {}),

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -155,8 +155,8 @@ describe("enforceIngressAcl — verdict-sourced member resolution", () => {
 
     expect(result.earlyResponse).toBeUndefined();
     expect(result.resolvedMember).not.toBeNull();
-    expect(result.resolvedMember!.channel.status).toBe("active");
-    expect(result.resolvedMember!.channel.policy).toBe("allow");
+    expect(result.resolvedMember!.status).toBe("active");
+    expect(result.resolvedMember!.policy).toBe("allow");
     // Member came from the verdict, never the local contact store.
     expect(findContactChannelCalls.length).toBe(0);
   });
@@ -171,7 +171,8 @@ describe("enforceIngressAcl — verdict-sourced member resolution", () => {
     );
 
     expect(result.earlyResponse).toBeUndefined();
-    expect(result.resolvedMember!.contact.role).toBe("guardian");
+    expect(result.resolvedMember).not.toBeNull();
+    expect(result.resolvedMember!.status).toBe("active");
     expect(findContactChannelCalls.length).toBe(0);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -39,7 +39,8 @@ import {
   redeemInviteByCode,
 } from "../../invite-redemption-service.js";
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
-import { resolvedMemberFromVerdict } from "../../trust-verdict-consumer.js";
+import type { VerdictMember } from "../../trust-verdict-consumer.js";
+import { verdictMemberFromVerdict } from "../../trust-verdict-consumer.js";
 
 const log = getLogger("runtime-http");
 
@@ -102,7 +103,7 @@ export type ResolvedMember = {
 };
 
 export interface AclResult {
-  resolvedMember: ResolvedMember | null;
+  resolvedMember: VerdictMember | null;
   /** When set, the caller must return this response immediately. */
   earlyResponse?: Record<string, unknown>;
   /**
@@ -186,7 +187,7 @@ export async function enforceIngressAcl(
 
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member intercepts.
-  const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
+  const resolvedMember: VerdictMember | null = verdictMemberFromVerdict(verdict);
 
   // A verdict carrying member identity but no resolvable member
   // (malformed/unknown ACL) fails closed, not treated as a stranger.
@@ -518,8 +519,8 @@ export async function enforceIngressAcl(
     }
 
     if (resolvedMember) {
-      if (resolvedMember.channel.status !== "active") {
-        const isBlockedMember = resolvedMember.channel.status === "blocked";
+      if (resolvedMember.status !== "active") {
+        const isBlockedMember = resolvedMember.status === "blocked";
         // Bootstrap commands must pass through for re-verifiable states
         // (pending/revoked), but never for blocked members.
         let denyInactiveMember = true;
@@ -540,7 +541,7 @@ export async function enforceIngressAcl(
             log.info(
               {
                 sourceChannel,
-                channelId: resolvedMember.channel.id,
+                channelId: resolvedMember.channelId,
                 hasValidBootstrapSession: false,
               },
               "Ingress ACL: inactive member bootstrap bypass denied",
@@ -625,11 +626,11 @@ export async function enforceIngressAcl(
         if (!isBlockedMember && denyInactiveMember) {
           if (
             (effectiveAdmissionPolicy === "strangers" &&
-              resolvedMember.channel.status !== "revoked") ||
+              resolvedMember.status !== "revoked") ||
             ((effectiveAdmissionPolicy === "any_contact" ||
               effectiveAdmissionPolicy === "guardian_only") &&
-              (resolvedMember.channel.status === "pending" ||
-                resolvedMember.channel.status === "unverified"))
+              (resolvedMember.status === "pending" ||
+                resolvedMember.status === "unverified"))
           ) {
             denyInactiveMember = false;
           }
@@ -639,8 +640,8 @@ export async function enforceIngressAcl(
           log.info(
             {
               sourceChannel,
-              channelId: resolvedMember.channel.id,
-              status: resolvedMember.channel.status,
+              channelId: resolvedMember.channelId,
+              status: resolvedMember.status,
             },
             "Ingress ACL: member not active, denying",
           );
@@ -650,7 +651,7 @@ export async function enforceIngressAcl(
           // the guardian made an explicit decision to block them.
           if (
             sourceChannel === "slack" &&
-            resolvedMember.channel.status !== "blocked" &&
+            resolvedMember.status !== "blocked" &&
             (canonicalSenderId ?? rawSenderId)
           ) {
             const slackVerifyResult = initiateSlackVerificationChallenge({
@@ -668,7 +669,7 @@ export async function enforceIngressAcl(
                   actorDisplayName,
                   actorUsername,
                   previousMemberStatus: channelStatusToMemberStatus(
-                    resolvedMember.channel.status,
+                    resolvedMember.status,
                   ),
                   messagePreview: truncate(
                     trimmedContent,
@@ -726,7 +727,7 @@ export async function enforceIngressAcl(
           // re-approve. Blocked members are intentionally excluded — the
           // guardian already made an explicit decision to block them.
           let guardianNotified = false;
-          if (resolvedMember.channel.status !== "blocked") {
+          if (resolvedMember.status !== "blocked") {
             try {
               const accessResult = await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
@@ -736,7 +737,7 @@ export async function enforceIngressAcl(
                 actorDisplayName,
                 actorUsername,
                 previousMemberStatus: channelStatusToMemberStatus(
-                  resolvedMember.channel.status,
+                  resolvedMember.status,
                 ),
                 messagePreview: truncate(
                   trimmedContent,
@@ -790,16 +791,16 @@ export async function enforceIngressAcl(
             earlyResponse: {
               accepted: true,
               denied: true,
-              reason: `member_${channelStatusToMemberStatus(resolvedMember.channel.status)}`,
+              reason: `member_${channelStatusToMemberStatus(resolvedMember.status)}`,
               ...(!inactiveReplyDelivered && { replyText: inactiveReplyText }),
             },
           };
         }
       }
 
-      if (resolvedMember.channel.policy === "deny") {
+      if (resolvedMember.policy === "deny") {
         log.info(
-          { sourceChannel, channelId: resolvedMember.channel.id },
+          { sourceChannel, channelId: resolvedMember.channelId },
           "Ingress ACL: member policy deny",
         );
         const denyReplyText =

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -14,7 +14,7 @@ import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { getLogger } from "../../../util/logger.js";
 import { getGuardianBinding } from "../../channel-verification-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "../channel-route-shared.js";
-import type { ResolvedMember } from "./acl-enforcement.js";
+import type { VerdictMember } from "../../trust-verdict-consumer.js";
 
 const log = getLogger("runtime-http");
 
@@ -23,7 +23,7 @@ const log = getLogger("runtime-http");
 // ---------------------------------------------------------------------------
 
 export interface EscalationInterceptParams {
-  resolvedMember: ResolvedMember | null;
+  resolvedMember: VerdictMember | null;
   canonicalAssistantId: string;
   sourceChannel: ChannelId;
   sourceInterface: InterfaceId;
@@ -72,7 +72,7 @@ export async function handleEscalationIntercept(
     rawSenderId,
   } = params;
 
-  if (resolvedMember?.channel.policy !== "escalate") {
+  if (resolvedMember?.policy !== "escalate") {
     return null;
   }
 
@@ -80,7 +80,7 @@ export async function handleEscalationIntercept(
   if (!binding) {
     // Fail-closed: can't escalate without a guardian to route to
     log.info(
-      { sourceChannel, channelId: resolvedMember.channel.id },
+      { sourceChannel, channelId: resolvedMember.channelId },
       "Ingress ACL: escalate policy but no guardian binding, denying",
     );
     return {


### PR DESCRIPTION
## Summary
- ACL enforcement, escalation-intercept, and inbound-message-handler read status/policy from the verdict-owned VerdictMember instead of the schema-derived ContactChannel; data source (gateway verdict) and all decisions unchanged.

Part of plan: combo11-phase-a-read-decoupling.md (PR 2 of 11)