### PR TITLE
fix(invites): gate already-member/blocked checks on the gateway verdict

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -7,8 +7,13 @@
  * persisted, or returned in the outcome.
  */
 
+import {
+  getInboundTrustVerdict,
+  getPhoneCallerVerdict,
+} from "../calls/inbound-trust-reader.js";
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel, getContact } from "../contacts/contact-store.js";
+import type { ChannelStatus } from "../contacts/types.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
 import { getSqlite } from "../memory/db-connection.js";
@@ -23,8 +28,22 @@ import {
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { hashVoiceCode } from "../util/voice-code.js";
+import { verdictMemberFromVerdict } from "./trust-verdict-consumer.js";
 
 const log = getLogger("invite-redemption-service");
+
+/**
+ * Resolve the sender's existing member status for the already_member/blocked
+ * gate from the gateway trust verdict. Falls back to the local channel status
+ * only when the gateway returns no verdict.
+ */
+async function resolveMemberGateStatus(
+  verdict: Awaited<ReturnType<typeof getInboundTrustVerdict>>,
+  localChannelStatus: ChannelStatus | null,
+): Promise<ChannelStatus | null> {
+  if (verdict) return verdictMemberFromVerdict(verdict)?.status ?? null;
+  return localChannelStatus;
+}
 
 // ---------------------------------------------------------------------------
 // Gateway lifecycle bridge (shared by all redemption paths)
@@ -218,18 +237,22 @@ export async function redeemInvite(params: {
   const targetMismatch =
     existingContact && existingContact.id !== invite.contactId;
 
-  if (
-    existingChannel &&
-    existingChannel.status === "active" &&
-    !targetMismatch
-  ) {
+  const gateStatus = await resolveMemberGateStatus(
+    await getInboundTrustVerdict({
+      channelType: sourceChannel as ChannelId,
+      actorExternalId: canonicalUserId,
+    }),
+    existingChannel?.status ?? null,
+  );
+
+  if (existingChannel && gateStatus === "active" && !targetMismatch) {
     return { ok: true, type: "already_member", memberId: existingChannel.id };
   }
 
   // Blocked members cannot bypass the guardian's explicit block via invite
   // links. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
-  if (existingChannel && existingChannel.status === "blocked") {
+  if (existingChannel && gateStatus === "blocked") {
     return { ok: false, reason: "invalid_token" };
   }
 
@@ -465,11 +488,12 @@ export async function redeemVoiceInviteCode(params: {
   // should bind the sender's identity to the target contact, not the existing one.
   const targetMismatch = voiceContact && voiceContact.id !== invite.contactId;
 
-  if (
-    existingVoiceChannel &&
-    existingVoiceChannel.status === "active" &&
-    !targetMismatch
-  ) {
+  const gateStatus = await resolveMemberGateStatus(
+    await getPhoneCallerVerdict(canonicalCallerId),
+    existingVoiceChannel?.status ?? null,
+  );
+
+  if (existingVoiceChannel && gateStatus === "active" && !targetMismatch) {
     return {
       ok: true,
       type: "already_member",
@@ -478,7 +502,7 @@ export async function redeemVoiceInviteCode(params: {
   }
 
   // Blocked members cannot bypass the guardian's explicit block
-  if (existingVoiceChannel && existingVoiceChannel.status === "blocked") {
+  if (existingVoiceChannel && gateStatus === "blocked") {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
@@ -639,18 +663,22 @@ export async function redeemInviteByCode(params: {
   const targetMismatch =
     existingContact && existingContact.id !== invite.contactId;
 
-  if (
-    existingChannel &&
-    existingChannel.status === "active" &&
-    !targetMismatch
-  ) {
+  const gateStatus = await resolveMemberGateStatus(
+    await getInboundTrustVerdict({
+      channelType: sourceChannel as ChannelId,
+      actorExternalId: canonicalUserId,
+    }),
+    existingChannel?.status ?? null,
+  );
+
+  if (existingChannel && gateStatus === "active" && !targetMismatch) {
     return { ok: true, type: "already_member", memberId: existingChannel.id };
   }
 
   // Blocked members cannot bypass the guardian's explicit block via invite
   // codes. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
-  if (existingChannel && existingChannel.status === "blocked") {
+  if (existingChannel && gateStatus === "blocked") {
     return { ok: false, reason: "invalid_token" };
   }
 


### PR DESCRIPTION
## Summary
- Invite redemption resolves already_member/blocked/proceed from the gateway trust verdict (text + voice) instead of the local channel status column; findContactChannel kept only as the verdict-null transitional fallback. Member-activation write unchanged.

Part of plan: combo11-phase-a-read-decoupling.md (PR 7 of 11)