### PR TITLE
fix(skills): contacts tools read role/stats from the gateway-relayed read

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -1,10 +1,17 @@
-import type { ContactWithChannels } from "../../../../contacts/types.js";
+import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import { cliIpcCall } from "../../../../ipc/cli-client.js";
 import { resolveGuardianName } from "../../../../prompts/user-reference.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+
+function guardianAwareName(contact: Pick<ContactRead, "role" | "displayName">) {
+  return contact.role === "guardian"
+    ? resolveGuardianName(contact.displayName)
+    : contact.displayName;
+}
 
 export async function executeContactMerge(
   input: Record<string, unknown>,
@@ -22,10 +29,10 @@ export async function executeContactMerge(
 
   // Validate both contacts exist before merging
   const [keepRes, mergeRes] = await Promise.all([
-    cliIpcCall<{ contact: ContactWithChannels }>("getContact", {
+    cliIpcCall<{ contact: ContactRead }>("getContact", {
       pathParams: { id: keepId },
     }),
-    cliIpcCall<{ contact: ContactWithChannels }>("getContact", {
+    cliIpcCall<{ contact: ContactRead }>("getContact", {
       pathParams: { id: mergeId },
     }),
   ]);
@@ -42,7 +49,7 @@ export async function executeContactMerge(
 
   const mergeResult = await cliIpcCall<{
     ok: boolean;
-    contact: ContactWithChannels;
+    contact: ContactRead;
   }>("merge_contacts", {
     body: { keepId, mergeId },
   });
@@ -51,19 +58,22 @@ export async function executeContactMerge(
     return { content: `Error: ${mergeResult.error}`, isError: true };
   }
 
-  const merged = mergeResult.result!.contact;
-  const displayName =
-    merged.role === "guardian"
-      ? resolveGuardianName(merged.displayName)
-      : merged.displayName;
-  const keepName =
-    keepContact.role === "guardian"
-      ? resolveGuardianName(keepContact.displayName)
-      : keepContact.displayName;
-  const mergeName =
-    mergeContact.role === "guardian"
-      ? resolveGuardianName(mergeContact.displayName)
-      : mergeContact.displayName;
+  const mergedId = mergeResult.result!.contact.id;
+
+  // Re-read the surviving contact through the gateway-relayed read so role and
+  // interactionCount come from the gateway ContactRead.
+  const mergedRes = await cliIpcCall<{ contact: ContactRead }>("getContact", {
+    pathParams: { id: mergedId },
+  });
+
+  if (!mergedRes.ok) {
+    return { content: `Error: ${mergedRes.error}`, isError: true };
+  }
+
+  const merged = mergedRes.result!.contact;
+  const displayName = guardianAwareName(merged);
+  const keepName = guardianAwareName(keepContact);
+  const mergeName = guardianAwareName(mergeContact);
 
   const channelList = merged.channels
     .map(

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
@@ -1,4 +1,5 @@
-import type { ContactWithChannels } from "../../../../contacts/types.js";
+import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import { cliIpcCall } from "../../../../ipc/cli-client.js";
 import { resolveGuardianName } from "../../../../prompts/user-reference.js";
 import type {
@@ -6,7 +7,16 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 
-function formatContactSummary(c: ContactWithChannels): string {
+// The search route may carry an optional per-channel `externalChatId` not modeled
+// on the gateway `ContactRead` channel contract.
+type SearchChannel = ContactRead["channels"][number] & {
+  externalChatId?: string | null;
+};
+type SearchContact = Omit<ContactRead, "channels"> & {
+  channels: SearchChannel[];
+};
+
+function formatContactSummary(c: SearchContact): string {
   const displayName =
     c.role === "guardian" ? resolveGuardianName(c.displayName) : c.displayName;
   const parts = [`- **${displayName}** (ID: ${c.id})`];
@@ -45,7 +55,7 @@ export async function executeContactSearch(
     };
   }
 
-  const res = await cliIpcCall<ContactWithChannels[]>("search_contacts", {
+  const res = await cliIpcCall<SearchContact[]>("search_contacts", {
     body: { query, channelAddress, channelType, limit },
   });
 


### PR DESCRIPTION
## Summary
- contact-search + contact-merge skill tools source role/interactionCount from the gateway-relayed ContactRead instead of the assistant-DB columns; LLM-facing output unchanged for equivalent gateway state.

Part of plan: combo11-phase-a-read-decoupling.md (PR 8 of 11)