### PR TITLE
fix(macos): surface Accessibility-permission hint on observe-only computer-use

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -174,6 +174,13 @@ enum HostCuActionRunner {
             } catch {
                 log.warning("Post-action delay interrupted: \(error)")
             }
+        } else {
+            // Observe-only skips the action-path gate, but AX enumeration silently
+            // returns an empty tree without Accessibility. Surface the same hint the
+            // action path gives instead of returning a bare empty observation.
+            if !ActionExecutor.checkAccessibilityPermission(prompt: true) {
+                executionError = "Accessibility permission not granted. Grant Vellum access in System Settings > Privacy & Security > Accessibility, then retry."
+            }
         }
 
         // OBSERVE — capture AX tree, screenshot, etc.


### PR DESCRIPTION
## Summary
- observe-only CU skipped the Accessibility gate and returned a bare empty observation when permission was missing; now it surfaces the same hint the action path gives.
- No change to the granted-permission path.

Part of plan: cu-surface-fixes.md (PR 2 of 3)