### PR TITLE
fix(computer-use): accept target_client_id on computer_use_observe schema

### DIFF
--- a/assistant/src/__tests__/computer-use-tools.test.ts
+++ b/assistant/src/__tests__/computer-use-tools.test.ts
@@ -6,6 +6,7 @@ import {
   computerUseDoneTool,
   computerUseDragTool,
   computerUseKeyTool,
+  computerUseObserveTool,
   computerUseOpenAppTool,
   computerUseRespondTool,
   computerUseRunAppleScriptTool,
@@ -55,6 +56,18 @@ describe("computer-use tool definitions", () => {
     for (const tool of allComputerUseTools) {
       expect(tool.description!.length).toBeGreaterThan(0);
     }
+  });
+});
+
+// ── observe ─────────────────────────────────────────────────────────
+
+describe("computer_use_observe", () => {
+  test("supports target_client_id", () => {
+    const props = schema(computerUseObserveTool).properties as Record<
+      string,
+      { type: string }
+    >;
+    expect(props.target_client_id.type).toBe("string");
   });
 });
 

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -8,7 +8,12 @@
       "risk": "low",
       "input_schema": {
         "type": "object",
-        "properties": {},
+        "properties": {
+          "target_client_id": {
+            "type": "string",
+            "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
+          }
+        },
         "required": []
       },
       "executor": "tools/computer-use-observe.ts",

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -437,7 +437,7 @@ export const computerUseRespondTool = {
 // observe
 // ---------------------------------------------------------------------------
 
-const computerUseObserveTool = {
+export const computerUseObserveTool = {
   name: "computer_use_observe",
   description:
     "Capture the current screen state. Returns the accessibility tree with [ID] element references and optionally a screenshot.\n\nThe accessibility tree shows interactive elements like [3] AXButton 'Save' or [17] AXTextField 'Search'. Use element_id to target these elements in subsequent actions - this is much more reliable than pixel coordinates.\n\nCall this before your first computer use action, or to check screen state without acting.",
@@ -447,7 +447,13 @@ const computerUseObserveTool = {
 
   input_schema: {
     type: "object",
-    properties: {},
+    properties: {
+      target_client_id: {
+        type: "string",
+        description:
+          "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`.",
+      },
+    },
     required: [],
   },
 


### PR DESCRIPTION
## Summary
- Add target_client_id to computer_use_observe input_schema in both definitions.ts and the bundled-skill TOOLS.json (kept in sync per the manifest regression test).
- observe now exposes the same targeting field the action tools already have; required/risk unchanged.

Part of plan: cu-surface-fixes.md (PR 3 of 3)