### PR TITLE
fix(surfaces): thread submitter actor principal into surface-action turns so CU/app-control work

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -26,6 +26,7 @@ interface ProcessMessageCall {
   requestId?: string;
   activeSurfaceId?: string;
   displayContent?: string;
+  sourceActorPrincipalId?: string;
 }
 
 function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
@@ -69,6 +70,7 @@ function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
         requestId: options.requestId,
         activeSurfaceId: options.activeSurfaceId,
         displayContent: options.displayContent,
+        sourceActorPrincipalId: options.sourceActorPrincipalId,
       });
       return "msg-1";
     },
@@ -141,6 +143,69 @@ describe("surface action delivery to assistant", () => {
 
     // Verify the requestId was tracked as a surface action
     expect(ctx.surfaceActionRequestIds.size).toBe(1);
+  });
+
+  test("idle pending follow-up path threads submitter principal into processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "table",
+      title: "Items",
+      data: {
+        columns: [{ id: "name", label: "Name" }],
+        rows: [{ id: "r1", cells: { name: "Item 1" } }],
+      },
+      actions: [{ id: "archive", label: "Archive" }],
+    });
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+
+    await handleSurfaceAction(
+      ctx,
+      surfaceId,
+      "archive",
+      { selectedIds: ["r1"] },
+      "principal-committer",
+    );
+
+    expect(ctx.processMessageCalls.length).toBe(1);
+    expect(ctx.processMessageCalls[0].sourceActorPrincipalId).toBe(
+      "principal-committer",
+    );
+  });
+
+  test("idle history-restored path threads submitter principal into processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // History-restored surface: surfaceState exists, pendingSurfaceActions
+    // does not — exercises the immediate (idle) fallthrough.
+    ctx.surfaceState.set("hist-surface-p", {
+      surfaceType: "table",
+      data: {
+        columns: [{ id: "col", label: "Col" }],
+        rows: [],
+      } as unknown as SurfaceData,
+      title: "History Table",
+      actions: [{ id: "delete", label: "Delete" }],
+    });
+
+    await handleSurfaceAction(
+      ctx,
+      "hist-surface-p",
+      "delete",
+      { selectedIds: ["row-1"] },
+      "principal-committer",
+    );
+
+    expect(ctx.processMessageCalls.length).toBe(1);
+    expect(ctx.processMessageCalls[0].sourceActorPrincipalId).toBe(
+      "principal-committer",
+    );
   });
 
   test("table action without selection data still triggers processMessage", async () => {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1386,6 +1386,8 @@ export interface ProcessMessageOptions {
    */
   overrideProfile?: string;
   displayContent?: string;
+  /** JWT-verified committer principal for turn-scoped host-proxy authorization. */
+  sourceActorPrincipalId?: string;
 }
 
 // ── processMessage ───────────────────────────────────────────────────
@@ -1409,6 +1411,7 @@ export async function processMessage(
     callSite,
     overrideProfile,
     displayContent,
+    sourceActorPrincipalId,
   } = options;
   await conversation.ensureActorScopedHistory();
   // Snapshot persona context at turn start so later tool turns can't pick up
@@ -1416,7 +1419,7 @@ export async function processMessage(
   conversation.currentTurnTrustContext = conversation.trustContext;
   conversation.currentTurnAuthContext = conversation.authContext;
   conversation.currentTurnSourceActorPrincipalId =
-    conversation.authContext?.actorPrincipalId;
+    sourceActorPrincipalId ?? conversation.authContext?.actorPrincipalId;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
   conversation.currentActiveSurfaceId = activeSurfaceId;

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2048,6 +2048,7 @@ export async function handleSurfaceAction(
         requestId,
         activeSurfaceId: surfaceId,
         displayContent,
+        sourceActorPrincipalId,
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
@@ -2342,6 +2343,7 @@ export async function handleSurfaceAction(
       requestId,
       activeSurfaceId: surfaceId,
       displayContent,
+      sourceActorPrincipalId,
     })
     .catch((err) => {
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1695,6 +1695,10 @@ export async function handleSurfaceAction(
   surfaceId: string,
   actionId: string,
   data?: Record<string, unknown>,
+  // JWT-verified committer principal; threaded so enqueued turns can
+  // reconstruct the same-user binding for host proxies (CU / app-control),
+  // mirroring the normal message path.
+  sourceActorPrincipalId?: string,
 ): Promise<SurfaceActionResult> {
   // ── Standalone surface interception ──────────────────────────────
   // Daemon-driven surfaces (from `requestInteractiveUi`) register a
@@ -1987,6 +1991,7 @@ export async function handleSurfaceAction(
       requestId,
       activeSurfaceId: surfaceId,
       displayContent,
+      sourceActorPrincipalId,
     });
 
     if (result.rejected) {
@@ -2233,6 +2238,7 @@ export async function handleSurfaceAction(
     requestId,
     activeSurfaceId: surfaceId,
     displayContent,
+    sourceActorPrincipalId,
   });
   if (result.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2049,8 +2049,15 @@ export class Conversation {
     surfaceId: string,
     actionId: string,
     data?: Record<string, unknown>,
+    sourceActorPrincipalId?: string,
   ): Promise<SurfaceActionResult> {
-    return handleSurfaceActionImpl(this, surfaceId, actionId, data);
+    return handleSurfaceActionImpl(
+      this,
+      surfaceId,
+      actionId,
+      data,
+      sourceActorPrincipalId,
+    );
   }
 
   handleSurfaceUndo(surfaceId: string): void {

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -386,6 +386,30 @@ describe("triggerSurfaceAction handler", () => {
     ]);
   });
 
+  test("resolves dev-bypass to the guardian principal before threading the turn", async () => {
+    httpAuthDisabled = true;
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-dev-thread");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-dt", actionId: "act-dt" },
+      headers: { "x-vellum-actor-principal-id": "dev-bypass" },
+    });
+
+    // dev-bypass is translated so the surface turn matches the SSE host-proxy
+    // client's registered guardian principal (CU/app-control same-actor check).
+    expect(live.surfaceActionCalls).toEqual([
+      {
+        surfaceId: "surf-dt",
+        actionId: "act-dt",
+        data: undefined,
+        sourceActorPrincipalId: GUARDIAN_PRINCIPAL,
+      },
+    ]);
+  });
+
   test("propagates accepted=false rejection as BadRequestError", async () => {
     const live = makeStub("conv-reject");
     live.handleSurfaceActionResult = {

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -30,6 +30,7 @@ interface StubConversation {
     surfaceId: string;
     actionId: string;
     data: unknown;
+    sourceActorPrincipalId?: string;
   }>;
 }
 
@@ -148,8 +149,14 @@ function makeStub(id: string): StubConversation {
       surfaceId: string,
       actionId: string,
       data: unknown,
+      sourceActorPrincipalId?: string,
     ) => {
-      stub.surfaceActionCalls.push({ surfaceId, actionId, data });
+      stub.surfaceActionCalls.push({
+        surfaceId,
+        actionId,
+        data,
+        sourceActorPrincipalId,
+      });
       if (stub.handleSurfaceActionThrows) throw stub.handleSurfaceActionThrows;
       return stub.handleSurfaceActionResult;
     },
@@ -357,6 +364,26 @@ describe("triggerSurfaceAction handler", () => {
     expect(rawGetCalls).toHaveLength(1);
     expect(rawGetCalls[0]!.sql).toContain("ESCAPE");
     expect(rawGetCalls[0]!.params).toEqual([`%"surfaceId":"\\%"%`]);
+  });
+
+  test("threads x-vellum-actor-principal-id into handleSurfaceAction", async () => {
+    const live = makeStub("conv-principal");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-p", actionId: "act-p" },
+      headers: { "x-vellum-actor-principal-id": "principal-committer" },
+    });
+
+    expect(live.surfaceActionCalls).toEqual([
+      {
+        surfaceId: "surf-p",
+        actionId: "act-p",
+        data: undefined,
+        sourceActorPrincipalId: "principal-committer",
+      },
+    ]);
   });
 
   test("propagates accepted=false rejection as BadRequestError", async () => {

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -181,6 +181,7 @@ async function handleSurfaceAction({
       surfaceId,
       actionId,
       data,
+      actorPrincipalId ?? undefined,
     );
     const result =
       raw && typeof raw === "object" && "accepted" in raw

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -16,7 +16,10 @@ import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
-import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
+import {
+  findLocalGuardianPrincipalId,
+  resolveActorPrincipalIdForLocalGuardian,
+} from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import { parseCallbackData } from "./channel-route-shared.js";
 import {
@@ -176,12 +179,18 @@ async function handleSurfaceAction({
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
   await applyTrustContext(conversation, actorPrincipalId);
 
+  // Translate dev-bypass → real guardian so the surface turn's principal matches
+  // the SSE host-proxy client's registered principal; otherwise CU/app-control
+  // same-actor checks reject the turn. Real principals pass through unchanged.
+  const resolvedActorPrincipalId =
+    await resolveActorPrincipalIdForLocalGuardian(actorPrincipalId ?? undefined);
+
   try {
     const raw = await conversation.handleSurfaceAction(
       surfaceId,
       actionId,
       data,
-      actorPrincipalId ?? undefined,
+      resolvedActorPrincipalId,
     );
     const result =
       raw && typeof raw === "object" && "accepted" in raw


### PR DESCRIPTION
## Summary
- Thread the surface-action submitter's actor principal (x-vellum-actor-principal-id) through handleSurfaceAction into both enqueueMessage call sites, mirroring the normal message path.
- Fixes CU / app-control being blocked ('Computer use is not available for the current actor.') when a turn is triggered from a UI surface button instead of a typed message.

Part of plan: cu-surface-fixes.md (PR 1 of 3)