### PR TITLE
Combo 11 Phase A — decouple consumers from assistant ACL columns

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -94,9 +94,19 @@ const resolveGuardianList = async (input?: { channelTypes?: string[] }) => {
   return channels
     .map((channelType) => {
       const found = findGuardianForChannel(channelType);
-      return found ? { channelType, status: "active" } : null;
+      if (!found) return null;
+      return {
+        channelType,
+        contactId: found.contact.id,
+        principalId: found.contact.principalId ?? null,
+        displayName: found.contact.displayName ?? null,
+        address: found.channel.address,
+        externalChatId: found.channel.externalChatId ?? null,
+        status: "active",
+        verifiedAt: found.channel.verifiedAt ?? null,
+      };
     })
-    .filter((g): g is { channelType: string; status: string } => g !== null);
+    .filter((g) => g !== null);
 };
 
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
@@ -345,12 +355,12 @@ describe("guardian service challenge validation", () => {
     }
   });
 
-  test("validateAndConsumeVerification does not create a guardian binding (caller responsibility)", () => {
+  test("validateAndConsumeVerification does not create a guardian binding (caller responsibility)", async () => {
     const { secret } = createInboundVerificationSession("telegram");
 
     validateAndConsumeVerification("telegram", secret, "user-42", "chat-42");
 
-    const binding = getGuardianBinding("asst-1", "telegram");
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).toBeNull();
   });
 
@@ -422,7 +432,7 @@ describe("guardian service challenge validation", () => {
     expect(result2.success).toBe(false);
   });
 
-  test("validateAndConsumeVerification succeeds with voice channel", () => {
+  test("validateAndConsumeVerification succeeds with voice channel", async () => {
     const { secret } = createInboundVerificationSession("phone");
 
     const result = validateAndConsumeVerification(
@@ -439,7 +449,7 @@ describe("guardian service challenge validation", () => {
 
     // validateAndConsumeVerification no longer creates bindings — that is
     // now handled by the gateway's verification intercepts.
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).toBeNull();
   });
 
@@ -475,7 +485,7 @@ describe("guardian service challenge validation", () => {
     expect(telegramResult.success).toBe(true);
   });
 
-  test("validateAndConsumeVerification succeeds even with existing binding (conflict check is caller responsibility)", () => {
+  test("validateAndConsumeVerification succeeds even with existing binding (conflict check is caller responsibility)", async () => {
     // Create initial guardian binding
     createGuardianBinding({
       channel: "telegram",
@@ -484,7 +494,7 @@ describe("guardian service challenge validation", () => {
       guardianDeliveryChatId: "old-chat",
     });
 
-    const oldBinding = getGuardianBinding("asst-1", "telegram");
+    const oldBinding = await getGuardianBinding("asst-1", "telegram");
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe("old-user");
 
@@ -499,7 +509,7 @@ describe("guardian service challenge validation", () => {
     // Challenge validation succeeds — the caller decides how to handle binding conflicts
     expect(result.success).toBe(true);
 
-    const binding = getGuardianBinding("asst-1", "telegram");
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).not.toBeNull();
     expect(binding!.guardianExternalUserId).toBe("old-user");
   });
@@ -514,7 +524,7 @@ describe("guardian identity check", () => {
     resetTables();
   });
 
-  test("isGuardian returns true for matching user", () => {
+  test("isGuardian returns true for matching user", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -522,10 +532,10 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(true);
+    expect(await isGuardian("asst-1", "telegram", "user-42")).toBe(true);
   });
 
-  test("isGuardian returns false for non-matching user", () => {
+  test("isGuardian returns false for non-matching user", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -533,14 +543,14 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    expect(isGuardian("asst-1", "telegram", "user-99")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "user-99")).toBe(false);
   });
 
-  test("isGuardian returns false when no binding exists", () => {
-    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(false);
+  test("isGuardian returns false when no binding exists", async () => {
+    expect(await isGuardian("asst-1", "telegram", "user-42")).toBe(false);
   });
 
-  test("isGuardian returns false after binding is revoked", () => {
+  test("isGuardian returns false after binding is revoked", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -550,10 +560,10 @@ describe("guardian identity check", () => {
 
     serviceRevokeBinding("asst-1", "telegram");
 
-    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "user-42")).toBe(false);
   });
 
-  test("getGuardianBinding returns the active binding", () => {
+  test("getGuardianBinding returns the active binding", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -561,17 +571,17 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    const binding = getGuardianBinding("asst-1", "telegram");
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).not.toBeNull();
     expect(binding!.guardianExternalUserId).toBe("user-42");
   });
 
-  test("getGuardianBinding returns null when no binding exists", () => {
-    const binding = getGuardianBinding("asst-1", "telegram");
+  test("getGuardianBinding returns null when no binding exists", async () => {
+    const binding = await getGuardianBinding("asst-1", "telegram");
     expect(binding).toBeNull();
   });
 
-  test("isGuardian works for voice channel", () => {
+  test("isGuardian works for voice channel", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "phone-user-1",
@@ -579,13 +589,13 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    expect(isGuardian("asst-1", "phone", "phone-user-1")).toBe(true);
-    expect(isGuardian("asst-1", "phone", "phone-user-2")).toBe(false);
+    expect(await isGuardian("asst-1", "phone", "phone-user-1")).toBe(true);
+    expect(await isGuardian("asst-1", "phone", "phone-user-2")).toBe(false);
     // Telegram guardian should not match voice channel
-    expect(isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
   });
 
-  test("serviceRevokeBinding revokes the active binding", () => {
+  test("serviceRevokeBinding revokes the active binding", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -595,7 +605,7 @@ describe("guardian identity check", () => {
 
     const result = serviceRevokeBinding("asst-1", "telegram");
     expect(result).toBe(true);
-    expect(getGuardianBinding("asst-1", "telegram")).toBeNull();
+    expect(await getGuardianBinding("asst-1", "telegram")).toBeNull();
   });
 });
 
@@ -886,7 +896,7 @@ describe("channel-scoped guardian resolution", () => {
     resetTables();
   });
 
-  test("isGuardian resolves independently per channel", () => {
+  test("isGuardian resolves independently per channel", async () => {
     // Create guardian binding on telegram
     createGuardianBinding({
       channel: "telegram",
@@ -903,15 +913,15 @@ describe("channel-scoped guardian resolution", () => {
     });
 
     // user-alpha is guardian for telegram but not voice
-    expect(isGuardian("self", "telegram", "user-alpha")).toBe(true);
-    expect(isGuardian("self", "phone", "user-alpha")).toBe(false);
+    expect(await isGuardian("self", "telegram", "user-alpha")).toBe(true);
+    expect(await isGuardian("self", "phone", "user-alpha")).toBe(false);
 
     // user-beta is guardian for voice but not telegram
-    expect(isGuardian("self", "phone", "user-beta")).toBe(true);
-    expect(isGuardian("self", "telegram", "user-beta")).toBe(false);
+    expect(await isGuardian("self", "phone", "user-beta")).toBe(true);
+    expect(await isGuardian("self", "telegram", "user-beta")).toBe(false);
   });
 
-  test("getGuardianBinding returns different bindings for different channels", () => {
+  test("getGuardianBinding returns different bindings for different channels", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-alpha",
@@ -925,8 +935,8 @@ describe("channel-scoped guardian resolution", () => {
       guardianDeliveryChatId: "chat-beta",
     });
 
-    const bindingTelegram = getGuardianBinding("self", "telegram");
-    const bindingVoice = getGuardianBinding("self", "phone");
+    const bindingTelegram = await getGuardianBinding("self", "telegram");
+    const bindingVoice = await getGuardianBinding("self", "phone");
 
     expect(bindingTelegram).not.toBeNull();
     expect(bindingVoice).not.toBeNull();
@@ -934,7 +944,7 @@ describe("channel-scoped guardian resolution", () => {
     expect(bindingVoice!.guardianExternalUserId).toBe("user-beta");
   });
 
-  test("revoking binding for one channel does not affect another", () => {
+  test("revoking binding for one channel does not affect another", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-alpha",
@@ -950,11 +960,11 @@ describe("channel-scoped guardian resolution", () => {
 
     serviceRevokeBinding("self", "telegram");
 
-    expect(getGuardianBinding("self", "telegram")).toBeNull();
-    expect(getGuardianBinding("self", "phone")).not.toBeNull();
+    expect(await getGuardianBinding("self", "telegram")).toBeNull();
+    expect(await getGuardianBinding("self", "phone")).not.toBeNull();
   });
 
-  test("validateAndConsumeVerification scoped to channel", () => {
+  test("validateAndConsumeVerification scoped to channel", async () => {
     // Create challenge on telegram
     const { secret: secretTelegram } =
       createInboundVerificationSession("telegram");
@@ -987,8 +997,8 @@ describe("channel-scoped guardian resolution", () => {
     );
     expect(resultVoice.success).toBe(true);
 
-    const bindingTelegram = getGuardianBinding("self", "telegram");
-    const bindingVoice = getGuardianBinding("self", "phone");
+    const bindingTelegram = await getGuardianBinding("self", "telegram");
+    const bindingVoice = await getGuardianBinding("self", "phone");
     expect(bindingTelegram).toBeNull();
     expect(bindingVoice).toBeNull();
   });
@@ -1303,7 +1313,7 @@ describe("voice guardian challenge validation", () => {
     }
   });
 
-  test("validateAndConsumeVerification does not create a guardian binding for voice (caller responsibility)", () => {
+  test("validateAndConsumeVerification does not create a guardian binding for voice (caller responsibility)", async () => {
     const { secret } = createInboundVerificationSession("phone");
 
     validateAndConsumeVerification(
@@ -1313,7 +1323,7 @@ describe("voice guardian challenge validation", () => {
       "voice-chat-1",
     );
 
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).toBeNull();
   });
 
@@ -1387,7 +1397,7 @@ describe("voice guardian challenge validation", () => {
     expect(result2.success).toBe(false);
   });
 
-  test("validateAndConsumeVerification succeeds even with existing voice binding (conflict check is caller responsibility)", () => {
+  test("validateAndConsumeVerification succeeds even with existing voice binding (conflict check is caller responsibility)", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "old-voice-user",
@@ -1395,7 +1405,7 @@ describe("voice guardian challenge validation", () => {
       guardianDeliveryChatId: "old-voice-chat",
     });
 
-    const oldBinding = getGuardianBinding("asst-1", "phone");
+    const oldBinding = await getGuardianBinding("asst-1", "phone");
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe("old-voice-user");
 
@@ -1411,7 +1421,7 @@ describe("voice guardian challenge validation", () => {
     expect(result.success).toBe(true);
 
     // The original binding is untouched (no side effects)
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).not.toBeNull();
     expect(binding!.guardianExternalUserId).toBe("old-voice-user");
   });
@@ -1426,7 +1436,7 @@ describe("voice guardian identity and revocation", () => {
     resetTables();
   });
 
-  test("isGuardian works for voice channel", () => {
+  test("isGuardian works for voice channel", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1434,13 +1444,13 @@ describe("voice guardian identity and revocation", () => {
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    expect(isGuardian("asst-1", "phone", "voice-user-1")).toBe(true);
-    expect(isGuardian("asst-1", "phone", "voice-user-2")).toBe(false);
+    expect(await isGuardian("asst-1", "phone", "voice-user-1")).toBe(true);
+    expect(await isGuardian("asst-1", "phone", "voice-user-2")).toBe(false);
     // Voice guardian should not match telegram channel
-    expect(isGuardian("asst-1", "telegram", "voice-user-1")).toBe(false);
+    expect(await isGuardian("asst-1", "telegram", "voice-user-1")).toBe(false);
   });
 
-  test("getGuardianBinding returns voice binding", () => {
+  test("getGuardianBinding returns voice binding", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1448,13 +1458,13 @@ describe("voice guardian identity and revocation", () => {
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    const binding = getGuardianBinding("asst-1", "phone");
+    const binding = await getGuardianBinding("asst-1", "phone");
     expect(binding).not.toBeNull();
     expect(binding!.channel).toBe("phone");
     expect(binding!.guardianExternalUserId).toBe("voice-user-1");
   });
 
-  test("revokeBinding clears active voice guardian binding", () => {
+  test("revokeBinding clears active voice guardian binding", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1464,10 +1474,10 @@ describe("voice guardian identity and revocation", () => {
 
     const result = serviceRevokeBinding("asst-1", "phone");
     expect(result).toBe(true);
-    expect(getGuardianBinding("asst-1", "phone")).toBeNull();
+    expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
   });
 
-  test("revokeBinding for voice does not affect telegram binding", () => {
+  test("revokeBinding for voice does not affect telegram binding", async () => {
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "voice-user-1",
@@ -1483,8 +1493,8 @@ describe("voice guardian identity and revocation", () => {
 
     serviceRevokeBinding("asst-1", "phone");
 
-    expect(getGuardianBinding("asst-1", "phone")).toBeNull();
-    expect(getGuardianBinding("asst-1", "telegram")).not.toBeNull();
+    expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
+    expect(await getGuardianBinding("asst-1", "telegram")).not.toBeNull();
   });
 });
 
@@ -1742,7 +1752,7 @@ describe("HTTP handler voice guardian verification", () => {
     expect(resp!.bound).toBe(false);
 
     // Verify binding is actually revoked
-    expect(getGuardianBinding("self", "phone")).toBeNull();
+    expect(await getGuardianBinding("self", "phone")).toBeNull();
   });
 
   test("revoke for voice does not affect telegram binding", async () => {
@@ -1768,8 +1778,8 @@ describe("HTTP handler voice guardian verification", () => {
 
     await handleChannelVerificationSession(msg);
 
-    expect(getGuardianBinding("self", "phone")).toBeNull();
-    expect(getGuardianBinding("self", "telegram")).not.toBeNull();
+    expect(await getGuardianBinding("self", "phone")).toBeNull();
+    expect(await getGuardianBinding("self", "telegram")).not.toBeNull();
   });
 });
 

--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -135,11 +135,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     mockOnConversationCreatedCallbacks.length = 0;
   });
 
-  test("emits guardian.question for trusted-contact sessions", () => {
+  test("emits guardian.question for trusted-contact sessions", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -160,7 +160,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(payload.requesterIdentifier).toBe("@requester");
   });
 
-  test("skips guardian actor sessions (self-approve)", () => {
+  test("skips guardian actor sessions (self-approve)", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext: TrustContext = {
       sourceChannel: "telegram",
@@ -168,7 +168,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
       guardianExternalUserId: "guardian-1",
     };
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -182,14 +182,14 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("skips unknown actor sessions", () => {
+  test("skips unknown actor sessions", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
     };
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -203,13 +203,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("skips when guardian identity is missing", () => {
+  test("skips when guardian identity is missing", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext({
       guardianExternalUserId: undefined,
     });
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -223,13 +223,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("skips when no guardian binding exists for channel", () => {
+  test("skips when no guardian binding exists for channel", async () => {
     const canonicalRequest = makeCanonicalRequest({ sourceChannel: "phone" });
     const trustContext = makeTrustedContactContext({
       sourceChannel: "phone",
     });
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -243,11 +243,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("sets correct attention hints for urgency", () => {
+  test("sets correct attention hints for urgency", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -261,11 +261,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(hints.visibleInSourceNow).toBe(false);
   });
 
-  test("uses dedupe key scoped to canonical request ID", () => {
+  test("uses dedupe key scoped to canonical request ID", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -277,11 +277,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     );
   });
 
-  test("creates vellum delivery row via onConversationCreated callback", () => {
+  test("creates vellum delivery row via onConversationCreated callback", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -298,18 +298,20 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     });
 
     const deliveries = listCanonicalGuardianDeliveries(canonicalRequest.id);
-    expect(deliveries).toHaveLength(1);
-    expect(deliveries[0].destinationChannel).toBe("vellum");
-    expect(deliveries[0].destinationConversationId).toBe(
+    const vellumDelivery = deliveries.find(
+      (d) => d.destinationChannel === "vellum",
+    );
+    expect(vellumDelivery).toBeDefined();
+    expect(vellumDelivery?.destinationConversationId).toBe(
       "guardian-conversation-1",
     );
   });
 
-  test("uses custom assistantId when provided", () => {
+  test("uses custom assistantId when provided", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -324,13 +326,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("does not pass assistantId to notification signal", () => {
+  test("does not pass assistantId to notification signal", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
     // assistantId is used internally for guardian binding lookup but is no
     // longer forwarded to the notification signal after the assistantId removal refactor.
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -340,13 +342,13 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals[0].assistantId).toBeUndefined();
   });
 
-  test("includes requesterChatId as null when not provided", () => {
+  test("includes requesterChatId as null when not provided", async () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext({
       requesterChatId: undefined,
     });
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -357,7 +359,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(payload.requesterChatId).toBeNull();
   });
 
-  test("skips when binding guardian identity does not match canonical request guardian", () => {
+  test("skips when binding guardian identity does not match canonical request guardian", async () => {
     // Create a canonical request where guardianExternalUserId differs from the
     // binding's guardianExternalUserId ('guardian-1' in the mock).
     const canonicalRequest = makeCanonicalRequest({
@@ -365,7 +367,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     });
     const trustContext = makeTrustedContactContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",
@@ -379,7 +381,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("does not skip when canonical request guardian identity is null", () => {
+  test("does not skip when canonical request guardian identity is null", async () => {
     // When guardianExternalUserId is null on the canonical request (e.g. desktop
     // flow), the identity check should be skipped and the bridge should proceed.
     const canonicalRequest = makeCanonicalRequest({
@@ -387,7 +389,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     });
     const trustContext = makeTrustedContactContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-1",

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -3,8 +3,9 @@
  *
  * handleListContacts (non-search) and handleGetContact relay to the gateway
  * via `ipcCallPersistent`. On the happy path they serve gateway-sourced data
- * and do NOT read the assistant DB. On IPC failure they fall back to the
- * assistant-DB read and log a warning. getContact still 404s for unknown ids.
+ * and do NOT read the assistant DB. On IPC failure they FAIL CLOSED — the relay
+ * error propagates rather than falling back to the assistant DB. getContact
+ * surfaces a clean gateway not-found as a 404.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -213,16 +214,15 @@ describe("handleListContacts relay", () => {
     expect(result.contacts[0].displayName).toBe("Your Guardian");
   });
 
-  test("falls back to the assistant DB on IPC failure", async () => {
+  test("fails closed on IPC failure (no assistant-DB fallback)", async () => {
     ipcStub = () => {
       throw new Error("gateway down");
     };
 
-    const result = await handleListContacts({});
+    await expect(handleListContacts({})).rejects.toThrow("gateway down");
 
     expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
-    expect(localCalls).toContain("listContacts");
-    expect(result.contacts[0].id).toBe("local-1");
+    expect(localCalls).toEqual([]);
   });
 
   test("search params stay daemon-native and log the boundary note", async () => {
@@ -384,26 +384,24 @@ describe("handleGetContact relay", () => {
     expect(localCalls).toEqual([]);
   });
 
-  test("falls back to the assistant DB on IPC transport failure", async () => {
+  test("fails closed on IPC transport failure (no assistant-DB fallback)", async () => {
     ipcStub = () => {
       throw new Error("gateway down");
     };
 
-    const result = await handleGetContact("gw-1");
+    await expect(handleGetContact("gw-1")).rejects.toThrow("gateway down");
 
     expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
-    expect(localCalls).toContain("getContact");
-    expect(result.contact.id).toBe("gw-1");
+    expect(localCalls).toEqual([]);
   });
 
-  test("fallback path still 404s for unknown ids", async () => {
-    ipcStub = () => {
-      throw new Error("gateway down");
-    };
+  test("clean gateway not-found surfaces as a 404 for unknown ids", async () => {
+    ipcStub = () => null;
 
     await expect(handleGetContact("missing")).rejects.toThrow(
       'Contact "missing" not found',
     );
-    expect(localCalls).toContain("getContact");
+    expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_get_rich"]);
+    expect(localCalls).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -40,6 +40,8 @@ function resetGatewayIpc() {
   gatewayIpc.calls = [];
 }
 
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
 import {
   findContactChannel,
   getContact,
@@ -56,6 +58,7 @@ import {
   type InviteRedemptionOutcome,
   redeemInvite,
   redeemInviteByCode,
+  resolveMemberGateStatus,
 } from "../runtime/invite-redemption-service.js";
 import { hashVoiceCode } from "../util/voice-code.js";
 
@@ -761,5 +764,45 @@ describe("invite-redemption-service", () => {
         address: "gw-revoked-code-user",
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveMemberGateStatus", () => {
+  const memberlessVerdict: TrustVerdict = {
+    trustClass: "unverified_contact",
+    canonicalSenderId: "telegram:blocked-user",
+  };
+  const memberVerdict: TrustVerdict = {
+    trustClass: "trusted_contact",
+    canonicalSenderId: "telegram:active-user",
+    contactId: "contact-1",
+    channelId: "channel-1",
+    type: "telegram",
+    address: "active-user",
+    status: "active",
+    policy: "allow",
+  };
+
+  test("uses the verdict member status when the verdict resolves a member", async () => {
+    expect(await resolveMemberGateStatus(memberVerdict, "blocked")).toBe(
+      "active",
+    );
+  });
+
+  test("falls back to local status when a non-null verdict carries no member", async () => {
+    // A previously blocked contact with a valid invite must stay blocked even
+    // when the verdict is non-null but memberless (externalChatId-only match /
+    // resolutionFailed), so it can't bypass the gate.
+    expect(await resolveMemberGateStatus(memberlessVerdict, "blocked")).toBe(
+      "blocked",
+    );
+  });
+
+  test("falls back to local status when the verdict is null", async () => {
+    expect(await resolveMemberGateStatus(null, "blocked")).toBe("blocked");
+  });
+
+  test("returns null when neither verdict member nor local status is present", async () => {
+    expect(await resolveMemberGateStatus(memberlessVerdict, null)).toBeNull();
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -187,9 +187,12 @@ mock.module("../calls/channel-admission-reader.js", () => ({
 let mockMidCallVerdict:
   | import("@vellumai/gateway-client").TrustVerdict
   | null = null;
-// When set, the mid-call verdict reader blocks on this gate before returning,
-// simulating a slow gateway round-trip so a test can drive a prompt into the
-// re-resolution await window.
+// When set, the mid-call re-resolution verdict reader blocks on this gate
+// before returning, simulating a slow gateway round-trip so a test can drive a
+// prompt into the re-resolution await window. The gate targets the mid-call
+// re-resolution read (getInboundTrustVerdict) only — the per-caller redemption
+// gate read (getPhoneCallerVerdict) resolves immediately so invite redemption
+// reaches activation before the gated re-resolution runs.
 let mockMidCallVerdictGate: Promise<void> | null = null;
 const realInboundTrustReaderModule = {
   ...(await import("../calls/inbound-trust-reader.js")),
@@ -205,6 +208,14 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
       return realInboundTrustReaderModule.getInboundTrustVerdict(input);
     }
     if (mockMidCallVerdictGate) await mockMidCallVerdictGate;
+    return mockMidCallVerdict;
+  },
+  getPhoneCallerVerdict: async (otherPartyNumber: string | undefined) => {
+    if (!inboundTrustMockActive) {
+      return realInboundTrustReaderModule.getPhoneCallerVerdict(
+        otherPartyNumber,
+      );
+    }
     return mockMidCallVerdict;
   },
 }));
@@ -5990,7 +6001,10 @@ describe("relay-server", () => {
     const redemptionDone = relay.handleMessage(
       JSON.stringify({ type: "dtmf", digit: digits[digits.length - 1] }),
     );
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Let the redemption chain (gateway claim, caller-verdict read, DB write)
+    // drain up to activation, which flips the state to "connected" before
+    // entering the gated re-resolution.
+    await new Promise((resolve) => setTimeout(resolve, 50));
     // Activation already reached the terminal state before re-resolution.
     expect(relay.getConnectionState()).toBe("connected");
 

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -1735,7 +1735,7 @@ describe("relay-server", () => {
     // Guardian binding is NOT created by the assistant — the gateway owns
     // binding creation for inbound voice verification. The assistant only
     // transitions to connected state and starts the normal call flow.
-    const binding = getGuardianBinding("self", "phone");
+    const binding = await getGuardianBinding("self", "phone");
     expect(binding).toBeNull();
 
     // Orchestrator greeting should have fired
@@ -1806,7 +1806,7 @@ describe("relay-server", () => {
     expect(relay.getConnectionState()).toBe("connected");
 
     // Binding is NOT created by the assistant — gateway owns this.
-    const binding = getGuardianBinding("self", "phone");
+    const binding = await getGuardianBinding("self", "phone");
     expect(binding).toBeNull();
 
     // Greeting should have started
@@ -2327,6 +2327,9 @@ describe("relay-server", () => {
     for (const digit of secret) {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
+
+    // Let the fire-and-forget verification result handler flush
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     // Verification should have succeeded
     expect(relay.isVerificationSessionActive()).toBe(false);
@@ -4777,7 +4780,7 @@ describe("relay-server", () => {
     expect(relay.getConnectionState()).toBe("connected");
 
     // Guardian binding is NOT created by the assistant — gateway owns this.
-    const binding = getGuardianBinding("self", "phone");
+    const binding = await getGuardianBinding("self", "phone");
     expect(binding).toBeNull();
 
     // Normal greeting should fire (from mockSendMessage), not the handoff copy

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -335,7 +335,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
     };
   });
 
-  test("trusted-contact confirmation_request emits guardian.question and creates delivery records", () => {
+  test("trusted-contact confirmation_request emits guardian.question and creates delivery records", async () => {
     const canonicalRequest = createCanonicalGuardianRequest({
       id: `req-bridge-${Date.now()}`,
       kind: "tool_approval",
@@ -352,7 +352,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
 
     const trustContext = makeTrustedContactTrustContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-bridge-1",
@@ -371,7 +371,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
     expect(payload.requesterIdentifier).toBe("@requester");
   });
 
-  test("bridge + tool_grant_request both use guardian.question for unified routing", () => {
+  test("bridge + tool_grant_request both use guardian.question for unified routing", async () => {
     // The confirmation_request bridge and tool_grant_request helper both
     // use 'guardian.question' as the notification signal, ensuring consistent
     // guardian routing regardless of the approval path.
@@ -391,7 +391,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
 
     const trustContext = makeTrustedContactTrustContext();
 
-    bridgeConfirmationRequestToGuardian({
+    await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-unified-1",
@@ -432,7 +432,7 @@ describe("(c) no-binding flow: trusted contact fails fast without guardian bindi
     expect(state.promptWaitingAllowed).toBe(false);
   });
 
-  test("bridge skips when no guardian binding exists for channel", () => {
+  test("bridge skips when no guardian binding exists for channel", async () => {
     const canonicalRequest = createCanonicalGuardianRequest({
       id: `req-nobinding-${Date.now()}`,
       kind: "tool_approval",
@@ -449,7 +449,7 @@ describe("(c) no-binding flow: trusted contact fails fast without guardian bindi
 
     const trustContext = makeTrustedContactTrustContext();
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-nobinding",
@@ -543,7 +543,7 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
     expect(resolveRoutingState(withoutRoute).canBeInteractive).toBe(false);
   });
 
-  test("bridge skips unknown actor sessions entirely", () => {
+  test("bridge skips unknown actor sessions entirely", async () => {
     const canonicalRequest = createCanonicalGuardianRequest({
       id: `req-unknown-${Date.now()}`,
       kind: "tool_approval",
@@ -563,7 +563,7 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
       trustClass: "unknown",
     };
 
-    const result = bridgeConfirmationRequestToGuardian({
+    const result = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-unknown",
@@ -965,7 +965,7 @@ describe("cross-milestone integration checks", () => {
     );
   });
 
-  test("M2+M4: bridge and tool_grant_request target the same guardian identity", () => {
+  test("M2+M4: bridge and tool_grant_request target the same guardian identity", async () => {
     // Both the confirmation_request bridge (M2) and tool grant request escalation (M4)
     // use the guardian binding's guardianExternalUserId to route notifications.
     // Verify this consistency:
@@ -986,7 +986,7 @@ describe("cross-milestone integration checks", () => {
 
     const trustContext = makeTrustedContactTrustContext();
 
-    const bridgeResult = bridgeConfirmationRequestToGuardian({
+    const bridgeResult = await bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
       conversationId: "conv-consistency",

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -267,9 +267,9 @@ type CreateInboundVoiceSessionResult = {
  * returned without creating a duplicate. This handles Twilio webhook
  * replays gracefully.
  */
-export function createInboundVoiceSession(
+export async function createInboundVoiceSession(
   input: CreateInboundVoiceSessionInput,
-): CreateInboundVoiceSessionResult {
+): Promise<CreateInboundVoiceSessionResult> {
   const {
     callSid,
     fromNumber,
@@ -312,7 +312,7 @@ export function createInboundVoiceSession(
   updateCallSession(session.id, { providerCallSid: callSid });
   session.providerCallSid = callSid;
 
-  const callerIsGuardian = isGuardian(assistantId, "phone", fromNumber);
+  const callerIsGuardian = await isGuardian(assistantId, "phone", fromNumber);
   const metadataHints: string[] = [
     callerIsGuardian
       ? "Caller is the guardian"

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1164,7 +1164,7 @@ export class RelayConnection {
     const assistantId = this.verificationAssistantId;
     const fromNumber = this.verificationFromNumber;
 
-    const result = attemptVerificationCode({
+    const result = await attemptVerificationCode({
       verificationAssistantId: assistantId,
       verificationFromNumber: fromNumber,
       enteredCode,

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -112,9 +112,9 @@ type VerificationCallResult =
  * so the caller can apply side-effects (state mutations, TTS, session
  * updates) without this function needing access to the relay connection.
  */
-export function attemptVerificationCode(
+export async function attemptVerificationCode(
   params: VerificationCallParams,
-): VerificationCallResult {
+): Promise<VerificationCallResult> {
   const {
     verificationAssistantId,
     verificationFromNumber,
@@ -142,7 +142,7 @@ export function attemptVerificationCode(
     let canonicalPrincipal: string | undefined;
 
     if (result.verificationType === "guardian") {
-      const existingBinding = getGuardianBinding(
+      const existingBinding = await getGuardianBinding(
         verificationAssistantId,
         "phone",
       );
@@ -155,7 +155,7 @@ export function attemptVerificationCode(
         };
       } else {
         // Resolve canonical principal from the vellum channel binding
-        const vellumBinding = getGuardianBinding(
+        const vellumBinding = await getGuardianBinding(
           verificationAssistantId,
           "vellum",
         );

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -299,7 +299,7 @@ async function processVoiceWebhook(
       "Inbound voice webhook — creating/reusing session",
     );
 
-    const { session } = createInboundVoiceSession({
+    const { session } = await createInboundVoiceSession({
       callSid,
       fromNumber: callerFrom,
       toNumber: callerTo,

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -1,10 +1,17 @@
-import type { ContactWithChannels } from "../../../../contacts/types.js";
+import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import { cliIpcCall } from "../../../../ipc/cli-client.js";
 import { resolveGuardianName } from "../../../../prompts/user-reference.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+
+function guardianAwareName(contact: Pick<ContactRead, "role" | "displayName">) {
+  return contact.role === "guardian"
+    ? resolveGuardianName(contact.displayName)
+    : contact.displayName;
+}
 
 export async function executeContactMerge(
   input: Record<string, unknown>,
@@ -22,10 +29,10 @@ export async function executeContactMerge(
 
   // Validate both contacts exist before merging
   const [keepRes, mergeRes] = await Promise.all([
-    cliIpcCall<{ contact: ContactWithChannels }>("getContact", {
+    cliIpcCall<{ contact: ContactRead }>("getContact", {
       pathParams: { id: keepId },
     }),
-    cliIpcCall<{ contact: ContactWithChannels }>("getContact", {
+    cliIpcCall<{ contact: ContactRead }>("getContact", {
       pathParams: { id: mergeId },
     }),
   ]);
@@ -42,7 +49,7 @@ export async function executeContactMerge(
 
   const mergeResult = await cliIpcCall<{
     ok: boolean;
-    contact: ContactWithChannels;
+    contact: ContactRead;
   }>("merge_contacts", {
     body: { keepId, mergeId },
   });
@@ -51,19 +58,22 @@ export async function executeContactMerge(
     return { content: `Error: ${mergeResult.error}`, isError: true };
   }
 
-  const merged = mergeResult.result!.contact;
-  const displayName =
-    merged.role === "guardian"
-      ? resolveGuardianName(merged.displayName)
-      : merged.displayName;
-  const keepName =
-    keepContact.role === "guardian"
-      ? resolveGuardianName(keepContact.displayName)
-      : keepContact.displayName;
-  const mergeName =
-    mergeContact.role === "guardian"
-      ? resolveGuardianName(mergeContact.displayName)
-      : mergeContact.displayName;
+  const mergedId = mergeResult.result!.contact.id;
+
+  // Re-read the surviving contact through the gateway-relayed read so role and
+  // interactionCount come from the gateway ContactRead.
+  const mergedRes = await cliIpcCall<{ contact: ContactRead }>("getContact", {
+    pathParams: { id: mergedId },
+  });
+
+  if (!mergedRes.ok) {
+    return { content: `Error: ${mergedRes.error}`, isError: true };
+  }
+
+  const merged = mergedRes.result!.contact;
+  const displayName = guardianAwareName(merged);
+  const keepName = guardianAwareName(keepContact);
+  const mergeName = guardianAwareName(mergeContact);
 
   const channelList = merged.channels
     .map(

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
@@ -1,4 +1,5 @@
-import type { ContactWithChannels } from "../../../../contacts/types.js";
+import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import { cliIpcCall } from "../../../../ipc/cli-client.js";
 import { resolveGuardianName } from "../../../../prompts/user-reference.js";
 import type {
@@ -6,7 +7,16 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 
-function formatContactSummary(c: ContactWithChannels): string {
+// The search route may carry an optional per-channel `externalChatId` not modeled
+// on the gateway `ContactRead` channel contract.
+type SearchChannel = ContactRead["channels"][number] & {
+  externalChatId?: string | null;
+};
+type SearchContact = Omit<ContactRead, "channels"> & {
+  channels: SearchChannel[];
+};
+
+function formatContactSummary(c: SearchContact): string {
   const displayName =
     c.role === "guardian" ? resolveGuardianName(c.displayName) : c.displayName;
   const parts = [`- **${displayName}** (ID: ${c.id})`];
@@ -45,7 +55,7 @@ export async function executeContactSearch(
     };
   }
 
-  const res = await cliIpcCall<ContactWithChannels[]>("search_contacts", {
+  const res = await cliIpcCall<SearchContact[]>("search_contacts", {
     body: { query, channelAddress, channelType, limit },
   });
 

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
@@ -129,4 +129,29 @@ describe("redeemA2AInvite", () => {
     const result = redeemA2AInvite({ sender: SENDER });
     expect(result.success).toBe(true);
   });
+
+  test("activeConnections counts a2a channel existence, not status", () => {
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+
+    expect(getA2AConfig().activeConnections).toBe(1);
+
+    // Readiness is existence-based: a non-active stored status still counts.
+    const sqlite = getSqlite();
+    sqlite.run("UPDATE contact_channels SET status = 'unverified'");
+    invalidateConfigCache();
+    expect(getA2AConfig().activeConnections).toBe(1);
+  });
+
+  test("already-connected guard fires regardless of stored channel status", () => {
+    const first = redeemA2AInvite({ sender: SENDER });
+    expect(first.success).toBe(true);
+
+    const sqlite = getSqlite();
+    sqlite.run("UPDATE contact_channels SET status = 'revoked'");
+
+    const second = redeemA2AInvite({ sender: SENDER });
+    expect(second.alreadyConnected).toBe(true);
+    expect(second.contactId).toBe(first.contactId);
+  });
 });

--- a/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
@@ -8,6 +8,8 @@ let mockGuardians: GuardianDelivery[] | null = null;
 let mockBinding: { guardianExternalUserId: string; guardianDeliveryChatId: string } | null = null;
 let mockContactChannel: { channel: ContactChannel } | null = null;
 let mockChannel: ContactChannel | null = null;
+let mockGwContactChannels: Array<{ id: string; status: string; verifiedAt: number | null }> | null =
+  null;
 let ipcCalls: Array<{ method: string; payload: unknown }> = [];
 
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
@@ -35,6 +37,37 @@ mock.module("../../../contacts/contact-events.js", () => ({
 mock.module("../../../ipc/gateway-client.js", () => ({
   ipcCallPersistent: async (method: string, payload: unknown) => {
     ipcCalls.push({ method, payload });
+    if (method === "contacts_get_rich") {
+      if (mockGwContactChannels == null) return { ok: true, contact: null };
+      return {
+        ok: true,
+        contact: {
+          id: "contact-1",
+          displayName: "Pat",
+          role: "contact",
+          interactionCount: 0,
+          createdAt: 0,
+          updatedAt: 0,
+          channels: mockGwContactChannels.map((c) => ({
+            id: c.id,
+            contactId: "contact-1",
+            type: "telegram",
+            address: "user-123",
+            isPrimary: true,
+            externalUserId: null,
+            status: c.status,
+            policy: "allow",
+            verifiedAt: c.verifiedAt,
+            verifiedVia: null,
+            lastSeenAt: null,
+            interactionCount: 0,
+            lastInteraction: null,
+            revokedReason: null,
+            blockedReason: null,
+          })),
+        },
+      };
+    }
     return {
       ok: true,
       didWrite: true,
@@ -159,26 +192,33 @@ describe("revokeVerificationForChannel", () => {
 describe("verifyTrustedContact already-verified gate", () => {
   beforeEach(() => {
     mockGuardians = null;
+    mockGwContactChannels = null;
     mockChannel = channel();
   });
 
-  test("short-circuits when the gateway delivery is active and verified", async () => {
-    mockGuardians = [delivery({ status: "active", verifiedAt: 1700000000 })];
+  test("short-circuits when the gateway contact channel is active and verified", async () => {
+    // Arbitrary trusted contact (non-guardian) — read from the contact-channel
+    // gateway read, which covers all contacts.
+    mockGwContactChannels = [
+      { id: "ch-1", status: "active", verifiedAt: 1700000000 },
+    ];
     const result = await verifyTrustedContact("ch-1", "assistant-1");
     expect(result.success).toBe(false);
     expect(result.error).toBe("already_verified");
   });
 
-  test("does not short-circuit when the gateway delivery has no verifiedAt", async () => {
-    // DB column says verified, but the gateway delivery is unverified — proceed.
+  test("does not short-circuit when the gateway channel has no verifiedAt", async () => {
+    // DB column says verified, but the gateway channel is unverified — proceed.
     mockChannel = channel({ status: "active", verifiedAt: 1700000000 });
-    mockGuardians = [delivery({ status: "active", verifiedAt: null })];
+    mockGwContactChannels = [
+      { id: "ch-1", status: "pending", verifiedAt: null },
+    ];
     const result = await verifyTrustedContact("ch-1", "assistant-1");
     expect(result.error).not.toBe("already_verified");
   });
 
-  test("does not short-circuit when the gateway has no delivery", async () => {
-    mockGuardians = [];
+  test("does not short-circuit when the gateway has no matching channel", async () => {
+    mockGwContactChannels = [];
     const result = await verifyTrustedContact("ch-1", "assistant-1");
     expect(result.error).not.toBe("already_verified");
   });

--- a/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+import type { ContactChannel } from "../../../contacts/types.js";
+
+let mockGuardians: GuardianDelivery[] | null = null;
+let mockBinding: { guardianExternalUserId: string; guardianDeliveryChatId: string } | null = null;
+let mockContactChannel: { channel: ContactChannel } | null = null;
+let mockChannel: ContactChannel | null = null;
+let ipcCalls: Array<{ method: string; payload: unknown }> = [];
+
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async (input?: { channelTypes?: string[] }) => {
+    if (mockGuardians == null) return null;
+    if (!input?.channelTypes) return mockGuardians;
+    return mockGuardians.filter((g) =>
+      input.channelTypes!.includes(g.channelType),
+    );
+  },
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findContactChannel: () => mockContactChannel,
+  findGuardianForChannel: () => null,
+  getChannelById: () => mockChannel,
+  getContact: () => ({ id: "contact-1", displayName: "Pat" }),
+}));
+
+mock.module("../../../contacts/contact-events.js", () => ({
+  emitContactChange: () => {},
+  onContactChange: () => {},
+}));
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (method: string, payload: unknown) => {
+    ipcCalls.push({ method, payload });
+    return {
+      ok: true,
+      didWrite: true,
+      channel: {
+        id: "ch-1",
+        contactId: "contact-1",
+        type: "telegram",
+        address: "user-123",
+        status: "revoked",
+        revokedReason: "guardian_binding_revoked",
+      },
+    };
+  },
+  ipcCall: async () => null,
+}));
+
+mock.module("../../../runtime/channel-verification-service.js", () => ({
+  getGuardianBinding: () => mockBinding,
+  revokeBinding: () => true,
+  revokePendingSessions: () => {},
+  createOutboundSession: () => ({
+    sessionId: "sess",
+    secret: "code",
+    expiresAt: Date.now() + 1000,
+  }),
+  countRecentSendsToDestination: () => 0,
+  isGuardianBoundForChannel: async () => false,
+  updateSessionDelivery: () => {},
+}));
+
+mock.module("../../../runtime/verification-outbound-actions.js", () => ({
+  cancelOutbound: () => {},
+  deliverVerificationEmail: () => {},
+  deliverVerificationSlack: () => {},
+  deliverVerificationTelegram: () => {},
+  DESTINATION_RATE_WINDOW_MS: 1000,
+  MAX_SENDS_PER_DESTINATION_WINDOW: 5,
+  normalizeTelegramDestination: (d: string) => d,
+  resendOutbound: () => ({}),
+  startOutbound: async () => ({}),
+}));
+
+import {
+  revokeVerificationForChannel,
+  verifyTrustedContact,
+} from "../config-channels.js";
+
+function channel(overrides: Partial<ContactChannel> = {}): ContactChannel {
+  return {
+    id: "ch-1",
+    contactId: "contact-1",
+    type: "telegram",
+    address: "user-123",
+    isPrimary: true,
+    externalChatId: "chat-123",
+    // DB columns are intentionally a terminal state to prove the gates ignore
+    // them and read from the gateway delivery instead.
+    status: "revoked",
+    policy: {} as ContactChannel["policy"],
+    verifiedAt: null,
+    verifiedVia: null,
+    inviteId: null,
+    revokedReason: null,
+    blockedReason: null,
+    lastSeenAt: null,
+    interactionCount: 0,
+    lastInteraction: null,
+    updatedAt: null,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+function delivery(overrides: Partial<GuardianDelivery> = {}): GuardianDelivery {
+  return {
+    channelType: "telegram",
+    contactId: "contact-1",
+    address: "user-123",
+    externalChatId: "chat-123",
+    status: "active",
+    verifiedAt: 1700000000,
+    ...overrides,
+  };
+}
+
+describe("revokeVerificationForChannel", () => {
+  beforeEach(() => {
+    mockGuardians = null;
+    mockBinding = { guardianExternalUserId: "user-123", guardianDeliveryChatId: "chat-123" };
+    mockContactChannel = { channel: channel() };
+    ipcCalls = [];
+  });
+
+  test("relays mark_channel_revoked when the gateway delivery is live", async () => {
+    mockGuardians = [delivery({ status: "active" })];
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).toContain("mark_channel_revoked");
+  });
+
+  test("skips a redundant revoke when the gateway delivery is already revoked", async () => {
+    // Local DB status is the live "active" here, but the gateway (SoT) says
+    // revoked — the gate must follow the gateway and not relay.
+    mockContactChannel = { channel: channel({ status: "active" }) };
+    mockGuardians = [delivery({ status: "revoked" })];
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).not.toContain("mark_channel_revoked");
+  });
+
+  test("skips the relay when the gateway has no delivery for the channel", async () => {
+    mockGuardians = [];
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).not.toContain("mark_channel_revoked");
+  });
+
+  test("skips the relay when the gateway is unreachable", async () => {
+    mockGuardians = null;
+    await revokeVerificationForChannel("telegram");
+    expect(ipcCalls.map((c) => c.method)).not.toContain("mark_channel_revoked");
+  });
+});
+
+describe("verifyTrustedContact already-verified gate", () => {
+  beforeEach(() => {
+    mockGuardians = null;
+    mockChannel = channel();
+  });
+
+  test("short-circuits when the gateway delivery is active and verified", async () => {
+    mockGuardians = [delivery({ status: "active", verifiedAt: 1700000000 })];
+    const result = await verifyTrustedContact("ch-1", "assistant-1");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("already_verified");
+  });
+
+  test("does not short-circuit when the gateway delivery has no verifiedAt", async () => {
+    // DB column says verified, but the gateway delivery is unverified — proceed.
+    mockChannel = channel({ status: "active", verifiedAt: 1700000000 });
+    mockGuardians = [delivery({ status: "active", verifiedAt: null })];
+    const result = await verifyTrustedContact("ch-1", "assistant-1");
+    expect(result.error).not.toBe("already_verified");
+  });
+
+  test("does not short-circuit when the gateway has no delivery", async () => {
+    mockGuardians = [];
+    const result = await verifyTrustedContact("ch-1", "assistant-1");
+    expect(result.error).not.toBe("already_verified");
+  });
+});

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -96,13 +96,11 @@ export function getA2AConfig(): A2AConfigResult {
   const config = getConfig();
   const enabled = config.a2a?.enabled ?? false;
 
+  // a2a is peer binding outside the human-trust ACL model — the gateway has no
+  // canonical a2a channel status, so channel existence is the readiness signal.
   const contacts = searchContacts({ channelType: "a2a" });
   const activeConnections = contacts.reduce((count, c) => {
-    return (
-      count +
-      c.channels.filter((ch) => ch.type === "a2a" && ch.status === "active")
-        .length
-    );
+    return count + c.channels.filter((ch) => ch.type === "a2a").length;
   }, 0);
 
   return { success: true, enabled, activeConnections };
@@ -270,12 +268,9 @@ export function redeemA2AInvite(params: {
     setA2AConfig();
   }
 
-  // 2. Check for existing active contact with this sender
+  // 2. Check for existing contact with this sender (a2a binding existence)
   const existing = findContactByAddress("a2a", params.sender.assistantId);
-  if (
-    existing &&
-    existing.channels.some((ch) => ch.type === "a2a" && ch.status === "active")
-  ) {
+  if (existing && existing.channels.some((ch) => ch.type === "a2a")) {
     return { success: true, alreadyConnected: true, contactId: existing.id };
   }
 
@@ -373,10 +368,7 @@ export async function acceptA2AInvite(params: {
   // 2. Short-circuit if already connected — avoids a network round-trip
   //    and consuming a token on the sender side.
   const existing = findContactByAddress("a2a", params.senderAssistantId);
-  if (
-    existing &&
-    existing.channels.some((ch) => ch.type === "a2a" && ch.status === "active")
-  ) {
+  if (existing && existing.channels.some((ch) => ch.type === "a2a")) {
     return { success: true, alreadyConnected: true, contactId: existing.id };
   }
 

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -140,13 +140,13 @@ export async function createInboundChallenge(
   };
 }
 
-export function getVerificationStatus(
+export async function getVerificationStatus(
   channel?: ChannelId,
-): ChannelVerificationSessionResult {
+): Promise<ChannelVerificationSessionResult> {
   const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? "telegram";
 
-  const binding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
+  const binding = await getGuardianBinding(resolvedAssistantId, resolvedChannel);
 
   // Read the contact directly to get displayName — getGuardianBinding is a
   // compatibility shim that doesn't carry metadataJson.
@@ -214,7 +214,10 @@ export async function revokeVerificationForChannel(
 
   // Capture binding before revoking so we can downgrade the guardian's
   // channel — without this, the guardian would still pass the ACL check.
-  const bindingBeforeRevoke = getGuardianBinding(assistantId, resolvedChannel);
+  const bindingBeforeRevoke = await getGuardianBinding(
+    assistantId,
+    resolvedChannel,
+  );
   if (!bindingBeforeRevoke) {
     return {
       success: true,
@@ -621,7 +624,7 @@ export async function handleChannelVerificationSession(
         });
       }
     } else if (msg.action === "status") {
-      const result = getVerificationStatus(channel);
+      const result = await getVerificationStatus(channel);
       broadcastMessage({
         type: "channel_verification_session_response",
         ...result,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,7 +1,10 @@
 import { createHash, randomBytes } from "node:crypto";
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";
-import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+import {
+  GetContactIpcResponseSchema,
+  MarkChannelRevokedIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { startVerificationCall } from "../../calls/call-domain.js";
 import type { ChannelId } from "../../channels/types.js";
@@ -100,6 +103,25 @@ async function deliveryForChannel(
         (channel.externalChatId != null &&
           g.externalChatId === channel.externalChatId)),
   );
+}
+
+/**
+ * Read a contact channel's verified state from the gateway contact-channel read
+ * (ACL source of truth). Covers all contacts, not just guardian deliveries.
+ * Returns `undefined` when the gateway is unreachable or has no such channel.
+ */
+async function gatewayContactChannelState(
+  channel: Pick<ContactChannel, "id" | "contactId">,
+): Promise<{ status: string; verifiedAt: number | null } | undefined> {
+  const result = await ipcCallPersistent("contacts_get_rich", {
+    contactId: channel.contactId,
+  });
+  if (!result || (result as { contact?: unknown }).contact == null) {
+    return undefined;
+  }
+  const { contact } = GetContactIpcResponseSchema.parse(result);
+  const ch = contact.channels.find((c) => c.id === channel.id);
+  return ch ? { status: ch.status, verifiedAt: ch.verifiedAt } : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -325,10 +347,10 @@ export async function verifyTrustedContact(
     };
   }
 
-  // Already-verified short-circuit derived from the gateway delivery (ACL SoT)
-  // rather than the assistant DB status/verifiedAt columns.
-  const delivery = await deliveryForChannel(channel);
-  if (delivery?.status === "active" && delivery.verifiedAt != null) {
+  // Already-verified short-circuit derived from the gateway contact-channel read
+  // (ACL SoT), which covers all contacts — not just guardian deliveries.
+  const gwState = await gatewayContactChannelState(channel);
+  if (gwState?.status === "active" && gwState.verifiedAt != null) {
     return {
       success: false,
       error: "already_verified",

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
 import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { startVerificationCall } from "../../calls/call-domain.js";
@@ -11,7 +12,8 @@ import {
   getChannelById,
   getContact,
 } from "../../contacts/contact-store.js";
-import type { ChannelStatus } from "../../contacts/types.js";
+import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
+import type { ContactChannel } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { getBindingByChannelChat } from "../../memory/external-conversation-store.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
@@ -75,6 +77,29 @@ export function getReadinessService(): ChannelReadinessService {
     _readinessService = createReadinessService();
   }
   return _readinessService;
+}
+
+// ---------------------------------------------------------------------------
+// Gateway delivery lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the gateway-owned delivery (ACL source of truth) for a contact
+ * channel, matching on type and either address or externalChatId. Returns
+ * `undefined` when the gateway is unreachable or has no binding for it.
+ */
+async function deliveryForChannel(
+  channel: Pick<ContactChannel, "type" | "address" | "externalChatId">,
+): Promise<GuardianDelivery | undefined> {
+  const guardians = await getGuardianDelivery({ channelTypes: [channel.type] });
+  if (!guardians) return undefined;
+  return guardians.find(
+    (g) =>
+      g.channelType === channel.type &&
+      ((channel.address && g.address === channel.address) ||
+        (channel.externalChatId != null &&
+          g.externalChatId === channel.externalChatId)),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -206,13 +231,16 @@ export async function revokeVerificationForChannel(
 
   // Relay the ACL downgrade to the gateway (source of truth). The gateway's
   // mark_channel_revoked enforces the guardian guard and dual-writes the
-  // contact-channel status back to the assistant DB.
+  // contact-channel status back to the assistant DB. Gate on the gateway
+  // delivery's live status, not the assistant DB column, so a redundant revoke
+  // is still skipped for an already-revoked binding.
   if (contactResult) {
-    const channelStatus: ChannelStatus = contactResult.channel.status;
+    const delivery = await deliveryForChannel(contactResult.channel);
+    const deliveryStatus = delivery?.status;
     if (
-      channelStatus === "active" ||
-      channelStatus === "pending" ||
-      channelStatus === "unverified"
+      deliveryStatus === "active" ||
+      deliveryStatus === "pending" ||
+      deliveryStatus === "unverified"
     ) {
       const result = await ipcCallPersistent("mark_channel_revoked", {
         contactChannelId: contactResult.channel.id,
@@ -294,7 +322,10 @@ export async function verifyTrustedContact(
     };
   }
 
-  if (channel.status === "active" && channel.verifiedAt != null) {
+  // Already-verified short-circuit derived from the gateway delivery (ACL SoT)
+  // rather than the assistant DB status/verifiedAt columns.
+  const delivery = await deliveryForChannel(channel);
+  if (delivery?.status === "active" && delivery.verifiedAt != null) {
     return {
       success: false,
       error: "already_verified",

--- a/assistant/src/runtime/__tests__/channel-verification-service.test.ts
+++ b/assistant/src/runtime/__tests__/channel-verification-service.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Gateway guardian-delivery list drives both getGuardianBinding and isGuardian:
+// null = couldn't determine, [] = authoritative unbound, one active entry =
+// bound. Tests set this to mirror the gateway-owned ACL state.
+let mockGuardianList: Array<Record<string, unknown>> | null = [];
+const cachedCalls: Array<{ channelTypes?: string[] } | undefined> = [];
+
+const resolveList = (input?: { channelTypes?: string[] }) => {
+  cachedCalls.push(input);
+  return Promise.resolve(mockGuardianList);
+};
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: resolveList,
+  getGuardianDeliveryFresh: resolveList,
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+
+const { getGuardianBinding, isGuardian } = await import(
+  "../channel-verification-service.js"
+);
+
+const TELEGRAM_DELIVERY = {
+  channelType: "telegram",
+  contactId: "contact-1",
+  principalId: "principal-1",
+  displayName: "Guardian",
+  address: "guardian-handle",
+  externalChatId: "chat-1",
+  status: "active",
+  verifiedAt: 1700,
+};
+
+describe("getGuardianBinding", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    cachedCalls.length = 0;
+  });
+
+  test("filters delivery by the requested channel type", async () => {
+    await getGuardianBinding("asst-1", "telegram");
+    expect(cachedCalls).toEqual([{ channelTypes: ["telegram"] }]);
+  });
+
+  test("returns null when no guardian is bound", async () => {
+    mockGuardianList = [];
+    expect(await getGuardianBinding("asst-1", "telegram")).toBeNull();
+  });
+
+  test("returns null when the gateway is unreachable", async () => {
+    mockGuardianList = null;
+    expect(await getGuardianBinding("asst-1", "telegram")).toBeNull();
+  });
+
+  test("synthesizes the binding from the gateway delivery", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+
+    const binding = await getGuardianBinding("asst-1", "telegram");
+
+    expect(binding).not.toBeNull();
+    expect(binding?.assistantId).toBe("asst-1");
+    expect(binding?.channel).toBe("telegram");
+    expect(binding?.id).toBe("contact-1");
+    expect(binding?.guardianPrincipalId).toBe("principal-1");
+    expect(binding?.guardianExternalUserId).toBe("guardian-handle");
+    expect(binding?.guardianDeliveryChatId).toBe("chat-1");
+    expect(binding?.verifiedAt).toBe(1700);
+    expect(binding?.status).toBe("active");
+    expect(binding?.verifiedVia).toBe("verified");
+  });
+
+  test("falls back to empty strings for absent optional delivery fields", async () => {
+    mockGuardianList = [
+      {
+        channelType: "telegram",
+        contactId: "contact-2",
+        address: "addr",
+        status: "active",
+      },
+    ];
+
+    const binding = await getGuardianBinding("asst-1", "telegram");
+
+    expect(binding?.guardianPrincipalId).toBe("");
+    expect(binding?.guardianDeliveryChatId).toBe("");
+    expect(binding?.verifiedAt).toBe(0);
+  });
+
+  test("ignores deliveries for a different channel", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
+  });
+});
+
+describe("isGuardian", () => {
+  beforeEach(() => {
+    mockGuardianList = [];
+    cachedCalls.length = 0;
+  });
+
+  test("returns true when the address matches the gateway guardian", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await isGuardian("asst-1", "telegram", "guardian-handle")).toBe(true);
+  });
+
+  test("compares case-insensitively", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await isGuardian("asst-1", "telegram", "GUARDIAN-HANDLE")).toBe(true);
+  });
+
+  test("returns false for a non-matching address", async () => {
+    mockGuardianList = [TELEGRAM_DELIVERY];
+    expect(await isGuardian("asst-1", "telegram", "someone-else")).toBe(false);
+  });
+
+  test("returns false when no guardian is bound", async () => {
+    mockGuardianList = [];
+    expect(await isGuardian("asst-1", "telegram", "guardian-handle")).toBe(
+      false,
+    );
+  });
+
+  test("returns false when the gateway is unreachable", async () => {
+    mockGuardianList = null;
+    expect(await isGuardian("asst-1", "telegram", "guardian-handle")).toBe(
+      false,
+    );
+  });
+});

--- a/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
+++ b/assistant/src/runtime/__tests__/is-guardian-bound-for-channel.test.ts
@@ -7,11 +7,13 @@ let mockGuardianList: Array<Record<string, unknown>> | null = [];
 const freshCalls: Array<{ channelTypes?: string[] } | undefined> = [];
 
 mock.module("../../contacts/guardian-delivery-reader.js", () => ({
-  // Existence guard must read fresh (uncached) — only this variant is stubbed.
+  // Existence guard reads fresh (uncached); the binding/identity reads use the
+  // cached variant. The service imports both, so both must be stubbed.
   getGuardianDeliveryFresh: (input?: { channelTypes?: string[] }) => {
     freshCalls.push(input);
     return Promise.resolve(mockGuardianList);
   },
+  getGuardianDelivery: () => Promise.resolve(mockGuardianList),
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -14,6 +14,7 @@ import {
   resolvedMemberFromVerdict,
   trustContextFromVerdict,
   verdictHasMemberIdentity,
+  verdictMemberFromVerdict,
   verdictMemberUnresolvable,
 } from "../trust-verdict-consumer.js";
 
@@ -604,6 +605,84 @@ describe("resolvedMemberFromVerdict", () => {
       expect(member!.channel.status).toBe(status);
       expect(member!.channel.policy).toBe("deny");
     }
+  });
+});
+
+describe("verdictMemberFromVerdict", () => {
+  test("active member verdict yields the narrow ACL view", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "active",
+      policy: "allow",
+      verifiedAt: 1700000000,
+      memberDisplayName: "Dora",
+    } satisfies TrustVerdict;
+
+    expect(verdictMemberFromVerdict(verdict)).toEqual({
+      contactId: "contact-1",
+      channelId: "channel-1",
+      status: "active",
+      policy: "allow",
+      verifiedAt: 1700000000,
+      displayName: "Dora",
+    });
+  });
+
+  test("blocked member verdict surfaces status/policy verbatim, null defaults", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-3",
+      contactId: "contact-3",
+      channelId: "channel-3",
+      status: "blocked",
+      policy: "deny",
+    } satisfies TrustVerdict;
+
+    expect(verdictMemberFromVerdict(verdict)).toEqual({
+      contactId: "contact-3",
+      channelId: "channel-3",
+      status: "blocked",
+      policy: "deny",
+      verifiedAt: null,
+      displayName: null,
+    });
+  });
+
+  test("memberless verdict (no contactId/channelId) returns null", () => {
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "unknown",
+        canonicalSenderId: "u-2",
+      } satisfies TrustVerdict),
+    ).toBeNull();
+  });
+
+  test("invalid enum (unknown status/policy) returns null (fail-closed)", () => {
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-7",
+        contactId: "contact-7",
+        channelId: "channel-7",
+        status: "quarantined",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toBeNull();
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-6",
+        contactId: "contact-6",
+        channelId: "channel-6",
+        status: "active",
+        policy: "bogus",
+      } satisfies TrustVerdict),
+    ).toBeNull();
   });
 });
 

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -749,7 +749,7 @@ async function createCanonicalRequestForConfirmation(
     });
 
     if (trustContext && conversation) {
-      bridgeConfirmationRequestToGuardian({
+      await bridgeConfirmationRequestToGuardian({
         canonicalRequest,
         trustContext,
         conversationId,

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -9,9 +9,9 @@
 import { createHash, randomBytes } from "crypto";
 import { v4 as uuid } from "uuid";
 
-import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { revokeGuardianBinding } from "../contacts/contacts-write.js";
 import {
+  getGuardianDelivery,
   getGuardianDeliveryFresh,
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
@@ -323,33 +323,35 @@ export function validateAndConsumeVerification(
 
 /**
  * Look up the active guardian binding for a given assistant and channel.
- * Reads from the contacts table via findGuardianForChannel and
- * synthesizes a GuardianBinding-shaped object.
- * Returns null when no contacts match.
+ * Reads the gateway-owned GuardianDelivery and synthesizes a
+ * GuardianBinding-shaped object. Returns null when no guardian is bound or
+ * the gateway is unreachable.
  */
-export function getGuardianBinding(
+export async function getGuardianBinding(
   assistantId: string,
   channel: string,
-): GuardianBinding | null {
-  const result = findGuardianForChannel(channel);
-  if (result) {
-    return {
-      id: result.channel.id,
-      assistantId,
-      channel,
-      guardianExternalUserId: result.channel.address,
-      guardianDeliveryChatId: result.channel.externalChatId ?? "",
-      guardianPrincipalId: result.contact.principalId ?? "",
-      status: "active" as const,
-      verifiedAt: result.channel.verifiedAt ?? 0,
-      verifiedVia: result.channel.verifiedVia ?? "",
-      metadataJson: null,
-      createdAt: result.channel.createdAt,
-      updatedAt: result.channel.updatedAt ?? result.channel.createdAt,
-    };
-  }
+): Promise<GuardianBinding | null> {
+  const list = await getGuardianDelivery({ channelTypes: [channel] });
+  const delivery = list ? guardianForChannel(list, channel) : undefined;
+  if (!delivery) return null;
 
-  return null;
+  const now = Date.now();
+  return {
+    id: delivery.contactId,
+    assistantId,
+    channel,
+    guardianExternalUserId: delivery.address,
+    guardianDeliveryChatId: delivery.externalChatId ?? "",
+    guardianPrincipalId: delivery.principalId ?? "",
+    status: "active" as const,
+    verifiedAt: delivery.verifiedAt ?? 0,
+    // verifiedVia is not carried on the delivery contract; a bound guardian
+    // is verified by definition.
+    verifiedVia: "verified",
+    metadataJson: null,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 /**
@@ -376,17 +378,16 @@ export async function isGuardianBoundForChannel(
  * Check whether the given external user is the active guardian for
  * the specified assistant and channel.
  */
-export function isGuardian(
+export async function isGuardian(
   assistantId: string,
   channel: string,
   address: string,
-): boolean {
-  const result = findGuardianForChannel(channel);
-  if (result) {
-    return result.channel.address.toLowerCase() === address.toLowerCase();
-  }
+): Promise<boolean> {
+  const list = await getGuardianDelivery({ channelTypes: [channel] });
+  const delivery = list ? guardianForChannel(list, channel) : undefined;
+  if (!delivery) return false;
 
-  return false;
+  return delivery.address.toLowerCase() === address.toLowerCase();
 }
 
 /**

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -70,9 +70,9 @@ export type BridgeConfirmationRequestResult =
  *
  * Fire-and-forget safe: notification emission errors are logged but not propagated.
  */
-export function bridgeConfirmationRequestToGuardian(
+export async function bridgeConfirmationRequestToGuardian(
   params: BridgeConfirmationRequestParams,
-): BridgeConfirmationRequestResult {
+): Promise<BridgeConfirmationRequestResult> {
   const {
     canonicalRequest,
     trustContext,
@@ -100,7 +100,7 @@ export function bridgeConfirmationRequestToGuardian(
   }
 
   const sourceChannel = trustContext.sourceChannel;
-  const binding = getGuardianBinding(assistantId, sourceChannel);
+  const binding = await getGuardianBinding(assistantId, sourceChannel);
   if (!binding) {
     log.debug(
       { sourceChannel, assistantId },

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -7,8 +7,13 @@
  * persisted, or returned in the outcome.
  */
 
+import {
+  getInboundTrustVerdict,
+  getPhoneCallerVerdict,
+} from "../calls/inbound-trust-reader.js";
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel, getContact } from "../contacts/contact-store.js";
+import type { ChannelStatus } from "../contacts/types.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
 import { getSqlite } from "../memory/db-connection.js";
@@ -23,8 +28,22 @@ import {
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { hashVoiceCode } from "../util/voice-code.js";
+import { verdictMemberFromVerdict } from "./trust-verdict-consumer.js";
 
 const log = getLogger("invite-redemption-service");
+
+/**
+ * Resolve the sender's existing member status for the already_member/blocked
+ * gate from the gateway trust verdict. Falls back to the local channel status
+ * only when the gateway returns no verdict.
+ */
+async function resolveMemberGateStatus(
+  verdict: Awaited<ReturnType<typeof getInboundTrustVerdict>>,
+  localChannelStatus: ChannelStatus | null,
+): Promise<ChannelStatus | null> {
+  if (verdict) return verdictMemberFromVerdict(verdict)?.status ?? null;
+  return localChannelStatus;
+}
 
 // ---------------------------------------------------------------------------
 // Gateway lifecycle bridge (shared by all redemption paths)
@@ -218,18 +237,22 @@ export async function redeemInvite(params: {
   const targetMismatch =
     existingContact && existingContact.id !== invite.contactId;
 
-  if (
-    existingChannel &&
-    existingChannel.status === "active" &&
-    !targetMismatch
-  ) {
+  const gateStatus = await resolveMemberGateStatus(
+    await getInboundTrustVerdict({
+      channelType: sourceChannel as ChannelId,
+      actorExternalId: canonicalUserId,
+    }),
+    existingChannel?.status ?? null,
+  );
+
+  if (existingChannel && gateStatus === "active" && !targetMismatch) {
     return { ok: true, type: "already_member", memberId: existingChannel.id };
   }
 
   // Blocked members cannot bypass the guardian's explicit block via invite
   // links. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
-  if (existingChannel && existingChannel.status === "blocked") {
+  if (existingChannel && gateStatus === "blocked") {
     return { ok: false, reason: "invalid_token" };
   }
 
@@ -465,11 +488,12 @@ export async function redeemVoiceInviteCode(params: {
   // should bind the sender's identity to the target contact, not the existing one.
   const targetMismatch = voiceContact && voiceContact.id !== invite.contactId;
 
-  if (
-    existingVoiceChannel &&
-    existingVoiceChannel.status === "active" &&
-    !targetMismatch
-  ) {
+  const gateStatus = await resolveMemberGateStatus(
+    await getPhoneCallerVerdict(canonicalCallerId),
+    existingVoiceChannel?.status ?? null,
+  );
+
+  if (existingVoiceChannel && gateStatus === "active" && !targetMismatch) {
     return {
       ok: true,
       type: "already_member",
@@ -478,7 +502,7 @@ export async function redeemVoiceInviteCode(params: {
   }
 
   // Blocked members cannot bypass the guardian's explicit block
-  if (existingVoiceChannel && existingVoiceChannel.status === "blocked") {
+  if (existingVoiceChannel && gateStatus === "blocked") {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
@@ -639,18 +663,22 @@ export async function redeemInviteByCode(params: {
   const targetMismatch =
     existingContact && existingContact.id !== invite.contactId;
 
-  if (
-    existingChannel &&
-    existingChannel.status === "active" &&
-    !targetMismatch
-  ) {
+  const gateStatus = await resolveMemberGateStatus(
+    await getInboundTrustVerdict({
+      channelType: sourceChannel as ChannelId,
+      actorExternalId: canonicalUserId,
+    }),
+    existingChannel?.status ?? null,
+  );
+
+  if (existingChannel && gateStatus === "active" && !targetMismatch) {
     return { ok: true, type: "already_member", memberId: existingChannel.id };
   }
 
   // Blocked members cannot bypass the guardian's explicit block via invite
   // codes. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
-  if (existingChannel && existingChannel.status === "blocked") {
+  if (existingChannel && gateStatus === "blocked") {
     return { ok: false, reason: "invalid_token" };
   }
 

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -35,14 +35,18 @@ const log = getLogger("invite-redemption-service");
 /**
  * Resolve the sender's existing member status for the already_member/blocked
  * gate from the gateway trust verdict. Falls back to the local channel status
- * only when the gateway returns no verdict.
+ * when the verdict is absent or carries no resolvable member status (e.g. an
+ * externalChatId-only match or a resolutionFailed verdict), so a locally
+ * blocked contact can't bypass the gate.
  */
-async function resolveMemberGateStatus(
+export async function resolveMemberGateStatus(
   verdict: Awaited<ReturnType<typeof getInboundTrustVerdict>>,
   localChannelStatus: ChannelStatus | null,
 ): Promise<ChannelStatus | null> {
-  if (verdict) return verdictMemberFromVerdict(verdict)?.status ?? null;
-  return localChannelStatus;
+  const memberStatus = verdict
+    ? verdictMemberFromVerdict(verdict)?.status
+    : null;
+  return memberStatus ?? localChannelStatus;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -13,8 +13,8 @@ import {
 } from "../calls/inbound-trust-reader.js";
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel, getContact } from "../contacts/contact-store.js";
-import type { ChannelStatus } from "../contacts/types.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
+import type { ChannelStatus } from "../contacts/types.js";
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
 import { getSqlite } from "../memory/db-connection.js";
 import {

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -10,6 +10,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { GuardianDelivery } from "@vellumai/gateway-client";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 
 type IpcCall = { method: string; params?: Record<string, unknown> };
@@ -73,14 +74,36 @@ mock.module("../../channel-verification-service.js", () => ({
   getGuardianBinding: mock(() => guardianBinding),
 }));
 
-// Contact-store lookup that resolves the guardian's channel to downgrade.
-let contactChannel: { id: string; status: string } | null = null;
+// Contact-store lookup that resolves the guardian's channel to downgrade. The
+// channel carries the type/address/externalChatId the gateway delivery is
+// matched against (see deliveryForChannel).
+let contactChannel: {
+  id: string;
+  status: string;
+  type: string;
+  address: string;
+  externalChatId: string;
+} | null = null;
 const actualContactStore = await import("../../../contacts/contact-store.js");
 mock.module("../../../contacts/contact-store.js", () => ({
   ...actualContactStore,
   findContactChannel: mock(() =>
     contactChannel ? { channel: contactChannel, contact: { id: "c1" } } : null,
   ),
+}));
+
+// Gateway delivery (ACL source of truth). The revoke gate relays only when the
+// matching delivery is live (active/pending/unverified); already-revoked or a
+// missing delivery short-circuits the relay.
+let guardianDeliveries: GuardianDelivery[] | null = null;
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: mock(async (input?: { channelTypes?: string[] }) => {
+    if (guardianDeliveries == null) return null;
+    if (!input?.channelTypes) return guardianDeliveries;
+    return guardianDeliveries.filter((g) =>
+      input.channelTypes!.includes(g.channelType),
+    );
+  }),
 }));
 
 // Guard: the contact-channel ACL write moves to the gateway relay and must
@@ -122,7 +145,24 @@ describe("verification revoke relay", () => {
       guardianExternalUserId: "guardian-user",
       guardianDeliveryChatId: "chat-1",
     };
-    contactChannel = { id: "ch1", status: "active" };
+    contactChannel = {
+      id: "ch1",
+      status: "active",
+      type: "telegram",
+      address: "guardian-user",
+      externalChatId: "chat-1",
+    };
+    // Gateway delivery is live by default, so the revoke relay fires.
+    guardianDeliveries = [
+      {
+        channelType: "telegram",
+        contactId: "c1",
+        address: "guardian-user",
+        externalChatId: "chat-1",
+        status: "active",
+        verifiedAt: 1700000000,
+      },
+    ];
     ipcCallPersistentMock.mockClear();
     cancelOutboundMock.mockClear();
     revokePendingSessionsMock.mockClear();
@@ -263,8 +303,19 @@ describe("verification revoke relay", () => {
     expect(result.bound).toBe(false);
   });
 
-  test("skips the relay when the resolved channel is already revoked", async () => {
-    contactChannel = { id: "ch1", status: "revoked" };
+  test("skips the relay when the gateway delivery is already revoked", async () => {
+    // The gateway (source of truth) already shows the channel revoked, so the
+    // redundant relay is skipped even though session/binding teardown runs.
+    guardianDeliveries = [
+      {
+        channelType: "telegram",
+        contactId: "c1",
+        address: "guardian-user",
+        externalChatId: "chat-1",
+        status: "revoked",
+        verifiedAt: 1700000000,
+      },
+    ];
 
     await revokeHandler({ body: { channel: "telegram" } });
 

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the contacts read API.
+ *
+ * `handleListContacts`, `handleGetContact`, and the `search_contacts`
+ * no-filter case relay to the gateway rich read (`contacts_list_rich` /
+ * `contacts_get_rich`), which is the source of truth for the ACL fields
+ * (`role`/`status`/`policy`/`verifiedAt`/`interactionCount`/`lastInteraction`).
+ * These tests assert the serialized response shape is gateway-sourced and
+ * unchanged for the web client, that no read path falls back to the assistant
+ * DB, and that a relay failure fails closed (surfaces an error) instead of
+ * reading local ACL.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+let ipcCalls: { method: string; params?: Record<string, unknown> }[] = [];
+let ipcResult: unknown = {};
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if any read path falls back to the assistant DB for ACL
+// fields. The relay read paths must source role/status/stats from the gateway.
+const actualContactStore = await import("../../../contacts/contact-store.js");
+
+const contactStoreReadGuard = mock(() => {
+  throw new Error(
+    "assistant contact-store read must not happen on the gateway relay path",
+  );
+});
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  getContact: contactStoreReadGuard,
+  listContacts: contactStoreReadGuard,
+  getAssistantContactMetadata: contactStoreReadGuard,
+}));
+
+const { handleListContacts, handleGetContact, ROUTES } = await import(
+  "../contact-routes.js"
+);
+
+const gatewayChannel = {
+  id: "ch_1",
+  contactId: "ct_1",
+  type: "sms",
+  address: "+15550100",
+  isPrimary: true,
+  externalUserId: null,
+  status: "active",
+  policy: "allow",
+  verifiedAt: 1700,
+  verifiedVia: "invite",
+  lastSeenAt: 1800,
+  interactionCount: 7,
+  lastInteraction: 1900,
+  revokedReason: null,
+  blockedReason: null,
+};
+
+const gatewayContact = {
+  id: "ct_1",
+  displayName: "Alice",
+  role: "member",
+  notes: "a note",
+  contactType: "human",
+  lastInteraction: 1900,
+  interactionCount: 7,
+  createdAt: 1000,
+  updatedAt: 1500,
+  channels: [gatewayChannel],
+};
+
+describe("contacts read API relays from the gateway", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = {};
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    contactStoreReadGuard.mockClear();
+  });
+
+  test("list relays to contacts_list_rich and serializes the gateway ACL fields", async () => {
+    ipcResult = { ok: true, contacts: [gatewayContact] };
+
+    const result = await handleListContacts({ limit: "50" });
+
+    expect(ipcCalls).toEqual([
+      { method: "contacts_list_rich", params: { limit: 50 } },
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.contacts).toHaveLength(1);
+
+    const [contact] = result.contacts;
+    // ACL fields are gateway-sourced and reach the web client unchanged.
+    expect(contact.role).toBe("member");
+    expect(contact.interactionCount).toBe(7);
+    expect(contact.lastInteraction).toBe(1900);
+    const channel = contact.channels[0] as Record<string, unknown>;
+    expect(channel.status).toBe("active");
+    expect(channel.policy).toBe("allow");
+    expect(channel.verifiedAt).toBe(1700);
+    expect(channel.interactionCount).toBe(7);
+    expect(channel.lastInteraction).toBe(1900);
+    // Channel compat echoes address into externalUserId for older clients.
+    expect(channel.externalUserId).toBe("+15550100");
+
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("list forwards the role filter to the gateway", async () => {
+    ipcResult = { ok: true, contacts: [] };
+
+    await handleListContacts({ limit: "10", role: "guardian" });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "contacts_list_rich",
+        params: { limit: 10, role: "guardian" },
+      },
+    ]);
+  });
+
+  test("list fails closed when the gateway relay is unavailable", async () => {
+    ipcError = new IpcCallError("gateway down", {
+      statusCode: 503,
+      errorCode: "UNAVAILABLE",
+    });
+
+    await expect(handleListContacts({ limit: "50" })).rejects.toMatchObject({
+      message: "gateway down",
+      statusCode: 503,
+    });
+    // No assistant-DB fallback read.
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("get relays to contacts_get_rich and serializes the gateway ACL fields", async () => {
+    ipcResult = { ok: true, contact: gatewayContact };
+
+    const result = await handleGetContact("ct_1");
+
+    expect(ipcCalls).toEqual([
+      { method: "contacts_get_rich", params: { contactId: "ct_1" } },
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.contact.role).toBe("member");
+    expect(result.contact.interactionCount).toBe(7);
+    const channel = result.contact.channels[0] as Record<string, unknown>;
+    expect(channel.status).toBe("active");
+    expect(channel.externalUserId).toBe("+15550100");
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("get surfaces a clean gateway not-found as a 404", async () => {
+    ipcResult = { ok: true };
+
+    await expect(handleGetContact("missing")).rejects.toMatchObject({
+      statusCode: 404,
+    });
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("get fails closed on a relay failure (no assistant-DB fallback)", async () => {
+    ipcError = new IpcCallError("gateway down", {
+      statusCode: 503,
+      errorCode: "UNAVAILABLE",
+    });
+
+    await expect(handleGetContact("ct_1")).rejects.toMatchObject({
+      message: "gateway down",
+      statusCode: 503,
+    });
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("search no-filter relays to the gateway list read", async () => {
+    ipcResult = { ok: true, contacts: [gatewayContact] };
+
+    const route = ROUTES.find((r) => r.operationId === "search_contacts");
+    expect(route).toBeDefined();
+
+    const contacts = (await route!.handler({ body: {} })) as Array<{
+      role: string;
+      interactionCount: number;
+      channels: { status: string }[];
+    }>;
+
+    expect(ipcCalls).toEqual([
+      { method: "contacts_list_rich", params: { limit: 50 } },
+    ]);
+    expect(contacts[0].role).toBe("member");
+    expect(contacts[0].interactionCount).toBe(7);
+    expect(contacts[0].channels[0].status).toBe("active");
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/global-search-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/global-search-routes.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the global-search contacts ordering source.
+ *
+ * Recency ordering for contacts surfaces `contacts.updatedAt`, never the
+ * channel-derived `lastInteraction` column. Daemon-native contact search
+ * carries no gateway-relayed ContactRead, so `updatedAt` is the deterministic
+ * ordering key.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { ContactWithChannels } from "../../../contacts/types.js";
+
+let searchContactsResult: ContactWithChannels[] = [];
+
+const searchContactsMock = mock(() => searchContactsResult);
+
+const actualContactStore = await import("../../../contacts/contact-store.js");
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  searchContacts: searchContactsMock,
+}));
+
+const { ROUTES } = await import("../global-search-routes.js");
+
+const handler = ROUTES.find((r) => r.operationId === "search_global")!.handler;
+
+function makeContact(
+  overrides: Partial<ContactWithChannels>,
+): ContactWithChannels {
+  return {
+    id: "ct_1",
+    displayName: "Alice",
+    notes: null,
+    lastInteraction: null,
+    interactionCount: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    role: "contact",
+    contactType: "human",
+    principalId: null,
+    userFile: null,
+    channels: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  searchContactsResult = [];
+  searchContactsMock.mockClear();
+});
+
+describe("global-search contacts recency source", () => {
+  test("surfaces contacts.updatedAt as lastInteraction, not the channel column", async () => {
+    searchContactsResult = [
+      makeContact({
+        id: "ct_1",
+        displayName: "Alice",
+        updatedAt: 5000,
+        lastInteraction: 9999,
+      }),
+    ];
+
+    const result = (await handler({
+      queryParams: { q: "ali", categories: "contacts" },
+    })) as { results: { contacts: { id: string; lastInteraction: number }[] } };
+
+    expect(result.results.contacts).toHaveLength(1);
+    expect(result.results.contacts[0].lastInteraction).toBe(5000);
+  });
+
+  test("preserves searchContacts ordering deterministically", async () => {
+    searchContactsResult = [
+      makeContact({ id: "ct_a", displayName: "A", updatedAt: 300 }),
+      makeContact({ id: "ct_b", displayName: "B", updatedAt: 200 }),
+      makeContact({ id: "ct_c", displayName: "C", updatedAt: 100 }),
+    ];
+
+    const result = (await handler({
+      queryParams: { q: "x", categories: "contacts" },
+    })) as { results: { contacts: { id: string; lastInteraction: number }[] } };
+
+    expect(result.results.contacts.map((c) => c.id)).toEqual([
+      "ct_a",
+      "ct_b",
+      "ct_c",
+    ]);
+    expect(result.results.contacts.map((c) => c.lastInteraction)).toEqual([
+      300, 200, 100,
+    ]);
+  });
+});

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -192,12 +192,12 @@ export async function handleCreateVerificationSession({
 /**
  * GET /v1/channel-verification-sessions/status
  */
-function handleGetVerificationStatus({
+async function handleGetVerificationStatus({
   queryParams = {},
   body = {},
 }: RouteHandlerArgs) {
   const channel = (queryParams.channel ?? (body as Record<string, unknown>).channel) as ChannelId | undefined;
-  return getVerificationStatus(channel);
+  return await getVerificationStatus(channel);
 }
 
 /**

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -17,8 +17,6 @@ import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import {
-  getAssistantContactMetadata,
-  getContact,
   listContacts,
   mergeContacts,
   searchContacts,
@@ -139,9 +137,10 @@ const contactSchema = z.object({
 
 /**
  * Relay a non-search contact list read to the gateway (source of truth for ACL
- * fields), falling back to the assistant DB on IPC failure. Shared by the GET
- * `contacts` list and the `search_contacts` no-filter case so both serve
- * gateway-sourced data consistently.
+ * fields). Shared by the GET `contacts` list and the `search_contacts`
+ * no-filter case so both serve gateway-sourced data consistently. Fail-closed:
+ * a relay failure surfaces as an error rather than reading ACL from the
+ * assistant DB.
  */
 async function relayListContacts(
   limit: number,
@@ -158,15 +157,7 @@ async function relayListContacts(
       contacts: contacts.map(prepareContactResponse),
     };
   } catch (err) {
-    log.warn(
-      { err },
-      "relayListContacts: gateway relay failed; falling back to assistant DB",
-    );
-    const contacts = listContacts(limit, role);
-    return {
-      ok: true,
-      contacts: contacts.map(prepareContactResponse),
-    };
+    rethrowGatewayError(err);
   }
 }
 
@@ -240,25 +231,10 @@ export async function handleGetContact(contactId: string) {
       assistantMetadata: assistantMetadata ?? undefined,
     };
   } catch (err) {
-    // A clean not-found is a real 404 — don't fall back or mask it.
+    // A clean not-found is a real 404. Any other relay failure fails closed
+    // rather than reading ACL from the assistant DB.
     if (err instanceof NotFoundError) throw err;
-    log.warn(
-      { err, contactId },
-      "handleGetContact: gateway relay failed; falling back to assistant DB",
-    );
-    const contact = getContact(contactId);
-    if (!contact) {
-      throw new NotFoundError(`Contact "${contactId}" not found`);
-    }
-    const assistantMeta =
-      contact.contactType === "assistant"
-        ? getAssistantContactMetadata(contact.id)
-        : undefined;
-    return {
-      ok: true,
-      contact: prepareContactResponse(contact),
-      assistantMetadata: assistantMeta ?? undefined,
-    };
+    rethrowGatewayError(err);
   }
 }
 

--- a/assistant/src/runtime/routes/global-search-routes.ts
+++ b/assistant/src/runtime/routes/global-search-routes.ts
@@ -263,7 +263,9 @@ async function handleGlobalSearch({
       id: c.id,
       displayName: c.displayName,
       notes: c.notes,
-      lastInteraction: c.lastInteraction,
+      // Daemon-native search has no gateway-relayed read; recency orders on
+      // contacts.updatedAt, not the channel-derived lastInteraction column.
+      lastInteraction: c.updatedAt,
     }));
   }
 

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -14,7 +14,6 @@
 import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import {
   type CanonicalGuardianRequest,
   listPendingRequestsByConversationScope,
@@ -23,6 +22,7 @@ import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import type { GuardianDecisionPrompt } from "../guardian-decision-types.js";
 import { buildOneTimeDecisionActions } from "../guardian-decision-types.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -73,16 +73,15 @@ async function handleGuardianActionDecision({
   // Resolve the actor's guardian principal ID. The HTTP adapter injects it
   // from the AuthContext via the x-vellum-actor-principal-id header.
   // For dev bypass (HTTP auth disabled) the synthetic "dev-bypass" principal
-  // won't match the real guardian binding, so fall back to the local guardian
-  // binding to avoid identity_mismatch.
+  // won't match the real guardian binding, so resolve the local guardian
+  // principal to avoid identity_mismatch.
   let guardianPrincipalId: string | undefined =
     headers["x-vellum-actor-principal-id"] ?? undefined;
   if (
     isHttpAuthDisabled() &&
     headers["x-vellum-actor-principal-id"] === "dev-bypass"
   ) {
-    const binding = findGuardianForChannel("vellum");
-    guardianPrincipalId = binding?.contact.principalId ?? undefined;
+    guardianPrincipalId = (await findLocalGuardianPrincipalId()) ?? undefined;
   }
 
   const result = await processGuardianDecision({

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -680,7 +680,7 @@ export async function handleChannelInbound({
       canonicalAssistantId,
       assistantId,
       content,
-      channelId: resolvedMember?.channel.id,
+      channelId: resolvedMember?.channelId,
     });
   }
 
@@ -761,7 +761,7 @@ export async function handleChannelInbound({
       : enforceAdmissionPolicy({
           sourceChannel,
           trustClass: trustCtx.trustClass,
-          memberStatus: resolvedMember?.channel.status,
+          memberStatus: resolvedMember?.status,
           policy: admissionPolicyFromGateway,
         });
   if (!admissionResult.admitted) {
@@ -811,7 +811,7 @@ export async function handleChannelInbound({
         ...(resolvedMember
           ? {
               previousMemberStatus: channelStatusToMemberStatus(
-                resolvedMember.channel.status,
+                resolvedMember.status,
               ),
             }
           : {}),

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -935,7 +935,7 @@ export async function handleChannelInbound({
   }
 
   // ── Ingress escalation ──
-  const escalationResponse = handleEscalationIntercept({
+  const escalationResponse = await handleEscalationIntercept({
     resolvedMember,
     canonicalAssistantId,
     sourceChannel,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -155,8 +155,8 @@ describe("enforceIngressAcl — verdict-sourced member resolution", () => {
 
     expect(result.earlyResponse).toBeUndefined();
     expect(result.resolvedMember).not.toBeNull();
-    expect(result.resolvedMember!.channel.status).toBe("active");
-    expect(result.resolvedMember!.channel.policy).toBe("allow");
+    expect(result.resolvedMember!.status).toBe("active");
+    expect(result.resolvedMember!.policy).toBe("allow");
     // Member came from the verdict, never the local contact store.
     expect(findContactChannelCalls.length).toBe(0);
   });
@@ -171,7 +171,8 @@ describe("enforceIngressAcl — verdict-sourced member resolution", () => {
     );
 
     expect(result.earlyResponse).toBeUndefined();
-    expect(result.resolvedMember!.contact.role).toBe("guardian");
+    expect(result.resolvedMember).not.toBeNull();
+    expect(result.resolvedMember!.status).toBe("active");
     expect(findContactChannelCalls.length).toBe(0);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -39,7 +39,8 @@ import {
   redeemInviteByCode,
 } from "../../invite-redemption-service.js";
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
-import { resolvedMemberFromVerdict } from "../../trust-verdict-consumer.js";
+import type { VerdictMember } from "../../trust-verdict-consumer.js";
+import { verdictMemberFromVerdict } from "../../trust-verdict-consumer.js";
 
 const log = getLogger("runtime-http");
 
@@ -102,7 +103,7 @@ export type ResolvedMember = {
 };
 
 export interface AclResult {
-  resolvedMember: ResolvedMember | null;
+  resolvedMember: VerdictMember | null;
   /** When set, the caller must return this response immediately. */
   earlyResponse?: Record<string, unknown>;
   /**
@@ -186,7 +187,7 @@ export async function enforceIngressAcl(
 
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member intercepts.
-  const resolvedMember: ResolvedMember | null = resolvedMemberFromVerdict(verdict);
+  const resolvedMember: VerdictMember | null = verdictMemberFromVerdict(verdict);
 
   // A verdict carrying member identity but no resolvable member
   // (malformed/unknown ACL) fails closed, not treated as a stranger.
@@ -518,8 +519,8 @@ export async function enforceIngressAcl(
     }
 
     if (resolvedMember) {
-      if (resolvedMember.channel.status !== "active") {
-        const isBlockedMember = resolvedMember.channel.status === "blocked";
+      if (resolvedMember.status !== "active") {
+        const isBlockedMember = resolvedMember.status === "blocked";
         // Bootstrap commands must pass through for re-verifiable states
         // (pending/revoked), but never for blocked members.
         let denyInactiveMember = true;
@@ -540,7 +541,7 @@ export async function enforceIngressAcl(
             log.info(
               {
                 sourceChannel,
-                channelId: resolvedMember.channel.id,
+                channelId: resolvedMember.channelId,
                 hasValidBootstrapSession: false,
               },
               "Ingress ACL: inactive member bootstrap bypass denied",
@@ -625,11 +626,11 @@ export async function enforceIngressAcl(
         if (!isBlockedMember && denyInactiveMember) {
           if (
             (effectiveAdmissionPolicy === "strangers" &&
-              resolvedMember.channel.status !== "revoked") ||
+              resolvedMember.status !== "revoked") ||
             ((effectiveAdmissionPolicy === "any_contact" ||
               effectiveAdmissionPolicy === "guardian_only") &&
-              (resolvedMember.channel.status === "pending" ||
-                resolvedMember.channel.status === "unverified"))
+              (resolvedMember.status === "pending" ||
+                resolvedMember.status === "unverified"))
           ) {
             denyInactiveMember = false;
           }
@@ -639,8 +640,8 @@ export async function enforceIngressAcl(
           log.info(
             {
               sourceChannel,
-              channelId: resolvedMember.channel.id,
-              status: resolvedMember.channel.status,
+              channelId: resolvedMember.channelId,
+              status: resolvedMember.status,
             },
             "Ingress ACL: member not active, denying",
           );
@@ -650,7 +651,7 @@ export async function enforceIngressAcl(
           // the guardian made an explicit decision to block them.
           if (
             sourceChannel === "slack" &&
-            resolvedMember.channel.status !== "blocked" &&
+            resolvedMember.status !== "blocked" &&
             (canonicalSenderId ?? rawSenderId)
           ) {
             const slackVerifyResult = initiateSlackVerificationChallenge({
@@ -668,7 +669,7 @@ export async function enforceIngressAcl(
                   actorDisplayName,
                   actorUsername,
                   previousMemberStatus: channelStatusToMemberStatus(
-                    resolvedMember.channel.status,
+                    resolvedMember.status,
                   ),
                   messagePreview: truncate(
                     trimmedContent,
@@ -726,7 +727,7 @@ export async function enforceIngressAcl(
           // re-approve. Blocked members are intentionally excluded — the
           // guardian already made an explicit decision to block them.
           let guardianNotified = false;
-          if (resolvedMember.channel.status !== "blocked") {
+          if (resolvedMember.status !== "blocked") {
             try {
               const accessResult = await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
@@ -736,7 +737,7 @@ export async function enforceIngressAcl(
                 actorDisplayName,
                 actorUsername,
                 previousMemberStatus: channelStatusToMemberStatus(
-                  resolvedMember.channel.status,
+                  resolvedMember.status,
                 ),
                 messagePreview: truncate(
                   trimmedContent,
@@ -790,16 +791,16 @@ export async function enforceIngressAcl(
             earlyResponse: {
               accepted: true,
               denied: true,
-              reason: `member_${channelStatusToMemberStatus(resolvedMember.channel.status)}`,
+              reason: `member_${channelStatusToMemberStatus(resolvedMember.status)}`,
               ...(!inactiveReplyDelivered && { replyText: inactiveReplyText }),
             },
           };
         }
       }
 
-      if (resolvedMember.channel.policy === "deny") {
+      if (resolvedMember.policy === "deny") {
         log.info(
-          { sourceChannel, channelId: resolvedMember.channel.id },
+          { sourceChannel, channelId: resolvedMember.channelId },
           "Ingress ACL: member policy deny",
         );
         const denyReplyText =

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -14,7 +14,7 @@ import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { getLogger } from "../../../util/logger.js";
 import { getGuardianBinding } from "../../channel-verification-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "../channel-route-shared.js";
-import type { ResolvedMember } from "./acl-enforcement.js";
+import type { VerdictMember } from "../../trust-verdict-consumer.js";
 
 const log = getLogger("runtime-http");
 
@@ -23,7 +23,7 @@ const log = getLogger("runtime-http");
 // ---------------------------------------------------------------------------
 
 export interface EscalationInterceptParams {
-  resolvedMember: ResolvedMember | null;
+  resolvedMember: VerdictMember | null;
   canonicalAssistantId: string;
   sourceChannel: ChannelId;
   sourceInterface: InterfaceId;
@@ -72,7 +72,7 @@ export async function handleEscalationIntercept(
     rawSenderId,
   } = params;
 
-  if (resolvedMember?.channel.policy !== "escalate") {
+  if (resolvedMember?.policy !== "escalate") {
     return null;
   }
 
@@ -80,7 +80,7 @@ export async function handleEscalationIntercept(
   if (!binding) {
     // Fail-closed: can't escalate without a guardian to route to
     log.info(
-      { sourceChannel, channelId: resolvedMember.channel.id },
+      { sourceChannel, channelId: resolvedMember.channelId },
       "Ingress ACL: escalate policy but no guardian binding, denying",
     );
     return {

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -13,8 +13,8 @@ import { storePayload } from "../../../memory/delivery-crud.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { getLogger } from "../../../util/logger.js";
 import { getGuardianBinding } from "../../channel-verification-service.js";
-import { GUARDIAN_APPROVAL_TTL_MS } from "../channel-route-shared.js";
 import type { VerdictMember } from "../../trust-verdict-consumer.js";
+import { GUARDIAN_APPROVAL_TTL_MS } from "../channel-route-shared.js";
 
 const log = getLogger("runtime-http");
 

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -49,9 +49,9 @@ export interface EscalationInterceptParams {
  * Returns a Response if the escalation was handled (the pipeline should
  * short-circuit), or null to continue the pipeline.
  */
-export function handleEscalationIntercept(
+export async function handleEscalationIntercept(
   params: EscalationInterceptParams,
-): Record<string, unknown> | null {
+): Promise<Record<string, unknown> | null> {
   const {
     resolvedMember,
     canonicalAssistantId,
@@ -76,7 +76,7 @@ export function handleEscalationIntercept(
     return null;
   }
 
-  const binding = getGuardianBinding(canonicalAssistantId, sourceChannel);
+  const binding = await getGuardianBinding(canonicalAssistantId, sourceChannel);
   if (!binding) {
     // Fail-closed: can't escalate without a guardian to route to
     log.info(

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -10,7 +10,6 @@
 import { z } from "zod";
 
 import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -117,16 +116,15 @@ async function handleSurfaceAction({
   const aprDecision = parseCallbackData(actionId, "vellum");
   if (aprDecision) {
     // Resolve the actor's guardian principal ID. In dev mode the synthetic
-    // "dev-bypass" principal won't match the real guardian binding, so fall
-    // back to the local guardian binding — mirrors guardian-action-routes.ts.
+    // "dev-bypass" principal won't match the real guardian binding, so resolve
+    // the local guardian principal — mirrors guardian-action-routes.ts.
     let guardianPrincipalId: string | undefined =
       headers?.["x-vellum-actor-principal-id"] ?? undefined;
     if (
       isHttpAuthDisabled() &&
       headers?.["x-vellum-actor-principal-id"] === "dev-bypass"
     ) {
-      const binding = findGuardianForChannel("vellum");
-      guardianPrincipalId = binding?.contact.principalId ?? undefined;
+      guardianPrincipalId = (await findLocalGuardianPrincipalId()) ?? undefined;
     }
 
     const result = await processGuardianDecision({

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -59,9 +59,9 @@ export type ToolGrantRequestResult =
  * Returns a result indicating whether a new request was created, an existing
  * one was deduped, or the escalation failed (no binding, missing identity).
  */
-export function createOrReuseToolGrantRequest(
+export async function createOrReuseToolGrantRequest(
   params: ToolGrantRequestParams,
-): ToolGrantRequestResult {
+): Promise<ToolGrantRequestResult> {
   const {
     assistantId,
     sourceChannel,
@@ -78,7 +78,7 @@ export function createOrReuseToolGrantRequest(
     return { failed: true, reason: "missing_identity" };
   }
 
-  const binding = getGuardianBinding(assistantId, sourceChannel);
+  const binding = await getGuardianBinding(assistantId, sourceChannel);
   if (!binding) {
     log.debug(
       { sourceChannel, assistantId },

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -152,6 +152,44 @@ function isChannelPolicy(value: string): value is ChannelPolicy {
 }
 
 /**
+ * The ACL fields a gateway verdict carries for a resolved member, decoupled
+ * from the schema-derived {@link ContactChannel}.
+ */
+export interface VerdictMember {
+  contactId: string;
+  channelId: string;
+  status: ChannelStatus;
+  policy: ChannelPolicy;
+  verifiedAt: number | null;
+  displayName: string | null;
+}
+
+/**
+ * Extract the narrow {@link VerdictMember} ACL view from a gateway verdict.
+ *
+ * Mirrors {@link resolvedMemberFromVerdict}'s guards (contactId/channelId
+ * present + known status/policy enums), failing closed to null otherwise.
+ */
+export function verdictMemberFromVerdict(
+  verdict: TrustVerdict,
+): VerdictMember | null {
+  if (!verdict.contactId || !verdict.channelId) return null;
+  if (!verdict.status || !verdict.policy) return null;
+  if (!isChannelStatus(verdict.status) || !isChannelPolicy(verdict.policy)) {
+    return null;
+  }
+
+  return {
+    contactId: verdict.contactId,
+    channelId: verdict.channelId,
+    status: verdict.status,
+    policy: verdict.policy,
+    verifiedAt: verdict.verifiedAt ?? null,
+    displayName: verdict.memberDisplayName ?? null,
+  };
+}
+
+/**
  * Build a synthetic {@link ResolvedMember} from a gateway verdict.
  *
  * ACL + identity only; info fields are placeholders, re-joined locally by

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -224,7 +224,7 @@ export async function startOutbound(
       originConversationId,
     );
   } else if (channel === "phone") {
-    return startOutboundVoice(
+    return await startOutboundVoice(
       params.destination,
       assistantId,
       channel,
@@ -232,7 +232,7 @@ export async function startOutbound(
       originConversationId,
     );
   } else if (channel === "slack") {
-    return startOutboundSlack(
+    return await startOutboundSlack(
       params.destination,
       assistantId,
       channel,
@@ -240,7 +240,7 @@ export async function startOutbound(
       originConversationId,
     );
   } else if (channel === "email") {
-    return startOutboundEmail(
+    return await startOutboundEmail(
       params.destination,
       assistantId,
       channel,
@@ -274,7 +274,7 @@ async function startOutboundTelegram(
     };
   }
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,
@@ -394,13 +394,13 @@ async function startOutboundTelegram(
   };
 }
 
-function startOutboundVoice(
+async function startOutboundVoice(
   rawDestination: string | undefined,
   assistantId: string,
   channel: ChannelId,
   rebind?: boolean,
   originConversationId?: string,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   if (!rawDestination) {
     return {
       success: false,
@@ -422,7 +422,7 @@ function startOutboundVoice(
     };
   }
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,
@@ -591,13 +591,13 @@ export function deliverVerificationEmail(
   })();
 }
 
-function startOutboundSlack(
+async function startOutboundSlack(
   destination: string | undefined,
   assistantId: string,
   channel: ChannelId,
   rebind?: boolean,
   originConversationId?: string,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   if (!destination) {
     return {
       success: false,
@@ -607,7 +607,7 @@ function startOutboundSlack(
     };
   }
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,
@@ -669,13 +669,13 @@ function startOutboundSlack(
   };
 }
 
-function startOutboundEmail(
+async function startOutboundEmail(
   destination: string | undefined,
   assistantId: string,
   channel: ChannelId,
   rebind?: boolean,
   originConversationId?: string,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   if (!destination) {
     return {
       success: false,
@@ -688,7 +688,7 @@ function startOutboundEmail(
 
   const normalizedEmail = destination.trim().toLowerCase();
 
-  const existingBinding = getGuardianBinding(assistantId, channel);
+  const existingBinding = await getGuardianBinding(assistantId, channel);
   if (existingBinding && !rebind) {
     return {
       success: false,

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -21,7 +21,7 @@ import {
   countRecentSendsToDestination,
   createOutboundSession,
   findActiveSession,
-  getGuardianBinding,
+  isGuardianBoundForChannel,
   updateSessionDelivery,
   updateSessionStatus,
 } from "./channel-verification-service.js";
@@ -274,8 +274,8 @@ async function startOutboundTelegram(
     };
   }
 
-  const existingBinding = await getGuardianBinding(assistantId, channel);
-  if (existingBinding && !rebind) {
+  const alreadyBound = await isGuardianBoundForChannel(channel);
+  if (alreadyBound && !rebind) {
     return {
       success: false,
       error: "already_bound",
@@ -422,8 +422,8 @@ async function startOutboundVoice(
     };
   }
 
-  const existingBinding = await getGuardianBinding(assistantId, channel);
-  if (existingBinding && !rebind) {
+  const alreadyBound = await isGuardianBoundForChannel(channel);
+  if (alreadyBound && !rebind) {
     return {
       success: false,
       error: "already_bound",
@@ -607,8 +607,8 @@ async function startOutboundSlack(
     };
   }
 
-  const existingBinding = await getGuardianBinding(assistantId, channel);
-  if (existingBinding && !rebind) {
+  const alreadyBound = await isGuardianBoundForChannel(channel);
+  if (alreadyBound && !rebind) {
     return {
       success: false,
       error: "already_bound",
@@ -688,8 +688,8 @@ async function startOutboundEmail(
 
   const normalizedEmail = destination.trim().toLowerCase();
 
-  const existingBinding = await getGuardianBinding(assistantId, channel);
-  if (existingBinding && !rebind) {
+  const alreadyBound = await isGuardianBoundForChannel(channel);
+  if (alreadyBound && !rebind) {
     return {
       success: false,
       error: "already_bound",

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -553,7 +553,7 @@ export class ToolApprovalHandler {
         const inputDigest =
           deferredConsumeParams?.inputDigest ??
           computeToolApprovalDigest(name, input);
-        const escalation = createOrReuseToolGrantRequest({
+        const escalation = await createOrReuseToolGrantRequest({
           assistantId: context.assistantId,
           sourceChannel: context.executionChannel as ChannelId,
           conversationId: context.conversationId,

--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -8,11 +8,6 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import { desc, eq } from "drizzle-orm";
-
-import { generateUserFileSlug } from "../../contacts/contact-store.js";
-import { getDb } from "../../memory/db-connection.js";
-import { contacts } from "../../memory/schema/contacts.js";
 import type { WorkspaceMigration } from "./types.js";
 
 // ── Inlined helpers ───────────────────────────────────────────────
@@ -122,35 +117,9 @@ export const seedPersonaDirsMigration: WorkspaceMigration = {
     // template from disk, since migration 031 deletes that template file.
     if (content === LEGACY_USER_MD_TEMPLATE_STRIPPED) return;
 
-    // Determine destination filename based on guardian contact
-    let destFilename = "guardian.md";
-    try {
-      const db = getDb();
-      const guardian = db
-        .select()
-        .from(contacts)
-        .where(eq(contacts.role, "guardian"))
-        .orderBy(desc(contacts.createdAt))
-        .limit(1)
-        .get();
-
-      if (guardian) {
-        if (guardian.userFile) {
-          destFilename = guardian.userFile;
-        } else {
-          const slug = generateUserFileSlug(guardian.displayName);
-          db.update(contacts)
-            .set({ userFile: slug })
-            .where(eq(contacts.id, guardian.id))
-            .run();
-          destFilename = slug;
-        }
-      }
-    } catch {
-      // DB might not be initialized yet — fall back to guardian.md
-    }
-
-    const destPath = join(workspaceDir, "users", destFilename);
+    // Seed the canonical `users/guardian.md` — the runtime persona resolver
+    // falls back to this name, so no assistant-DB lookup is needed.
+    const destPath = join(workspaceDir, "users", "guardian.md");
     if (!existsSync(destPath)) {
       copyFileSync(userMdPath, destPath);
     }

--- a/assistant/src/workspace/migrations/019-scope-journal-to-guardian.ts
+++ b/assistant/src/workspace/migrations/019-scope-journal-to-guardian.ts
@@ -8,10 +8,6 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import { desc, eq } from "drizzle-orm";
-
-import { getDb } from "../../memory/db-connection.js";
-import { contacts } from "../../memory/schema/contacts.js";
 import type { WorkspaceMigration } from "./types.js";
 
 export const scopeJournalToGuardianMigration: WorkspaceMigration = {
@@ -40,26 +36,9 @@ export const scopeJournalToGuardianMigration: WorkspaceMigration = {
     });
     if (mdFiles.length === 0) return;
 
-    // Resolve guardian user slug (same pattern as 017-seed-persona-dirs)
-    let slug = "guardian";
-    try {
-      const db = getDb();
-      const guardian = db
-        .select()
-        .from(contacts)
-        .where(eq(contacts.role, "guardian"))
-        .orderBy(desc(contacts.createdAt))
-        .limit(1)
-        .get();
-      if (guardian?.userFile) {
-        slug = guardian.userFile.replace(/\.md$/, "");
-      }
-    } catch {
-      // DB not ready — use fallback "guardian"
-    }
-
-    // Create per-user directory and move files (renameSync preserves birthtimes)
-    const destDir = join(journalDir, slug);
+    // Scope under the canonical `guardian` slug — the runtime resolver falls
+    // back to it, so no assistant-DB lookup is needed.
+    const destDir = join(journalDir, "guardian");
     mkdirSync(destDir, { recursive: true });
     for (const f of mdFiles) {
       const src = join(journalDir, f);


### PR DESCRIPTION
## Summary
Phase A of retiring the 11 redundant assistant-DB ACL columns (`contacts.role/principalId`; `contact_channels.status/policy/verifiedAt/verifiedVia/revokedReason/blockedReason/lastSeenAt/interactionCount/lastInteraction`). Moves every non-voice consumer off those fields so nothing reads ACL from the assistant DB — **columns stay in place**, so this is deploy-safe. The destructive drop + write-side migration live in Phase B (`combo11-phase-b-write-and-drop.md`), which requires all of Phase A merged first.

## PRs merged into this feature branch
- #35874 — PR 1: verdict-owned member ACL type (`VerdictMember` + `verdictMemberFromVerdict`)
- #35885 — PR 2: ACL gates (acl-enforcement / escalation-intercept / inbound-message-handler) consume `VerdictMember`
- #35878 — PR 3: contacts API serves role/status/stats from the gateway relay only (fail-closed)
- #35882 — PR 4: channel-verification synthesizes guardian binding from gateway delivery
- #35879 — PR 5: config-channels revoke/verify gates derive from gateway delivery
- #35875 — PR 6: config-a2a readiness derived without the status column
- #35886 — PR 7: invite redemption already-member/blocked gate via gateway verdict
- #35887 — PR 8: contacts skill tools read role/stats from the gateway-relayed read
- #35884 — PR 9: global-search recency ordering off `updatedAt` (not lastInteraction)
- #35876 — PR 10: dev-bypass principal resolved via gateway identity
- #35877 — PR 11: migrations 017/019 resolve guardian without the role column

## Notes for review
- **PR 4 has the largest blast radius**: making `getGuardianBinding`/`isGuardian` async cascaded `await` through ~13 production files + their tests. Worth focused review.
- **PR 3** intentionally leaves two daemon-native read paths (true-search + contactType-filter) reading the assistant DB — gateway-native search is design-blocked; out of scope for Phase A.
- The base was rebased onto current main to pick up #35872 (image-fallback/v0.10.1 CI fix) that landed mid-run.

Part of plan: combo11-phase-a-read-decoupling.md