### PR TITLE
Fix computer-use from surface-action turns + observe warts

### DIFF
--- a/assistant/src/__tests__/computer-use-tools.test.ts
+++ b/assistant/src/__tests__/computer-use-tools.test.ts
@@ -6,6 +6,7 @@ import {
   computerUseDoneTool,
   computerUseDragTool,
   computerUseKeyTool,
+  computerUseObserveTool,
   computerUseOpenAppTool,
   computerUseRespondTool,
   computerUseRunAppleScriptTool,
@@ -55,6 +56,18 @@ describe("computer-use tool definitions", () => {
     for (const tool of allComputerUseTools) {
       expect(tool.description!.length).toBeGreaterThan(0);
     }
+  });
+});
+
+// ── observe ─────────────────────────────────────────────────────────
+
+describe("computer_use_observe", () => {
+  test("supports target_client_id", () => {
+    const props = schema(computerUseObserveTool).properties as Record<
+      string,
+      { type: string }
+    >;
+    expect(props.target_client_id.type).toBe("string");
   });
 });
 

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -26,6 +26,7 @@ interface ProcessMessageCall {
   requestId?: string;
   activeSurfaceId?: string;
   displayContent?: string;
+  sourceActorPrincipalId?: string;
 }
 
 function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
@@ -69,6 +70,7 @@ function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
         requestId: options.requestId,
         activeSurfaceId: options.activeSurfaceId,
         displayContent: options.displayContent,
+        sourceActorPrincipalId: options.sourceActorPrincipalId,
       });
       return "msg-1";
     },
@@ -141,6 +143,69 @@ describe("surface action delivery to assistant", () => {
 
     // Verify the requestId was tracked as a surface action
     expect(ctx.surfaceActionRequestIds.size).toBe(1);
+  });
+
+  test("idle pending follow-up path threads submitter principal into processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "table",
+      title: "Items",
+      data: {
+        columns: [{ id: "name", label: "Name" }],
+        rows: [{ id: "r1", cells: { name: "Item 1" } }],
+      },
+      actions: [{ id: "archive", label: "Archive" }],
+    });
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+
+    await handleSurfaceAction(
+      ctx,
+      surfaceId,
+      "archive",
+      { selectedIds: ["r1"] },
+      "principal-committer",
+    );
+
+    expect(ctx.processMessageCalls.length).toBe(1);
+    expect(ctx.processMessageCalls[0].sourceActorPrincipalId).toBe(
+      "principal-committer",
+    );
+  });
+
+  test("idle history-restored path threads submitter principal into processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // History-restored surface: surfaceState exists, pendingSurfaceActions
+    // does not — exercises the immediate (idle) fallthrough.
+    ctx.surfaceState.set("hist-surface-p", {
+      surfaceType: "table",
+      data: {
+        columns: [{ id: "col", label: "Col" }],
+        rows: [],
+      } as unknown as SurfaceData,
+      title: "History Table",
+      actions: [{ id: "delete", label: "Delete" }],
+    });
+
+    await handleSurfaceAction(
+      ctx,
+      "hist-surface-p",
+      "delete",
+      { selectedIds: ["row-1"] },
+      "principal-committer",
+    );
+
+    expect(ctx.processMessageCalls.length).toBe(1);
+    expect(ctx.processMessageCalls[0].sourceActorPrincipalId).toBe(
+      "principal-committer",
+    );
   });
 
   test("table action without selection data still triggers processMessage", async () => {

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -8,7 +8,12 @@
       "risk": "low",
       "input_schema": {
         "type": "object",
-        "properties": {},
+        "properties": {
+          "target_client_id": {
+            "type": "string",
+            "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
+          }
+        },
         "required": []
       },
       "executor": "tools/computer-use-observe.ts",

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1386,6 +1386,8 @@ export interface ProcessMessageOptions {
    */
   overrideProfile?: string;
   displayContent?: string;
+  /** JWT-verified committer principal for turn-scoped host-proxy authorization. */
+  sourceActorPrincipalId?: string;
 }
 
 // ── processMessage ───────────────────────────────────────────────────
@@ -1409,6 +1411,7 @@ export async function processMessage(
     callSite,
     overrideProfile,
     displayContent,
+    sourceActorPrincipalId,
   } = options;
   await conversation.ensureActorScopedHistory();
   // Snapshot persona context at turn start so later tool turns can't pick up
@@ -1416,7 +1419,7 @@ export async function processMessage(
   conversation.currentTurnTrustContext = conversation.trustContext;
   conversation.currentTurnAuthContext = conversation.authContext;
   conversation.currentTurnSourceActorPrincipalId =
-    conversation.authContext?.actorPrincipalId;
+    sourceActorPrincipalId ?? conversation.authContext?.actorPrincipalId;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
   conversation.currentActiveSurfaceId = activeSurfaceId;

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1695,6 +1695,10 @@ export async function handleSurfaceAction(
   surfaceId: string,
   actionId: string,
   data?: Record<string, unknown>,
+  // JWT-verified committer principal; threaded so enqueued turns can
+  // reconstruct the same-user binding for host proxies (CU / app-control),
+  // mirroring the normal message path.
+  sourceActorPrincipalId?: string,
 ): Promise<SurfaceActionResult> {
   // ── Standalone surface interception ──────────────────────────────
   // Daemon-driven surfaces (from `requestInteractiveUi`) register a
@@ -1987,6 +1991,7 @@ export async function handleSurfaceAction(
       requestId,
       activeSurfaceId: surfaceId,
       displayContent,
+      sourceActorPrincipalId,
     });
 
     if (result.rejected) {
@@ -2043,6 +2048,7 @@ export async function handleSurfaceAction(
         requestId,
         activeSurfaceId: surfaceId,
         displayContent,
+        sourceActorPrincipalId,
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
@@ -2233,6 +2239,7 @@ export async function handleSurfaceAction(
     requestId,
     activeSurfaceId: surfaceId,
     displayContent,
+    sourceActorPrincipalId,
   });
   if (result.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
@@ -2336,6 +2343,7 @@ export async function handleSurfaceAction(
       requestId,
       activeSurfaceId: surfaceId,
       displayContent,
+      sourceActorPrincipalId,
     })
     .catch((err) => {
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2049,8 +2049,15 @@ export class Conversation {
     surfaceId: string,
     actionId: string,
     data?: Record<string, unknown>,
+    sourceActorPrincipalId?: string,
   ): Promise<SurfaceActionResult> {
-    return handleSurfaceActionImpl(this, surfaceId, actionId, data);
+    return handleSurfaceActionImpl(
+      this,
+      surfaceId,
+      actionId,
+      data,
+      sourceActorPrincipalId,
+    );
   }
 
   handleSurfaceUndo(surfaceId: string): void {

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -30,6 +30,7 @@ interface StubConversation {
     surfaceId: string;
     actionId: string;
     data: unknown;
+    sourceActorPrincipalId?: string;
   }>;
 }
 
@@ -148,8 +149,14 @@ function makeStub(id: string): StubConversation {
       surfaceId: string,
       actionId: string,
       data: unknown,
+      sourceActorPrincipalId?: string,
     ) => {
-      stub.surfaceActionCalls.push({ surfaceId, actionId, data });
+      stub.surfaceActionCalls.push({
+        surfaceId,
+        actionId,
+        data,
+        sourceActorPrincipalId,
+      });
       if (stub.handleSurfaceActionThrows) throw stub.handleSurfaceActionThrows;
       return stub.handleSurfaceActionResult;
     },
@@ -357,6 +364,50 @@ describe("triggerSurfaceAction handler", () => {
     expect(rawGetCalls).toHaveLength(1);
     expect(rawGetCalls[0]!.sql).toContain("ESCAPE");
     expect(rawGetCalls[0]!.params).toEqual([`%"surfaceId":"\\%"%`]);
+  });
+
+  test("threads x-vellum-actor-principal-id into handleSurfaceAction", async () => {
+    const live = makeStub("conv-principal");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-p", actionId: "act-p" },
+      headers: { "x-vellum-actor-principal-id": "principal-committer" },
+    });
+
+    expect(live.surfaceActionCalls).toEqual([
+      {
+        surfaceId: "surf-p",
+        actionId: "act-p",
+        data: undefined,
+        sourceActorPrincipalId: "principal-committer",
+      },
+    ]);
+  });
+
+  test("resolves dev-bypass to the guardian principal before threading the turn", async () => {
+    httpAuthDisabled = true;
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-dev-thread");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-dt", actionId: "act-dt" },
+      headers: { "x-vellum-actor-principal-id": "dev-bypass" },
+    });
+
+    // dev-bypass is translated so the surface turn matches the SSE host-proxy
+    // client's registered guardian principal (CU/app-control same-actor check).
+    expect(live.surfaceActionCalls).toEqual([
+      {
+        surfaceId: "surf-dt",
+        actionId: "act-dt",
+        data: undefined,
+        sourceActorPrincipalId: GUARDIAN_PRINCIPAL,
+      },
+    ]);
   });
 
   test("propagates accepted=false rejection as BadRequestError", async () => {

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -16,7 +16,10 @@ import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
-import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
+import {
+  findLocalGuardianPrincipalId,
+  resolveActorPrincipalIdForLocalGuardian,
+} from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import { parseCallbackData } from "./channel-route-shared.js";
 import {
@@ -176,11 +179,18 @@ async function handleSurfaceAction({
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
   await applyTrustContext(conversation, actorPrincipalId);
 
+  // Translate dev-bypass → real guardian so the surface turn's principal matches
+  // the SSE host-proxy client's registered principal; otherwise CU/app-control
+  // same-actor checks reject the turn. Real principals pass through unchanged.
+  const resolvedActorPrincipalId =
+    await resolveActorPrincipalIdForLocalGuardian(actorPrincipalId ?? undefined);
+
   try {
     const raw = await conversation.handleSurfaceAction(
       surfaceId,
       actionId,
       data,
+      resolvedActorPrincipalId,
     );
     const result =
       raw && typeof raw === "object" && "accepted" in raw

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -437,7 +437,7 @@ export const computerUseRespondTool = {
 // observe
 // ---------------------------------------------------------------------------
 
-const computerUseObserveTool = {
+export const computerUseObserveTool = {
   name: "computer_use_observe",
   description:
     "Capture the current screen state. Returns the accessibility tree with [ID] element references and optionally a screenshot.\n\nThe accessibility tree shows interactive elements like [3] AXButton 'Save' or [17] AXTextField 'Search'. Use element_id to target these elements in subsequent actions - this is much more reliable than pixel coordinates.\n\nCall this before your first computer use action, or to check screen state without acting.",
@@ -447,7 +447,13 @@ const computerUseObserveTool = {
 
   input_schema: {
     type: "object",
-    properties: {},
+    properties: {
+      target_client_id: {
+        type: "string",
+        description:
+          "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`.",
+      },
+    },
     required: [],
   },
 

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -174,6 +174,13 @@ enum HostCuActionRunner {
             } catch {
                 log.warning("Post-action delay interrupted: \(error)")
             }
+        } else {
+            // Observe-only skips the action-path gate, but AX enumeration silently
+            // returns an empty tree without Accessibility. Surface the same hint the
+            // action path gives instead of returning a bare empty observation.
+            if !ActionExecutor.checkAccessibilityPermission(prompt: true) {
+                executionError = "Accessibility permission not granted. Grant Vellum access in System Settings > Privacy & Security > Accessibility, then retry."
+            }
         }
 
         // OBSERVE — capture AX tree, screenshot, etc.


### PR DESCRIPTION
## Summary
Fixes computer-use (CU) / app-control being blocked when a turn is triggered from a UI surface-action button instead of a typed chat message, plus two observe-path warts.

- **Bug 1 — surface-action actor identity (#35890):** Thread the surface-action submitter's actor principal (`x-vellum-actor-principal-id`) through `handleSurfaceAction` into the turn so the same-user binding that gates `host_cu` / `host_app_control` resolves. Covers both the queued (`enqueueMessage`) and idle (`processMessage`) dispatch paths, and resolves the `dev-bypass` synthetic principal to the local guardian so CU works in local `DISABLE_HTTP_AUTH` deployments.
- **Wart 2 — observe permission hint (#35888):** observe-only CU now surfaces the same Accessibility-permission hint the action path gives, instead of returning a bare empty observation.
- **Wart 3 — observe targeting schema (#35889):** `computer_use_observe` now accepts `target_client_id`, matching the action tools.

## Self-review result
PASS — 4 independent fresh-eyes passes (external feedback, plan faithfulness, repo integration, slop/reuse). Two Codex findings on #35890 (P1 idle-path threading, P2 dev-bypass normalization) were caught and fixed during the per-PR review gate before merge.

## PRs merged into feature branch
- #35888: fix(macos): surface Accessibility-permission hint on observe-only computer-use
- #35889: fix(computer-use): accept target_client_id on computer_use_observe schema
- #35890: fix(surfaces): thread submitter actor principal into surface-action turns (incl. idle-path + dev-bypass fixes)

## Optional follow-ups (non-blocking, surfaced by self-review)
- **DRY:** `surface-action-routes.ts` resolves `dev-bypass`→guardian twice per request (once in `applyTrustContext`, once in the new `resolveActorPrincipalIdForLocalGuardian` call). Cheap (5-min cached, single-flight) but duplicated logic with slightly divergent miss-semantics. Could consolidate to one resolution.
- **DRY:** the Accessibility-permission hint string is now triplicated in Swift (`HostCuExecutor.swift` action + observe paths, `AppControlExecutor.swift`); could extract a shared `static let`.
- **Pre-existing, out of scope:** the normal typed-message path (`conversation-routes.ts:1515`) also threads the raw `dev-bypass` header as `sourceActorPrincipalId`, so CU from a *typed* message may be subtly broken in `DISABLE_HTTP_AUTH` mode for the same reason this PR fixes for surfaces. Not touched here; worth a separate check.

Part of plan: cu-surface-fixes.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->