### PR TITLE
feat(web): workflow detail panel Figma redesign

### DIFF
--- a/clients/web/src/domains/chat/components/status-badge-pill.tsx
+++ b/clients/web/src/domains/chat/components/status-badge-pill.tsx
@@ -1,0 +1,31 @@
+/**
+ * Shared status-badge pill — the presentational shell behind both
+ * `StatusBadge` (subagent) and `WorkflowStatusBadge` (workflow). Each wrapper
+ * resolves its own status enum's `statusColor`/`statusLabel` and feeds them in,
+ * so the two badges are guaranteed identical in size and shape.
+ *
+ * `h-[23px]` and `rounded-[6px]` match the Figma mock (node 6063-150536) —
+ * deliberately more rectangular than the design scale's `--radius-md` (8px).
+ * The scale has no 6px token (sm=4, md=8), hence the explicit arbitrary values;
+ * the fixed height pins the badge to the mock rather than letting the
+ * line-height + padding determine it.
+ */
+export function StatusBadgePill({
+  color,
+  label,
+}: {
+  color: string;
+  label: string;
+}) {
+  return (
+    <span
+      className="inline-flex h-[23px] shrink-0 items-center gap-1 rounded-[6px] px-2 text-body-small-emphasised"
+      style={{
+        color,
+        backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)`,
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/clients/web/src/domains/chat/components/stop-button.tsx
+++ b/clients/web/src/domains/chat/components/stop-button.tsx
@@ -1,0 +1,29 @@
+import { Square } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+/**
+ * Outline "Stop" button shared by the workflow + subagent detail panel headers,
+ * so both share one set of dimensions (h-8, `Square` glyph, negative-strong
+ * outline that fills on hover). The label/aria copy varies per panel, so the
+ * caller supplies `ariaLabel` and `onClick`.
+ */
+export function StopButton({
+  onClick,
+  ariaLabel,
+}: {
+  onClick: () => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--system-negative-strong)] bg-transparent px-2.5 py-1.5 text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--system-negative-weak)]"
+    >
+      <Square className="h-3 w-3" fill="currentColor" />
+      <Typography variant="label-small-default">Stop</Typography>
+    </button>
+  );
+}

--- a/clients/web/src/domains/chat/components/subagent-status-badge.tsx
+++ b/clients/web/src/domains/chat/components/subagent-status-badge.tsx
@@ -3,23 +3,10 @@ import {
   statusColor,
   statusLabel,
 } from "@/utils/subagent-status";
+import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
 
 export function StatusBadge({ status }: { status: SubagentStatus }) {
-  const color = statusColor(status);
-  // `rounded-[6px]` and `h-[23px]` match the Figma mock (node 6063-150536) —
-  // deliberately more rectangular than the design scale's `--radius-md` (8px).
-  // The scale has no 6px token (sm=4, md=8), hence the explicit arbitrary
-  // values; the fixed height pins the badge to the mock rather than letting the
-  // line-height + padding determine it.
   return (
-    <span
-      className="inline-flex h-[23px] shrink-0 items-center gap-1 rounded-[6px] px-2 text-body-small-emphasised"
-      style={{
-        color,
-        backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)`,
-      }}
-    >
-      {statusLabel(status)}
-    </span>
+    <StatusBadgePill color={statusColor(status)} label={statusLabel(status)} />
   );
 }

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
@@ -1,10 +1,11 @@
 /**
- * The detail panel renders the run header (label + status badge) and a live
- * leaf tree. Each leaf row is keyed by `seq` and shows a status icon that
- * resolves in place — a spinner while running, a check when completed, an
- * alert when failed. The panel asks its host to fetch the journal on open
- * and again when the run reaches a terminal state, reconciling leaves a
- * dropped SSE event left stale.
+ * The detail panel renders the run header (icon tile + label + status badge),
+ * a metrics row, an Objective section, and a live "Subagents" list. Each
+ * subagent row is keyed by `seq` and shows a lead indicator that resolves in
+ * place — a three-dot pulse while running, a status glyph once terminal — the
+ * leaf's task name, and its latest activity. The panel asks its host to fetch
+ * the journal on open and again when the run reaches a terminal state,
+ * reconciling leaves a dropped SSE event left stale.
  */
 
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
@@ -14,6 +15,14 @@ mock.module("@/domains/chat/components/workflow-status-badge", () => ({
   WorkflowStatusBadge: ({ status }: { status: string }) => (
     <div data-testid="status-badge" data-status={status} />
   ),
+}));
+
+// Stub the avatar renderer so rows don't depend on the lazily-imported bundled
+// SVG chunk. (Mock the renderer, not `useBundledAvatarComponents` — Bun module
+// mocks are process-global and survive `mock.restore()`, so mocking the hook
+// here would leak into other files' tests that rely on the real one.)
+mock.module("@/components/avatar-renderer", () => ({
+  AvatarRenderer: () => <div data-testid="avatar" />,
 }));
 
 import { WorkflowDetailPanel } from "@/domains/chat/components/workflow-detail-panel";
@@ -81,12 +90,17 @@ describe("WorkflowDetailPanel", () => {
     expect(screen.getByText("run-xyz")).toBeDefined();
   });
 
-  test("renders one row per leaf with the correct status icon", () => {
+  test("renders one row per leaf with task name, activity, and a running indicator", () => {
     const { container } = render(
       <WorkflowDetailPanel
         entry={makeEntry({
           leaves: leafMap([
-            makeLeaf({ seq: 0, label: "Running leaf", status: "running" }),
+            makeLeaf({
+              seq: 0,
+              label: "Running leaf",
+              promptSummary: "Searching the web",
+              status: "running",
+            }),
             makeLeaf({ seq: 1, label: "Done leaf", status: "completed" }),
             makeLeaf({ seq: 2, label: "Broken leaf", status: "failed" }),
           ]),
@@ -98,9 +112,14 @@ describe("WorkflowDetailPanel", () => {
     expect(screen.getByText("Running leaf")).toBeDefined();
     expect(screen.getByText("Done leaf")).toBeDefined();
     expect(screen.getByText("Broken leaf")).toBeDefined();
+    // The running leaf's latest activity renders after the divider.
+    expect(screen.getByText("Searching the web")).toBeDefined();
 
-    // The running leaf shows a spinner.
-    expect(container.querySelectorAll(".animate-spin").length).toBe(1);
+    // Exactly one leaf is running, so the three-dot running indicator (3 dots)
+    // appears once; the terminal leaves show a static status icon instead of a
+    // spinner.
+    expect(container.querySelectorAll(".busy-indicator").length).toBe(3);
+    expect(container.querySelectorAll(".animate-spin").length).toBe(0);
   });
 
   test("renders the neutral cancelled icon for a cancelled leaf", () => {
@@ -115,10 +134,15 @@ describe("WorkflowDetailPanel", () => {
       />,
     );
 
-    // The cancelled icon carries an accessible "Cancelled" label and is
-    // neither the spinner nor the error icon.
+    // The cancelled icon carries an accessible "Cancelled" label and is not the
+    // running indicator.
     expect(screen.getByLabelText("Cancelled")).toBeDefined();
-    expect(container.querySelectorAll(".animate-spin").length).toBe(0);
+    expect(container.querySelectorAll(".busy-indicator").length).toBe(0);
+  });
+
+  test("shows an empty state when there are no subagents yet", () => {
+    render(<WorkflowDetailPanel entry={makeEntry({ leaves: new Map() })} onClose={noop} />);
+    expect(screen.getByText("No subagents yet")).toBeDefined();
   });
 
   test("requests the journal on open even when leaves are already present", () => {
@@ -191,29 +215,6 @@ describe("WorkflowDetailPanel", () => {
 
     // Same run, same (live) phase — the effect's deps are unchanged.
     expect(requested).toEqual(["run-stable"]);
-  });
-
-  test("renders the latest log message near the phase banner", () => {
-    render(
-      <WorkflowDetailPanel
-        entry={makeEntry({ phase: "Executing", message: "halfway there" })}
-        onClose={noop}
-      />,
-    );
-
-    expect(screen.getByText("Executing")).toBeDefined();
-    expect(screen.getByText("halfway there")).toBeDefined();
-  });
-
-  test("renders a log message even when no phase is set", () => {
-    render(
-      <WorkflowDetailPanel
-        entry={makeEntry({ phase: undefined, message: "still working" })}
-        onClose={noop}
-      />,
-    );
-
-    expect(screen.getByText("still working")).toBeDefined();
   });
 
   test("shows the Stop button only for an active run", () => {

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 mock.module("@/domains/chat/components/workflow-status-badge", () => ({
   WorkflowStatusBadge: ({ status }: { status: string }) => (
@@ -143,6 +143,94 @@ describe("WorkflowDetailPanel", () => {
   test("shows an empty state when there are no subagents yet", () => {
     render(<WorkflowDetailPanel entry={makeEntry({ leaves: new Map() })} onClose={noop} />);
     expect(screen.getByText("No subagents yet")).toBeDefined();
+  });
+
+  test("clicking a subagent row opens its detail with separate Prompt and Result sections", () => {
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({
+          leaves: leafMap([
+            makeLeaf({
+              seq: 0,
+              label: "Research leaf",
+              status: "completed",
+              promptSummary: "Search the web for X",
+              resultSummary: "Found three sources",
+            }),
+          ]),
+        })}
+        onClose={noop}
+      />,
+    );
+
+    // List view first — no Prompt/Result sections, no breadcrumb back.
+    expect(screen.getByText("Subagents")).toBeDefined();
+    expect(screen.queryByText("Prompt")).toBeNull();
+    expect(screen.queryByLabelText("Back to subagents")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Research leaf details" }),
+    );
+
+    // Detail view: prompt and result render as two separate, labeled sections.
+    expect(screen.getByText("Prompt")).toBeDefined();
+    expect(screen.getByText("Search the web for X")).toBeDefined();
+    expect(screen.getByText("Result")).toBeDefined();
+    expect(screen.getByText("Found three sources")).toBeDefined();
+    // The breadcrumb back affordance appears; the list is gone.
+    expect(screen.getByLabelText("Back to subagents")).toBeDefined();
+    expect(screen.queryByText("Subagents")).toBeNull();
+  });
+
+  test("Back returns from a leaf detail to the subagents list", () => {
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({
+          leaves: leafMap([
+            makeLeaf({
+              seq: 0,
+              label: "Research leaf",
+              status: "completed",
+              resultSummary: "done",
+            }),
+          ]),
+        })}
+        onClose={noop}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Research leaf details" }),
+    );
+    expect(screen.getByText("Prompt")).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText("Back to subagents"));
+    expect(screen.getByText("Subagents")).toBeDefined();
+    expect(screen.queryByText("Prompt")).toBeNull();
+  });
+
+  test("a running leaf with no result shows a running state in the Result section", () => {
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({
+          leaves: leafMap([
+            makeLeaf({
+              seq: 0,
+              label: "Busy leaf",
+              status: "running",
+              promptSummary: "Working on it",
+            }),
+          ]),
+        })}
+        onClose={noop}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Busy leaf details" }),
+    );
+    expect(screen.getByText("Working on it")).toBeDefined();
+    expect(screen.getByText("Running…")).toBeDefined();
   });
 
   test("requests the journal on open even when leaves are already present", () => {

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
@@ -15,6 +15,9 @@ mock.module("@/domains/chat/components/workflow-status-badge", () => ({
   WorkflowStatusBadge: ({ status }: { status: string }) => (
     <div data-testid="status-badge" data-status={status} />
   ),
+  WorkflowLeafStatusBadge: ({ status }: { status: string }) => (
+    <div data-testid="leaf-status-badge" data-status={status} />
+  ),
 }));
 
 // Stub the avatar renderer so rows don't depend on the lazily-imported bundled
@@ -180,6 +183,37 @@ describe("WorkflowDetailPanel", () => {
     // The breadcrumb back affordance appears; the list is gone.
     expect(screen.getByLabelText("Back to subagents")).toBeDefined();
     expect(screen.queryByText("Subagents")).toBeNull();
+  });
+
+  test("the drilled-in leaf header shows the leaf's status, not the parent workflow's", () => {
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({
+          status: "running",
+          leaves: leafMap([
+            makeLeaf({ seq: 0, label: "Failed leaf", status: "failed" }),
+          ]),
+        })}
+        onClose={noop}
+      />,
+    );
+
+    // List view: the badge reflects the (running) parent workflow.
+    expect(screen.getByTestId("status-badge").getAttribute("data-status")).toBe(
+      "running",
+    );
+    expect(screen.queryByTestId("leaf-status-badge")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Failed leaf details" }),
+    );
+
+    // Leaf view: the badge reflects the selected leaf (failed), and the parent
+    // workflow badge is gone.
+    expect(
+      screen.getByTestId("leaf-status-badge").getAttribute("data-status"),
+    ).toBe("failed");
+    expect(screen.queryByTestId("status-badge")).toBeNull();
   });
 
   test("Back returns from a leaf detail to the subagents list", () => {

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -18,7 +18,10 @@ import {
 } from "@/domains/chat/components/metric-card";
 import { StopButton } from "@/domains/chat/components/stop-button";
 import { WorkflowLeafDetail } from "@/domains/chat/components/workflow-leaf-detail";
-import { WorkflowStatusBadge } from "@/domains/chat/components/workflow-status-badge";
+import {
+    WorkflowLeafStatusBadge,
+    WorkflowStatusBadge,
+} from "@/domains/chat/components/workflow-status-badge";
 import { WorkflowSubagentRow } from "@/domains/chat/components/workflow-subagent-row";
 import type { WorkflowEntry } from "@/domains/chat/workflow-store";
 import { subagentTraits } from "@/utils/avatar-subagent";
@@ -165,7 +168,11 @@ export function WorkflowDetailPanel({
         >
           {headerTitle}
         </Typography>
-        <WorkflowStatusBadge status={entry.status} />
+        {selectedLeaf ? (
+          <WorkflowLeafStatusBadge status={selectedLeaf.status} />
+        ) : (
+          <WorkflowStatusBadge status={entry.status} />
+        )}
         <span className="flex-1" />
         {isRunning && onStop && (
           <StopButton

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -2,141 +2,24 @@
 import {
     ArrowDownToLine,
     ArrowUpFromLine,
-    Ban,
-    CircleCheck,
-    Loader2,
-    TriangleAlert,
     Users,
     Workflow,
     X,
 } from "lucide-react";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import {
     AnimatedMetricCard,
     formatNumber,
 } from "@/domains/chat/components/metric-card";
+import { StopButton } from "@/domains/chat/components/stop-button";
 import { WorkflowStatusBadge } from "@/domains/chat/components/workflow-status-badge";
-import type { WorkflowEntry, WorkflowLeaf } from "@/domains/chat/workflow-store";
+import { WorkflowSubagentRow } from "@/domains/chat/components/workflow-subagent-row";
+import type { WorkflowEntry } from "@/domains/chat/workflow-store";
 import { isActiveStatus } from "@/utils/workflow-status";
-import { Button, cn, Typography } from "@vellumai/design-library";
-
-// ---------------------------------------------------------------------------
-// Leaf tree
-// ---------------------------------------------------------------------------
-
-function LeafStatusIcon({ status }: { status: WorkflowLeaf["status"] }) {
-  const baseClass = "h-3.5 w-3.5 shrink-0";
-  switch (status) {
-    case "completed":
-      return (
-        <CircleCheck
-          className={baseClass}
-          style={{ color: "var(--system-positive-strong)" }}
-        />
-      );
-    case "failed":
-      return (
-        <TriangleAlert
-          className={baseClass}
-          style={{ color: "var(--system-negative-strong)" }}
-        />
-      );
-    case "cancelled":
-      return (
-        <Ban
-          className={baseClass}
-          style={{ color: "var(--content-secondary)" }}
-          role="img"
-          aria-label="Cancelled"
-        />
-      );
-    default:
-      return (
-        <Loader2
-          className={`${baseClass} animate-spin`}
-          style={{ color: "var(--primary-base)" }}
-        />
-      );
-  }
-}
-
-function LeafRow({ leaf }: { leaf: WorkflowLeaf }) {
-  const [expanded, setExpanded] = useState(false);
-  const hasDetail = Boolean(leaf.resultSummary);
-  const title = leaf.label ?? `Leaf ${leaf.seq}`;
-
-  return (
-    <div className="rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
-      <button
-        type="button"
-        disabled={!hasDetail}
-        onClick={() => setExpanded((prev) => !prev)}
-        className="flex w-full items-center gap-2 text-left disabled:cursor-default"
-      >
-        <LeafStatusIcon status={leaf.status} />
-        <Typography
-          variant="body-medium-default"
-          className="min-w-0 flex-1 truncate text-[var(--content-default)]"
-        >
-          {title}
-        </Typography>
-        {hasDetail && (
-          <Typography
-            variant="body-small-default"
-            className="shrink-0 text-[var(--content-tertiary)]"
-          >
-            {expanded ? "Hide" : "Details"}
-          </Typography>
-        )}
-      </button>
-
-      {leaf.promptSummary && (
-        <Typography
-          variant="body-medium-lighter"
-          as="p"
-          className="mt-1 whitespace-pre-wrap break-words text-[var(--content-secondary)]"
-        >
-          {leaf.promptSummary}
-        </Typography>
-      )}
-
-      {hasDetail && expanded && (
-        <Typography
-          variant="body-medium-lighter"
-          as="p"
-          className="mt-2 whitespace-pre-wrap break-words text-[var(--content-secondary)]"
-        >
-          {leaf.resultSummary}
-        </Typography>
-      )}
-    </div>
-  );
-}
-
-function LeafTree({ leaves }: { leaves: Map<number, WorkflowLeaf> }) {
-  const sorted = [...leaves.values()].sort((a, b) => a.seq - b.seq);
-
-  if (sorted.length === 0) {
-    return (
-      <Typography
-        variant="body-small-default"
-        className="py-4 text-center text-[var(--content-tertiary)]"
-      >
-        No agents yet
-      </Typography>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-2">
-      {sorted.map((leaf) => (
-        <LeafRow key={leaf.seq} leaf={leaf} />
-      ))}
-    </div>
-  );
-}
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+import { Button, Typography } from "@vellumai/design-library";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -162,6 +45,8 @@ export function WorkflowDetailPanel({
   const isRunning = isActiveStatus(entry.status);
   const title = entry.label ?? entry.runId;
   const agentCount = entry.agentsSpawned || entry.leaves.size;
+  const components = useBundledAvatarComponents();
+  const sortedLeaves = [...entry.leaves.values()].sort((a, b) => a.seq - b.seq);
 
   // Reconcile leaves against the journal once on open (while live) and
   // again when the run reaches a terminal state — a `final` fetch flips
@@ -174,10 +59,15 @@ export function WorkflowDetailPanel({
 
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
-      {/* Header */}
-      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-base)] px-5 py-4">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-overlay)]">
-          <Workflow className="h-4 w-4" style={{ color: "var(--content-secondary)" }} />
+      {/* Header. No breadcrumb at the top level — like the subagent timeline,
+          the breadcrumb only appears once a deeper view is drilled into, which
+          the workflow panel never does. */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] px-5 py-4">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[6px] bg-[var(--surface-overlay)]">
+          <Workflow
+            className="h-4 w-4"
+            style={{ color: "var(--content-secondary)" }}
+          />
         </div>
         <Typography
           variant="title-medium"
@@ -189,24 +79,18 @@ export function WorkflowDetailPanel({
         <WorkflowStatusBadge status={entry.status} />
         <span className="flex-1" />
         {isRunning && onStop && (
-          <button
-            type="button"
-            aria-label="Stop workflow"
+          <StopButton
             onClick={() => onStop(entry.runId)}
-            className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-[var(--system-negative-strong)] px-3 py-1.5 text-white transition-colors hover:bg-[color-mix(in_srgb,var(--system-negative-strong)_85%,black)]"
-          >
-            <Typography variant="label-small-default" className="text-white">
-              Stop
-            </Typography>
-          </button>
+            ariaLabel="Stop workflow"
+          />
         )}
         <Button
-          variant="ghost"
+          variant="outlined"
           iconOnly={<X />}
           onClick={onClose}
           aria-label="Close workflow detail"
           tooltip="Close"
-          className="shrink-0"
+          className="shrink-0 rounded-lg"
         />
       </div>
 
@@ -215,81 +99,68 @@ export function WorkflowDetailPanel({
         {/* Metrics row */}
         <div className="mb-5 grid grid-cols-3 gap-3">
           <AnimatedMetricCard
-            icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+            icon={
+              <ArrowDownToLine
+                className="h-4 w-4 shrink-0"
+                style={{ color: "var(--content-secondary)" }}
+              />
+            }
             target={entry.inputTokens}
             format={(n) => formatNumber(Math.round(n))}
             label="Input"
           />
           <AnimatedMetricCard
-            icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+            icon={
+              <ArrowUpFromLine
+                className="h-4 w-4 shrink-0"
+                style={{ color: "var(--content-secondary)" }}
+              />
+            }
             target={entry.outputTokens}
             format={(n) => formatNumber(Math.round(n))}
             label="Output"
           />
           <AnimatedMetricCard
-            icon={<Users className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+            icon={
+              <Users
+                className="h-4 w-4 shrink-0"
+                style={{ color: "var(--content-secondary)" }}
+              />
+            }
             target={agentCount}
             format={(n) => formatNumber(Math.round(n))}
             label="Agents"
           />
         </div>
 
-        {/* Phase banner, with the latest log line as a muted secondary row */}
-        {(entry.phase || entry.message) && (
-          <div className="mb-5 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-4 py-3">
-            {entry.phase && (
-              <Typography
-                variant="body-medium-default"
-                className="text-[var(--content-default)]"
-              >
-                {entry.phase}
-              </Typography>
-            )}
-            {entry.message && (
-              <Typography
-                variant="body-small-default"
-                as="p"
-                className={cn(
-                  "whitespace-pre-wrap break-words text-[var(--content-secondary)]",
-                  entry.phase && "mt-1",
-                )}
-              >
-                {entry.message}
-              </Typography>
-            )}
-          </div>
-        )}
-
-        {/* Summary section */}
-        {entry.summary && (
-          <div className="mb-5 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-4 py-3">
-            <Typography
-              variant="body-medium-default"
-              as="h3"
-              className="mb-2 text-[var(--content-emphasised)]"
-            >
-              Summary
-            </Typography>
-            <Typography
-              variant="body-medium-lighter"
-              as="p"
-              className="whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)]"
-            >
-              {entry.summary}
-            </Typography>
-          </div>
-        )}
-
-        {/* Leaf tree section */}
+        {/* Subagents section */}
         <div>
           <Typography
-            variant="title-medium"
+            variant="body-medium-default"
             as="h3"
             className="mb-4 text-[var(--content-emphasised)]"
           >
-            Agents
+            Subagents
           </Typography>
-          <LeafTree leaves={entry.leaves} />
+          {sortedLeaves.length === 0 ? (
+            <Typography
+              variant="body-small-default"
+              className="py-4 text-center text-[var(--content-tertiary)]"
+            >
+              No subagents yet
+            </Typography>
+          ) : (
+            <div className="flex flex-col gap-1">
+              {sortedLeaves.map((leaf) => (
+                <WorkflowSubagentRow
+                  key={leaf.seq}
+                  runId={entry.runId}
+                  leaf={leaf}
+                  components={components}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -1,22 +1,27 @@
 
 import {
     ArrowDownToLine,
+    ArrowLeft,
     ArrowUpFromLine,
+    ChevronRight,
     Users,
     Workflow,
     X,
 } from "lucide-react";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
+import { AvatarRenderer } from "@/components/avatar-renderer";
 import {
     AnimatedMetricCard,
     formatNumber,
 } from "@/domains/chat/components/metric-card";
 import { StopButton } from "@/domains/chat/components/stop-button";
+import { WorkflowLeafDetail } from "@/domains/chat/components/workflow-leaf-detail";
 import { WorkflowStatusBadge } from "@/domains/chat/components/workflow-status-badge";
 import { WorkflowSubagentRow } from "@/domains/chat/components/workflow-subagent-row";
 import type { WorkflowEntry } from "@/domains/chat/workflow-store";
+import { subagentTraits } from "@/utils/avatar-subagent";
 import { isActiveStatus } from "@/utils/workflow-status";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button, Typography } from "@vellumai/design-library";
@@ -48,6 +53,38 @@ export function WorkflowDetailPanel({
   const components = useBundledAvatarComponents();
   const sortedLeaves = [...entry.leaves.values()].sort((a, b) => a.seq - b.seq);
 
+  // Which leaf's nested detail is open (its `seq`), or `null` for the list view.
+  const [selectedLeafSeq, setSelectedLeafSeq] = useState<number | null>(null);
+
+  // Reset to the list when the run changes — the panel instance is reused
+  // across runs (no `key`), so a detail opened for one run must not leak onto
+  // the next.
+  const [prevRunId, setPrevRunId] = useState(entry.runId);
+  if (prevRunId !== entry.runId) {
+    setPrevRunId(entry.runId);
+    setSelectedLeafSeq(null);
+  }
+
+  // The selected leaf, or `undefined` when nothing is selected or the seq no
+  // longer exists (defensive — every view below gates on this, so a vanished
+  // leaf falls back to the list).
+  const selectedLeaf =
+    selectedLeafSeq != null ? entry.leaves.get(selectedLeafSeq) : undefined;
+  const selectedTraits = selectedLeaf
+    ? subagentTraits(`${entry.runId}:${selectedLeaf.seq}`)
+    : undefined;
+
+  // Returns from a leaf's nested detail to the subagents list. Shared by the
+  // header Back button and the breadcrumb's workflow crumb.
+  const handleBack = useCallback(() => setSelectedLeafSeq(null), []);
+
+  // The header/breadcrumb title tracks the deepest crumb: the workflow at the
+  // list, the drilled-into leaf once its detail is open.
+  const detailTitle = selectedLeaf
+    ? (selectedLeaf.label ?? `Subagent ${selectedLeaf.seq}`)
+    : "";
+  const headerTitle = selectedLeaf ? detailTitle : title;
+
   // Reconcile leaves against the journal once on open (while live) and
   // again when the run reaches a terminal state — a `final` fetch flips
   // any leaf left stuck "running" by a dropped SSE event. The store
@@ -59,22 +96,74 @@ export function WorkflowDetailPanel({
 
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
-      {/* Header. No breadcrumb at the top level — like the subagent timeline,
-          the breadcrumb only appears once a deeper view is drilled into, which
-          the workflow panel never does. */}
-      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] px-5 py-4">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[6px] bg-[var(--surface-overlay)]">
-          <Workflow
-            className="h-4 w-4"
-            style={{ color: "var(--content-secondary)" }}
+      {/* Breadcrumb — only shown once a leaf's nested detail is open; the
+          top-level subagents list has no breadcrumb. The workflow crumb is a
+          button that returns to the list, mirroring the header Back button. */}
+      {selectedLeaf && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hover)] px-5 py-3">
+          <button
+            type="button"
+            onClick={handleBack}
+            title={title}
+            className="min-w-0 shrink cursor-pointer truncate text-left text-[var(--content-default)] hover:underline"
+          >
+            <Typography variant="body-small-default" as="span">
+              {title}
+            </Typography>
+          </button>
+          <ChevronRight
+            className="h-2.5 w-2.5 shrink-0 text-[var(--content-tertiary)]"
+            aria-hidden
           />
+          <Typography
+            variant="body-small-default"
+            as="span"
+            title={detailTitle}
+            className="min-w-0 shrink truncate text-[var(--content-secondary)]"
+          >
+            {detailTitle}
+          </Typography>
         </div>
+      )}
+
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] px-5 py-4">
+        {selectedLeaf && (
+          <Button
+            variant="outlined"
+            iconOnly={<ArrowLeft />}
+            onClick={handleBack}
+            aria-label="Back to subagents"
+            tooltip="Back"
+            className="shrink-0 rounded-lg"
+          />
+        )}
+        {selectedLeaf ? (
+          components && selectedTraits ? (
+            <AvatarRenderer
+              components={components}
+              bodyShapeId={selectedTraits.bodyShape}
+              eyeStyleId={selectedTraits.eyeStyle}
+              colorId={selectedTraits.color}
+              size={32}
+            />
+          ) : (
+            <div style={{ width: 32, height: 32, flexShrink: 0 }} aria-hidden />
+          )
+        ) : (
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[6px] bg-[var(--surface-overlay)]">
+            <Workflow
+              className="h-4 w-4"
+              style={{ color: "var(--content-secondary)" }}
+            />
+          </div>
+        )}
         <Typography
           variant="title-medium"
-          title={title}
+          title={headerTitle}
           className="min-w-0 shrink truncate text-[var(--content-default)]"
         >
-          {title}
+          {headerTitle}
         </Typography>
         <WorkflowStatusBadge status={entry.status} />
         <span className="flex-1" />
@@ -94,74 +183,82 @@ export function WorkflowDetailPanel({
         />
       </div>
 
-      {/* Scrollable body */}
+      {/* Scrollable body — swaps to a leaf's nested detail when one is open,
+          keeping the header above mounted in both views. */}
       <div className="flex-1 overflow-y-auto px-5 py-5">
-        {/* Metrics row */}
-        <div className="mb-5 grid grid-cols-3 gap-3">
-          <AnimatedMetricCard
-            icon={
-              <ArrowDownToLine
-                className="h-4 w-4 shrink-0"
-                style={{ color: "var(--content-secondary)" }}
+        {selectedLeaf ? (
+          <WorkflowLeafDetail leaf={selectedLeaf} />
+        ) : (
+          <>
+            {/* Metrics row */}
+            <div className="mb-5 grid grid-cols-3 gap-3">
+              <AnimatedMetricCard
+                icon={
+                  <ArrowDownToLine
+                    className="h-4 w-4 shrink-0"
+                    style={{ color: "var(--content-secondary)" }}
+                  />
+                }
+                target={entry.inputTokens}
+                format={(n) => formatNumber(Math.round(n))}
+                label="Input"
               />
-            }
-            target={entry.inputTokens}
-            format={(n) => formatNumber(Math.round(n))}
-            label="Input"
-          />
-          <AnimatedMetricCard
-            icon={
-              <ArrowUpFromLine
-                className="h-4 w-4 shrink-0"
-                style={{ color: "var(--content-secondary)" }}
+              <AnimatedMetricCard
+                icon={
+                  <ArrowUpFromLine
+                    className="h-4 w-4 shrink-0"
+                    style={{ color: "var(--content-secondary)" }}
+                  />
+                }
+                target={entry.outputTokens}
+                format={(n) => formatNumber(Math.round(n))}
+                label="Output"
               />
-            }
-            target={entry.outputTokens}
-            format={(n) => formatNumber(Math.round(n))}
-            label="Output"
-          />
-          <AnimatedMetricCard
-            icon={
-              <Users
-                className="h-4 w-4 shrink-0"
-                style={{ color: "var(--content-secondary)" }}
+              <AnimatedMetricCard
+                icon={
+                  <Users
+                    className="h-4 w-4 shrink-0"
+                    style={{ color: "var(--content-secondary)" }}
+                  />
+                }
+                target={agentCount}
+                format={(n) => formatNumber(Math.round(n))}
+                label="Agents"
               />
-            }
-            target={agentCount}
-            format={(n) => formatNumber(Math.round(n))}
-            label="Agents"
-          />
-        </div>
-
-        {/* Subagents section */}
-        <div>
-          <Typography
-            variant="body-medium-default"
-            as="h3"
-            className="mb-4 text-[var(--content-emphasised)]"
-          >
-            Subagents
-          </Typography>
-          {sortedLeaves.length === 0 ? (
-            <Typography
-              variant="body-small-default"
-              className="py-4 text-center text-[var(--content-tertiary)]"
-            >
-              No subagents yet
-            </Typography>
-          ) : (
-            <div className="flex flex-col gap-1">
-              {sortedLeaves.map((leaf) => (
-                <WorkflowSubagentRow
-                  key={leaf.seq}
-                  runId={entry.runId}
-                  leaf={leaf}
-                  components={components}
-                />
-              ))}
             </div>
-          )}
-        </div>
+
+            {/* Subagents section */}
+            <div>
+              <Typography
+                variant="body-medium-default"
+                as="h3"
+                className="mb-4 text-[var(--content-emphasised)]"
+              >
+                Subagents
+              </Typography>
+              {sortedLeaves.length === 0 ? (
+                <Typography
+                  variant="body-small-default"
+                  className="py-4 text-center text-[var(--content-tertiary)]"
+                >
+                  No subagents yet
+                </Typography>
+              ) : (
+                <div className="flex flex-col gap-1">
+                  {sortedLeaves.map((leaf) => (
+                    <WorkflowSubagentRow
+                      key={leaf.seq}
+                      runId={entry.runId}
+                      leaf={leaf}
+                      components={components}
+                      onSelect={() => setSelectedLeafSeq(leaf.seq)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/workflow-leaf-detail.tsx
+++ b/clients/web/src/domains/chat/components/workflow-leaf-detail.tsx
@@ -1,0 +1,99 @@
+import { ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import {
+    AnimatedMetricCard,
+    formatNumber,
+} from "@/domains/chat/components/metric-card";
+import type { WorkflowLeaf } from "@/domains/chat/workflow-store";
+
+/** A labeled text block in the leaf detail — the prompt or the result. */
+function DetailSection({
+  title,
+  body,
+  emptyText,
+}: {
+  title: string;
+  body?: string;
+  emptyText: string;
+}) {
+  return (
+    <div className="mb-5">
+      <Typography
+        variant="body-medium-default"
+        as="h3"
+        className="mb-2 text-[var(--content-emphasised)]"
+      >
+        {title}
+      </Typography>
+      {body ? (
+        <Typography
+          variant="body-medium-lighter"
+          as="p"
+          className="whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)]"
+        >
+          {body}
+        </Typography>
+      ) : (
+        <Typography
+          variant="body-medium-lighter"
+          as="p"
+          className="text-[var(--content-tertiary)]"
+        >
+          {emptyText}
+        </Typography>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Nested detail view for a single workflow leaf (subagent), shown when its row
+ * in the list is clicked. Token metrics plus the prompt and result summaries as
+ * two separate, labeled sections — never blended into one line. The result is
+ * empty until the leaf finishes, so a running leaf shows a "Running…" state.
+ */
+export function WorkflowLeafDetail({ leaf }: { leaf: WorkflowLeaf }) {
+  const resultEmptyText =
+    leaf.status === "running" ? "Running…" : "No result summary";
+
+  return (
+    <div>
+      <div className="mb-5 grid grid-cols-2 gap-3">
+        <AnimatedMetricCard
+          icon={
+            <ArrowDownToLine
+              className="h-4 w-4 shrink-0"
+              style={{ color: "var(--content-secondary)" }}
+            />
+          }
+          target={leaf.inputTokens ?? 0}
+          format={(n) => formatNumber(Math.round(n))}
+          label="Input"
+        />
+        <AnimatedMetricCard
+          icon={
+            <ArrowUpFromLine
+              className="h-4 w-4 shrink-0"
+              style={{ color: "var(--content-secondary)" }}
+            />
+          }
+          target={leaf.outputTokens ?? 0}
+          format={(n) => formatNumber(Math.round(n))}
+          label="Output"
+        />
+      </div>
+      <DetailSection
+        title="Prompt"
+        body={leaf.promptSummary}
+        emptyText="No prompt summary"
+      />
+      <DetailSection
+        title="Result"
+        body={leaf.resultSummary}
+        emptyText={resultEmptyText}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/workflow-status-badge.tsx
+++ b/clients/web/src/domains/chat/components/workflow-status-badge.tsx
@@ -4,9 +4,58 @@ import {
   statusLabel,
 } from "@/utils/workflow-status";
 import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
+import type { WorkflowLeafStatus } from "@/domains/chat/workflow-store";
 
 export function WorkflowStatusBadge({ status }: { status: WorkflowRunStatus }) {
   return (
     <StatusBadgePill color={statusColor(status)} label={statusLabel(status)} />
+  );
+}
+
+// A leaf's status enum carries `cancelled` and omits the run-only terminals
+// (aborted / cap_exceeded / interrupted), so it can't reuse the run-status
+// helpers. Colors match the row's lead indicator.
+function leafStatusColor(status: WorkflowLeafStatus): string {
+  switch (status) {
+    case "completed":
+      return "var(--system-positive-strong)";
+    case "failed":
+      return "var(--system-negative-strong)";
+    case "cancelled":
+      return "var(--content-secondary)";
+    default:
+      return "var(--primary-base)";
+  }
+}
+
+function leafStatusLabel(status: WorkflowLeafStatus): string {
+  switch (status) {
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "Running";
+  }
+}
+
+/**
+ * Status badge for a single workflow leaf (subagent), used in the drilled-in
+ * leaf-detail header so the badge reflects the *selected leaf's* state rather
+ * than its parent workflow's. Shares the same pill shell as
+ * `WorkflowStatusBadge` so the two are identical in size and shape.
+ */
+export function WorkflowLeafStatusBadge({
+  status,
+}: {
+  status: WorkflowLeafStatus;
+}) {
+  return (
+    <StatusBadgePill
+      color={leafStatusColor(status)}
+      label={leafStatusLabel(status)}
+    />
   );
 }

--- a/clients/web/src/domains/chat/components/workflow-status-badge.tsx
+++ b/clients/web/src/domains/chat/components/workflow-status-badge.tsx
@@ -3,18 +3,10 @@ import {
   statusColor,
   statusLabel,
 } from "@/utils/workflow-status";
+import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
 
 export function WorkflowStatusBadge({ status }: { status: WorkflowRunStatus }) {
-  const color = statusColor(status);
   return (
-    <span
-      className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-0.5 text-label-small-default"
-      style={{
-        color,
-        backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)`,
-      }}
-    >
-      {statusLabel(status)}
-    </span>
+    <StatusBadgePill color={statusColor(status)} label={statusLabel(status)} />
   );
 }

--- a/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
+++ b/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
@@ -49,6 +49,8 @@ export interface WorkflowSubagentRowProps {
   leaf: WorkflowLeaf;
   /** Bundled avatar SVG components, or `null` until the lazy chunk resolves. */
   components: CharacterComponents | null;
+  /** Opens this leaf's nested detail view in the panel. */
+  onSelect: () => void;
 }
 
 /**
@@ -68,6 +70,7 @@ export function WorkflowSubagentRow({
   runId,
   leaf,
   components,
+  onSelect,
 }: WorkflowSubagentRowProps) {
   const title = leaf.label ?? `Subagent ${leaf.seq}`;
   const activity = leaf.promptSummary;
@@ -76,7 +79,12 @@ export function WorkflowSubagentRow({
   const traits = subagentTraits(`${runId}:${leaf.seq}`);
 
   return (
-    <div className="flex items-center justify-between gap-2 rounded-[6px] px-2 py-1.5 transition-colors hover:bg-[var(--surface-overlay)]">
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-label={`Open ${title} details`}
+      className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-[6px] px-2 py-1.5 text-left transition-colors hover:bg-[var(--surface-overlay)]"
+    >
       <div className="flex min-w-0 items-center gap-1.5">
         <LeadIndicator status={leaf.status} />
         {components ? (
@@ -115,6 +123,6 @@ export function WorkflowSubagentRow({
           </>
         )}
       </div>
-    </div>
+    </button>
   );
 }

--- a/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
+++ b/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
@@ -1,0 +1,120 @@
+import { Ban, CircleCheck, TriangleAlert } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { AvatarRenderer } from "@/components/avatar-renderer";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+import type { WorkflowLeaf } from "@/domains/chat/workflow-store";
+import type { CharacterComponents } from "@/types/avatar";
+import { subagentTraits } from "@/utils/avatar-subagent";
+
+/**
+ * Lead glyph for a subagent row: the pulsing three-dot "running" indicator
+ * while the leaf is in flight, otherwise a compact terminal status icon.
+ */
+function LeadIndicator({ status }: { status: WorkflowLeaf["status"] }) {
+  if (status === "running") {
+    return <ThreeDotIndicator className="shrink-0" dotSize={4} gap={2} />;
+  }
+  const baseClass = "h-3.5 w-3.5 shrink-0";
+  switch (status) {
+    case "completed":
+      return (
+        <CircleCheck
+          className={baseClass}
+          style={{ color: "var(--system-positive-strong)" }}
+        />
+      );
+    case "failed":
+      return (
+        <TriangleAlert
+          className={baseClass}
+          style={{ color: "var(--system-negative-strong)" }}
+        />
+      );
+    default:
+      return (
+        <Ban
+          className={baseClass}
+          style={{ color: "var(--content-secondary)" }}
+          role="img"
+          aria-label="Cancelled"
+        />
+      );
+  }
+}
+
+export interface WorkflowSubagentRowProps {
+  runId: string;
+  leaf: WorkflowLeaf;
+  /** Bundled avatar SVG components, or `null` until the lazy chunk resolves. */
+  components: CharacterComponents | null;
+}
+
+/**
+ * One row in the workflow panel's "Subagents" list — lead indicator, a
+ * deterministic avatar (seeded by `runId:seq` so each leaf gets a stable,
+ * distinct creature), the leaf's task name, a faint divider, and the leaf's
+ * latest activity.
+ *
+ * The trailing "N steps" count and a live, carouseling activity line are
+ * intentionally absent here: the daemon emits no per-leaf step/progress data
+ * today (leaves are not subagents and carry no event timeline). The static
+ * activity text below is the leaf's prompt summary. When the daemon grows
+ * per-leaf progress events, render the step count on the right and swap the
+ * static text for the shared `HeaderStepCarousel` — this row is the seam.
+ */
+export function WorkflowSubagentRow({
+  runId,
+  leaf,
+  components,
+}: WorkflowSubagentRowProps) {
+  const title = leaf.label ?? `Subagent ${leaf.seq}`;
+  const activity = leaf.promptSummary;
+  // Seed the avatar off the run + seq (leaves have no subagent id); the same
+  // leaf always renders the same avatar.
+  const traits = subagentTraits(`${runId}:${leaf.seq}`);
+
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-[6px] px-2 py-1.5 transition-colors hover:bg-[var(--surface-overlay)]">
+      <div className="flex min-w-0 items-center gap-1.5">
+        <LeadIndicator status={leaf.status} />
+        {components ? (
+          <AvatarRenderer
+            components={components}
+            bodyShapeId={traits.bodyShape}
+            eyeStyleId={traits.eyeStyle}
+            colorId={traits.color}
+            size={16}
+          />
+        ) : (
+          <div style={{ width: 16, height: 16, flexShrink: 0 }} aria-hidden />
+        )}
+        <Typography
+          variant="body-medium-default"
+          title={title}
+          className="shrink-0 whitespace-nowrap text-[var(--content-default)]"
+        >
+          {title}
+        </Typography>
+        {activity && (
+          <>
+            <span
+              aria-hidden
+              className="shrink-0 text-[var(--content-tertiary)] opacity-10"
+            >
+              |
+            </span>
+            <Typography
+              variant="body-medium-lighter"
+              title={activity}
+              className="min-w-0 truncate text-[var(--content-tertiary)]"
+            >
+              {activity}
+            </Typography>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
+++ b/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
@@ -101,7 +101,11 @@ export function WorkflowSubagentRow({
         <Typography
           variant="body-medium-default"
           title={title}
-          className="shrink-0 whitespace-nowrap text-[var(--content-default)]"
+          // Keep the task name at its natural width so short labels stay whole
+          // (the muted activity to its right is what truncates), but cap it so a
+          // pathologically long generated label ellipsizes within the 400px panel
+          // instead of overflowing the row.
+          className="max-w-[60%] shrink-0 truncate text-[var(--content-default)]"
         >
           {title}
         </Typography>

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
@@ -225,6 +225,36 @@ describe("computeWorkflowCardData — current step title/info", () => {
     expect(data.currentStepTitle).toBe("Research workflow");
     expect(data.currentStepInfo).toBe("reading sources");
   });
+
+  test("a terminal run prefers the final summary over a stale phase", () => {
+    // completeRun() leaves the last live phase set, so a finished card must
+    // surface the outcome (summary) instead of "Synthesizing…".
+    const data = computeWorkflowCardData(
+      makeEntry({
+        status: "completed",
+        label: "Research workflow",
+        phase: "Synthesizing",
+        summary: "Compiled all six divisions",
+        leaves: [
+          { seq: 0, label: "leaf", status: "completed", promptSummary: "go" },
+        ],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Research workflow");
+    expect(data.currentStepInfo).toBe("Compiled all six divisions");
+  });
+
+  test("a terminal run with no summary falls back to the log message, not the phase", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        status: "failed",
+        label: "Research workflow",
+        phase: "Synthesizing",
+        message: "hit an error",
+      }),
+    );
+    expect(data.currentStepInfo).toBe("hit an error");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
@@ -153,36 +153,69 @@ describe("computeWorkflowCardData — leaf mapping", () => {
 // ---------------------------------------------------------------------------
 
 describe("computeWorkflowCardData — current step title/info", () => {
-  test("phase drives the header when set", () => {
+  test("title is always the workflow name; phase rides the secondary line", () => {
     const data = computeWorkflowCardData(
       makeEntry({
+        label: "Research workflow",
         phase: "Planning",
         summary: "breaking down the goal",
         leaves: [{ seq: 0, label: "leaf", status: "running" }],
       }),
     );
-    expect(data.currentStepTitle).toBe("Planning");
-    expect(data.currentStepInfo).toBe("breaking down the goal");
+    expect(data.currentStepTitle).toBe("Research workflow");
+    expect(data.currentStepInfo).toBe("Planning");
   });
 
-  test("falls back to the latest leaf when no phase is set", () => {
+  test("the latest leaf's prompt rides the secondary line when no phase is set", () => {
     const data = computeWorkflowCardData(
       makeEntry({
+        label: "Research workflow",
         leaves: [
           { seq: 0, label: "First", status: "completed" },
           { seq: 1, label: "Latest", status: "running", promptSummary: "go" },
         ],
       }),
     );
-    expect(data.currentStepTitle).toBe("Latest");
+    expect(data.currentStepTitle).toBe("Research workflow");
     expect(data.currentStepInfo).toBe("go");
   });
 
-  test("falls back to the run label when there are no leaves or phase", () => {
+  test("a latest leaf with no prompt falls back to its label on the secondary line", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        label: "Research workflow",
+        leaves: [{ seq: 1, label: "Latest", status: "running" }],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Research workflow");
+    expect(data.currentStepInfo).toBe("Latest");
+  });
+
+  test("an unlabeled latest leaf no longer leaks 'Leaf <seq>' into the title", () => {
+    // Regression: the synthesis leaf carries no label, so the header used to
+    // fall back to `Leaf <seq>` ("Leaf 6") instead of the workflow's name.
+    const data = computeWorkflowCardData(
+      makeEntry({
+        label: "nba-all-teams",
+        leaves: [
+          { seq: 6, status: "running", promptSummary: "Compile the report" },
+        ],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("nba-all-teams");
+    expect(data.currentStepInfo).toBe("Compile the report");
+  });
+
+  test("uses the run label as the title with no leaves or phase", () => {
     const data = computeWorkflowCardData(
       makeEntry({ label: "Research workflow" }),
     );
     expect(data.currentStepTitle).toBe("Research workflow");
+  });
+
+  test("falls back to 'Workflow' when the run has no label", () => {
+    const data = computeWorkflowCardData(makeEntry({ label: undefined }));
+    expect(data.currentStepTitle).toBe("Workflow");
   });
 
   test("surfaces the log message as the secondary line with no phase or leaves", () => {

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
@@ -25,6 +25,7 @@ import {
   type WorkflowLeaf,
 } from "@/domains/chat/workflow-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { isActiveStatus } from "@/utils/workflow-status";
 import type { WorkflowRunStatus } from "@vellumai/assistant-api";
 import {
   type ToolCallCardData,
@@ -117,25 +118,44 @@ function sortedLeaves(entry: WorkflowEntry): WorkflowLeaf[] {
  * activity verb — the workflow card has nowhere else to surface its name;
  * it belongs in the title.
  *
- * The live activity is demoted to the secondary info line so the card still
- * reads as in-flight: the current `phase`, else the latest leaf's prompt
- * summary (or its label), else the latest `log(...)` `message`, else the
- * final `summary`. (A leaf with neither prompt nor label no longer leaks a
+ * While the run is active, the live activity is demoted to the secondary info
+ * line so the card still reads as in-flight: the current `phase`, else the
+ * latest leaf's prompt summary (or its label), else the latest `log(...)`
+ * `message`. (A leaf with neither prompt nor label no longer leaks a
  * `Leaf <seq>` fallback into the header — the row's own list still labels it.)
+ *
+ * Once the run is terminal, the secondary line reflects the *outcome* — the
+ * final `summary` — instead. `completeRun()` leaves the last `entry.phase` set,
+ * so without this gate a finished card would keep showing a stale live phase
+ * (e.g. "Synthesizing…") rather than the result.
  */
 function deriveCurrentStep(
   entry: WorkflowEntry,
   leaves: WorkflowLeaf[],
 ): { currentStepTitle: string; currentStepInfo: string } {
   const latest = leaves[leaves.length - 1];
+  const title = entry.label ?? "Workflow";
+
+  if (!isActiveStatus(entry.status)) {
+    return {
+      currentStepTitle: title,
+      currentStepInfo:
+        entry.summary ||
+        entry.message ||
+        latest?.resultSummary ||
+        latest?.promptSummary ||
+        latest?.label ||
+        "",
+    };
+  }
+
   return {
-    currentStepTitle: entry.label ?? "Workflow",
+    currentStepTitle: title,
     currentStepInfo:
       entry.phase ||
       latest?.promptSummary ||
       latest?.label ||
       entry.message ||
-      entry.summary ||
       "",
   };
 }

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
@@ -108,34 +108,35 @@ function sortedLeaves(entry: WorkflowEntry): WorkflowLeaf[] {
 }
 
 /**
- * Derive the header `(title, info)` tuple. When the run carries a `phase`
- * we surface it; otherwise we fall back to the latest leaf (the deepest
- * `seq`), and finally to the run label. The latest `log(...)` `message`
- * fills the secondary line when there is no more-specific leaf info or
- * phase, so a log-only update doesn't read as stale.
+ * Derive the header `(title, info)` tuple.
+ *
+ * The bold title is the workflow's *name* (`label`) — stable and
+ * recognizable, matching the detail panel header. The card's leading glyph
+ * is a generic workflow icon (no avatar), so unlike the subagent inline
+ * card — whose identity rides the avatar and whose title is the live
+ * activity verb — the workflow card has nowhere else to surface its name;
+ * it belongs in the title.
+ *
+ * The live activity is demoted to the secondary info line so the card still
+ * reads as in-flight: the current `phase`, else the latest leaf's prompt
+ * summary (or its label), else the latest `log(...)` `message`, else the
+ * final `summary`. (A leaf with neither prompt nor label no longer leaks a
+ * `Leaf <seq>` fallback into the header — the row's own list still labels it.)
  */
 function deriveCurrentStep(
   entry: WorkflowEntry,
   leaves: WorkflowLeaf[],
 ): { currentStepTitle: string; currentStepInfo: string } {
-  if (entry.phase) {
-    return {
-      currentStepTitle: entry.phase,
-      currentStepInfo: entry.summary ?? entry.message ?? entry.label ?? "",
-    };
-  }
-
   const latest = leaves[leaves.length - 1];
-  if (latest) {
-    return {
-      currentStepTitle: latest.label ?? `Leaf ${latest.seq}`,
-      currentStepInfo: latest.promptSummary ?? "",
-    };
-  }
-
   return {
     currentStepTitle: entry.label ?? "Workflow",
-    currentStepInfo: entry.message ?? entry.summary ?? "",
+    currentStepInfo:
+      entry.phase ||
+      latest?.promptSummary ||
+      latest?.label ||
+      entry.message ||
+      entry.summary ||
+      "",
   };
 }
 


### PR DESCRIPTION
## What

Redesign the top-level **workflow detail panel** to match the Figma mock,
sharing header primitives with the subagent detail panel, and add a nested
per-subagent (leaf) detail view.

[Figma — workflow details panel](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=6063-150302)

### Changes
- **Shared primitives (new):** `status-badge-pill.tsx`, `stop-button.tsx`.
  `WorkflowStatusBadge` and the subagent `StatusBadge` are thin wrappers over
  the same pill (identical `h-[23px]` / `rounded-[6px]`), and the workflow
  panel's Stop button uses the same outline style as the subagent panel's.
- **Workflow panel:** new header (icon tile + title + shared
  badge/Stop/outlined-close, **no breadcrumb** at the list level), metrics row,
  and a "Subagents" list via `workflow-subagent-row.tsx` (running indicator →
  terminal status glyph, deterministic avatar seeded by `runId:seq`, task name,
  faint divider, latest activity, hover state) replacing the old `LeafTree` /
  `LeafRow`.
- **Nested leaf detail (new):** clicking a subagent row swaps the body to a
  detail view (`workflow-leaf-detail.tsx`) — mirroring the subagent panel's
  pattern with a breadcrumb + Back button — showing the leaf's **Prompt** and
  **Result** summaries as two separate, labeled sections (not blended into one
  line), plus its token metrics. A running leaf with no result yet shows a
  "Running…" state.

### Notes
- **No Objective section:** the workflow run carries no objective/description
  field today, so shipping a lorem placeholder wasn't worth it. (Adding it with
  real data — the workflow's `meta.description`, persisted on the run row — is
  scoped as a follow-up.)
- The **subagent detail panel is left untouched** (on `main`'s version).
- Drops the panel's old phase banner + summary sections (absent from the mock).

### Deferred to a follow-up (Phase B, additive)
- **Live "latest task" carousel + per-row "N steps":** leaves carry no progress
  events or step count today. The row is the seam — Phase B adds a
  `workflow_leaf_progress` event + `stepCount` in the daemon, then swaps the
  static prompt-summary text for `HeaderStepCarousel` and renders the count.

## Testing
- Panel tests: 12 pass (incl. click → nested detail → breadcrumb Back).
- `bunx tsc --noEmit`, `bun run lint`: clean.
- CI: Type Check / Test / Lint / Build all green (rebased onto current `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
