### PR TITLE
docs(memory): explain the no-op stop() on the out-of-process worker handle (follow-up to #35835)

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -202,6 +202,10 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
       async runOnce(): Promise<number> {
         return 0;
       },
+      // No-op: shutdown always stops the worker process via the live-state
+      // PID probe in daemon/shutdown-handlers.ts, since it can't know whether
+      // the process was started here or out of band (e.g. `assistant memory
+      // worker start`) after boot.
       stop(): void {},
     };
   }


### PR DESCRIPTION
## Follow-up to #35835

Per review feedback from @dvargasfuertes:

> we should leave a one line comment here on why this is empty - namely that bc we stop the memory worker always bc we can't know for sure if it wasn't started after initial boot up

Adds a comment on the out-of-process worker handle's empty `stop()` in `jobs-worker.ts` explaining that shutdown always stops the worker via the live-state PID probe in `shutdown-handlers.ts`, because it can't know whether the process was started by the daemon or out of band (e.g. `assistant memory worker start`) after boot.

Comment-only change — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy66BQcGQ9FHq78dg8kA8R)_