### PR TITLE
Remove requiresCredential/credentials from PluginInitContext

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -221,7 +221,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/sanity-routes.ts", // Sanity connect/discover routes (reads stored api_token from credential store)
       "runtime/routes/platform-routes.ts", // CLI platform connect/disconnect/status routes (CLI-migrated to IPC)
       "ipc/skill-routes/providers.ts", // host.providers.secureKeys.getProviderKey IPC route (out-of-process SkillHost companion)
-      "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup

--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -4,32 +4,19 @@
  * Covers:
  * - A noop `init()` fires with a valid `PluginInitContext` that exposes every
  *   documented field.
- * - `requiresCredential` entries are resolved through the credential store
- *   helper and arrive in `ctx.credentials`.
  * - Version-mismatch registration fails with an error that names the plugin
  *   (the registry enforces this at `registerPlugin` time, so bootstrap never
  *   sees the malformed plugin).
  * - Shutdown hook walks plugins in reverse registration order.
  *
- * Uses `mock.module` to stub `security/secure-keys.js` so credential
- * resolution doesn't hit the real backend. `resetPluginRegistryForTests()`
- * isolates registry state between cases.
+ * `resetPluginRegistryForTests()` isolates registry state between cases.
  */
 
 import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-// Mock credential store before importing the bootstrap module so the
-// module-under-test captures the stubbed binding.
-const getSecureKeyAsyncMock = mock(
-  async (_account: string): Promise<string | undefined> => undefined,
-);
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: getSecureKeyAsyncMock,
-}));
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import { clearFeatureFlagOverridesCache } from "../config/assistant-feature-flags.js";
 import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
@@ -68,7 +55,6 @@ function buildPlugin(
     onShutdown?: () => Promise<void>;
   } = {},
   options: {
-    requiresCredential?: string[];
     requiresFlag?: string[];
   } = {},
 ): Plugin {
@@ -94,9 +80,6 @@ function buildPlugin(
     manifest: {
       name,
       version: "0.0.1",
-      ...(options.requiresCredential
-        ? { requiresCredential: options.requiresCredential }
-        : {}),
       ...(options.requiresFlag ? { requiresFlag: options.requiresFlag } : {}),
     },
     ...rest,
@@ -107,8 +90,6 @@ function buildPlugin(
 describe("plugin bootstrap", () => {
   beforeEach(async () => {
     resetPluginRegistryForTests();
-    getSecureKeyAsyncMock.mockReset();
-    getSecureKeyAsyncMock.mockImplementation(async () => undefined);
     // Reset feature-flag cache so tests start from a known state. Individual
     // tests that exercise `requiresFlag` use `setOverridesForTesting(...)`
     // to install their own overrides.
@@ -133,7 +114,6 @@ describe("plugin bootstrap", () => {
 
     // Every documented field must be present on the context passed to init.
     expect(ctx.config).toBeUndefined(); // no `plugins.alpha` block in fake config
-    expect(ctx.credentials).toEqual({});
     expect(ctx.logger).toBeDefined();
     expect(typeof (ctx.logger as { info: unknown }).info).toBe("function");
     // Storage dir lives under getWorkspaceDir()/plugins-data/<name> and must have
@@ -143,52 +123,6 @@ describe("plugin bootstrap", () => {
     );
     expect(existsSync(ctx.pluginStorageDir)).toBe(true);
     expect(ctx.assistantVersion).toBe(APP_VERSION);
-  });
-
-  test("credential resolution: init receives the resolved value under credentials[key]", async () => {
-    getSecureKeyAsyncMock.mockImplementation(async (account: string) => {
-      if (account === "some-key") return "super-secret-value";
-      return undefined;
-    });
-
-    let received: PluginInitContext | undefined;
-    const plugin = buildPlugin(
-      "credentialed",
-      {
-        async init(ctx) {
-          received = ctx;
-        },
-      },
-      { requiresCredential: ["some-key"] },
-    );
-    registerPlugin(plugin);
-
-    await bootstrapPlugins();
-
-    expect(getSecureKeyAsyncMock).toHaveBeenCalledTimes(1);
-    expect(getSecureKeyAsyncMock).toHaveBeenCalledWith("some-key");
-    expect(received?.credentials).toEqual({ "some-key": "super-secret-value" });
-  });
-
-  test("credential resolution: a plugin whose required credential is missing is skipped, not fatal", async () => {
-    // GIVEN a plugin that requires a credential the store cannot resolve
-    getSecureKeyAsyncMock.mockImplementation(async () => undefined);
-    registerPlugin(
-      buildPlugin(
-        "missing-cred",
-        { async init() {} },
-        { requiresCredential: ["absent-key"] },
-      ),
-    );
-
-    // WHEN bootstrap runs
-    // THEN it completes without throwing — the unresolvable credential is
-    // contained to that plugin (same per-plugin isolation as an init throw)
-    await bootstrapPlugins();
-
-    // AND the plugin is dropped from the registry
-    const names = getRegisteredPlugins().map((p) => p.manifest.name);
-    expect(names).not.toContain("missing-cred");
   });
 
   test("version mismatch: external plugin loader rejects when peerDependency unsatisfied", async () => {
@@ -555,11 +489,7 @@ describe("plugin bootstrap", () => {
     registerPlugin(plugin);
 
     // Create the .disabled sentinel in the workspace plugins dir.
-    const sentinelDir = join(
-      TEST_WORKSPACE_DIR,
-      "plugins",
-      "sentinel-off",
-    );
+    const sentinelDir = join(TEST_WORKSPACE_DIR, "plugins", "sentinel-off");
     const { mkdir, writeFile } = await import("node:fs/promises");
     await mkdir(sentinelDir, { recursive: true });
     await writeFile(join(sentinelDir, ".disabled"), "");

--- a/assistant/src/__tests__/plugin-route-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-route-contribution.test.ts
@@ -22,26 +22,15 @@
  *     each plugin's shutdown only removes its own route — the other plugin's
  *     route stays live until its own teardown runs.
  *
- * Uses `mock.module` to stub credential resolution — bootstrap otherwise
- * tries to hit the real secure-key backend. `resetPluginRegistryForTests()`
- * isolates plugin-registry state and `resetSkillRoutesForTests()` isolates
- * skill-route-registry state between cases.
+ * `resetPluginRegistryForTests()` isolates plugin-registry state and
+ * `resetSkillRoutesForTests()` isolates skill-route-registry state between
+ * cases.
  */
 
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-// Stub the credential store before importing bootstrap so the module binds to
-// the mock. Plugins in these tests don't declare `requiresCredential`, but
-// the mock keeps the test hermetic regardless of what the backend would do.
-const getSecureKeyAsyncMock = mock(
-  async (_account: string): Promise<string | undefined> => undefined,
-);
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: getSecureKeyAsyncMock,
-}));
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
 import { runShutdownHooks } from "../daemon/shutdown-registry.js";
@@ -113,8 +102,6 @@ describe("plugin route contributions", () => {
   beforeEach(async () => {
     resetPluginRegistryForTests();
     resetSkillRoutesForTests();
-    getSecureKeyAsyncMock.mockReset();
-    getSecureKeyAsyncMock.mockImplementation(async () => undefined);
     await rm(TEST_WORKSPACE_DIR, { recursive: true, force: true });
   });
 

--- a/assistant/src/__tests__/plugin-tool-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-tool-contribution.test.ts
@@ -16,28 +16,15 @@
  * - Direct `registerPluginTools` / `unregisterPluginTools` semantics,
  *   including the plugin-scoped ref count.
  *
- * Uses `mock.module` to stub the credential store so bootstrap doesn't hit
- * the real backend. `resetPluginRegistryForTests()` and
- * `__clearRegistryForTesting()` isolate registry state between cases so
- * this file can run alongside other plugin/tool-registry tests without
- * cross-contamination.
+ * `resetPluginRegistryForTests()` and `__clearRegistryForTesting()` isolate
+ * registry state between cases so this file can run alongside other
+ * plugin/tool-registry tests without cross-contamination.
  */
 
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-// Mock the credential store before importing the bootstrap so the module
-// under test captures the stubbed binding. Bootstrap only calls this for
-// plugins that declare `requiresCredential`; the tests in this file don't,
-// so the stub simply returns undefined.
-const getSecureKeyAsyncMock = mock(
-  async (_account: string): Promise<string | undefined> => undefined,
-);
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: getSecureKeyAsyncMock,
-}));
 
 import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
 import { runShutdownHooks } from "../daemon/shutdown-registry.js";
@@ -134,8 +121,6 @@ describe("plugin tool contributions", () => {
     // assertions about which tools are present. We don't need any of the
     // eager/host tools for these tests.
     __clearRegistryForTesting();
-    getSecureKeyAsyncMock.mockReset();
-    getSecureKeyAsyncMock.mockImplementation(async () => undefined);
     await rm(TEST_WORKSPACE_DIR, { recursive: true, force: true });
   });
 

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -38,7 +38,6 @@ describe("plugin core types", () => {
     const manifest: PluginManifest = {
       name: "sample-plugin",
       version: "0.1.0",
-      requiresCredential: ["SAMPLE_API_KEY"],
       requiresFlag: ["sample-feature"],
       config: { parse: (input: unknown) => input },
     };
@@ -61,7 +60,6 @@ describe("plugin core types", () => {
         async init(ctx: PluginInitContext) {
           // Touch every field so refactors that rename any of them break here.
           void ctx.config;
-          void ctx.credentials;
           void ctx.logger;
           void ctx.pluginStorageDir;
           void ctx.assistantVersion;

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -19,24 +19,20 @@
  *    dropped from the registry via {@link unregisterPlugin} so none of its
  *    hooks participate in the turn lifecycle. This is the primary mechanism for
  *    shipping experimental plugins behind a feature flag.
- * 4. Resolves the plugin's `manifest.requiresCredential` entries via the
- *    credential store helper ({@link getSecureKeyAsync}). In Docker mode
- *    that helper goes through the CES HTTP API transparently; in local mode
- *    it hits the encrypted file store / CES RPC backend.
- * 5. Validates the config block under `plugins.<name>` against
+ * 4. Validates the config block under `plugins.<name>` against
  *    `manifest.config` if the manifest supplies a parser-like validator
  *    (Zod schemas with `.parse()` are supported; anything else is passed
  *    through untouched).
- * 6. Creates `<workspaceDir>/plugins-data/<plugin>/` on demand for per-plugin
+ * 5. Creates `<workspaceDir>/plugins-data/<plugin>/` on demand for per-plugin
  *    writable state and exposes it via {@link PluginInitContext.pluginStorageDir}.
- * 7. For each surviving plugin, registers its contributed tools and routes
+ * 6. For each surviving plugin, registers its contributed tools and routes
  *    into their global registries via {@link registerPluginTools} and
  *    {@link registerSkillRoute}. Contributions land BEFORE `init()` so
  *    the plugin's hook can observe a registry where its own model-visible
  *    surface is already wired — useful for plugins that want to attach
  *    metadata, warm caches, or otherwise interact with their own
  *    contributions during initialization.
- * 8. Awaits `plugin.init(ctx)` sequentially. An init failure is contained to
+ * 7. Awaits `plugin.init(ctx)` sequentially. An init failure is contained to
  *    the offending plugin: its already-registered tools and routes are rolled
  *    back, it is dropped from the registry, the failure is logged, and
  *    bootstrap continues with the remaining plugins. A single plugin's failure
@@ -76,7 +72,6 @@ import {
   type SkillRouteHandle,
   unregisterSkillRoute,
 } from "../runtime/skill-route-registry.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
 import {
   registerPluginTools,
   unregisterPluginTools,
@@ -87,25 +82,6 @@ import { APP_VERSION } from "../version.js";
 import { registerShutdownHook } from "./shutdown-registry.js";
 
 const log = getLogger("plugins-bootstrap");
-
-/**
- * Resolve one credential value. Returns the raw secret string or throws a
- * {@link PluginExecutionError} tagged with the plugin name so the caller can
- * fail startup with clear attribution.
- */
-async function resolveCredentialOrThrow(
-  pluginName: string,
-  credentialKey: string,
-): Promise<string> {
-  const value = await getSecureKeyAsync(credentialKey);
-  if (value === undefined || value === "") {
-    throw new PluginExecutionError(
-      `plugin ${pluginName} requires credential "${credentialKey}" but the credential store returned no value`,
-      pluginName,
-    );
-  }
-  return value;
-}
 
 /**
  * Validate a plugin config block. If the manifest supplies a parser-like
@@ -346,11 +322,6 @@ async function initializePlugin(
   let initCompleted = false;
 
   try {
-    const credentials: Record<string, string> = {};
-    for (const key of plugin.manifest.requiresCredential ?? []) {
-      credentials[key] = await resolveCredentialOrThrow(name, key);
-    }
-
     const config = validatePluginConfig(
       name,
       plugin.manifest.config,
@@ -359,7 +330,6 @@ async function initializePlugin(
 
     const initContext = {
       config,
-      credentials,
       logger: log.child({ plugin: name }),
       pluginStorageDir: ensurePluginStorageDir(name),
       assistantVersion: APP_VERSION,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -72,15 +72,13 @@ export type PluginHookFn<TCtx = unknown> = (
 // ─── Init context ────────────────────────────────────────────────────────────
 
 /**
- * Context passed to `Plugin.init()` during bootstrap. Carries resolved
- * config/credentials, a pino-compatible logger scoped to the plugin, a
- * per-plugin writable data directory, and the assistant's version metadata.
+ * Context passed to `Plugin.init()` during bootstrap. Carries the resolved
+ * config, a pino-compatible logger scoped to the plugin, a per-plugin
+ * writable data directory, and the assistant's version metadata.
  */
 export interface PluginInitContext {
   /** Parsed config for this plugin (may be `unknown` until the manifest validates). */
   config: unknown;
-  /** Resolved credential values keyed by the entries of `manifest.requiresCredential`. */
-  credentials: Record<string, string>;
   /** Pino-compatible child logger bound to `{ plugin: <name> }`. */
   logger: PluginLogger;
   /** Absolute path to `<workspaceDir>/plugins-data/<plugin>/` (created by bootstrap). */

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -18,7 +18,13 @@
  * cached entry.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
@@ -648,7 +654,6 @@ export async function populateCacheAtBoot(
       try {
         const initContext: PluginInitContext = {
           config: getConfig().plugins?.[pluginName],
-          credentials: {},
           logger: log.child({ plugin: pluginName }),
           pluginStorageDir: ensurePluginStorageDir(pluginName),
           assistantVersion: APP_VERSION,

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -47,8 +47,6 @@ export interface PluginManifest {
    * own version at load time.
    */
   version: string;
-  /** Credential keys the plugin needs resolved before `init()` runs. */
-  requiresCredential?: string[];
   /**
    * Assistant feature-flag keys that must all be enabled for this plugin to
    * activate. Checked by `bootstrapPlugins` via `isAssistantFeatureFlagEnabled`

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -156,7 +156,6 @@ import type { PluginInitContext } from "@vellumai/plugin-api";
 
 export default async function init(ctx: PluginInitContext): Promise<void> {
   // ctx.config            — your validated config (typed `unknown` for now)
-  // ctx.credentials       — resolved credential values, keyed by manifest entry
   // ctx.logger            — pino child, bound to { plugin: <name> }
   // ctx.pluginStorageDir  — writable dir at <workspace>/plugins-data/<name>/
   // ctx.assistantVersion  — host semver string


### PR DESCRIPTION
## Why

We're retiring the host-mediated plugin credential-injection path. Previously a plugin could declare `manifest.requiresCredential: [...]` and the bootstrap would pre-resolve each key through the credential store (`getSecureKeyAsync`) and hand the plugin a `ctx.credentials` bag at `init()`. This baked a per-plugin secret-resolution responsibility into the host. Plugins that need secrets should resolve them through the workspace provider/credential APIs instead, so the host's plugin bootstrap no longer touches the credential store at all.

## What changed

- **`PluginInitContext`** — drops the `credentials: Record<string, string>` field.
- **`PluginManifest`** — drops the `requiresCredential?: string[]` field.
- **`external-plugins-bootstrap.ts`** — removes the credential-resolution step, the `resolveCredentialOrThrow` helper, and the `getSecureKeyAsync` import; bootstrap no longer reads the credential store. Module docstring renumbered accordingly.
- **`mtime-cache.ts`** (user-plugin loader) — drops `credentials: {}` from the user-plugin init context.
- **`plugins/README.md`** — removes the `ctx.credentials` line from the `init` hook example.
- **Tests** — removes the two credential-resolution cases and the now-dead `secure-keys` mock scaffolding from the plugin bootstrap/contribution/types tests, plus the stale `external-plugins-bootstrap.ts` entry from the secure-keys allowlist in `credential-security-invariants.test.ts`.

## Verification

- `bun test` for the four plugin test files: **37 pass / 0 fail**
- `credential-security-invariants.test.ts`: **29 pass / 0 fail**
- Pre-commit hook lint + scoped type-check: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01289qg9gWg5ca2HuvCkRYo4)_