### PR TITLE
test(db): fix flaky db-repair backfill tests on slow machines

### DIFF
--- a/assistant/src/cli/commands/db/__tests__/repair.test.ts
+++ b/assistant/src/cli/commands/db/__tests__/repair.test.ts
@@ -456,6 +456,9 @@ async function initSchema(): Promise<void> {
   clearStoredDb("memory");
 }
 
+// Every test here runs initSchema(), which replays the full production
+// migration suite, plus at least one repair pass. On a loaded machine that
+// comfortably exceeds bun's 5s per-test default, so each gets a 30s ceiling.
 describe("assistant db repair — conversation-backfill step", () => {
   test("backfills a disk-only conversation into SQLite", async () => {
     await initSchema();
@@ -499,7 +502,7 @@ describe("assistant db repair — conversation-backfill step", () => {
     } finally {
       verify.close();
     }
-  });
+  }, 30_000);
 
   test("skips conversations already present (idempotent)", async () => {
     await initSchema();
@@ -516,8 +519,6 @@ describe("assistant db repair — conversation-backfill step", () => {
     expect(parsed.steps[1].result.data.recovered).toBe(0);
     expect(parsed.steps[1].result.data.skipped).toBe(1);
     expect(parsed.steps[1].result.status).toBe("ok");
-    // Two full repair passes (each walks the DB via integrity-check) exceed
-    // bun's 5s per-test default, so raise the ceiling to keep CI stable.
   }, 30_000);
 
   test("reports nothing-to-backfill on an empty conversations dir", async () => {
@@ -529,7 +530,7 @@ describe("assistant db repair — conversation-backfill step", () => {
     expect(parsed.steps[1].result.status).toBe("ok");
     expect(parsed.steps[1].result.summary).toContain("nothing to backfill");
     expect(parsed.steps[1].result.data.recovered).toBe(0);
-  });
+  }, 30_000);
 
   test("surfaces warnings for malformed meta.json without erroring the step", async () => {
     await initSchema();
@@ -547,5 +548,5 @@ describe("assistant db repair — conversation-backfill step", () => {
         w.includes("malformed meta.json"),
       ),
     ).toBe(true);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary
- The `conversation-backfill` tests in `repair.test.ts` each call `initSchema()` (which replays the full production migration suite) plus at least one `db repair` pass. On a loaded/slow machine that work exceeds bun's 5s per-test default timeout, producing an intermittent `1 fail` out of 16.
- The `idempotent` test already carried a `30_000` ceiling for this exact reason; the other three backfill tests did the same heavy work but ran under the 5s default. Give all four the 30s ceiling and hoist the rationale into one describe-level comment.
- Pure test-timeout change — no production behavior touched; raising a timeout can only prevent spurious failures, never mask a real one.

## Original prompt
A run of `src/cli/commands/db/__tests__/repair.test.ts` reported 15 pass / 1 fail under bun 1.3.11, with no indication of which test failed. The suite passed consistently in isolation (27 runs across bun 1.3.9 and 1.3.11), pointing to a timing-sensitive flake rather than a logic bug. The reporter's run took 20.72s vs ~3s locally — ~7× slower — which tips the ~1s backfill tests past bun's 5s default and matches the existing precedent comment on the idempotent test.