### PR TITLE
fix(computer-use): don't flag selection/cursor key actions as NO VISIBLE EFFECT

### DIFF
--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -513,6 +513,71 @@ describe("HostCuProxy", () => {
       expect(proxy.consecutiveUnchangedSteps).toBe(0);
     });
 
+    test("exempt key clears the no-effect streak between non-exempt no-ops", async () => {
+      setup();
+
+      // Establish previous AX tree
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent1 = sentMessages[0] as Record<string, unknown>;
+      proxy.processObservation(sent1.requestId as string, {
+        axTree: "TextField [1]",
+      });
+      await p1;
+
+      // Non-exempt no-diff click — streak = 1
+      const p2 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        2,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent2 = sentMessages[1] as Record<string, unknown>;
+      proxy.processObservation(sent2.requestId as string, {
+        axTree: "TextField [1]",
+      });
+      await p2;
+      expect(proxy.consecutiveUnchangedSteps).toBe(1);
+
+      // Exempt cmd+a no-diff — must CLEAR the streak, not just skip it
+      const p3 = proxy.request(
+        "computer_use_key",
+        { key: "cmd+a" },
+        "session-1",
+        3,
+      );
+      proxy.recordAction("computer_use_key", { key: "cmd+a" });
+      const sent3 = sentMessages[2] as Record<string, unknown>;
+      proxy.processObservation(sent3.requestId as string, {
+        axTree: "TextField [1]",
+      });
+      await p3;
+      expect(proxy.consecutiveUnchangedSteps).toBe(0);
+
+      // Next non-exempt no-diff click — streak = 1 again, NOT a "2 consecutive"
+      // escalation bridged across the exempt keypress.
+      const p4 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        4,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent4 = sentMessages[3] as Record<string, unknown>;
+      proxy.processObservation(sent4.requestId as string, {
+        axTree: "TextField [1]",
+      });
+      const result4 = await p4;
+      expect(proxy.consecutiveUnchangedSteps).toBe(1);
+      expect(result4.content).not.toContain("2 consecutive");
+    });
+
     test("still warns for a non-exempt key (enter) with no diff", async () => {
       setup();
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -725,6 +725,57 @@ describe("HostCuProxy", () => {
       );
     });
 
+    test("loop detection ignores the same combo sent to different clients", () => {
+      setup();
+
+      // Same key, different target desktops — not a repeat on one UI, so loop
+      // detection must NOT fire. Routing fields are kept in the signature.
+      proxy.recordAction("computer_use_key", {
+        key: "cmd+a",
+        target_client_id: "client-a",
+      });
+      proxy.recordAction("computer_use_key", {
+        key: "cmd+a",
+        target_client_id: "client-b",
+      });
+      proxy.recordAction("computer_use_key", {
+        key: "cmd+a",
+        target_client_id: "client-c",
+      });
+
+      const result = proxy.formatObservation({
+        axTree: "Button [1]",
+      });
+
+      expect(result.content).not.toContain("WARNING: You've repeated");
+    });
+
+    test("loop detection fires for the same combo+client across spellings", () => {
+      setup();
+
+      // Same target client, equivalent spellings — still a repeat on one UI.
+      proxy.recordAction("computer_use_key", {
+        key: "cmd+a",
+        target_client_id: "client-a",
+      });
+      proxy.recordAction("computer_use_key", {
+        key: "command+a",
+        target_client_id: "client-a",
+      });
+      proxy.recordAction("computer_use_key", {
+        key: "cmd + a",
+        target_client_id: "client-a",
+      });
+
+      const result = proxy.formatObservation({
+        axTree: "Button [1]",
+      });
+
+      expect(result.content).toContain(
+        "WARNING: You've repeated the same action (computer_use_key) 3 times",
+      );
+    });
+
     test("resets consecutive count when diff is present", async () => {
       setup();
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -705,6 +705,26 @@ describe("HostCuProxy", () => {
       expect(result.content).not.toContain("NO VISIBLE EFFECT");
     });
 
+    test("loop detection fires for the same exempt combo spelled differently", () => {
+      setup();
+
+      // Equivalent spellings the mac helper executes identically must count as
+      // the same action — otherwise a stuck session could repeat cmd+a forever
+      // (no-effect warning is suppressed for exempt keys, so loop detection is
+      // the only remaining guard).
+      proxy.recordAction("computer_use_key", { key: "cmd+a" });
+      proxy.recordAction("computer_use_key", { key: "command+a" });
+      proxy.recordAction("computer_use_key", { key: "cmd + a" });
+
+      const result = proxy.formatObservation({
+        axTree: "Button [1]",
+      });
+
+      expect(result.content).toContain(
+        "WARNING: You've repeated the same action (computer_use_key) 3 times",
+      );
+    });
+
     test("resets consecutive count when diff is present", async () => {
       setup();
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -477,6 +477,128 @@ describe("HostCuProxy", () => {
       expect(result2.content).not.toContain("NO VISIBLE EFFECT");
     });
 
+    test("skips unchanged warning and counter after a selection-only key (cmd+a)", async () => {
+      setup();
+
+      // Establish previous AX tree
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent1 = sentMessages[0] as Record<string, unknown>;
+      proxy.processObservation(sent1.requestId as string, {
+        axTree: "TextField [1]",
+      });
+      await p1;
+
+      // cmd+a only changes selection — AX tree can't show it, so empty diff
+      // is expected and must NOT warn or bump the unchanged counter.
+      const p2 = proxy.request(
+        "computer_use_key",
+        { key: "cmd+a" },
+        "session-1",
+        2,
+      );
+      proxy.recordAction("computer_use_key", { key: "cmd+a" });
+      const sent2 = sentMessages[1] as Record<string, unknown>;
+      proxy.processObservation(sent2.requestId as string, {
+        axTree: "TextField [1]",
+        // No axDiff — selection change is invisible in the AX tree
+      });
+      const result2 = await p2;
+      expect(result2.content).not.toContain("NO VISIBLE EFFECT");
+      expect(proxy.consecutiveUnchangedSteps).toBe(0);
+    });
+
+    test("still warns for a non-exempt key (enter) with no diff", async () => {
+      setup();
+
+      // Establish previous AX tree
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent1 = sentMessages[0] as Record<string, unknown>;
+      proxy.processObservation(sent1.requestId as string, {
+        axTree: "Button [1]",
+      });
+      await p1;
+
+      // enter is not in the exempt set — an empty diff should still warn.
+      const p2 = proxy.request(
+        "computer_use_key",
+        { key: "enter" },
+        "session-1",
+        2,
+      );
+      proxy.recordAction("computer_use_key", { key: "enter" });
+      const sent2 = sentMessages[1] as Record<string, unknown>;
+      proxy.processObservation(sent2.requestId as string, {
+        axTree: "Button [1]",
+      });
+      const result2 = await p2;
+      expect(result2.content).toContain("NO VISIBLE EFFECT");
+      expect(proxy.consecutiveUnchangedSteps).toBe(1);
+    });
+
+    test("still warns for a non-exempt action (click) with no diff", async () => {
+      setup();
+
+      // Establish previous AX tree
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent1 = sentMessages[0] as Record<string, unknown>;
+      proxy.processObservation(sent1.requestId as string, {
+        axTree: "Button [1]",
+      });
+      await p1;
+
+      const p2 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        2,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent2 = sentMessages[1] as Record<string, unknown>;
+      proxy.processObservation(sent2.requestId as string, {
+        axTree: "Button [1]",
+      });
+      const result2 = await p2;
+      expect(result2.content).toContain("NO VISIBLE EFFECT");
+      expect(proxy.consecutiveUnchangedSteps).toBe(1);
+    });
+
+    test("loop detection still fires for repeated identical exempt keys", () => {
+      setup();
+
+      // Even though `up` is exempt from the unchanged-effect warning, repeating
+      // the same key must still be caught by loop detection.
+      proxy.recordAction("computer_use_key", { key: "up" });
+      proxy.recordAction("computer_use_key", { key: "up" });
+      proxy.recordAction("computer_use_key", { key: "up" });
+
+      const result = proxy.formatObservation({
+        axTree: "Button [1]",
+      });
+
+      expect(result.content).toContain(
+        "WARNING: You've repeated the same action (computer_use_key) 3 times",
+      );
+      expect(result.content).not.toContain("NO VISIBLE EFFECT");
+    });
+
     test("resets consecutive count when diff is present", async () => {
       setup();
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -513,6 +513,47 @@ describe("HostCuProxy", () => {
       expect(proxy.consecutiveUnchangedSteps).toBe(0);
     });
 
+    test("exempts key combos regardless of spacing, case, alias, or modifier order", async () => {
+      // All of these normalize to an exempt combo the mac helper would execute
+      // identically: spaced, uppercase, alt->option alias, command->cmd alias,
+      // and reversed modifier order.
+      const variants = ["cmd + a", "CMD+A", "alt+tab", "command+c", "tab+shift"];
+
+      for (const [i, variant] of variants.entries()) {
+        setup();
+
+        // Establish previous AX tree
+        const p1 = proxy.request(
+          "computer_use_click",
+          { element_id: 1 },
+          `session-${i}`,
+          1,
+        );
+        proxy.recordAction("computer_use_click", { element_id: 1 });
+        const sent1 = sentMessages[0] as Record<string, unknown>;
+        proxy.processObservation(sent1.requestId as string, {
+          axTree: "TextField [1]",
+        });
+        await p1;
+
+        const p2 = proxy.request(
+          "computer_use_key",
+          { key: variant },
+          `session-${i}`,
+          2,
+        );
+        proxy.recordAction("computer_use_key", { key: variant });
+        const sent2 = sentMessages[1] as Record<string, unknown>;
+        proxy.processObservation(sent2.requestId as string, {
+          axTree: "TextField [1]",
+          // No axDiff — invisible-by-design change
+        });
+        const result2 = await p2;
+        expect(result2.content).not.toContain("NO VISIBLE EFFECT");
+        expect(proxy.consecutiveUnchangedSteps).toBe(0);
+      }
+    });
+
     test("exempt key clears the no-effect streak between non-exempt no-ops", async () => {
       setup();
 

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -133,6 +133,22 @@ function isNoDiffKeyAction(action: ActionRecord | undefined): boolean {
   );
 }
 
+/**
+ * Canonical signature for loop detection. Key presses collapse equivalent
+ * spellings (`cmd+a`, `command+a`, `cmd + a`) to one signature so a stuck
+ * session retrying the same combo with alias/whitespace variants is still
+ * caught — important now that exempt keys no longer emit no-effect warnings.
+ */
+function actionSignature(record: ActionRecord): string {
+  if (
+    record.toolName === "computer_use_key" &&
+    typeof record.input.key === "string"
+  ) {
+    return `computer_use_key:${canonicalizeKeyCombo(record.input.key)}`;
+  }
+  return `${record.toolName}:${JSON.stringify(record.input)}`;
+}
+
 // ---------------------------------------------------------------------------
 // HostCuProxy
 // ---------------------------------------------------------------------------
@@ -470,10 +486,9 @@ export class HostCuProxy {
 
     if (this._actionHistory.length >= LOOP_DETECTION_WINDOW) {
       const recent = this._actionHistory.slice(-LOOP_DETECTION_WINDOW);
+      const firstSignature = actionSignature(recent[0]);
       const allIdentical = recent.every(
-        (r) =>
-          r.toolName === recent[0].toolName &&
-          JSON.stringify(r.input) === JSON.stringify(recent[0].input),
+        (r) => actionSignature(r) === firstSignature,
       );
       if (allIdentical) {
         parts.push(

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -135,16 +135,23 @@ function isNoDiffKeyAction(action: ActionRecord | undefined): boolean {
 
 /**
  * Canonical signature for loop detection. Key presses collapse equivalent
- * spellings (`cmd+a`, `command+a`, `cmd + a`) to one signature so a stuck
- * session retrying the same combo with alias/whitespace variants is still
- * caught — important now that exempt keys no longer emit no-effect warnings.
+ * spellings (`cmd+a`, `command+a`, `cmd + a`) of the same combo so a stuck
+ * session retrying it with alias/whitespace variants is still caught —
+ * important now that exempt keys no longer emit no-effect warnings. Only the
+ * `key` value is normalized; all other input fields (e.g. the routing
+ * `target_client_id`) are preserved, so the same combo sent to different
+ * desktop clients is not mistaken for a repeat.
  */
 function actionSignature(record: ActionRecord): string {
   if (
     record.toolName === "computer_use_key" &&
     typeof record.input.key === "string"
   ) {
-    return `computer_use_key:${canonicalizeKeyCombo(record.input.key)}`;
+    const normalizedInput = {
+      ...record.input,
+      key: canonicalizeKeyCombo(record.input.key),
+    };
+    return `computer_use_key:${JSON.stringify(normalizedInput)}`;
   }
   return `${record.toolName}:${JSON.stringify(record.input)}`;
 }

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -44,14 +44,15 @@ const MAX_HISTORY_ENTRIES = 10;
 const LOOP_DETECTION_WINDOW = 3;
 const CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD = 2;
 
-// computer_use_key actions that change only selection/cursor/clipboard state.
+// computer_use_key combos that change only selection/cursor/clipboard state.
 // The AX tree models none of these, so they always produce an empty diff —
 // exempt them from the "NO VISIBLE EFFECT" signal (mirrors computer_use_wait).
-const NO_AX_DIFF_KEYS = new Set([
+// Stored in canonical form (see canonicalizeKeyCombo): modifier aliases
+// normalized and ordered, so `cmd + a`, `command+a`, `alt+tab`, `tab+shift`
+// all match.
+const NO_AX_DIFF_KEY_COMBOS = new Set([
   "cmd+a",
-  "command+a",
   "cmd+c",
-  "command+c",
   "up",
   "down",
   "left",
@@ -59,6 +60,39 @@ const NO_AX_DIFF_KEYS = new Set([
   "shift+tab",
   "option+tab",
 ]);
+
+// Modifier aliases mirror the mac helper's ActionExecutor.pressKey so the
+// exemption check matches exactly what the helper will execute.
+const KEY_MODIFIER_ALIASES: Record<string, string> = {
+  cmd: "cmd",
+  command: "cmd",
+  option: "option",
+  alt: "option",
+  ctrl: "ctrl",
+  control: "ctrl",
+  shift: "shift",
+};
+const KEY_MODIFIER_ORDER = ["cmd", "ctrl", "option", "shift"];
+
+/**
+ * Normalize a key combo the way the mac helper does (lowercase, split on `+`,
+ * trim, alias modifiers) into a canonical `mods…+base` string with modifiers
+ * in a fixed order — so order/alias/whitespace variants compare equal.
+ */
+function canonicalizeKeyCombo(key: string): string {
+  const mods = new Set<string>();
+  let base = "";
+  for (const raw of key.toLowerCase().split("+")) {
+    const part = raw.trim();
+    if (part.length === 0) continue;
+    const mod = KEY_MODIFIER_ALIASES[part];
+    if (mod) mods.add(mod);
+    else base = part; // last non-modifier wins, matching the executor
+  }
+  return [...KEY_MODIFIER_ORDER.filter((m) => mods.has(m)), base]
+    .filter((s) => s.length > 0)
+    .join("+");
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -94,7 +128,8 @@ function isNoDiffKeyAction(action: ActionRecord | undefined): boolean {
   if (action?.toolName !== "computer_use_key") return false;
   const key = action.input.key;
   return (
-    typeof key === "string" && NO_AX_DIFF_KEYS.has(key.trim().toLowerCase())
+    typeof key === "string" &&
+    NO_AX_DIFF_KEY_COMBOS.has(canonicalizeKeyCombo(key))
   );
 }
 

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -44,6 +44,22 @@ const MAX_HISTORY_ENTRIES = 10;
 const LOOP_DETECTION_WINDOW = 3;
 const CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD = 2;
 
+// computer_use_key actions that change only selection/cursor/clipboard state.
+// The AX tree models none of these, so they always produce an empty diff —
+// exempt them from the "NO VISIBLE EFFECT" signal (mirrors computer_use_wait).
+const NO_AX_DIFF_KEYS = new Set([
+  "cmd+a",
+  "command+a",
+  "cmd+c",
+  "command+c",
+  "up",
+  "down",
+  "left",
+  "right",
+  "shift+tab",
+  "option+tab",
+]);
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -67,6 +83,19 @@ export interface ActionRecord {
   toolName: string;
   input: Record<string, unknown>;
   reasoning?: string;
+}
+
+/**
+ * True when `action` is a computer_use_key press whose key only mutates
+ * selection/cursor/clipboard state — changes the AX tree cannot represent, so
+ * an empty diff is expected rather than a sign the action did nothing.
+ */
+function isNoDiffKeyAction(action: ActionRecord | undefined): boolean {
+  if (action?.toolName !== "computer_use_key") return false;
+  const key = action.input.key;
+  return (
+    typeof key === "string" && NO_AX_DIFF_KEYS.has(key.trim().toLowerCase())
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -385,8 +414,9 @@ export class HostCuProxy {
           ? this._actionHistory[this._actionHistory.length - 1]
           : undefined;
       const isWaitAction = lastAction?.toolName === "computer_use_wait";
+      const isNoDiffKey = isNoDiffKeyAction(lastAction);
 
-      if (!isWaitAction) {
+      if (!isWaitAction && !isNoDiffKey) {
         if (
           this._consecutiveUnchangedSteps >=
           CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD
@@ -505,10 +535,15 @@ export class HostCuProxy {
 
   private updateStateFromObservation(obs: CuObservationResult): void {
     if (this._stepCount > 0) {
+      const lastAction =
+        this._actionHistory.length > 0
+          ? this._actionHistory[this._actionHistory.length - 1]
+          : undefined;
       if (
         obs.axDiff == null &&
         this._previousAXTree != null &&
-        obs.axTree != null
+        obs.axTree != null &&
+        !isNoDiffKeyAction(lastAction)
       ) {
         this._consecutiveUnchangedSteps++;
       } else if (obs.axDiff != null) {

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -539,15 +539,14 @@ export class HostCuProxy {
         this._actionHistory.length > 0
           ? this._actionHistory[this._actionHistory.length - 1]
           : undefined;
-      if (
-        obs.axDiff == null &&
-        this._previousAXTree != null &&
-        obs.axTree != null &&
-        !isNoDiffKeyAction(lastAction)
-      ) {
-        this._consecutiveUnchangedSteps++;
-      } else if (obs.axDiff != null) {
+      if (obs.axDiff != null || isNoDiffKeyAction(lastAction)) {
+        // A real diff, or an exempt key whose effect is invisible by design,
+        // breaks the no-effect streak — clear it rather than preserving a
+        // stale count so an intervening cmd+a can't bridge two no-op actions
+        // into a false "consecutive" escalation.
         this._consecutiveUnchangedSteps = 0;
+      } else if (this._previousAXTree != null && obs.axTree != null) {
+        this._consecutiveUnchangedSteps++;
       }
     }
 


### PR DESCRIPTION
## Summary
- Selection/cursor/clipboard-only key presses (`cmd+a`, `cmd+c`, arrow keys, `shift+tab`, `option+tab`) change state the macOS AX tree does not model, so they always produce an empty diff and were falsely flagged "NO VISIBLE EFFECT" — misleading the agent into abandoning a working action (confirmed: `cmd+a` then typing correctly replaced field contents, yet the daemon warned twice and escalated).
- In `host-cu-proxy.ts`, added a `NO_AX_DIFF_KEYS` set + an `isNoDiffKeyAction()` helper and exempt those `computer_use_key` actions the same way `computer_use_wait` is already exempt: `formatObservation()` skips the warning, and `updateStateFromObservation()` skips incrementing the consecutive-unchanged counter.
- Loop detection is untouched — a genuinely stuck agent repeating the same exempt key is still caught. Daemon-only; no Swift/native changes.

## Original prompt
Computer-use reports "NO VISIBLE EFFECT" (escalating after 2 in a row) when an action produces no AX-tree diff. Some keyboard actions legitimately change only selection/cursor/clipboard state, which the AX tree can't represent, so they always diff-empty and trip a false warning. The ask: in `assistant/src/daemon/host-cu-proxy.ts`, treat a known set of such keys like the existing `computer_use_wait` exemption — don't warn and don't increment the unchanged counter — without weakening loop detection or modifying the signed Swift mac-helper, with tests extending `host-cu-proxy.test.ts`.