### PR TITLE
feat(gateway): expose an upsert-verified-channel IPC for invite activation

### DIFF
--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -90,6 +90,10 @@ const markChannelRevokedHandler = contactRoutes.find(
   (r) => r.method === "mark_channel_revoked",
 )!.handler;
 
+const upsertVerifiedChannelHandler = contactRoutes.find(
+  (r) => r.method === "upsert_verified_channel",
+)!.handler;
+
 beforeAll(async () => {
   await initGatewayDb();
 });
@@ -345,5 +349,129 @@ describe("mark_channel_revoked IPC handler", () => {
     await expect(
       markChannelRevokedHandler({ contactChannelId: "nonexistent" }),
     ).rejects.toThrow(/not found/);
+  });
+});
+
+describe("upsert_verified_channel IPC handler", () => {
+  test("creates + verifies a new gateway channel and returns it", async () => {
+    const before = Date.now();
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-new",
+      externalChatId: "chat-new",
+    })) as {
+      ok: boolean;
+      verified: boolean;
+      channel: {
+        id: string;
+        contactId: string;
+        type: string;
+        address: string;
+        status: string;
+        verifiedAt: number | null;
+        verifiedVia: string | null;
+      };
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.verified).toBe(true);
+    expect(res.channel.type).toBe("vellum");
+    expect(res.channel.address).toBe("addr-new");
+    expect(res.channel.status).toBe("active");
+    expect(res.channel.verifiedVia).toBe("challenge");
+    expect(res.channel.verifiedAt!).toBeGreaterThanOrEqual(before);
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.type, "vellum"))
+      .get();
+    expect(row!.status).toBe("active");
+  });
+
+  test("updates an existing unverified gateway channel to verified", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
+
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-ch1",
+      externalChatId: "chat-1",
+    })) as { ok: boolean; verified: boolean; channel: { status: string } };
+
+    expect(res.ok).toBe(true);
+    expect(res.verified).toBe(true);
+    expect(res.channel.status).toBe("active");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("active");
+    expect(row!.verifiedAt).not.toBeNull();
+  });
+
+  test("does not reactivate a blocked gateway channel (verified:false, no channel)", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "blocked" });
+
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-ch1",
+      externalChatId: "chat-1",
+    })) as { ok: boolean; verified: boolean; channel?: unknown };
+
+    expect(res.ok).toBe(true);
+    expect(res.verified).toBe(false);
+    expect(res.channel).toBeUndefined();
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("blocked");
+  });
+
+  test("does not reactivate a revoked gateway channel (verified:false)", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "revoked" });
+
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-ch1",
+      externalChatId: "chat-1",
+    })) as { ok: boolean; verified: boolean };
+
+    expect(res.ok).toBe(true);
+    expect(res.verified).toBe(false);
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.status).toBe("revoked");
+  });
+
+  test("round-trips verifiedVia=\"invite\" (free string, not the restricted enum)", async () => {
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-invite",
+      externalChatId: "chat-invite",
+      verifiedVia: "invite",
+    })) as { ok: boolean; verified: boolean; channel: { verifiedVia: string } };
+
+    expect(res.ok).toBe(true);
+    expect(res.verified).toBe(true);
+    expect(res.channel.verifiedVia).toBe("invite");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.address, "addr-invite"))
+      .get();
+    expect(row!.verifiedVia).toBe("invite");
   });
 });

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -15,12 +15,18 @@ import {
   MarkChannelVerifiedIpcParamsSchema,
   MarkChannelVerifiedIpcResponseSchema,
   UpdateContactChannelIpcParamsSchema,
+  UpsertVerifiedChannelIpcParamsSchema,
+  UpsertVerifiedChannelIpcResponseSchema,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { z } from "zod";
 
 import { ContactStore } from "../db/contact-store.js";
 import { updateContactChannelCore } from "../http/routes/contacts-control-plane-proxy.js";
 import { getLogger } from "../logger.js";
+import {
+  getGatewayChannelByKey,
+  upsertVerifiedContactChannel,
+} from "../verification/contact-helpers.js";
 import { canonicalizeInboundIdentity } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
 
@@ -212,6 +218,43 @@ export const contactRoutes: IpcRoute[] = [
           verifiedAt: channel.verifiedAt,
           verifiedVia: channel.verifiedVia,
         },
+      });
+    },
+  },
+  {
+    method: "upsert_verified_channel",
+    schema: UpsertVerifiedChannelIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { type, address, externalChatId, displayName, username, verifiedVia } =
+        UpsertVerifiedChannelIpcParamsSchema.parse(params);
+
+      const { verified } = await upsertVerifiedContactChannel({
+        sourceChannel: type,
+        externalUserId: address,
+        externalChatId,
+        displayName,
+        username,
+        verifiedVia,
+      });
+
+      // A blocked/revoked skip is not an error: surface it as verified:false
+      // with no channel rather than throwing.
+      if (!verified) {
+        return UpsertVerifiedChannelIpcResponseSchema.parse({
+          ok: true,
+          verified: false,
+        });
+      }
+
+      // Read the post-write state from the gateway (source of truth) by the
+      // canonical logical key the helper writes under.
+      const canonicalAddress =
+        canonicalizeInboundIdentity(type, address) ?? address;
+      const channel = getGatewayChannelByKey(type, canonicalAddress);
+      return UpsertVerifiedChannelIpcResponseSchema.parse({
+        ok: true,
+        verified: true,
+        ...(channel ? { channel } : {}),
       });
     },
   },

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -194,6 +194,46 @@ export function gatewayChannelStatus(type: string, address: string): string | nu
   return row?.status ?? null;
 }
 
+export interface VerifiedChannelRow {
+  id: string;
+  contactId: string;
+  type: string;
+  address: string;
+  status: string;
+  verifiedAt: number | null;
+  verifiedVia: string | null;
+}
+
+/**
+ * Read the authoritative gateway channel row by the logical key
+ * (type, address) COLLATE NOCASE. Used to project an upsert result back to the
+ * caller; the source-of-truth row carries the post-write state.
+ */
+export function getGatewayChannelByKey(
+  type: string,
+  address: string,
+): VerifiedChannelRow | null {
+  const row = getGatewayDb()
+    .select({
+      id: gwContactChannels.id,
+      contactId: gwContactChannels.contactId,
+      type: gwContactChannels.type,
+      address: gwContactChannels.address,
+      status: gwContactChannels.status,
+      verifiedAt: gwContactChannels.verifiedAt,
+      verifiedVia: gwContactChannels.verifiedVia,
+    })
+    .from(gwContactChannels)
+    .where(
+      and(
+        eq(gwContactChannels.type, type),
+        sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+      ),
+    )
+    .get();
+  return row ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // Upsert
 // ---------------------------------------------------------------------------

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -137,6 +137,42 @@ export type MarkChannelVerifiedIpcResponse = z.infer<
   typeof MarkChannelVerifiedIpcResponseSchema
 >;
 
+export const UpsertVerifiedChannelIpcParamsSchema = z.object({
+  type: z.string().min(1),
+  address: z.string().min(1),
+  externalChatId: z.string().min(1),
+  displayName: z.string().optional(),
+  username: z.string().optional(),
+  // Audit source for the verification. Free text (DB column is text) so the
+  // invite-activation path can pass "invite"; do not narrow to an enum.
+  verifiedVia: z.string().optional(),
+});
+
+export type UpsertVerifiedChannelIpcParams = z.infer<
+  typeof UpsertVerifiedChannelIpcParamsSchema
+>;
+
+export const UpsertVerifiedChannelIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  verified: z.boolean(),
+  // Present only when verified — a blocked/revoked skip omits the channel.
+  channel: z
+    .object({
+      id: z.string(),
+      contactId: z.string(),
+      type: z.string(),
+      address: z.string(),
+      status: z.string(),
+      verifiedAt: z.number().nullable(),
+      verifiedVia: z.string().nullable(),
+    })
+    .optional(),
+});
+
+export type UpsertVerifiedChannelIpcResponse = z.infer<
+  typeof UpsertVerifiedChannelIpcResponseSchema
+>;
+
 export const MarkChannelRevokedIpcParamsSchema = z.object({
   contactChannelId: z.string().min(1),
   // Audit reason for the downgrade. The verification-revoke flow passes


### PR DESCRIPTION
## Summary
- Add upsert_verified_channel IPC over the existing upsertVerifiedContactChannel (create-or-update verified channel; verifiedVia accepts "invite"; blocked/revoked channels are not reactivated). Additive/gateway-only — no assistant caller yet.

Part of plan: combo11-phase-b1-gateway-write-ownership.md (PR 1 of 3)