### PR TITLE
feat(memory): make `memory worker` start/stop/status manage the synchronous runner

### DIFF
--- a/assistant/src/cli/commands/memory/__tests__/worker.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/worker.test.ts
@@ -3,10 +3,11 @@
  *
  * Validates:
  *   - Subcommand registration (start, stop, status) under `memory worker`.
- *   - `status` reports running/not_running via PID-file liveness.
- *   - `stop` sends SIGTERM to a live worker and errors when none is running.
- *   - `start` refuses to spawn when a worker is already running, and reports
- *     the PID once the spawned process writes its PID file.
+ *   - `status` reports the worker process state, `memory.worker.enabled`, and
+ *     the synchronous in-process runner via PID/marker-file liveness.
+ *   - `stop` sends SIGTERM to a live worker and disables the config flag, and
+ *     still disables the flag (success) when no worker is running.
+ *   - `start` spawns/reuses the worker process and enables the config flag.
  */
 
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -22,10 +23,19 @@ import { Command } from "commander";
 
 let tmpDir: string;
 let pidPath: string;
+let markerPath: string;
 let logOutput: string[] = [];
+
+/** In-memory stand-in for the on-disk raw config the CLI reads/writes. */
+let rawConfig: Record<string, unknown> = {};
 
 /** Records (pid, signal) pairs passed to the mocked process.kill. */
 let killCalls: Array<{ pid: number; signal: string | number }> = [];
+
+function workerEnabledFromRaw(): boolean {
+  const memory = rawConfig.memory as { worker?: { enabled?: unknown } };
+  return memory?.worker?.enabled === true;
+}
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -33,6 +43,31 @@ let killCalls: Array<{ pid: number; signal: string | number }> = [];
 
 mock.module("../../../../util/platform.js", () => ({
   getMemoryWorkerPidPath: () => pidPath,
+  getMemorySyncRunnerMarkerPath: () => markerPath,
+}));
+
+mock.module("../../../../config/loader.js", () => ({
+  loadRawConfig: () => structuredClone(rawConfig),
+  saveRawConfig: (config: Record<string, unknown>) => {
+    rawConfig = structuredClone(config);
+  },
+  getConfigReadOnly: () => ({
+    memory: { worker: { enabled: workerEnabledFromRaw() } },
+  }),
+  setNestedValue: (
+    obj: Record<string, unknown>,
+    path: string,
+    value: unknown,
+  ) => {
+    const keys = path.split(".");
+    let cur = obj;
+    for (let i = 0; i < keys.length - 1; i++) {
+      const k = keys[i];
+      if (cur[k] == null || typeof cur[k] !== "object") cur[k] = {};
+      cur = cur[k] as Record<string, unknown>;
+    }
+    cur[keys[keys.length - 1]] = value;
+  },
 }));
 
 const capture = (...args: unknown[]) => {
@@ -135,8 +170,10 @@ function stubProcessKill(livePids: Set<number>): () => void {
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "memory-worker-test-"));
   pidPath = join(tmpDir, "memory-worker.pid");
+  markerPath = join(tmpDir, "memory-sync-runner.pid");
   logOutput = [];
   killCalls = [];
+  rawConfig = {};
   process.exitCode = 0;
 });
 
@@ -165,7 +202,7 @@ describe("subcommand registration", () => {
 // ---------------------------------------------------------------------------
 
 describe("memory worker status", () => {
-  test("reports not_running when no PID file exists", async () => {
+  test("reports not_running with workerEnabled and syncRunner when nothing is running", async () => {
     const { exitCode, stdout } = await runCommand([
       "memory",
       "worker",
@@ -173,7 +210,11 @@ describe("memory worker status", () => {
       "--json",
     ]);
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout)).toEqual({ status: "not_running" });
+    expect(JSON.parse(stdout)).toEqual({
+      status: "not_running",
+      workerEnabled: false,
+      syncRunner: { status: "not_running" },
+    });
   });
 
   test("reports running when PID file points at a live process", async () => {
@@ -190,6 +231,45 @@ describe("memory worker status", () => {
       expect(JSON.parse(stdout)).toEqual({
         status: "running",
         pid: process.pid,
+        workerEnabled: false,
+        syncRunner: { status: "not_running" },
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  test("reflects memory.worker.enabled from config", async () => {
+    rawConfig = { memory: { worker: { enabled: true } } };
+    const restore = stubProcessKill(new Set());
+    try {
+      const { exitCode, stdout } = await runCommand([
+        "memory",
+        "worker",
+        "status",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout)).toMatchObject({ workerEnabled: true });
+    } finally {
+      restore();
+    }
+  });
+
+  test("reports the synchronous runner as running when its marker is live", async () => {
+    writeFileSync(markerPath, String(process.pid));
+    const restore = stubProcessKill(new Set([process.pid]));
+    try {
+      const { exitCode, stdout } = await runCommand([
+        "memory",
+        "worker",
+        "status",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout)).toMatchObject({
+        status: "not_running",
+        syncRunner: { status: "running", pid: process.pid },
       });
     } finally {
       restore();
@@ -207,7 +287,11 @@ describe("memory worker status", () => {
         "--json",
       ]);
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({ status: "not_running" });
+      expect(JSON.parse(stdout)).toEqual({
+        status: "not_running",
+        workerEnabled: false,
+        syncRunner: { status: "not_running" },
+      });
       expect(existsSync(pidPath)).toBe(false);
     } finally {
       restore();
@@ -220,18 +304,25 @@ describe("memory worker status", () => {
 // ---------------------------------------------------------------------------
 
 describe("memory worker stop", () => {
-  test("errors with exit 1 when no worker is running", async () => {
+  test("disables the config flag and succeeds when no worker is running", async () => {
+    rawConfig = { memory: { worker: { enabled: true } } };
     const { exitCode, stdout } = await runCommand([
       "memory",
       "worker",
       "stop",
       "--json",
     ]);
-    expect(exitCode).toBe(1);
-    expect(JSON.parse(stdout)).toMatchObject({ ok: false });
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      ok: true,
+      workerWasRunning: false,
+      workerEnabled: false,
+    });
+    expect(workerEnabledFromRaw()).toBe(false);
   });
 
-  test("sends SIGTERM to a running worker", async () => {
+  test("sends SIGTERM to a running worker and disables the flag", async () => {
+    rawConfig = { memory: { worker: { enabled: true } } };
     writeFileSync(pidPath, String(process.pid));
     const restore = stubProcessKill(new Set([process.pid]));
     try {
@@ -242,11 +333,16 @@ describe("memory worker stop", () => {
         "--json",
       ]);
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({ ok: true, pid: process.pid });
+      expect(JSON.parse(stdout)).toEqual({
+        ok: true,
+        pid: process.pid,
+        workerEnabled: false,
+      });
       expect(killCalls).toContainEqual({
         pid: process.pid,
         signal: "SIGTERM",
       });
+      expect(workerEnabledFromRaw()).toBe(false);
     } finally {
       restore();
     }
@@ -258,7 +354,7 @@ describe("memory worker stop", () => {
 // ---------------------------------------------------------------------------
 
 describe("memory worker start", () => {
-  test("refuses to start when a worker is already running", async () => {
+  test("reuses an already-running worker and enables the flag", async () => {
     writeFileSync(pidPath, String(process.pid));
     const restore = stubProcessKill(new Set([process.pid]));
     try {
@@ -268,17 +364,20 @@ describe("memory worker start", () => {
         "start",
         "--json",
       ]);
-      expect(exitCode).toBe(1);
+      expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toMatchObject({
-        ok: false,
+        ok: true,
         pid: process.pid,
+        alreadyRunning: true,
+        workerEnabled: true,
       });
+      expect(workerEnabledFromRaw()).toBe(true);
     } finally {
       restore();
     }
   });
 
-  test("spawns the worker and reports the PID it writes", async () => {
+  test("spawns the worker, reports its PID, and enables the flag", async () => {
     const restore = stubProcessKill(new Set());
     const originalSpawn = Bun.spawn;
     // Simulate the spawned worker writing its PID file on startup.
@@ -294,7 +393,37 @@ describe("memory worker start", () => {
         "--json",
       ]);
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toMatchObject({ ok: true, pid: 424242 });
+      expect(JSON.parse(stdout)).toMatchObject({
+        ok: true,
+        pid: 424242,
+        workerEnabled: true,
+      });
+      expect(workerEnabledFromRaw()).toBe(true);
+    } finally {
+      (Bun as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
+      restore();
+    }
+  });
+
+  test("leaves the config flag untouched when the spawn fails", async () => {
+    const restore = stubProcessKill(new Set());
+    const originalSpawn = Bun.spawn;
+    // Spawn returns but never writes a PID file → spawnMemoryWorkerProcess
+    // throws after its wait loop, so the flag must stay disabled.
+    (Bun as { spawn: typeof Bun.spawn }).spawn = (() => ({
+      unref: () => {},
+      pid: 0,
+    })) as unknown as typeof Bun.spawn;
+    try {
+      const { exitCode, stdout } = await runCommand([
+        "memory",
+        "worker",
+        "start",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      expect(JSON.parse(stdout)).toMatchObject({ ok: false });
+      expect(workerEnabledFromRaw()).toBe(false);
     } finally {
       (Bun as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
       restore();

--- a/assistant/src/cli/commands/memory/worker.ts
+++ b/assistant/src/cli/commands/memory/worker.ts
@@ -7,24 +7,48 @@
  *
  * Subcommands:
  *
- *   - `start`  — spawn the worker process (detached, background).
- *   - `stop`   — send SIGTERM to the running worker process.
- *   - `status` — report whether the worker process is running.
+ *   - `start`  — spawn the worker process and enable `memory.worker.enabled`,
+ *     standing the daemon's synchronous in-process runner down.
+ *   - `stop`   — SIGTERM the worker process and disable `memory.worker.enabled`,
+ *     handing the queue back to the synchronous in-process runner.
+ *   - `status` — report the worker process state, the `memory.worker.enabled`
+ *     config value, and whether the synchronous in-process runner is going.
  *
  * All three run directly in the CLI process (transport: "local") — no IPC
- * round-trip to the daemon.
+ * round-trip to the daemon. The daemon's worker supervisor re-reads
+ * `memory.worker.enabled` each poll and stands its synchronous runner down (or
+ * resumes it) accordingly, so flipping the flag here switches the running
+ * daemon's mode without a restart.
  */
 
 import type { Command } from "commander";
 
 import {
+  getConfigReadOnly,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import {
   probeMemoryWorker,
+  probeSyncRunner,
   spawnMemoryWorkerProcess,
 } from "../../../memory/worker-control.js";
 import { getMemoryWorkerPidPath } from "../../../util/platform.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+
+/**
+ * Persist `memory.worker.enabled` to the on-disk config via the shared
+ * raw-config helpers, so only this leaf changes (schema defaults are not baked
+ * into the file). The assistant picks the change up on its next config read.
+ */
+function setWorkerEnabled(enabled: boolean): void {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "memory.worker.enabled", enabled);
+  saveRawConfig(raw);
+}
 
 // ---------------------------------------------------------------------------
 // `start`
@@ -38,6 +62,9 @@ async function startWorker(
   try {
     result = await spawnMemoryWorkerProcess();
   } catch (err) {
+    // Spawn failed — leave `memory.worker.enabled` untouched so the daemon's
+    // synchronous runner keeps draining the queue rather than standing down
+    // for a worker that never came up.
     const msg = err instanceof Error ? err.message : String(err);
     if (shouldOutputJson(cmd)) {
       writeOutput(cmd, { ok: false, error: msg });
@@ -48,25 +75,28 @@ async function startWorker(
     return;
   }
 
-  if (result.alreadyRunning) {
-    const msg = `Memory worker is already running (PID ${result.pid})`;
-    if (shouldOutputJson(cmd)) {
-      writeOutput(cmd, { ok: false, error: msg, pid: result.pid });
-    } else {
-      log.error(msg);
-    }
-    process.exitCode = 1;
-    return;
-  }
+  // The worker process is up (freshly spawned or already running). Enable the
+  // flag so the daemon's supervisor stands its synchronous runner down (and so
+  // the daemon spawns the worker again on the next restart).
+  setWorkerEnabled(true);
 
   if (shouldOutputJson(cmd)) {
     writeOutput(cmd, {
       ok: true,
       pid: result.pid,
+      alreadyRunning: result.alreadyRunning,
       pidPath: getMemoryWorkerPidPath(),
+      workerEnabled: true,
     });
   } else {
-    log.info(`Memory worker started (PID ${result.pid})`);
+    log.info(
+      result.alreadyRunning
+        ? `Memory worker is already running (PID ${result.pid})`
+        : `Memory worker started (PID ${result.pid})`,
+    );
+    log.info(
+      "Enabled memory.worker.enabled; the synchronous in-process runner will stand down",
+    );
   }
 }
 
@@ -75,15 +105,28 @@ async function startWorker(
 // ---------------------------------------------------------------------------
 
 function stopWorker(opts: { json?: boolean }, cmd: Command): void {
+  // Persist the preference first: `stop` means "hand the queue back to the
+  // synchronous in-process runner." Disabling the flag makes the daemon's
+  // supervisor resume processing in-process on its next poll and lines the next
+  // daemon restart up with synchronous mode; the SIGTERM below then stops the
+  // now-redundant worker process.
+  setWorkerEnabled(false);
+
   const current = probeMemoryWorker();
   if (current.status !== "running" || current.pid == null) {
-    const msg = "Memory worker is not running";
+    // No worker process to signal — flipping the flag alone restores
+    // synchronous mode, so this is success, not an error.
     if (shouldOutputJson(cmd)) {
-      writeOutput(cmd, { ok: false, error: msg });
+      writeOutput(cmd, {
+        ok: true,
+        workerWasRunning: false,
+        workerEnabled: false,
+      });
     } else {
-      log.error(msg);
+      log.info(
+        "Memory worker process was not running; disabled memory.worker.enabled (synchronous runner active)",
+      );
     }
-    process.exitCode = 1;
     return;
   }
 
@@ -93,7 +136,7 @@ function stopWorker(opts: { json?: boolean }, cmd: Command): void {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (shouldOutputJson(cmd)) {
-      writeOutput(cmd, { ok: false, error: msg, pid });
+      writeOutput(cmd, { ok: false, error: msg, pid, workerEnabled: false });
     } else {
       log.error(`Failed to stop memory worker (PID ${pid}): ${msg}`);
     }
@@ -102,9 +145,12 @@ function stopWorker(opts: { json?: boolean }, cmd: Command): void {
   }
 
   if (shouldOutputJson(cmd)) {
-    writeOutput(cmd, { ok: true, pid });
+    writeOutput(cmd, { ok: true, pid, workerEnabled: false });
   } else {
     log.info(`Memory worker stop signal sent (PID ${pid})`);
+    log.info(
+      "Disabled memory.worker.enabled; the synchronous in-process runner will take over",
+    );
   }
 }
 
@@ -113,14 +159,25 @@ function stopWorker(opts: { json?: boolean }, cmd: Command): void {
 // ---------------------------------------------------------------------------
 
 function statusWorker(opts: { json?: boolean }, cmd: Command): void {
-  const result = probeMemoryWorker();
+  const worker = probeMemoryWorker();
+  const syncRunner = probeSyncRunner();
+  const workerEnabled = getConfigReadOnly().memory.worker.enabled;
+
   if (shouldOutputJson(cmd)) {
-    writeOutput(cmd, result);
+    writeOutput(cmd, { ...worker, workerEnabled, syncRunner });
   } else {
-    if (result.status === "running") {
-      log.info(`Memory worker is running (PID ${result.pid})`);
+    if (worker.status === "running") {
+      log.info(`Memory worker process is running (PID ${worker.pid})`);
     } else {
-      log.info("Memory worker is not running");
+      log.info("Memory worker process is not running");
+    }
+    log.info(`memory.worker.enabled: ${workerEnabled}`);
+    if (syncRunner.status === "running") {
+      log.info(
+        `Synchronous in-process runner is running (PID ${syncRunner.pid})`,
+      );
+    } else {
+      log.info("Synchronous in-process runner is not running");
     }
   }
 }
@@ -139,7 +196,11 @@ export function registerMemoryWorkerCommand(memory: Command): void {
         "after",
         `
 The memory worker processes embedding, consolidation, and cleanup jobs in a
-separate OS process so they do not block the daemon's main event loop.
+separate OS process so they do not block the assistant's main event loop.
+
+\`start\` enables memory.worker.enabled and \`stop\` disables it, so the
+assistant's synchronous in-process runner stands down (start) or takes back over
+(stop) without a restart.
 
 Examples:
   $ assistant memory worker start
@@ -149,7 +210,9 @@ Examples:
 
       worker
         .command("start")
-        .description("Start the memory worker as a background process")
+        .description(
+          "Start the memory worker process and enable memory.worker.enabled",
+        )
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .action(async (opts: { json?: boolean }, cmd: Command) => {
           await startWorker(opts, cmd);
@@ -157,7 +220,9 @@ Examples:
 
       worker
         .command("stop")
-        .description("Stop the running memory worker process")
+        .description(
+          "Stop the memory worker process and disable memory.worker.enabled",
+        )
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .action((opts: { json?: boolean }, cmd: Command) => {
           stopWorker(opts, cmd);
@@ -165,7 +230,9 @@ Examples:
 
       worker
         .command("status")
-        .description("Check whether the memory worker process is running")
+        .description(
+          "Report worker process state, memory.worker.enabled, and the synchronous runner",
+        )
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .action((opts: { json?: boolean }, cmd: Command) => {
           statusWorker(opts, cmd);

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -84,7 +84,7 @@ export const MemoryWorkerConfigSchema = z
       .boolean({ error: "memory.worker.enabled must be a boolean" })
       .default(false)
       .describe(
-        "Whether the memory jobs worker runs as a separate OS process spawned at assistant startup (the `assistant memory worker` implementation) instead of on the assistant's main event loop. Only affects startup; shutdown stops whichever worker is actually running.",
+        "Whether the memory jobs worker runs as a separate OS process instead of the assistant's synchronous in-process runner. The assistant's worker supervisor re-reads this flag on every poll: while it is set, the in-process runner stands down (the out-of-process worker, spawned at startup when set, owns the queue); while it is unset, the in-process runner drains the queue. `assistant memory worker start`/`stop` flip the flag (and spawn/stop the worker process) to switch modes at runtime without a restart.",
       ),
   })
   .describe("Memory jobs worker process configuration");

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -977,10 +977,11 @@ export async function runDaemon(): Promise<void> {
         }
       }
 
-      // `startMemoryJobsWorker` selects the worker implementation based on
-      // `memory.worker.enabled` (in-process vs. a separate OS process).
-      // Shutdown stops whichever worker is actually running — see
-      // shutdown-handlers.ts.
+      // `startMemoryJobsWorker` starts the in-process supervisor (which owns
+      // the synchronous runner and stands down when an out-of-process worker is
+      // live) and spawns the out-of-process worker at boot when
+      // `memory.worker.enabled` is set. Shutdown stops whichever worker is
+      // actually running — see shutdown-handlers.ts.
       log.info("Daemon startup: starting memory worker");
       bgRefs.memoryWorker = startMemoryJobsWorker();
 

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -93,7 +93,11 @@ import {
   memoryV2ConsolidateJob,
 } from "./v2/consolidation-job.js";
 import { memoryV2SweepJob } from "./v2/sweep-job.js";
-import { spawnMemoryWorkerProcess } from "./worker-control.js";
+import {
+  removeSyncRunnerMarker,
+  spawnMemoryWorkerProcess,
+  writeSyncRunnerMarker,
+} from "./worker-control.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -163,23 +167,33 @@ export interface MemoryJobsWorker {
 }
 
 /**
- * Start the memory jobs worker using the configured implementation.
+ * Start the daemon's memory jobs worker supervisor.
  *
- * `memory.worker.enabled` selects between two implementations:
- *   - enabled: spawn the worker as a separate OS process (the same path as
- *     `assistant memory worker start`), keeping long-running jobs off the
- *     caller's event loop.
- *   - disabled (default): run the worker in-process on the caller's event
- *     loop.
+ * The daemon always runs the in-process supervisor returned here. The
+ * supervisor owns the synchronous in-process runner and reconciles to
+ * `memory.worker.enabled` on every poll, re-reading the flag from disk so a
+ * runtime change takes effect without a restart:
+ *   - flag off (default): drain the queue in-process and publish the
+ *     sync-runner marker so `status` reports the synchronous runner as going.
+ *   - flag on: stand down (the out-of-process worker owns the queue) and clear
+ *     the marker.
+ * Gating on the flag — rather than on the worker process actually being present
+ * — keeps exactly one drainer active and avoids a boot race: when the flag is
+ * on the supervisor never processes, so it can't claim jobs that the spawning
+ * worker's startup recovery would then reset out from under it.
  *
- * The flag is read here so callers don't branch on it themselves. It only
- * governs which implementation starts; shutdown stops whichever worker is
- * actually running (see daemon/shutdown-handlers.ts), so the handle returned
- * for the out-of-process implementation has a no-op `stop()`.
+ * `memory.worker.enabled` is also the persisted boot preference: when set, the
+ * out-of-process worker is spawned here at startup so it is running
+ * immediately. The CLI `memory worker start`/`stop` commands flip the flag (and
+ * spawn/stop the worker process), so the supervisor switches the running daemon
+ * between synchronous and out-of-process modes within one poll. When the flag
+ * is on but no worker process is running, neither drainer processes — `status`
+ * surfaces this (worker not running, synchronous runner not running).
  *
  * This dispatcher must not be used as the standalone worker process's entry —
- * that would recurse and fork-bomb. `worker-process.ts` calls
- * {@link startInProcessMemoryJobsWorker} directly.
+ * that would recurse and fork-bomb, and the flag-on worker process would stand
+ * itself down. `worker-process.ts` calls {@link startInProcessMemoryJobsWorker}
+ * directly with no options.
  */
 export function startMemoryJobsWorker(): MemoryJobsWorker {
   if (getConfig().memory.worker?.enabled === true) {
@@ -195,31 +209,31 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
       .catch((err) =>
         log.warn(
           { err },
-          "Failed to start memory worker process — memory jobs will not be processed",
+          "Failed to start memory worker process — the in-process supervisor will drain the queue instead",
         ),
       );
-    return {
-      async runOnce(): Promise<number> {
-        return 0;
-      },
-      // No-op: shutdown always stops the worker process via the live-state
-      // PID probe in daemon/shutdown-handlers.ts, since it can't know whether
-      // the process was started here or out of band (e.g. `assistant memory
-      // worker start`) after boot.
-      stop(): void {},
-    };
   }
 
-  return startInProcessMemoryJobsWorker();
+  return startInProcessMemoryJobsWorker({ standDownForWorkerProcess: true });
 }
 
 /**
  * Run the memory jobs worker in-process on the caller's event loop: poll for
  * claimable jobs with adaptive backoff until {@link MemoryJobsWorker.stop} is
- * called. This is the worker loop itself — used directly by the daemon (when
- * `memory.worker.enabled` is off) and by the standalone worker process.
+ * called. This is the worker loop itself — used by the daemon supervisor (with
+ * `standDownForWorkerProcess`) and by the standalone worker process (without).
+ *
+ * When `standDownForWorkerProcess` is set the loop acts as the daemon's
+ * synchronous-runner supervisor: each tick it skips processing while
+ * `memory.worker.enabled` is on (clearing the sync-runner marker), and
+ * publishes the marker while it owns processing. The standalone worker process
+ * must NOT set this — it runs precisely when the flag is on and would otherwise
+ * stand itself down forever.
  */
-export function startInProcessMemoryJobsWorker(): MemoryJobsWorker {
+export function startInProcessMemoryJobsWorker(
+  opts: { standDownForWorkerProcess?: boolean } = {},
+): MemoryJobsWorker {
+  const standDownForWorkerProcess = opts.standDownForWorkerProcess === true;
   const recovered = resetRunningJobsToPending();
   if (recovered > 0) {
     log.info({ recovered }, "Recovered stale running memory jobs");
@@ -242,11 +256,39 @@ export function startInProcessMemoryJobsWorker(): MemoryJobsWorker {
   let tickRunning = false;
   let timer: ReturnType<typeof setTimeout>;
   let currentIntervalMs = POLL_INTERVAL_MIN_MS;
+  // Tracks whether this supervisor currently owns processing (and so has
+  // published the sync-runner marker). Only meaningful when
+  // `standDownForWorkerProcess` is set.
+  let syncRunnerMarked = false;
 
   const tick = async () => {
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
+      if (
+        standDownForWorkerProcess &&
+        getConfig().memory.worker?.enabled === true
+      ) {
+        // The out-of-process worker owns the queue — stand the synchronous
+        // runner down so jobs aren't processed twice, and retract the marker.
+        if (syncRunnerMarked) {
+          removeSyncRunnerMarker();
+          syncRunnerMarked = false;
+        }
+        // Switching modes is a rare operator action, so poll at the slow cap
+        // while standing down: it still picks up a `memory worker stop` (which
+        // flips the flag back off) within one interval, without waking every
+        // couple seconds for the whole time the worker owns the queue.
+        currentIntervalMs = POLL_INTERVAL_MAX_MS;
+        return;
+      }
+      if (standDownForWorkerProcess && !syncRunnerMarked) {
+        // The flag is off — this in-process runner owns processing. Publish the
+        // marker so `memory worker status` reports the synchronous runner as
+        // going.
+        writeSyncRunnerMarker(process.pid);
+        syncRunnerMarked = true;
+      }
       const processed = await runMemoryJobsOnce({
         enableScheduledCleanup: true,
       });
@@ -295,6 +337,10 @@ export function startInProcessMemoryJobsWorker(): MemoryJobsWorker {
     stop(): void {
       stopped = true;
       clearTimeout(timer);
+      if (syncRunnerMarked) {
+        removeSyncRunnerMarker();
+        syncRunnerMarked = false;
+      }
     },
   };
 }

--- a/assistant/src/memory/worker-control.ts
+++ b/assistant/src/memory/worker-control.ts
@@ -7,15 +7,66 @@
  * so the PID-file bookkeeping lives here in one place.
  */
 
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
 
 import { getCurrentLogFilePath } from "../util/logger.js";
-import { getMemoryWorkerPidPath } from "../util/platform.js";
+import {
+  getMemorySyncRunnerMarkerPath,
+  getMemoryWorkerPidPath,
+} from "../util/platform.js";
 
 export interface MemoryWorkerStatus {
   status: "running" | "not_running";
   pid?: number;
+}
+
+/** True when `err` is a Node ESRCH error ("no such process"). */
+function isEsrchError(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ESRCH"
+  );
+}
+
+/**
+ * Read a PID file and report liveness. A missing or malformed file reports
+ * not_running; a file pointing at a dead process is cleaned up and reported as
+ * not_running. Shared by the worker-process PID file and the sync-runner
+ * marker so both probe identically.
+ */
+function probePidFile(path: string): MemoryWorkerStatus {
+  if (!existsSync(path)) return { status: "not_running" };
+
+  const raw = readFileSync(path, "utf-8").trim();
+  const pid = parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) return { status: "not_running" };
+
+  try {
+    process.kill(pid, 0);
+    return { status: "running", pid };
+  } catch (err: unknown) {
+    if (isEsrchError(err)) {
+      // Stale file — clean it up.
+      try {
+        unlinkSync(path);
+      } catch {
+        // best-effort
+      }
+      return { status: "not_running" };
+    }
+    throw err;
+  }
 }
 
 /**
@@ -24,32 +75,44 @@ export interface MemoryWorkerStatus {
  * as not_running.
  */
 export function probeMemoryWorker(): MemoryWorkerStatus {
-  const pidPath = getMemoryWorkerPidPath();
-  if (!existsSync(pidPath)) return { status: "not_running" };
+  return probePidFile(getMemoryWorkerPidPath());
+}
 
-  const raw = readFileSync(pidPath, "utf-8").trim();
-  const pid = parseInt(raw, 10);
-  if (!Number.isFinite(pid) || pid <= 0) return { status: "not_running" };
+/**
+ * Inspect the sync-runner marker to determine whether the daemon's in-process
+ * synchronous runner is currently draining the memory-job queue. The daemon's
+ * worker supervisor writes the marker (with its own PID) only while it owns
+ * processing, so a live marker means the synchronous runner is going. A stale
+ * marker (daemon gone) is cleaned up and reported as not_running.
+ */
+export function probeSyncRunner(): MemoryWorkerStatus {
+  return probePidFile(getMemorySyncRunnerMarkerPath());
+}
 
+/**
+ * Publish the sync-runner marker recording `pid` (the daemon process). Called
+ * by the worker supervisor when its in-process synchronous runner takes over
+ * processing. Best-effort: a write failure only affects status reporting, not
+ * job processing.
+ */
+export function writeSyncRunnerMarker(pid: number): void {
   try {
-    process.kill(pid, 0);
-    return { status: "running", pid };
-  } catch (err: unknown) {
-    if (
-      err &&
-      typeof err === "object" &&
-      "code" in err &&
-      err.code === "ESRCH"
-    ) {
-      // Stale PID file — clean it up.
-      try {
-        unlinkSync(pidPath);
-      } catch {
-        // best-effort
-      }
-      return { status: "not_running" };
-    }
-    throw err;
+    writeFileSync(getMemorySyncRunnerMarkerPath(), String(pid), { flag: "w" });
+  } catch {
+    // best-effort — the marker is a status hint, not a correctness invariant
+  }
+}
+
+/**
+ * Remove the sync-runner marker. Called by the worker supervisor when it stands
+ * down for an out-of-process worker, and on daemon shutdown. Best-effort.
+ */
+export function removeSyncRunnerMarker(): void {
+  try {
+    const path = getMemorySyncRunnerMarkerPath();
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // best-effort
   }
 }
 

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -248,6 +248,20 @@ export function getMemoryWorkerPidPath(): string {
 }
 
 /**
+ * Returns the path to the memory sync-runner marker file
+ * ($VELLUM_WORKSPACE_DIR/memory-sync-runner.pid).
+ *
+ * The daemon's in-process memory-jobs supervisor writes this marker (with its
+ * own PID) while the synchronous in-process runner is actively draining the
+ * queue, and removes it when it stands down for an out-of-process worker. It
+ * lets `assistant memory worker status` report whether the synchronous runner
+ * is still going without an IPC round-trip to the daemon.
+ */
+export function getMemorySyncRunnerMarkerPath(): string {
+  return join(getWorkspaceDir(), "memory-sync-runner.pid");
+}
+
+/**
  * Returns the workspace root for user-facing state.
  *
  * When the VELLUM_WORKSPACE_DIR env var is set, returns that value (used in


### PR DESCRIPTION
## Why

Two pieces of `memory worker` feedback (plus a follow-up):

1. `assistant memory worker status` should also report `memory.worker.enabled` and whether the old synchronous runner is still going.
2. `assistant memory worker start` should automatically stop the synchronous runner and enable the config flag.
3. `assistant memory worker stop` should disable the config flag and start the synchronous runner.

The synchronous in-process runner lives inside the daemon, while the `memory worker` CLI is `local` transport (no IPC). So the CLI and daemon coordinate through the config flag and a marker file the daemon polls — no new IPC surface.

## What changed

**Daemon supervisor (`jobs-worker.ts`)** — the daemon now always runs an in-process supervisor that re-reads `memory.worker.enabled` on every poll:
- flag **off** (default): drains the queue in-process and publishes a sync-runner marker (`memory-sync-runner.pid`) recording the daemon PID.
- flag **on**: stands the synchronous runner down (the out-of-process worker owns the queue) and clears the marker.

Gating on the flag rather than on worker-process presence is deliberate: it avoids a boot race where the supervisor's first tick could claim jobs that the spawning worker's startup `resetRunningJobsToPending()` would then reset out from under it. The standalone worker process keeps calling the loop with no options (it always processes).

**CLI (`worker.ts`)**:
- `status` — adds `workerEnabled` and a `syncRunner` probe (via the marker) to the output.
- `start` — enables the flag once the worker process is up (standing the synchronous runner down). Now reuses an already-running worker instead of erroring, and leaves the flag untouched if the spawn fails (so the synchronous runner keeps draining rather than standing down for a worker that never came up).
- `stop` — disables the flag (handing the queue back to the synchronous runner) and SIGTERMs the worker. With no worker running it now succeeds (the flag flip alone restores synchronous mode) instead of erroring.

The flag is written via `loadRawConfig`/`saveRawConfig` so only that leaf changes; the daemon picks it up on its next signature-checked config read.

Also updated the `memory.worker.enabled` schema description and the lifecycle/shutdown comments to match.

## Testing

- `bun test src/cli/commands/memory/__tests__/worker.test.ts src/__tests__/memory-jobs-worker-backoff.test.ts` — 14 pass (status reports flag + sync-runner; start/stop flip the flag; spawn-failure leaves the flag untouched).
- `bunx tsc --noEmit`, `bun run lint`, `prettier --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8J6UzgJcKdVJvWyw4kh1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8J6UzgJcKdVJvWyw4kh1c)_