### PR TITLE
fix(contacts): revoke member/guardian channels through the gateway first

### DIFF
--- a/assistant/src/contacts/__tests__/contacts-write-revoke-relay.test.ts
+++ b/assistant/src/contacts/__tests__/contacts-write-revoke-relay.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the gateway-first member-revoke relay.
+ *
+ * revokeMemberChannel downgrades the channel's ACL status through the gateway
+ * (source of truth) via `ipcCallPersistent("mark_channel_revoked", ...)` first,
+ * then mirrors the downgrade to the assistant DB best-effort. A local mirror
+ * failure is swallowed so the gateway-owned outcome stands.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ContactWriteResult } from "../types.js";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+let ipcCalls: IpcCall[] = [];
+let ipcOk = true;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    return {
+      ok: ipcOk,
+      didWrite: ipcOk,
+      channel: {
+        id: (params?.contactChannelId as string) ?? "ch1",
+        contactId: "c1",
+        type: "telegram",
+        address: "addr",
+        status: "revoked",
+        revokedReason: (params?.reason as string) ?? null,
+      },
+    };
+  },
+);
+const actualGatewayClient = await import("../../ipc/gateway-client.js");
+mock.module("../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Local channel lookup gating the redundant-revoke skip.
+let localChannelStatus: string | null = "active";
+const actualContactStore = await import("../contact-store.js");
+mock.module("../contact-store.js", () => ({
+  ...actualContactStore,
+  getChannelById: mock((id: string) =>
+    localChannelStatus
+      ? { id, contactId: "c1", type: "telegram", status: localChannelStatus }
+      : null,
+  ),
+}));
+
+// Local-mirror primitive.
+const revokeMemberResult: ContactWriteResult = {
+  contact: { id: "c1" } as ContactWriteResult["contact"],
+  channel: { id: "ch1", status: "revoked" } as ContactWriteResult["channel"],
+};
+const revokeMemberMock = mock((_memberId: string, _reason?: string) =>
+  revokeMemberResult,
+);
+const actualContactsWrite = await import("../contacts-write.js");
+mock.module("../contacts-write.js", () => ({
+  ...actualContactsWrite,
+  revokeMember: revokeMemberMock,
+}));
+
+const { revokeMemberChannel } = await import("../member-write-relay.js");
+
+describe("revokeMemberChannel gateway-first relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcOk = true;
+    localChannelStatus = "active";
+    ipcCallPersistentMock.mockClear();
+    revokeMemberMock.mockClear();
+    revokeMemberMock.mockImplementation(() => revokeMemberResult);
+  });
+
+  test("relays the revoke to the gateway before mirroring locally", async () => {
+    const result = await revokeMemberChannel("ch1", "removed");
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "mark_channel_revoked",
+        params: { contactChannelId: "ch1", reason: "removed" },
+      },
+    ]);
+    expect(revokeMemberMock).toHaveBeenCalledTimes(1);
+    expect(revokeMemberMock).toHaveBeenCalledWith("ch1", "removed");
+    expect(result).toBe(revokeMemberResult);
+  });
+
+  test("strips the composite contactId:channelId prefix before the relay", async () => {
+    await revokeMemberChannel("c1:ch1");
+
+    expect(ipcCalls[0]?.params?.contactChannelId).toBe("ch1");
+    // The local mirror still receives the original composite id it accepts.
+    expect(revokeMemberMock).toHaveBeenCalledWith("c1:ch1", undefined);
+  });
+
+  test("skips the relay when the gateway channel is already revoked", async () => {
+    localChannelStatus = "revoked";
+
+    const result = await revokeMemberChannel("ch1");
+
+    expect(ipcCalls).toEqual([]);
+    expect(revokeMemberMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  test("swallows a local-mirror failure without throwing; the gateway revoke stands", async () => {
+    revokeMemberMock.mockImplementation(() => {
+      throw new Error("local mirror exploded");
+    });
+
+    const result = await revokeMemberChannel("ch1", "removed");
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(result).toBeNull();
+  });
+
+  test("throws when the gateway relay returns ok: false", async () => {
+    ipcOk = false;
+
+    let thrown: Error | undefined;
+    try {
+      await revokeMemberChannel("ch1");
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    // Local mirror must not run when the gateway refuses the downgrade.
+    expect(revokeMemberMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/contacts/member-write-relay.ts
+++ b/assistant/src/contacts/member-write-relay.ts
@@ -1,0 +1,68 @@
+/**
+ * Gateway-first member-channel write relay.
+ *
+ * The gateway is the ACL source of truth. Each write goes to the gateway first;
+ * the assistant-DB write in contacts-write.ts is a best-effort local mirror that
+ * never throws and never gates the gateway-owned outcome.
+ */
+
+import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import { log } from "../daemon/handlers/shared.js";
+import { ipcCallPersistent } from "../ipc/gateway-client.js";
+import { getChannelById } from "./contact-store.js";
+import { revokeMember } from "./contacts-write.js";
+import type { ContactWriteResult } from "./types.js";
+
+// ── Revoke ───────────────────────────────────────────────────────────
+
+/**
+ * Revoke a member channel gateway-first, then mirror the downgrade to the
+ * assistant DB best-effort. The memberId may be a plain channel ID or the
+ * composite contactId:channelId form revokeMember accepts.
+ *
+ * Returns the local ContactWriteResult so callers still get the native
+ * contact/channel, or null when the local mirror produces no result.
+ */
+export async function revokeMemberChannel(
+  memberId: string,
+  reason?: string,
+): Promise<ContactWriteResult | null> {
+  const channelId = memberId.includes(":") ? memberId.split(":")[1] : memberId;
+
+  // Skip a redundant relay when the channel is already revoked. The gateway
+  // dual-write keeps this local status in sync, so it's an adequate guard
+  // without an extra gateway round-trip. A missing local row still relays so
+  // the gateway stays authoritative.
+  const localChannel = getChannelById(channelId);
+  if (localChannel && localChannel.status === "revoked") {
+    return null;
+  }
+
+  const result = await ipcCallPersistent("mark_channel_revoked", {
+    contactChannelId: channelId,
+    reason,
+  });
+  const parsed = MarkChannelRevokedIpcResponseSchema.parse(result);
+  if (!parsed.ok) {
+    throw new Error("mark_channel_revoked relay returned ok: false");
+  }
+
+  return mirrorLocalRevoke(memberId, reason);
+}
+
+/** Best-effort local mirror of the revoke. Swallows failures. */
+function mirrorLocalRevoke(
+  memberId: string,
+  reason?: string,
+): ContactWriteResult | null {
+  try {
+    return revokeMember(memberId, reason);
+  } catch (err) {
+    log.error(
+      { err, memberId },
+      "Local revoke mirror failed after gateway revoke; gateway downgrade stands",
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Member revoke + non-config-channels guardian-binding revoke relay mark_channel_revoked to the gateway first; the assistant-DB write is demoted to a best-effort mirror. contacts-write primitives stay sync.

### Verify-first finding
- `revokeVerificationForChannel` (the config-channels guardian-revoke path in `daemon/handlers/config-channels.ts`) ALREADY relays `mark_channel_revoked` gateway-first, gating on the live gateway-delivery status, then calls `revokeBinding` purely as assistant-owned binding teardown. Left untouched.
- `revokeBinding` (`channel-verification-service.ts:397`) has exactly ONE production caller — the config-channels path above. It is NOT a local-only ACL writer; it is the binding teardown invoked AFTER the gateway downgrade. Repointing it would double-relay (forbidden), so it stays as-is.
- `revokeMember` (`contacts-write.ts:139`) has NO production caller today (only tests); it is the sync local-mirror primitive.
- Net: the genuine gateway-first work is the new `revokeMemberChannel` relay, which is the gateway-first entry point for member revocation. It relays `mark_channel_revoked` first, gates on the local status for a redundant-revoke skip, then mirrors via the sync `revokeMember` in a swallow-and-log try/catch. `revokeMember`/`revokeGuardianBinding` stay sync.

Part of plan: combo11-phase-b1-gateway-write-ownership.md (PR 3 of 3)