### PR TITLE
fix(advisor): stream search + reasoning activity, not just the final advice

### DIFF
--- a/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
@@ -173,6 +173,34 @@ describe("consultAdvisor", () => {
     expect(joined).toContain("Here is the advice.");
   });
 
+  test("surfaces a failure note (not 'Searched') when a web search errors", async () => {
+    providerSupportsWeb = true;
+    streamEvents = [
+      { type: "server_tool_start", name: "web_search", toolUseId: "s1", input: {} },
+      {
+        type: "server_tool_complete",
+        toolUseId: "s1",
+        isError: true,
+        errorCode: "query_too_long",
+        resolvedInput: { query: "an overly long query" },
+      },
+    ];
+    streamDeltas = ["Proceeding without search."];
+    const chunks: string[] = [];
+
+    await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+      onText: (c) => chunks.push(c),
+    });
+
+    const joined = chunks.join("");
+    expect(joined).toContain("Web search failed");
+    expect(joined).not.toContain("🔎 Searched:");
+    // The consult still continues and streams its guidance.
+    expect(joined).toContain("Proceeding without search.");
+  });
+
   test("streams the model's reasoning summary to onText", async () => {
     streamEvents = [{ type: "thinking_delta", thinking: "weighing tradeoffs" }];
     const chunks: string[] = [];

--- a/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
@@ -10,6 +10,7 @@ let sendMessageError: Error | null = null;
 let providerResolves = true;
 let providerSupportsWeb = false;
 let streamDeltas: string[] = [];
+let streamEvents: Array<Record<string, unknown>> = [];
 
 const fakeProvider = {
   name: "mock-advisor-provider",
@@ -20,9 +21,11 @@ const fakeProvider = {
     sendMessageArgs = { messages, options } as Record<string, unknown>;
     if (sendMessageError) throw sendMessageError;
     const onEvent = (
-      options as { onEvent?: (e: { type: string; text?: string }) => void }
+      options as { onEvent?: (e: Record<string, unknown>) => void }
     ).onEvent;
     if (onEvent) {
+      // Activity (search/thinking) streams before the final advice text.
+      for (const ev of streamEvents) onEvent(ev);
       for (const text of streamDeltas) onEvent({ type: "text_delta", text });
     }
     return {
@@ -70,6 +73,7 @@ beforeEach(() => {
   providerResolves = true;
   providerSupportsWeb = false;
   streamDeltas = [];
+  streamEvents = [];
   resetAdvisorStateForTests();
 });
 
@@ -139,6 +143,45 @@ describe("consultAdvisor", () => {
     expect(options.tools?.map((t) => t.name)).toEqual(["web_search"]);
     // tool_choice must not be `none`, or the provider suppresses its server tool.
     expect(optionConfig().tool_choice).toEqual({ type: "auto" });
+  });
+
+  test("streams web-search activity to onText, not just the final advice", async () => {
+    providerSupportsWeb = true;
+    streamEvents = [
+      { type: "server_tool_start", name: "web_search", toolUseId: "s1", input: {} },
+      {
+        type: "server_tool_complete",
+        toolUseId: "s1",
+        isError: false,
+        resolvedInput: { query: "vellum streaming" },
+      },
+    ];
+    streamDeltas = ["Here is ", "the advice."];
+    const chunks: string[] = [];
+
+    await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+      onText: (c) => chunks.push(c),
+    });
+
+    const joined = chunks.join("");
+    // The drawer isn't silent during the search prefix...
+    expect(joined).toContain("Searching the web");
+    expect(joined).toContain("Searched: vellum streaming");
+    // ...and the advice text still streams.
+    expect(joined).toContain("Here is the advice.");
+  });
+
+  test("streams the model's reasoning summary to onText", async () => {
+    streamEvents = [{ type: "thinking_delta", thinking: "weighing tradeoffs" }];
+    const chunks: string[] = [];
+    await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+      onText: (c) => chunks.push(c),
+    });
+    expect(chunks.join("")).toContain("weighing tradeoffs");
   });
 
   test("embeds the runtime context in the advisor system prompt", async () => {

--- a/assistant/src/plugins/defaults/advisor/consult.ts
+++ b/assistant/src/plugins/defaults/advisor/consult.ts
@@ -95,17 +95,16 @@ function withTimeout(signal: AbortSignal | undefined, ms: number): AbortSignal {
 
 /**
  * Build the streaming sink for a consult: forward the advisor's live activity
- * to `onText` so the tool-output drawer streams *throughout* the consult rather
- * than sitting silent until the final advice lands.
+ * to `onText` so the tool-output drawer streams throughout the consult instead
+ * of sitting silent until the final advice lands.
  *
- * Before web search the consult was a tool-less one-shot, so the only live
- * activity was the advice text. With full context + native web search the
- * advisor now searches (up to 5×) and reasons before writing — forwarding only
- * `text_delta` left the drawer blank for that whole prefix, which read as "not
- * streaming". We now also surface the reasoning summary (when the model emits
- * one) and a one-line note per web search. The complete guidance is still
- * returned by `consultAdvisor`; the renderer swaps it in once the tool result
- * arrives.
+ * The consult searches the web (up to 5×) and reasons over full context before
+ * writing its guidance. Forwarding the visible advice text alone would leave
+ * the drawer blank for that whole prefix, so the sink also surfaces the
+ * reasoning summary (when the model emits one) and a one-line note per web
+ * search — a success note with the query, or a failure note when the search
+ * errors. The complete guidance is still returned by `consultAdvisor`; the
+ * renderer swaps it in once the tool result arrives.
  */
 function advisorActivitySink(
   onText: (chunk: string) => void,
@@ -123,8 +122,17 @@ function advisorActivitySink(
         break;
       case "server_tool_complete": {
         const rawQuery = event.resolvedInput?.["query"];
-        if (typeof rawQuery === "string" && rawQuery.trim().length > 0) {
-          onText(`\n🔎 Searched: ${rawQuery.trim()}\n`);
+        const query = typeof rawQuery === "string" ? rawQuery.trim() : "";
+        if (event.isError) {
+          // A failed search (e.g. `query_too_long`, `max_uses_exceeded`) must
+          // not be announced as a success — the advisor proceeds without it.
+          onText(
+            query
+              ? `\n⚠️ Web search failed: ${query}\n`
+              : "\n⚠️ Web search failed.\n",
+          );
+        } else if (query) {
+          onText(`\n🔎 Searched: ${query}\n`);
         }
         break;
       }

--- a/assistant/src/plugins/defaults/advisor/consult.ts
+++ b/assistant/src/plugins/defaults/advisor/consult.ts
@@ -78,11 +78,11 @@ export interface ConsultParams {
   runtimeContext?: string | null;
   signal?: AbortSignal;
   /**
-   * Optional sink for the advisor's generated text as it streams. Each call
-   * receives an incremental chunk (a provider `text_delta`). Wiring this to the
-   * tool's `onOutput` surfaces the consult live as `tool_output_chunk` while the
-   * advisor model is still generating; the complete guidance is still returned
-   * as the resolved string.
+   * Optional sink for the advisor's live activity as it generates: incremental
+   * advice text, the reasoning summary (when surfaced), and a note per web
+   * search. Wiring this to the tool's `onOutput` surfaces the consult live as
+   * `tool_output_chunk` while the advisor is still working; the complete
+   * guidance is still returned as the resolved string. See `advisorActivitySink`.
    */
   onText?: (chunk: string) => void;
 }
@@ -91,6 +91,47 @@ export interface ConsultParams {
 function withTimeout(signal: AbortSignal | undefined, ms: number): AbortSignal {
   const timeout = AbortSignal.timeout(ms);
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+/**
+ * Build the streaming sink for a consult: forward the advisor's live activity
+ * to `onText` so the tool-output drawer streams *throughout* the consult rather
+ * than sitting silent until the final advice lands.
+ *
+ * Before web search the consult was a tool-less one-shot, so the only live
+ * activity was the advice text. With full context + native web search the
+ * advisor now searches (up to 5×) and reasons before writing — forwarding only
+ * `text_delta` left the drawer blank for that whole prefix, which read as "not
+ * streaming". We now also surface the reasoning summary (when the model emits
+ * one) and a one-line note per web search. The complete guidance is still
+ * returned by `consultAdvisor`; the renderer swaps it in once the tool result
+ * arrives.
+ */
+function advisorActivitySink(
+  onText: (chunk: string) => void,
+): (event: ProviderEvent) => void {
+  return (event) => {
+    switch (event.type) {
+      case "text_delta":
+        if (event.text) onText(event.text);
+        break;
+      case "thinking_delta":
+        if (event.thinking) onText(event.thinking);
+        break;
+      case "server_tool_start":
+        if (event.name === "web_search") onText("\n🔎 Searching the web…\n");
+        break;
+      case "server_tool_complete": {
+        const rawQuery = event.resolvedInput?.["query"];
+        if (typeof rawQuery === "string" && rawQuery.trim().length > 0) {
+          onText(`\n🔎 Searched: ${rawQuery.trim()}\n`);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
 }
 
 /**
@@ -131,14 +172,10 @@ export async function consultAdvisor(params: ConsultParams): Promise<string> {
       params.runtimeContext,
     ),
     ...(webEnabled ? { tools: [ADVISOR_WEB_SEARCH_TOOL] } : {}),
-    // Forward the model's visible text deltas to the caller's sink so the
-    // guidance streams live. Other event types (thinking, usage) ride their
-    // own channels and are intentionally not surfaced as tool output.
-    onEvent: onText
-      ? (event: ProviderEvent) => {
-          if (event.type === "text_delta" && event.text) onText(event.text);
-        }
-      : undefined,
+    // Stream the consult's activity live (advice text, reasoning summary, and a
+    // note per web search) so the drawer isn't blank while the advisor searches
+    // and reasons before writing its guidance. See `advisorActivitySink`.
+    onEvent: onText ? advisorActivitySink(onText) : undefined,
     config: {
       callSite: ADVISOR_CALL_SITE,
       ...override,


### PR DESCRIPTION
## What

The advisor's tool-output drawer was silent until the very end, while bash streams live. Root cause (audited on `main`): the consult forwards **only `text_delta`** to `onOutput`, but #35844 ("full context + blocking") made the advisor **search the web (up to 5×) and reason over full context before writing any advice**. During that prefix the only events are `server_tool_*` and `thinking_delta` — none forwarded — so the drawer stayed blank. Bash streams stdout from the first byte, so it never has a silent prefix; hence "bash streams, advisor doesn't."

The producer→drawer pipeline itself is correctly wired (verified end-to-end: `onText`→`ctx.onOutput`→`tool_output_chunk`→drawer; every provider wrapper forwards `onEvent`; the Anthropic client streams `text_delta` unconditionally; the executor passes the same `onOutput`-bearing context to plugin tools). So this is purely about *what* the consult surfaces.

## How

Replace the `text_delta`-only handler with a single `advisorActivitySink` that forwards the advisor's live activity:
- **advice text** (`text_delta`),
- **reasoning summary** (`thinking_delta`, when the model emits one),
- **a one-line note per web search** (`server_tool_start` → "🔎 Searching the web…", `server_tool_complete` → "🔎 Searched: \<query\>").

The complete guidance is still returned as the resolved string; the web renderer swaps the clean final advice in once the `tool_result` lands — so the drawer shows a live "working" view, then settles to clean advice.

## Notes
- **Producer-only.** No daemon/web changes — `onOutput`→`tool_output_chunk`→drawer is already wired (and proven by bash).
- I also checked the native-search routing (`provider.supportsNativeWebSearch` vs the send target's `useNativeWebSearch`): they resolve from the **same** provider via `CallSiteConfiguredProvider` (and `supportsNativeWebSearch` is a getter for `useNativeWebSearch` on the Anthropic client), so `web_search` is never stranded as an unrunnable client tool — verified not a bug.

## Test
- `consult.test.ts`: asserts the consult forwards web-search activity (`server_tool_start`/`complete`) and the reasoning summary to `onText`, alongside the streamed advice text. Advisor suite (14 tests) + lint pass; advisor files typecheck clean (the local pre-commit/push typecheck trips only on a pre-existing missing `@slack/types` dep, unrelated — CI re-checks with deps installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)