### PR TITLE
fix(invites): write activated member channels to the gateway first

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -64,6 +64,28 @@ mock.module("../runtime/approval-message-composer.js", () => ({
   composeApprovalMessageGenerative: async () => "mock generative message",
 }));
 
+// Stub the gateway IPC so redemption claims + activation relays resolve
+// deterministically without a running gateway socket.
+const gatewayIpcCalls: Array<{
+  method: string;
+  params?: Record<string, unknown>;
+}> = [];
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    gatewayIpcCalls.push({ method, params });
+    if (method === "record_invite_redemption") {
+      return { ok: true, updated: true, mirrored: true };
+    }
+    if (method === "upsert_verified_channel") {
+      return { ok: true, verified: true };
+    }
+    return undefined;
+  },
+}));
+
 import {
   findContactChannel,
   upsertContact,
@@ -98,6 +120,7 @@ function resetState(): void {
   db.run("DELETE FROM contacts");
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
+  gatewayIpcCalls.length = 0;
   msgCounter = 0;
 }
 
@@ -176,6 +199,11 @@ describe("inbound invite redemption intercept", () => {
     });
     expect(result).not.toBeNull();
     expect(result!.channel.status).toBe("active");
+
+    // The activation is written to the gateway via upsert_verified_channel.
+    expect(
+      gatewayIpcCalls.some((c) => c.method === "upsert_verified_channel"),
+    ).toBe(true);
 
     // Verify a welcome reply was delivered
     expect(deliverReplyCalls.length).toBe(1);

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -30,6 +30,9 @@ mock.module("../ipc/gateway-client.js", () => ({
       if (gatewayIpc.claimThrows) throw new Error("gateway unreachable");
       return gatewayIpc.claim;
     }
+    if (method === "upsert_verified_channel") {
+      return { ok: true, verified: true };
+    }
     return undefined;
   },
 }));
@@ -102,6 +105,11 @@ describe("invite-redemption-service", () => {
       memberId: expect.any(String),
       inviteId: invite.id,
     });
+
+    // The activation is written to the gateway via upsert_verified_channel.
+    expect(
+      gatewayIpc.calls.some((c) => c.method === "upsert_verified_channel"),
+    ).toBe(true);
   });
 
   test("marks channel as verified via invite on redemption", async () => {
@@ -359,6 +367,18 @@ describe("invite-redemption-service", () => {
     // Should succeed — redeemer's channel is bound to Mom
     expect(outcome.ok).toBe(true);
     expect((outcome as { type: string }).type).toBe("redeemed");
+
+    // Gateway-first: the activation relays the target contactId so the gateway
+    // binds the channel to Mom (not the guardian) — the binding is not lost.
+    const upsert = gatewayIpc.calls.find(
+      (c) => c.method === "upsert_verified_channel",
+    );
+    expect(upsert).toBeDefined();
+    expect(upsert!.params).toMatchObject({
+      type: "telegram",
+      address: "guardian-tg-id",
+      contactId: momContact.id,
+    });
 
     // Verify the redeemer's Telegram ID is now bound to Mom's contact
     const result = findContactChannel({

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -27,6 +27,9 @@ mock.module("../ipc/gateway-client.js", () => ({
       if (gatewayIpc.claimThrows) throw new Error("gateway unreachable");
       return gatewayIpc.claim;
     }
+    if (method === "upsert_verified_channel") {
+      return { ok: true, verified: true };
+    }
     return undefined;
   },
 }));
@@ -204,6 +207,13 @@ describe("redeemVoiceInviteCode", () => {
     );
     expect(claim).toBeDefined();
     expect(claim!.params).toMatchObject({ redeemedByExternalUserId: phone });
+
+    // The activation is written to the gateway via upsert_verified_channel.
+    const upsert = gatewayIpc.calls.find(
+      (c) => c.method === "upsert_verified_channel",
+    );
+    expect(upsert).toBeDefined();
+    expect(upsert!.params).toMatchObject({ type: "phone", address: phone });
   });
 
   test("rejects voice redemption when the gateway claim is not consumable (no mutation)", async () => {

--- a/assistant/src/contacts/__tests__/member-write-relay.test.ts
+++ b/assistant/src/contacts/__tests__/member-write-relay.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the gateway-first member-activation relay.
+ *
+ * activateMemberChannel writes the activated channel through the gateway
+ * (source of truth) via `ipcCallPersistent("upsert_verified_channel", ...)`
+ * first, then mirrors the activation to the assistant DB best-effort. A local
+ * mirror failure is swallowed so the gateway-owned outcome stands; a gateway
+ * refusal (verified:false) skips the local mirror entirely.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ContactWriteResult } from "../types.js";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+let ipcCalls: IpcCall[] = [];
+let ipcVerified = true;
+let ipcThrows = false;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcThrows) throw new Error("gateway unavailable");
+    return {
+      ok: true,
+      verified: ipcVerified,
+      channel: ipcVerified
+        ? {
+            id: "gw-ch1",
+            contactId: (params?.contactId as string) ?? "gw-c1",
+            type: (params?.type as string) ?? "telegram",
+            address: (params?.address as string) ?? "addr",
+            status: "active",
+            verifiedAt: 1,
+            verifiedVia: (params?.verifiedVia as string) ?? "invite",
+          }
+        : undefined,
+    };
+  },
+);
+const actualGatewayClient = await import("../../ipc/gateway-client.js");
+mock.module("../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Local-mirror primitive.
+const localResult: ContactWriteResult = {
+  contact: { id: "c1" } as ContactWriteResult["contact"],
+  channel: { id: "ch1", status: "active" } as ContactWriteResult["channel"],
+};
+let mirrorCallOrder = -1;
+const upsertContactChannelMock = mock(
+  (_params: Record<string, unknown>): ContactWriteResult | null => {
+    mirrorCallOrder = ipcCalls.length;
+    return localResult;
+  },
+);
+const actualContactsWrite = await import("../contacts-write.js");
+mock.module("../contacts-write.js", () => ({
+  ...actualContactsWrite,
+  upsertContactChannel: upsertContactChannelMock,
+}));
+
+const { activateMemberChannel } = await import("../member-write-relay.js");
+
+describe("activateMemberChannel gateway-first relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcVerified = true;
+    ipcThrows = false;
+    mirrorCallOrder = -1;
+    ipcCallPersistentMock.mockClear();
+    upsertContactChannelMock.mockClear();
+    upsertContactChannelMock.mockImplementation(() => {
+      mirrorCallOrder = ipcCalls.length;
+      return localResult;
+    });
+  });
+
+  test("relays to the gateway before mirroring locally, threading the target contact", async () => {
+    const result = await activateMemberChannel({
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+      externalChatId: "chat-1",
+      displayName: "Mom",
+      contactId: "target-mom",
+      inviteId: "inv-1",
+      verifiedVia: "invite",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "upsert_verified_channel",
+        params: {
+          type: "telegram",
+          address: "user-1",
+          externalChatId: "chat-1",
+          displayName: "Mom",
+          username: undefined,
+          verifiedVia: "invite",
+          contactId: "target-mom",
+        },
+      },
+    ]);
+    // The local mirror ran AFTER the gateway relay.
+    expect(mirrorCallOrder).toBe(1);
+    expect(upsertContactChannelMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(localResult);
+  });
+
+  test("fails open and still mirrors locally when the gateway relay throws", async () => {
+    ipcThrows = true;
+
+    const result = await activateMemberChannel({
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+      externalChatId: "chat-1",
+      contactId: "target-mom",
+    });
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(upsertContactChannelMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(localResult);
+  });
+
+  test("swallows a local-mirror failure without throwing; the gateway write stands", async () => {
+    upsertContactChannelMock.mockImplementation(() => {
+      throw new Error("local mirror exploded");
+    });
+
+    const result = await activateMemberChannel({
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+      externalChatId: "chat-1",
+    });
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(result).toBeNull();
+  });
+
+  test("skips the local mirror when the gateway refuses the channel (verified:false)", async () => {
+    ipcVerified = false;
+
+    const result = await activateMemberChannel({
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+      externalChatId: "chat-1",
+      contactId: "target-mom",
+    });
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(upsertContactChannelMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  test("derives the address from externalChatId when no externalUserId is present", async () => {
+    await activateMemberChannel({
+      sourceChannel: "phone",
+      externalChatId: "+15551234567",
+    });
+
+    expect(ipcCalls[0]?.params).toMatchObject({
+      type: "phone",
+      address: "+15551234567",
+      externalChatId: "+15551234567",
+    });
+  });
+});

--- a/assistant/src/contacts/member-write-relay.ts
+++ b/assistant/src/contacts/member-write-relay.ts
@@ -6,13 +6,108 @@
  * never throws and never gates the gateway-owned outcome.
  */
 
-import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+import {
+  MarkChannelRevokedIpcResponseSchema,
+  UpsertVerifiedChannelIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { log } from "../daemon/handlers/shared.js";
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
 import { getChannelById } from "./contact-store.js";
-import { revokeMember } from "./contacts-write.js";
+import { revokeMember, upsertContactChannel } from "./contacts-write.js";
 import type { ContactWriteResult } from "./types.js";
+
+// ── Activate ─────────────────────────────────────────────────────────
+
+export interface ActivateMemberChannelParams {
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  contactId?: string;
+  displayName?: string;
+  username?: string;
+  inviteId?: string;
+  verifiedAt?: number;
+  verifiedVia?: string;
+  policy?: string;
+}
+
+/**
+ * Activate a member channel gateway-first, then mirror the activation to the
+ * assistant DB best-effort. The gateway owns the ACL outcome; the local mirror
+ * supplies the native contact/channel callers still wire downstream.
+ *
+ * A gateway failure fails open with a logged warning (matching the redemption
+ * service's record_invite_redemption posture) so a transient gateway outage
+ * never drops a legitimate activation — the local mirror still stands.
+ *
+ * Returns the local ContactWriteResult, or null when the mirror yields none.
+ */
+export async function activateMemberChannel(
+  params: ActivateMemberChannelParams,
+): Promise<ContactWriteResult | null> {
+  const address = params.externalUserId ?? params.externalChatId;
+  const externalChatId = params.externalChatId ?? params.externalUserId;
+
+  if (address && externalChatId) {
+    try {
+      const result = await ipcCallPersistent("upsert_verified_channel", {
+        type: params.sourceChannel,
+        address,
+        externalChatId,
+        displayName: params.displayName,
+        username: params.username,
+        verifiedVia: params.verifiedVia ?? "invite",
+        contactId: params.contactId,
+      });
+      const parsed = UpsertVerifiedChannelIpcResponseSchema.parse(result);
+      // The gateway refused the actor (blocked/revoked): do NOT mirror an
+      // active local channel for an actor the gateway has denied.
+      if (!parsed.verified) {
+        log.warn(
+          { sourceChannel: params.sourceChannel },
+          "Gateway refused the channel activation; skipping the local mirror",
+        );
+        return null;
+      }
+    } catch (err) {
+      log.warn(
+        { err, sourceChannel: params.sourceChannel },
+        "upsert_verified_channel relay unavailable — failing open (local mirror still applies)",
+      );
+    }
+  }
+
+  return mirrorLocalActivation(params);
+}
+
+/** Best-effort local mirror of the activation. Swallows failures. */
+function mirrorLocalActivation(
+  params: ActivateMemberChannelParams,
+): ContactWriteResult | null {
+  try {
+    return upsertContactChannel({
+      sourceChannel: params.sourceChannel,
+      externalUserId: params.externalUserId,
+      externalChatId: params.externalChatId,
+      displayName: params.displayName,
+      username: params.username,
+      role: "contact",
+      status: "active",
+      policy: params.policy ?? "allow",
+      inviteId: params.inviteId,
+      verifiedAt: params.verifiedAt,
+      verifiedVia: params.verifiedVia ?? "invite",
+      contactId: params.contactId,
+    });
+  } catch (err) {
+    log.error(
+      { err, sourceChannel: params.sourceChannel },
+      "Local activation mirror failed after gateway activation; gateway outcome stands",
+    );
+    return null;
+  }
+}
 
 // ── Revoke ───────────────────────────────────────────────────────────
 

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -13,10 +13,9 @@ import {
 } from "../calls/inbound-trust-reader.js";
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel, getContact } from "../contacts/contact-store.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
+import { activateMemberChannel } from "../contacts/member-write-relay.js";
 import type { ChannelStatus } from "../contacts/types.js";
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
-import { getSqlite } from "../memory/db-connection.js";
 import {
   findActiveVoiceInvites,
   findByInviteCodeHash,
@@ -274,14 +273,10 @@ export async function redeemInvite(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
-  // Inactive member reactivation: when the user already has a member record
-  // in a non-active state (revoked/pending), reactivate it via upsertContactChannel
-  // and consume an invite use atomically. The fresh-member path below also
-  // uses upsertContactChannel to keep contacts in sync.
+  // Inactive member reactivation: when the user already has a member record in
+  // a non-active state (revoked/pending), reactivate it gateway-first then
+  // consume an invite use. The fresh-member path below mirrors this.
   if (existingChannel && !targetMismatch) {
-    // Sentinel error used to trigger a transaction rollback when the invite
-    // was concurrently revoked/expired between pre-validation and write time.
-    const STALE_INVITE = Symbol("stale_invite");
     const canonicalMemberId = existingChannel.address;
     const canonicalCallerId = externalUserId
       ? canonicalizeInboundIdentity(sourceChannel as ChannelId, externalUserId)
@@ -293,42 +288,30 @@ export async function redeemInvite(params: {
         ? existingContact.displayName
         : displayName;
 
-    let reactivated: ReturnType<typeof upsertContactChannel> | undefined;
+    // Gateway-first: activate the member channel on the authoritative gateway
+    // before the assistant DB; the local mirror is best-effort.
+    const reactivated = await activateMemberChannel({
+      sourceChannel,
+      externalUserId,
+      externalChatId,
+      // Reactivation should not overwrite a guardian-managed nickname.
+      displayName: preservedDisplayName,
+      username,
+      policy: "allow",
+      inviteId: invite.id,
+      verifiedAt: Date.now(),
+      verifiedVia: "invite",
+      contactId: invite.contactId,
+    });
+
     try {
-      getSqlite()
-        .transaction(() => {
-          reactivated = upsertContactChannel({
-            sourceChannel,
-            externalUserId,
-            externalChatId,
-            // Reactivation should not overwrite a guardian-managed nickname.
-            displayName: preservedDisplayName,
-            username,
-            role: "contact",
-            status: "active",
-            policy: "allow",
-            inviteId: invite.id,
-            verifiedAt: Date.now(),
-            verifiedVia: "invite",
-            contactId: invite.contactId,
-          });
-
-          const recorded = recordInviteUse({
-            inviteId: invite.id,
-            externalUserId,
-            externalChatId,
-          });
-
-          // If the invite was revoked/expired between pre-validation and this
-          // write, recordInviteUse returns false — throw to roll back the
-          // member reactivation so the DB stays consistent.
-          if (!recorded) throw STALE_INVITE;
-        })
-        .immediate();
-    } catch (err) {
-      if (err === STALE_INVITE) {
+      if (
+        !recordInviteUse({ inviteId: invite.id, externalUserId, externalChatId })
+      ) {
+        // Invite revoked/expired between pre-validation and write.
         return { ok: false, reason: "invalid_token" };
       }
+    } catch (err) {
       // Rare: the gateway claim already consumed the row but the assistant
       // mutation failed — a recoverable wasted gateway use; no cross-process
       // rollback is attempted.
@@ -359,39 +342,29 @@ export async function redeemInvite(params: {
     }
   }
 
-  const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
-  let freshResult: ReturnType<typeof upsertContactChannel> | undefined;
+  // Gateway-first: activate the member channel on the authoritative gateway
+  // before the assistant DB; the local mirror is best-effort.
+  const freshResult = await activateMemberChannel({
+    sourceChannel,
+    externalUserId,
+    externalChatId,
+    displayName: freshDisplayName,
+    username,
+    policy: "allow",
+    inviteId: invite.id,
+    verifiedAt: Date.now(),
+    verifiedVia: "invite",
+    contactId: invite.contactId,
+  });
+
   try {
-    getSqlite()
-      .transaction(() => {
-        freshResult = upsertContactChannel({
-          sourceChannel,
-          externalUserId,
-          externalChatId,
-          displayName: freshDisplayName,
-          username,
-          role: "contact",
-          status: "active",
-          policy: "allow",
-          inviteId: invite.id,
-          verifiedAt: Date.now(),
-          verifiedVia: "invite",
-          contactId: invite.contactId,
-        });
-
-        const recorded = recordInviteUse({
-          inviteId: invite.id,
-          externalUserId,
-          externalChatId,
-        });
-
-        if (!recorded) throw STALE_INVITE_FRESH;
-      })
-      .immediate();
-  } catch (err) {
-    if (err === STALE_INVITE_FRESH) {
+    if (
+      !recordInviteUse({ inviteId: invite.id, externalUserId, externalChatId })
+    ) {
+      // Invite revoked/expired between pre-validation and write.
       return { ok: false, reason: "invalid_token" };
     }
+  } catch (err) {
     // Rare: gateway claim succeeded but the assistant mutation failed — a
     // recoverable wasted gateway use; no cross-process rollback attempted.
     log.error(
@@ -524,10 +497,6 @@ export async function redeemVoiceInviteCode(params: {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
-  // Atomic redemption: upsert member + consume invite use in a transaction
-  const STALE_INVITE = Symbol("stale_invite");
-  let memberId: string | undefined;
-
   // When the invite targets a specific contact, preserve the target contact's
   // guardian-assigned display name if it has one.
   let preservedDisplayName = voiceContact?.displayName?.trim().length
@@ -540,36 +509,31 @@ export async function redeemVoiceInviteCode(params: {
     }
   }
 
+  // Gateway-first: activate the member channel on the authoritative gateway
+  // before the assistant DB; the local mirror is best-effort.
+  const writeResult = await activateMemberChannel({
+    sourceChannel: "phone",
+    externalUserId: callerExternalUserId,
+    externalChatId: callerExternalUserId,
+    displayName: preservedDisplayName,
+    policy: "allow",
+    inviteId: invite.id,
+    verifiedAt: Date.now(),
+    verifiedVia: "invite",
+    contactId: invite.contactId,
+  });
+
   try {
-    getSqlite()
-      .transaction(() => {
-        const writeResult = upsertContactChannel({
-          sourceChannel: "phone",
-          externalUserId: callerExternalUserId,
-          externalChatId: callerExternalUserId,
-          displayName: preservedDisplayName,
-          role: "contact",
-          status: "active",
-          policy: "allow",
-          inviteId: invite.id,
-          verifiedAt: Date.now(),
-          verifiedVia: "invite",
-          contactId: invite.contactId,
-        });
-        memberId = writeResult!.channel.id;
-
-        const recorded = recordInviteUse({
-          inviteId: invite.id,
-          externalUserId: callerExternalUserId,
-        });
-
-        if (!recorded) throw STALE_INVITE;
+    if (
+      !recordInviteUse({
+        inviteId: invite.id,
+        externalUserId: callerExternalUserId,
       })
-      .immediate();
-  } catch (err) {
-    if (err === STALE_INVITE) {
+    ) {
+      // Invite revoked/expired between pre-validation and write.
       return { ok: false, reason: "invalid_or_expired" };
     }
+  } catch (err) {
     // Rare: gateway claim succeeded but the assistant mutation failed — a
     // recoverable wasted gateway use; no cross-process rollback attempted.
     log.error(
@@ -582,7 +546,7 @@ export async function redeemVoiceInviteCode(params: {
   return {
     ok: true,
     type: "redeemed",
-    memberId: memberId!,
+    memberId: writeResult!.channel.id,
     inviteId: invite.id,
   };
 }
@@ -699,10 +663,9 @@ export async function redeemInviteByCode(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
-  // Inactive member reactivation: reactivate via upsertContactChannel and consume
-  // an invite use atomically.
+  // Inactive member reactivation: reactivate gateway-first, then consume an
+  // invite use.
   if (existingChannel && !targetMismatch) {
-    const STALE_INVITE_REACTIVATE = Symbol("stale_invite_reactivate");
     const canonicalMemberId = existingChannel.address;
     const canonicalCallerId = externalUserId
       ? canonicalizeInboundIdentity(sourceChannel as ChannelId, externalUserId)
@@ -714,38 +677,29 @@ export async function redeemInviteByCode(params: {
         ? existingContact.displayName
         : displayName;
 
-    let reactivated: ReturnType<typeof upsertContactChannel> | undefined;
+    // Gateway-first: activate the member channel on the authoritative gateway
+    // before the assistant DB; the local mirror is best-effort.
+    const reactivated = await activateMemberChannel({
+      sourceChannel,
+      externalUserId,
+      externalChatId,
+      displayName: preservedDisplayName,
+      username,
+      policy: "allow",
+      inviteId: invite.id,
+      verifiedAt: Date.now(),
+      verifiedVia: "invite",
+      contactId: invite.contactId,
+    });
+
     try {
-      getSqlite()
-        .transaction(() => {
-          reactivated = upsertContactChannel({
-            sourceChannel,
-            externalUserId,
-            externalChatId,
-            displayName: preservedDisplayName,
-            username,
-            role: "contact",
-            status: "active",
-            policy: "allow",
-            inviteId: invite.id,
-            verifiedAt: Date.now(),
-            verifiedVia: "invite",
-            contactId: invite.contactId,
-          });
-
-          const recorded = recordInviteUse({
-            inviteId: invite.id,
-            externalUserId,
-            externalChatId,
-          });
-
-          if (!recorded) throw STALE_INVITE_REACTIVATE;
-        })
-        .immediate();
-    } catch (err) {
-      if (err === STALE_INVITE_REACTIVATE) {
+      if (
+        !recordInviteUse({ inviteId: invite.id, externalUserId, externalChatId })
+      ) {
+        // Invite revoked/expired between pre-validation and write.
         return { ok: false, reason: "invalid_token" };
       }
+    } catch (err) {
       // Rare: gateway claim succeeded but the assistant mutation failed — a
       // recoverable wasted gateway use; no cross-process rollback attempted.
       log.error(
@@ -775,39 +729,29 @@ export async function redeemInviteByCode(params: {
     }
   }
 
-  const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
-  let freshResult: ReturnType<typeof upsertContactChannel> | undefined;
+  // Gateway-first: activate the member channel on the authoritative gateway
+  // before the assistant DB; the local mirror is best-effort.
+  const freshResult = await activateMemberChannel({
+    sourceChannel,
+    externalUserId,
+    externalChatId,
+    displayName: freshDisplayName,
+    username,
+    policy: "allow",
+    inviteId: invite.id,
+    verifiedAt: Date.now(),
+    verifiedVia: "invite",
+    contactId: invite.contactId,
+  });
+
   try {
-    getSqlite()
-      .transaction(() => {
-        freshResult = upsertContactChannel({
-          sourceChannel,
-          externalUserId,
-          externalChatId,
-          displayName: freshDisplayName,
-          username,
-          role: "contact",
-          status: "active",
-          policy: "allow",
-          inviteId: invite.id,
-          verifiedAt: Date.now(),
-          verifiedVia: "invite",
-          contactId: invite.contactId,
-        });
-
-        const recorded = recordInviteUse({
-          inviteId: invite.id,
-          externalUserId,
-          externalChatId,
-        });
-
-        if (!recorded) throw STALE_INVITE_FRESH;
-      })
-      .immediate();
-  } catch (err) {
-    if (err === STALE_INVITE_FRESH) {
+    if (
+      !recordInviteUse({ inviteId: invite.id, externalUserId, externalChatId })
+    ) {
+      // Invite revoked/expired between pre-validation and write.
       return { ok: false, reason: "invalid_token" };
     }
+  } catch (err) {
     // Rare: gateway claim succeeded but the assistant mutation failed — a
     // recoverable wasted gateway use; no cross-process rollback attempted.
     log.error(

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -62,6 +62,11 @@ mock.module("../db/connection.js", () => ({
               return Array.from({ length: n }, () => ({ id: "x" }));
             },
           }),
+          // reassignChannelContact re-parents a channel via a bare update.
+          run: () => {
+            void table;
+            gwUpdates.push({ set, where });
+          },
         }),
       }),
     }),
@@ -596,6 +601,88 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       c.sql.includes("UPDATE contact_channels"),
     );
     expect(update!.params).toContain("manual");
+  });
+});
+
+describe("upsertVerifiedContactChannel — invite target-contact binding", () => {
+  test("reassigns an existing channel to the supplied target contact", async () => {
+    // The redeemer's channel currently lives under a different contact (the
+    // guardian); the invite binds it to the target contact "mom".
+    queryRows = [
+      { channelId: "ch-redeemer", contactId: "co-guardian", channelStatus: "active" },
+    ];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "redeemer-tg",
+      externalChatId: "redeemer-tg",
+      verifiedVia: "invite",
+      contactId: "co-mom",
+    });
+
+    // Assistant mirror re-parents the channel to the target contact.
+    const reparent = runCalls.find(
+      (c) =>
+        c.sql.includes("UPDATE contact_channels") &&
+        c.sql.includes("contact_id = ?"),
+    );
+    expect(reparent).toBeTruthy();
+    expect(reparent!.params).toEqual(["co-mom", "ch-redeemer"]);
+
+    // Gateway channel re-parented to the target contact too.
+    const gwReparent = gwUpdates.find(
+      (u) => (u.set as { contactId?: string }).contactId === "co-mom",
+    );
+    expect(gwReparent).toBeTruthy();
+
+    // The verified gateway write lands under the bound (target) contact.
+    expect(
+      gwUpdates.some(
+        (u) => (u.set as { status?: string }).status === "active",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not reassign when the channel already belongs to the target contact", async () => {
+    queryRows = [
+      { channelId: "ch-x", contactId: "co-mom", channelStatus: "active" },
+    ];
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "redeemer-tg",
+      externalChatId: "redeemer-tg",
+      verifiedVia: "invite",
+      contactId: "co-mom",
+    });
+
+    const reparent = runCalls.find(
+      (c) =>
+        c.sql.includes("UPDATE contact_channels") &&
+        c.sql.includes("contact_id = ?"),
+    );
+    expect(reparent).toBeUndefined();
+  });
+
+  test("creates a fresh channel under the supplied target contact", async () => {
+    queryRows = [];
+    gwSelectStatus = null;
+
+    await upsertVerifiedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "fresh-tg",
+      externalChatId: "fresh-tg",
+      verifiedVia: "invite",
+      contactId: "co-target",
+    });
+
+    // The assistant contact INSERT uses the supplied target contactId, not a
+    // freshly minted UUID.
+    const contactInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT OR IGNORE INTO contacts"),
+    );
+    expect(contactInsert).toBeTruthy();
+    expect(contactInsert!.params[0]).toBe("co-target");
   });
 });
 

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -225,8 +225,15 @@ export const contactRoutes: IpcRoute[] = [
     method: "upsert_verified_channel",
     schema: UpsertVerifiedChannelIpcParamsSchema,
     handler: async (params?: Record<string, unknown>) => {
-      const { type, address, externalChatId, displayName, username, verifiedVia } =
-        UpsertVerifiedChannelIpcParamsSchema.parse(params);
+      const {
+        type,
+        address,
+        externalChatId,
+        displayName,
+        username,
+        verifiedVia,
+        contactId,
+      } = UpsertVerifiedChannelIpcParamsSchema.parse(params);
 
       const { verified } = await upsertVerifiedContactChannel({
         sourceChannel: type,
@@ -235,6 +242,7 @@ export const contactRoutes: IpcRoute[] = [
         displayName,
         username,
         verifiedVia,
+        contactId,
       });
 
       // A blocked/revoked skip is not an error: surface it as verified:false

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -176,6 +176,41 @@ function writeVerifiedGatewayChannel(params: {
 }
 
 /**
+ * Re-parent a gateway channel to the invite's target contact, ensuring the
+ * target contact row exists first. Best-effort: a gateway DB error is logged,
+ * not thrown, so a legitimate activation still proceeds.
+ */
+function reassignChannelContact(params: {
+  channelId: string;
+  toContactId: string;
+  displayName: string;
+  now: number;
+}): void {
+  const { channelId, toContactId, displayName, now } = params;
+  try {
+    const gwDb = getGatewayDb();
+    gwDb
+      .insert(gwContacts)
+      .values({
+        id: toContactId,
+        displayName,
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+      .run();
+    gwDb
+      .update(gwContactChannels)
+      .set({ contactId: toContactId, updatedAt: now })
+      .where(eq(gwContactChannels.id, channelId))
+      .run();
+  } catch (gwErr) {
+    log.warn({ err: gwErr }, "Gateway channel reassignment dual-write failed");
+  }
+}
+
+/**
  * Read the authoritative gateway row status for an actor by the logical key
  * (type, address) COLLATE NOCASE. The gateway is the source of truth; the
  * assistant mirror can lag behind a block/revoke landed gateway-side.
@@ -260,9 +295,16 @@ export async function upsertVerifiedContactChannel(params: {
   displayName?: string;
   username?: string;
   verifiedVia?: string;
+  contactId?: string;
 }): Promise<{ verified: boolean }> {
   const now = Date.now();
-  const { sourceChannel, externalChatId, displayName, username } = params;
+  const {
+    sourceChannel,
+    externalChatId,
+    displayName,
+    username,
+    contactId: targetContactId,
+  } = params;
   const verifiedVia = params.verifiedVia ?? "challenge";
 
   const address =
@@ -315,6 +357,26 @@ export async function upsertVerifiedContactChannel(params: {
       return { verified: false };
     }
 
+    // Bind to the invite's target contact when supplied: an invite can attach a
+    // redeemer's existing channel to a different contact, so reassign the
+    // channel's parent (gateway + assistant mirror) before activating.
+    const boundContactId =
+      targetContactId && targetContactId !== row.contactId
+        ? targetContactId
+        : row.contactId;
+    if (boundContactId !== row.contactId) {
+      reassignChannelContact({
+        channelId: row.channelId,
+        toContactId: boundContactId,
+        displayName: contactDisplayName,
+        now,
+      });
+      await assistantDbRun(
+        `UPDATE contact_channels SET contact_id = ? WHERE id = ?`,
+        [boundContactId, row.channelId],
+      );
+    }
+
     // Gateway is source of truth: write it FIRST, then activate the assistant
     // mirror only if the gateway accepted the write. The assistant channel id
     // may not exist in the gateway DB (legacy/unmirrored) or live under a
@@ -323,7 +385,7 @@ export async function upsertVerifiedContactChannel(params: {
     try {
       const wrote = writeVerifiedGatewayChannel({
         assistantChannelId: row.channelId,
-        contactId: row.contactId,
+        contactId: boundContactId,
         type: sourceChannel,
         address,
         externalChatId,
@@ -374,8 +436,9 @@ export async function upsertVerifiedContactChannel(params: {
   // No existing channel: create contact + channel. Gateway is source of truth,
   // so write it FIRST and create the assistant mirror only if the gateway
   // accepted the write — never leave an active assistant channel for an actor
-  // the gateway has blocked/revoked.
-  const contactId = crypto.randomUUID();
+  // the gateway has blocked/revoked. Bind to the invite's target contact when
+  // supplied so the new channel lands under it.
+  const contactId = targetContactId ?? crypto.randomUUID();
   const channelId = crypto.randomUUID();
 
   // The parent contact is conflict-tolerant (a pre-existing contact is fine).

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -146,6 +146,11 @@ export const UpsertVerifiedChannelIpcParamsSchema = z.object({
   // Audit source for the verification. Free text (DB column is text) so the
   // invite-activation path can pass "invite"; do not narrow to an enum.
   verifiedVia: z.string().optional(),
+  // Target contact to bind the channel to (invite redemption). When set, an
+  // existing channel for the same (type,address) under a different contact is
+  // reassigned to this contact, mirroring the assistant's
+  // reassignConflictingChannels.
+  contactId: z.string().min(1).optional(),
 });
 
 export type UpsertVerifiedChannelIpcParams = z.infer<


### PR DESCRIPTION
## Summary
- Invite-redemption member activation/reactivation now writes to the gateway via `upsert_verified_channel` first, with the assistant DB write demoted to a best-effort mirror; `contacts-write.ts` stays sync. A gateway outage fails open (logged warning) so a legitimate activation is never dropped; a gateway refusal (`verified:false`) skips the local mirror so a blocked actor is never left active locally.
- All five activation/reactivation call sites in `invite-redemption-service.ts` (text fresh + reactivation, code fresh + reactivation, voice) route through the new async `activateMemberChannel`. The old per-site `getSqlite().transaction()` wrapping (local upsert + recordInviteUse) is removed: the gateway is now the SoT and the local mirror is best-effort, so the activation runs gateway-first then `recordInviteUse` consumes the use.

## Verify-first: target-contact binding — IPC contract EXTENDED
The pre-existing local activation passes the invite's TARGET `contactId` (e.g. bind a redeemer's channel to "Mom", not the guardian) with `reassignConflictingChannels`. PR 1's `upsert_verified_channel` IPC had NO `contactId` and `upsertVerifiedContactChannel` derived/created the gateway contact from the channel identity — so routing the gateway write through it would have mis-attached the channel under the wrong gateway contact (or left it under the guardian on reassignment), a correctness regression.

Decision: NOT preserved without a change → extended the contract. Added optional `contactId` to `UpsertVerifiedChannelIpcParamsSchema`, threaded it through the `upsert_verified_channel` handler into `upsertVerifiedContactChannel`, which now re-parents an existing channel (gateway row + assistant mirror) to the supplied target contact when it differs, and lands a fresh channel under the supplied contact id (mirroring the assistant's `reassignConflictingChannels`). Added gateway tests for the reassignment + fresh-bind paths; the existing "binds redeemer to the invite's target contact" redemption test still passes and now also asserts the gateway relay carries the target `contactId`.

Part of plan: combo11-phase-b1-gateway-write-ownership.md (PR 2 of 3)