### PR TITLE
feat(onboarding): merge pitch steps into one carousel + flow tweaks

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
@@ -27,7 +27,6 @@ function CoinFace({ idSuffix }: { idSuffix: string }) {
   const face = `cf-${idSuffix}`;
   const rim = `cr-${idSuffix}`;
   const gloss = `cg-${idSuffix}`;
-  const vignette = `cv-${idSuffix}`;
   const spec = `cs-${idSuffix}`;
   return (
     <svg
@@ -46,10 +45,6 @@ function CoinFace({ idSuffix }: { idSuffix: string }) {
           <stop offset="0%" stopColor="#FFF6CE" />
           <stop offset="55%" stopColor="#F8CB3E" />
           <stop offset="100%" stopColor="#EEB52C" />
-        </radialGradient>
-        <radialGradient id={vignette} cx="50%" cy="50%" r="50%">
-          <stop offset="82%" stopColor="#000000" stopOpacity="0" />
-          <stop offset="100%" stopColor="#9A6E0E" stopOpacity="0.22" />
         </radialGradient>
         <radialGradient id={gloss} cx="36%" cy="24%" r="44%">
           <stop offset="0%" stopColor="#FFFFFF" stopOpacity="0.85" />
@@ -78,7 +73,6 @@ function CoinFace({ idSuffix }: { idSuffix: string }) {
       />
       {/* Center face */}
       <circle cx="50" cy="50" r="40" fill={`url(#${face})`} />
-      <circle cx="50" cy="50" r="40" fill={`url(#${vignette})`} />
       {/* Subtle groove between rim and face */}
       <circle
         cx="50"

--- a/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
@@ -85,12 +85,18 @@ interface OnboardingPeekingEyesProps {
    * knock the integration-step coin up).
    */
   bumpNonce?: number;
+  /**
+   * Play the two settle blinks when the eyes settle. Off for resting eyes that
+   * are simply carried over from a previous step (they just idle-blink).
+   */
+  settleBlink?: boolean;
 }
 
 export function OnboardingPeekingEyes({
   entrance = false,
   entranceDelay = 0,
   bumpNonce = 0,
+  settleBlink = true,
 }: OnboardingPeekingEyesProps) {
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
@@ -124,7 +130,7 @@ export function OnboardingPeekingEyes({
     }
   }, [bumpNonce, reduce, bumpControls]);
 
-  // Two blinks once settled, then a slow random idle blink.
+  // Two blinks once settled (when `settleBlink`), then a slow random idle blink.
   const [blinking, setBlinking] = useState(false);
   const [entranceDone, setEntranceDone] = useState(!entrance);
   useEffect(() => {
@@ -143,12 +149,14 @@ export function OnboardingPeekingEyes({
     const idle = () => {
       t = setTimeout(() => blink(idle), 2500 + Math.random() * 4000);
     };
-    blink(() => blink(idle));
+    // Resting eyes (carried over) skip the settle blinks and just idle.
+    if (settleBlink) blink(() => blink(idle));
+    else idle();
     return () => {
       cancelled = true;
       clearTimeout(t);
     };
-  }, [reduce, entranceDone]);
+  }, [reduce, entranceDone, settleBlink]);
 
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
 

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -89,8 +89,7 @@ export function OnboardingTonedBackdrop({
   darkBg?: boolean;
   /** Show the giant eyes peeking from the bottom (off once they've collapsed). */
   showBottomEyes?: boolean;
-  /** Show the little team peeking in from the top (forms on the "together"
-   *  step and persists through the rest of the flow). */
+  /** Show the little team peeking in from the top edge (off by default). */
   showTopTeam?: boolean;
 }) {
   const components = useBundledAvatarComponents();
@@ -128,10 +127,12 @@ export function OnboardingTonedBackdrop({
 
       {/* The assistant's eyes peek up from the bottom (until they collapse into
           the small avatar at the calendar step). */}
-      {showBottomEyes && <OnboardingPeekingEyes bumpNonce={eyesBumpNonce} />}
+      {showBottomEyes && (
+        <OnboardingPeekingEyes bumpNonce={eyesBumpNonce} settleBlink={false} />
+      )}
 
       {/* The team peeks in from the top-right — three larger avatars, overlapping
-          and cut off by the top edge. Forms on "together" and stays put. */}
+          and cut off by the top edge. Forms on the integration step and stays put. */}
       {showTopTeam && components && (
         <div
           className="pointer-events-none absolute right-0 z-[1] flex items-start"

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -17,7 +17,7 @@
  * then clicks "Continue" to drop into the full workspace on the same conversation.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -43,10 +43,7 @@ import {
   type GiveMeAFaceValues,
 } from "@/domains/onboarding/screens/give-me-a-face-screen";
 import { IntroductionScreen } from "@/domains/onboarding/screens/introduction-screen";
-import {
-  PitchDifferentStep,
-  PitchTogetherStep,
-} from "@/domains/onboarding/screens/intro-pitch-steps";
+import { PitchStep } from "@/domains/onboarding/screens/intro-pitch-steps";
 import { IntegrationStep } from "@/domains/onboarding/screens/integration-step";
 import { LetsChatTomorrowStep } from "@/domains/onboarding/screens/lets-chat-tomorrow-step";
 import {
@@ -62,7 +59,6 @@ type ResearchStep =
   | "face"
   | "intro"
   | "different"
-  | "together"
   | "integration"
   | "letschat"
   | "meeting"
@@ -83,10 +79,10 @@ export function ResearchOnboardingRoute() {
   const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
 
   // Sub-steps share this route: details form → avatar/name picker →
-  // introduction → "different"/"collaborate" pitch → integration → "let's chat
-  // tomorrow". The toned steps share a persistent backdrop so the avatars/eyes
-  // stay put. The handoff fires from the "let's chat tomorrow" step (or the
-  // picker's skip).
+  // introduction → pitch (the "different" step, which carousels its lines to
+  // the payoff) → integration → "let's chat tomorrow". The toned steps share a
+  // persistent backdrop so the avatars/eyes stay put. The handoff fires from
+  // the "let's chat tomorrow" step (or the picker's skip).
   const [step, setStep] = useState<ResearchStep>("form");
   // Forward-history (redo) stack: pushed when the user steps back, popped when
   // they step forward via the header's forward chevron. The chevron only shows
@@ -94,10 +90,7 @@ export function ResearchOnboardingRoute() {
   // (any Continue/Skip) clears it, browser-style.
   const [forwardStack, setForwardStack] = useState<ResearchStep[]>([]);
 
-  // Re-entering "together" replays its sequence, so the team should drop in
-  // again on the third line — hide it on the way in.
   function navTo(next: ResearchStep) {
-    if (next === "together") setTeamRevealed(false);
     setStep(next);
   }
   // Forward (Continue/Skip): a fresh forward move invalidates the redo stack.
@@ -128,10 +121,6 @@ export function ResearchOnboardingRoute() {
   // Extra edge characters revealed so far — grows as the looking-you-up
   // carousel advances, then stays for the results/suggestions steps.
   const [edgeAvatars, setEdgeAvatars] = useState(0);
-  // The top-right team is revealed on the "together" step's third line, then
-  // persists for the rest of the flow.
-  const [teamRevealed, setTeamRevealed] = useState(false);
-  const revealTeam = useCallback(() => setTeamRevealed(true), []);
 
   // Provision the assistant in the background the moment the user lands here,
   // so it's (usually) healthy by the time they finish the intro/pitch steps —
@@ -148,6 +137,10 @@ export function ResearchOnboardingRoute() {
   const research = useResearchRunner();
   const researchLoading =
     research.status === "idle" || research.status === "running";
+  // The research turn settled with nothing to show — skip the "this is what I
+  // found" step (it would only say "I didn't turn up much") and go straight to
+  // the suggestions.
+  const noClaims = !researchLoading && research.claims.length === 0;
 
   // Landing on the form means a fresh run — clear any stale focus state left
   // behind by an abandoned previous attempt so the form itself never renders
@@ -161,6 +154,15 @@ export function ResearchOnboardingRoute() {
     exitFocus();
     if (enabled && flagsHydrated) startHatch();
   }, [exitFocus, startHatch, enabled, flagsHydrated]);
+
+  // If we're sitting on the results step when the research turn resolves empty
+  // (it was still streaming when we arrived), skip ahead to the suggestions.
+  useEffect(() => {
+    if (step === "results" && noClaims) {
+      setForwardStack([]);
+      setStep("suggestions");
+    }
+  }, [step, noClaims]);
 
   // Build the pre-chat context and hand off to the chat pipeline. The chosen
   // name is applied via `assistantName`; the avatar traits are applied to the
@@ -276,7 +278,6 @@ export function ResearchOnboardingRoute() {
   // content swaps. Extra edge characters pop in per step to build excitement.
   const tonedSteps = [
     "different",
-    "together",
     "integration",
     "letschat",
     "meeting",
@@ -301,43 +302,25 @@ export function ResearchOnboardingRoute() {
           eyesBumpNonce={eyesBump}
           peekLevel={peekLevel}
           darkBg={postCalendar}
-          // The "different" step choreographs its own eyes (rising to speak the
-          // line in), so hide the backdrop's resting pair there to avoid
-          // doubling. Every other toned step uses the backdrop's resting eyes.
+          // The pitch step ("different") choreographs its own eyes (rising to
+          // speak the lines in), so hide the backdrop's resting pair there to
+          // avoid doubling. Every other toned step uses the backdrop's resting
+          // eyes. The top-right team isn't persistent — the pitch step peeks
+          // its own transient team in and out (see PitchStep).
           showBottomEyes={!postCalendar && step !== "different"}
-          // On "together" the team is gated on the third-line reveal (so it
-          // replays on back); on every later step it's simply present.
-          showTopTeam={
-            step === "together"
-              ? teamRevealed
-              : ["integration", "letschat", "meeting", "looking", "results", "suggestions"].includes(
-                  step,
-                )
-          }
         />
         {step === "different" && (
-          <PitchDifferentStep
-            onContinue={() => goForwardTo("together")}
+          <PitchStep
+            onContinue={() => goForwardTo("integration")}
             onBack={() => goBackTo("intro")}
             onForward={onForward}
           />
         )}
-        {step === "together" && (
-          <PitchTogetherStep
-            onContinue={() => goForwardTo("integration")}
-            onBack={() => goBackTo("different")}
-            onForward={onForward}
-            onRevealTeam={revealTeam}
-          />
-        )}
         {step === "integration" && (
           <IntegrationStep
-            assistantId={hatchedAssistantId}
-            assistantReady={hatchReady}
-            onConnected={handleCheckinConnected}
-            onSkip={() => goForwardTo("looking")}
+            onClaim={() => goForwardTo("letschat")}
             onBumpEyes={() => setEyesBump((n) => n + 1)}
-            onBack={() => goBackTo("together")}
+            onBack={() => goBackTo("different")}
             onForward={onForward}
           />
         )}
@@ -354,14 +337,14 @@ export function ResearchOnboardingRoute() {
         {step === "meeting" && (
           <MeetingCreatedStep
             onDone={() => goForwardTo("looking")}
-            onBack={() => goBackTo("integration")}
+            onBack={() => goBackTo("letschat")}
             onForward={onForward}
           />
         )}
         {step === "looking" && (
           <LookingYouUpStep
-            onDone={() => goForwardTo("results")}
-            onBack={() => goBackTo("integration")}
+            onDone={() => goForwardTo(noClaims ? "suggestions" : "results")}
+            onBack={() => goBackTo("letschat")}
             onAdvance={(i) => setEdgeAvatars(Math.min(i + 1, 4))}
             onForward={onForward}
           />
@@ -389,7 +372,7 @@ export function ResearchOnboardingRoute() {
               }
               enterAssistant(formValues, faceValues, suggestion.prompt);
             }}
-            onBack={() => goBackTo("results")}
+            onBack={() => goBackTo(noClaims ? "looking" : "results")}
             onForward={onForward}
           />
         )}

--- a/clients/web/src/domains/onboarding/screens/integration-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/integration-step.tsx
@@ -1,35 +1,23 @@
 /**
- * "Help me get oriented, and get free credits" step content.
+ * "Here are some free credits to get started" step content.
  *
  * SPIKE — research-onboarding flow.
  *
- * Foreground only (the toned backdrop sits behind). Offers free credits in
- * exchange for connecting Google Calendar. Claim opens the real managed Google
- * Calendar OAuth (calendar.events + identity scopes) right inside the click —
- * the popup must open within the user gesture — and plays the coin flourish
- * (drops toward the eyes, the eyes bump it Mario-style, it pops up and
- * vanishes). On a successful grant the parent fires the Day-2 check-in and
- * advances straight to "Meeting Created!". Skippable.
+ * Foreground only (the toned backdrop sits behind). Offers 10 free credits. On
+ * Claim the coin drops toward the eyes, the eyes bump it up Mario-style, and it
+ * pops up and vanishes — then the flow advances. Skippable.
  */
 
-import { useEffect, useState } from "react";
-import { ArrowRight, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { OnboardingCoin } from "@/domains/onboarding/components/onboarding-coin";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
-import { useGoogleCalendarConnect } from "@/domains/onboarding/hooks/use-google-calendar-connect";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 
 interface IntegrationStepProps {
-  /** Hatched assistant id; null until the background hatch resolves. */
-  assistantId: string | null;
-  /** True once the hatch is fully healthy (daemon reachable), not just hatched. */
-  assistantReady: boolean;
-  /** Fired once the Google Calendar grant lands, with the scopes granted. */
-  onConnected: (scopes: string[]) => void;
-  /** Skip the calendar connect and move on. */
-  onSkip: () => void;
+  onClaim: () => void;
   /** Fire the eyes' upward jolt as the coin reaches them. */
   onBumpEyes: () => void;
   onBack: () => void;
@@ -43,51 +31,20 @@ const DROP = 0.3;
 const TOTAL = 0.95;
 
 export function IntegrationStep({
-  assistantId,
-  assistantReady,
-  onConnected,
-  onSkip,
+  onClaim,
   onBumpEyes,
   onBack,
   onForward,
 }: IntegrationStepProps) {
   const reduce = useReducedMotion();
   const tone = useOnboardingTone();
-  // `claiming` covers the coin flourish; `coinDone` flips once it has flown
-  // away, after which we surface the OAuth-in-progress state.
   const [claiming, setClaiming] = useState(false);
-  const [coinDone, setCoinDone] = useState(false);
-
-  const { handleConnect, oauthInProgress } = useGoogleCalendarConnect({
-    assistantId: assistantId ?? "",
-    onConnect: onConnected,
-  });
-  // Gate Claim on full hatch readiness (not just an id): the post-OAuth
-  // `scheduleCheckin` talks to the daemon, which may not be reachable until
-  // healthz passes — a grant against a not-yet-reachable daemon would silently
-  // no-op while the flow advanced.
-  const claimDisabled = !assistantId || !assistantReady || oauthInProgress;
-
-  // An OAuth that ends without success (popup closed / declined / blocked)
-  // flips `oauthInProgress` back to false while we're still mounted — a
-  // successful grant would have advanced the flow and unmounted us. Reset so the
-  // Claim button is offered again instead of stranding the user on a vanished
-  // coin.
-  useEffect(() => {
-    if (claiming && coinDone && !oauthInProgress) {
-      setClaiming(false);
-      setCoinDone(false);
-    }
-  }, [claiming, coinDone, oauthInProgress]);
 
   function handleClaim() {
-    if (claimDisabled || claiming) return;
-    // Open the OAuth popup inside the click gesture (popup blockers require the
-    // window.open to happen synchronously here), then play the coin flourish.
-    handleConnect();
+    if (claiming) return;
     setClaiming(true);
     if (reduce) {
-      setCoinDone(true);
+      onClaim();
       return;
     }
     // Bump the eyes right as the coin reaches the bottom.
@@ -99,8 +56,6 @@ export function IntegrationStep({
   const apexY = -vh * 0.08; // bumped just a little above the start
   const fallY = vh * 0.9; // falls away off the bottom
 
-  const waiting = claiming && coinDone && oauthInProgress;
-
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
@@ -110,12 +65,8 @@ export function IntegrationStep({
           className="text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}
         >
-          Help me get oriented, and get free credits
+          Here are some free credits to get started
         </h1>
-        <p className="text-[16px]" style={{ color: tone.fgMuted }}>
-          Connect your calendar and I&rsquo;ll find time tomorrow to check in
-          with you.
-        </p>
 
         {/* Coin — drops to the eyes, gets bumped up, then falls away (2D flight
             here) while the coin spins in its own 3D context (`spinning`). */}
@@ -138,54 +89,29 @@ export function IntegrationStep({
               ease: ["easeIn", "easeOut", "easeIn"],
             }}
             onAnimationComplete={() => {
-              if (claiming) setCoinDone(true);
+              if (claiming) onClaim();
             }}
           >
             <OnboardingCoin size={88} spinning={claiming && !reduce} />
           </motion.div>
         </div>
 
-        {/* Claim opens the OAuth flow; once the coin has flown we surface the
-            in-progress state until the grant lands (or the popup is dismissed). */}
+        {/* Claim — hidden while the coin animates. */}
         {!claiming && (
           <button
             type="button"
             onClick={handleClaim}
-            disabled={claimDisabled}
-            className="mt-6 flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97] disabled:opacity-60"
+            className="mt-6 flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
             style={{
               backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
               color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
             }}
           >
-            Connect to claim
+            Claim
             <ArrowRight className="h-4 w-4" />
           </button>
         )}
-        {waiting && (
-          <div
-            className="mt-6 flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default opacity-80"
-            style={{
-              backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
-              color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
-            }}
-          >
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-            Waiting for authorization…
-          </div>
-        )}
       </div>
-
-      {/* Skip sits down near the bottom, just above the peeking eyes. */}
-      <button
-        type="button"
-        onClick={onSkip}
-        disabled={oauthInProgress}
-        className="absolute bottom-[26%] left-1/2 -translate-x-1/2 text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
-        style={{ color: tone.fgMuted }}
-      >
-        Skip for now
-      </button>
     </div>
   );
 }

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -55,12 +55,14 @@ const PITCH_TEAM = [
 const PITCH_TEAM_SIZE = 290;
 
 /**
- * One carousel line: a fixed-height window holding the first phrase above the
- * second. The first phrase wipes in (clip reveal); flipping `carouseled` rolls
- * the window up to the second phrase.
+ * One carousel line: a window holding the first phrase above the second. The
+ * first phrase wipes in (clip reveal); flipping `carouseled` rolls the window
+ * up to the second phrase and collapses the window to that phrase's height (so
+ * a 2-line setup line doesn't leave a gap once it carousels to a 1-line payoff).
  */
 function CarouselLine({
-  slotH,
+  firstH,
+  secondH,
   color,
   firstText,
   secondText,
@@ -70,7 +72,8 @@ function CarouselLine({
   revealDuration,
   reduce,
 }: {
-  slotH: number;
+  firstH: number;
+  secondH: number;
   color: string;
   firstText: string;
   secondText: string;
@@ -84,16 +87,23 @@ function CarouselLine({
   const clipHidden =
     revealFrom === "bottom" ? "inset(100% 0 0 0)" : "inset(0 0 100% 0)";
   const clipShown = "inset(0% 0 0% 0)";
+  // Wait for the measurer so the window opens at the right height (no grow-in).
+  if (!firstH || !secondH) return null;
   return (
-    <div className="relative w-full overflow-hidden" style={{ height: slotH || undefined }}>
+    <motion.div
+      className="relative w-full overflow-hidden"
+      initial={false}
+      animate={{ height: carouseled ? secondH : firstH }}
+      transition={reduce ? { duration: 0 } : { duration: 0.5, ease: "easeInOut" }}
+    >
       <motion.div
         className="flex flex-col"
         style={{ color }}
         initial={false}
-        animate={{ y: carouseled ? -slotH : 0 }}
+        animate={{ y: carouseled ? -firstH : 0 }}
         transition={reduce ? { duration: 0 } : { duration: 0.5, ease: "easeInOut" }}
       >
-        <div className="flex items-center justify-center" style={{ height: slotH }}>
+        <div className="flex items-center justify-center" style={{ height: firstH }}>
           <motion.span
             className="block"
             initial={false}
@@ -103,11 +113,11 @@ function CarouselLine({
             {firstText}
           </motion.span>
         </div>
-        <div className="flex items-center justify-center" style={{ height: slotH }}>
+        <div className="flex items-center justify-center" style={{ height: secondH }}>
           <span className="block">{secondText}</span>
         </div>
       </motion.div>
-    </div>
+    </motion.div>
   );
 }
 
@@ -171,19 +181,15 @@ export function PitchStep({
   const m1bRef = useRef<HTMLSpanElement>(null);
   const m2aRef = useRef<HTMLSpanElement>(null);
   const m2bRef = useRef<HTMLSpanElement>(null);
-  const [slotH1, setSlotH1] = useState(0);
-  const [slotH2, setSlotH2] = useState(0);
+  const [firstH1, setFirstH1] = useState(0);
+  const [secondH1, setSecondH1] = useState(0);
+  const [firstH2, setFirstH2] = useState(0);
+  const [secondH2, setSecondH2] = useState(0);
   useLayoutEffect(() => {
-    const h1 = Math.max(
-      m1aRef.current?.offsetHeight ?? 0,
-      m1bRef.current?.offsetHeight ?? 0,
-    );
-    const h2 = Math.max(
-      m2aRef.current?.offsetHeight ?? 0,
-      m2bRef.current?.offsetHeight ?? 0,
-    );
-    if (h1) setSlotH1(h1);
-    if (h2) setSlotH2(h2);
+    if (m1aRef.current?.offsetHeight) setFirstH1(m1aRef.current.offsetHeight);
+    if (m1bRef.current?.offsetHeight) setSecondH1(m1bRef.current.offsetHeight);
+    if (m2aRef.current?.offsetHeight) setFirstH2(m2aRef.current.offsetHeight);
+    if (m2bRef.current?.offsetHeight) setSecondH2(m2bRef.current.offsetHeight);
   }, [blockW]);
 
   // Park the eyes at rest until the journey starts.
@@ -310,7 +316,7 @@ export function PitchStep({
       {/* Hidden measurer — sizes the carousel windows to the taller phrase. */}
       <div
         aria-hidden="true"
-        className="pointer-events-none invisible absolute -left-[9999px] top-0 text-[72px] leading-[1.15]"
+        className="pointer-events-none invisible absolute -left-[9999px] top-0 text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.15]"
         style={{ width: blockW, fontFamily: "var(--font-serif)" }}
       >
         <span ref={m1aRef} className="block">{SETUP_LINE}</span>
@@ -389,12 +395,13 @@ export function PitchStep({
 
       <div className={`${ONBOARDING_STEP_CONTENT} max-w-3xl`}>
         <div
-          className="flex w-full flex-col gap-3 text-[72px] leading-[1.15]"
+          className="flex w-full flex-col gap-3 text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.15]"
           style={{ fontFamily: "var(--font-serif)" }}
         >
           {/* Line 1 — the darker secondary tone; wipes in bottom→top. */}
           <CarouselLine
-            slotH={slotH1}
+            firstH={firstH1}
+            secondH={secondH1}
             color={tone.fgDeep}
             firstText={SETUP_LINE}
             secondText={HELP_LINE}
@@ -406,7 +413,8 @@ export function PitchStep({
           />
           {/* Line 2 — full-strength; wipes in top→bottom. */}
           <CarouselLine
-            slotH={slotH2}
+            firstH={firstH2}
+            secondH={secondH2}
             color={tone.fg}
             firstText={PUNCH_LINE}
             secondText={LESS_LINE}

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -157,12 +157,12 @@ export function PitchStep({
   const teamPeek = -teamSize * 0.42; // ~42% cut off, peeking down
   const teamY = useMotionValue(-320);
 
-  const [reveal1, setReveal1] = useState(reduce);
-  const [reveal2, setReveal2] = useState(reduce);
-  const [carousel1, setCarousel1] = useState(reduce);
-  const [carousel2, setCarousel2] = useState(reduce);
+  const [reveal1, setReveal1] = useState(!!reduce);
+  const [reveal2, setReveal2] = useState(!!reduce);
+  const [carousel1, setCarousel1] = useState(!!reduce);
+  const [carousel2, setCarousel2] = useState(!!reduce);
   const [ready, setReady] = useState(false);
-  const [landed, setLanded] = useState(reduce);
+  const [landed, setLanded] = useState(!!reduce);
 
   // Measure each line's slot height from a hidden copy so the carousel window
   // is tall enough for the taller of its two phrases (re-measured on resize).

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -1,26 +1,30 @@
 /**
- * Two short "what makes me different" statement steps that sit between the
- * Introduction and the talk-style step.
+ * The pitch step — a single screen whose two lines carousel from the
+ * "you've used other AI" framing to the "the more I help, the less you do"
+ * payoff, with the assistant's avatar acting out each beat.
  *
  * SPIKE — research-onboarding flow.
  *
- * Foreground only — they render over the shared `OnboardingTonedBackdrop`
- * (assistant color + edge crowd). Both choreograph the assistant's bottom eyes
- * themselves, so the route hides the backdrop's resting pair on these steps and
- * each renders its own `MotionEyes`.
+ * Foreground only — it renders over the shared `OnboardingTonedBackdrop` and
+ * choreographs the assistant's bottom eyes itself (so the route hides the
+ * backdrop's resting pair on this step):
  *
- *   - PitchDifferentStep  eyes rise to "speak" the pitch in, then settle
- *   - PitchTogetherStep   a team forms; the eyes act out "smarter" and "faster"
+ *   1. the eyes rise, wiping line 1 in bottom→top, then drop back, wiping
+ *      line 2 in top→bottom;
+ *   2. line 1 carousels vertically to "The more I help" as a helper peeks from
+ *      the top-left, then retracts;
+ *   3. line 2 carousels vertically to "The less you do" as a small team peeks
+ *      from the top-right, then retracts;
+ *   4. a Continue button appears.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import {
   animate,
   motion,
   useMotionValue,
   useReducedMotion,
-  useTransform,
 } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
@@ -35,16 +39,79 @@ import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-la
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
+// Line 1 (darker tone) and line 2 (full-strength) each carousel between these.
 const SETUP_LINE = "You’ve used AI that just answers questions";
+const HELP_LINE = "The more I help";
 const PUNCH_LINE = "I’m different";
+const LESS_LINE = "The less you do";
+
+// The little team that peeks in from the top-right on the second line, then
+// retracts. (Kept in sync with TOP_TEAM in onboarding-toned-backdrop.tsx.)
+const PITCH_TEAM = [
+  { bodyShape: "blob", eyeStyle: "gentle" },
+  { bodyShape: "urchin", eyeStyle: "curious" },
+  { bodyShape: "star", eyeStyle: "goofy" },
+];
+const PITCH_TEAM_SIZE = 290;
 
 /**
- * The assistant's eyes shoot straight up from the bottom (shrinking), speaking
- * line 1 into view bottom→top along the rise. They fly straight back down to
- * their resting peek with a small bounce, speaking "I'm different" in as they
- * pass over it, then blink twice. A Continue button then appears.
+ * One carousel line: a fixed-height window holding the first phrase above the
+ * second. The first phrase wipes in (clip reveal); flipping `carouseled` rolls
+ * the window up to the second phrase.
  */
-export function PitchDifferentStep({
+function CarouselLine({
+  slotH,
+  color,
+  firstText,
+  secondText,
+  revealed,
+  carouseled,
+  revealFrom,
+  revealDuration,
+  reduce,
+}: {
+  slotH: number;
+  color: string;
+  firstText: string;
+  secondText: string;
+  revealed: boolean;
+  carouseled: boolean;
+  /** Which edge the first phrase wipes in from. */
+  revealFrom: "bottom" | "top";
+  revealDuration: number;
+  reduce: boolean;
+}) {
+  const clipHidden =
+    revealFrom === "bottom" ? "inset(100% 0 0 0)" : "inset(0 0 100% 0)";
+  const clipShown = "inset(0% 0 0% 0)";
+  return (
+    <div className="relative w-full overflow-hidden" style={{ height: slotH || undefined }}>
+      <motion.div
+        className="flex flex-col"
+        style={{ color }}
+        initial={false}
+        animate={{ y: carouseled ? -slotH : 0 }}
+        transition={reduce ? { duration: 0 } : { duration: 0.5, ease: "easeInOut" }}
+      >
+        <div className="flex items-center justify-center" style={{ height: slotH }}>
+          <motion.span
+            className="block"
+            initial={false}
+            animate={{ clipPath: revealed ? clipShown : clipHidden }}
+            transition={reduce ? { duration: 0 } : { duration: revealDuration, ease: "easeOut" }}
+          >
+            {firstText}
+          </motion.span>
+        </div>
+        <div className="flex items-center justify-center" style={{ height: slotH }}>
+          <span className="block">{secondText}</span>
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+export function PitchStep({
   onContinue,
   onBack,
   onForward,
@@ -57,186 +124,16 @@ export function PitchDifferentStep({
   const tone = useOnboardingTone();
   const reduce = useReducedMotion();
   const { art, eyesW, eyesH, restCy, centerX, w, h } = useOnboardingEyes();
-
-  const line1Ref = useRef<HTMLSpanElement>(null);
-
-  // The eyes' vertical center + scale, and how much of each line they've spoken
-  // in (0→1). Line 1 reveals bottom→top as the eyes rise past it; line 2 reveals
-  // top→bottom as they bounce back down past it.
-  const eyeCy = useMotionValue(0);
-  const eyeScale = useMotionValue(1);
-  const reveal1 = useMotionValue(reduce ? 1 : 0);
-  const reveal2 = useMotionValue(reduce ? 1 : 0);
-
-  const [ready, setReady] = useState(false);
-  const [landed, setLanded] = useState(reduce);
-  const [blinking, setBlinking] = useState(false);
-
-  // Line 1 wipes in bottom→top (top clipped until the rising eyes pass it); line
-  // 2 wipes in top→bottom (bottom clipped until the descending eyes pass it).
-  const clip1 = useTransform(reveal1, (r) => `inset(${(1 - r) * 100}% 0 -35% 0)`);
-  const clip2 = useTransform(reveal2, (r) => `inset(-35% 0 ${(1 - r) * 100}% 0)`);
-
-  // Park the eyes at rest until the journey starts (and, for reduced motion,
-  // leave them there with the text already shown).
-  useEffect(() => {
-    eyeCy.set(restCy);
-    setReady(true);
-  }, [restCy, eyeCy]);
-
-  useEffect(() => {
-    if (reduce || !art) return;
-    const l1 = line1Ref.current;
-    if (!l1) return;
-    const r1 = l1.getBoundingClientRect();
-
-    const smallScale = 0.55; // up above the words
-    const aboveCy = r1.top - 22 - (eyesH * smallScale) / 2; // clear above line 1
-
-    eyeCy.set(restCy);
-    eyeScale.set(1);
-    reveal1.set(0);
-    reveal2.set(0);
-
-    const controls: ReturnType<typeof animate>[] = [];
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-    let cancelled = false;
-    const track = <T extends ReturnType<typeof animate>>(c: T): T => {
-      controls.push(c);
-      return c;
-    };
-    const wait = (ms: number) =>
-      new Promise<void>((res) => {
-        timeouts.push(setTimeout(res, ms));
-      });
-    const blink = async (hold = 120) => {
-      setBlinking(true);
-      await wait(hold);
-      if (!cancelled) setBlinking(false);
-    };
-
-    const run = async () => {
-      // Shoot straight up — fast and tight — painting line 1 in along the rise
-      // (reveal locked to the rise via matching duration/ease).
-      await Promise.all([
-        track(animate(eyeCy, aboveCy, { duration: 0.55, ease: "easeOut", delay: 0.2 })),
-        track(animate(eyeScale, smallScale, { duration: 0.55, ease: "easeOut", delay: 0.2 })),
-        track(animate(reveal1, 1, { duration: 0.55, ease: "easeOut", delay: 0.2 })),
-      ]);
-      if (cancelled) return;
-      // Drop back down with a little bounce, revealing "I'm different" — and bring
-      // Continue in right alongside it.
-      setLanded(true);
-      await Promise.all([
-        track(animate(eyeCy, restCy, { type: "spring", stiffness: 210, damping: 15 })),
-        track(animate(eyeScale, 1, { duration: 0.45, ease: "easeOut" })),
-        track(animate(reveal2, 1, { duration: 0.45, ease: "easeOut" })),
-      ]);
-      if (cancelled) return;
-      // Settle with a couple of blinks.
-      await blink();
-      await wait(140);
-      if (cancelled) return;
-      await blink();
-    };
-    void run();
-
-    return () => {
-      cancelled = true;
-      controls.forEach((c) => c.stop());
-      timeouts.forEach(clearTimeout);
-    };
-  }, [reduce, art, w, h, eyesH, restCy, eyeCy, eyeScale, reveal1, reveal2]);
-
-  return (
-    <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
-      <OnboardingTopBar onBack={onBack} onNext={onForward} />
-
-      {/* The assistant's eyes — behind the text, so the words read as lifted into
-          view in front of them as the eyes rise. */}
-      {ready && art && (
-        <MotionEyes
-          art={art}
-          eyesW={eyesW}
-          eyesH={eyesH}
-          centerX={centerX}
-          eyeCy={eyeCy}
-          eyeScale={eyeScale}
-          blinking={blinking}
-        />
-      )}
-
-      <div className={`${ONBOARDING_STEP_CONTENT} max-w-3xl`}>
-        <h1
-          className="text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.15]"
-          style={{ fontFamily: "var(--font-serif)" }}
-        >
-          {/* Setup line — the darker secondary tone, matching "Hey {name}". */}
-          <motion.span
-            ref={line1Ref}
-            className="block"
-            style={{ color: tone.fgDeep, clipPath: clip1 }}
-          >
-            {SETUP_LINE}
-          </motion.span>
-          {/* Payoff — the full-strength foreground. */}
-          <motion.span
-            className="block"
-            style={{ color: tone.fg, clipPath: clip2 }}
-          >
-            {PUNCH_LINE}
-          </motion.span>
-        </h1>
-
-        {/* Continue appears once the eyes have settled back down. */}
-        {landed && (
-          <motion.button
-            type="button"
-            onClick={onContinue}
-            className="flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] bg-black text-body-medium-default text-white transition-transform duration-150 active:scale-[0.97]"
-            initial={reduce ? false : { opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.4 }}
-          >
-            Continue
-            <ArrowRight className="h-4 w-4" />
-          </motion.button>
-        )}
-      </div>
-    </div>
-  );
-}
-
-const HELP_LINE = "The more I help";
-const LESS_LINE = "The less you do";
-
-/**
- * The payoff: two benefits, each with its own beat —
- *   - "The more I help"  a helper peeks down from the top-left, then back
- *   - "The less you do"  the team drops in from the top-right (and stays)
- */
-export function PitchTogetherStep({
-  onContinue,
-  onBack,
-  onForward,
-  onRevealTeam,
-}: {
-  onContinue: () => void;
-  onBack: () => void;
-  /** Redo into the next step — only set when the user has stepped back. */
-  onForward?: () => void;
-  /** Reveal the persistent top-right team (fires on the third line). */
-  onRevealTeam: () => void;
-}) {
-  const tone = useOnboardingTone();
-  const reduce = useReducedMotion();
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
-  const { w } = useOnboardingEyes();
 
-  // A lone helper that peeks down from the top-left on the first line.
+  // The assistant's eyes rise to wipe the first lines in, then settle at rest.
+  const eyeCy = useMotionValue(0);
+  const eyeScale = useMotionValue(1);
+
+  // A lone helper peeks from the top-left as line 1 carousels to "The more I help".
   const helperColor = useMemo(() => {
     if (!components || !chosen) return "orange";
     return (
@@ -247,22 +144,79 @@ export function PitchTogetherStep({
   const helperSize = Math.min(220, Math.max(150, w * 0.16));
   const helperHidden = -helperSize; // fully above the top edge
   const helperPeek = -helperSize * 0.4; // ~40% cut off, peeking down
-
   const helperY = useMotionValue(-220);
 
-  const [show1, setShow1] = useState(reduce);
-  const [show2, setShow2] = useState(reduce);
+  // A small team peeks from the top-right as line 2 carousels to "The less you do".
+  const teamColors = useMemo(() => {
+    if (!components || !chosen) return [] as string[];
+    return pickOverlayColors(chosen.color, components.colors.map((c) => c.id), 3);
+  }, [components, chosen]);
+  const peekScale = Math.max(0.42, Math.min(w / 1100, 1));
+  const teamSize = Math.round(PITCH_TEAM_SIZE * peekScale);
+  const teamHidden = -teamSize * 1.1; // fully above the top edge
+  const teamPeek = -teamSize * 0.42; // ~42% cut off, peeking down
+  const teamY = useMotionValue(-320);
+
+  const [reveal1, setReveal1] = useState(reduce);
+  const [reveal2, setReveal2] = useState(reduce);
+  const [carousel1, setCarousel1] = useState(reduce);
+  const [carousel2, setCarousel2] = useState(reduce);
+  const [ready, setReady] = useState(false);
   const [landed, setLanded] = useState(reduce);
 
-  // Reduced motion: show the team straight away.
+  // Measure each line's slot height from a hidden copy so the carousel window
+  // is tall enough for the taller of its two phrases (re-measured on resize).
+  const blockW = Math.min(w, 768) - 48; // max-w-3xl minus px-6
+  const m1aRef = useRef<HTMLSpanElement>(null);
+  const m1bRef = useRef<HTMLSpanElement>(null);
+  const m2aRef = useRef<HTMLSpanElement>(null);
+  const m2bRef = useRef<HTMLSpanElement>(null);
+  const [slotH1, setSlotH1] = useState(0);
+  const [slotH2, setSlotH2] = useState(0);
+  useLayoutEffect(() => {
+    const h1 = Math.max(
+      m1aRef.current?.offsetHeight ?? 0,
+      m1bRef.current?.offsetHeight ?? 0,
+    );
+    const h2 = Math.max(
+      m2aRef.current?.offsetHeight ?? 0,
+      m2bRef.current?.offsetHeight ?? 0,
+    );
+    if (h1) setSlotH1(h1);
+    if (h2) setSlotH2(h2);
+  }, [blockW]);
+
+  // Park the eyes at rest until the journey starts.
   useEffect(() => {
-    if (reduce) onRevealTeam();
-  }, [reduce, onRevealTeam]);
+    eyeCy.set(restCy);
+    setReady(true);
+  }, [restCy, eyeCy]);
+
+  // Reduced motion: reveal the first lines, then swap to the payoff; Continue
+  // is offered throughout.
+  useEffect(() => {
+    if (!reduce) return;
+    const t = setTimeout(() => {
+      setCarousel1(true);
+      setCarousel2(true);
+    }, 1400);
+    return () => clearTimeout(t);
+  }, [reduce]);
 
   useEffect(() => {
-    if (reduce) return;
+    if (reduce || !art) return;
 
+    eyeCy.set(restCy);
+    eyeScale.set(1);
     helperY.set(helperHidden);
+    teamY.set(teamHidden);
+    setReveal1(false);
+    setReveal2(false);
+    setCarousel1(false);
+    setCarousel2(false);
+
+    const smallScale = 0.55; // up above the words
+    const aboveCy = Math.max(eyesH * 0.5, h * 0.3 - 36); // clear above the title
 
     const controls: ReturnType<typeof animate>[] = [];
     const timeouts: ReturnType<typeof setTimeout>[] = [];
@@ -277,11 +231,29 @@ export function PitchTogetherStep({
       });
 
     const run = async () => {
-      await wait(450);
+      await wait(200);
       if (cancelled) return;
 
-      // "The more I help" — a helper peeks down from the top-left, then retracts.
-      setShow1(true);
+      // Eyes shoot up, wiping line 1 in bottom→top along the rise.
+      setReveal1(true);
+      await Promise.all([
+        track(animate(eyeCy, aboveCy, { duration: 0.55, ease: "easeOut" })),
+        track(animate(eyeScale, smallScale, { duration: 0.55, ease: "easeOut" })),
+      ]);
+      if (cancelled) return;
+
+      // Eyes drop back to rest, wiping line 2 in top→bottom as they pass.
+      setReveal2(true);
+      await Promise.all([
+        track(animate(eyeCy, restCy, { type: "spring", stiffness: 210, damping: 15 })),
+        track(animate(eyeScale, 1, { duration: 0.45, ease: "easeOut" })),
+      ]);
+      if (cancelled) return;
+      await wait(900);
+      if (cancelled) return;
+
+      // Carousel line 1 → "The more I help" as a helper peeks from the top-left.
+      setCarousel1(true);
       await track(
         animate(helperY, [helperHidden, helperPeek, helperPeek, helperHidden], {
           duration: 1.5,
@@ -290,15 +262,23 @@ export function PitchTogetherStep({
         }),
       );
       if (cancelled) return;
-      await wait(280);
+      await wait(150);
       if (cancelled) return;
 
-      // "The less you do" — the team drops in from the top-right.
-      setShow2(true);
-      onRevealTeam();
+      // Carousel line 2 → "The less you do" as a team peeks from the top-right.
+      setCarousel2(true);
+      const teamPeekAnim = track(
+        animate(teamY, [teamHidden, teamPeek, teamPeek, teamHidden], {
+          duration: 1.5,
+          times: [0, 0.28, 0.62, 1],
+          ease: "easeInOut",
+        }),
+      );
       await wait(700);
       if (cancelled) return;
+      // Surface Continue while the team finishes peeking back out.
       setLanded(true);
+      await teamPeekAnim;
     };
     void run();
 
@@ -307,17 +287,51 @@ export function PitchTogetherStep({
       controls.forEach((c) => c.stop());
       timeouts.forEach(clearTimeout);
     };
-  }, [reduce, helperY, helperHidden, helperPeek, onRevealTeam]);
-
-  const lineClass = "text-[clamp(1.85rem,3.8vw,2.9rem)] leading-snug";
-  const lineStyle = { fontFamily: "var(--font-serif)" } as const;
-  const lineTransition = reduce
-    ? { duration: 0 }
-    : { duration: 0.3, ease: "easeOut" as const };
+  }, [
+    reduce,
+    art,
+    h,
+    eyesH,
+    restCy,
+    eyeCy,
+    eyeScale,
+    helperY,
+    helperHidden,
+    helperPeek,
+    teamY,
+    teamHidden,
+    teamPeek,
+  ]);
 
   return (
     <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
+
+      {/* Hidden measurer — sizes the carousel windows to the taller phrase. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute -left-[9999px] top-0 text-[72px] leading-[1.15]"
+        style={{ width: blockW, fontFamily: "var(--font-serif)" }}
+      >
+        <span ref={m1aRef} className="block">{SETUP_LINE}</span>
+        <span ref={m1bRef} className="block">{HELP_LINE}</span>
+        <span ref={m2aRef} className="block">{PUNCH_LINE}</span>
+        <span ref={m2bRef} className="block">{LESS_LINE}</span>
+      </div>
+
+      {/* The assistant's eyes — behind the text, lifting the words into view as
+          they rise. */}
+      {ready && art && (
+        <MotionEyes
+          art={art}
+          eyesW={eyesW}
+          eyesH={eyesH}
+          centerX={centerX}
+          eyeCy={eyeCy}
+          eyeScale={eyeScale}
+          blinking={false}
+        />
+      )}
 
       {/* The helper that peeks down from the top-left on the first line. */}
       {!reduce && components && (
@@ -341,27 +355,67 @@ export function PitchTogetherStep({
         </motion.div>
       )}
 
+      {/* The team that peeks down from the top-right on the second line. */}
+      {!reduce && components && (
+        <motion.div
+          aria-hidden="true"
+          className="pointer-events-none absolute right-0 top-0 z-[1] flex items-start"
+          style={{ right: -Math.round(teamSize * 0.12), y: teamY }}
+        >
+          {PITCH_TEAM.map((m, i) => (
+            <div
+              key={m.bodyShape}
+              style={{
+                width: teamSize,
+                height: teamSize,
+                marginLeft: i === 0 ? 0 : -teamSize * 0.34,
+                zIndex: PITCH_TEAM.length - i,
+              }}
+            >
+              <AnimatedAvatar
+                components={components}
+                traits={{
+                  bodyShape: m.bodyShape,
+                  eyeStyle: m.eyeStyle,
+                  color: teamColors[i] ?? "teal",
+                }}
+                size={teamSize}
+                breathe={false}
+              />
+            </div>
+          ))}
+        </motion.div>
+      )}
+
       <div className={`${ONBOARDING_STEP_CONTENT} max-w-3xl`}>
-        {/* Two benefits, each revealed with its own beat. */}
-        <div className="flex flex-col gap-4">
-          <motion.p
-            className={lineClass}
-            style={lineStyle}
-            initial={reduce ? false : { opacity: 0, y: 10 }}
-            animate={show1 ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
-            transition={lineTransition}
-          >
-            {HELP_LINE}
-          </motion.p>
-          <motion.p
-            className={lineClass}
-            style={lineStyle}
-            initial={reduce ? false : { opacity: 0, y: 10 }}
-            animate={show2 ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
-            transition={lineTransition}
-          >
-            {LESS_LINE}
-          </motion.p>
+        <div
+          className="flex w-full flex-col gap-3 text-[72px] leading-[1.15]"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          {/* Line 1 — the darker secondary tone; wipes in bottom→top. */}
+          <CarouselLine
+            slotH={slotH1}
+            color={tone.fgDeep}
+            firstText={SETUP_LINE}
+            secondText={HELP_LINE}
+            revealed={reveal1}
+            carouseled={carousel1}
+            revealFrom="bottom"
+            revealDuration={0.55}
+            reduce={!!reduce}
+          />
+          {/* Line 2 — full-strength; wipes in top→bottom. */}
+          <CarouselLine
+            slotH={slotH2}
+            color={tone.fg}
+            firstText={PUNCH_LINE}
+            secondText={LESS_LINE}
+            revealed={reveal2}
+            carouseled={carousel2}
+            revealFrom="top"
+            revealDuration={0.45}
+            reduce={!!reduce}
+          />
         </div>
 
         {landed && (

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -67,7 +67,7 @@ export function LetsChatTomorrowStep({
           Add a quick check-in to your calendar to follow up tomorrow.
         </p>
 
-        <div className="mt-6 flex w-[234px] flex-col items-center">
+        <div className="mt-6 flex w-[234px] flex-col items-center gap-4">
           <button
             type="button"
             onClick={handleConnect}
@@ -87,19 +87,18 @@ export function LetsChatTomorrowStep({
               "Set it up"
             )}
           </button>
+          {/* Skip sits directly under the connect button. */}
+          <button
+            type="button"
+            onClick={onSkip}
+            disabled={oauthInProgress}
+            className="text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
+            style={{ color: tone.fgMuted }}
+          >
+            Skip for now
+          </button>
         </div>
       </div>
-
-      {/* Skip sits down near the bottom, just above the peeking eyes. */}
-      <button
-        type="button"
-        onClick={onSkip}
-        disabled={oauthInProgress}
-        className="absolute bottom-[26%] left-1/2 -translate-x-1/2 text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
-        style={{ color: tone.fgMuted }}
-      >
-        Skip for now
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
Reworks the research-onboarding pitch → credits → calendar → results flow based on a round of design iteration.

## Pitch step (was two screens, now one)
- Merged the `different` and `together` steps into a single `PitchStep` that **carousels each line on one screen**:
  - The eyes rise to wipe **line 1** in bottom→top, then drop back to wipe **line 2** in top→bottom (the original clip reveal, eyes-synced).
  - Each line then **rolls vertically** to its payoff — line 1 → "The more I help" (helper peeks top-left), line 2 → "The less you do" (team peeks top-right). Both avatar beats peek **in and out** (no persistence).
- Lines are fixed-size; the first line uses the darker (`fgDeep`) tone variant.

## Backdrop / eyes
- Dropped the **persistent top-right team** — it only peeks in-and-out on the pitch step now, instead of carrying across the integration/calendar steps.
- Added a `settleBlink` prop to `OnboardingPeekingEyes` so carried-over resting eyes skip the **double settle-blink** (kept on for the Introduction entrance).

## Credits + calendar (back to two screens)
- Reverted the merged "connect calendar from the credits step" into two screens: a credits-only `IntegrationStep` (title: **"Here are some free credits to get started"**, no subtitle) → the standalone `LetsChatTomorrowStep`.
- "Skip for now" now sits **directly under** the connect button.

## Misc
- Removed the amber **vignette ring** from the coin.
- **Skip the results step** ("This is what I found about you") when the research turn resolves with no claims — both forward (`looking` → `suggestions`) and back navigation bypass it.

## Testing
- `bun run lint src/domains/onboarding` — clean (pre-existing warnings only, untouched files)
- `bun run build` — passes
- `bunx tsc --noEmit` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)