### PR TITLE
Install research-onboarding plugins globally by persona, not per-suggestion

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -379,14 +379,13 @@ export function ResearchOnboardingRoute() {
           <SuggestionsStep
             suggestions={research.suggestions}
             loading={researchLoading}
+            installedPlugins={research.installedPlugins}
             onSuggestionClick={async (suggestion) => {
-              // For a plugin-backed suggestion, wait out the background install
-              // so the new chat can discover the plugin's skills (else it
-              // silently degrades to a generic prompt). Usually instant — the
-              // install kicked off while the user reviewed the results.
-              if (suggestion.plugin) {
-                await research.awaitPluginInstall(suggestion.plugin);
-              }
+              // Wait out any background capability installs so the new chat can
+              // discover their skills (else it silently degrades to a generic
+              // prompt). Usually instant — installs kicked off while the user
+              // reviewed the results.
+              await research.awaitPluginInstalls();
               enterAssistant(formValues, faceValues, suggestion.prompt);
             }}
             onBack={() => goBackTo("results")}

--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -5,7 +5,7 @@
  * plugins (e.g. marketing-expert) during onboarding research. These pin that it
  * only appears when a catalog is passed (back-compat for the route's fallback
  * kickoff), stays compact under a growing catalog, and instructs the model to
- * tag a suggestion with a plugin name.
+ * return a top-level `plugins` install list.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -26,10 +26,10 @@ describe("buildResearchPrompt — capabilities", () => {
   test("omits the capabilities block when no catalog is passed", () => {
     const prompt = buildResearchPrompt(SUBJECT);
     expect(prompt).not.toContain("Capabilities you can offer");
-    expect(prompt).not.toContain('"plugin"');
+    expect(prompt).not.toContain('"plugins"');
   });
 
-  test("injects passed capabilities and the plugin-tag instruction", () => {
+  test("injects passed capabilities and the plugins-list instruction", () => {
     const caps: AvailableCapability[] = [
       { name: "marketing-expert", description: "Full-stack marketing." },
       { name: "admin-copilot", description: "Proactive chief-of-staff." },
@@ -39,7 +39,7 @@ describe("buildResearchPrompt — capabilities", () => {
     expect(prompt).toContain("Capabilities you can offer");
     expect(prompt).toContain("- marketing-expert — Full-stack marketing.");
     expect(prompt).toContain("- admin-copilot — Proactive chief-of-staff.");
-    expect(prompt).toContain('"plugin"');
+    expect(prompt).toContain('"plugins"');
   });
 
   test("caps the injected list so a large catalog can't bloat the prompt", () => {

--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -40,6 +40,9 @@ describe("buildResearchPrompt — capabilities", () => {
     expect(prompt).toContain("- marketing-expert — Full-stack marketing.");
     expect(prompt).toContain("- admin-copilot — Proactive chief-of-staff.");
     expect(prompt).toContain('"plugins"');
+    // The canonical "exactly this shape" example must show plugins first, so a
+    // model following the schema literally still emits the install list.
+    expect(prompt.indexOf('"plugins"')).toBeLessThan(prompt.indexOf('"claims"'));
   });
 
   test("caps the injected list so a large catalog can't bloat the prompt", () => {

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -57,7 +57,7 @@ function renderCapabilitiesBlock(capabilities: AvailableCapability[]): string {
 Capabilities you can offer me — specialized skillsets you can invoke on my behalf, not generic chat:
 ${lines}
 
-Optionally add a "plugin" key (exact name from the list above) to a suggestion, but ONLY when that skillset genuinely does that card's concrete work and fits what you researched about my real work — never to fill a quota. Tag AT MOST ONE suggestion; zero is fine and often correct. Shape: { "suggestion": "...", "prompt": "...", "plugin": "<exact name>" }.
+Add ONE more top-level key alongside "claims" and "suggestions": a "plugins" array naming the 1-2 capabilities from the list above (exact names) that best fit who I am — judged by what you researched about my real role, stack, and day-to-day work. These get set up for me automatically as part of getting started, so pick by overall fit to ME, not to any single suggestion. Prefer fewer over forcing a match; use [] if nothing clearly fits. Example: "plugins": ["<exact name from the list above>"]. Don't reference the setup in the claims or suggestions text.
 `;
 }
 

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -71,6 +71,12 @@ export function buildResearchPrompt(
   const role = occupation.trim();
   const hobbyText = hobby?.trim() ?? "";
   const capabilitiesBlock = renderCapabilitiesBlock(availableCapabilities);
+  // When capabilities are advertised, the canonical shape MUST show `plugins`
+  // first — otherwise "respond with exactly this shape" (which the example
+  // defines) would tell the model to omit it, and nothing gets installed.
+  const pluginsExample = capabilitiesBlock
+    ? `"plugins": ["<exact name from the list above>"], `
+    : "";
 
   const identity =
     [
@@ -88,7 +94,7 @@ Get to know me. Search the web for what's publicly known about the person matchi
 
 CRITICAL: your final reply must be ONLY a JSON object. No preamble, no explanation, no prose, nothing before or after it. Do your thinking and searching, then respond with exactly this shape and nothing else:
 
-{ "claims": [ { "claim": "Senior engineer at an AI infra startup", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Based in Boulder, CO", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Active climber on Mountain Project", "confidence": "maybe", "sources": [] }, { "claim": "Focused on evals or model serving infrastructure", "confidence": "guessing", "sources": ["https://github.com/example-user"] } ], "suggestions": [ { "suggestion": "I'll build you a dashboard for your eval runs", "prompt": "Build me a dashboard to track my eval runs." }, { "suggestion": "I'll watch arXiv for new eval papers and brief you weekly", "prompt": "Send me a weekly brief on new eval papers from arXiv." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ] }
+{ ${pluginsExample}"claims": [ { "claim": "Senior engineer at an AI infra startup", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Based in Boulder, CO", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Active climber on Mountain Project", "confidence": "maybe", "sources": [] }, { "claim": "Focused on evals or model serving infrastructure", "confidence": "guessing", "sources": ["https://github.com/example-user"] } ], "suggestions": [ { "suggestion": "I'll build you a dashboard for your eval runs", "prompt": "Build me a dashboard to track my eval runs." }, { "suggestion": "I'll watch arXiv for new eval papers and brief you weekly", "prompt": "Send me a weekly brief on new eval papers from arXiv." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ] }
 
 Rules for "claims":
 

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -57,7 +57,7 @@ function renderCapabilitiesBlock(capabilities: AvailableCapability[]): string {
 Capabilities you can offer me — specialized skillsets you can invoke on my behalf, not generic chat:
 ${lines}
 
-Add ONE more top-level key alongside "claims" and "suggestions": a "plugins" array naming the 1-2 capabilities from the list above (exact names) that best fit who I am — judged by what you researched about my real role, stack, and day-to-day work. These get set up for me automatically as part of getting started, so pick by overall fit to ME, not to any single suggestion. Prefer fewer over forcing a match; use [] if nothing clearly fits. Example: "plugins": ["<exact name from the list above>"]. Don't reference the setup in the claims or suggestions text.
+Add a "plugins" array as the FIRST key in your JSON object, before "claims" and "suggestions": the 1-2 capabilities from the list above (exact names) that best fit who I am — judged by what you researched about my real role, stack, and day-to-day work. (Emit it first so setup can start while you finish the rest.) These get set up for me automatically as part of getting started, so pick by overall fit to ME, not to any single suggestion. Prefer fewer over forcing a match; use [] if nothing clearly fits. Example: "plugins": ["<exact name from the list above>"]. Don't reference the setup in the claims or suggestions text.
 `;
 }
 

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -183,6 +183,13 @@ export interface ResearchRunnerState {
   status: ResearchStatus;
   claims: ResearchFact[];
   suggestions: ResearchSuggestion[];
+  /**
+   * Capabilities being installed for the assistant this run — the model's
+   * top-level `plugins` picks, narrowed to names present in the fetched catalog.
+   * Persona-level (not tied to a suggestion); surfaced so the UI can confirm
+   * what was set up. Empty when plugins are disabled or nothing fit.
+   */
+  installedPlugins: string[];
 }
 
 export interface StartResearchOptions {
@@ -202,13 +209,12 @@ export interface UseResearchRunner extends ResearchRunnerState {
    */
   start: (options: StartResearchOptions) => void;
   /**
-   * Await the background install of a plugin a suggestion is tagged with, so the
-   * click doesn't open the chat before `<workspace>/plugins/<name>` exists —
-   * otherwise the plugin's skills aren't discoverable in the new conversation
-   * and the suggestion silently degrades to a generic prompt. Resolves
-   * immediately when nothing is pending for that name.
+   * Await every background plugin install this run kicked off, so the click
+   * doesn't open the chat before each `<workspace>/plugins/<name>` exists —
+   * otherwise the installed skills aren't discoverable in the new conversation.
+   * Resolves immediately when nothing is pending.
    */
-  awaitPluginInstall: (name: string) => Promise<void>;
+  awaitPluginInstalls: () => Promise<void>;
 }
 
 type GetMessage = MessagesGetResponses[200]["messages"][number];
@@ -266,6 +272,7 @@ export function useResearchRunner(): UseResearchRunner {
     status: "idle",
     claims: [],
     suggestions: [],
+    installedPlugins: [],
   });
   // Monotonic run id: every fresh run claims the next id; in-flight loops bail
   // the moment a newer run supersedes them. Paired with the last subject key so
@@ -273,8 +280,8 @@ export function useResearchRunner(): UseResearchRunner {
   const runIdRef = useRef(0);
   const subjectKeyRef = useRef<string | null>(null);
   // Background plugin installs keyed by name, so the suggestion click can await
-  // the matching install before opening the chat (see `awaitPluginInstall`).
-  // Promises stay resolved in the map, so awaiting a settled one is instant.
+  // them all before opening the chat (see `awaitPluginInstalls`). Promises stay
+  // resolved in the map, so awaiting a settled one is instant.
   const installPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
 
   const start = useCallback(
@@ -287,7 +294,12 @@ export function useResearchRunner(): UseResearchRunner {
       const isStale = () => runIdRef.current !== runId;
       // Fresh run — drop installs tracked for a superseded subject.
       installPromisesRef.current.clear();
-      setState({ status: "running", claims: [], suggestions: [] });
+      setState({
+        status: "running",
+        claims: [],
+        suggestions: [],
+        installedPlugins: [],
+      });
 
       void (async () => {
         try {
@@ -295,10 +307,11 @@ export function useResearchRunner(): UseResearchRunner {
           if (isStale()) return;
 
           // Advertise the live marketplace catalog to the research turn so it can
-          // tag a suggestion with a plugin whose skills the prompt would trigger.
-          // Only when the external-plugin surface is enabled for this assistant;
-          // otherwise run plain research with no plugin injection or install.
-          // Best-effort: an empty list just omits the capabilities block.
+          // pick the capabilities that best fit the person (returned as a
+          // top-level `plugins` list) for us to install. Only when the external-
+          // plugin surface is enabled for this assistant; otherwise run plain
+          // research with no plugin injection or install. Best-effort: an empty
+          // list just omits the capabilities block.
           const pluginsEnabled = await awaitExternalPluginsEnabled(isStale);
           if (isStale()) return;
           const { capabilities, validNames } = pluginsEnabled
@@ -354,11 +367,11 @@ export function useResearchRunner(): UseResearchRunner {
           const deadline = Date.now() + MAX_POLL_MS;
           let lastText = "";
           let stableReads = 0;
-          // Installs fire the moment a tagged suggestion first streams in
-          // (overlapping the user's results-review screens) so the plugin is
-          // materialized before the click opens the chat. Tracked by promise so
-          // the click can await a still-running one. Idempotent, so racing the
-          // same name is fine.
+          // Installs fire as soon as the model's `plugins` picks parse (which the
+          // parser only honors once the payload is complete), overlapping the
+          // user's results-review screens so the capabilities are materialized
+          // before the click opens the chat. Tracked by promise so the click can
+          // await still-running ones. Idempotent, so racing the same name is fine.
           const installs = installPromisesRef.current;
           while (Date.now() < deadline) {
             await sleep(POLL_INTERVAL_MS);
@@ -372,19 +385,25 @@ export function useResearchRunner(): UseResearchRunner {
             const messages = listed.data?.messages ?? [];
             const text = latestAssistantText(messages);
             if (text) {
-              const { claims, suggestions, complete } =
+              const { claims, suggestions, plugins, complete } =
                 parseResearchResultStreaming(text);
-              setState({ status: "running", claims, suggestions });
-              for (const s of suggestions) {
-                // Gate on the fetched catalog so a hallucinated name never hits
-                // the install route; skip ones already in flight.
-                if (s.plugin && validNames.has(s.plugin) && !installs.has(s.plugin)) {
+              // Narrow the model's picks to the catalog we actually fetched so a
+              // hallucinated name never hits the install route; fire each new one.
+              const validPlugins = plugins.filter((name) => validNames.has(name));
+              for (const name of validPlugins) {
+                if (!installs.has(name)) {
                   installs.set(
-                    s.plugin,
-                    installCapabilityBestEffort(assistantId, s.plugin),
+                    name,
+                    installCapabilityBestEffort(assistantId, name),
                   );
                 }
               }
+              setState({
+                status: "running",
+                claims,
+                suggestions,
+                installedPlugins: validPlugins,
+              });
               stableReads = text === lastText ? stableReads + 1 : 0;
               lastText = text;
               // Prefer to settle only once the payload is complete, so a pause
@@ -408,13 +427,9 @@ export function useResearchRunner(): UseResearchRunner {
     [],
   );
 
-  const awaitPluginInstall = useCallback(
-    async (name: string): Promise<void> => {
-      const pending = installPromisesRef.current.get(name);
-      if (pending) await pending;
-    },
-    [],
-  );
+  const awaitPluginInstalls = useCallback(async (): Promise<void> => {
+    await Promise.all([...installPromisesRef.current.values()]);
+  }, []);
 
-  return { ...state, start, awaitPluginInstall };
+  return { ...state, start, awaitPluginInstalls };
 }

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -367,11 +367,12 @@ export function useResearchRunner(): UseResearchRunner {
           const deadline = Date.now() + MAX_POLL_MS;
           let lastText = "";
           let stableReads = 0;
-          // Installs fire as soon as the model's `plugins` picks parse (which the
-          // parser only honors once the payload is complete), overlapping the
-          // user's results-review screens so the capabilities are materialized
-          // before the click opens the chat. Tracked by promise so the click can
-          // await still-running ones. Idempotent, so racing the same name is fine.
+          // Installs fire as soon as the model's `plugins` array closes — emitted
+          // first in the reply, so this lands early while claims/suggestions are
+          // still streaming, overlapping the user's results-review screens so the
+          // capabilities are materialized before the click opens the chat. Tracked
+          // by promise so the click can await still-running ones. Idempotent, so
+          // racing the same name is fine.
           const installs = installPromisesRef.current;
           while (Date.now() < deadline) {
             await sleep(POLL_INTERVAL_MS);

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -209,10 +209,11 @@ export interface UseResearchRunner extends ResearchRunnerState {
    */
   start: (options: StartResearchOptions) => void;
   /**
-   * Await every background plugin install this run kicked off, so the click
-   * doesn't open the chat before each `<workspace>/plugins/<name>` exists —
-   * otherwise the installed skills aren't discoverable in the new conversation.
-   * Resolves immediately when nothing is pending.
+   * Block a suggestion click until the persona plugins are ready: first waits
+   * for the run to settle (so the `plugins` picks are parsed and their installs
+   * enqueued — even if the click beat the parse), then for every install to
+   * finish, so the chat never opens before each `<workspace>/plugins/<name>`
+   * exists. Resolves quickly once the run is done and nothing is pending.
    */
   awaitPluginInstalls: () => Promise<void>;
 }
@@ -283,6 +284,13 @@ export function useResearchRunner(): UseResearchRunner {
   // them all before opening the chat (see `awaitPluginInstalls`). Promises stay
   // resolved in the map, so awaiting a settled one is instant.
   const installPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
+  // Resolves when the current run settles (done/error) — by which point the
+  // model's `plugins` picks have been parsed and their installs kicked off. The
+  // suggestion click awaits this BEFORE awaiting the installs, so a click that
+  // lands while research is still streaming can't open the chat before the
+  // persona plugins have even been selected (the empty install map would
+  // otherwise resolve instantly).
+  const runSettledRef = useRef<Promise<void>>(Promise.resolve());
 
   const start = useCallback(
     ({ awaitAssistantId, subject, conversationTitle }: StartResearchOptions) => {
@@ -292,7 +300,12 @@ export function useResearchRunner(): UseResearchRunner {
       const runId = runIdRef.current + 1;
       runIdRef.current = runId;
       const isStale = () => runIdRef.current !== runId;
-      // Fresh run — drop installs tracked for a superseded subject.
+      // Fresh run — drop installs tracked for a superseded subject, and arm a new
+      // settle latch the click can await (resolved in the runner's `finally`).
+      let resolveSettled: () => void = () => {};
+      runSettledRef.current = new Promise<void>((res) => {
+        resolveSettled = res;
+      });
       installPromisesRef.current.clear();
       setState({
         status: "running",
@@ -422,6 +435,10 @@ export function useResearchRunner(): UseResearchRunner {
           if (isStale()) return;
           captureError(err, { context: "research_onboarding_runner" });
           setState((s) => ({ ...s, status: "error" }));
+        } finally {
+          // Release the click gate on every exit path (done, error, or a stale
+          // bail-out) so `awaitPluginInstalls` can never hang on a superseded run.
+          resolveSettled();
         }
       })();
     },
@@ -429,6 +446,11 @@ export function useResearchRunner(): UseResearchRunner {
   );
 
   const awaitPluginInstalls = useCallback(async (): Promise<void> => {
+    // First wait for the run to settle so the model's `plugins` picks have been
+    // parsed and their installs enqueued — otherwise a click that beats the
+    // parse would await an empty map and open the chat before any plugin exists.
+    // Then await the installs themselves.
+    await runSettledRef.current;
     await Promise.all([...installPromisesRef.current.values()]);
   }, []);
 

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { ArrowRight, X } from "lucide-react";
+import { ArrowRight, Check, X } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
@@ -319,33 +319,6 @@ export function ResearchResultsStep({
 // ---------------------------------------------------------------------------
 
 /**
- * Vibrant badge colors handed out to plugins by order of first appearance, so
- * two different plugins on the same screen never collide on one color (a hash
- * would). See `pluginColorByOrder` in `SuggestionsStep`.
- */
-const PLUGIN_CHIP_PALETTE = [
-  "#6366F1", // indigo
-  "#EC4899", // pink
-  "#10B981", // emerald
-  "#F59E0B", // amber
-  "#06B6D4", // cyan
-  "#A855F7", // violet
-  "#EF4444", // red
-  "#14B8A6", // teal
-];
-
-/** Black or white text for legibility on a given `#rrggbb` chip color (YIQ). */
-function chipTextColor(hex: string): string {
-  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
-  if (!m) return "#FFFFFF";
-  const n = parseInt(m[1]!, 16);
-  const yiq =
-    (((n >> 16) & 0xff) * 299 + ((n >> 8) & 0xff) * 587 + (n & 0xff) * 114) /
-    1000;
-  return yiq > 150 ? "#1A1A1A" : "#FFFFFF";
-}
-
-/**
  * Generic fallbacks shown only if the research turn produced no suggestions
  * (failure / sparse subject) so the step is never empty once it's done loading.
  * Each pairs the assistant-voiced card text with the user-voiced prompt sent on
@@ -370,9 +343,17 @@ const FALLBACK_SUGGESTIONS: ResearchSuggestion[] = [
   },
 ];
 
+/** Join names into a readable list: "A", "A and B", "A, B, and C". */
+function formatNameList(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
 export function SuggestionsStep({
   suggestions,
   loading,
+  installedPlugins = [],
   onSuggestionClick,
   onBack,
   onForward,
@@ -382,9 +363,12 @@ export function SuggestionsStep({
   /** True while the research turn is still streaming. */
   loading: boolean;
   /**
-   * Opens the chat on the clicked suggestion. Receives the whole suggestion so
-   * the caller can await any tagged plugin's install before navigating.
+   * Capabilities installed for the assistant this run (from the model's
+   * persona-level `plugins` picks, already catalog-gated). Surfaced as a small
+   * confirmation note; empty when none were set up.
    */
+  installedPlugins?: string[];
+  /** Opens the chat on the clicked suggestion (sends its user-voiced prompt). */
   onSuggestionClick: (suggestion: ResearchSuggestion) => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
@@ -401,19 +385,9 @@ export function SuggestionsStep({
         ? []
         : FALLBACK_SUGGESTIONS;
 
-  // Hand each distinct plugin its own palette color by order of first
-  // appearance, so two different plugins never end up the same color.
-  const pluginColorByOrder = new Map<string, string>();
-  for (const s of items) {
-    if (s.plugin && !pluginColorByOrder.has(s.plugin)) {
-      pluginColorByOrder.set(
-        s.plugin,
-        PLUGIN_CHIP_PALETTE[
-          pluginColorByOrder.size % PLUGIN_CHIP_PALETTE.length
-        ]!,
-      );
-    }
-  }
+  const pluginLabels = installedPlugins
+    .map(pluginDisplayName)
+    .filter((label) => label.length > 0);
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
@@ -433,46 +407,42 @@ export function SuggestionsStep({
         </p>
 
         <div className="flex flex-col gap-3">
-          {items.map((s, i) => {
-            const chipBg = s.plugin
-              ? pluginColorByOrder.get(s.plugin)
-              : undefined;
-            return (
-              <motion.button
-                key={`${i}-${s.suggestion}`}
-                type="button"
-                onClick={() => onSuggestionClick(s)}
-                initial={reduce ? false : { opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={
-                  reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
-                }
-                className="relative rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
-                style={{
-                  backgroundColor: tone.isLight
-                    ? "rgba(0,0,0,0.06)"
-                    : "rgba(255,255,255,0.1)",
-                }}
-              >
-                <span>{s.suggestion}</span>
-                {s.plugin && chipBg && (
-                  // Solid per-plugin colored badge straddling the card's
-                  // top-right edge — each plugin gets its own distinct color.
-                  <span
-                    className="absolute -top-2.5 right-4 inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold leading-none"
-                    style={{
-                      backgroundColor: chipBg,
-                      color: chipTextColor(chipBg),
-                      boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
-                    }}
-                  >
-                    {pluginDisplayName(s.plugin)}
-                  </span>
-                )}
-              </motion.button>
-            );
-          })}
+          {items.map((s, i) => (
+            <motion.button
+              key={`${i}-${s.suggestion}`}
+              type="button"
+              onClick={() => onSuggestionClick(s)}
+              initial={reduce ? false : { opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={
+                reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
+              }
+              className="rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
+              style={{
+                backgroundColor: tone.isLight
+                  ? "rgba(0,0,0,0.06)"
+                  : "rgba(255,255,255,0.1)",
+              }}
+            >
+              <span>{s.suggestion}</span>
+            </motion.button>
+          ))}
         </div>
+
+        {pluginLabels.length > 0 && (
+          <motion.div
+            className="mt-5 flex items-center gap-2 text-[13px]"
+            style={{ color: tone.fgMuted }}
+            initial={reduce ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 0.2 }}
+          >
+            <Check className="h-4 w-4 shrink-0" />
+            <span>
+              Set up {formatNameList(pluginLabels)} to help with your work
+            </span>
+          </motion.div>
+        )}
       </div>
     </div>
   );

--- a/clients/web/src/utils/research-facts.test.ts
+++ b/clients/web/src/utils/research-facts.test.ts
@@ -1,11 +1,13 @@
 /**
- * Contract tests for the research-fact parser's plugin tagging.
+ * Contract tests for the research-fact parser's top-level `plugins` install
+ * list.
  *
- * The research-onboarding flow lets the assistant tag a suggestion with the
- * marketplace plugin (`plugin`) whose skills its prompt should trigger; the
- * runner background-installs any tagged plugin. These tests pin that the
- * optional `plugin` field round-trips, stays absent for ordinary suggestions,
- * and survives the streaming-tolerant extraction unchanged.
+ * The research-onboarding flow lets the assistant pick the marketplace
+ * capabilities that best fit the person (a persona-level `plugins` array, NOT
+ * tied to any one suggestion); the runner installs them for the assistant. These
+ * tests pin that the array round-trips, normalizes (trim/dedupe/drop non-string)
+ * and — because the runner must never act on a half-written array — is only
+ * honored once the whole payload parses complete.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -15,65 +17,51 @@ import {
   pluginDisplayName,
 } from "@/utils/research-facts";
 
-describe("parseResearchResultStreaming — plugin tagging", () => {
-  test("parses the optional plugin field on a suggestion", () => {
+describe("parseResearchResultStreaming — plugins install list", () => {
+  test("parses the top-level plugins array", () => {
     const text = JSON.stringify({
       claims: [],
-      suggestions: [
-        {
-          suggestion: "I'll sharpen your positioning and run a teardown",
-          prompt: "Sharpen my positioning and run a competitive teardown",
-          plugin: "marketing-expert",
-        },
-      ],
+      suggestions: [{ suggestion: "a", prompt: "a" }],
+      plugins: ["marketing-expert", "admin-copilot"],
     });
 
-    const { suggestions } = parseResearchResultStreaming(text);
+    const { plugins } = parseResearchResultStreaming(text);
 
-    expect(suggestions).toHaveLength(1);
-    expect(suggestions[0]?.plugin).toBe("marketing-expert");
+    expect(plugins).toEqual(["marketing-expert", "admin-copilot"]);
   });
 
-  test("leaves plugin undefined for an ordinary suggestion", () => {
+  test("defaults to an empty array when the key is absent", () => {
     const text = JSON.stringify({
       claims: [],
-      suggestions: [
-        { suggestion: "I'll plan your trip", prompt: "Plan my trip" },
-      ],
+      suggestions: [{ suggestion: "I'll plan your trip", prompt: "Plan my trip" }],
     });
 
-    const { suggestions } = parseResearchResultStreaming(text);
+    const { plugins } = parseResearchResultStreaming(text);
 
-    expect(suggestions[0]).toBeDefined();
-    expect(suggestions[0]?.plugin).toBeUndefined();
+    expect(plugins).toEqual([]);
   });
 
-  test("trims plugin whitespace and drops blank tags", () => {
+  test("trims, de-dupes, and drops blank or non-string entries", () => {
     const text = JSON.stringify({
-      suggestions: [
-        { suggestion: "a", prompt: "a", plugin: "  admin-copilot  " },
-        { suggestion: "b", prompt: "b", plugin: "   " },
-      ],
+      suggestions: [{ suggestion: "a", prompt: "a" }],
+      plugins: ["  admin-copilot  ", "admin-copilot", "   ", 7, "growth-coach"],
     });
 
-    const { suggestions } = parseResearchResultStreaming(text);
+    const { plugins } = parseResearchResultStreaming(text);
 
-    expect(suggestions[0]?.plugin).toBe("admin-copilot");
-    expect(suggestions[1]?.plugin).toBeUndefined();
+    expect(plugins).toEqual(["admin-copilot", "growth-coach"]);
   });
 
-  test("surfaces a tagged suggestion mid-stream before the array closes", () => {
-    // Unterminated payload: suggestions array still open, trailing object
-    // half-written. The first, complete object must still surface with its tag.
+  test("is not honored while the payload is still streaming", () => {
+    // The plugins array trails the JSON; acting on a half-written one would risk
+    // a truncated name. Until the whole payload parses, plugins stays empty.
     const partial =
-      '{ "claims": [], "suggestions": [ ' +
-      '{ "suggestion": "I\'ll run GTM", "prompt": "Run my GTM", "plugin": "marketing-expert" }, ' +
-      '{ "suggestion": "half';
+      '{ "claims": [], "suggestions": [ { "suggestion": "a", "prompt": "a" } ], "plugins": [ "marketing-exp';
 
-    const { suggestions } = parseResearchResultStreaming(partial);
+    const { plugins, complete } = parseResearchResultStreaming(partial);
 
-    expect(suggestions).toHaveLength(1);
-    expect(suggestions[0]?.plugin).toBe("marketing-expert");
+    expect(complete).toBe(false);
+    expect(plugins).toEqual([]);
   });
 });
 

--- a/clients/web/src/utils/research-facts.test.ts
+++ b/clients/web/src/utils/research-facts.test.ts
@@ -52,15 +52,25 @@ describe("parseResearchResultStreaming — plugins install list", () => {
     expect(plugins).toEqual(["admin-copilot", "growth-coach"]);
   });
 
-  test("is not honored while the payload is still streaming", () => {
-    // The plugins array trails the JSON; acting on a half-written one would risk
-    // a truncated name. Until the whole payload parses, plugins stays empty.
+  test("is honored as soon as its array closes, before the payload completes", () => {
+    // The prompt emits `plugins` first so installs can start ASAP. A closed
+    // plugins array is honored even while claims/suggestions are still streaming.
     const partial =
-      '{ "claims": [], "suggestions": [ { "suggestion": "a", "prompt": "a" } ], "plugins": [ "marketing-exp';
+      '{ "plugins": ["github", "marketing-expert"], "claims": [ { "claim": "Founder';
 
     const { plugins, complete } = parseResearchResultStreaming(partial);
 
     expect(complete).toBe(false);
+    expect(plugins).toEqual(["github", "marketing-expert"]);
+  });
+
+  test("a still-open plugins array is not honored (avoids a truncated name)", () => {
+    // Half-written array, no closing `]`: acting on it could install a truncated
+    // name, so it stays empty until the array terminates.
+    const partial = '{ "plugins": [ "marketing-exp';
+
+    const { plugins } = parseResearchResultStreaming(partial);
+
     expect(plugins).toEqual([]);
   });
 });

--- a/clients/web/src/utils/research-facts.ts
+++ b/clients/web/src/utils/research-facts.ts
@@ -168,6 +168,45 @@ function normalizePlugins(raw: unknown): string[] {
   return names;
 }
 
+/**
+ * Parse the top-level `plugins` array as soon as it has fully CLOSED, even while
+ * the rest of the payload is still streaming. The prompt emits `plugins` first
+ * precisely so installs can start early — but we only act on a `]`-terminated
+ * array, never a half-written one (a truncated name must never hit the install
+ * route). Returns [] until the array closes. String-aware so a `]` inside a
+ * value doesn't end the scan early.
+ */
+function parseClosedPluginsArray(body: string): string[] {
+  const scope = arrayScopeFor(body, "plugins");
+  if (scope === null) return [];
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < scope.length; i++) {
+    const c = scope[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') inString = true;
+    else if (c === "[") depth++;
+    else if (c === "]") {
+      if (depth > 0) {
+        depth--;
+        continue;
+      }
+      try {
+        return normalizePlugins(JSON.parse(`[${scope.slice(0, i + 1)}`));
+      } catch {
+        return [];
+      }
+    }
+  }
+  return [];
+}
+
 /** Body after a `"key": [` opening, or null if that array isn't present yet. */
 function arrayScopeFor(body: string, key: string): string | null {
   const k = body.indexOf(`"${key}"`);
@@ -188,8 +227,9 @@ export interface ResearchResult {
    * Marketplace capability install names the model judged a good overall fit for
    * the user (top-level `plugins` array). Persona-level, NOT tied to any single
    * suggestion: the runner installs these for the assistant globally and gates
-   * them against the fetched catalog first. Only populated once the payload
-   * parses complete (`complete: true`); `[]` while still streaming.
+   * them against the fetched catalog first. The prompt emits this array first so
+   * it's honored as soon as it closes — even mid-stream, before `complete` — to
+   * start installs ASAP; `[]` until the array is fully terminated.
    */
   plugins: string[];
   /**
@@ -278,7 +318,12 @@ export function parseResearchResultStreaming(text: string): ResearchResult {
           .map(toSuggestion)
           .filter((s): s is ResearchSuggestion => s !== null);
 
-  return { claims, suggestions, plugins: [], complete: false };
+  return {
+    claims,
+    suggestions,
+    plugins: parseClosedPluginsArray(body),
+    complete: false,
+  };
 }
 
 /**

--- a/clients/web/src/utils/research-facts.ts
+++ b/clients/web/src/utils/research-facts.ts
@@ -51,16 +51,6 @@ export interface ResearchSuggestion {
    * talking to itself.
    */
   prompt: string;
-  /**
-   * Optional marketplace plugin (install name, e.g. "marketing-expert") whose
-   * skills this suggestion's prompt is designed to trigger. Set by the model
-   * when it matches a capability from the injected catalog to the user's
-   * situation. The runner background-installs any tagged plugin so its skills
-   * are discoverable in the fresh conversation the click opens (plugin-resident
-   * skills load per-conversation from disk — no daemon restart needed). Absent
-   * for ordinary suggestions.
-   */
-  plugin?: string;
 }
 
 /** Bare registrable domain from a URL (www stripped), or null if unparseable. */
@@ -155,12 +145,27 @@ function toSuggestion(entry: unknown): ResearchSuggestion | null {
     typeof rawPrompt === "string" && rawPrompt.trim()
       ? rawPrompt.trim()
       : suggestion.trim();
-  const rawPlugin = (entry as { plugin?: unknown }).plugin;
-  const plugin =
-    typeof rawPlugin === "string" && rawPlugin.trim()
-      ? rawPlugin.trim()
-      : undefined;
-  return { suggestion: suggestion.trim(), prompt, ...(plugin ? { plugin } : {}) };
+  return { suggestion: suggestion.trim(), prompt };
+}
+
+/**
+ * Normalize the top-level `plugins` install list: keep non-blank string names,
+ * trimmed and de-duplicated, order-stable. Anything that isn't a clean string
+ * array yields `[]`. The runner gates these against the fetched catalog before
+ * installing, so a hallucinated name here never reaches the install route.
+ */
+function normalizePlugins(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const name = entry.trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
 }
 
 /** Body after a `"key": [` opening, or null if that array isn't present yet. */
@@ -179,6 +184,14 @@ export interface ResearchResult {
    * card and the user-voiced message sent when it's clicked.
    */
   suggestions: ResearchSuggestion[];
+  /**
+   * Marketplace capability install names the model judged a good overall fit for
+   * the user (top-level `plugins` array). Persona-level, NOT tied to any single
+   * suggestion: the runner installs these for the assistant globally and gates
+   * them against the fetched catalog first. Only populated once the payload
+   * parses complete (`complete: true`); `[]` while still streaming.
+   */
+  plugins: string[];
   /**
    * True once the reply parses as ONE complete, well-formed JSON object — i.e.
    * the full payload has arrived and was parsed by `JSON.parse` (not the
@@ -223,17 +236,20 @@ function parseWholePayload(body: string): Record<string, unknown> | null {
  * top-level array as `claims` for back-compat.
  */
 export function parseResearchResultStreaming(text: string): ResearchResult {
-  if (!text) return { claims: [], suggestions: [], complete: false };
+  if (!text) return { claims: [], suggestions: [], plugins: [], complete: false };
   const body = stripFence(text);
 
   // Fast path: the whole payload parsed in one shot. Correct (handles escaping)
   // and authoritative once the reply has fully arrived — so it also tells the
-  // caller the result is `complete` and safe to settle on.
+  // caller the result is `complete` and safe to settle on. The `plugins` install
+  // list is only honored here (not in the streaming fallback) so we never act on
+  // a half-written array.
   const whole = parseWholePayload(body);
   if (whole) {
     return {
       claims: mapEntries(whole.claims, toFact),
       suggestions: mapEntries(whole.suggestions, toSuggestion),
+      plugins: normalizePlugins(whole.plugins),
       complete: true,
     };
   }
@@ -262,7 +278,7 @@ export function parseResearchResultStreaming(text: string): ResearchResult {
           .map(toSuggestion)
           .filter((s): s is ResearchSuggestion => s !== null);
 
-  return { claims, suggestions, complete: false };
+  return { claims, suggestions, plugins: [], complete: false };
 }
 
 /**


### PR DESCRIPTION
**Stacked on #35917** (the de-slot prompt change) — review/merge that first, or merge this and the base folds in.

## Why

The research-onboarding flow tagged individual suggestions with a `plugin` key and installed it only when *that card* was clicked. In practice the model almost never tagged anything: the prompt gated it hard ("at most one, only when it does THAT card's concrete work"), so it usually emitted nothing and no capability got installed. Meanwhile the install endpoint (`POST /v1/assistants/{id}/plugins/install`) is **already assistant-global** — the per-suggestion coupling bought nothing but the under-tagging.

## What

Move selection to the **persona level**. The model now returns a top-level `plugins` array naming the 1–2 capabilities that best fit who the user is (from the research), and the runner installs them for the assistant globally — decoupled from which suggestion gets clicked. Suggestions revert to plain `{ suggestion, prompt }`.

- **prompt** (`research-prompt.ts`): capabilities block now asks for the top-level `plugins` list instead of per-suggestion tagging.
- **parser** (`research-facts.ts`): `ResearchSuggestion` drops `plugin`; `ResearchResult` gains `plugins: string[]`, honored **only once the payload parses complete** so we never act on a half-written array. `normalizePlugins` trims/dedupes/drops non-strings.
- **runner** (`research-runner.ts`): installs the catalog-gated picks (hallucination safety unchanged — still filtered through `validNames`); exposes `installedPlugins` for the UI; `awaitPluginInstall(name)` → `awaitPluginInstalls()` (awaits all before the chat opens).
- **UI** (`research-result-steps.tsx`): drops the per-card plugin chips + color palette; adds a small "Set up X to help with your work" confirmation note on the suggestions step.

## Safety / scope

- Still gated behind the `external-plugins` flag and the `vellum-ai`-only catalog filter — no change to which plugins are eligible.
- The `research-onboarding` feature flag still gates the whole flow.
- Parser + prompt + filter tests updated for the new contract; lint + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)