### PR TITLE
fix(telemetry): emit card normalization events via captureMessage (LUM-2568)

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -583,12 +583,20 @@ function normalizeCardShowData(
           (typeof input[k] === "string" &&
             (input[k] as string).trim().length > 0),
       );
-      Sentry.addBreadcrumb({
-        category: "card-normalization",
-        message: `alias recovery: ${usedAliases.join(", ")} → body`,
-        level: "info",
-        data: { usedAliases, candidateCount: candidates.length },
-      });
+      try {
+        Sentry.withScope((scope) => {
+          scope.setLevel("info");
+          scope.setTag("card_normalization", "alias_recovery");
+          scope.setTag("target_field", "body");
+          scope.setContext("card_normalization", {
+            used_aliases: usedAliases,
+            candidate_count: candidates.length,
+          });
+          Sentry.captureMessage("card_normalization:alias_recovery:body");
+        });
+      } catch {
+        // Never let telemetry break card rendering.
+      }
     }
   }
   for (const key of bodyAliasKeys) {
@@ -605,11 +613,16 @@ function normalizeCardShowData(
     ]);
     if (aliased !== undefined) {
       normalized.title = aliased;
-      Sentry.addBreadcrumb({
-        category: "card-normalization",
-        message: `alias recovery: title`,
-        level: "info",
-      });
+      try {
+        Sentry.withScope((scope) => {
+          scope.setLevel("info");
+          scope.setTag("card_normalization", "alias_recovery");
+          scope.setTag("target_field", "title");
+          Sentry.captureMessage("card_normalization:alias_recovery:title");
+        });
+      } catch {
+        // Never let telemetry break card rendering.
+      }
     }
   }
   for (const key of titleAliasKeys) {
@@ -634,11 +647,16 @@ function normalizeCardShowData(
     ]);
     if (aliased !== undefined) {
       normalized.subtitle = aliased;
-      Sentry.addBreadcrumb({
-        category: "card-normalization",
-        message: `alias recovery: subtitle`,
-        level: "info",
-      });
+      try {
+        Sentry.withScope((scope) => {
+          scope.setLevel("info");
+          scope.setTag("card_normalization", "alias_recovery");
+          scope.setTag("target_field", "subtitle");
+          Sentry.captureMessage("card_normalization:alias_recovery:subtitle");
+        });
+      } catch {
+        // Never let telemetry break card rendering.
+      }
     }
   }
   for (const key of subtitleAliasKeys) {
@@ -688,12 +706,19 @@ function normalizeCardShowData(
       { droppedKeys },
       "ui_show card data carried keys the card contract does not model; their content will not render",
     );
-    Sentry.addBreadcrumb({
-      category: "card-normalization",
-      message: `dropped keys: ${droppedKeys.join(", ")}`,
-      level: "warning",
-      data: { droppedKeys },
-    });
+    try {
+      Sentry.withScope((scope) => {
+        scope.setLevel("warning");
+        scope.setTag("card_normalization", "dropped_keys");
+        scope.setContext("card_normalization", {
+          dropped_keys: droppedKeys,
+          dropped_count: droppedKeys.length,
+        });
+        Sentry.captureMessage("card_normalization:dropped_keys");
+      });
+    } catch {
+      // Never let telemetry break card rendering.
+    }
   }
   const parsed = CardSurfaceDataSchema.safeParse(normalized);
   if (parsed.success) {
@@ -2912,18 +2937,22 @@ export async function surfaceProxyResolver(
         if (result.success) {
           valid.push(result.data);
         } else {
-          Sentry.addBreadcrumb({
-            category: "card-normalization",
-            message: "action parse failure (individual)",
-            level: "warning",
-            data: {
-              issuePaths: result.error.issues.map((i) => i.path.join(".")),
-              keys:
-                typeof raw === "object" && raw !== null
-                  ? Object.keys(raw)
-                  : [typeof raw],
-            },
-          });
+          try {
+            Sentry.withScope((scope) => {
+              scope.setLevel("warning");
+              scope.setTag("card_normalization", "action_parse_failure");
+              scope.setContext("card_normalization", {
+                issue_paths: result.error.issues.map((i) => i.path.join(".")),
+                keys:
+                  typeof raw === "object" && raw !== null
+                    ? Object.keys(raw)
+                    : [typeof raw],
+              });
+              Sentry.captureMessage("card_normalization:action_parse_failure");
+            });
+          } catch {
+            // Never let telemetry break card rendering.
+          }
         }
       }
       inputActions = valid.length > 0 ? valid : undefined;
@@ -2961,11 +2990,24 @@ export async function surfaceProxyResolver(
         !hasTemplate &&
         !hasActions
       ) {
-        Sentry.addBreadcrumb({
-          category: "card-normalization",
-          message: "empty card rejected",
-          level: "warning",
-        });
+        try {
+          Sentry.withScope((scope) => {
+            scope.setLevel("warning");
+            scope.setTag("card_normalization", "empty_card_rejected");
+            scope.setContext("card_normalization", {
+              surface_type: surfaceType,
+              has_title: hasTitle,
+              has_body: hasBody,
+              has_subtitle: hasSubtitle,
+              has_metadata: hasMetadata,
+              has_template: hasTemplate,
+              has_actions: hasActions,
+            });
+            Sentry.captureMessage("card_normalization:empty_card_rejected");
+          });
+        } catch {
+          // Never let telemetry break card rendering.
+        }
         return {
           content:
             "Error: ui_show card requires content — provide `data.body`, a `template` (e.g. task_progress with steps), `data.metadata`, `data.subtitle`, a `title`, or `actions`. The surface was not displayed because it carried no renderable content. Resend ui_show with populated card content.",

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -711,9 +711,11 @@ function normalizeCardShowData(
         scope.setLevel("warning");
         scope.setTag("card_normalization", "dropped_keys");
         scope.setContext("card_normalization", {
-          dropped_keys: droppedKeys,
           dropped_count: droppedKeys.length,
         });
+        // Key names are model-controlled, so they ride in `extra`, which
+        // beforeSend redacts (it does not scrub `contexts`) — see instrument.ts.
+        scope.setExtra("dropped_keys", droppedKeys);
         Sentry.captureMessage("card_normalization:dropped_keys");
       });
     } catch {
@@ -2943,11 +2945,16 @@ export async function surfaceProxyResolver(
               scope.setTag("card_normalization", "action_parse_failure");
               scope.setContext("card_normalization", {
                 issue_paths: result.error.issues.map((i) => i.path.join(".")),
-                keys:
-                  typeof raw === "object" && raw !== null
-                    ? Object.keys(raw)
-                    : [typeof raw],
               });
+              // raw object keys are model-controlled, so they ride in `extra`,
+              // which beforeSend redacts (it does not scrub `contexts`) — see
+              // instrument.ts.
+              scope.setExtra(
+                "raw_keys",
+                typeof raw === "object" && raw !== null
+                  ? Object.keys(raw)
+                  : [typeof raw],
+              );
               Sentry.captureMessage("card_normalization:action_parse_failure");
             });
           } catch {


### PR DESCRIPTION
## Summary

The 6 `Sentry.addBreadcrumb()` calls with `category: "card-normalization"` in `assistant/src/daemon/conversation-surfaces.ts` **never reached Sentry**. Breadcrumbs are passive — they only flush when an error fires in the same scope. But `normalizeCardShowData()` / `surfaceProxyResolver()` succeed gracefully and never raise, so the breadcrumbs were silently dropped and the normalization telemetry was effectively dark.

This replaces each breadcrumb with `Sentry.withScope()` + `Sentry.captureMessage()`, which creates a **standalone event** that ships regardless of whether an error occurs. The pattern mirrors the existing SSE-shed telemetry (`runtime/routes/events-routes.ts:219-230`) and the event-loop watchdog (`daemon/event-loop-watchdog.ts:110-122`).

## What changed

All 6 sites in `conversation-surfaces.ts`:

| Site | Event | Level |
| --- | --- | --- |
| Body alias recovery | `card_normalization:alias_recovery:body` | `info` |
| Title alias recovery | `card_normalization:alias_recovery:title` | `info` |
| Subtitle alias recovery | `card_normalization:alias_recovery:subtitle` | `info` |
| Dropped keys | `card_normalization:dropped_keys` | `warning` |
| Action parse failure | `card_normalization:action_parse_failure` | `warning` |
| Empty card rejected | `card_normalization:empty_card_rejected` | `warning` |

Conventions applied to every call:

- **`scope.setTag("card_normalization", "<event_type>")`** on every event so all events are queryable by `card_normalization:*` in Sentry.
- **`scope.setContext("card_normalization", { … })`** for structured data (arrays/objects); tags reserved for indexed/filterable scalars.
- **`info`** level for alias recovery (expected normalization); **`warning`** for dropped keys, parse failures, and empty-card rejections (unexpected shapes worth investigating).
- Each capture wrapped in `try/catch` with an empty catch — telemetry must never break card rendering (matches the SSE-shed and watchdog patterns).
- Message format `card_normalization:<event_type>` (colon-separated, snake_case) for clean Sentry issue grouping.

## What was preserved

- The existing `log.warn()` calls are kept (local debugging).
- No new imports — `Sentry` was already imported.
- No changes to `instrument.ts`. The existing `beforeSend` consent gate (`instrument.ts:90`) already gates all events on `getCachedShareDiagnostics()` and redacts PII; `captureMessage` events flow through it automatically.

## Verification

- `bunx tsc --noEmit` in `assistant/` — clean (exit 0).
- `bun run lint` in `assistant/` — clean (exit 0).
- `prettier --check` on the changed file — clean.
- Zero remaining `addBreadcrumb` / `card-normalization` references in the file.
- Pre-commit hook re-ran format + lint + type-check — all passed.

## Linear

LUM-2568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMGfnkjzELruBZG4yBEDwz)_