### PR TITLE
fix(macos): per-environment identity for mac-helper (side-by-side installs)

### DIFF
--- a/clients/macos/.gitignore
+++ b/clients/macos/.gitignore
@@ -11,3 +11,4 @@ native/hotkey-helper/.build/
 native/mac-helper/.build/
 resources/cli-lockfile
 resources/.vellum-mac-helper.source-hash
+resources/.vellum-mac-helper*.Info.plist

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
@@ -3,24 +3,25 @@
 <plist version="1.0">
 <dict>
     <!--
-      Embedded into the bare executable's __TEXT,__info_plist section by
-      build-mac-helper.sh. TCC consults the requesting binary's Info.plist
-      for usage strings when the helper itself (not just the responsible
-      host app) is attributed for microphone / speech-recognition access,
-      so the dictation-partials session can prompt and run without a full
-      .app bundle.
+      Template: build-mac-helper.sh substitutes the __HELPER_*__ placeholders
+      per VELLUM_ENVIRONMENT, then embeds the result into the bare executable's
+      __TEXT,__info_plist section. TCC consults the requesting binary's
+      Info.plist for usage strings when the helper itself (not just the
+      responsible host app) is attributed for microphone / speech-recognition
+      access, so the dictation-partials session can prompt and run without a
+      full .app bundle.
     -->
     <key>CFBundleIdentifier</key>
-    <string>ai.vellum.assistant.mac-helper</string>
+    <string>__HELPER_BUNDLE_ID__</string>
     <key>CFBundleExecutable</key>
     <string>vellum-mac-helper</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <!-- User-facing name + icon in System Settings → Privacy & Security. -->
     <key>CFBundleName</key>
-    <string>Vellum Helper</string>
+    <string>__HELPER_DISPLAY_NAME__</string>
     <key>CFBundleDisplayName</key>
-    <string>Vellum Helper</string>
+    <string>__HELPER_DISPLAY_NAME__</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>

--- a/clients/macos/scripts/build-mac-helper.sh
+++ b/clients/macos/scripts/build-mac-helper.sh
@@ -7,7 +7,7 @@ OUTPUT_DIR="$ROOT_DIR/resources"
 OUTPUT_BUNDLE="$OUTPUT_DIR/vellum-mac-helper.app"
 OUTPUT="$OUTPUT_BUNDLE/Contents/MacOS/vellum-mac-helper"
 OUTPUT_INFO_PLIST="$OUTPUT_BUNDLE/Contents/Info.plist"
-INFO_PLIST="$PACKAGE_DIR/Sources/MacHelperExecutable/Info.plist"
+TEMPLATE_PLIST="$PACKAGE_DIR/Sources/MacHelperExecutable/Info.plist"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "build-mac-helper: skipping non-macOS host"
@@ -27,18 +27,42 @@ if [ -n "${ELECTRON_TARGET_ARCH:-}" ]; then
   esac
 fi
 
-# Embed Info.plist (bundle id + microphone / speech-recognition usage
-# strings) into the bare executable so TCC can attribute permission
-# prompts for the dictation-partials session without a full .app bundle.
-INFO_PLIST="$PACKAGE_DIR/Sources/MacHelperExecutable/Info.plist"
+# Per-environment helper identity so side-by-side installs (e.g. Vellum +
+# Vellum Dev) get distinct TCC entries instead of colliding on one shared
+# bundle id. Mirrors the app's appId/productName scheme in
+# electron-builder.config.cjs; production keeps the bare id + name so existing
+# grants persist.
+ENV="${VELLUM_ENVIRONMENT:-local}"
+if [ "$ENV" = "production" ]; then
+  HELPER_BUNDLE_ID="ai.vellum.assistant.mac-helper"
+  HELPER_DISPLAY_NAME="Vellum Helper"
+else
+  ENV_CAP="$(printf '%s' "${ENV:0:1}" | tr '[:lower:]' '[:upper:]')${ENV:1}"
+  HELPER_BUNDLE_ID="ai.vellum.assistant-${ENV}.mac-helper"
+  HELPER_DISPLAY_NAME="Vellum Helper ${ENV_CAP}"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+# Render the templated Info.plist, then embed it into the bare executable's
+# __info_plist section so TCC can attribute permission prompts for the
+# dictation-partials session without a full .app bundle. Content-address the
+# filename: llbuild ignores content changes to a fixed -sectcreate input path
+# and would skip relinking on an env switch, embedding a stale plist — a new
+# identity must yield a new path to force the relink.
+rm -f "$OUTPUT_DIR"/.vellum-mac-helper.*.Info.plist
+RENDERED_TMP="$(mktemp)"
+sed -e "s|__HELPER_BUNDLE_ID__|${HELPER_BUNDLE_ID}|g" \
+    -e "s|__HELPER_DISPLAY_NAME__|${HELPER_DISPLAY_NAME}|g" \
+    "$TEMPLATE_PLIST" > "$RENDERED_TMP"
+RENDERED_PLIST="$OUTPUT_DIR/.vellum-mac-helper.$(shasum -a 256 "$RENDERED_TMP" | cut -c1-16).Info.plist"
+mv -f "$RENDERED_TMP" "$RENDERED_PLIST"
 BUILD_ARGS+=(
   -Xlinker -sectcreate
   -Xlinker __TEXT
   -Xlinker __info_plist
-  -Xlinker "$INFO_PLIST"
+  -Xlinker "$RENDERED_PLIST"
 )
 
-mkdir -p "$OUTPUT_DIR"
 # Legacy layouts (bare binary / old name) — always clear.
 rm -f "$OUTPUT_DIR/hotkey-helper" "$OUTPUT_DIR/vellum-mac-helper" "$OUTPUT_DIR/Info.plist"
 xcrun swift build "${BUILD_ARGS[@]}"
@@ -55,7 +79,7 @@ ICON_SRC="$ROOT_DIR/build/icon.icns"
 # no-op rebuild (e.g. `bun run dev`'s postinstall) would re-prompt. The
 # signed binary never byte-matches the unsigned build output, so compare
 # against a hash marker of the inputs recorded at install time.
-HASH_INPUTS=("$BUILD_DIR/vellum-mac-helper" "$INFO_PLIST" "$ROOT_DIR/scripts/entitlements/helper.plist")
+HASH_INPUTS=("$BUILD_DIR/vellum-mac-helper" "$RENDERED_PLIST" "$ROOT_DIR/scripts/entitlements/helper.plist")
 [ -f "$ICON_SRC" ] && HASH_INPUTS+=("$ICON_SRC")
 SOURCE_HASH="$(cat "${HASH_INPUTS[@]}" | shasum -a 256 | cut -d' ' -f1)"
 HASH_MARKER="$OUTPUT_DIR/.vellum-mac-helper.source-hash"
@@ -68,7 +92,7 @@ else
   rm -rf "$OUTPUT_BUNDLE"
   mkdir -p "$OUTPUT_BUNDLE/Contents/MacOS"
   cp "$BUILD_DIR/vellum-mac-helper" "$OUTPUT"
-  cp "$INFO_PLIST" "$OUTPUT_INFO_PLIST"
+  cp "$RENDERED_PLIST" "$OUTPUT_INFO_PLIST"
   chmod 755 "$OUTPUT"
   if [ -f "$ICON_SRC" ]; then
     mkdir -p "$OUTPUT_BUNDLE/Contents/Resources"


### PR DESCRIPTION
## Summary
- The macOS helper's bundle id and display name were hard-coded (`ai.vellum.assistant.mac-helper` / "Vellum Helper"), identical across all environments. Since TCC keys a signed binary on its designated requirement (bundle id + Team id), side-by-side installs (e.g. **Vellum** + **Vellum Dev**) collapsed into a **single shared "Vellum Helper" permission entry**, even though the main apps already get distinct entries via per-env `appId`/`productName`.
- `Info.plist` is now a template with `__HELPER_BUNDLE_ID__` / `__HELPER_DISPLAY_NAME__` placeholders; `build-mac-helper.sh` renders them per `VELLUM_ENVIRONMENT`, mirroring the app's scheme in `electron-builder.config.cjs`. **Production keeps its exact current id + name** so existing Accessibility/Screen-Recording/Mic/Speech grants persist; non-prod envs get `ai.vellum.assistant-<env>.mac-helper` / "Vellum Helper <Env>".
- The rendered plist filename is content-addressed (hash suffix) so an identity change yields a new `-sectcreate` input path, forcing SwiftPM to relink the embedded `__info_plist` section instead of reusing a stale one from its link cache. Added a `.gitignore` rule for the rendered plists.

## Original prompt
Following the earlier rename (#35906), we established that side-by-side installs of different Vellum environments are a real scenario, and that the shared helper bundle id would make all environments collide on one TCC permission entry. This change gives each environment's helper its own distinct identity (bundle id + display name) — chosen mid-segment scheme `ai.vellum.assistant-<env>.mac-helper` to parallel the app's `...-electron-<env>` — while keeping production's identity byte-identical to preserve existing users' grants.

## Testing
Built locally on macOS across `production`, `dev`, `staging`, `local`; for each, the bundle's `Contents/Info.plist`, the embedded Mach-O `__info_plist` section, **and** the codesign `Identifier` all agree on the expected per-env id/name, and the signature verifies. Confirmed same-env no-op rebuilds still skip ("bundle unchanged"), env switches reinstall, and build artifacts (rendered plists) stay gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)