### PR TITLE
feat(onboarding): add post-consent destination helper for research flow

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-destination.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
+import { routes } from "@/utils/routes";
+
+describe("onboardingDestinationAfterConsent", () => {
+  test("flag enabled on web routes to the research flow", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        researchOnboardingEnabled: true,
+        isNative: false,
+      }),
+    ).toBe(routes.onboarding.research);
+  });
+
+  test("flag enabled on native keeps the hatching path (web-only guard)", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        researchOnboardingEnabled: true,
+        isNative: true,
+      }),
+    ).toBe(routes.onboarding.hatching);
+  });
+
+  test("flag disabled on web keeps the hatching path", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        researchOnboardingEnabled: false,
+        isNative: false,
+      }),
+    ).toBe(routes.onboarding.hatching);
+  });
+});

--- a/clients/web/src/domains/onboarding/onboarding-destination.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.ts
@@ -1,0 +1,28 @@
+import { routes } from "@/utils/routes";
+
+/**
+ * Decide where the standard onboarding flow goes after the user accepts
+ * consent on the privacy screen.
+ *
+ * When the research-onboarding flag is enabled AND we're on the web platform,
+ * new users are dropped into the research flow (`/assistant/onboarding/research`),
+ * which runs its own background hatch and walks the user to chat — so the
+ * hatching screen is intentionally skipped. The redirect is web-only: native /
+ * Electron-wrapped users always keep the standard hatching path. Otherwise we
+ * keep the standard hatching path too.
+ *
+ * Because the `research-onboarding` flag defaults to `false`, a `true` value
+ * here already implies the LaunchDarkly response has landed, so no separate
+ * hydration check is needed at the call site.
+ */
+export function onboardingDestinationAfterConsent({
+  researchOnboardingEnabled,
+  isNative,
+}: {
+  researchOnboardingEnabled: boolean;
+  isNative: boolean;
+}): string {
+  return researchOnboardingEnabled && !isNative
+    ? routes.onboarding.research
+    : routes.onboarding.hatching;
+}


### PR DESCRIPTION
## Summary
- Add pure `onboardingDestinationAfterConsent` helper that returns the research-onboarding route when the flag is enabled on web, else the hatching route
- Web-only guard via `isNative`; unit tests cover all three branches

Part of plan: onboarding-research-post-signup.md (PR 1 of 2)