### PR TITLE
fix(onboarding): show setup lines on reduced-motion pitch

### DIFF
--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -167,10 +167,13 @@ export function PitchStep({
   const teamPeek = -teamSize * 0.42; // ~42% cut off, peeking down
   const teamY = useMotionValue(-320);
 
+  // Under reduced motion the setup lines show first (reveal true) but the
+  // carousel starts unrolled (false) so the reduced-motion effect can swap to
+  // the payoff after a beat — otherwise the setup copy is never seen.
   const [reveal1, setReveal1] = useState(!!reduce);
   const [reveal2, setReveal2] = useState(!!reduce);
-  const [carousel1, setCarousel1] = useState(!!reduce);
-  const [carousel2, setCarousel2] = useState(!!reduce);
+  const [carousel1, setCarousel1] = useState(false);
+  const [carousel2, setCarousel2] = useState(false);
   const [ready, setReady] = useState(false);
   const [landed, setLanded] = useState(!!reduce);
 


### PR DESCRIPTION
Follow-up to #35915, which merged before this last review fix landed.

Under `prefers-reduced-motion`, the pitch step initialized `carousel1`/`carousel2` from `reduce` (so `true`), mounting the pitch already scrolled to the payoff ("The more I help" / "The less you do") — reduced-motion users never saw the setup lines ("You've used AI…" / "I'm different"), dropping half the pitch copy.

Fix: keep the reveal states `true` (show the setup lines immediately) but start the carousel states `false`, so the reduced-motion effect flips them to the payoff after its delay.

Flagged by Codex on #35915 as a P2; the PR was merged before the fix was pushed, so this lands it separately.

## Testing
- `bun run typecheck` — passes
- `bunx tsc --noEmit` — clean (after SDK regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)