### PR TITLE
feat(onboarding): land new users in research flow after consent when flag on

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-destination.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.test.ts
@@ -9,6 +9,7 @@ describe("onboardingDestinationAfterConsent", () => {
       onboardingDestinationAfterConsent({
         researchOnboardingEnabled: true,
         isNative: false,
+        isLocalMode: false,
       }),
     ).toBe(routes.onboarding.research);
   });
@@ -18,6 +19,17 @@ describe("onboardingDestinationAfterConsent", () => {
       onboardingDestinationAfterConsent({
         researchOnboardingEnabled: true,
         isNative: true,
+        isLocalMode: false,
+      }),
+    ).toBe(routes.onboarding.hatching);
+  });
+
+  test("flag enabled in local mode keeps the hatching path (research is managed-only)", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        researchOnboardingEnabled: true,
+        isNative: false,
+        isLocalMode: true,
       }),
     ).toBe(routes.onboarding.hatching);
   });
@@ -27,6 +39,7 @@ describe("onboardingDestinationAfterConsent", () => {
       onboardingDestinationAfterConsent({
         researchOnboardingEnabled: false,
         isNative: false,
+        isLocalMode: false,
       }),
     ).toBe(routes.onboarding.hatching);
   });

--- a/clients/web/src/domains/onboarding/onboarding-destination.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.ts
@@ -11,6 +11,12 @@ import { routes } from "@/utils/routes";
  * Electron-wrapped users always keep the standard hatching path. Otherwise we
  * keep the standard hatching path too.
  *
+ * Local-mode onboarding (carrying `?hosting=local`/`docker`) also keeps the
+ * standard hatching path: the research route only supports the managed hatch
+ * (`useBackgroundHatch()` → managed `hatchAssistant()`) and never consumes the
+ * `hosting` param, so routing a local/docker user there would bypass the local
+ * provider-key/local hatch flow and provision the wrong assistant.
+ *
  * Because the `research-onboarding` flag defaults to `false`, a `true` value
  * here already implies the LaunchDarkly response has landed, so no separate
  * hydration check is needed at the call site.
@@ -18,11 +24,13 @@ import { routes } from "@/utils/routes";
 export function onboardingDestinationAfterConsent({
   researchOnboardingEnabled,
   isNative,
+  isLocalMode,
 }: {
   researchOnboardingEnabled: boolean;
   isNative: boolean;
+  isLocalMode: boolean;
 }): string {
-  return researchOnboardingEnabled && !isNative
+  return researchOnboardingEnabled && !isNative && !isLocalMode
     ? routes.onboarding.research
     : routes.onboarding.hatching;
 }

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -43,6 +43,8 @@ mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
 // Mutable platform/flag state so individual tests can flip them.
 let nativePlatform = false;
 let researchFlag = false;
+let localMode = false;
+mock.module("@/lib/local-mode", () => ({ isLocalMode: () => localMode }));
 mock.module("@/runtime/native-auth", () => ({
   useIsNativePlatform: () => nativePlatform,
 }));
@@ -104,11 +106,13 @@ describe("PrivacyScreen — Start navigation", () => {
     emitFunnelStepCompletedMock.mockClear();
     researchFlag = false;
     nativePlatform = false;
+    localMode = false;
   });
   afterEach(() => {
     cleanup();
     researchFlag = false;
     nativePlatform = false;
+    localMode = false;
   });
 
   test("preview mode replays forward into prechat without persisting consent", () => {
@@ -154,6 +158,18 @@ describe("PrivacyScreen — Start navigation", () => {
   test("flag on but native keeps the standard hatching flow", () => {
     researchFlag = true;
     nativePlatform = true;
+    searchParamsValue = new URLSearchParams();
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
+  });
+
+  test("flag on but local mode keeps the standard hatching flow (research is managed-only)", () => {
+    researchFlag = true;
+    nativePlatform = false;
+    localMode = true;
     searchParamsValue = new URLSearchParams();
     render(<PrivacyScreen />);
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -40,15 +40,20 @@ mock.module("@/domains/onboarding/funnel-events", () => ({
 }));
 
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
+// Mutable platform/flag state so individual tests can flip them.
+let nativePlatform = false;
+let researchFlag = false;
 mock.module("@/runtime/native-auth", () => ({
-  useIsNativePlatform: () => false,
+  useIsNativePlatform: () => nativePlatform,
 }));
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: { use: { user: () => ({ id: "user-1" }) } },
   useHasPlatformSession: () => false,
 }));
 mock.module("@/stores/client-feature-flag-store", () => ({
-  useClientFeatureFlagStore: { use: { stringFlags: () => ({}) } },
+  useClientFeatureFlagStore: {
+    use: { stringFlags: () => ({}), researchOnboarding: () => researchFlag },
+  },
 }));
 
 // Light passthroughs for layout/design-library so the screen renders in happy-dom.
@@ -97,8 +102,14 @@ describe("PrivacyScreen — Start navigation", () => {
     navigateMock.mockClear();
     saveConsentMock.mockClear();
     emitFunnelStepCompletedMock.mockClear();
+    researchFlag = false;
+    nativePlatform = false;
   });
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    researchFlag = false;
+    nativePlatform = false;
+  });
 
   test("preview mode replays forward into prechat without persisting consent", () => {
     searchParamsValue = new URLSearchParams("preview=true");
@@ -122,6 +133,32 @@ describe("PrivacyScreen — Start navigation", () => {
     clickStart();
 
     expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
+  });
+
+  test("flag on (web) persists consent and advances to the research flow, preserving hosting", () => {
+    researchFlag = true;
+    nativePlatform = false;
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.research)).toBe(true);
+    expect(target).toContain("hosting=managed");
+  });
+
+  test("flag on but native keeps the standard hatching flow", () => {
+    researchFlag = true;
+    nativePlatform = true;
+    searchParamsValue = new URLSearchParams();
+    render(<PrivacyScreen />);
+
+    clickStart();
+
     expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
   });
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -15,6 +15,7 @@ import {
     resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
+import { isLocalMode } from "@/lib/local-mode";
 import {
     usePrivacyConsent,
     useShareAnalytics,
@@ -82,7 +83,11 @@ export function PrivacyScreen() {
     const params = new URLSearchParams();
     if (hostingParam) params.set("hosting", hostingParam);
     const qs = params.toString();
-    const destination = onboardingDestinationAfterConsent({ researchOnboardingEnabled, isNative });
+    const destination = onboardingDestinationAfterConsent({
+      researchOnboardingEnabled,
+      isNative,
+      isLocalMode: isLocalMode(),
+    });
     void navigate(`${destination}${qs ? `?${qs}` : ""}`);
   }, [
     privacyConsent,

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -14,6 +14,7 @@ import {
     onboardingFunnelVariantFromExperiment,
     resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
+import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import {
     usePrivacyConsent,
     useShareAnalytics,
@@ -36,6 +37,7 @@ export function PrivacyScreen() {
   const isNative = useIsNativePlatform();
   const preChatExperimentArm =
     useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
+  const researchOnboardingEnabled = useClientFeatureFlagStore.use.researchOnboarding();
   const preferredFunnelVariant =
     onboardingFunnelVariantFromExperiment(preChatExperimentArm);
   const [shareAnalytics, setShareAnalyticsReal] = useShareAnalytics();
@@ -80,7 +82,8 @@ export function PrivacyScreen() {
     const params = new URLSearchParams();
     if (hostingParam) params.set("hosting", hostingParam);
     const qs = params.toString();
-    void navigate(`${routes.onboarding.hatching}${qs ? `?${qs}` : ""}`);
+    const destination = onboardingDestinationAfterConsent({ researchOnboardingEnabled, isNative });
+    void navigate(`${destination}${qs ? `?${qs}` : ""}`);
   }, [
     privacyConsent,
     hasPlatformSession,
@@ -88,6 +91,7 @@ export function PrivacyScreen() {
     isPreview,
     navigate,
     preferredFunnelVariant,
+    researchOnboardingEnabled,
     searchParams,
     shareAnalytics,
     shareDiagnostics,


### PR DESCRIPTION
## Summary
- Privacy screen `onStart` routes flag-on web signups into the research-onboarding flow instead of the hatching screen, via the `onboardingDestinationAfterConsent` helper
- Web-only (native keeps standard flow); behind the default-off `research-onboarding` flag; consent still persisted and `hosting` param preserved
- Tests cover flag-off, flag-on-web, and flag-on-native Start destinations

Part of plan: onboarding-research-post-signup.md (PR 2 of 2)