### PR TITLE
fix(web): move restart/recovery/onboarding cards above backups in debug settings

### DIFF
--- a/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -87,20 +87,6 @@ export function DebugControlsPanel() {
         </div>
       ) : assistant ? (
         <div className="space-y-4">
-          {platformGate === "disabled" && (
-            <PlatformLoginNotice>
-              Log in to the Vellum platform to manage backups.
-            </PlatformLoginNotice>
-          )}
-          {platformGate !== "disabled" && (
-            <div className="rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
-              <h3 className="mb-3 text-body-medium-default text-[var(--content-default)]">
-                Backups
-              </h3>
-              <AssistantBackups assistantId={assistant.id} />
-            </div>
-          )}
-
           <div className="flex items-center justify-between rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
             <div className="min-w-0">
               <p className="text-body-medium-default text-[var(--content-default)]">
@@ -121,34 +107,48 @@ export function DebugControlsPanel() {
             maintenanceMode={assistant.maintenance_mode}
             onMaintenanceModeChange={() => fetchAssistant(true)}
           />
+
+          {showInternalControls && (
+            <div className="flex items-center justify-between rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
+              <div className="min-w-0">
+                <p className="text-body-medium-default text-[var(--content-default)]">
+                  Replay onboarding (Vellum-only)
+                </p>
+                <p className="text-body-small-default text-[var(--content-tertiary)]">
+                  Clear local onboarding flags and re-walk the privacy → hatch
+                  screens. Your existing assistant is preserved.
+                </p>
+              </div>
+              <div className="ml-4 shrink-0">
+                <Button
+                  variant="outlined"
+                  leftIcon={<RotateCw />}
+                  onClick={handleReplayOnboarding}
+                >
+                  Replay
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {platformGate === "disabled" && (
+            <PlatformLoginNotice>
+              Log in to the Vellum platform to manage backups.
+            </PlatformLoginNotice>
+          )}
+          {platformGate !== "disabled" && (
+            <div className="rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
+              <h3 className="mb-3 text-body-medium-default text-[var(--content-default)]">
+                Backups
+              </h3>
+              <AssistantBackups assistantId={assistant.id} />
+            </div>
+          )}
         </div>
       ) : (
         <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
           No assistant found. Hatch an assistant to access debug controls.
         </p>
-      )}
-
-      {showInternalControls && (
-        <div className="flex items-center justify-between rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
-          <div className="min-w-0">
-            <p className="text-body-medium-default text-[var(--content-default)]">
-              Replay onboarding (Vellum-only)
-            </p>
-            <p className="text-body-small-default text-[var(--content-tertiary)]">
-              Clear local onboarding flags and re-walk the privacy → hatch
-              screens. Your existing assistant is preserved.
-            </p>
-          </div>
-          <div className="ml-4 shrink-0">
-            <Button
-              variant="outlined"
-              leftIcon={<RotateCw />}
-              onClick={handleReplayOnboarding}
-            >
-              Replay
-            </Button>
-          </div>
-        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Reorder the Debug Controls settings panel so the **Restart Assistant**, **Recovery Mode**, and **Replay onboarding** cards appear above the **Backups** table.
- The Replay onboarding card (internal-only) now lives inside the assistant block, grouped with the other assistant action cards. As a result it renders only when an assistant exists, matching its own copy ("Your existing assistant is preserved").
- Pure JSX reorder — no logic, handler, or styling changes.

## Original prompt
While confirming that a user-facing assistant restart endpoint already exists (surfaced in Settings → Debug Controls), the user asked to reorder that panel: move the Restart, Recovery Mode, and Replay onboarding cards above the table of backups so the action cards are grouped at the top.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/35929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->