### PR TITLE
feat(advisor): read workspace files; sharpen recall query

### DIFF
--- a/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
@@ -11,6 +11,12 @@ let providerResolves = true;
 let providerSupportsWeb = false;
 let streamDeltas: string[] = [];
 let streamEvents: Array<Record<string, unknown>> = [];
+// Multi-turn scripting for the tool-loop tests: each queued entry is returned
+// by one `sendMessage` call (e.g. a `tool_use` turn followed by a final turn).
+// When empty, the provider returns the default single `responseText` turn.
+let responseQueue: Array<{ content: unknown[]; stopReason: string }> = [];
+// Snapshot of every call's messages, so tests can assert what was fed back.
+let sendMessageCalls: Array<{ messages: unknown[]; options: unknown }> = [];
 
 const fakeProvider = {
   name: "mock-advisor-provider",
@@ -19,6 +25,10 @@ const fakeProvider = {
   },
   async sendMessage(messages: unknown, options: unknown) {
     sendMessageArgs = { messages, options } as Record<string, unknown>;
+    sendMessageCalls.push({
+      messages: Array.isArray(messages) ? [...messages] : [],
+      options,
+    });
     if (sendMessageError) throw sendMessageError;
     const onEvent = (
       options as { onEvent?: (e: Record<string, unknown>) => void }
@@ -28,14 +38,36 @@ const fakeProvider = {
       for (const ev of streamEvents) onEvent(ev);
       for (const text of streamDeltas) onEvent({ type: "text_delta", text });
     }
+    const scripted = responseQueue.shift();
     return {
-      content: [{ type: "text", text: responseText }],
+      content: scripted?.content ?? [{ type: "text", text: responseText }],
       model: "mock-model",
       usage: { inputTokens: 1, outputTokens: 1 },
-      stopReason: "end_turn",
+      stopReason: scripted?.stopReason ?? "end_turn",
     };
   },
 };
+
+// The advisor's `read_file` tool reads through these shared filesystem modules;
+// stub them so the loop tests never touch disk. The returned content echoes the
+// requested path, so tests can assert the file content was fed back.
+mock.module("../../../../tools/shared/filesystem/path-policy.js", () => ({
+  sandboxPolicy: (path: string, dir: string) => ({
+    ok: true,
+    resolved: `${dir}/${path}`,
+  }),
+}));
+mock.module("../../../../tools/shared/filesystem/file-ops-service.js", () => ({
+  FileSystemOps: class {
+    constructor(_policy: unknown) {}
+    readFileSafe({ path }: { path: string }) {
+      if (path.includes("missing")) {
+        return { ok: false, error: { code: "NOT_FOUND", message: "no such file" } };
+      }
+      return { ok: true, value: { content: `1\tCONTENTS OF ${path}` } };
+    }
+  },
+}));
 
 const realPsm = await import("../../../../providers/provider-send-message.js");
 mock.module("../../../../providers/provider-send-message.js", () => ({
@@ -74,6 +106,8 @@ beforeEach(() => {
   providerSupportsWeb = false;
   streamDeltas = [];
   streamEvents = [];
+  responseQueue = [];
+  sendMessageCalls = [];
   resetAdvisorStateForTests();
 });
 
@@ -143,6 +177,114 @@ describe("consultAdvisor", () => {
     expect(options.tools?.map((t) => t.name)).toEqual(["web_search"]);
     // tool_choice must not be `none`, or the provider suppresses its server tool.
     expect(optionConfig().tool_choice).toEqual({ type: "auto" });
+  });
+
+  test("attaches read_file only when a workingDir is provided", async () => {
+    await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+      workingDir: "/work",
+    });
+    let opts = sendMessageArgs?.options as { tools?: Array<{ name: string }> };
+    expect(opts.tools?.map((t) => t.name)).toContain("read_file");
+
+    await consultAdvisor({ systemPrompt: null, messages: [userMsg("hi")] });
+    opts = sendMessageArgs?.options as { tools?: Array<{ name: string }> };
+    expect(opts.tools?.some((t) => t.name === "read_file") ?? false).toBe(false);
+  });
+
+  test("reads a workspace file the advisor requests, then advises with it", async () => {
+    // Turn 1: advisor asks to read a file. Turn 2: it gives advice.
+    responseQueue = [
+      {
+        content: [
+          { type: "tool_use", id: "r1", name: "read_file", input: { path: "src/app.ts" } },
+        ],
+        stopReason: "tool_use",
+      },
+      {
+        content: [{ type: "text", text: "Given src/app.ts, drain the pool on shutdown." }],
+        stopReason: "end_turn",
+      },
+    ];
+    const chunks: string[] = [];
+
+    const advice = await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("review my plan")],
+      workingDir: "/work",
+      onText: (c) => chunks.push(c),
+    });
+
+    // The final advice is returned...
+    expect(advice).toContain("drain the pool on shutdown");
+    // ...a read note streamed to the drawer...
+    expect(chunks.join("")).toContain("Read src/app.ts");
+    // ...and the file content was fed back to the model on the 2nd call.
+    expect(JSON.stringify(sendMessageCalls[1]?.messages)).toContain(
+      "CONTENTS OF src/app.ts",
+    );
+    expect(sendMessageCalls).toHaveLength(2);
+  });
+
+  test("feeds an error result back when a requested file can't be read", async () => {
+    responseQueue = [
+      {
+        content: [
+          { type: "tool_use", id: "r1", name: "read_file", input: { path: "missing.ts" } },
+        ],
+        stopReason: "tool_use",
+      },
+      {
+        content: [{ type: "text", text: "Can't see that file; here's my best guidance." }],
+        stopReason: "end_turn",
+      },
+    ];
+    const chunks: string[] = [];
+
+    const advice = await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("review my plan")],
+      workingDir: "/work",
+      onText: (c) => chunks.push(c),
+    });
+
+    expect(chunks.join("")).toContain("Couldn't read missing.ts");
+    expect(JSON.stringify(sendMessageCalls[1]?.messages)).toContain("no such file");
+    expect(advice).toContain("best guidance");
+  });
+
+  test("caps total file reads so a runaway consult terminates", async () => {
+    // The model asks to read one file every turn, forever. The loop must stop.
+    for (let i = 0; i < 30; i++) {
+      responseQueue.push({
+        content: [
+          { type: "tool_use", id: `r${i}`, name: "read_file", input: { path: `f${i}.ts` } },
+        ],
+        stopReason: "tool_use",
+      });
+    }
+
+    await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("review my plan")],
+      workingDir: "/work",
+    });
+
+    // Bounded by ADVISOR_MAX_TOOL_ITERATIONS (12) + the initial call — never 31.
+    expect(sendMessageCalls.length).toBeLessThanOrEqual(13);
+  });
+
+  test("does not attach read_file or loop when no workingDir is set", async () => {
+    // Even if the model returns a tool_use, with no workingDir there is no
+    // read_file tool, so the consult stays a one-shot and doesn't loop.
+    responseText = "Just advice, no tools.";
+    const advice = await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+    });
+    expect(advice).toBe("Just advice, no tools.");
+    expect(sendMessageCalls).toHaveLength(1);
   });
 
   test("streams web-search activity to onText, not just the final advice", async () => {

--- a/assistant/src/plugins/defaults/advisor/__tests__/context-pack.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/context-pack.test.ts
@@ -26,6 +26,30 @@ describe("deriveRecallQuery", () => {
     ).toBeNull();
     expect(deriveRecallQuery([])).toBeNull();
   });
+
+  test("skips a trivial acknowledgement and recalls the substantive request", () => {
+    const query = deriveRecallQuery([
+      userMsg("refactor the auth worker pool to drain on shutdown"),
+      { role: "assistant", content: [{ type: "text", text: "here's a plan…" }] },
+      userMsg("go ahead"),
+    ]);
+    expect(query).toBe("refactor the auth worker pool to drain on shutdown");
+  });
+
+  test("treats punctuated/cased acknowledgements as trivial too", () => {
+    for (const ack of ["Go ahead!", "Yes.", "do it", "  ok  ", "👍"]) {
+      const query = deriveRecallQuery([
+        userMsg("design the streaming protocol"),
+        userMsg(ack),
+      ]);
+      expect(query).toBe("design the streaming protocol");
+    }
+  });
+
+  test("falls back to the latest user text when every turn is an acknowledgement", () => {
+    const query = deriveRecallQuery([userMsg("yes"), userMsg("go ahead")]);
+    expect(query).toBe("go ahead");
+  });
 });
 
 describe("buildAdvisorContext", () => {

--- a/assistant/src/plugins/defaults/advisor/consult.ts
+++ b/assistant/src/plugins/defaults/advisor/consult.ts
@@ -4,9 +4,14 @@
  * Routed entirely through the assistant's own inference: `getConfiguredProvider`
  * resolves the general-purpose `inference` call site (with the advisor profile
  * applied as an `overrideProfile`) to a provider/model/credentials from the
- * configured profiles — managed-proxy or BYOK, no separate API key. The consult
- * then runs a tool-less, capped one-shot completion through `provider.sendMessage`
- * and returns the text.
+ * configured profiles — managed-proxy or BYOK, no separate API key.
+ *
+ * The consult runs through `provider.sendMessage` and returns the advice text.
+ * It is a one-shot completion unless grounding tools are attached: `web_search`
+ * (when the provider runs search server-side) and `read_file` (when a working
+ * directory is known). `read_file` executes in the workspace, so the consult
+ * then runs a bounded read loop — capped on total reads and turns — feeding each
+ * file back to the advisor before it writes its guidance.
  */
 
 import { getConfig } from "../../../config/loader.js";
@@ -17,9 +22,11 @@ import {
   userMessage,
 } from "../../../providers/provider-send-message.js";
 import type {
+  ContentBlock,
   Message,
   ProviderEvent,
   ToolDefinition,
+  ToolUseContent,
 } from "../../../providers/types.js";
 import { ADVISOR_CONFIG } from "./config.js";
 import { advisorRequestText, buildAdvisorSystem } from "./steering.js";
@@ -51,6 +58,95 @@ const ADVISOR_WEB_SEARCH_TOOL: ToolDefinition = {
 };
 
 /**
+ * A client-side tool that lets the advisor read files in the agent's workspace,
+ * so it can verify the plan against the actual code instead of trusting the
+ * transcript's summary. Only attached when the consult resolves a `workingDir`.
+ *
+ * Unlike `web_search` (which the provider runs server-side, keeping the consult
+ * a one-shot), this tool executes in the daemon — so attaching it turns the
+ * consult into a bounded read loop (see `consultAdvisor`). Reads are confined to
+ * the working directory by `sandboxPolicy`, exactly like the agent's own
+ * `file_read` tool.
+ */
+const ADVISOR_READ_FILE_TOOL: ToolDefinition = {
+  name: "read_file",
+  description:
+    "Read the contents of a file in the agent's workspace to ground your guidance in the actual code rather than the transcript's summary. The path is relative to the agent's working directory (or absolute within it). Returns line-numbered text. Use `offset`/`limit` to page through a large file.",
+  input_schema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description:
+          "Path to the file, relative to the working directory or absolute within it.",
+      },
+      offset: {
+        type: "number",
+        description: "1-indexed line to start reading from (optional).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of lines to read (optional).",
+      },
+    },
+    required: ["path"],
+  },
+};
+
+/** Total file reads allowed across one consult. */
+const ADVISOR_MAX_FILE_READS = 10;
+/** Model turns that may request reads before the consult must conclude. */
+const ADVISOR_MAX_TOOL_ITERATIONS = 12;
+/** Per-read cap on the content fed back into the consult prompt. */
+const ADVISOR_FILE_READ_CHAR_CAP = 12_000;
+
+/**
+ * Execute one advisor `read_file` call against the workspace. Path safety and
+ * size limits are delegated to the same `sandboxPolicy` + `FileSystemOps` the
+ * agent's `file_read` tool uses, so the advisor can never read outside the
+ * working directory. Modules are pulled in via dynamic `import()` to avoid a
+ * static cycle between this bootstrap-loaded plugin and the tools layer (the
+ * same pattern `context-pack.ts` uses).
+ */
+async function readWorkspaceFileForAdvisor(
+  input: Record<string, unknown>,
+  workingDir: string,
+): Promise<{ content: string; isError: boolean; path: string }> {
+  const path = typeof input["path"] === "string" ? input["path"].trim() : "";
+  if (!path) {
+    return { content: "Error: path is required.", isError: true, path: "" };
+  }
+  try {
+    const [{ FileSystemOps }, { sandboxPolicy }] = await Promise.all([
+      import("../../../tools/shared/filesystem/file-ops-service.js"),
+      import("../../../tools/shared/filesystem/path-policy.js"),
+    ]);
+    const ops = new FileSystemOps((candidate, opts) =>
+      sandboxPolicy(candidate, workingDir, opts),
+    );
+    const result = ops.readFileSafe({
+      path,
+      offset: typeof input["offset"] === "number" ? input["offset"] : undefined,
+      limit: typeof input["limit"] === "number" ? input["limit"] : undefined,
+    });
+    if (!result.ok) {
+      const reason =
+        result.error.message ?? result.error.code ?? "could not read file";
+      return { content: `Error reading "${path}": ${reason}`, isError: true, path };
+    }
+    const { content } = result.value;
+    const capped =
+      content.length > ADVISOR_FILE_READ_CHAR_CAP
+        ? `${content.slice(0, ADVISOR_FILE_READ_CHAR_CAP)}\n…(truncated — pass offset/limit to read further)`
+        : content;
+    return { content: capped, isError: false, path };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { content: `Error reading "${path}": ${reason}`, isError: true, path };
+  }
+}
+
+/**
  * Resolve the routing override for the advisor consult. When the workspace has
  * set `llm.advisorProfile`, force it above the call-site layers so it is
  * authoritative; otherwise return `{}` so the `advisor` call site resolves to
@@ -76,6 +172,12 @@ export interface ConsultParams {
    * the agent can actually do. Omitted/null when nothing could be gathered.
    */
   runtimeContext?: string | null;
+  /**
+   * The agent's working directory. When provided, the consult attaches the
+   * `read_file` tool so the advisor can open and read workspace files to ground
+   * its guidance (path-confined to this directory). Omitted = no file access.
+   */
+  workingDir?: string;
   signal?: AbortSignal;
   /**
    * Optional sink for the advisor's live activity as it generates: incremental
@@ -168,18 +270,27 @@ export async function consultAdvisor(params: ConsultParams): Promise<string> {
 
   // Give the advisor live web access when — and only when — the resolved
   // provider runs search server-side (provider-native). Passing a `web_search`
-  // tool to a non-native provider would surface a client tool call this
-  // one-shot consult cannot execute, so we gate strictly on the capability and
-  // otherwise keep the consult tool-less.
+  // tool to a non-native provider would surface a client tool call this consult
+  // cannot execute, so gate strictly on the capability.
   const webEnabled = provider.supportsNativeWebSearch === true;
+  // Let the advisor read workspace files when a working directory is known.
+  const canReadFiles =
+    typeof params.workingDir === "string" && params.workingDir.length > 0;
+
+  const tools: ToolDefinition[] = [];
+  if (webEnabled) tools.push(ADVISOR_WEB_SEARCH_TOOL);
+  if (canReadFiles) tools.push(ADVISOR_READ_FILE_TOOL);
 
   const { onText } = params;
-  const response = await provider.sendMessage(messages, {
-    systemPrompt: buildAdvisorSystem(
-      params.systemPrompt,
-      params.runtimeContext,
-    ),
-    ...(webEnabled ? { tools: [ADVISOR_WEB_SEARCH_TOOL] } : {}),
+  // One deadline for the whole consult, shared across every turn of the read
+  // loop below so reads can't extend it past the configured timeout.
+  const consultSignal = withTimeout(params.signal, ADVISOR_CONFIG.timeoutMs);
+  const sendOptions = {
+    systemPrompt: buildAdvisorSystem(params.systemPrompt, params.runtimeContext, {
+      canReadFiles,
+      webSearch: webEnabled,
+    }),
+    ...(tools.length > 0 ? { tools } : {}),
     // Stream the consult's activity live (advice text, reasoning summary, and a
     // note per web search) so the drawer isn't blank while the advisor searches
     // and reasons before writing its guidance. See `advisorActivitySink`.
@@ -187,11 +298,69 @@ export async function consultAdvisor(params: ConsultParams): Promise<string> {
     config: {
       callSite: ADVISOR_CALL_SITE,
       ...override,
-      tool_choice: webEnabled ? { type: "auto" } : { type: "none" },
+      tool_choice: tools.length > 0 ? { type: "auto" } : { type: "none" },
     },
-    signal: withTimeout(params.signal, ADVISOR_CONFIG.timeoutMs),
-  });
+    signal: consultSignal,
+  };
 
-  const advice = extractAllText(response).trim();
+  // The consult is a one-shot completion unless `read_file` is attached. Web
+  // search resolves server-side and never pauses the turn, so a `tool_use` stop
+  // means the advisor wants to read a file: execute it in the workspace, feed
+  // the result back, and continue. The loop is bounded by total reads and turns
+  // so the consult stays fast. Advice text from every turn is accumulated (the
+  // model may write before reading), and the same text streams to the drawer.
+  const adviceParts: string[] = [];
+  let reads = 0;
+  let response = await provider.sendMessage(messages, sendOptions);
+
+  for (
+    let turn = 0;
+    response.stopReason === "tool_use" && turn < ADVISOR_MAX_TOOL_ITERATIONS;
+    turn++
+  ) {
+    const turnText = extractAllText(response).trim();
+    if (turnText) adviceParts.push(turnText);
+
+    const fileReads = response.content.filter(
+      (block): block is ToolUseContent =>
+        block.type === "tool_use" && block.name === "read_file",
+    );
+    if (fileReads.length === 0) break; // nothing client-side to satisfy
+
+    messages.push({ role: "assistant", content: response.content });
+    const toolResults: ContentBlock[] = [];
+    for (const call of fileReads) {
+      if (reads >= ADVISOR_MAX_FILE_READS || consultSignal.aborted) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: call.id,
+          content:
+            "Error: file-read budget for this consult is exhausted; give your guidance with what you have.",
+          is_error: true,
+        });
+        continue;
+      }
+      reads++;
+      const { content, isError, path } = await readWorkspaceFileForAdvisor(
+        call.input,
+        params.workingDir as string,
+      );
+      onText?.(isError ? `\n⚠️ Couldn't read ${path || "file"}\n` : `\n📄 Read ${path}\n`);
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: call.id,
+        content,
+        is_error: isError,
+      });
+    }
+    messages.push({ role: "user", content: toolResults });
+    if (consultSignal.aborted) break;
+    response = await provider.sendMessage(messages, sendOptions);
+  }
+
+  const finalText = extractAllText(response).trim();
+  if (finalText) adviceParts.push(finalText);
+
+  const advice = adviceParts.join("\n\n").trim();
   return advice.length > 0 ? advice : "(advisor returned no guidance)";
 }

--- a/assistant/src/plugins/defaults/advisor/context-pack.ts
+++ b/assistant/src/plugins/defaults/advisor/context-pack.ts
@@ -67,10 +67,42 @@ function summarize(description: string | undefined, max = 160): string {
   return truncate(firstSentence, max);
 }
 
-/** Pull the most recent user-authored text to seed the memory recall query. */
+/**
+ * Short acknowledgements that carry no recall signal. When the latest user turn
+ * is just "go ahead" / "yes" / "do it", keying the recall off it returns
+ * nothing useful — the advisor's actual subject is in the substantive request
+ * that preceded it. `deriveRecallQuery` skips these and recalls on the real ask.
+ */
+const TRIVIAL_ACKS: ReadonlySet<string> = new Set([
+  "yes", "yep", "yeah", "ya", "y", "ok", "okay", "k", "kk", "sure",
+  "sounds good", "go ahead", "go for it", "go", "do it", "do that",
+  "please do", "please", "proceed", "continue", "go on", "keep going",
+  "next", "makes sense", "agreed", "thanks", "thank you", "ty", "perfect",
+  "great", "nice", "cool", "awesome", "lgtm", "done", "right", "correct",
+  "exactly", "yes please", "that works", "works", "yup",
+]);
+
+/** Whether a user turn is a contentless acknowledgement with no recall signal. */
+function isTrivialAck(text: string): boolean {
+  const normalized = text
+    .trim()
+    .toLowerCase()
+    // Strip surrounding punctuation/symbols ("go ahead!", "yes." , "👍").
+    .replace(/^[\p{P}\p{S}\s]+|[\p{P}\p{S}\s]+$/gu, "");
+  return normalized.length === 0 || TRIVIAL_ACKS.has(normalized);
+}
+
+/**
+ * Seed the memory recall query from the transcript. Prefers the most recent
+ * *substantive* user message, skipping trivial acknowledgements ("go ahead",
+ * "yes") whose recall would be noise. Falls back to the most recent non-empty
+ * user text when every turn is an acknowledgement, so a query is still produced
+ * whenever the user has said anything.
+ */
 export function deriveRecallQuery(
   transcript: ReadonlyArray<Message>,
 ): string | null {
+  let fallback: string | null = null;
   for (let i = transcript.length - 1; i >= 0; i--) {
     const message = transcript[i];
     if (message.role !== "user") continue;
@@ -78,9 +110,11 @@ export function deriveRecallQuery(
       .map((block) => (block.type === "text" ? block.text : ""))
       .join(" ")
       .trim();
-    if (text.length > 0) return truncate(text, 500);
+    if (text.length === 0) continue;
+    if (fallback === null) fallback = truncate(text, 500);
+    if (!isTrivialAck(text)) return truncate(text, 500);
   }
-  return null;
+  return fallback;
 }
 
 /** `## Available tools` — the live tool set the agent can act with this turn. */

--- a/assistant/src/plugins/defaults/advisor/steering.ts
+++ b/assistant/src/plugins/defaults/advisor/steering.ts
@@ -39,9 +39,24 @@ export function stripSteering(systemPrompt: string | null): string | null {
  * project context, and recalled memory (see `buildAdvisorContext`) — so the
  * advisor can ground its recommendations in what the agent can actually do.
  */
+/**
+ * The tools the consult actually hands the advisor this turn. Each is gated on
+ * a runtime capability (`read_file` on a resolved workspace, `web_search` on a
+ * provider with native server-side search), so the system prompt must only
+ * advertise what's truly callable — otherwise the advisor is told it can do
+ * something the consult never attached.
+ */
+export interface AdvisorCapabilities {
+  /** The advisor may call `read_file` to read files in the agent's workspace. */
+  canReadFiles?: boolean;
+  /** The advisor may call `web_search` for current information. */
+  webSearch?: boolean;
+}
+
 export function buildAdvisorSystem(
   originalSystemPrompt: string | null,
   runtimeContext?: string | null,
+  capabilities?: AdvisorCapabilities,
 ): string {
   const base = `You are a senior advisor consulted by another AI agent working on a task — most often at the planning stage, before it starts building, but sometimes partway through. The entire conversation above is the agent's working context: its task or goal, every tool call it has made, and every result it has seen. The agent has paused to consult you because you bring a second, independent perspective it cannot get from inside its own reasoning loop. Your job is to maximize its odds of completing the task correctly and efficiently.
 
@@ -61,6 +76,22 @@ How to advise:
 
 Write as much as the guidance genuinely needs, and no more.`;
   let prompt = base;
+
+  const toolLines: string[] = [];
+  if (capabilities?.canReadFiles) {
+    toolLines.push(
+      "- `read_file`: open a file in the agent's workspace (path relative to its working directory) and read its line-numbered contents. Use it to check the agent's claims against the actual code and to inspect the specific files its plan hinges on — don't speculate about a file you can simply open.",
+    );
+  }
+  if (capabilities?.webSearch) {
+    toolLines.push(
+      "- `web_search`: search the web for current information. Reach for it when a decision turns on a time-sensitive or external fact you're unsure of, rather than assuming.",
+    );
+  }
+  if (toolLines.length > 0) {
+    prompt += `\n\nYou have tools for this consultation — use them to ground your advice in evidence before you give it, not after:\n${toolLines.join("\n")}`;
+  }
+
   if (originalSystemPrompt) {
     prompt += `\n\nFor context, the agent is operating under this system prompt:\n<agent_system_prompt>\n${originalSystemPrompt}\n</agent_system_prompt>`;
   }

--- a/assistant/src/plugins/defaults/advisor/tools/advisor.ts
+++ b/assistant/src/plugins/defaults/advisor/tools/advisor.ts
@@ -74,6 +74,8 @@ const advisorTool: ToolDefinition = {
         systemPrompt: capture?.systemPrompt ?? null,
         messages,
         runtimeContext,
+        // The advisor's `read_file` tool is path-confined to this directory.
+        workingDir: ctx.workingDir,
         signal: ctx.signal,
         // Stream the advisor's guidance live as it generates: each delta is
         // surfaced as a `tool_output_chunk` for this tool call and rendered in


### PR DESCRIPTION
## What

Two upgrades to what the advisor can do with its situational context.

### 1. The advisor can now read workspace files

Previously the advisor only received a *description* of the agent's environment (a top-level dir listing + open-doc titles) — it couldn't open a file. So it had to trust the transcript's summary of code it could otherwise inspect.

Now, when the consult resolves a `workingDir`, it attaches a client-side **`read_file`** tool and runs a **bounded read loop**:

- `web_search` still resolves **server-side** (one-shot, unchanged). A `tool_use` stop means the advisor wants to **read a file** — we execute it in the daemon, feed the contents back, and continue.
- Reads go through the **same `sandboxPolicy` + `FileSystemOps`** the agent's own `file_read` tool uses, so the advisor is **path-confined to the working directory** — it can't read outside the workspace. (Modules are pulled via dynamic `import()`, matching `context-pack.ts`, to avoid a static cycle.)
- **Bounded**: ≤10 reads, ≤12 model turns, 12k chars/read, all sharing the consult's existing deadline — so it can't run away or blow up the prompt.
- The advisor's **system prompt now advertises** `read_file` (and `web_search`) — closing the prior gap where it was handed tools it was never told it had — so it grounds advice in the actual code *before* writing it.

Read activity streams to the tool-output drawer (`📄 Read <path>`) via the existing `onOutput` pipeline.

### 2. Smarter recall query (Rec 1)

`deriveRecallQuery` keyed memory recall off the **last user message** — useless when that's a bare `"go ahead"` / `"yes"`. It now **skips trivial acknowledgements** and recalls on the most recent **substantive** user request, falling back to the latest non-empty turn so a query is still produced when every turn is an ack.

## Design note — why a loop, and why bounded

The consult is intentionally a one-shot completion; web search fit that because it's server-side. File reading is a **client-side** op, so it genuinely requires a tool-execution loop. I kept that loop tightly bounded (read/turn/char caps, shared deadline) so the advisor stays a *fast* second opinion rather than turning into an open-ended agent. The full design discussion (incl. why recall stayed a pre-fetch rather than a tool) is in the thread that led to this PR.

## Test

- `consult.test.ts` (20 pass): `read_file` is attached only with a `workingDir`; a requested file is read and fed back; read errors return an error tool-result and the consult still advises; the loop is **capped** against a model that requests reads forever; no `workingDir` ⇒ no tool, no loop.
- `context-pack.test.ts` (7 pass): recall skips punctuated/cased acknowledgements and recalls the substantive request; falls back when every turn is an ack.
- Lint + typecheck clean. (The advisor suite shows 4 failures *only* in a single-process full-dir run — a pre-existing cross-file `mock.module` isolation quirk, identical on `main`; every file passes in isolation as CI runs them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)