### PR TITLE
feat(onboarding): add formatCheckinTime helper for check-in confirmation copy

### DIFF
--- a/clients/web/src/domains/onboarding/format-checkin-time.test.ts
+++ b/clients/web/src/domains/onboarding/format-checkin-time.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Tests for formatCheckinTime, which turns the daemon's booked check-in start
+ * (ISO) + an optional timeZone into a short wall-clock time for confirmation
+ * copy. These pin the valid/empty/invalid contract and that a bad timeZone is
+ * tolerated rather than thrown.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { formatCheckinTime } from "@/domains/onboarding/format-checkin-time";
+
+describe("formatCheckinTime", () => {
+  test("formats a valid instant in the supplied timeZone as a short time", () => {
+    // 2024-01-15T19:30:00Z is 2:30 PM in America/New_York (EST, UTC-5).
+    const result = formatCheckinTime(
+      "2024-01-15T19:30:00Z",
+      "America/New_York",
+    );
+    expect(result).toMatch(/^\d{1,2}:\d{2}\s?(AM|PM)$/i);
+  });
+
+  test("returns null for empty/invalid input", () => {
+    expect(formatCheckinTime(undefined)).toBeNull();
+    expect(formatCheckinTime("")).toBeNull();
+    expect(formatCheckinTime("not-a-date")).toBeNull();
+  });
+
+  test("tolerates a bad timeZone and still returns a formatted string", () => {
+    const result = formatCheckinTime("2024-01-15T19:30:00Z", "Not/AZone");
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe("string");
+  });
+});

--- a/clients/web/src/domains/onboarding/format-checkin-time.ts
+++ b/clients/web/src/domains/onboarding/format-checkin-time.ts
@@ -1,0 +1,27 @@
+/**
+ * Format the booked check-in start (ISO string from the daemon's
+ * /onboarding/checkin response) into a short wall-clock time like "2:30 PM",
+ * rendered in the event's own timeZone when one is supplied. Returns null for
+ * an unparseable/empty input so callers can fall back to generic copy.
+ */
+export function formatCheckinTime(
+  startIso: string | undefined | null,
+  timeZone?: string | null,
+): string | null {
+  if (!startIso) return null;
+  const date = new Date(startIso);
+  if (Number.isNaN(date.getTime())) return null;
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      ...(timeZone ? { timeZone } : {}),
+    }).format(date);
+  } catch {
+    // Bad/unknown timeZone → format in the local zone rather than throw.
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(date);
+  }
+}


### PR DESCRIPTION
## Summary
- Add pure formatCheckinTime helper that turns the daemon's booked check-in start (ISO) + timeZone into a short wall-clock time like "2:30 PM", returning null for empty/invalid input.
- Unit tests cover valid input, empty/invalid input, and a bad timeZone.

Part of plan: checkin-scheduled-time-copy.md (PR 1 of 4)