### PR TITLE
feat(onboarding): show booked check-in time on the confirmation step

### DIFF
--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -4,7 +4,7 @@
  * SPIKE — research-onboarding flow.
  *
  * These render the visual sequence that follows the calendar step:
- *   - MeetingCreatedStep   a brief "Meeting Created!" confirmation
+ *   - MeetingCreatedStep   a brief "Check-in scheduled…" confirmation
  *   - LookingYouUpStep     a loading carousel ("looking you up")
  *   - ResearchResultsStep  the editable "Alright, this is what I got:" claims
  *   - SuggestionsStep      tappable suggestions that open a new chat
@@ -75,22 +75,29 @@ const MINI = 48;
  * Reverse of the Introduction grow-in. The toned backdrop (behind) blends to
  * black and hides its bottom eyes; here the eyes lead — shrinking and rising
  * up out of the bottom (the opposite of growing + sinking) — and the body
- * follows a beat later, shrinking into a small avatar beside the "Meeting
- * Created!" text. The edge characters stay (they live in the backdrop).
+ * follows a beat later, shrinking into a small avatar beside the "Check-in
+ * scheduled…" text. The edge characters stay (they live in the backdrop).
  */
 export function MeetingCreatedStep({
   onDone,
   onBack,
   onForward,
+  scheduledTime,
 }: {
   onDone: () => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /** Pre-formatted wall-clock time (e.g. "2:30 PM"); generic copy when absent. */
+  scheduledTime?: string;
 }) {
   const { components, chosen } = useChosenAvatar();
   const reduce = useReducedMotion();
   const { w, h } = useViewportSize();
+
+  const title = scheduledTime
+    ? `Check-in scheduled for tomorrow at ${scheduledTime}!`
+    : "Check-in scheduled!";
 
   useEffect(() => {
     const t = setTimeout(onDone, 2600);
@@ -144,13 +151,13 @@ export function MeetingCreatedStep({
           )}
         </div>
         <motion.span
-          className="whitespace-nowrap text-[2.6rem] leading-none"
+          className="max-w-[60vw] text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}
           initial={reduce ? false : { opacity: 0, x: -8 }}
           animate={{ opacity: 1, x: 0 }}
           transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 0.9 }}
         >
-          Meeting Created!
+          {title}
         </motion.span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- MeetingCreatedStep takes an optional scheduledTime prop and renders "Check-in scheduled for tomorrow at {time}!" when present, falling back to "Check-in scheduled!".
- Replaces the hardcoded "Meeting Created!" copy; lets the longer serif title wrap instead of overflowing.

Part of plan: checkin-scheduled-time-copy.md (PR 3 of 4)