### PR TITLE
feat(onboarding): surface booked start time from scheduleCheckin

### DIFF
--- a/clients/web/src/domains/onboarding/checkin-scheduler.test.ts
+++ b/clients/web/src/domains/onboarding/checkin-scheduler.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for scheduleCheckin's result contract: it must surface the daemon's
+ * booked start time + timeZone on a real booking, and collapse every failure
+ * mode (not scheduled, response not ok, thrown SDK call) to `{ scheduled: false }`
+ * with no start/timeZone.
+ *
+ * NOTE: `bun mock.module` can leak across files — run this file singly:
+ *   bun test src/domains/onboarding/checkin-scheduler.test.ts
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+interface CheckinCall {
+  path: { assistant_id: string };
+  body: {
+    userName?: string;
+    assistantName?: string;
+    timezone?: string;
+  };
+  throwOnError: false;
+}
+
+let calls: CheckinCall[] = [];
+let responseOk = true;
+let responseStatus = 200;
+let scheduled = true;
+let start: string | undefined = "2026-06-25T16:00:00-07:00";
+let timeZone: string | undefined = "America/Los_Angeles";
+let shouldThrow = false;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  onboardingCheckinPost: (opts: CheckinCall) => {
+    calls.push(opts);
+    if (shouldThrow) {
+      return Promise.reject(new Error("network blew up"));
+    }
+    return Promise.resolve({
+      data: responseOk ? { scheduled, start, timeZone } : undefined,
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
+}));
+
+const { scheduleCheckin } = await import("./checkin-scheduler");
+
+afterEach(() => {
+  calls = [];
+  responseOk = true;
+  responseStatus = 200;
+  scheduled = true;
+  start = "2026-06-25T16:00:00-07:00";
+  timeZone = "America/Los_Angeles";
+  shouldThrow = false;
+});
+
+describe("scheduleCheckin", () => {
+  test("returns the booked start + timeZone on a successful booking", async () => {
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({
+      scheduled: true,
+      start: "2026-06-25T16:00:00-07:00",
+      timeZone: "America/Los_Angeles",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toEqual({ assistant_id: "a1" });
+  });
+
+  test("returns { scheduled: false } with no start when the daemon did not book", async () => {
+    scheduled = false;
+
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({ scheduled: false });
+    expect(result.start).toBeUndefined();
+    expect(result.timeZone).toBeUndefined();
+  });
+
+  test("returns { scheduled: false } when the response is not ok", async () => {
+    responseOk = false;
+    responseStatus = 500;
+
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({ scheduled: false });
+  });
+
+  test("swallows a thrown SDK call and returns { scheduled: false }", async () => {
+    shouldThrow = true;
+
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({ scheduled: false });
+  });
+});

--- a/clients/web/src/domains/onboarding/checkin-scheduler.ts
+++ b/clients/web/src/domains/onboarding/checkin-scheduler.ts
@@ -10,8 +10,9 @@
  *
  * Best-effort and fire-and-forget: a failure here must not block the
  * onboarding handoff, so every error is swallowed and surfaced only via the
- * returned boolean. The endpoint itself returns `scheduled: false` (not an
- * error) when no calendar is connected or the calendar scope wasn't granted.
+ * returned result's `scheduled` flag. The endpoint itself returns
+ * `scheduled: false` (not an error) when no calendar is connected or the
+ * calendar scope wasn't granted.
  */
 
 import { onboardingCheckinPost } from "@/generated/daemon/sdk.gen";
@@ -22,16 +23,27 @@ export interface ScheduleCheckinOptions {
   assistantName?: string;
 }
 
+export interface CheckinScheduleResult {
+  /** True only when the daemon actually booked an event. */
+  scheduled: boolean;
+  /** ISO start of the booked event (present only when scheduled). */
+  start?: string;
+  /** IANA timeZone the event was booked in (present only when scheduled). */
+  timeZone?: string;
+}
+
 /**
- * Book the Day 2 Check-in event. Returns `true` when an event was created,
- * `false` otherwise (no calendar connected, scope not granted, or any error —
- * all treated identically as "best-effort, carry on").
+ * Book the Day 2 Check-in event. Resolves to `{ scheduled: true, start,
+ * timeZone }` when an event was created, surfacing the daemon's booked start
+ * time and timeZone. Resolves to `{ scheduled: false }` otherwise (no calendar
+ * connected, scope not granted, or any error — all treated identically as
+ * "best-effort, carry on"); `start`/`timeZone` are only set on a real booking.
  */
 export async function scheduleCheckin({
   assistantId,
   userName,
   assistantName,
-}: ScheduleCheckinOptions): Promise<boolean> {
+}: ScheduleCheckinOptions): Promise<CheckinScheduleResult> {
   try {
     // Carry the browser timezone so "tomorrow" and the 12pm–5pm window resolve
     // to the user's local clock when the daemon books the slot. The daemon
@@ -53,8 +65,15 @@ export async function scheduleCheckin({
       throwOnError: false,
     });
 
-    return result.response?.ok === true && result.data?.scheduled === true;
+    const ok =
+      result.response?.ok === true && result.data?.scheduled === true;
+    if (!ok) return { scheduled: false };
+    return {
+      scheduled: true,
+      start: result.data?.start,
+      timeZone: result.data?.timeZone,
+    };
   } catch {
-    return false;
+    return { scheduled: false };
   }
 }


### PR DESCRIPTION
## Summary
- scheduleCheckin now resolves to a CheckinScheduleResult ({ scheduled, start?, timeZone? }) instead of a bare boolean, surfacing the daemon's booked event start + timeZone.
- start/timeZone are only populated on a real booking; failures and exceptions return { scheduled: false }.
- Adds tests covering success, not-scheduled, and thrown SDK paths.

Part of plan: checkin-scheduled-time-copy.md (PR 2 of 4)