### PR TITLE
fix(surfaces): restore actor resolution clobbered by v0.10.2 release merge

### DIFF
--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -33,8 +33,10 @@ const fakeProvider = {
 // Mock @vellumai/plugin-api — only the runtime handles the plugin imports.
 // `extractAllText` stays real (imported from the relative path, not plugin-api).
 mock.module("@vellumai/plugin-api", () => ({
-  doesSupportVision: (profile: ModelProfileInfo) =>
-    visionProfiles.has(profile.key),
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModels.has(arg)
+      : visionProfiles.has(arg.key),
   getModelProfiles: () => mockProfiles,
   getConfiguredProvider: async () => (providerResolves ? fakeProvider : null),
 }));
@@ -358,9 +360,10 @@ describe("image-fallback post-tool-use hook", () => {
     );
   });
 
-  test("is a no-op when the active model supports vision", async () => {
-    visionProfiles = new Set(["text-only"]); // active profile supports vision
+  test("is a no-op when the model that ran supports vision", async () => {
+    visionModels = new Set(["vision-model"]);
     const ctx = makeToolCtx({
+      model: "vision-model",
       toolResponse: toolResult([imageBlock("shot1")]),
     });
     await postToolUse(ctx);
@@ -409,5 +412,30 @@ describe("image-fallback post-tool-use hook", () => {
     await postToolUse(ctx);
     const text = (ctx.toolResponse.contentBlocks![0] as { text: string }).text;
     expect(text).not.toContain("saved to");
+  });
+
+  test("is a no-op when contentBlocks carry no image", async () => {
+    const textBlock = { type: "text" as const, text: "just text" };
+    const ctx = makeToolCtx({ toolResponse: toolResult([textBlock]) });
+    await postToolUse(ctx);
+    expect(ctx.toolResponse.contentBlocks![0]).toEqual(textBlock);
+  });
+
+  test("gates on ctx.model, not the workspace active profile", async () => {
+    // The active profile is vision-capable, but the model that actually ran
+    // (ctx.model) is text-only — the model that ran must win, so the image is
+    // captioned.
+    mockProfiles = [
+      profile("vision-active", { isActive: true }),
+      profile("vision-profile", {}),
+    ];
+    visionProfiles = new Set(["vision-active", "vision-profile"]);
+    visionModels = new Set<string>(); // "text-only-model" is text-only
+    const ctx = makeToolCtx({
+      model: "text-only-model",
+      toolResponse: toolResult([imageBlock("shot1")]),
+    });
+    await postToolUse(ctx);
+    expect(ctx.toolResponse.contentBlocks![0].type).toBe("text");
   });
 });

--- a/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
@@ -1,5 +1,5 @@
 /**
- * Default `post-tool-use` hook: when the active model is text-only, captions
+ * Default `post-tool-use` hook: when the turn's model is text-only, captions
  * the image blocks a tool returns (e.g. a `browser_screenshot`) and
  * substitutes the caption as a text block so the result stays sendable to a
  * provider that would otherwise reject the raw image.
@@ -9,15 +9,14 @@
  * rather than the top-level message content the `user-prompt-submit` hook
  * handles. Both share {@link captionImageBlocks}.
  *
- * The active model is resolved from the workspace's active profile — the
- * post-tool-use context carries the running model, and the active profile is
- * what the loop is executing this turn. If that profile supports vision, the
- * hook is a no-op and the image reaches the model untouched.
+ * Capability is read straight off `ctx.model` — the provider-reported model id
+ * for the turn that issued this tool call — so the decision tracks the model
+ * that actually ran, including a text-only override. The substitution is in
+ * place, so the persisted/displayed tool result carries the caption too.
  */
 
 import {
   doesSupportVision,
-  getModelProfiles,
   type PluginHookFn,
   type PostToolUseContext,
 } from "@vellumai/plugin-api";
@@ -26,13 +25,13 @@ import { captionImageBlocks } from "../src/caption-blocks.js";
 import { findVisionProfile } from "../src/vision-caption.js";
 
 const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+  // Cheapest gate first: bail unless the tool actually returned an image,
+  // before touching the model catalog or resolving a vision profile.
   const blocks = ctx.toolResponse.contentBlocks;
-  if (blocks == null || blocks.length === 0) return;
+  if (blocks == null || !blocks.some((b) => b.type === "image")) return;
 
-  // If the active model already supports vision, leave the image in place.
-  const activeProfile = getModelProfiles().find((p) => p.isActive);
-  if (activeProfile == null) return;
-  if (doesSupportVision(activeProfile)) return;
+  // If the model that ran already supports vision, leave the image in place.
+  if (doesSupportVision(ctx.model)) return;
 
   // Find a vision-capable profile for captioning.
   const visionProfileKey = findVisionProfile();

--- a/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
@@ -14,7 +14,7 @@
  * 2. Finds a vision-capable profile for captioning via `findVisionProfile`.
  *    If none exists, images are replaced with a fail-open placeholder so the
  *    model at least knows an image was present.
- * 3. Replaces each `ImageContent` block with a `[Image …]` text caption via
+ * 3. Replaces each image block with a `[Image …]` text caption via
  *    {@link captionImageBlocks} (which also persists the original and caches
  *    captions across turns).
  *
@@ -23,13 +23,14 @@
  */
 
 import {
-  doesSupportVision,
-  getModelProfiles,
   type PluginHookFn,
   type UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
-import { captionImageBlocks } from "../src/caption-blocks.js";
+import {
+  captionImageBlocks,
+  needsImageFallback,
+} from "../src/caption-blocks.js";
 import { findVisionProfile } from "../src/vision-caption.js";
 
 const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -1,30 +1,61 @@
 /**
  * Shared image→text substitution for the image-fallback plugin's hooks.
  *
- * Two hooks replace `image` content blocks with a text caption when the active
+ * Two hooks replace `image` content blocks with a text caption when the turn's
  * model can't process images: `user-prompt-submit` handles user-attached
  * images, and `post-tool-use` handles images a tool returns (e.g. a browser
- * screenshot). This module holds the per-block substitution they share —
- * persist the original image to a known location, caption it via a
- * vision-capable profile, and swap in a `[Image …]` text block.
+ * screenshot). This module holds what they share — deciding whether a profile
+ * needs the fallback ({@link needsImageFallback}) and the per-block
+ * substitution ({@link captionImageBlocks}): persist the original image to a
+ * known location, caption it via a vision-capable profile, and swap in a
+ * `[Image …]` text block.
  *
- * The caption text states up front that the active model can't view images and
- * the image was auto-described to text, so the model treats the block as a
- * derived description rather than a verbatim transcript.
+ * The substitution mutates the blocks in place, so the caption replaces the
+ * image everywhere the block is referenced (the provider-bound history and the
+ * persisted/displayed copy alike) — a text-only turn does not keep the raw
+ * image around.
+ *
+ * The caption text states up front that the model can't view images and the
+ * image was auto-described to text, so the model treats the block as a derived
+ * description rather than a verbatim transcript.
  *
  * Fail-open is the dominant error mode: a captioning failure leaves a
  * placeholder text block rather than the raw image (which a text-only provider
  * would reject) or nothing (which would lose information).
  */
 
-import type {
-  ContentBlock,
-  ImageContent,
-  PluginLogger,
+import {
+  type ContentBlock,
+  doesSupportVision,
+  getModelProfiles,
+  type ImageContent,
+  type PluginLogger,
 } from "@vellumai/plugin-api";
 
 import { persistImage } from "./image-persist.js";
 import { captionImage } from "./vision-caption.js";
+
+/**
+ * Whether the profile a turn runs needs image→text fallback (i.e. it can't
+ * process images itself).
+ *
+ * Used by `user-prompt-submit`, whose context carries the profile key rather
+ * than the resolved model id: prefer the turn's `modelProfileKey` — which
+ * carries a text-only override even when the workspace's active profile is
+ * vision-capable — and fall back to the active profile only when the key is
+ * `null` (profile unchanged since the last notified turn). Returns `false` when
+ * no profile resolves or the resolved model already supports vision, in which
+ * case the image reaches the model untouched.
+ */
+export function needsImageFallback(modelProfileKey: string | null): boolean {
+  const profiles = getModelProfiles();
+  const activeProfile =
+    modelProfileKey != null
+      ? profiles.find((p) => p.key === modelProfileKey)
+      : profiles.find((p) => p.isActive);
+  if (activeProfile == null) return false;
+  return !doesSupportVision(activeProfile);
+}
 
 /**
  * Replace every `image` block in `blocks` (in place) with a text caption so a

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -429,7 +429,7 @@ export async function selectPool(
     try {
       response = await provider.sendMessage([userMsg], {
         tools: [SELECT_PAGES_TOOL],
-        systemPrompt: SYSTEM_PROMPT,
+        systemPrompt,
         config: {
           callSite: MEMORY_V3_SELECT_CALL_SITE,
           tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -386,6 +386,30 @@ describe("triggerSurfaceAction handler", () => {
     ]);
   });
 
+  test("resolves dev-bypass to the guardian principal before threading the turn", async () => {
+    httpAuthDisabled = true;
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-dev-thread");
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-dt", actionId: "act-dt" },
+      headers: { "x-vellum-actor-principal-id": "dev-bypass" },
+    });
+
+    // dev-bypass is translated so the surface turn matches the SSE host-proxy
+    // client's registered guardian principal (CU/app-control same-actor check).
+    expect(live.surfaceActionCalls).toEqual([
+      {
+        surfaceId: "surf-dt",
+        actionId: "act-dt",
+        data: undefined,
+        sourceActorPrincipalId: GUARDIAN_PRINCIPAL,
+      },
+    ]);
+  });
+
   test("propagates accepted=false rejection as BadRequestError", async () => {
     const live = makeStub("conv-reject");
     live.handleSurfaceActionResult = {

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -14,11 +14,7 @@ import type { TrustContext } from "../../daemon/trust-context.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
-import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
-import {
-  resolveActorPrincipalIdForLocalGuardian,
-  resolveLocalTrustContext,
-} from "../local-actor-identity.js";
+import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
 import {
   findLocalGuardianPrincipalId,
   resolveActorPrincipalIdForLocalGuardian,
@@ -180,12 +176,6 @@ async function handleSurfaceAction({
 
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
   await applyTrustContext(conversation, actorPrincipalId);
-
-  // Translate dev-bypass → real guardian so the surface turn's principal matches
-  // the SSE host-proxy client's registered principal; otherwise CU/app-control
-  // same-actor checks reject the turn. Real principals pass through unchanged.
-  const resolvedActorPrincipalId =
-    await resolveActorPrincipalIdForLocalGuardian(actorPrincipalId ?? undefined);
 
   // Translate dev-bypass → real guardian so the surface turn's principal matches
   // the SSE host-proxy client's registered principal; otherwise CU/app-control


### PR DESCRIPTION
## Summary
The v0.10.2 release merge (#35927) botched its conflict resolution and re-clobbered three areas back to broken states — including re-introducing a regression #35872 had already fixed. This restores all affected files to their last-good pre-merge state (commit `0f6f65b8`). For every file, the **only** commit touching it since `0f6f65b8` is the v0.10.2 merge, so each change is a clean revert of the re-clobber and nothing else.

- **Surface-action actor resolution (the original ask):** `surface-action-routes.ts` had the dev-bypass actor-resolution change double-applied (duplicate `resolvedActorPrincipalId` const) and its imports corrupted — `reResolveTrustOnResetDrift` (still called) left unimported, `resolveActorPrincipalIdForLocalGuardian` imported twice (duplicate identifier). The merge also deleted the `"resolves dev-bypass to the guardian principal before threading the turn"` test. Both restored.
- **image-fallback plugin (lint + type breakage on main):** the merge reverted the plugin to its pre-#35872 state, leaving `needsImageFallback` used but no longer exported/imported (TS2304) and dead `doesSupportVision`/`getModelProfiles` imports (eslint). Restored `caption-blocks.ts`, both hooks, and the test.
- **memory-v3 pool selector:** `selectPool`'s documented `systemPrompt` override param was hardcoded back to `SYSTEM_PROMPT`, leaving it unused (eslint). Re-threaded.

## Original prompt
The v0.10.2 release merge appeared to undo work on `main`, specifically in `assistant/src/runtime/routes/surface-action-routes.ts` and the surrounding actor-resolution logic — the ask was to get back to the behavior previously on `main`. Investigation traced it to a bad conflict resolution; while fixing it, CI surfaced that the same merge also re-broke `main`'s lint and typecheck in the image-fallback plugin and the memory-v3 selector (re-clobbering #35872), so those restores are bundled in to get main green again.
