### PR TITLE
feat(onboarding): "Check-in scheduled for tomorrow at {time}!" confirmation

### DIFF
--- a/clients/web/src/domains/onboarding/checkin-scheduler.test.ts
+++ b/clients/web/src/domains/onboarding/checkin-scheduler.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for scheduleCheckin's result contract: it must surface the daemon's
+ * booked start time + timeZone on a real booking, and collapse every failure
+ * mode (not scheduled, response not ok, thrown SDK call) to `{ scheduled: false }`
+ * with no start/timeZone.
+ *
+ * NOTE: `bun mock.module` can leak across files — run this file singly:
+ *   bun test src/domains/onboarding/checkin-scheduler.test.ts
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+interface CheckinCall {
+  path: { assistant_id: string };
+  body: {
+    userName?: string;
+    assistantName?: string;
+    timezone?: string;
+  };
+  throwOnError: false;
+}
+
+let calls: CheckinCall[] = [];
+let responseOk = true;
+let responseStatus = 200;
+let scheduled = true;
+let start: string | undefined = "2026-06-25T16:00:00-07:00";
+let timeZone: string | undefined = "America/Los_Angeles";
+let shouldThrow = false;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  onboardingCheckinPost: (opts: CheckinCall) => {
+    calls.push(opts);
+    if (shouldThrow) {
+      return Promise.reject(new Error("network blew up"));
+    }
+    return Promise.resolve({
+      data: responseOk ? { scheduled, start, timeZone } : undefined,
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
+}));
+
+const { scheduleCheckin } = await import("./checkin-scheduler");
+
+afterEach(() => {
+  calls = [];
+  responseOk = true;
+  responseStatus = 200;
+  scheduled = true;
+  start = "2026-06-25T16:00:00-07:00";
+  timeZone = "America/Los_Angeles";
+  shouldThrow = false;
+});
+
+describe("scheduleCheckin", () => {
+  test("returns the booked start + timeZone on a successful booking", async () => {
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({
+      scheduled: true,
+      start: "2026-06-25T16:00:00-07:00",
+      timeZone: "America/Los_Angeles",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toEqual({ assistant_id: "a1" });
+  });
+
+  test("returns { scheduled: false } with no start when the daemon did not book", async () => {
+    scheduled = false;
+
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({ scheduled: false });
+    expect(result.start).toBeUndefined();
+    expect(result.timeZone).toBeUndefined();
+  });
+
+  test("returns { scheduled: false } when the response is not ok", async () => {
+    responseOk = false;
+    responseStatus = 500;
+
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({ scheduled: false });
+  });
+
+  test("swallows a thrown SDK call and returns { scheduled: false }", async () => {
+    shouldThrow = true;
+
+    const result = await scheduleCheckin({ assistantId: "a1" });
+
+    expect(result).toEqual({ scheduled: false });
+  });
+});

--- a/clients/web/src/domains/onboarding/checkin-scheduler.ts
+++ b/clients/web/src/domains/onboarding/checkin-scheduler.ts
@@ -10,8 +10,9 @@
  *
  * Best-effort and fire-and-forget: a failure here must not block the
  * onboarding handoff, so every error is swallowed and surfaced only via the
- * returned boolean. The endpoint itself returns `scheduled: false` (not an
- * error) when no calendar is connected or the calendar scope wasn't granted.
+ * returned result's `scheduled` flag. The endpoint itself returns
+ * `scheduled: false` (not an error) when no calendar is connected or the
+ * calendar scope wasn't granted.
  */
 
 import { onboardingCheckinPost } from "@/generated/daemon/sdk.gen";
@@ -22,16 +23,27 @@ export interface ScheduleCheckinOptions {
   assistantName?: string;
 }
 
+export interface CheckinScheduleResult {
+  /** True only when the daemon actually booked an event. */
+  scheduled: boolean;
+  /** ISO start of the booked event (present only when scheduled). */
+  start?: string;
+  /** IANA timeZone the event was booked in (present only when scheduled). */
+  timeZone?: string;
+}
+
 /**
- * Book the Day 2 Check-in event. Returns `true` when an event was created,
- * `false` otherwise (no calendar connected, scope not granted, or any error —
- * all treated identically as "best-effort, carry on").
+ * Book the Day 2 Check-in event. Resolves to `{ scheduled: true, start,
+ * timeZone }` when an event was created, surfacing the daemon's booked start
+ * time and timeZone. Resolves to `{ scheduled: false }` otherwise (no calendar
+ * connected, scope not granted, or any error — all treated identically as
+ * "best-effort, carry on"); `start`/`timeZone` are only set on a real booking.
  */
 export async function scheduleCheckin({
   assistantId,
   userName,
   assistantName,
-}: ScheduleCheckinOptions): Promise<boolean> {
+}: ScheduleCheckinOptions): Promise<CheckinScheduleResult> {
   try {
     // Carry the browser timezone so "tomorrow" and the 12pm–5pm window resolve
     // to the user's local clock when the daemon books the slot. The daemon
@@ -53,8 +65,15 @@ export async function scheduleCheckin({
       throwOnError: false,
     });
 
-    return result.response?.ok === true && result.data?.scheduled === true;
+    const ok =
+      result.response?.ok === true && result.data?.scheduled === true;
+    if (!ok) return { scheduled: false };
+    return {
+      scheduled: true,
+      start: result.data?.start,
+      timeZone: result.data?.timeZone,
+    };
   } catch {
-    return false;
+    return { scheduled: false };
   }
 }

--- a/clients/web/src/domains/onboarding/format-checkin-time.test.ts
+++ b/clients/web/src/domains/onboarding/format-checkin-time.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Tests for formatCheckinTime, which turns the daemon's booked check-in start
+ * (ISO) + an optional timeZone into a short wall-clock time for confirmation
+ * copy. These pin the valid/empty/invalid contract and that a bad timeZone is
+ * tolerated rather than thrown.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { formatCheckinTime } from "@/domains/onboarding/format-checkin-time";
+
+describe("formatCheckinTime", () => {
+  test("formats a valid instant in the supplied timeZone as a short time", () => {
+    // 2024-01-15T19:30:00Z is 2:30 PM in America/New_York (EST, UTC-5).
+    const result = formatCheckinTime(
+      "2024-01-15T19:30:00Z",
+      "America/New_York",
+    );
+    expect(result).toMatch(/^\d{1,2}:\d{2}\s?(AM|PM)$/i);
+  });
+
+  test("returns null for empty/invalid input", () => {
+    expect(formatCheckinTime(undefined)).toBeNull();
+    expect(formatCheckinTime("")).toBeNull();
+    expect(formatCheckinTime("not-a-date")).toBeNull();
+  });
+
+  test("tolerates a bad timeZone and still returns a formatted string", () => {
+    const result = formatCheckinTime("2024-01-15T19:30:00Z", "Not/AZone");
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe("string");
+  });
+});

--- a/clients/web/src/domains/onboarding/format-checkin-time.ts
+++ b/clients/web/src/domains/onboarding/format-checkin-time.ts
@@ -1,0 +1,27 @@
+/**
+ * Format the booked check-in start (ISO string from the daemon's
+ * /onboarding/checkin response) into a short wall-clock time like "2:30 PM",
+ * rendered in the event's own timeZone when one is supplied. Returns null for
+ * an unparseable/empty input so callers can fall back to generic copy.
+ */
+export function formatCheckinTime(
+  startIso: string | undefined | null,
+  timeZone?: string | null,
+): string | null {
+  if (!startIso) return null;
+  const date = new Date(startIso);
+  if (Number.isNaN(date.getTime())) return null;
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      ...(timeZone ? { timeZone } : {}),
+    }).format(date);
+  } catch {
+    // Bad/unknown timeZone → format in the local zone rather than throw.
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(date);
+  }
+}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -33,6 +33,7 @@ import { buildResearchPrompt } from "@/domains/onboarding/research-prompt";
 import { useBackgroundHatch } from "@/domains/onboarding/use-background-hatch";
 import { useResearchRunner } from "@/domains/onboarding/research-runner";
 import { scheduleCheckin } from "@/domains/onboarding/checkin-scheduler";
+import { formatCheckinTime } from "@/domains/onboarding/format-checkin-time";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import {
   ResearchOnboardingScreen,
@@ -116,6 +117,9 @@ export function ResearchOnboardingRoute() {
     null,
   );
   const [faceValues, setFaceValues] = useState<GiveMeAFaceValues | null>(null);
+  // Formatted booked check-in time ("2:30 PM"), set when scheduleCheckin lands;
+  // null until then (or if booking failed) → confirmation shows generic copy.
+  const [checkinTime, setCheckinTime] = useState<string | null>(null);
   // Bumped by the integration step's coin to jolt the bottom eyes.
   const [eyesBump, setEyesBump] = useState(0);
   // Extra edge characters revealed so far — grows as the looking-you-up
@@ -256,10 +260,15 @@ export function ResearchOnboardingRoute() {
       const fullName = [formValues.firstName.trim(), formValues.lastName.trim()]
         .filter(Boolean)
         .join(" ");
+      setCheckinTime(null);
       void scheduleCheckin({
         assistantId: hatchedAssistantId,
         userName: fullName || undefined,
         assistantName: faceValues?.name?.trim() || undefined,
+      }).then((result) => {
+        if (result.scheduled) {
+          setCheckinTime(formatCheckinTime(result.start, result.timeZone));
+        }
       });
     }
     goForwardTo("meeting");
@@ -336,6 +345,7 @@ export function ResearchOnboardingRoute() {
         )}
         {step === "meeting" && (
           <MeetingCreatedStep
+            scheduledTime={checkinTime ?? undefined}
             onDone={() => goForwardTo("looking")}
             onBack={() => goBackTo("letschat")}
             onForward={onForward}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -120,6 +120,9 @@ export function ResearchOnboardingRoute() {
   // Formatted booked check-in time ("2:30 PM"), set when scheduleCheckin lands;
   // null until then (or if booking failed) → confirmation shows generic copy.
   const [checkinTime, setCheckinTime] = useState<string | null>(null);
+  // True while the booking request is in flight, so the confirmation step can
+  // hold (capped) until the booked time is known instead of advancing early.
+  const [checkinPending, setCheckinPending] = useState(false);
   // Bumped by the integration step's coin to jolt the bottom eyes.
   const [eyesBump, setEyesBump] = useState(0);
   // Extra edge characters revealed so far — grows as the looking-you-up
@@ -261,15 +264,18 @@ export function ResearchOnboardingRoute() {
         .filter(Boolean)
         .join(" ");
       setCheckinTime(null);
+      setCheckinPending(true);
       void scheduleCheckin({
         assistantId: hatchedAssistantId,
         userName: fullName || undefined,
         assistantName: faceValues?.name?.trim() || undefined,
-      }).then((result) => {
-        if (result.scheduled) {
-          setCheckinTime(formatCheckinTime(result.start, result.timeZone));
-        }
-      });
+      })
+        .then((result) => {
+          if (result.scheduled) {
+            setCheckinTime(formatCheckinTime(result.start, result.timeZone));
+          }
+        })
+        .finally(() => setCheckinPending(false));
     }
     goForwardTo("meeting");
   }
@@ -346,6 +352,7 @@ export function ResearchOnboardingRoute() {
         {step === "meeting" && (
           <MeetingCreatedStep
             scheduledTime={checkinTime ?? undefined}
+            awaitingTime={checkinPending}
             onDone={() => goForwardTo("looking")}
             onBack={() => goBackTo("letschat")}
             onForward={onForward}

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -71,6 +71,11 @@ export function MiniAssistant({ size = 48 }: { size?: number }) {
 
 const MINI = 48;
 
+// The confirmation animation runs ~2.6s; that's the minimum on-screen time.
+const MEETING_MIN_MS = 2600;
+// Cap how long we hold for a slow-but-pending booking before advancing anyway.
+const MEETING_MAX_MS = 6000;
+
 /**
  * Reverse of the Introduction grow-in. The toned backdrop (behind) blends to
  * black and hides its bottom eyes; here the eyes lead — shrinking and rising
@@ -83,6 +88,7 @@ export function MeetingCreatedStep({
   onBack,
   onForward,
   scheduledTime,
+  awaitingTime,
 }: {
   onDone: () => void;
   onBack: () => void;
@@ -90,6 +96,8 @@ export function MeetingCreatedStep({
   onForward?: () => void;
   /** Pre-formatted wall-clock time (e.g. "2:30 PM"); generic copy when absent. */
   scheduledTime?: string;
+  /** True while the check-in booking is still in flight; holds the step (capped) so a slow-but-successful booking can still reveal the time. */
+  awaitingTime?: boolean;
 }) {
   const { components, chosen } = useChosenAvatar();
   const reduce = useReducedMotion();
@@ -99,10 +107,17 @@ export function MeetingCreatedStep({
     ? `Check-in scheduled for tomorrow at ${scheduledTime}!`
     : "Check-in scheduled!";
 
+  // Hold the step long enough to reveal the booked time. While a booking is
+  // still in flight and we don't yet have the time, wait up to the cap; once
+  // the time lands (or the booking settles, or we were never waiting) advance
+  // after the normal minimum. The effect re-runs when those inputs change, so
+  // the timer re-anchors to the moment the time arrives.
   useEffect(() => {
-    const t = setTimeout(onDone, 2600);
+    const holdForBooking = awaitingTime && !scheduledTime;
+    const delay = holdForBooking ? MEETING_MAX_MS : MEETING_MIN_MS;
+    const t = setTimeout(onDone, delay);
     return () => clearTimeout(t);
-  }, [onDone]);
+  }, [onDone, awaitingTime, scheduledTime]);
 
   // Mini avatar slot: left of the title, in a left-anchored group.
   const groupLeft = w / 2 - 170;

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -4,7 +4,7 @@
  * SPIKE — research-onboarding flow.
  *
  * These render the visual sequence that follows the calendar step:
- *   - MeetingCreatedStep   a brief "Meeting Created!" confirmation
+ *   - MeetingCreatedStep   a brief "Check-in scheduled…" confirmation
  *   - LookingYouUpStep     a loading carousel ("looking you up")
  *   - ResearchResultsStep  the editable "Alright, this is what I got:" claims
  *   - SuggestionsStep      tappable suggestions that open a new chat
@@ -75,22 +75,29 @@ const MINI = 48;
  * Reverse of the Introduction grow-in. The toned backdrop (behind) blends to
  * black and hides its bottom eyes; here the eyes lead — shrinking and rising
  * up out of the bottom (the opposite of growing + sinking) — and the body
- * follows a beat later, shrinking into a small avatar beside the "Meeting
- * Created!" text. The edge characters stay (they live in the backdrop).
+ * follows a beat later, shrinking into a small avatar beside the "Check-in
+ * scheduled…" text. The edge characters stay (they live in the backdrop).
  */
 export function MeetingCreatedStep({
   onDone,
   onBack,
   onForward,
+  scheduledTime,
 }: {
   onDone: () => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /** Pre-formatted wall-clock time (e.g. "2:30 PM"); generic copy when absent. */
+  scheduledTime?: string;
 }) {
   const { components, chosen } = useChosenAvatar();
   const reduce = useReducedMotion();
   const { w, h } = useViewportSize();
+
+  const title = scheduledTime
+    ? `Check-in scheduled for tomorrow at ${scheduledTime}!`
+    : "Check-in scheduled!";
 
   useEffect(() => {
     const t = setTimeout(onDone, 2600);
@@ -144,13 +151,13 @@ export function MeetingCreatedStep({
           )}
         </div>
         <motion.span
-          className="whitespace-nowrap text-[2.6rem] leading-none"
+          className="max-w-[60vw] text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}
           initial={reduce ? false : { opacity: 0, x: -8 }}
           animate={{ opacity: 1, x: 0 }}
           transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 0.9 }}
         >
-          Meeting Created!
+          {title}
         </motion.span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
During the research-onboarding flow, after the user grants Google Calendar access and the Day-2 check-in event is booked, the confirmation screen now reads **"Check-in scheduled for tomorrow at {time}!"** (e.g. "Check-in scheduled for tomorrow at 2:30 PM!") instead of the static **"Meeting Created!"**. The daemon's `/onboarding/checkin` response already returned the booked `start`/`timeZone` — this threads them through to the UI. Falls back to "Check-in scheduled!" when the time isn't yet available.

## Self-review result
Skipped per user request (small, well-scoped 4-PR change; each PR went through the per-PR CI + review gate).

## PRs merged into feature branch
- #35932: feat(onboarding): add formatCheckinTime helper for check-in confirmation copy
- #35934: feat(onboarding): surface booked start time from scheduleCheckin
- #35933: feat(onboarding): show booked check-in time on the confirmation step
- #35937: feat(onboarding): thread booked check-in time into the confirmation step

Part of plan: checkin-scheduled-time-copy.md