### PR TITLE
polish(onboarding): reword research-onboarding plugin confirmation note

### DIFF
--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { ArrowRight, Check, X } from "lucide-react";
+import { ArrowRight, X } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
@@ -459,9 +459,13 @@ export function SuggestionsStep({
             animate={{ opacity: 1 }}
             transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 0.2 }}
           >
-            <Check className="h-4 w-4 shrink-0" />
+            <span className="shrink-0 leading-none" aria-hidden>
+              *
+            </span>
             <span>
-              Set up {formatNameList(pluginLabels)} to help with your work
+              I already set up the {formatNameList(pluginLabels)}{" "}
+              {pluginLabels.length === 1 ? "plugin" : "plugins"} based on what I
+              know about you
             </span>
           </motion.div>
         )}


### PR DESCRIPTION
## What

On the final research-onboarding step ("Here's what we could do first"), polish the installed-plugins confirmation note:

- Drop the checkmark icon in favor of an asterisk (`*`).
- Reword from "Set up {plugins} to help with your work" → **"I already set up the {plugins} plugin(s) based on what I know about you"**, with singular/plural handling.

## Before / After

- Before: `✓ Set up Git Workflow to help with your work`
- After: `* I already set up the Git Workflow plugin based on what I know about you`

The asterisk is decorative (`aria-hidden`); the list join and plugin display names are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)