### PR TITLE
feat(web): add SubagentAvatarBadge with state-respective status indicator

### DIFF
--- a/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests for `SubagentAvatarBadge`.
+ *
+ * Drives the Zustand subagent store (spawn + changeStatus) and asserts the
+ * under-avatar indicator reflects the subagent's real status: running dots
+ * while in-flight, a green check on `completed`, and a red ✕ on `aborted`
+ * (canceled) / `failed`. Confirms the deterministic avatar chip renders and
+ * that state is exposed via `data-status` (not colour alone).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { SubagentAvatarBadge } from "@/components/avatar/subagent-avatar-badge";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import type { SubagentStatus } from "@vellumai/assistant-api";
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  useSubagentStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function spawn(id: string, status: SubagentStatus) {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: id,
+    label: "Research Agent",
+    objective: "Find the answer",
+    timestamp: NOW,
+  });
+  useSubagentStore.getState().changeStatus({ subagentId: id, status });
+}
+
+describe("SubagentAvatarBadge", () => {
+  test("renders the deterministic avatar chip", () => {
+    spawn("sa-avatar", "running");
+    const { container } = render(<SubagentAvatarBadge subagentId="sa-avatar" />);
+    expect(
+      container.querySelector('[aria-label="Subagent sa-avatar"]'),
+    ).not.toBeNull();
+  });
+
+  test("running → running dots indicator with data-status=running", () => {
+    spawn("sa-running", "running");
+    const { getByTestId } = render(
+      <SubagentAvatarBadge subagentId="sa-running" />,
+    );
+    const indicator = getByTestId("subagent-avatar-badge-status");
+    expect(indicator.getAttribute("data-status")).toBe("running");
+    expect(indicator.getAttribute("aria-label")).toBe("running");
+    // Three pulsing dots use the shared busy-indicator class.
+    expect(indicator.querySelectorAll(".busy-indicator").length).toBe(3);
+  });
+
+  test("completed → green check, no dots", () => {
+    spawn("sa-done", "completed");
+    const { getByTestId } = render(<SubagentAvatarBadge subagentId="sa-done" />);
+    const indicator = getByTestId("subagent-avatar-badge-status");
+    expect(indicator.getAttribute("data-status")).toBe("completed");
+    expect(indicator.getAttribute("aria-label")).toBe("completed");
+    expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
+    expect(
+      indicator.querySelector(".text-\\[var\\(--system-positive-strong\\)\\]"),
+    ).not.toBeNull();
+  });
+
+  test("aborted → red ✕ with data-status=aborted", () => {
+    spawn("sa-aborted", "aborted");
+    const { getByTestId } = render(
+      <SubagentAvatarBadge subagentId="sa-aborted" />,
+    );
+    const indicator = getByTestId("subagent-avatar-badge-status");
+    expect(indicator.getAttribute("data-status")).toBe("aborted");
+    // Canceled reads distinctly from failed for assistive tech.
+    expect(indicator.getAttribute("aria-label")).toBe("canceled");
+    expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
+    expect(
+      indicator.querySelector(".text-\\[var\\(--system-negative-strong\\)\\]"),
+    ).not.toBeNull();
+  });
+
+  test("failed → red ✕ with data-status=failed", () => {
+    spawn("sa-failed", "failed");
+    const { getByTestId } = render(
+      <SubagentAvatarBadge subagentId="sa-failed" />,
+    );
+    const indicator = getByTestId("subagent-avatar-badge-status");
+    expect(indicator.getAttribute("data-status")).toBe("failed");
+    expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
+    expect(
+      indicator.querySelector(".text-\\[var\\(--system-negative-strong\\)\\]"),
+    ).not.toBeNull();
+  });
+
+  test("renders no status indicator before the entry lands in the store", () => {
+    const { queryByTestId } = render(
+      <SubagentAvatarBadge subagentId="missing" />,
+    );
+    expect(queryByTestId("subagent-avatar-badge-status")).toBeNull();
+    // The circle wrapper still renders.
+    expect(queryByTestId("subagent-avatar-badge")).not.toBeNull();
+  });
+});

--- a/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
@@ -52,6 +52,8 @@ describe("SubagentAvatarBadge", () => {
     const indicator = getByTestId("subagent-avatar-badge-status");
     expect(indicator.getAttribute("data-status")).toBe("running");
     expect(indicator.getAttribute("aria-label")).toBe("running");
+    // `role="img"` exposes the aria-label as a stable accessible name.
+    expect(indicator.getAttribute("role")).toBe("img");
     // Three pulsing dots use the shared busy-indicator class.
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(3);
   });

--- a/clients/web/src/components/avatar/subagent-avatar-badge.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.tsx
@@ -87,6 +87,11 @@ export function SubagentAvatarBadge({
 
       {badgeState && (
         <span
+          // `role="img"` makes the `aria-label` a reliably-exposed accessible
+          // name: the indicator is a small graphic conveying state, and its
+          // running dots / lucide glyphs are hidden from assistive tech, so a
+          // bare generic <span> would leave the status non-visually invisible.
+          role="img"
           data-testid="subagent-avatar-badge-status"
           data-status={status}
           aria-label={status && STATUS_ARIA_LABEL[status]}

--- a/clients/web/src/components/avatar/subagent-avatar-badge.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.tsx
@@ -1,0 +1,108 @@
+/**
+ * Collapsed-summary subagent avatar unit (Figma node `6063:148535`, 32×32).
+ *
+ * Renders a 32px white circle holding the deterministic
+ * `SubagentAvatarChip`, with a state-respective status indicator beneath
+ * the avatar: pulsing running dots while in-flight, a green check when the
+ * subagent completes, and a red ✕ when it's canceled (aborted) or fails.
+ * The indicator reflects the subagent's ACTUAL live status — it never
+ * shows a stuck running indicator on a finished subagent.
+ *
+ * The status buckets mirror `deriveCardState`'s loading / complete / error
+ * split in `use-subagent-card-data` so the collapsed badge and the expanded
+ * row read consistently. Badge state is exposed non-visually (via
+ * `aria-label` + a `data-status` attr), not by colour alone.
+ */
+
+import { Check, X } from "lucide-react";
+
+import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import type { SubagentStatus } from "@vellumai/assistant-api";
+
+export interface SubagentAvatarBadgeProps {
+  subagentId: string;
+  className?: string;
+}
+
+/** Three display buckets for the under-avatar indicator. */
+type BadgeState = "in-flight" | "completed" | "errored";
+
+/**
+ * Map a subagent status to its badge bucket. Mirrors the loading / complete
+ * / error split of `deriveCardState` in `use-subagent-card-data`:
+ * `running` / `pending` / `awaiting_input` are in-flight, `completed` is a
+ * clean finish, and `failed` / `aborted` (canceled) read as an error.
+ */
+function deriveBadgeState(status: SubagentStatus): BadgeState {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "failed":
+    case "aborted":
+      return "errored";
+    default:
+      return "in-flight";
+  }
+}
+
+/**
+ * Accessible label for the indicator, exposing the precise state to
+ * assistive tech (so canceled reads differently from failed even though they
+ * share the red ✕ glyph). Keyed by the raw status, not the coarse bucket.
+ */
+const STATUS_ARIA_LABEL: Record<SubagentStatus, string> = {
+  running: "running",
+  pending: "pending",
+  awaiting_input: "awaiting input",
+  completed: "completed",
+  failed: "failed",
+  aborted: "canceled",
+};
+
+export function SubagentAvatarBadge({
+  subagentId,
+  className,
+}: SubagentAvatarBadgeProps) {
+  // Atomic selector: re-render only when this subagent's status changes.
+  const status = useSubagentStore((s) => s.byId[subagentId]?.status);
+
+  // Entry not in the store yet (spawn race) — render the circle without an
+  // indicator rather than a stuck running state.
+  const badgeState = status ? deriveBadgeState(status) : undefined;
+
+  return (
+    <div
+      data-testid="subagent-avatar-badge"
+      className={`relative flex h-8 w-8 items-center justify-center rounded-full bg-[var(--surface-lift)] ${className ?? ""}`.trim()}
+    >
+      {/* Avatar sits slightly above centre (~6px from top) to leave room for
+          the indicator beneath it, per the mock. */}
+      <SubagentAvatarChip
+        subagentId={subagentId}
+        size={14}
+        className="absolute top-[6px]"
+      />
+
+      {badgeState && (
+        <span
+          data-testid="subagent-avatar-badge-status"
+          data-status={status}
+          aria-label={status && STATUS_ARIA_LABEL[status]}
+          className="absolute bottom-[3px] left-1/2 flex -translate-x-1/2 items-center justify-center"
+        >
+          {badgeState === "in-flight" && (
+            <ThreeDotIndicator dotSize={3} gap={2} />
+          )}
+          {badgeState === "completed" && (
+            <Check className="h-3 w-3 text-[var(--system-positive-strong)]" />
+          )}
+          {badgeState === "errored" && (
+            <X className="h-3 w-3 text-[var(--system-negative-strong)]" />
+          )}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add SubagentAvatarBadge: 32px circle avatar with under-avatar status indicator (running dots / green check / red X) driven by live subagent status.

Part of plan: spawning-subagents-ui-redesign.md (PR 1 of 5)