### PR TITLE
feat(web): restyle subagent inline card as transparent list row (steps→stop order)

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
@@ -2,9 +2,10 @@
  * Tests for `SubagentInlineProgressCard`.
  *
  * Drives the Zustand subagent store with fixture timelines and asserts
- * the rendered shell's title/info/pill transitions, the spawn-race
- * `null` fallback, and the deterministic avatar trait variation across
- * subagent IDs.
+ * the rendered row's title/info/step-count transitions, the
+ * steps-before-stop DOM order, the transparent-with-hover row chrome, the
+ * spawn-race `null` fallback, and the deterministic avatar trait variation
+ * across subagent IDs.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -63,9 +64,9 @@ describe("SubagentInlineProgressCard — fixture timeline", () => {
     // the live reasoning preview moves to the subtitle.
     expect(getByText("Research Agent")).toBeTruthy();
     expect(getByText("Checking the docs")).toBeTruthy();
-    // Single-step cards suppress the count pill — it only shows for 2+.
+    // Single-step rows suppress the step count — it only shows for 2+.
     expect(queryByText("1 step")).toBeNull();
-    expect(getByTestId("subagent-inline-card-shell")).toBeTruthy();
+    expect(getByTestId("subagent-inline-progress-card")).toBeTruthy();
   });
 
   test("transitions to Working when a tool_call lands after text", () => {
@@ -193,6 +194,50 @@ describe("SubagentInlineProgressCard — header action", () => {
       });
     });
     expect(queryByTestId("subagent-inline-card-stop")).toBeNull();
+  });
+
+  test("step count renders before the stop button in DOM order", () => {
+    spawn("sa-order");
+    const store = useSubagentStore.getState();
+    // Two steps so the step count is shown (single-step rows suppress it).
+    store.receiveEvent({
+      subagentId: "sa-order",
+      event: { type: "assistant_text_delta", text: "Searching" },
+      timestamp: NOW + 100,
+    });
+    store.receiveEvent({
+      subagentId: "sa-order",
+      event: {
+        type: "tool_use_start",
+        toolName: "bash",
+        input: { command: "ls -la" },
+      },
+      timestamp: NOW + 200,
+    });
+
+    const { getByTestId } = render(
+      <SubagentInlineProgressCard
+        subagentId="sa-order"
+        onStopSubagent={() => {}}
+      />,
+    );
+
+    const stepCount = getByTestId("subagent-inline-card-step-count");
+    const stop = getByTestId("subagent-inline-card-stop");
+    // The step count precedes the stop button in the rendered DOM.
+    expect(
+      stepCount.compareDocumentPosition(stop) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test("the row is transparent by default and paints surface-active on hover", () => {
+    spawn("sa-hover");
+    const { getByTestId } = render(
+      <SubagentInlineProgressCard subagentId="sa-hover" />,
+    );
+    const row = getByTestId("subagent-inline-progress-card");
+    expect(row.className).toContain("hover:bg-[var(--surface-active)]");
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.test.tsx
@@ -156,6 +156,31 @@ describe("SubagentInlineProgressCard — header action", () => {
     expect(seen).toEqual(["sa-open"]);
   });
 
+  test("Enter on the row opens the panel, but Enter from the stop button does not", () => {
+    spawn("sa-keydown");
+    const seen: string[] = [];
+    const { getByTestId } = render(
+      <SubagentInlineProgressCard
+        subagentId="sa-keydown"
+        onSubagentClick={(id) => seen.push(id)}
+        onStopSubagent={() => {}}
+      />,
+    );
+
+    const row = getByTestId("subagent-inline-progress-card");
+    const stop = getByTestId("subagent-inline-card-stop");
+
+    // Enter originating on the stop button bubbles to the row handler, but the
+    // row must ignore it (target !== currentTarget) so the button's own
+    // keyboard activation is not hijacked.
+    fireEvent.keyDown(stop, { key: "Enter" });
+    expect(seen).toEqual([]);
+
+    // Enter on the row itself still opens the panel.
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(seen).toEqual(["sa-keydown"]);
+  });
+
   test("no expand toggle is exposed — there is no inline body", () => {
     spawn("sa-no-expand");
     act(() => {

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
@@ -69,6 +69,11 @@ export function SubagentInlineProgressCard({
 
   const handleRowKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      // Only react when the row itself is focused. A focusable child (the
+      // stop button) bubbles its Enter/Space keydown here before its own
+      // click fires; without this guard the row would hijack that activation
+      // — opening the panel and `preventDefault()`-ing the button's click.
+      if (e.target !== e.currentTarget) return;
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         onSubagentClick?.(subagentId);

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
@@ -1,8 +1,11 @@
 /**
  * Inline subagent progress card rendered per-subagent in the assistant
- * transcript. Built on `ToolProgressCardShell` with the
- * `SubagentAvatarChip` slotted into the leading-icon slot per
- * Figma node `4922-103839`.
+ * transcript. A transparent, full-width list row (Figma node
+ * `6063:148642`): a status indicator (running dots or terminal icon), the
+ * subagent avatar, the `Task Name | detail` carousel, then a plain
+ * "X steps" count and an in-flight stop button — laid out left→right.
+ * Transparent by default; the whole row paints `--surface-active` at
+ * `rounded-md` on hover.
  *
  * Subscribes to the subagent store via `useSubagentCardData(subagentId)`.
  * Returns `null` when the entry isn't in the store yet — handles the
@@ -11,30 +14,31 @@
  * wires this into the transcript; this PR ships the component standalone.
  *
  * Interaction model:
- *   - Clicking anywhere on the header row opens the subagent's full
- *     timeline panel via `onSubagentClick`. There is no inline expand —
- *     the panel is the only detail view, so a separate open affordance
- *     and an inline timeline both end up redundant.
- *   - Stop is exposed via `onStopSubagent`; the shell renders a small
- *     stop chip in the right rail while the subagent is in-flight.
+ *   - Clicking anywhere on the row (other than the stop button) opens the
+ *     subagent's full timeline panel via `onSubagentClick`. There is no
+ *     inline expand — the panel is the only detail view. The row is a
+ *     `<div role="button">` (not a `<button>`) because it nests the stop
+ *     `<button>`, and nested buttons are invalid HTML.
+ *   - Stop is exposed via `onStopSubagent`; a small stop button renders in
+ *     the right cluster while the subagent is in-flight.
  */
 
-import { Square } from "lucide-react";
-import { useCallback, type MouseEvent } from "react";
+import { AlertCircle, CheckCircle2, Square } from "lucide-react";
+import { useCallback, type KeyboardEvent, type MouseEvent } from "react";
 
-import { Button } from "@vellumai/design-library";
+import { Button, Typography } from "@vellumai/design-library";
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
-import { PhaseGroupedStepList } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
-import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
 import { useSubagentCardData } from "@/domains/chat/hooks/use-subagent-card-data";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 
 export interface SubagentInlineProgressCardProps {
   subagentId: string;
   /**
-   * Invoked when the user activates the "open full timeline" button in
-   * the right rail. Routes to the subagent detail panel.
+   * Invoked when the user activates the row (anywhere but the stop button).
+   * Routes to the subagent detail panel.
    */
   onSubagentClick?: (subagentId: string) => void;
   /**
@@ -50,18 +54,28 @@ export function SubagentInlineProgressCard({
   onStopSubagent,
 }: SubagentInlineProgressCardProps) {
   const data = useSubagentCardData(subagentId);
-  // The subagent's task name (e.g. "research-car-brands") titles the card so it
+  // The subagent's task name (e.g. "research-car-brands") titles the row so it
   // reads as "which subagent"; the derived live status/detail moves to the
-  // subtitle (below).
+  // detail slot (below).
   const label = useSubagentStore((s) => s.byId[subagentId]?.label);
-  // The shell's `loading` state subsumes running / pending / awaiting_input
+  // The `loading` state subsumes running / pending / awaiting_input
   // (see `deriveCardState` in use-subagent-card-data) — exactly the window
   // where stopping the subagent is a meaningful action.
   const isRunning = data?.state === "loading";
 
-  const handleHeaderClick = useCallback(() => {
+  const handleRowClick = useCallback(() => {
     onSubagentClick?.(subagentId);
   }, [onSubagentClick, subagentId]);
+
+  const handleRowKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onSubagentClick?.(subagentId);
+      }
+    },
+    [onSubagentClick, subagentId],
+  );
 
   const handleStop = useCallback(
     (e: MouseEvent) => {
@@ -73,65 +87,93 @@ export function SubagentInlineProgressCard({
 
   // Spawn-race: assistant message references a subagent before the
   // `subagent_spawned` event lands. Render `null` rather than a blank
-  // shell so the transcript doesn't flicker an empty card.
+  // row so the transcript doesn't flicker an empty card.
   if (!data) return null;
 
-  const leadingIcon = <SubagentAvatarChip subagentId={subagentId} size={20} />;
-
   // Title = the subagent's task name. The derived status `data.currentStepTitle`
-  // ("Working", "Searching the web") and its detail collapse into the subtitle:
-  // prefer the specific detail, falling back to the status word when a step
-  // carries none (e.g. a web_search, whose detail is empty) or when the only
-  // "detail" is the label itself (no steps yet) — so the subtitle never reads
-  // blank or echoes the title.
+  // ("Working", "Searching the web") and its detail collapse into the detail
+  // slot: prefer the specific detail, falling back to the status word when a
+  // step carries none (e.g. a web_search, whose detail is empty) or when the
+  // only "detail" is the label itself (no steps yet) — so the detail never
+  // reads blank or echoes the title.
   const headerTitle = label ?? data.currentStepTitle;
   const headerInfo =
     data.currentStepInfo && data.currentStepInfo !== label
       ? data.currentStepInfo
       : data.currentStepTitle;
 
-  // Stop button only — the open affordance is gone; the whole header row
-  // now fires `onSubagentClick` via the shell's `onHeaderClick` override.
-  // The shell slots this into a right-aligned flex rail (8px gap to the
-  // step-count pill); we use the design-library icon button so the stop
-  // affordance matches the platform button chrome.
-  const actionSlot =
-    onStopSubagent && isRunning ? (
-      <Button
-        variant="dangerGhost"
-        size="compact"
-        iconOnly={<Square fill="currentColor" />}
-        aria-label="Stop subagent"
-        data-testid="subagent-inline-card-stop"
-        onClick={handleStop}
-      />
-    ) : undefined;
+  // Leading status indicator. Mirrors the shared shell's `StatusIndicator`:
+  // running → animated three-dot; terminal → green check / red alert. Kept
+  // local rather than coupling the row to the shell's chrome.
+  const statusIndicator = isRunning ? (
+    <ThreeDotIndicator
+      className="shrink-0"
+      data-testid="subagent-inline-card-status-indicator"
+    />
+  ) : data.state === "complete" ? (
+    <CheckCircle2
+      data-testid="subagent-inline-card-status-indicator"
+      aria-hidden="true"
+      className="h-[14px] w-[14px] shrink-0 text-[var(--system-positive-strong)]"
+    />
+  ) : (
+    <AlertCircle
+      data-testid="subagent-inline-card-status-indicator"
+      aria-hidden="true"
+      className="h-[14px] w-[14px] shrink-0 text-[var(--system-negative-strong)]"
+    />
+  );
+
+  // Plain tertiary "X steps" — hidden for 0/1-step rows where it's noise
+  // next to the carousel detail that already describes the single step.
+  const stepCount = data.stepCount;
+  const showStepCount =
+    !!stepCount &&
+    !stepCount.startsWith("0 ") &&
+    !stepCount.startsWith("1 ");
 
   return (
-    <div className="w-full" data-testid="subagent-inline-progress-card">
-      <ToolProgressCardShell
-        data-testid="subagent-inline-card-shell"
-        statusIndicatorTestId="subagent-inline-card-status-indicator"
-        state={data.state}
-        leadingIcon={leadingIcon}
-        currentStepTitle={headerTitle}
-        currentStepInfo={headerInfo}
-        stepCount={data.stepCount}
-        // The shell's expanded body is unused — there is no inline timeline
-        // to reveal. Disabling expand keeps the shell from tracking state
-        // that would never be exposed via UI.
-        disableExpand
-        headerActionSlot={actionSlot}
-        onHeaderClick={onSubagentClick ? handleHeaderClick : undefined}
-        headerAriaLabel={
-          onSubagentClick ? "Open subagent" : undefined
-        }
-      >
-        {/* Children unused — `disableExpand` suppresses the body region. */}
-        <div className="hidden">
-          <PhaseGroupedStepList steps={data.steps} />
-        </div>
-      </ToolProgressCardShell>
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid="subagent-inline-progress-card"
+      aria-label={onSubagentClick ? "Open subagent" : undefined}
+      onClick={handleRowClick}
+      onKeyDown={handleRowKeyDown}
+      className="group flex w-full items-center justify-between gap-2 rounded-md p-2 text-left hover:bg-[var(--surface-active)]"
+    >
+      <span className="flex min-w-0 flex-1 items-center gap-1">
+        {statusIndicator}
+        <span className="mx-1 flex shrink-0 items-center">
+          <SubagentAvatarChip subagentId={subagentId} size={16} />
+        </span>
+        <HeaderStepCarousel
+          currentStepTitle={headerTitle}
+          currentStepInfo={headerInfo}
+          bypassDwell={data.state !== "loading"}
+        />
+      </span>
+      <span className="flex shrink-0 items-center gap-2">
+        {showStepCount ? (
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+            data-testid="subagent-inline-card-step-count"
+          >
+            {stepCount}
+          </Typography>
+        ) : null}
+        {onStopSubagent && isRunning ? (
+          <Button
+            variant="dangerGhost"
+            size="compact"
+            iconOnly={<Square fill="currentColor" />}
+            aria-label="Stop subagent"
+            data-testid="subagent-inline-card-stop"
+            onClick={handleStop}
+          />
+        ) : null}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restyle SubagentInlineProgressCard as a transparent full-width list row with hover background, avatar, Task Name | detail carousel, and steps-before-stop ordering. Shared ToolProgressCardShell untouched.

Part of plan: spawning-subagents-ui-redesign.md (PR 3 of 5)