### PR TITLE
feat(research-onboarding): polish suggestions, avatar pool, and mobile layout

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-character-stage.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-character-stage.tsx
@@ -32,7 +32,7 @@ const CENTER_POINT = { x: 0.5, y: 0.4 };
  * Slight per-slot tilt (degrees) so the edge cast isn't all bolt-upright. Some
  * are left at 0. Indexed by edge slot; the centered avatar is always upright.
  */
-export const SLOT_ROTATIONS = [-8, 6, 9, 0, 7, -6, 5, 0, -7, 4];
+export const SLOT_ROTATIONS = [-8, 6, 9, 0, 7, -6, 5, 0, -7, 4, -5, 6];
 function slotRotation(slot: number): number {
   return SLOT_ROTATIONS[slot % SLOT_ROTATIONS.length] ?? 0;
 }
@@ -63,7 +63,7 @@ function centerSize(w: number, h: number): number {
 export function edgeSlots(w: number, h: number, edgeRadius: number): { x: number; y: number }[] {
   const side = edgeRadius * 0.4; // ~60% of the avatar clipped off-screen
   const corner = edgeRadius * 0.48;
-  // Order matches HARDCODED_POOL indices 1–9 (see onboarding-avatar-pool-store).
+  // Order matches HARDCODED_POOL indices 1–11 (see onboarding-avatar-pool-store).
   return [
     { x: corner, y: corner }, // 0 top-left corner → purple blob
     { x: w * 0.3, y: side }, // 1 top, left of center → orange star
@@ -74,6 +74,8 @@ export function edgeSlots(w: number, h: number, edgeRadius: number): { x: number
     { x: corner, y: h - corner }, // 6 bottom-left corner → green ghost
     { x: side, y: h * 0.5 }, // 7 left mid → orange sprout
     { x: w - side, y: h * 0.3 }, // 8 right upper → teal star
+    { x: w * 0.38, y: h - side }, // 9 bottom, left of center → pink flower
+    { x: w * 0.62, y: h - side }, // 10 bottom, right of center → yellow cloud
   ];
 }
 
@@ -142,6 +144,15 @@ export function OnboardingCharacterStage({
 }: OnboardingCharacterStageProps) {
   const { w, h } = useViewport();
   const reduce = useReducedMotion();
+
+  // On narrow screens the side avatars sit behind the title/fields and feel
+  // crowded, so the edge cast is kept to the top (slots 0–3) and bottom corners
+  // (5, 6). Dropped on mobile: the side slots 4 (right-lower), 7 (left-mid), 8
+  // (right-upper), plus the two bottom-center slots 9/10 (desktop-only, else the
+  // bottom re-crowds). Those characters stay reachable via the arrows.
+  const isMobile = w < 640;
+  const MOBILE_HIDDEN_SLOTS = new Set([4, 7, 8, 9, 10]);
+  const slotHidden = (slot: number) => isMobile && MOBILE_HIDDEN_SLOTS.has(slot);
 
   // Every avatar renders in the large edge box; the center one is scaled down.
   const size = edgeSize(w, h);
@@ -216,8 +227,10 @@ export function OnboardingCharacterStage({
 
         // Previously centered — the exact opposite of the entering move: it
         // shrinks + fades away at the center, teleports off-screen (invisible),
-        // then flies in from the edge and bounces into its slot.
+        // then flies in from the edge and bounces into its slot. If that slot is
+        // hidden on mobile, skip it so it doesn't land in a dropped side slot.
         if (isExiting) {
+          if (slotHidden(exiting.toSlot)) return null;
           const to = slots[exiting.toSlot]!;
           const off = offscreenPoint(to, centerX, centerY, w, h);
           return (
@@ -251,9 +264,12 @@ export function OnboardingCharacterStage({
           );
         }
 
+        const charSlot = slotOfChar.get(i) ?? 0;
+        // Drop the side-slot characters on mobile (they're not the center).
+        if (!isCenter && slotHidden(charSlot)) return null;
         const point = isCenter
           ? { x: centerX, y: centerY }
-          : slots[slotOfChar.get(i) ?? 0]!;
+          : slots[charSlot]!;
         return (
           <motion.div
             key={i}

--- a/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
@@ -52,11 +52,12 @@ export function OnboardingEdgeCharacters() {
   const size = edgeSize(w, h);
   const positions = useMemo(() => edgeSlots(w, h, size / 2), [w, h, size]);
 
-  // On mobile the form is full-width with left-aligned labels, so a left-edge
-  // avatar sits right behind them. Drop the mid-left slot there and keep the
-  // cast to the top, right, and bottom. (Slot 7 is the left-mid sprout.)
+  // On mobile the form fills the width, so the side avatars sit right behind it
+  // and feel crowded. Keep only the top edge (slots 0–3) and bottom corners
+  // (5, 6), dropping the side slots 4 (right-lower), 7 (left-mid), 8 (right-
+  // upper) and the desktop-only bottom-center slots 9/10.
   const isMobile = w < 640;
-  const HIDDEN_ON_MOBILE = new Set([7]);
+  const HIDDEN_ON_MOBILE = new Set([4, 7, 8, 9, 10]);
 
   if (!components || characters.length === 0) return null;
 

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -53,14 +53,21 @@ const PEEKERS: {
   colorIdx: number;
   base: number;
   pos: (s: number) => Record<string, number | string>;
+  /**
+   * Kept on narrow screens, where the content fills the middle and most of the
+   * width. `mobilePos` rides the four corners (clear of the content) so the
+   * crowd spreads into the corners instead of bunching along the bottom.
+   */
+  mobile?: boolean;
+  mobilePos?: (s: number) => Record<string, number | string>;
 }[] = [
   { bodyShape: "sprout", eyeStyle: "curious", colorIdx: 0, base: 230, pos: (s) => ({ left: -s * 0.32, top: "40%" }) },
   { bodyShape: "flower", eyeStyle: "goofy", colorIdx: 1, base: 230, pos: (s) => ({ right: -s * 0.32, top: "40%" }) },
-  { bodyShape: "star", eyeStyle: "dazed", colorIdx: 2, base: 240, pos: (s) => ({ left: "16%", bottom: -s * 0.42 }) },
-  { bodyShape: "burst", eyeStyle: "angry", colorIdx: 0, base: 240, pos: (s) => ({ right: "16%", bottom: -s * 0.42 }) },
+  { bodyShape: "star", eyeStyle: "dazed", colorIdx: 2, base: 240, mobile: true, pos: (s) => ({ left: "16%", bottom: -s * 0.42 }), mobilePos: (s) => ({ left: -s * 0.3, bottom: -s * 0.3 }) },
+  { bodyShape: "burst", eyeStyle: "angry", colorIdx: 0, base: 240, mobile: true, pos: (s) => ({ right: "16%", bottom: -s * 0.42 }), mobilePos: (s) => ({ right: -s * 0.3, bottom: -s * 0.3 }) },
   { bodyShape: "blob", eyeStyle: "gentle", colorIdx: 1, base: 220, pos: (s) => ({ left: "42%", bottom: -s * 0.5 }) },
-  { bodyShape: "urchin", eyeStyle: "curious", colorIdx: 2, base: 220, pos: (s) => ({ left: -s * 0.28, bottom: "16%" }) },
-  { bodyShape: "burst", eyeStyle: "quirky", colorIdx: 0, base: 220, pos: (s) => ({ right: -s * 0.28, bottom: "16%" }) },
+  { bodyShape: "urchin", eyeStyle: "curious", colorIdx: 2, base: 220, mobile: true, pos: (s) => ({ left: -s * 0.28, bottom: "16%" }), mobilePos: (s) => ({ left: -s * 0.3, top: -s * 0.3 }) },
+  { bodyShape: "burst", eyeStyle: "quirky", colorIdx: 0, base: 220, mobile: true, pos: (s) => ({ right: -s * 0.28, bottom: "16%" }), mobilePos: (s) => ({ right: -s * 0.3, top: -s * 0.3 }) },
   { bodyShape: "flower", eyeStyle: "quirky", colorIdx: 1, base: 230, pos: (s) => ({ left: "30%", bottom: -s * 0.4 }) },
 ];
 
@@ -99,6 +106,9 @@ export function OnboardingTonedBackdrop({
   const { w } = useViewport();
   // Shrink the peeking characters on smaller screens (full size ≥ ~1100px wide).
   const peekScale = Math.max(0.42, Math.min(w / 1100, 1));
+  // On narrow screens the content fills the middle, so the crowd retreats to a
+  // smaller, corner-only set (see PEEKERS `mobile` / `mobilePos`).
+  const isMobile = w < 640;
 
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
 
@@ -176,17 +186,23 @@ export function OnboardingTonedBackdrop({
         </div>
       )}
 
-      {/* The crowd peeks in around the edges — more reveal as steps progress. */}
+      {/* The crowd peeks in around the edges — more reveal as steps progress.
+          On narrow screens the side/top peekers crowd the content, so only the
+          ones rising from the bottom edge are kept. */}
       {components && (
         <AnimatePresence>
-          {PEEKERS.slice(0, Math.max(0, peekLevel)).map((p, i) => {
+          {(isMobile ? PEEKERS.filter((p) => p.mobile) : PEEKERS)
+            .slice(0, Math.max(0, peekLevel))
+            .map((p, i) => {
             const size = Math.round(p.base * peekScale);
+            const position =
+              isMobile && p.mobilePos ? p.mobilePos(size) : p.pos(size);
             return (
               <motion.div
                 key={`peek-${i}`}
                 aria-hidden="true"
                 className="pointer-events-none fixed z-[1]"
-                style={{ ...p.pos(size), width: size, height: size }}
+                style={{ ...position, width: size, height: size }}
                 initial={reduce ? false : { scale: 0, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 exit={reduce ? undefined : { scale: 0, opacity: 0 }}

--- a/clients/web/src/domains/onboarding/onboarding-avatar-pool-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-avatar-pool-store.ts
@@ -21,26 +21,29 @@ import { createSelectors } from "@/utils/create-selectors";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
 /** How many characters to scatter / cycle through. */
-export const AVATAR_POOL_SIZE = 10;
+export const AVATAR_POOL_SIZE = 12;
 
 /**
- * The hand-picked cast, chosen to match the design. Body shapes are all
- * distinct (one of each of the 10), with colors + eye styles picked to resemble
- * the reference. Index 0 is the picker's initial centered avatar.
+ * The hand-picked cast, chosen to match the design. Spans all 9 body shapes and
+ * all 9 eye styles (a few unavoidably repeat across 12 characters) so the picker
+ * shows the full variety instead of leaning on the same faces. Index 0 is the
+ * picker's initial centered avatar.
  */
-// Index 0 is the center; indices 1–9 fill the picker's edge slots in order (see
+// Index 0 is the center; indices 1–11 fill the picker's edge slots in order (see
 // `edgeSlots` in onboarding-character-stage). Tuned to match the design.
 const HARDCODED_POOL: CharacterTraits[] = [
   { bodyShape: "urchin", eyeStyle: "goofy", color: "teal" }, // center: teal spiky
   { bodyShape: "blob", eyeStyle: "grumpy", color: "purple" }, // top-left: purple blob
-  { bodyShape: "star", eyeStyle: "goofy", color: "orange" }, // top L: orange star
-  { bodyShape: "blob", eyeStyle: "goofy", color: "pink" }, // top R: pink blob
+  { bodyShape: "star", eyeStyle: "surprised", color: "orange" }, // top L: orange star
+  { bodyShape: "blob", eyeStyle: "gentle", color: "pink" }, // top R: pink blob
   { bodyShape: "ninja", eyeStyle: "angry", color: "yellow" }, // top-right: yellow angular
   { bodyShape: "urchin", eyeStyle: "curious", color: "pink" }, // right lower: pink spiky
-  { bodyShape: "burst", eyeStyle: "angry", color: "orange" }, // bottom-right: orange burst
+  { bodyShape: "burst", eyeStyle: "quirky", color: "orange" }, // bottom-right: orange burst
   { bodyShape: "ghost", eyeStyle: "bashful", color: "green" }, // bottom-left: green sleepy
-  { bodyShape: "sprout", eyeStyle: "curious", color: "orange" }, // left mid: orange-red
-  { bodyShape: "star", eyeStyle: "dazed", color: "teal" }, // right upper: teal star
+  { bodyShape: "sprout", eyeStyle: "dazed", color: "orange" }, // left mid: orange-red
+  { bodyShape: "star", eyeStyle: "goofy", color: "teal" }, // right upper: teal star
+  { bodyShape: "flower", eyeStyle: "angry", color: "pink" }, // bottom L of center: pink flower
+  { bodyShape: "cloud", eyeStyle: "curious", color: "yellow" }, // bottom R of center: yellow cloud
 ];
 
 interface OnboardingAvatarPoolState {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -179,12 +179,17 @@ export function ResearchOnboardingRoute() {
     values: ResearchOnboardingValues,
     face: GiveMeAFaceValues | null,
     entryPrompt?: string,
+    { skip = false }: { skip?: boolean } = {},
   ) {
     const { firstName, lastName, role, hobbies } = values;
     const fullName = [firstName.trim(), lastName.trim()]
       .filter(Boolean)
       .join(" ");
     const trimmedFirstName = firstName.trim();
+    // The research kickoff path is the only one that auto-sends a research
+    // prompt and renders focused; suggestions send their prompt as a normal
+    // chat, and "Skip to Chat" sends nothing at all.
+    const isResearch = !skip && entryPrompt === undefined;
 
     const context: PreChatOnboardingContext = {
       // Required handoff fields — no tool/task/tone collection in this flow.
@@ -194,24 +199,29 @@ export function ResearchOnboardingRoute() {
       ...(fullName ? { userName: fullName } : {}),
       // `occupation` is the prechat profile's field name for the person's role.
       ...(role.trim() ? { occupation: role.trim() } : {}),
-      // First message: the picked suggestion if we're entering from one,
-      // otherwise the research kickoff prompt.
-      initialMessage:
-        entryPrompt ??
-        buildResearchPrompt({
-          firstName,
-          lastName,
-          occupation: role,
-          hobby: hobbies.join(", "),
-        }),
-      // Friendly title for the behind-the-scenes research conversation.
-      ...(entryPrompt
+      // First message: the picked suggestion if entering from one, otherwise the
+      // research kickoff prompt. Omitted on "Skip to Chat" so the user lands in a
+      // blank chat ready to type.
+      ...(skip
         ? {}
         : {
+            initialMessage:
+              entryPrompt ??
+              buildResearchPrompt({
+                firstName,
+                lastName,
+                occupation: role,
+                hobby: hobbies.join(", "),
+              }),
+          }),
+      // Friendly title for the behind-the-scenes research conversation.
+      ...(isResearch
+        ? {
             title: trimmedFirstName
               ? `Getting to know ${trimmedFirstName}`
               : "Getting to know you",
-          }),
+          }
+        : {}),
       // Apply the avatar name chosen on the picker (if any).
       ...(face?.name?.trim() ? { assistantName: face.name.trim() } : {}),
     };
@@ -222,10 +232,11 @@ export function ResearchOnboardingRoute() {
     // the assistant is hatched (they're not part of the pre-chat context).
     setPendingAvatarTraits(face?.traits ?? null);
 
-    // The research pass renders in the focused presentation; entering directly
-    // from a suggestion is a normal chat, so only focus for the research path.
-    if (!entryPrompt) enterFocus();
-    lifecycleService.markExpectingFirstMessage();
+    // The research pass renders in the focused presentation; entering from a
+    // suggestion (or skipping) is a normal chat, so only focus for research.
+    if (isResearch) enterFocus();
+    // No auto-sent first message when skipping, so don't arm the expectation.
+    if (!skip) lifecycleService.markExpectingFirstMessage();
     // Pin the refresh to the background-hatched assistant so the handoff targets
     // it (not a previously-selected one) and doesn't trigger a second hatch.
     void lifecycleService
@@ -387,6 +398,10 @@ export function ResearchOnboardingRoute() {
               // reviewed the results.
               await research.awaitPluginInstalls();
               enterAssistant(formValues, faceValues, suggestion.prompt);
+            }}
+            onSkip={async () => {
+              await research.awaitPluginInstalls();
+              enterAssistant(formValues, faceValues, undefined, { skip: true });
             }}
             onBack={() => goBackTo(noClaims ? "looking" : "results")}
             onForward={onForward}

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -72,6 +72,9 @@ export function GiveMeAFaceScreen({
   const [arrangement, setArrangement] = useState<Arrangement | null>(null);
   const [name, setName] = useState("");
   const [editingName, setEditingName] = useState(false);
+  // Once the user edits the name, stop prefilling it from the avatar's default
+  // so their custom name survives cycling through avatars.
+  const nameCustomized = useRef(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
   // The current swap: the newly selected char + the slot it came from
   // (entering), and the old center + the slot it's heading to (exiting).
@@ -92,10 +95,11 @@ export function GiveMeAFaceScreen({
     if (arrangement) setSelectedIndex(arrangement.centerChar);
   }, [arrangement, setSelectedIndex]);
 
-  // Prefill the name for the centered avatar, swapping it as you cycle.
+  // Prefill the name for the centered avatar, swapping it as you cycle — but
+  // never clobber a name the user has typed.
   const centerChar = arrangement?.centerChar;
   useEffect(() => {
-    if (centerChar != null) {
+    if (centerChar != null && !nameCustomized.current) {
       setName(ASSISTANT_NAMES[centerChar % ASSISTANT_NAMES.length]!);
     }
   }, [centerChar]);
@@ -209,7 +213,10 @@ export function GiveMeAFaceScreen({
           <input
             ref={nameInputRef}
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              nameCustomized.current = true;
+              setName(e.target.value);
+            }}
             onBlur={() => setEditingName(false)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {

--- a/clients/web/src/domains/onboarding/screens/integration-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/integration-step.tsx
@@ -60,7 +60,7 @@ export function IntegrationStep({
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-[26%] flex -translate-x-1/2 flex-col items-center gap-3 px-6 text-center">
+      <div className="absolute left-1/2 top-[26%] flex w-full max-w-xl -translate-x-1/2 flex-col items-center gap-3 px-6 text-center">
         <h1
           className="text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -16,14 +16,14 @@
  * loading / empty presentation while the turn is still streaming.
  */
 
-import { useEffect, useState } from "react";
-import { ArrowRight, Check, X } from "lucide-react";
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ArrowRight, X } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
-import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import { useOnboardingTone, type OnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import {
   pluginDisplayName,
@@ -54,13 +54,25 @@ function useChosenAvatar() {
   return { components, chosen };
 }
 
-/** The chosen assistant as a small live avatar (for the heading rows). */
-export function MiniAssistant({ size = 48 }: { size?: number }) {
+/** The chosen assistant as a live avatar (for the heading rows). */
+export function MiniAssistant({
+  size = 64,
+  isStreaming = false,
+}: {
+  size?: number;
+  /** Morph the body while active (e.g. during the looking-you-up carousel). */
+  isStreaming?: boolean;
+}) {
   const { components, chosen } = useChosenAvatar();
   if (!components || !chosen) return <div style={{ width: size, height: size }} />;
   return (
     <div className="shrink-0" style={{ width: size, height: size }}>
-      <AnimatedAvatar components={components} traits={chosen} size={size} />
+      <AnimatedAvatar
+        components={components}
+        traits={chosen}
+        size={size}
+        isStreaming={isStreaming}
+      />
     </div>
   );
 }
@@ -219,8 +231,10 @@ export function LookingYouUpStep({
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
-      <div className="absolute left-1/2 top-[26%] flex w-full max-w-xl -translate-x-1/2 items-center gap-3 px-6">
-        <MiniAssistant />
+      {/* Top-align so the avatar stays put as messages change line count
+          (centering would bob it up and down between carousel lines). */}
+      <div className="absolute left-1/2 top-[14%] sm:top-[26%] flex w-full max-w-xl -translate-x-1/2 items-start gap-3 px-6">
+        <MiniAssistant isStreaming />
         <AnimatePresence mode="wait">
           <motion.p
             key={index}
@@ -271,7 +285,7 @@ export function ResearchResultsStep({
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-[26%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6">
+      <div className="absolute left-1/2 top-[14%] sm:top-[26%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6">
         <div className="flex items-center gap-3">
           <MiniAssistant />
           <h1 className="text-[2.2rem] leading-none" style={{ fontFamily: "var(--font-serif)" }}>
@@ -365,11 +379,136 @@ const FALLBACK_SUGGESTIONS: ResearchSuggestion[] = [
   },
 ];
 
-/** Join names into a readable list: "A", "A and B", "A, B, and C". */
-function formatNameList(names: string[]): string {
-  if (names.length <= 1) return names[0] ?? "";
-  if (names.length === 2) return `${names[0]} and ${names[1]}`;
-  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+/** A plugin name rendered as a pill tinted with the chosen avatar's color. */
+function PluginPill({ label, tone }: { label: string; tone: OnboardingTone }) {
+  return (
+    <span
+      className="inline-flex items-center whitespace-nowrap rounded-full px-2.5 py-[3px] text-[12px] font-medium align-middle"
+      style={{ backgroundColor: tone.bg, color: tone.fg }}
+    >
+      {label}
+    </span>
+  );
+}
+
+/** Interleave plugin pills with readable connectors: "A", "A and B", "A, B, and C". */
+function joinPills(labels: string[], tone: OnboardingTone) {
+  return labels.map((label, i) => {
+    let connector = "";
+    if (i > 0) {
+      const isLast = i === labels.length - 1;
+      connector = isLast ? (labels.length === 2 ? " and " : ", and ") : ", ";
+    }
+    return (
+      <Fragment key={label}>
+        {connector}
+        <PluginPill label={label} tone={tone} />
+      </Fragment>
+    );
+  });
+}
+
+/** Avatar box size — the same at the heading and where it lands by the note. */
+const HEADING_AVATAR = 64;
+const NOTE_AVATAR = HEADING_AVATAR;
+
+type Anchor = { x: number; y: number };
+
+/**
+ * The "already set up …" confirmation line. No avatar of its own — it just
+ * reserves a small landing slot (`slotRef`) for the single avatar that flies
+ * down from the heading — and names the installed plugins as avatar-tinted
+ * pills.
+ */
+function PluginSetupNote({
+  pluginLabels,
+  tone,
+  reduce,
+  slotRef,
+  revealed,
+}: {
+  pluginLabels: string[];
+  tone: OnboardingTone;
+  reduce: boolean | null;
+  slotRef: React.RefObject<HTMLDivElement | null>;
+  /** True once the avatar has landed — the text only appears then. */
+  revealed: boolean;
+}) {
+  const plural = pluginLabels.length > 1;
+  return (
+    <div className="mt-12 flex items-center gap-3">
+      <div
+        ref={slotRef}
+        className="shrink-0"
+        style={{ width: NOTE_AVATAR, height: NOTE_AVATAR }}
+      />
+      <motion.p
+        className="text-[14px]"
+        style={{ color: tone.fg }}
+        initial={false}
+        animate={{ opacity: revealed ? 1 : 0, x: revealed ? 0 : -6 }}
+        transition={reduce ? { duration: 0 } : { duration: 0.35 }}
+      >
+        Already set up the {joinPills(pluginLabels, tone)} plugin{plural ? "s" : ""}{" "}
+        to help with your work
+      </motion.p>
+    </div>
+  );
+}
+
+/**
+ * The chosen avatar as a single overlay that rests over the heading and — once
+ * the plugin note is present and the layout has settled — flies down along a
+ * curved arc to the note's landing slot and stays there (shrinking from the
+ * heading size to the note size). Positions are measured from the slots so the
+ * flight tracks the real layout as suggestions stream in.
+ */
+function FlyingHeadingAvatar({
+  head,
+  note,
+  flyToNote,
+  reduce,
+  onLanded,
+}: {
+  head: Anchor;
+  note?: Anchor;
+  flyToNote: boolean;
+  reduce: boolean | null;
+  /** Fired when the flight to the note finishes (gates the note text reveal). */
+  onLanded: () => void;
+}) {
+  const { components, chosen } = useChosenAvatar();
+  if (!components || !chosen) return null;
+
+  const half = HEADING_AVATAR / 2;
+  const landing = flyToNote && note ? note : head;
+
+  // Same size throughout (no shrink); straight vertical drop into the note slot.
+  const animate = {
+    x: landing.x - half,
+    y: landing.y - half,
+  };
+
+  return (
+    <motion.div
+      className="pointer-events-none absolute left-0 top-0"
+      style={{ width: HEADING_AVATAR, height: HEADING_AVATAR, transformOrigin: "center" }}
+      initial={false}
+      animate={animate}
+      transition={
+        reduce
+          ? { duration: 0 }
+          : flyToNote && note
+            ? { type: "spring", duration: 0.9, bounce: 0.45 }
+            : { duration: 0.4 }
+      }
+      onAnimationComplete={() => {
+        if (flyToNote && note) onLanded();
+      }}
+    >
+      <AnimatedAvatar components={components} traits={chosen} size={HEADING_AVATAR} />
+    </motion.div>
+  );
 }
 
 export function SuggestionsStep({
@@ -377,6 +516,7 @@ export function SuggestionsStep({
   loading,
   installedPlugins = [],
   onSuggestionClick,
+  onSkip,
   onBack,
   onForward,
 }: {
@@ -392,6 +532,8 @@ export function SuggestionsStep({
   installedPlugins?: string[];
   /** Opens the chat on the clicked suggestion (sends its user-voiced prompt). */
   onSuggestionClick: (suggestion: ResearchSuggestion) => void;
+  /** Skips the suggestions and drops the user straight into a blank chat. */
+  onSkip: () => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
@@ -410,22 +552,96 @@ export function SuggestionsStep({
   const pluginLabels = installedPlugins
     .map(pluginDisplayName)
     .filter((label) => label.length > 0);
+  const hasNote = pluginLabels.length > 0;
+
+  // A single avatar starts over the heading slot and flies down to the note's
+  // landing slot. We measure both slot centers (relative to the column) so the
+  // flight follows the real layout as suggestions stream in and reflow.
+  const columnRef = useRef<HTMLDivElement>(null);
+  const headSlotRef = useRef<HTMLDivElement>(null);
+  const noteSlotRef = useRef<HTMLDivElement>(null);
+  const [anchors, setAnchors] = useState<{ head: Anchor; note?: Anchor } | null>(
+    null,
+  );
+  const [flown, setFlown] = useState(false);
+  const [landed, setLanded] = useState(false);
+
+  useLayoutEffect(() => {
+    const measure = () => {
+      const col = columnRef.current;
+      const head = headSlotRef.current;
+      if (!col || !head) return;
+      const c = col.getBoundingClientRect();
+      const center = (r: DOMRect): Anchor => ({
+        x: r.left - c.left + r.width / 2,
+        y: r.top - c.top + r.height / 2,
+      });
+      const note = noteSlotRef.current;
+      setAnchors({
+        head: center(head.getBoundingClientRect()),
+        note: note ? center(note.getBoundingClientRect()) : undefined,
+      });
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+    // Intentionally not re-measuring on `flown`: the head anchor must stay at
+    // its pre-collapse position so the flight starts from where the avatar sat.
+  }, [items.length, hasNote]);
+
+  // Fly down the moment we have the data: as soon as the note slot is measured.
+  const noteY = anchors?.note?.y;
+  useEffect(() => {
+    if (!hasNote || noteY === undefined || flown) return;
+    setFlown(true);
+  }, [hasNote, noteY, flown]);
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-[26%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6">
-        <div className="flex items-center gap-3">
-          <MiniAssistant />
+      <div
+        ref={columnRef}
+        className="absolute left-1/2 top-[14%] sm:top-[26%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6"
+      >
+        <div className="flex items-center">
+          {/*
+            Empty slot the flying avatar rests over. Once the avatar departs
+            (`flown`), it collapses its width + right margin so the title slides
+            smoothly to left-aligned.
+          */}
+          <motion.div
+            ref={headSlotRef}
+            className="shrink-0"
+            style={{ height: HEADING_AVATAR }}
+            initial={false}
+            animate={
+              flown
+                ? { width: 0, marginRight: 0 }
+                : { width: HEADING_AVATAR, marginRight: 12 }
+            }
+            transition={reduce ? { duration: 0 } : { duration: 0.5, ease: "easeInOut" }}
+          />
           <h1 className="text-[2.2rem] leading-none" style={{ fontFamily: "var(--font-serif)" }}>
             Here&rsquo;s what we could do first
           </h1>
         </div>
         <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
-          {items.length > 0
-            ? "Pick one to jump in — or start your own thing."
-            : "Putting together a few ideas…"}
+          {items.length > 0 ? (
+            <>
+              Pick one to jump in — or start your own thing.{" "}
+              <button
+                type="button"
+                onClick={onSkip}
+                className="underline underline-offset-2 transition-opacity hover:opacity-80"
+                style={{ color: tone.fg }}
+              >
+                Skip to Chat
+              </button>
+            </>
+          ) : (
+            "Putting together a few ideas…"
+          )}
         </p>
 
         <div className="flex flex-col gap-3">
@@ -451,19 +667,24 @@ export function SuggestionsStep({
           ))}
         </div>
 
-        {pluginLabels.length > 0 && (
-          <motion.div
-            className="mt-5 flex items-center gap-2 text-[13px]"
-            style={{ color: tone.fgMuted }}
-            initial={reduce ? false : { opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 0.2 }}
-          >
-            <Check className="h-4 w-4 shrink-0" />
-            <span>
-              Set up {formatNameList(pluginLabels)} to help with your work
-            </span>
-          </motion.div>
+        {hasNote && (
+          <PluginSetupNote
+            pluginLabels={pluginLabels}
+            tone={tone}
+            reduce={reduce}
+            slotRef={noteSlotRef}
+            revealed={landed}
+          />
+        )}
+
+        {anchors && (
+          <FlyingHeadingAvatar
+            head={anchors.head}
+            note={anchors.note}
+            flyToNote={flown && hasNote && anchors.note !== undefined}
+            reduce={reduce}
+            onLanded={() => setLanded(true)}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
Polish pass on the research-onboarding flow, driven by visual QA across desktop and mobile.

## Suggestions screen
- The chosen avatar now flies **straight down** from the heading into the plugin note — a spring drop with a small bounce. As it leaves, the heading title slides smoothly to left-aligned, and the "Already set up the {plugin} plugin to help with your work" text reveals **only once the avatar lands**.
- Plugin names render as **pills tinted with the avatar color**.
- New inline **"Skip to Chat"** link — enters a blank chat (no auto-sent message, no research focus), awaiting any pending plugin installs first.
- More spacing between the suggestion cards and the note.

## Avatar pool
- The cast now spans **all 9 eye styles and all 9 body shapes** — previously it repeated `goofy`/`angry`/`curious` and never showed `surprised`/`gentle`/`quirky` (or the `cloud`/`flower` bodies).
- Grew the pool to 12 with two new bottom-center characters, and added **two desktop-only bottom-center edge slots** so the picker/backdrop fill the bottom edge. Kept off mobile to avoid re-crowding.

## Avatars / carousel
- Larger avatars on the looking-up, results, and suggestions steps.
- The looking-up carousel avatar **morphs while streaming** and is **top-aligned** so it no longer bobs up/down as messages change line count.

## Mobile layout
- Content sits higher (`top-14%` vs `sm:top-26%`).
- The edge crowd retreats to **corners / top + bottom only** on phones, across the form screen, face picker, and result steps, so it stops sitting behind the content.

## Fixes
- Custom assistant name now **persists when cycling avatars** on the face picker (was reset to the avatar default).
- Fixed the **"free credits" title wrapping word-per-line on mobile** — the column had no width, so it collapsed to ~50% of the viewport; now `w-full max-w-xl`.

## Testing
- `bun run typecheck`, `eslint`, and `bun run build` all pass.
- Onboarding handoff tests (`prechat-context`, `onboarding-lifecycle-sync`) pass.
- Visually QA'd each change across desktop and mobile during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)