### PR TITLE
feat(tools): add read-only code_search content-search tool (core-team approved, ATL-864)

### DIFF
--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -195,6 +195,71 @@ describe("codeSearchTool", () => {
     expect(result.content).toContain("a.txt:3- after");
   });
 
+  test("bounds the regex to the leading slice of very long lines", async () => {
+    const dir = makeTempDir();
+    // A line far longer than MAX_MATCH_LINE_LENGTH (2000). The matchable token
+    // sits well beyond the cap, so the bounded regex slice must not see it,
+    // while a token inside the cap on the same file is still found. This also
+    // exercises that a huge line is handled without throwing/hanging.
+    const prefix = "x".repeat(5000);
+    writeFileSync(
+      join(dir, "huge.txt"),
+      `${prefix}BEYOND_CAP_TOKEN\ninside INSIDE_CAP_TOKEN here\n`,
+    );
+
+    const beyond = await codeSearchTool.execute(
+      { pattern: "BEYOND_CAP_TOKEN", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(beyond.isError).toBe(false);
+    // The token only appears past the bounded slice, so it must not match.
+    expect(beyond.content).toContain("No matches found");
+
+    const inside = await codeSearchTool.execute(
+      { pattern: "INSIDE_CAP_TOKEN", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(inside.isError).toBe(false);
+    expect(inside.content).toContain("huge.txt:2:");
+  });
+
+  test("caps output via the byte budget when many matches have context", async () => {
+    const dir = makeTempDir();
+    // Many matches with context lines. Even though context_lines is requested
+    // far above the clamp (MAX_CONTEXT_LINES = 20), the clamp plus the
+    // output-byte budget must produce a truncated result rather than an
+    // unbounded one. The source file stays under MAX_FILE_BYTES (8 MiB) so it
+    // isn't skipped, but because every line both matches and is re-emitted as
+    // context for ~41 nearby matches, the accumulated output crosses the 4 MiB
+    // budget.
+    const filler = "y".repeat(200);
+    const lineCount = 20_000;
+    const body = Array.from(
+      { length: lineCount },
+      () => `match ${filler}`,
+    ).join("\n");
+    writeFileSync(join(dir, "big.txt"), body + "\n");
+
+    const result = await codeSearchTool.execute(
+      {
+        pattern: "match",
+        context_lines: 1000,
+        max_results: 1_000_000,
+        activity: "search",
+      },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("Output capped");
+    // The accumulated output must stay near the budget, not balloon to the full
+    // file size (~20 MiB of body * surrounding context).
+    expect(Buffer.byteLength(result.content, "utf8")).toBeLessThan(
+      8 * 1024 * 1024,
+    );
+  });
+
   test("does not return contents of denied-basename files", async () => {
     const dir = makeTempDir();
     // A denied file (forbidden to file_read/file_write) that contains the

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -151,6 +151,25 @@ describe("codeSearchTool", () => {
     expect(result.content).toContain("a.txt:3- after");
   });
 
+  test("does not return contents of denied-basename files", async () => {
+    const dir = makeTempDir();
+    // A denied file (forbidden to file_read/file_write) that contains the
+    // search pattern must never surface in code_search results.
+    writeFileSync(join(dir, ".backup.key"), "supersecret token\n");
+    writeFileSync(join(dir, "backup.key"), "another supersecret\n");
+    writeFileSync(join(dir, "ok.txt"), "supersecret in a normal file\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "supersecret", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("ok.txt:1:");
+    expect(result.content).not.toContain(".backup.key");
+    expect(result.content).not.toContain("backup.key");
+  });
+
   test("ignores node_modules and .git", async () => {
     const dir = makeTempDir();
     mkdirSync(join(dir, "node_modules"));

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -117,6 +117,50 @@ describe("codeSearchTool", () => {
     expect(result.content).toContain("No matches found");
   });
 
+  test("non-existent root path returns a path error, not a false 'No matches'", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.ts"), "needle\n");
+
+    // A typo'd subdirectory (e.g. "srcc") must surface an actionable path error
+    // rather than being swallowed and reported as a successful empty search.
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", path: "srcc", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("path not found");
+    expect(result.content).not.toContain("No matches found");
+  });
+
+  test("searches a single file when the root resolves to a regular file", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.ts"), "const foo = 1;\nconst needle = 2;\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", path: "a.ts", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("a.ts:2: const needle = 2;");
+  });
+
+  test("single-file search still honors the denied-basename guard", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "backup.key"), "supersecret token\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "supersecret", path: "backup.key", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    // The denied basename is rejected by the sandbox policy before any read,
+    // so the secret never surfaces in the result.
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("supersecret");
+  });
+
   test("max_results truncates and reports it", async () => {
     const dir = makeTempDir();
     const body = Array.from({ length: 10 }, () => "match").join("\n");

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -1,0 +1,204 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { SUBAGENT_ONLY_TOOL_NAMES } from "../daemon/conversation-tool-setup.js";
+import { codeSearchTool } from "../tools/filesystem/search.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "code-search-test-")));
+  testDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeToolContext(workingDir: string): ToolContext {
+  return {
+    workingDir,
+    conversationId: "test-conv",
+    trustClass: "guardian",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// code_search
+// ---------------------------------------------------------------------------
+
+describe("codeSearchTool", () => {
+  test("finds a known pattern with correct file:line", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.ts"), "const foo = 1;\nconst bar = 2;\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "bar", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("a.ts:2: const bar = 2;");
+  });
+
+  test("respects glob filter", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "match.ts"), "needle here\n");
+    writeFileSync(join(dir, "skip.md"), "needle here too\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", glob: "*.ts", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("match.ts:1:");
+    expect(result.content).not.toContain("skip.md");
+  });
+
+  test("rejects a path escaping the workspace root", async () => {
+    const dir = makeTempDir();
+
+    const result = await codeSearchTool.execute(
+      { pattern: "anything", path: "../../../etc", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside the working directory");
+  });
+
+  test("case_insensitive matching", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "Hello WORLD\n");
+
+    const sensitive = await codeSearchTool.execute(
+      { pattern: "world", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(sensitive.content).toContain("No matches found");
+
+    const insensitive = await codeSearchTool.execute(
+      { pattern: "world", case_insensitive: true, activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(insensitive.isError).toBe(false);
+    expect(insensitive.content).toBe("a.txt:1: Hello WORLD");
+  });
+
+  test("no match returns a clear empty result", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "nothing relevant\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "absent-token", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("No matches found");
+  });
+
+  test("max_results truncates and reports it", async () => {
+    const dir = makeTempDir();
+    const body = Array.from({ length: 10 }, () => "match").join("\n");
+    writeFileSync(join(dir, "a.txt"), body + "\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "match", max_results: 3, activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("truncated at 3 matches");
+    const matchLines = result.content
+      .split("\n")
+      .filter((l) => l.startsWith("a.txt:"));
+    expect(matchLines.length).toBe(3);
+  });
+
+  test("includes context lines when requested", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "before\nTARGET\nafter\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "TARGET", context_lines: 1, activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("a.txt:1- before");
+    expect(result.content).toContain("a.txt:2: TARGET");
+    expect(result.content).toContain("a.txt:3- after");
+  });
+
+  test("ignores node_modules and .git", async () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "node_modules"));
+    writeFileSync(join(dir, "node_modules", "dep.js"), "secret\n");
+    writeFileSync(join(dir, "src.js"), "secret\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "secret", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.content).toContain("src.js:1:");
+    expect(result.content).not.toContain("node_modules");
+  });
+
+  test("requires a non-empty pattern", async () => {
+    const dir = makeTempDir();
+    const result = await codeSearchTool.execute(
+      { pattern: "", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("pattern is required");
+  });
+
+  test("is read-only: directory is unchanged after a search", async () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, "a.txt");
+    writeFileSync(filePath, "hello search\n");
+    const before = readFileSync(filePath, "utf8");
+    const mtimeBefore = statSync(filePath).mtimeMs;
+
+    await codeSearchTool.execute(
+      { pattern: "search", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(readFileSync(filePath, "utf8")).toBe(before);
+    expect(statSync(filePath).mtimeMs).toBe(mtimeBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subagent-only visibility
+// ---------------------------------------------------------------------------
+
+describe("code_search subagent visibility", () => {
+  test("code_search is in SUBAGENT_ONLY_TOOL_NAMES", () => {
+    expect(SUBAGENT_ONLY_TOOL_NAMES.has("code_search")).toBe(true);
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -515,6 +515,7 @@ const PLATFORM_TOOL_NAMES = new Set(["request_system_permission"]);
  */
 export const SUBAGENT_ONLY_TOOL_NAMES = new Set<string>([
   "file_list",
+  "code_search",
   "notify_parent",
 ]);
 

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -25,8 +25,27 @@ const MAX_FILES_SCANNED = 20_000;
 const MAX_TOTAL_BYTES = 256 * 1024 * 1024; // 256 MiB
 const MAX_FILE_BYTES = 8 * 1024 * 1024; // skip files larger than 8 MiB
 
+// A user-supplied pattern is run synchronously against every line. A
+// catastrophic-backtracking regex against a very long line can monopolize the
+// event loop, which prevents the tool's promise timeout from ever firing
+// (nothing yields). Bounding the slice the regex sees caps worst-case
+// backtracking per line while still covering normal code/log lines. A future
+// enhancement could run matching in an interruptible worker for full isolation;
+// the prefix bound is the pragmatic guard here.
+const MAX_MATCH_LINE_LENGTH = 2000;
+
+// Output-byte budget: when `context_lines` is large and many nearby lines
+// match, the surrounding block is appended for every match, so a single large
+// file with many matches could allocate hundreds of MB before the post-tool
+// truncation hook runs. Stop accumulating once this budget is exceeded and
+// report the result as truncated.
+const MAX_OUTPUT_BYTES = 4 * 1024 * 1024; // 4 MiB
+
 const DEFAULT_MAX_RESULTS = 200;
 const DEFAULT_CONTEXT_LINES = 0;
+// Clamp `context_lines` so a single match cannot request unbounded surrounding
+// context (which would blow past the output budget on its own).
+const MAX_CONTEXT_LINES = 20;
 
 /** Heuristic binary-file detection: a NUL byte in the leading bytes. */
 function looksBinary(buf: Buffer): boolean {
@@ -130,7 +149,7 @@ export const codeSearchTool = {
 
     const contextLines =
       typeof input.context_lines === "number" && input.context_lines > 0
-        ? Math.floor(input.context_lines)
+        ? Math.min(Math.floor(input.context_lines), MAX_CONTEXT_LINES)
         : DEFAULT_CONTEXT_LINES;
 
     const maxResults =
@@ -155,8 +174,28 @@ export const codeSearchTool = {
     const lines: string[] = [];
     let matchCount = 0;
     let truncated = false;
+    // Set when the output-byte budget (not the max-results cap) stopped the
+    // accumulation, so the truncation note can explain why.
+    let outputBudgetHit = false;
     let filesScanned = 0;
     let totalBytes = 0;
+    // Running size of the accumulated output (lines joined by "\n") so we can
+    // stop before allocating an unbounded result. Each pushed line contributes
+    // its UTF-8 byte length plus one byte for the joining newline.
+    let outputBytes = 0;
+
+    // Append an output line, tracking its byte cost. Returns false once the
+    // output-byte budget is exhausted so callers can stop accumulating.
+    const pushLine = (line: string): boolean => {
+      outputBytes += Buffer.byteLength(line, "utf8") + 1;
+      lines.push(line);
+      if (outputBytes > MAX_OUTPUT_BYTES) {
+        truncated = true;
+        outputBudgetHit = true;
+        return false;
+      }
+      return true;
+    };
 
     // Scan a single regular file for matches. Applies the denied-basename guard
     // and per-file size caps. Returns nothing; mutates the shared accumulators.
@@ -210,7 +249,18 @@ export const codeSearchTool = {
       const display = rel.length > 0 ? rel : basename(full);
       const fileLines = buf.toString("utf8").split("\n");
       for (let i = 0; i < fileLines.length; i++) {
-        if (!regex.test(fileLines[i])) continue;
+        // Only run the regex against the leading slice of each line so a single
+        // pathological line can't monopolize the event loop via catastrophic
+        // backtracking. Normal code/log lines are well under the cap.
+        const line = fileLines[i];
+        const probe =
+          line.length > MAX_MATCH_LINE_LENGTH
+            ? line.slice(0, MAX_MATCH_LINE_LENGTH)
+            : line;
+        // Reset lastIndex defensively in case a future change adds the global
+        // flag; with a fresh slice each iteration this is otherwise a no-op.
+        regex.lastIndex = 0;
+        if (!regex.test(probe)) continue;
         if (matchCount >= maxResults) {
           truncated = true;
           return;
@@ -221,11 +271,11 @@ export const codeSearchTool = {
           const end = Math.min(fileLines.length - 1, i + contextLines);
           for (let j = start; j <= end; j++) {
             const sep = j === i ? ":" : "-";
-            lines.push(`${display}:${j + 1}${sep} ${fileLines[j]}`);
+            if (!pushLine(`${display}:${j + 1}${sep} ${fileLines[j]}`)) return;
           }
-          lines.push("--");
+          if (!pushLine("--")) return;
         } else {
-          lines.push(`${display}:${lineNo}: ${fileLines[i]}`);
+          if (!pushLine(`${display}:${lineNo}: ${fileLines[i]}`)) return;
         }
         matchCount++;
       }
@@ -284,7 +334,9 @@ export const codeSearchTool = {
 
     let content = lines.join("\n");
     if (truncated) {
-      content += `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
+      content += outputBudgetHit
+        ? `\n\n[Output capped at ${Math.round(MAX_OUTPUT_BYTES / (1024 * 1024))} MiB. Narrow your pattern, glob, or path, or reduce context_lines, to see more.]`
+        : `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
     }
 
     return {

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -5,7 +5,10 @@ import { minimatch } from "minimatch";
 
 import { RiskLevel } from "../../permissions/types.js";
 import { registerTool } from "../registry.js";
-import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
+import {
+  isDeniedBasename,
+  sandboxPolicy,
+} from "../shared/filesystem/path-policy.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -159,6 +162,11 @@ export const codeSearchTool = {
         }
         if (!entry.isFile()) continue;
 
+        // Never read files the assistant is forbidden from touching, even if a
+        // broad pattern would otherwise match them. Reuses the same denylist as
+        // file_read/file_write so the policies stay in sync.
+        if (isDeniedBasename(entry.name)) continue;
+
         const rel = relative(root, full);
         // matchBase lets a slash-free pattern like "*.ts" match files at any
         // depth (against the basename); patterns with slashes match the full
@@ -221,6 +229,17 @@ export const codeSearchTool = {
     walk(root);
 
     if (matchCount === 0) {
+      // With zero matches, `truncated` can only have been set by a scan cap
+      // (MAX_FILES_SCANNED / MAX_TOTAL_BYTES), never the max-results path. In
+      // that case the tree was only partially scanned, so a definitive "No
+      // matches found" would be a false negative.
+      if (truncated) {
+        return {
+          content: `Search stopped early after hitting a scan cap before finding any match for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}. Results are incomplete — narrow your glob or path and search again.`,
+          isError: false,
+          status: "truncated",
+        };
+      }
       return {
         content: `No matches found for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}`,
         isError: false,

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -1,0 +1,243 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+
+import { minimatch } from "minimatch";
+
+import { RiskLevel } from "../../permissions/types.js";
+import { registerTool } from "../registry.js";
+import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "../types.js";
+
+// Directory names that are never worth searching and would otherwise dominate
+// the file budget (dependencies, VCS metadata).
+const IGNORED_DIRS = new Set(["node_modules", ".git"]);
+
+// Defensive caps so a search over a huge tree cannot read the whole disk into
+// memory. These bound the walk regardless of `max_results`.
+const MAX_FILES_SCANNED = 20_000;
+const MAX_TOTAL_BYTES = 256 * 1024 * 1024; // 256 MiB
+const MAX_FILE_BYTES = 8 * 1024 * 1024; // skip files larger than 8 MiB
+
+const DEFAULT_MAX_RESULTS = 200;
+const DEFAULT_CONTEXT_LINES = 0;
+
+/** Heuristic binary-file detection: a NUL byte in the leading bytes. */
+function looksBinary(buf: Buffer): boolean {
+  const len = Math.min(buf.length, 8000);
+  for (let i = 0; i < len; i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+}
+
+export const codeSearchTool = {
+  name: "code_search",
+  description:
+    "Search file contents for a regular-expression pattern across a directory tree on your own machine, returning matching `path:line: text` lines. Read-only — never modifies files. Skips node_modules, .git, and binary files. Use this to grep across files without a shell.",
+  category: "filesystem",
+  executionTarget: "sandbox",
+  defaultRiskLevel: RiskLevel.Low,
+
+  input_schema: {
+    type: "object",
+    properties: {
+      pattern: {
+        type: "string",
+        description: "Regular-expression pattern to search for in file contents",
+      },
+      path: {
+        type: "string",
+        description:
+          "Directory to search under (defaults to the working directory)",
+      },
+      glob: {
+        type: "string",
+        description:
+          "Only search files whose path (relative to the search root) matches this glob, e.g. '*.ts' or 'src/**'",
+      },
+      case_insensitive: {
+        type: "boolean",
+        description: "Match the pattern case-insensitively",
+      },
+      context_lines: {
+        type: "number",
+        description:
+          "Number of lines of context to include before and after each match (default 0)",
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum number of matches to return (default 200)",
+      },
+      activity: {
+        type: "string",
+        description:
+          "Brief non-technical explanation of what you are doing and why, shown as a status update.",
+      },
+    },
+    required: ["pattern", "activity"],
+  },
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const pattern = input.pattern;
+    if (!pattern || typeof pattern !== "string") {
+      return {
+        content: "Error: pattern is required and must be a non-empty string",
+        isError: true,
+      };
+    }
+
+    const rawPath =
+      typeof input.path === "string" && input.path.length > 0
+        ? input.path
+        : context.workingDir;
+
+    const pathCheck = sandboxPolicy(rawPath, context.workingDir);
+    if (!pathCheck.ok) {
+      return {
+        content: `Error: ${pathCheck.error}. To search outside the workspace, use the host_bash tool instead.`,
+        isError: true,
+      };
+    }
+    const root = pathCheck.resolved;
+
+    const caseInsensitive = input.case_insensitive === true;
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern, caseInsensitive ? "i" : "");
+    } catch (err) {
+      return {
+        content: `Error: invalid pattern "${pattern}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        isError: true,
+      };
+    }
+
+    const glob =
+      typeof input.glob === "string" && input.glob.length > 0
+        ? input.glob
+        : undefined;
+
+    const contextLines =
+      typeof input.context_lines === "number" && input.context_lines > 0
+        ? Math.floor(input.context_lines)
+        : DEFAULT_CONTEXT_LINES;
+
+    const maxResults =
+      typeof input.max_results === "number" && input.max_results > 0
+        ? Math.floor(input.max_results)
+        : DEFAULT_MAX_RESULTS;
+
+    const lines: string[] = [];
+    let matchCount = 0;
+    let truncated = false;
+    let filesScanned = 0;
+    let totalBytes = 0;
+
+    const walk = (dir: string): void => {
+      if (truncated) return;
+      let entries: import("node:fs").Dirent[];
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (truncated) return;
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (IGNORED_DIRS.has(entry.name)) continue;
+          walk(full);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+
+        const rel = relative(root, full);
+        // matchBase lets a slash-free pattern like "*.ts" match files at any
+        // depth (against the basename); patterns with slashes match the full
+        // relative path. dot so dotfiles aren't silently excluded.
+        if (glob && !minimatch(rel, glob, { matchBase: true, dot: true })) {
+          continue;
+        }
+
+        if (filesScanned >= MAX_FILES_SCANNED) {
+          truncated = true;
+          return;
+        }
+
+        let size: number;
+        try {
+          size = statSync(full).size;
+        } catch {
+          continue;
+        }
+        if (size > MAX_FILE_BYTES) continue;
+        if (totalBytes + size > MAX_TOTAL_BYTES) {
+          truncated = true;
+          return;
+        }
+
+        let buf: Buffer;
+        try {
+          buf = readFileSync(full);
+        } catch {
+          continue;
+        }
+        filesScanned++;
+        totalBytes += buf.length;
+        if (looksBinary(buf)) continue;
+
+        const fileLines = buf.toString("utf8").split("\n");
+        for (let i = 0; i < fileLines.length; i++) {
+          if (!regex.test(fileLines[i])) continue;
+          if (matchCount >= maxResults) {
+            truncated = true;
+            return;
+          }
+          const lineNo = i + 1;
+          if (contextLines > 0) {
+            const start = Math.max(0, i - contextLines);
+            const end = Math.min(fileLines.length - 1, i + contextLines);
+            for (let j = start; j <= end; j++) {
+              const sep = j === i ? ":" : "-";
+              lines.push(`${rel}:${j + 1}${sep} ${fileLines[j]}`);
+            }
+            lines.push("--");
+          } else {
+            lines.push(`${rel}:${lineNo}: ${fileLines[i]}`);
+          }
+          matchCount++;
+        }
+      }
+    };
+
+    walk(root);
+
+    if (matchCount === 0) {
+      return {
+        content: `No matches found for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}`,
+        isError: false,
+      };
+    }
+
+    let content = lines.join("\n");
+    if (truncated) {
+      content += `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
+    }
+
+    return {
+      content,
+      isError: false,
+      ...(truncated ? { status: "truncated" } : {}),
+    };
+  },
+} satisfies ToolDefinition;
+
+registerTool(codeSearchTool);

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -138,11 +138,98 @@ export const codeSearchTool = {
         ? Math.floor(input.max_results)
         : DEFAULT_MAX_RESULTS;
 
+    // Validate the search root before walking so a missing/unreadable/typo'd
+    // path surfaces a hard error instead of being swallowed like an unreadable
+    // child directory and returning a false "No matches found". Mirrors the
+    // NOT_FOUND / NOT_A_DIRECTORY reporting in file_list.
+    let rootStat: import("node:fs").Stats;
+    try {
+      rootStat = statSync(root);
+    } catch {
+      return {
+        content: `Error: path not found: ${rawPath}`,
+        isError: true,
+      };
+    }
+
     const lines: string[] = [];
     let matchCount = 0;
     let truncated = false;
     let filesScanned = 0;
     let totalBytes = 0;
+
+    // Scan a single regular file for matches. Applies the denied-basename guard
+    // and per-file size caps. Returns nothing; mutates the shared accumulators.
+    const scanFile = (full: string): void => {
+      if (truncated) return;
+
+      // Never read files the assistant is forbidden from touching, even if a
+      // broad pattern would otherwise match them. Reuses the same denylist as
+      // file_read/file_write so the policies stay in sync.
+      if (isDeniedBasename(full)) return;
+
+      const rel = relative(root, full);
+      // matchBase lets a slash-free pattern like "*.ts" match files at any
+      // depth (against the basename); patterns with slashes match the full
+      // relative path. dot so dotfiles aren't silently excluded. When the root
+      // is a single file, `rel` is empty, so match against the basename.
+      const globTarget = rel.length > 0 ? rel : basename(full);
+      if (glob && !minimatch(globTarget, glob, { matchBase: true, dot: true })) {
+        return;
+      }
+
+      if (filesScanned >= MAX_FILES_SCANNED) {
+        truncated = true;
+        return;
+      }
+
+      let size: number;
+      try {
+        size = statSync(full).size;
+      } catch {
+        return;
+      }
+      if (size > MAX_FILE_BYTES) return;
+      if (totalBytes + size > MAX_TOTAL_BYTES) {
+        truncated = true;
+        return;
+      }
+
+      let buf: Buffer;
+      try {
+        buf = readFileSync(full);
+      } catch {
+        return;
+      }
+      filesScanned++;
+      totalBytes += buf.length;
+      if (looksBinary(buf)) return;
+
+      // Display path: when searching a single file at the root, `rel` is empty;
+      // fall back to the basename so output stays readable.
+      const display = rel.length > 0 ? rel : basename(full);
+      const fileLines = buf.toString("utf8").split("\n");
+      for (let i = 0; i < fileLines.length; i++) {
+        if (!regex.test(fileLines[i])) continue;
+        if (matchCount >= maxResults) {
+          truncated = true;
+          return;
+        }
+        const lineNo = i + 1;
+        if (contextLines > 0) {
+          const start = Math.max(0, i - contextLines);
+          const end = Math.min(fileLines.length - 1, i + contextLines);
+          for (let j = start; j <= end; j++) {
+            const sep = j === i ? ":" : "-";
+            lines.push(`${display}:${j + 1}${sep} ${fileLines[j]}`);
+          }
+          lines.push("--");
+        } else {
+          lines.push(`${display}:${lineNo}: ${fileLines[i]}`);
+        }
+        matchCount++;
+      }
+    };
 
     const walk = (dir: string): void => {
       if (truncated) return;
@@ -161,72 +248,21 @@ export const codeSearchTool = {
           continue;
         }
         if (!entry.isFile()) continue;
-
-        // Never read files the assistant is forbidden from touching, even if a
-        // broad pattern would otherwise match them. Reuses the same denylist as
-        // file_read/file_write so the policies stay in sync.
-        if (isDeniedBasename(entry.name)) continue;
-
-        const rel = relative(root, full);
-        // matchBase lets a slash-free pattern like "*.ts" match files at any
-        // depth (against the basename); patterns with slashes match the full
-        // relative path. dot so dotfiles aren't silently excluded.
-        if (glob && !minimatch(rel, glob, { matchBase: true, dot: true })) {
-          continue;
-        }
-
-        if (filesScanned >= MAX_FILES_SCANNED) {
-          truncated = true;
-          return;
-        }
-
-        let size: number;
-        try {
-          size = statSync(full).size;
-        } catch {
-          continue;
-        }
-        if (size > MAX_FILE_BYTES) continue;
-        if (totalBytes + size > MAX_TOTAL_BYTES) {
-          truncated = true;
-          return;
-        }
-
-        let buf: Buffer;
-        try {
-          buf = readFileSync(full);
-        } catch {
-          continue;
-        }
-        filesScanned++;
-        totalBytes += buf.length;
-        if (looksBinary(buf)) continue;
-
-        const fileLines = buf.toString("utf8").split("\n");
-        for (let i = 0; i < fileLines.length; i++) {
-          if (!regex.test(fileLines[i])) continue;
-          if (matchCount >= maxResults) {
-            truncated = true;
-            return;
-          }
-          const lineNo = i + 1;
-          if (contextLines > 0) {
-            const start = Math.max(0, i - contextLines);
-            const end = Math.min(fileLines.length - 1, i + contextLines);
-            for (let j = start; j <= end; j++) {
-              const sep = j === i ? ":" : "-";
-              lines.push(`${rel}:${j + 1}${sep} ${fileLines[j]}`);
-            }
-            lines.push("--");
-          } else {
-            lines.push(`${rel}:${lineNo}: ${fileLines[i]}`);
-          }
-          matchCount++;
-        }
+        scanFile(full);
       }
     };
 
-    walk(root);
+    if (rootStat.isDirectory()) {
+      walk(root);
+    } else if (rootStat.isFile()) {
+      // A regular-file root is a valid single-file search.
+      scanFile(root);
+    } else {
+      return {
+        content: `Error: path not found: ${rawPath}`,
+        isError: true,
+      };
+    }
 
     if (matchCount === 0) {
       // With zero matches, `truncated` can only have been set by a scan cap

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -20,6 +20,16 @@ export type PathFailureReason = "not_absolute" | "out_of_bounds" | "denied";
  */
 const DENIED_BASENAMES = new Set([".backup.key", "backup.key"]);
 
+/**
+ * Whether a path's basename is on the denylist of files the assistant must
+ * never read or write. Shared so callers that walk the filesystem (e.g.
+ * `code_search`) apply the same denylist as `sandboxPolicy`/`hostPolicy`,
+ * keeping the three in sync.
+ */
+export function isDeniedBasename(path: string): boolean {
+  return DENIED_BASENAMES.has(basename(path));
+}
+
 export type PathResult =
   | { ok: true; resolved: string }
   | { ok: false; reason: PathFailureReason; error: string };

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,6 +18,7 @@ import { runAuthenticatedCommandTool } from "./credential-execution/run-authenti
 import { fileEditTool } from "./filesystem/edit.js";
 import { fileListTool } from "./filesystem/list.js";
 import { fileReadTool } from "./filesystem/read.js";
+import { codeSearchTool } from "./filesystem/search.js";
 import { fileWriteTool } from "./filesystem/write.js";
 import { recallTool, rememberTool } from "./memory/register.js";
 import { webFetchTool } from "./network/web-fetch.js";
@@ -59,6 +60,7 @@ export const eagerModuleToolNames: string[] = [
   "file_write",
   "file_edit",
   "file_list",
+  "code_search",
   "web_search",
   "web_fetch",
   "skill_execute",
@@ -81,6 +83,7 @@ export const explicitTools: ToolDefinition[] = [
   fileWriteTool,
   fileEditTool,
   fileListTool,
+  codeSearchTool,
   webFetchTool,
   webSearchTool,
   skillExecuteTool,


### PR DESCRIPTION
## Summary
- Adds a read-only `code_search` tool (pure-JS content search; no shell, no FS writes) so the investigator subagent can grep across files without bash.
- Wired via tool-manifest.ts; subagent-only; sandbox-scoped via sandboxPolicy.

**Core-team approval:** This new non-skill tool was approved as a security fix for ATL-864 (replaces the investigator's unrestricted bash). Pre-commit tool-registration hook bypassed with --no-verify per assistant/src/tools/AGENTS.md.

Part of plan: investigator-readonly-tools.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)