### PR TITLE
feat(web): add SubagentSpawnGroup collapsible wrapper for spawned subagents

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for `SubagentSpawnGroup`.
+ *
+ * Drives the Zustand subagent store with spawned ids so badges/rows render,
+ * then asserts the collapse/expand contract: the resting state is the compact
+ * `SubagentAvatarRow` summary (badges present, list rows absent); "Details"
+ * expands into the `SubagentInlineProgressCard` list plus a "Collapse" toggle;
+ * and "Collapse" returns to the summary.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SubagentSpawnGroup } from "@/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  useSubagentStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Spawn `count` subagents and return their ids so badges/rows render. */
+function spawnIds(count: number): string[] {
+  const ids = Array.from({ length: count }, (_, i) => `sa-${i}`);
+  for (const id of ids) {
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: id,
+      label: "Research Agent",
+      objective: "Find the answer",
+      timestamp: NOW,
+    });
+  }
+  return ids;
+}
+
+describe("SubagentSpawnGroup", () => {
+  test("renders null for an empty id set", () => {
+    const { container } = render(<SubagentSpawnGroup subagentIds={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("defaults to the collapsed avatar summary (no list rows)", () => {
+    const ids = spawnIds(3);
+    const { queryAllByTestId } = render(
+      <SubagentSpawnGroup subagentIds={ids} />,
+    );
+
+    // Badges present, but the expanded list rows are not yet rendered.
+    expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(3);
+    expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(0);
+  });
+
+  test("Details expands to the row list plus a Collapse toggle", () => {
+    const ids = spawnIds(3);
+    const { getByTestId, queryAllByTestId } = render(
+      <SubagentSpawnGroup subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-avatar-row-details"));
+
+    // The summary is replaced by one inline card per id, capped by Collapse.
+    expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(3);
+    expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(0);
+    expect(getByTestId("subagent-spawn-group-collapse")).toBeTruthy();
+  });
+
+  test("Collapse returns to the avatar summary", () => {
+    const ids = spawnIds(3);
+    const { getByTestId, queryAllByTestId, queryByTestId } = render(
+      <SubagentSpawnGroup subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("subagent-avatar-row-details"));
+    fireEvent.click(getByTestId("subagent-spawn-group-collapse"));
+
+    expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(3);
+    expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(0);
+    expect(queryByTestId("subagent-spawn-group-collapse")).toBeNull();
+  });
+
+  test("threads onSubagentClick and onStopSubagent to each expanded row", () => {
+    const ids = spawnIds(2);
+    // Mark in-flight so the stop button renders on the rows.
+    for (const id of ids) {
+      useSubagentStore.getState().changeStatus({ subagentId: id, status: "running" });
+    }
+
+    const clicked: string[] = [];
+    const stopped: string[] = [];
+    const { getByTestId, getAllByTestId } = render(
+      <SubagentSpawnGroup
+        subagentIds={ids}
+        onSubagentClick={(id) => clicked.push(id)}
+        onStopSubagent={(id) => stopped.push(id)}
+      />,
+    );
+
+    fireEvent.click(getByTestId("subagent-avatar-row-details"));
+
+    const rows = getAllByTestId("subagent-inline-progress-card");
+    fireEvent.click(rows[0]);
+    expect(clicked).toEqual([ids[0]]);
+
+    const stopButtons = getAllByTestId("subagent-inline-card-stop");
+    fireEvent.click(stopButtons[1]);
+    expect(stopped).toEqual([ids[1]]);
+  });
+});

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
@@ -1,0 +1,77 @@
+/**
+ * Collapsible wrapper for a set of spawned subagents.
+ *
+ * Resting (collapsed) state shows the compact `SubagentAvatarRow` summary
+ * (capped avatars + `+N` overflow + a "Details" toggle). Activating "Details"
+ * expands into the full per-subagent list of `SubagentInlineProgressCard`
+ * rows, capped by a "Collapse" toggle (Figma node `6063:148770`) that returns
+ * to the summary.
+ *
+ * `onSubagentClick` / `onStopSubagent` are threaded straight through to each
+ * expanded row. Renders `null` for an empty id set.
+ */
+
+import { ChevronUp } from "lucide-react";
+import { useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { SubagentAvatarRow } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
+import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
+
+export interface SubagentSpawnGroupProps {
+  subagentIds: string[];
+  onSubagentClick?: (subagentId: string) => void;
+  onStopSubagent?: (subagentId: string) => void;
+}
+
+export function SubagentSpawnGroup({
+  subagentIds,
+  onSubagentClick,
+  onStopSubagent,
+}: SubagentSpawnGroupProps) {
+  // Default collapsed — the avatar summary is the resting state in the mocks.
+  const [expanded, setExpanded] = useState(false);
+
+  if (subagentIds.length === 0) return null;
+
+  if (!expanded) {
+    return (
+      <SubagentAvatarRow
+        subagentIds={subagentIds}
+        onExpand={() => setExpanded(true)}
+      />
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="flex w-full flex-col gap-1.5">
+        {subagentIds.map((id) => (
+          <SubagentInlineProgressCard
+            key={id}
+            subagentId={id}
+            onSubagentClick={onSubagentClick}
+            onStopSubagent={onStopSubagent}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setExpanded(false)}
+        aria-label="Collapse subagent details"
+        data-testid="subagent-spawn-group-collapse"
+        className="mt-2 flex items-center gap-1"
+      >
+        <Typography
+          variant="body-medium-default"
+          className="text-[var(--content-tertiary)]"
+        >
+          Collapse
+        </Typography>
+        <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add SubagentSpawnGroup: defaults to the collapsed SubagentAvatarRow summary; Details expands to the SubagentInlineProgressCard row list + a Collapse toggle. Threads onSubagentClick/onStopSubagent to each row. Returns null for empty input.

Part of plan: spawning-subagents-ui-redesign.md (PR 4 of 5)