### PR TITLE
fix(macos): re-apply Sendable conformance to AXElement and WindowInfo

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/AccessibilityTree.swift
@@ -4,7 +4,7 @@ import os
 
 private let log = Logger(subsystem: "ai.vellum.mac-helper", category: "AXTree")
 
-struct AXElement: Identifiable {
+struct AXElement: Identifiable, Sendable {
     let id: Int
     let role: String
     let title: String?
@@ -19,7 +19,7 @@ struct AXElement: Identifiable {
     let placeholderValue: String?
 }
 
-struct WindowInfo {
+struct WindowInfo: Sendable {
     let elements: [AXElement]
     let windowTitle: String
     let appName: String


### PR DESCRIPTION
## Summary
- The `Release v0.10.2 (#35927)` merge into main reverted the `Sendable` conformance that #35870 added to `AXElement` and `WindowInfo`, re-breaking the Electron mac-helper Swift build.
- `WindowInfo` is returned across a `Task.detached` boundary in `enumerateSecondaryWindows`; without `Sendable` the compile fails with `type 'WindowInfo' does not conform to the 'Sendable' protocol`.
- Both are value types composed entirely of `Sendable` members, so this re-adds the explicit `Sendable` conformance (identical to #35870).

## Original prompt
The macOS Electron build was failing on main with `type 'WindowInfo' does not conform to the 'Sendable' protocol` in AccessibilityTree.swift, causing the `@vellumai/macos` postinstall to exit 1. Investigation showed the fix had already landed in #35870 but was clobbered by the v0.10.2 release merge — a recurrence of the known pattern where release merges re-break main. This re-applies the two-line conformance fix on top of current main.