### PR TITLE
fix(onboarding): re-prompt when Google grant lacks calendar scope

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -33,6 +33,7 @@ import { buildResearchPrompt } from "@/domains/onboarding/research-prompt";
 import { useBackgroundHatch } from "@/domains/onboarding/use-background-hatch";
 import { useResearchRunner } from "@/domains/onboarding/research-runner";
 import { scheduleCheckin } from "@/domains/onboarding/checkin-scheduler";
+import { GOOGLE_CALENDAR_EVENTS_SCOPE } from "@/domains/onboarding/hooks/use-google-calendar-connect";
 import { formatCheckinTime } from "@/domains/onboarding/format-checkin-time";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import {
@@ -123,6 +124,12 @@ export function ResearchOnboardingRoute() {
   // True while the booking request is in flight, so the confirmation step can
   // hold (capped) until the booked time is known instead of advancing early.
   const [checkinPending, setCheckinPending] = useState(false);
+  // Set when the Google grant landed WITHOUT the calendar.events scope (the user
+  // didn't tick the calendar box on Google's granular-consent screen). The
+  // connection succeeds but no event can be booked, so we keep the user on the
+  // "let's chat tomorrow" step with a recoverable re-prompt instead of advancing
+  // to a false confirmation.
+  const [missingCalendarScope, setMissingCalendarScope] = useState(false);
   // Bumped by the integration step's coin to jolt the bottom eyes.
   const [eyesBump, setEyesBump] = useState(0);
   // Extra edge characters revealed so far — grows as the looking-you-up
@@ -269,7 +276,20 @@ export function ResearchOnboardingRoute() {
   // Day-2 check-in: once the Google Calendar grant lands, fire the check-in
   // prompt into its own conversation (best-effort, never blocks) and advance to
   // the "Meeting Created!" confirmation.
-  function handleCheckinConnected() {
+  //
+  // The grant can "connect" without the calendar.events scope when the user
+  // skips the calendar checkbox on Google's granular-consent screen. That's a
+  // recoverable user error — not a transient daemon failure — so hold on this
+  // step with a re-prompt rather than booking nothing and showing a false
+  // confirmation. The daemon collapses "not connected" and "scope not granted"
+  // into one best-effort skip, so the client's own scope check is the only
+  // signal that distinguishes this case.
+  function handleCheckinConnected(scopes: string[]) {
+    if (!scopes.includes(GOOGLE_CALENDAR_EVENTS_SCOPE)) {
+      setMissingCalendarScope(true);
+      return;
+    }
+    setMissingCalendarScope(false);
     if (hatchedAssistantId && formValues) {
       const fullName = [formValues.firstName.trim(), formValues.lastName.trim()]
         .filter(Boolean)
@@ -355,7 +375,12 @@ export function ResearchOnboardingRoute() {
             assistantId={hatchedAssistantId}
             assistantReady={hatchReady}
             onConnected={handleCheckinConnected}
-            onSkip={() => goForwardTo("looking")}
+            missingCalendarScope={missingCalendarScope}
+            onRetry={() => setMissingCalendarScope(false)}
+            onSkip={() => {
+              setMissingCalendarScope(false);
+              goForwardTo("looking");
+            }}
             onBack={() => goBackTo("integration")}
             onForward={onForward}
           />

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -281,11 +281,19 @@ export function ResearchOnboardingRoute() {
   // skips the calendar checkbox on Google's granular-consent screen. That's a
   // recoverable user error — not a transient daemon failure — so hold on this
   // step with a re-prompt rather than booking nothing and showing a false
-  // confirmation. The daemon collapses "not connected" and "scope not granted"
-  // into one best-effort skip, so the client's own scope check is the only
-  // signal that distinguishes this case.
+  // confirmation.
+  //
+  // Only block on a POSITIVE denial: a populated scope list that lacks
+  // calendar.events (a real denial still carries the identity scopes, so it's
+  // never empty). An empty list is ambiguous — the connection row may not have
+  // synced yet, the fetch may have failed, or a legacy connection may omit
+  // scope data — so treat it as unknown and fall through to the best-effort
+  // schedule. This mirrors the daemon resolver, which rejects only when a
+  // connection positively lacks a required scope and never on unknown data.
   function handleCheckinConnected(scopes: string[]) {
-    if (!scopes.includes(GOOGLE_CALENDAR_EVENTS_SCOPE)) {
+    const calendarDenied =
+      scopes.length > 0 && !scopes.includes(GOOGLE_CALENDAR_EVENTS_SCOPE);
+    if (calendarDenied) {
       setMissingCalendarScope(true);
       return;
     }

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the "let's chat tomorrow" step's calendar-scope re-prompt.
+ *
+ * Single-file `bun test` only — `mock.module` leaks across files in this repo,
+ * so run this file on its own (or via scripts/run-tests.ts).
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Capture the onConnect callback the step hands to the hook so a test can fire
+// it with an arbitrary scope set, and spy on the connect trigger.
+let capturedOnConnect: ((scopes: string[]) => void) | null = null;
+const handleConnectMock = mock(() => {});
+
+mock.module("@/domains/onboarding/hooks/use-google-calendar-connect", () => ({
+  useGoogleCalendarConnect: ({
+    onConnect,
+  }: {
+    onConnect: (scopes: string[]) => void;
+  }) => {
+    capturedOnConnect = onConnect;
+    return { handleConnect: handleConnectMock, oauthInProgress: false };
+  },
+}));
+
+mock.module("@/domains/onboarding/onboarding-tone", () => ({
+  useOnboardingTone: () => ({
+    bg: "#000000",
+    isLight: false,
+    fg: "#FFFFFF",
+    fgDeep: "#000000",
+    fgMuted: "rgba(255,255,255,0.65)",
+    wash: "rgba(255,255,255,0.12)",
+  }),
+}));
+
+const { LetsChatTomorrowStep } = await import(
+  "@/domains/onboarding/screens/lets-chat-tomorrow-step"
+);
+
+const RE_PROMPT = /Access not enabled/;
+
+function renderStep(props: Partial<Parameters<typeof LetsChatTomorrowStep>[0]>) {
+  return render(
+    <LetsChatTomorrowStep
+      assistantId="asst-1"
+      assistantReady
+      onConnected={() => {}}
+      onSkip={() => {}}
+      onBack={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe("LetsChatTomorrowStep", () => {
+  beforeEach(() => {
+    capturedOnConnect = null;
+    handleConnectMock.mockClear();
+  });
+  afterEach(cleanup);
+
+  test("forwards the granted scopes to onConnected", () => {
+    const onConnected = mock((_scopes: string[]) => {});
+    renderStep({ onConnected });
+
+    capturedOnConnect?.(["openid", "calendar.events"]);
+
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(onConnected.mock.calls[0]?.[0]).toEqual([
+      "openid",
+      "calendar.events",
+    ]);
+  });
+
+  test("hides the re-prompt and shows 'Set it up' by default", () => {
+    renderStep({ missingCalendarScope: false });
+
+    expect(screen.queryByText(RE_PROMPT)).toBeNull();
+    expect(screen.getByText("Set it up")).toBeDefined();
+  });
+
+  test("shows the re-prompt and 'Try again' when the scope is missing", () => {
+    renderStep({ missingCalendarScope: true });
+
+    expect(screen.getByText(RE_PROMPT)).toBeDefined();
+    expect(screen.getByText("Try again")).toBeDefined();
+  });
+
+  test("clears the re-prompt then reopens consent on retry click", () => {
+    const onRetry = mock(() => {});
+    renderStep({ missingCalendarScope: true, onRetry });
+
+    fireEvent.click(screen.getByText("Try again"));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(handleConnectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -33,6 +33,14 @@ interface LetsChatTomorrowStepProps {
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /**
+   * True when a prior grant connected without the calendar.events scope (the
+   * calendar checkbox was left unticked on Google's consent screen). Surfaces an
+   * inline re-prompt instead of advancing to a confirmation that never booked.
+   */
+  missingCalendarScope?: boolean;
+  /** Clears the missing-scope re-prompt as the user starts a fresh attempt. */
+  onRetry?: () => void;
 }
 
 export function LetsChatTomorrowStep({
@@ -42,12 +50,20 @@ export function LetsChatTomorrowStep({
   onSkip,
   onBack,
   onForward,
+  missingCalendarScope = false,
+  onRetry,
 }: LetsChatTomorrowStepProps) {
   const tone = useOnboardingTone();
   const { handleConnect, oauthInProgress } = useGoogleCalendarConnect({
     assistantId: assistantId ?? "",
     onConnect: onConnected,
   });
+  // Clear any stale re-prompt before reopening the consent popup so the message
+  // reflects only the latest attempt.
+  const handleConnectClick = () => {
+    onRetry?.();
+    handleConnect();
+  };
   // Wait for full readiness (not just an id): the post-OAuth `scheduleCheckin`
   // hits the daemon, which may not be reachable until healthz passes.
   const connectDisabled = !assistantId || !assistantReady || oauthInProgress;
@@ -61,16 +77,20 @@ export function LetsChatTomorrowStep({
           className="text-[2.6rem] leading-tight"
           style={{ fontFamily: "var(--font-serif)" }}
         >
-          I&rsquo;ll also check in with you
+          {missingCalendarScope
+            ? "Access not enabled"
+            : "I’ll also check in with you"}
         </h1>
         <p className="text-[16px]" style={{ color: tone.fgMuted }}>
-          Add a quick check-in to your calendar to follow up tomorrow.
+          {missingCalendarScope
+            ? "Check the box next to the Google Calendar permission so I can book the check-in."
+            : "Add a quick check-in to your calendar to follow up tomorrow."}
         </p>
 
         <div className="mt-6 flex w-[234px] flex-col items-center gap-4">
           <button
             type="button"
-            onClick={handleConnect}
+            onClick={handleConnectClick}
             disabled={connectDisabled}
             className="flex h-11 w-full items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97] disabled:opacity-60"
             style={{
@@ -83,6 +103,8 @@ export function LetsChatTomorrowStep({
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
                 Waiting for authorization…
               </>
+            ) : missingCalendarScope ? (
+              "Try again"
             ) : (
               "Set it up"
             )}

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -83,10 +83,11 @@ export function MiniAssistant({
 
 const MINI = 48;
 
-// The confirmation animation runs ~2.6s; that's the minimum on-screen time.
-const MEETING_MIN_MS = 2600;
+// The confirmation animation runs ~1.3s to reveal the title; hold well past it
+// so the booked time stays readable for ~3s before advancing.
+const MEETING_MIN_MS = 4500;
 // Cap how long we hold for a slow-but-pending booking before advancing anyway.
-const MEETING_MAX_MS = 6000;
+const MEETING_MAX_MS = 7000;
 
 /**
  * Reverse of the Introduction grow-in. The toned backdrop (behind) blends to
@@ -131,8 +132,17 @@ export function MeetingCreatedStep({
     return () => clearTimeout(t);
   }, [onDone, awaitingTime, scheduledTime]);
 
-  // Mini avatar slot: left of the title, in a left-anchored group.
-  const groupLeft = w / 2 - 170;
+  // Center the avatar+title group as a unit. The title width varies a lot — the
+  // booked-time variant is far wider than the generic copy — so a fixed left
+  // offset shoves it off-center; measure the rendered group and center it.
+  // Re-measures when the title swaps (e.g. the booked time lands late).
+  const groupRef = useRef<HTMLDivElement>(null);
+  const [groupWidth, setGroupWidth] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    if (groupRef.current) setGroupWidth(groupRef.current.offsetWidth);
+  }, [title, w, h]);
+
+  const groupLeft = groupWidth != null ? (w - groupWidth) / 2 : w / 2 - 170;
   const slotCx = groupLeft + MINI / 2;
   const slotCy = h * 0.26 + MINI / 2;
 
@@ -149,11 +159,12 @@ export function MeetingCreatedStep({
       <OnboardingTopBar onBack={onBack} onNext={onForward} tone="light" />
 
       <div
+        ref={groupRef}
         className="absolute flex items-center gap-4"
         style={{ left: groupLeft, top: h * 0.26 }}
       >
         <div className="relative" style={{ width: MINI, height: MINI }}>
-          {components && chosen && (
+          {components && chosen && groupWidth != null && (
             <motion.div
               className="absolute inset-0"
               style={{ transformOrigin: "center" }}


### PR DESCRIPTION
## Problem

In the research-onboarding check-in step, completing Google Calendar OAuth **without ticking the calendar permission checkbox** on Google's granular-consent screen still "connects" — but the grant lacks `calendar.events`. The daemon then books nothing, yet the UI advanced straight to a false **"Check-in scheduled!"** confirmation.

## Approach

The daemon deliberately collapses "not connected" and "scope not granted" into a single best-effort skip (`reason: "calendar_unavailable"` in `schedule-checkin.ts`), so the **client-side scope check is the only signal** that distinguishes this recoverable case. At the moment the connect callback fires, the OAuth connection already succeeded, so the real question is simply "did the user grant `calendar.events`" — which the client already has in `connection.scopes_granted`.

- `research-onboarding-route.tsx`: `handleCheckinConnected(scopes)` now branches on `scopes.includes(GOOGLE_CALENDAR_EVENTS_SCOPE)`. Missing → set `missingCalendarScope`, **hold on the step** (no advance). Present → existing schedule + advance.
- `lets-chat-tomorrow-step.tsx`: new `missingCalendarScope` + `onRetry` props swap the title/subtitle to a re-prompt ("Access not enabled" / "Check the box next to the Google Calendar permission so I can book the check-in.") and relabel the button **"Try again"**; clicking clears the prompt and reopens consent.

## Also in this PR

- **`MeetingCreatedStep` centering**: the booked-time title is far wider than the generic copy and was shoved off-center by a fixed left offset. Now the avatar+title group is measured and centered as a unit (re-measures when the booked time lands late).
- **Longer hold**: confirmation min on-screen time 2.6s → 4.5s so the booked time stays readable for ~3s.

## Tests

New `lets-chat-tomorrow-step.test.tsx` (4 cases): scopes forwarded to `onConnected`, default vs. missing-scope rendering, retry click wiring. `bun test`, `bun run typecheck`, `eslint`, and `audit:cross-domain:check` all pass.

> Note: opened without a Linear ticket per request, so it won't auto-link/close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)