### PR TITLE
fix(plugins): activate installed plugins without a daemon restart

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -7,7 +7,14 @@
  * cache miss (changed mtime → re-import), plugin deletion (eviction),
  * and hook collection across multiple plugins.
  */
-import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -27,6 +34,11 @@ import {
   populateCacheAtBoot,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
+import {
+  getAllToolDefinitions,
+  getPluginToolDefinitions,
+  getToolOwner,
+} from "../tools/registry.js";
 
 // ─── Test fixtures ───────────────────────────────────────────────────────────
 
@@ -512,5 +524,122 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     const { readFileSync: rf, existsSync: ex } = await import("node:fs");
     expect(ex(sentinel)).toBe(true);
     expect(rf(sentinel, "utf8")).toBe("x");
+  });
+});
+
+// ─── Runtime activation (hot-reload without a daemon restart) ──────────────────
+
+/**
+ * Write a hook that appends `token` to `markerPath` each time it runs, so a
+ * test can count how many times `init`/`shutdown` fired.
+ */
+function writeMarkerHook(
+  dir: string,
+  hookName: string,
+  markerPath: string,
+  token: string,
+): void {
+  writeHook(
+    dir,
+    hookName,
+    `import { appendFileSync } from "node:fs";\nexport default () => { appendFileSync(${JSON.stringify(markerPath)}, ${JSON.stringify(`${token}\n`)}); };`,
+  );
+}
+
+const TOOL_SRC = (name: string) =>
+  `export default { name: ${JSON.stringify(name)}, description: "test", parameters: { type: "object", properties: {} } };`;
+
+/**
+ * Simulate the per-turn plugin hook dispatch that drives runtime reconciliation
+ * in production: any `getUserHooksFor` call runs `scanPlugins`, which activates
+ * newly present plugins and deactivates removed ones. The hook name is
+ * irrelevant — the scan runs regardless of whether a plugin defines that hook.
+ */
+async function triggerScan(): Promise<void> {
+  await getUserHooksFor("user-prompt-submit");
+}
+
+describe("plugin runtime activation", () => {
+  test("a plugin installed after boot becomes live on the next scan", async () => {
+    await populateCacheAtBoot(); // empty plugins dir
+    expect(getAllToolDefinitions().some((t) => t.name === "late-tool")).toBe(
+      false,
+    );
+
+    const dir = freshPluginDir("late-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "late-plugin" });
+    writeTool(dir, "late-tool", TOOL_SRC("late-tool"));
+    const initMarker = join(ROOT, "late-init.log");
+    writeMarkerHook(dir, "init", initMarker, "init");
+
+    await triggerScan();
+
+    // Registered into the global registry as a plugin-owned tool, and exposed
+    // to the per-turn resolver via getPluginToolDefinitions().
+    expect(getToolOwner("late-tool")).toEqual({
+      kind: "plugin",
+      id: "late-plugin",
+    });
+    expect(getAllToolDefinitions().some((t) => t.name === "late-tool")).toBe(
+      true,
+    );
+    expect(getPluginToolDefinitions().some((t) => t.name === "late-tool")).toBe(
+      true,
+    );
+    // init ran exactly once.
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
+  });
+
+  test("activation is idempotent — repeated scans do not re-run init", async () => {
+    const dir = freshPluginDir("idem-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "idem-plugin" });
+    writeTool(dir, "idem-tool", TOOL_SRC("idem-tool"));
+    const initMarker = join(ROOT, "idem-init.log");
+    writeMarkerHook(dir, "init", initMarker, "init");
+
+    await populateCacheAtBoot();
+    await triggerScan();
+    await triggerScan();
+
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
+    // Registered exactly once (no refcount inflation from re-registration).
+    expect(getToolOwner("idem-tool")).toEqual({
+      kind: "plugin",
+      id: "idem-plugin",
+    });
+  });
+
+  test("removing a plugin directory deactivates it (unregister + shutdown)", async () => {
+    const dir = freshPluginDir("temp-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "temp-plugin" });
+    writeTool(dir, "temp-tool", TOOL_SRC("temp-tool"));
+    const shutdownMarker = join(ROOT, "temp-shutdown.log");
+    writeMarkerHook(dir, "shutdown", shutdownMarker, "bye");
+
+    await populateCacheAtBoot();
+    expect(getToolOwner("temp-tool")?.kind).toBe("plugin");
+
+    rmSync(dir, { recursive: true, force: true });
+    await triggerScan();
+
+    expect(getToolOwner("temp-tool")).toBeUndefined();
+    expect(getPluginToolDefinitions().some((t) => t.name === "temp-tool")).toBe(
+      false,
+    );
+    expect(existsSync(shutdownMarker)).toBe(true);
+  });
+
+  test("disabling a plugin at runtime tears down its tools", async () => {
+    const dir = freshPluginDir("disable-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "disable-plugin" });
+    writeTool(dir, "disable-tool", TOOL_SRC("disable-tool"));
+
+    await populateCacheAtBoot();
+    expect(getToolOwner("disable-tool")?.kind).toBe("plugin");
+
+    writeFileSync(join(dir, ".disabled"), "");
+    await triggerScan();
+
+    expect(getToolOwner("disable-tool")).toBeUndefined();
   });
 });

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -71,6 +71,19 @@ import { getCliLogger } from "../logger.js";
 
 const log = getCliLogger("plugins");
 
+/**
+ * A running assistant re-scans its plugins directory on its next turn (the
+ * per-turn plugin hook dispatch reaches `scanPlugins`), so a just-installed or
+ * just-removed plugin takes effect without a restart — its tools are activated
+ * and surfaced to conversations dynamically. This message tells the user that.
+ *
+ * Exception: Bun caches dynamic `import()` by URL for the process lifetime, so
+ * an in-place code *upgrade* at an already-imported path is not hot-swapped;
+ * the `upgrade` command keeps its explicit restart guidance.
+ */
+const PICKED_UP_AUTOMATICALLY =
+  "A running assistant will pick this up automatically on its next turn — no restart needed.";
+
 export function registerPluginsCommand(program: Command): void {
   registerCommand(program, {
     name: "plugins",
@@ -161,7 +174,7 @@ Examples:
               console.log(
                 `Installed plugin "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
               );
-              console.log("Restart the assistant to pick up the new plugin.");
+              console.log(PICKED_UP_AUTOMATICALLY);
             } catch (err) {
               if (err instanceof PluginAlreadyInstalledError) {
                 console.error(`${err.message}\nPass --force to overwrite.`);
@@ -245,9 +258,7 @@ Examples:
 
       plugins
         .command("list")
-        .description(
-          "List plugins installed in your workspace.",
-        )
+        .description("List plugins installed in your workspace.")
         .option("--json", "Emit machine-readable JSON instead of a table")
         .option(
           "--all",
@@ -276,8 +287,7 @@ Examples:
             const nameW = Math.max(4, ...rows.map((r) => r.name.length));
             const versionW = Math.max(7, ...rows.map((r) => r.version.length));
             const sourceW = Math.max(6, ...rows.map((r) => r.source.length));
-            const pad = (s: string, w: number) =>
-              s + " ".repeat(w - s.length);
+            const pad = (s: string, w: number) => s + " ".repeat(w - s.length);
             console.log(
               `${pad("NAME", nameW)}  ${pad("VERSION", versionW)}  ${pad("SOURCE", sourceW)}  STATUS`,
             );
@@ -294,9 +304,7 @@ Examples:
             console.log(
               `${all.length} plugin${all.length === 1 ? "" : "s"} ` +
                 `(${userCount} user, ${defaultCount} default` +
-                (disabledCount > 0
-                  ? `, ${disabledCount} disabled`
-                  : "") +
+                (disabledCount > 0 ? `, ${disabledCount} disabled` : "") +
                 `).`,
             );
             return;
@@ -540,7 +548,7 @@ Examples:
             console.log(
               `Uninstalled plugin "${result.name}" from ${result.target}`,
             );
-            console.log("Restart the assistant to drop the plugin.");
+            console.log(PICKED_UP_AUTOMATICALLY);
           } catch (err) {
             if (err instanceof InvalidPluginNameError) {
               console.error(err.message);
@@ -561,15 +569,14 @@ Examples:
       plugins
         .command("disable <name>")
         .description(
-          "Disable a plugin by creating a .disabled sentinel file. Works for both user-installed and default plugins. Restart the assistant for the change to take effect.",
+          "Disable a plugin by creating a .disabled sentinel file. Works for both user-installed and default plugins. Takes effect immediately in a running assistant; otherwise on next restart.",
         )
         .action((name: string) => {
           try {
             const result = disablePlugin(name);
             log.info({ name: result.name }, "plugin disabled");
-            console.log(
-              `Disabled plugin "${result.name}". Restart the assistant for the change to take effect.`,
-            );
+            console.log(`Disabled plugin "${result.name}".`);
+            console.log(PICKED_UP_AUTOMATICALLY);
           } catch (err) {
             if (
               err instanceof PluginAlreadyInStateException ||
@@ -589,15 +596,14 @@ Examples:
       plugins
         .command("enable <name>")
         .description(
-          "Re-enable a disabled plugin by removing the .disabled sentinel file. Restart the assistant for the change to take effect.",
+          "Re-enable a disabled plugin by removing the .disabled sentinel file. Takes effect immediately in a running assistant; otherwise on next restart.",
         )
         .action((name: string) => {
           try {
             const result = enablePlugin(name);
             log.info({ name: result.name }, "plugin enabled");
-            console.log(
-              `Enabled plugin "${result.name}". Restart the assistant for the change to take effect.`,
-            );
+            console.log(`Enabled plugin "${result.name}".`);
+            console.log(PICKED_UP_AUTOMATICALLY);
           } catch (err) {
             if (
               err instanceof PluginAlreadyInStateException ||

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
@@ -12,6 +12,7 @@ import type { ToolDefinition } from "../../providers/types.js";
 import {
   __clearRegistryForTesting,
   registerMcpTools,
+  registerPluginTools,
 } from "../../tools/registry.js";
 import type { Tool } from "../../tools/types.js";
 import { createResolveToolsCallback } from "../conversation-tool-setup.js";
@@ -26,6 +27,14 @@ function def(name: string): ToolDefinition {
 }
 
 function mcpTool(name: string): Tool {
+  return {
+    name,
+    description: name,
+    input_schema: def(name).input_schema,
+  } as unknown as Tool;
+}
+
+function pluginTool(name: string): Tool {
   return {
     name,
     description: name,
@@ -137,6 +146,32 @@ describe("createResolveToolsCallback — config.tools.exclude", () => {
     const names = resolver!([]).map((d) => d.name);
 
     expect(names).toEqual(["recall", "file_read"]);
+  });
+
+  test("plugin tool registered after resolver creation is picked up next turn", () => {
+    getConfigSpy = withExclude([]);
+    // Resolver created when only a core tool exists — no plugin yet, mirroring
+    // a conversation that started before the plugin was installed.
+    const resolver = createResolveToolsCallback([def("file_read")], makeCtx());
+    expect(resolver!([]).map((d) => d.name)).toEqual(["file_read"]);
+
+    // A plugin installed + activated mid-conversation lands its tool in the
+    // registry. The resolver must surface it on the next turn without the
+    // conversation being recreated (the plugin equivalent of `mcp reload`).
+    registerPluginTools("late-plugin", [pluginTool("admin_copilot_prefs")]);
+    const names = resolver!([]).map((d) => d.name);
+    expect(names).toContain("admin_copilot_prefs");
+    expect(names).toContain("file_read");
+  });
+
+  test("excluded plugin tool is omitted from the resolved tool list", () => {
+    registerPluginTools("ex-plugin", [pluginTool("ex_plugin_tool")]);
+    getConfigSpy = withExclude(["ex_plugin_tool"]);
+    const resolver = createResolveToolsCallback(
+      [def("file_read"), def("ex_plugin_tool")],
+      makeCtx(),
+    );
+    expect(resolver!([]).map((d) => d.name)).toEqual(["file_read"]);
   });
 
   test("excluded tool stays excluded under disk-pressure cleanup mode", () => {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -24,6 +24,7 @@ import { registerConversationSender } from "../tools/browser/browser-screencast.
 import type { ToolExecutor } from "../tools/executor.js";
 import {
   getMcpToolDefinitions,
+  getPluginToolDefinitions,
   getTool,
   getWorkspaceToolDefinitions,
   getWorkspaceToolNames,
@@ -673,14 +674,21 @@ export function createResolveToolsCallback(
 ): ((history: Message[]) => ToolDefinition[]) | undefined {
   if (toolDefs.length === 0) return undefined;
 
-  // Separate the initial tool defs into core (stable) and the two dynamic
-  // categories (MCP, workspace). We keep core tools from the snapshot and
-  // re-read MCP + workspace tools from the registry each turn.
+  // Separate the initial tool defs into core (stable) and the dynamic
+  // categories (MCP, workspace, plugin). We keep core tools from the snapshot
+  // and re-read the dynamic categories from the registry each turn. They differ
+  // downstream: plugin tools flow through the same context filter + subagent
+  // allowlist as core, while MCP and workspace tools are added raw.
   const initialMcpDefs = getMcpToolDefinitions();
+  const initialPluginDefs = getPluginToolDefinitions();
   const initialMcpNames = new Set(initialMcpDefs.map((d) => d.name));
   const initialWorkspaceNames = new Set(getWorkspaceToolNames());
+  const initialPluginNames = new Set(initialPluginDefs.map((d) => d.name));
   const coreToolDefs = toolDefs.filter(
-    (d) => !initialMcpNames.has(d.name) && !initialWorkspaceNames.has(d.name),
+    (d) =>
+      !initialMcpNames.has(d.name) &&
+      !initialWorkspaceNames.has(d.name) &&
+      !initialPluginNames.has(d.name),
   );
   log.debug(
     {
@@ -688,6 +696,8 @@ export function createResolveToolsCallback(
       mcpCount: initialMcpDefs.length,
       mcpTools: initialMcpDefs.map((d) => d.name),
       workspaceCount: initialWorkspaceNames.size,
+      pluginCount: initialPluginDefs.length,
+      pluginTools: initialPluginDefs.map((d) => d.name),
     },
     "Conversation tool resolver initialized",
   );
@@ -708,11 +718,18 @@ export function createResolveToolsCallback(
     // serialized, so the registry settles for a subsequent turn to read.
     void loadWorkspaceTools();
 
-    // Filter core tools based on current conversation context so that tools
-    // irrelevant to this turn (e.g. UI tools when no client is connected)
+    // Re-read plugin tool definitions from the registry each turn so a plugin
+    // installed/removed at runtime (activated by the per-turn scan in
+    // `plugins/mtime-cache.ts`) is picked up without recreating the
+    // conversation. Plugin tools share core's context filter + allowlist path,
+    // so combine them with the core snapshot before filtering.
+    const currentPluginDefs = getPluginToolDefinitions();
+
+    // Filter core + plugin tools based on current conversation context so that
+    // tools irrelevant to this turn (e.g. UI tools when no client is connected)
     // are omitted from the definitions sent to the provider.
-    const filteredCoreDefs = coreToolDefs.filter((d) =>
-      isToolActiveForContext(d.name, ctx),
+    const filteredCoreDefs = [...coreToolDefs, ...currentPluginDefs].filter(
+      (d) => isToolActiveForContext(d.name, ctx),
     );
 
     // When the conversation is acting as a subagent, restrict core tools to

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -323,6 +323,7 @@ async function scanPlugins(): Promise<void> {
       const manifest = await parsePluginManifest(pluginDir);
       const pluginName = manifest?.name ?? entry;
       if (discoveredPluginDirs.has(pluginDir)) {
+        await deactivatePlugin(pluginName);
         await evictPlugin(pluginDir, pluginName);
       }
       if (!disabledPluginDirs.has(pluginDir)) {
@@ -350,9 +351,10 @@ async function scanPlugins(): Promise<void> {
     await reconcilePluginTools(pluginDir, pluginName);
   }
 
-  // Evict cache entries for deleted plugins.
+  // Deactivate and evict cache entries for deleted plugins.
   for (const [pluginDir, pluginName] of discoveredPluginDirs) {
     if (!currentDirs.has(pluginDir)) {
+      await deactivatePlugin(pluginName);
       await evictPlugin(pluginDir, pluginName);
     }
   }
@@ -365,6 +367,15 @@ async function scanPlugins(): Promise<void> {
   );
   for (const [dir, name] of sorted) {
     discoveredPluginDirs.set(dir, name);
+  }
+
+  // Activate any plugin not yet brought up. Idempotent: already-active plugins
+  // are skipped by the `activatedNames` guard, so steady-state scans (one per
+  // hook dispatch) cost only a membership check per plugin. Tools were imported
+  // into `toolCache` by `reconcilePluginTools` above, so they are ready to
+  // register here.
+  for (const [dir, name] of discoveredPluginDirs) {
+    await activatePlugin(dir, name);
   }
 }
 
@@ -410,28 +421,121 @@ async function evictAll(): Promise<void> {
   disabledPluginDirs.clear();
 }
 
-// ─── Boot population ─────────────────────────────────────────────────────────
+// ─── Activation lifecycle ────────────────────────────────────────────────────
 
 /**
- * Plugins (and the workspace-hooks pseudo-owner) that were fully activated at
- * boot (tools registered + init hook run). Used by the shutdown hook to tear
- * down only what was actually brought up.
+ * Plugins (and the workspace-hooks pseudo-owner) fully activated (tools
+ * registered + `init` hook run) within this process, in activation order. The
+ * process shutdown hook walks this list in reverse to tear everything down.
  */
 const activatedPlugins: Array<{ name: string }> = [];
 
 /**
- * Populate the caches at boot by scanning the plugins directory once,
- * importing all surfaces, registering tools into the tool registry,
- * running `init` hooks, and installing a shutdown hook.
+ * Names in {@link activatedPlugins}, kept as a set for O(1) membership and —
+ * critically — reserved *synchronously* at the top of `activatePlugin`. The
+ * per-turn hook dispatch reaches `scanPlugins` on every turn (sometimes
+ * concurrently), so the synchronous reservation is what prevents a second scan
+ * from double-activating a plugin while its async `init()` is still in flight.
+ */
+const activatedNames = new Set<string>();
+
+const shutdownContext: PluginShutdownContext = {
+  assistantVersion: APP_VERSION,
+};
+
+/**
+ * Activate a single discovered plugin: pre-import its hooks, register its tools
+ * into the global tool registry, and run its `init` hook. Idempotent — a plugin
+ * already activated (or mid-activation) is skipped. Never throws; per-surface
+ * failures are logged and the plugin still counts as activated so the shutdown
+ * hook tears down whatever came up (mirrors boot semantics).
+ *
+ * Called from `scanPlugins`, which runs both at boot and on every subsequent
+ * scan — so a plugin whose files appear at runtime (installed via the CLI or
+ * provisioned out-of-band) becomes live without a daemon restart.
+ */
+async function activatePlugin(
+  pluginDir: string,
+  pluginName: string,
+): Promise<void> {
+  if (activatedNames.has(pluginName)) return;
+  // Reserve synchronously, before any await, so a re-entrant or concurrent
+  // scan observes this plugin as already handled.
+  activatedNames.add(pluginName);
+
+  // Pre-import all hooks so the first dispatch doesn't pay the import cost.
+  await preImportHooksDir(join(pluginDir, "hooks"), pluginName);
+
+  // Register this plugin's tools into the global tool registry so
+  // `getAllTools()` and `getTool()` can find them. Tools were already imported
+  // and cached by `reconcilePluginTools` during the scan.
+  const pluginTools = Array.from(toolCache.values())
+    .filter((c) => c.pluginName === pluginName)
+    .map((c) => c.tool);
+  if (pluginTools.length > 0) {
+    try {
+      registerPluginTools(pluginName, pluginTools);
+      log.info(
+        { plugin: pluginName, count: pluginTools.length },
+        "user plugin tools registered",
+      );
+    } catch (err) {
+      log.error(
+        { err, plugin: pluginName },
+        `Failed to register tools for user plugin ${pluginName}`,
+      );
+    }
+  }
+
+  // Run the `init` hook if present.
+  await runInitHook(pluginName);
+
+  activatedPlugins.push({ name: pluginName });
+}
+
+/**
+ * Deactivate a plugin whose directory was removed or disabled at runtime:
+ * unregister its tools and run its `shutdown` hook. Must run *before*
+ * `evictPlugin` clears the hook cache, since the shutdown hook is read from it.
+ * Idempotent — a plugin that was never activated is a no-op.
+ */
+async function deactivatePlugin(pluginName: string): Promise<void> {
+  if (!activatedNames.has(pluginName)) return;
+  activatedNames.delete(pluginName);
+  const idx = activatedPlugins.findIndex((p) => p.name === pluginName);
+  if (idx >= 0) activatedPlugins.splice(idx, 1);
+
+  // Unregister tools before running shutdown so the model-visible surface is
+  // clean before teardown.
+  try {
+    unregisterPluginTools(pluginName);
+  } catch (err) {
+    log.warn(
+      { err, plugin: pluginName },
+      "user plugin tool unregister failed (continuing)",
+    );
+  }
+
+  await runShutdownHook(pluginName, shutdownContext, "plugin-removed");
+}
+
+// ─── Boot population ─────────────────────────────────────────────────────────
+
+/**
+ * Populate the caches at boot by scanning the plugins directory once (which
+ * imports surfaces, registers tools, and runs `init` hooks via `activatePlugin`
+ * inside `scanPlugins`), activating standalone workspace hooks, and installing
+ * the process shutdown hook.
  *
  * This replaces the old `loadExternalPlugin` → `registerPlugin` →
  * `bootstrapPlugins` path for user plugins. Instead of registering whole
- * `Plugin` objects into the plugin registry, we register individual tools
- * into the tool registry and cache hooks by mtime. The `init` and
- * `shutdown` hooks are still run exactly once per boot, preserving the
- * activation lifecycle that plugins rely on.
+ * `Plugin` objects into the plugin registry, we register individual tools into
+ * the tool registry and cache hooks by mtime.
  *
- * Called by `loadUserPlugins()` during daemon startup.
+ * Called by `loadUserPlugins()` during daemon startup. After boot, the same
+ * `scanPlugins` → `activatePlugin`/`deactivatePlugin` reconciliation runs on
+ * every turn via `getUserHooksFor` (plugin hook dispatch), so plugins whose
+ * files appear or disappear at runtime are picked up without a restart.
  */
 export async function populateCacheAtBoot(
   opts: { importTimeoutMs?: number } = {},
@@ -440,42 +544,8 @@ export async function populateCacheAtBoot(
     setSurfaceImportTimeout(opts.importTimeoutMs);
   }
 
+  // Scans + activates every discovered plugin (tools registered + `init` run).
   await scanPlugins();
-
-  const shutdownContext: PluginShutdownContext = {
-    assistantVersion: APP_VERSION,
-  };
-
-  for (const [pluginDir, pluginName] of discoveredPluginDirs) {
-    // Pre-import all hooks so the first turn doesn't pay the import cost.
-    await preImportHooksDir(join(pluginDir, "hooks"), pluginName);
-
-    // Register user plugin tools into the global tool registry so
-    // `getAllTools()` and `getTool()` can find them. Tools were already
-    // imported and cached by `reconcilePluginTools` during `scanPlugins`.
-    const pluginTools = Array.from(toolCache.values())
-      .filter((c) => c.pluginName === pluginName)
-      .map((c) => c.tool);
-    if (pluginTools.length > 0) {
-      try {
-        registerPluginTools(pluginName, pluginTools);
-        log.info(
-          { plugin: pluginName, count: pluginTools.length },
-          "user plugin tools registered",
-        );
-      } catch (err) {
-        log.error(
-          { err, plugin: pluginName },
-          `Failed to register tools for user plugin ${pluginName}`,
-        );
-      }
-    }
-
-    // Run the `init` hook if present.
-    await runInitHook(pluginName);
-
-    activatedPlugins.push({ name: pluginName });
-  }
 
   // Activate standalone workspace hooks under `<workspace>/hooks/`. These
   // carry no package.json, no tools, and no install-date ordering — just hook
@@ -490,11 +560,14 @@ export async function populateCacheAtBoot(
   }
 
   // Register a single shutdown hook that walks all activated owners in reverse
-  // order, unregistering tools and running shutdown hooks.
-  const shutdownSnapshot = [...activatedPlugins];
+  // order, unregistering tools and running shutdown hooks. It reads the live
+  // `activatedPlugins` array at teardown time, so plugins activated after boot
+  // (runtime installs) are torn down too.
   registerShutdownHook("user-plugins", async (reason) => {
-    for (let i = shutdownSnapshot.length - 1; i >= 0; i--) {
-      const { name } = shutdownSnapshot[i]!;
+    for (let i = activatedPlugins.length - 1; i >= 0; i--) {
+      const entry = activatedPlugins[i];
+      if (entry === undefined) continue;
+      const { name } = entry;
 
       // Unregister tools before running shutdown so onShutdown sees a
       // clean model-visible surface. (No-op for the workspace-hooks owner,
@@ -533,6 +606,7 @@ export function resetPluginCacheForTests(): void {
   discoveredPluginDirs.clear();
   installDateCache.clear();
   activatedPlugins.length = 0;
+  activatedNames.clear();
   disabledPluginDirs.clear();
 }
 

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -549,6 +549,19 @@ export function getMcpToolDefinitions(): Tool[] {
 }
 
 /**
+ * Return tool definitions for all currently registered plugin-origin tools.
+ * Used by the session resolver to dynamically pick up plugin tools that were
+ * registered after session creation — e.g. a plugin installed at runtime and
+ * activated on a subsequent turn (see `plugins/mtime-cache.ts`). Mirrors
+ * {@link getMcpToolDefinitions} so a plugin install behaves like `mcp reload`.
+ */
+export function getPluginToolDefinitions(): Tool[] {
+  return Array.from(tools.values()).filter(
+    (t) => ownersByName.get(t.name)?.kind === "plugin",
+  );
+}
+
+/**
  * Return MCP tools grouped by their owning server ID. Each entry contains
  * the server ID and the tool definitions registered by that server.
  */


### PR DESCRIPTION
## Problem

A plugin's tools only entered the model's wire tool list at **daemon startup**. `populateCacheAtBoot()` was the only caller of `registerPluginTools()`, and a conversation reads a construction-time snapshot of the registry. So a plugin installed (or provisioned out-of-band, e.g. onto a managed daemon's volume) **after** the running daemon booted had its files on disk but its tools absent from every session — the "installed-but-dormant in live daemon" failure mode. This is what forced the admin-copilot skill to tell users *"the admin-copilot tools aren't loaded yet — restart the assistant."*

Diagnosed from an LLM-inspector export: all 3 provider calls carried the same 16 core tools, no `admin_copilot_prefs`, and the admin-copilot **skill** wasn't in the memory injection either — the live daemon simply hadn't loaded the plugin.

## Fix

Two layers, mirroring how **MCP tools already hot-reload** via `vellum mcp reload`:

1. **Activation lifecycle in the mtime cache** (`plugins/mtime-cache.ts`). Per-plugin bring-up/teardown is factored out of boot into idempotent `activatePlugin`/`deactivatePlugin`, reconciled inside `scanPlugins`. `scanPlugins` already runs every turn via `getUserHooksFor` (plugin hook dispatch), so a plugin whose files appear at runtime is activated (tools registered + `init` run) and a removed/disabled one is torn down (tools unregistered + `shutdown` run) — no restart. `activatedNames` is reserved synchronously so concurrent per-turn scans can't double-activate while `init()` is in flight.

2. **Dynamic per-turn resolution** (`daemon/conversation-tool-setup.ts`). `createResolveToolsCallback` now re-reads plugin-owned tools from the registry each turn (new `getPluginToolDefinitions`, the plugin analogue of `getMcpToolDefinitions`), so an **ongoing** conversation picks up a plugin activated mid-session without being recreated. Plugin tools keep flowing through the core context filter + subagent allowlist.

CLI `install`/`enable`/`disable`/`uninstall` now report that a running assistant picks the change up automatically instead of instructing a restart.

## Known limitation

`upgrade` keeps its restart guidance: Bun caches dynamic `import()` by URL for the process lifetime, so an **in-place code upgrade** at an already-imported path is not hot-swapped. Fresh installs (new paths) reload cleanly.

## Design note

The `plugins` CLI command is `local`-tagged and the `cli/no-daemon-internals` lint rule forbids it from calling the daemon over IPC (local commands must work daemon-independently). So reconciliation is driven by the per-turn scan rather than an explicit install-time IPC call — which is also what makes out-of-band provisioning (managed-daemon volumes) self-heal.

## Tests

- `mtime-cache.test.ts`: install-after-boot activation (tools registered + `init` once), idempotent repeated scans, dir-removal teardown (unregister + `shutdown`), runtime disable teardown.
- `conversation-tool-setup-exclude.test.ts`: a plugin tool registered **after** resolver creation is surfaced on the next turn; excluded plugin tool is omitted.
- Full plugin/registry/resolver suites green (`tsc`, `eslint`, prettier all pass).

## Review focus

- **Hot path:** the per-turn resolver now does one extra `getPluginToolDefinitions()` registry scan per turn (cheap, mirrors the existing MCP read) and runs plugin tools through `isToolActiveForContext` — verify this matches their prior treatment as core tools.
- **Concurrency:** the synchronous `activatedNames` reservation guarding async `init()`.

Risk: low-moderate (touches the per-turn tool resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)