### PR TITLE
feat(subagent): add consult-prompt module (buildAdvisorSystem, advisorRequestText)

### DIFF
--- a/assistant/src/subagent/__tests__/consult-prompt.test.ts
+++ b/assistant/src/subagent/__tests__/consult-prompt.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { advisorRequestText, buildAdvisorSystem } from "../consult-prompt.js";
+
+describe("buildAdvisorSystem", () => {
+  test("includes the senior-advisor framing", () => {
+    const prompt = buildAdvisorSystem(null);
+    expect(prompt).toContain("senior advisor");
+  });
+
+  test("embeds the parent prompt inside <agent_system_prompt> when provided", () => {
+    const prompt = buildAdvisorSystem("You are a coding agent.");
+    expect(prompt).toContain(
+      "<agent_system_prompt>\nYou are a coding agent.\n</agent_system_prompt>",
+    );
+  });
+
+  test("omits the <agent_system_prompt> block when no parent prompt is given", () => {
+    const prompt = buildAdvisorSystem(null);
+    expect(prompt).not.toContain("<agent_system_prompt>");
+  });
+
+  test("embeds the runtime context inside <agent_runtime_context> when provided", () => {
+    const prompt = buildAdvisorSystem(
+      "You are a coding agent.",
+      "## Available tools\n- bash — run commands",
+    );
+    expect(prompt).toContain("<agent_runtime_context>");
+    expect(prompt).toContain("- bash — run commands");
+  });
+
+  test("omits the <agent_runtime_context> block when no runtime context is given", () => {
+    const prompt = buildAdvisorSystem("You are a coding agent.");
+    expect(prompt).not.toContain("<agent_runtime_context>");
+  });
+});
+
+describe("advisorRequestText", () => {
+  test("is non-empty and asks for focused strategic guidance", () => {
+    const text = advisorRequestText();
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("focused strategic guidance");
+  });
+
+  test("imposes no length cap", () => {
+    // The request must not constrain how much the advisor writes.
+    expect(advisorRequestText()).not.toContain("words");
+  });
+});

--- a/assistant/src/subagent/consult-prompt.ts
+++ b/assistant/src/subagent/consult-prompt.ts
@@ -1,0 +1,57 @@
+/**
+ * Advice-framing prompt fragments for the advisor consult:
+ *  - `buildAdvisorSystem` — the advisor-facing system prompt; frames the role and,
+ *    for context, embeds the executor's own system prompt (and optional runtime
+ *    context).
+ *  - `advisorRequestText` — the final user turn appended to the transcript asking
+ *    for guidance.
+ */
+
+/**
+ * System prompt for the advisor sub-call. Frames the advisor's role and, for
+ * context, quotes the executor's own system prompt (as the advisor tool does —
+ * the advisor sees the system prompt as context about the executor's task).
+ *
+ * `runtimeContext`, when present, carries the agent's situational context that
+ * lives outside its system prompt — available tools and skills, workspace /
+ * project context, and recalled memory — so the advisor can ground its
+ * recommendations in what the agent can actually do.
+ */
+export function buildAdvisorSystem(
+  originalSystemPrompt: string | null,
+  runtimeContext?: string | null,
+): string {
+  const base = `You are a senior advisor consulted by another AI agent working on a task — most often at the planning stage, before it starts building, but sometimes partway through. The entire conversation above is the agent's working context: its task or goal, every tool call it has made, and every result it has seen. The agent has paused to consult you because you bring a second, independent perspective it cannot get from inside its own reasoning loop. Your job is to maximize its odds of completing the task correctly and efficiently.
+
+Evaluate the work along these dimensions, and lead with whatever matters most right now:
+
+- Approach & plan: If the agent has already drafted a plan or chosen an approach, pressure-test it — is it the right one, or is there a materially better path? If it hasn't committed to one yet, lay out a concrete plan for how to proceed. Either way, be specific about the path you would take and why.
+- Assumptions & requirements: Surface any wrong, unstated, or unverified assumption the agent is building on, and any part of the task it has misread, silently narrowed, or skipped. These are the failures it is least able to see itself.
+- Critical risk: Identify the single failure mode most likely to derail the task — or that already has — and how to avoid or recover from it.
+- Next step: Give one concrete action the agent can take immediately. Name the specific file, function, command, interface, or decision involved — not a generic direction.
+- Verification: If the agent has no clear way to confirm its work is correct, tell it how it will know.
+
+How to advise:
+- Be specific and grounded. Cite what you actually see in the transcript — a particular result, a line of reasoning, a command that failed. Never invent details that aren't there; if a decisive fact is missing, say what the agent should go find out.
+- Be decisive. Give a clear recommendation, not a menu of equally weighted options. When genuinely uncertain, say so and state what would resolve it.
+- Prioritize ruthlessly. Lead with the highest-leverage point. Don't restate at length what the agent already did well, and don't pad the response with minor nitpicks — a focused, well-reasoned critique beats an exhaustive one.
+- Stay in your lane. Advise the agent; do not role-play as it, write its final deliverable, or take its next action for it. If the agent is already on the right track, confirm it and sharpen the plan rather than manufacturing objections.
+
+Write as much as the guidance genuinely needs, and no more.`;
+  let prompt = base;
+  if (originalSystemPrompt) {
+    prompt += `\n\nFor context, the agent is operating under this system prompt:\n<agent_system_prompt>\n${originalSystemPrompt}\n</agent_system_prompt>`;
+  }
+  if (runtimeContext) {
+    prompt += `\n\nThe agent's runtime context — the tools and skills available to it, the loaded workspace/project context, and relevant memory — follows. Ground your recommendations in what the agent can actually do and what is around it; reference specific tools, skills, files, or memory where relevant.\n<agent_runtime_context>\n${runtimeContext}\n</agent_runtime_context>`;
+  }
+  return prompt;
+}
+
+/**
+ * The final user turn appended to the transcript for the advisor sub-call. Asks
+ * for guidance; imposes no length limit — the advisor decides how much to say.
+ */
+export function advisorRequestText(): string {
+  return `Review the conversation above — the task, the tool calls, and their results — and give focused strategic guidance on how to proceed.`;
+}


### PR DESCRIPTION
## Summary
- Copy the advisor advice-framing functions from the plugin's steering.ts into subagent/consult-prompt.ts.
- Plugin steering.ts untouched (deleted later in PR 8).

Part of plan: advisor-as-subagent-role.md (PR 3 of 9)