### PR TITLE
feat(subagent): sanitize inherited transcript for tool-less consult

### DIFF
--- a/assistant/src/subagent/__tests__/consult-transcript.test.ts
+++ b/assistant/src/subagent/__tests__/consult-transcript.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ContentBlock, Message } from "../../providers/types.js";
+import { sanitizeConsultTranscript } from "../consult-transcript.js";
+
+const text = (t: string): ContentBlock => ({ type: "text", text: t });
+
+describe("sanitizeConsultTranscript", () => {
+  test("drops thinking and redacted-thinking blocks", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("do the task")] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "secret", signature: "sig" },
+          { type: "redacted_thinking", data: "blob" },
+          text("here is my answer"),
+        ],
+      },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    expect(out).toHaveLength(2);
+    expect(out[1].content).toEqual([text("here is my answer")]);
+  });
+
+  test("drops a file block", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          text("read this"),
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "z",
+              filename: "f.pdf",
+            },
+          },
+        ],
+      },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    expect(out[0].content).toEqual([text("read this")]);
+  });
+
+  test("strips the pending tool_use from the final assistant turn", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("task")] },
+      {
+        role: "assistant",
+        content: [
+          text("let me consult the advisor"),
+          { type: "tool_use", id: "t1", name: "advisor", input: {} },
+        ],
+      },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    expect(out[1].content).toEqual([text("let me consult the advisor")]);
+  });
+
+  test("preserves completed client tool_use / tool_result pairs in earlier turns", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("task")] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "a", name: "bash", input: {} }],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "a", content: "output" }],
+      },
+      { role: "assistant", content: [text("done")] },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    expect(out[1].content[0]).toEqual({
+      type: "tool_use",
+      id: "a",
+      name: "bash",
+      input: {},
+    });
+    expect(out[2].content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "a",
+      content: "output",
+    });
+  });
+
+  test("drops a web-search server_tool_use AND its result together — no orphan", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("look it up")] },
+      {
+        role: "assistant",
+        content: [
+          text("searching"),
+          { type: "server_tool_use", id: "ws1", name: "web_search", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "ws1",
+            content: [{ title: "x", url: "y" }],
+          },
+        ],
+      },
+      { role: "assistant", content: [text("found it; here is the answer")] },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    const flat = out.flatMap((m) => m.content);
+    expect(flat.some((b) => b.type === "server_tool_use")).toBe(false);
+    expect(flat.some((b) => b.type === "web_search_tool_result")).toBe(false);
+    expect(flat).toContainEqual(text("searching"));
+    expect(flat).toContainEqual(text("found it; here is the answer"));
+  });
+
+  test("keeps top-level image blocks", () => {
+    const img: ContentBlock = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "x" },
+    };
+    const messages: Message[] = [
+      { role: "user", content: [text("look at this"), img] },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    expect(out[0].content).toEqual([text("look at this"), img]);
+  });
+
+  test("keeps image contentBlocks on a tool_result, dropping disallowed ones", () => {
+    const img: ContentBlock = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "x" },
+    };
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "a",
+            content: "screenshot",
+            contentBlocks: [
+              img,
+              {
+                type: "file",
+                source: {
+                  type: "base64",
+                  media_type: "application/pdf",
+                  data: "z",
+                  filename: "f.pdf",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    expect(out[0].content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "a",
+      content: "screenshot",
+      contentBlocks: [img],
+    });
+  });
+
+  test("drops messages that are empty after sanitization", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("task")] },
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "secret", signature: "sig" }],
+      },
+      { role: "assistant", content: [text("answer")] },
+    ];
+    const out = sanitizeConsultTranscript(messages);
+    expect(out).toHaveLength(2);
+    expect(out[0].content).toEqual([text("task")]);
+    expect(out[1].content).toEqual([text("answer")]);
+  });
+});

--- a/assistant/src/subagent/consult-transcript.ts
+++ b/assistant/src/subagent/consult-transcript.ts
@@ -1,0 +1,86 @@
+/**
+ * Sanitize an inherited parent transcript before it is injected into a
+ * tool-less advisor consult subagent.
+ *
+ * `Conversation.injectInheritedContext` injects the parent's messages VERBATIM
+ * with no sanitization, so the advisor path must run this over the parent
+ * messages before they are injected.
+ *
+ * Strips blocks the advisor shouldn't (or can't) replay:
+ *  - thinking / redacted-thinking (the advisor tool drops thinking),
+ *  - files,
+ *  - `server_tool_use` AND `web_search_tool_result` — provider-side tool calls
+ *    (e.g. web search) and their results are dropped *together*. Dropping the
+ *    result without its paired `server_tool_use` would leave an orphaned call
+ *    block the provider rejects, so any consult after prior web-search history
+ *    would fail; dropping both keeps the sequence valid.
+ *
+ * Images are preserved — top-level and nested inside `tool_result.contentBlocks`
+ * (which are recursively sanitized) — so the advisor sees what the executor saw.
+ * Visual tasks depend on it; the advisor profile is expected to be vision-capable.
+ *
+ * It also strips the *pending* client tool calls from the final assistant turn:
+ * at capture time the last assistant message can carry a `tool_use` with no
+ * matching `tool_result` yet, so sending it would be a dangling call. Earlier,
+ * completed `tool_use` / `tool_result` pairs are preserved intact.
+ *
+ * In-flight-turn parity — ensuring the assistant's just-written plan from the
+ * current turn is included while its dangling tool_use is stripped — is handled
+ * by the consumer (the wiring that calls this before injection); this function
+ * only strips a dangling `tool_use` IF it appears on the final assistant turn.
+ */
+
+import type { ContentBlock, Message } from "../providers/types.js";
+
+/** Drop disallowed blocks; recursively sanitize tool_result content. `null` = drop. */
+function sanitize(block: ContentBlock): ContentBlock | null {
+  switch (block.type) {
+    case "thinking":
+    case "redacted_thinking":
+    case "file":
+    case "server_tool_use":
+    case "web_search_tool_result":
+      return null;
+    case "tool_result": {
+      if (!block.contentBlocks) return block;
+      // Keep images (and other allowed blocks) nested in the tool result; drop
+      // the disallowed ones.
+      const contentBlocks = block.contentBlocks
+        .map(sanitize)
+        .filter((b): b is ContentBlock => b !== null);
+      return {
+        ...block,
+        contentBlocks: contentBlocks.length > 0 ? contentBlocks : undefined,
+      };
+    }
+    default:
+      // text, image, tool_use — kept.
+      return block;
+  }
+}
+
+export function sanitizeConsultTranscript(
+  messages: ReadonlyArray<Message>,
+): Message[] {
+  const out: Message[] = [];
+  const lastIndex = messages.length - 1;
+
+  messages.forEach((message, index) => {
+    let content = message.content
+      .map(sanitize)
+      .filter((b): b is ContentBlock => b !== null);
+
+    // The final assistant turn's client tool calls have no results yet — drop
+    // them so we never send a dangling tool_use. (server_tool_use is already
+    // dropped above.)
+    if (index === lastIndex && message.role === "assistant") {
+      content = content.filter(
+        (b) => b.type !== "tool_use" && b.type !== "server_tool_use",
+      );
+    }
+
+    if (content.length > 0) out.push({ role: message.role, content });
+  });
+
+  return out;
+}


### PR DESCRIPTION
## Summary
- Port the advisor transcript sanitizer (strip thinking/files/server-tool blocks + dangling final tool_use; preserve images) into subagent/consult-transcript.ts.
- Needed because injectInheritedContext injects parent messages verbatim.

Part of plan: advisor-as-subagent-role.md (PR 4 of 9)