### PR TITLE
feat(subagent): add tool-less read-only `advisor` role

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -13,6 +13,7 @@ const ALL_ROLES: SubagentRole[] = [
   "coder",
   "planner",
   "investigator",
+  "advisor",
 ];
 
 describe("SUBAGENT_ROLE_REGISTRY", () => {
@@ -32,18 +33,30 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     expect(SUBAGENT_ROLE_REGISTRY.general.allowedTools).toBeUndefined();
   });
 
-  test("all non-general roles have allowedTools as a non-empty array", () => {
+  test("all scoped tool-using roles have allowedTools as a non-empty array", () => {
     for (const role of ALL_ROLES) {
-      if (role === "general") continue;
+      // 'general' has no filter (undefined); 'advisor' is tool-less (empty).
+      if (role === "general" || role === "advisor") continue;
       const config = SUBAGENT_ROLE_REGISTRY[role];
       expect(Array.isArray(config.allowedTools)).toBe(true);
       expect(config.allowedTools!.length).toBeGreaterThan(0);
     }
   });
 
-  test('every role with allowedTools includes "notify_parent"', () => {
+  test("advisor is tool-less with an empty allowedTools array", () => {
+    const config = SUBAGENT_ROLE_REGISTRY.advisor;
+    expect(config.allowedTools).toEqual([]);
+  });
+
+  test("SubagentRole type includes advisor", () => {
+    const advisor: SubagentRole = "advisor";
+    expect(SUBAGENT_ROLE_REGISTRY[advisor]).toBeDefined();
+  });
+
+  test('every role with a non-empty allowlist includes "notify_parent"', () => {
     for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
-      if (config.allowedTools !== undefined) {
+      // 'advisor' is tool-less (empty allowlist) and intentionally has none.
+      if (config.allowedTools !== undefined && config.allowedTools.length > 0) {
         expect(config.allowedTools).toContain("notify_parent");
       }
     }

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1564,6 +1564,7 @@ describe("Subagent role-based spawn", () => {
       "coder",
       "planner",
       "investigator",
+      "advisor",
     ]);
     // role is not required
     expect(def.input_schema.required).not.toContain("role");

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -40,6 +40,7 @@ Each subagent is spawned with a role that determines its tool access. Choose the
 | `coder` | `bash`, `file_read`, `file_write`, `file_edit`, `web_search`, `recall`, `notify_parent` | Code changes, file editing, running commands, build/test tasks |
 | `planner` | `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Analysis, planning, synthesizing information, reviewing approaches |
 | `investigator` | `bash`, `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Root-cause analysis: debugging, log forensics, tracing behavior across many files. Shell access is for read-only investigation (grep/find/reading logs); returns a compact root-cause report |
+| `advisor` | None (tool-less) | Read-only senior-advisor consult. Runs on a stronger model, inherits full parent context, and BLOCKS until it returns guidance |
 
 All specialized roles (`researcher`, `coder`, `planner`) include `notify_parent` for mid-run communication with the parent.
 

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "subagent_spawn",
-      "description": "Spawn an independent subagent to work on a task in parallel. The subagent runs autonomously and its results are reported back when complete.\n\nTwo modes:\n- **Regular sub-agent** (fork: false or omitted): Gets only the objective + context fields. Use for self-contained tasks with clear objectives. Can use scoped roles (researcher, coder, planner).\n- **Fork** (fork: true): Inherits full parent context (messages, system prompt, memory). Shares KV cache for near-free context inheritance. Use when the task benefits from knowing what you've been discussing. Always runs as general role. Results are internal by default (send_result_to_user: false). Read with last_n: 1 to get only the final synthesis.\n\nDecision heuristic: Does the task need to know what we've been talking about? Fork. Is it self-contained? Regular sub-agent.",
+      "description": "Spawn an independent subagent to work on a task in parallel. The subagent runs autonomously and its results are reported back when complete.\n\nTwo modes:\n- **Regular sub-agent** (fork: false or omitted): Gets only the objective + context fields. Use for self-contained tasks with clear objectives. Can use scoped roles (researcher, coder, planner).\n- **Fork** (fork: true): Inherits full parent context (messages, system prompt, memory). Shares KV cache for near-free context inheritance. Use when the task benefits from knowing what you've been discussing. Always runs as general role. Results are internal by default (send_result_to_user: false). Read with last_n: 1 to get only the final synthesis.\n\nDecision heuristic: Does the task need to know what we've been talking about? Fork. Is it self-contained? Regular sub-agent.\n\nThe 'advisor' role is a synchronous, read-only \"consult a stronger advisor\" mode: it inherits your full context, has no tools, and BLOCKS until it returns focused strategic guidance in a single response.",
       "category": "orchestration",
       "risk": "low",
       "input_schema": {
@@ -36,9 +36,10 @@
               "researcher",
               "coder",
               "planner",
-              "investigator"
+              "investigator",
+              "advisor"
             ],
-            "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'investigator': root-cause analysis — debugging, log forensics, tracing behavior across many files; has bash for read-only investigation (grep/find/log inspection) and returns a compact root-cause report. 'general': full access (default). Ignored when fork: true (forks always use general)."
+            "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'investigator': root-cause analysis — debugging, log forensics, tracing behavior across many files; has bash for read-only investigation (grep/find/log inspection) and returns a compact root-cause report. 'advisor': synchronous, read-only \"consult a stronger advisor\" — inherits full context, has no tools, and blocks until it returns focused strategic guidance. 'general': full access (default). Ignored when fork: true (forks always use general)."
           },
           "inference_profile": {
             "type": "string",

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -116,7 +116,8 @@ export type SubagentRole =
   | "researcher"
   | "coder"
   | "planner"
-  | "investigator";
+  | "investigator"
+  | "advisor";
 
 export interface SubagentRoleConfig {
   /**
@@ -197,5 +198,11 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
         "Your final message must be a compact root-cause report with these sections: Symptom, Root cause, Evidence (file:line references), Suggested fix, Open questions.",
         "If you approach context limits, stop investigating and produce the report from what you have — a partial report delivered is worth more than a complete investigation lost.",
       ].join(" "),
+    },
+    advisor: {
+      allowedTools: [],
+      skillIds: [],
+      systemPromptPreamble:
+        "You are a read-only senior advisor consulted for a one-shot strategic review. Read the inherited conversation, then return focused, high-leverage guidance in a single response. You have no tools — you cannot search, read files, or run commands — so reason from the context you were given.",
     },
   };


### PR DESCRIPTION
## Summary
- Add an 'advisor' subagent role: empty (tool-less) allowlist, read-only senior-advisor preamble.
- Register it in SUBAGENT_ROLE_REGISTRY, the subagent_spawn role enum (TOOLS.json), and the SKILL.md role table.

Part of plan: advisor-as-subagent-role.md (PR 5 of 9)