### PR TITLE
feat(subagent): honor systemPromptOverride and explicit role on context-inheriting subagents

### DIFF
--- a/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
+++ b/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for decoupling message-inheritance from prompt source and role on
+ * context-inheriting subagents (forks).
+ *
+ * A fork normally pins the parent's system prompt verbatim and keeps the
+ * `general` role so its KV cache stays aligned with the parent. These tests
+ * verify the opt-out paths: a fork may supply its own `systemPromptOverride`
+ * (which is used as-is and does NOT set `hasSystemPromptOverride`), and a fork
+ * may carry an explicit read-only role (whose tool allowlist is applied). A
+ * plain fork (no override, no role) must still behave exactly as before.
+ *
+ * The harness stubs `Conversation` and the spawn() dependencies so we can call
+ * `SubagentManager.spawn()` directly and capture the constructed conversation's
+ * system prompt, `hasSystemPromptOverride` flag, and allowed-tools set.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+// ── Captured constructor state ──────────────────────────────────────────────
+
+interface CapturedConversationState {
+  systemPrompt: string;
+  hasSystemPromptOverride: boolean;
+  allowedTools: Set<string> | undefined;
+}
+
+const capturedConversations: CapturedConversationState[] = [];
+
+// Stub Conversation so spawn() never runs an agent loop — we only inspect how
+// it was constructed and configured.
+class FakeConversation {
+  private readonly captured: CapturedConversationState;
+
+  constructor(
+    _id: string,
+    _provider: unknown,
+    systemPrompt: string,
+    _sendToClient: (msg: ServerMessage) => void,
+    _workingDir: string,
+    _options?: unknown,
+  ) {
+    this.captured = {
+      systemPrompt,
+      hasSystemPromptOverride: false,
+      allowedTools: undefined,
+    };
+    capturedConversations.push(this.captured);
+  }
+  set hasSystemPromptOverride(value: boolean) {
+    this.captured.hasSystemPromptOverride = value;
+  }
+  get hasSystemPromptOverride(): boolean {
+    return this.captured.hasSystemPromptOverride;
+  }
+  conversationType = "background";
+  updateClient() {}
+  setIsSubagent() {}
+  setTrustContext() {}
+  setAuthContext() {}
+  getAuthContext() {
+    return undefined;
+  }
+  setAssistantId() {}
+  setSubagentAllowedTools(tools: Set<string>) {
+    this.captured.allowedTools = tools;
+  }
+  setPreactivatedSkillIds() {}
+  injectInheritedContext() {}
+  abort() {}
+  dispose() {}
+  messages = [];
+  usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+  sendToClient() {}
+  persistUserMessage() {
+    return { id: "msg-id", deduplicated: false };
+  }
+  runAgentLoop() {
+    return Promise.resolve();
+  }
+  getCurrentSystemPrompt() {
+    return "resolved-parent-prompt";
+  }
+}
+
+mock.module("../daemon/conversation.js", () => ({
+  Conversation: FakeConversation,
+}));
+
+mock.module("../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: () => ({ id: "conv-id" }),
+}));
+
+// Resolve a stub provider without touching connections/DB.
+const providerStub = { name: "anthropic", sendMessage: async () => ({}) };
+
+mock.module("../providers/connection-resolution.js", () => ({
+  resolveDefaultProvider: async () => providerStub,
+}));
+
+mock.module("../providers/call-site-routing.js", () => ({
+  wrapWithCallSiteRouting: (p: unknown) => p,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: { default: { provider: "anthropic", model: "claude-opus-4-7" } },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+mock.module("../config/llm-resolver.js", () => ({
+  resolveCallSiteConfig: () => ({ provider: "anthropic", maxTokens: 8192 }),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────
+
+import { clearConversations } from "../daemon/conversation-registry.js";
+import { SubagentManager } from "../subagent/manager.js";
+import type { SubagentConfig } from "../subagent/types.js";
+
+const PARENT_PROMPT = "You are the parent's system prompt.";
+
+type SpawnConfig = Omit<SubagentConfig, "id">;
+
+function makeForkSpawnConfig(
+  overrides: Partial<SpawnConfig> = {},
+): SpawnConfig {
+  return {
+    parentConversationId: `parent-${Math.random().toString(36).slice(2)}`,
+    label: "test fork",
+    objective: "do something",
+    fork: true,
+    parentSystemPrompt: PARENT_PROMPT,
+    ...overrides,
+  };
+}
+
+describe("SubagentManager fork — prompt source and role decoupling", () => {
+  let manager: SubagentManager;
+
+  beforeEach(() => {
+    clearConversations();
+    capturedConversations.length = 0;
+    manager = new SubagentManager();
+  });
+
+  afterEach(() => {
+    (manager as unknown as { stopSweep: () => void }).stopSweep();
+  });
+
+  /** Spawn a fork and return the single conversation that spawn() constructed. */
+  async function spawnFork(
+    overrides: Partial<SpawnConfig> = {},
+  ): Promise<CapturedConversationState> {
+    await manager.spawn(makeForkSpawnConfig(overrides), () => {});
+    const created = capturedConversations[0];
+    if (!created) throw new Error("Expected a subagent conversation");
+    return created;
+  }
+
+  test("fork with systemPromptOverride uses that prompt and does not set hasSystemPromptOverride", async () => {
+    const overridePrompt = "You are an advisor. Frame the context as advice.";
+    const created = await spawnFork({ systemPromptOverride: overridePrompt });
+
+    expect(created.systemPrompt).toBe(overridePrompt);
+    expect(created.hasSystemPromptOverride).toBe(false);
+  });
+
+  test("fork with explicit read-only role applies the role allowlist via setSubagentAllowedTools", async () => {
+    const created = await spawnFork({ role: "researcher" });
+
+    // The researcher role is read-only; its allowlist must be applied even for
+    // a fork.
+    expect(created.allowedTools).toBeInstanceOf(Set);
+    expect(created.allowedTools?.has("web_search")).toBe(true);
+    expect(created.allowedTools?.has("file_read")).toBe(true);
+    expect(created.allowedTools?.has("bash")).toBe(false);
+  });
+
+  test("plain fork (no override, no role) keeps parent prompt verbatim, general tools, and sets hasSystemPromptOverride", async () => {
+    const created = await spawnFork();
+
+    // Parent prompt verbatim, no tool filter (general role has no allowlist),
+    // and the prompt is pinned for KV-cache alignment.
+    expect(created.systemPrompt).toBe(PARENT_PROMPT);
+    expect(created.allowedTools).toBeUndefined();
+    expect(created.hasSystemPromptOverride).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -273,7 +273,7 @@ describe("SubagentManager fork spawn", () => {
     expect(memoryPolicy.includeDefaultFallback).toBe(true);
   });
 
-  test("fork forces general role and skips tool filtering", async () => {
+  test("fork defaults to general role (which has no tool allowlist)", async () => {
     const manager = new SubagentManager();
     const subagentId = "sub-fork-role";
 
@@ -286,14 +286,16 @@ describe("SubagentManager fork spawn", () => {
     fakeConversation.injectInheritedContext = () => {};
     fakeConversation.setSubagentAllowedTools = () => {};
 
-    // Create a fork state — in real spawn(), the role would be forced to
-    // "general" regardless of what was requested, and tool filtering skipped.
+    // A fork that does not request a role defaults to "general", which has
+    // `allowedTools: undefined` — so no tool filter is applied. (An explicit
+    // non-general role on a fork IS honored; that path is covered in
+    // subagent-fork-prompt-role.test.ts.)
     const state = makeState(
       subagentId,
       { isFork: true },
       {
         fork: true,
-        role: "general", // forced by spawn() logic
+        role: "general",
         parentMessages: FAKE_PARENT_MESSAGES,
         parentSystemPrompt: "Parent system prompt.",
       },
@@ -303,9 +305,6 @@ describe("SubagentManager fork spawn", () => {
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
 
-    // Tool filtering is only applied in spawn(), not runSubagent(), so we
-    // verify the logic directly: forks skip setSubagentAllowedTools.
-    // For this test, we verify the fork's role is general (which has no allowedTools).
     expect(state.config.role).toBe("general");
 
     asInternals(manager).stopSweep();

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -159,17 +159,20 @@ export class SubagentManager {
 
     // ── Resolve role ─────────────────────────────────────────────────
     const isFork = config.fork === true;
-    let role: SubagentRole = (config.role as SubagentRole) ?? "general";
+    const role: SubagentRole = (config.role as SubagentRole) ?? "general";
     if (isFork && role !== "general") {
+      // A context-inheriting subagent normally keeps the parent's `general`
+      // role so its KV cache stays aligned with the parent conversation. An
+      // explicit non-general role opts out of that alignment on purpose
+      // (e.g. the advisor role running on a stronger profile), so honor it.
       log.warn(
         {
           requestedRole: role,
           parentConversationId: config.parentConversationId,
           label: config.label,
         },
-        "Fork requested with non-general role — forcing general to preserve KV cache alignment",
+        "Fork requested with non-general role — caller opted out of parent KV-cache alignment",
       );
-      role = "general";
     }
     if (!SUBAGENT_ROLE_REGISTRY[role]) {
       throw new Error(
@@ -219,19 +222,21 @@ export class SubagentManager {
 
     let systemPrompt: string;
     if (isFork) {
-      // Forks use the parent's system prompt directly — no subagent preamble.
-      if (config.parentSystemPrompt) {
-        systemPrompt = config.parentSystemPrompt;
-      } else {
-        const resolved = parentConversation?.getCurrentSystemPrompt();
-        if (!resolved) {
-          throw new Error(
-            "Fork spawn requires a parent system prompt but neither config.parentSystemPrompt " +
-              "nor findConversation yielded one.",
-          );
-        }
-        systemPrompt = resolved;
+      // Forks default to the parent's system prompt verbatim — no subagent
+      // preamble — so the KV cache stays aligned with the parent. An explicit
+      // `systemPromptOverride` opts out of that alignment and takes precedence
+      // (e.g. the advisor role framing the inherited context as advice).
+      const resolved =
+        config.systemPromptOverride ??
+        config.parentSystemPrompt ??
+        parentConversation?.getCurrentSystemPrompt();
+      if (!resolved) {
+        throw new Error(
+          "Fork spawn requires a parent system prompt but neither config.parentSystemPrompt " +
+            "nor findConversation yielded one.",
+        );
       }
+      systemPrompt = resolved;
     } else {
       systemPrompt =
         config.systemPromptOverride ??
@@ -325,16 +330,19 @@ export class SubagentManager {
       conversation.setAssistantId(parentConversation.assistantId);
     }
 
-    if (isFork) {
-      // Force the fork to use the parent's system prompt as-is without dynamic rebuild.
-      // This ensures KV cache alignment with the parent conversation.
+    if (isFork && !config.systemPromptOverride) {
+      // A verbatim-prompt fork pins the parent's system prompt as-is, skipping
+      // the dynamic rebuild so the KV cache stays aligned with the parent. A
+      // fork that supplies its own override prompt opts out of that alignment,
+      // so leave `hasSystemPromptOverride` at its default.
       conversation.hasSystemPromptOverride = true;
     }
 
-    // Apply role-based tool filter if the role defines one.
-    // Skip for forks — general role has allowedTools: undefined, and forks
-    // should have the same tool access as the parent.
-    if (!isFork && roleConfig.allowedTools) {
+    // Apply the role's tool allowlist when one is defined. The `general` role
+    // has `allowedTools: undefined`, so default forks (which keep the general
+    // role) are unaffected; a fork carrying an explicit role gets its
+    // allowlist applied like any other subagent.
+    if (roleConfig.allowedTools) {
       conversation.setSubagentAllowedTools(new Set(roleConfig.allowedTools));
     }
 


### PR DESCRIPTION
## Summary
- Decouple message-inheritance from parent-verbatim prompt and forced-general role on forks.
- Honor systemPromptOverride and an explicit (read-only) role on context-inheriting subagents; plain forks unchanged.

Part of plan: advisor-as-subagent-role.md (PR 1 of 9)