### PR TITLE
fix(research-onboarding): archive the behind-the-scenes research conversation after it settles

### DIFF
--- a/clients/web/src/domains/onboarding/archive-research-conversation.test.ts
+++ b/clients/web/src/domains/onboarding/archive-research-conversation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for archiveResearchConversation's best-effort contract: it must call
+ * the archive endpoint with the right path + `throwOnError: false`, and swallow
+ * every failure mode (a thrown SDK call, a non-ok response) so the
+ * research-onboarding handoff is never blocked.
+ *
+ * NOTE: `bun mock.module` can leak across files — run this file singly:
+ *   bun test src/domains/onboarding/archive-research-conversation.test.ts
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+interface ArchiveCall {
+  path: { assistant_id: string; id: string };
+  throwOnError: false;
+}
+
+let calls: ArchiveCall[] = [];
+let responseOk = true;
+let responseStatus = 200;
+let shouldThrow = false;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  conversationsByIdArchivePost: (opts: ArchiveCall) => {
+    calls.push(opts);
+    if (shouldThrow) {
+      return Promise.reject(new Error("network blew up"));
+    }
+    return Promise.resolve({
+      data: {},
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
+}));
+
+const { archiveResearchConversation } = await import(
+  "./archive-research-conversation"
+);
+
+afterEach(() => {
+  calls = [];
+  responseOk = true;
+  responseStatus = 200;
+  shouldThrow = false;
+});
+
+describe("archiveResearchConversation", () => {
+  test("archives with the assistant + conversation path and throwOnError: false", async () => {
+    await archiveResearchConversation("a1", "c1");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toEqual({ assistant_id: "a1", id: "c1" });
+    expect(calls[0]?.throwOnError).toBe(false);
+  });
+
+  test("swallows a thrown SDK call without rejecting", async () => {
+    shouldThrow = true;
+
+    await expect(
+      archiveResearchConversation("a1", "c1"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("does not throw on a non-ok response", async () => {
+    responseOk = false;
+    responseStatus = 500;
+
+    await expect(
+      archiveResearchConversation("a1", "c1"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/onboarding/archive-research-conversation.ts
+++ b/clients/web/src/domains/onboarding/archive-research-conversation.ts
@@ -1,0 +1,37 @@
+/**
+ * Archives the dedicated "Getting to know X" side conversation the
+ * research-onboarding flow mints to run its behind-the-scenes research turn.
+ *
+ * That conversation is a throwaway side channel: it exists only to drive the
+ * research prompt whose claims/suggestions the in-flow result steps render. It
+ * must never surface in the user's chat sidebar when they land in their
+ * workspace, so once the research response has settled we archive it — the
+ * sidebar's `group-conversations.ts` drops `archivedAt != null` rows, so an
+ * archived conversation simply disappears from the list.
+ *
+ * Best-effort: this runs after the response is delivered, so a failure here
+ * must never block or surface in the flow. Every error is swallowed (reported
+ * to Sentry) and never rethrown, mirroring `checkin-scheduler.ts`.
+ */
+
+import { conversationsByIdArchivePost } from "@/generated/daemon/sdk.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+
+/**
+ * Archive the research-onboarding side conversation so it never appears in the
+ * chat sidebar. Best-effort and fire-and-forget: resolves regardless of outcome
+ * and never throws.
+ */
+export async function archiveResearchConversation(
+  assistantId: string,
+  conversationId: string,
+): Promise<void> {
+  try {
+    await conversationsByIdArchivePost({
+      path: { assistant_id: assistantId, id: conversationId },
+      throwOnError: false,
+    });
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_archive" });
+  }
+}

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -322,8 +322,11 @@ export function useResearchRunner(): UseResearchRunner {
       });
 
       void (async () => {
+        let resolvedAssistantId: string | undefined;
+        let createdConversationId: string | undefined;
         try {
           const assistantId = await awaitAssistantId();
+          resolvedAssistantId = assistantId;
           if (isStale()) return;
 
           // Advertise the live marketplace catalog to the research turn so it can
@@ -356,6 +359,7 @@ export function useResearchRunner(): UseResearchRunner {
             setState((s) => ({ ...s, status: "error" }));
             return;
           }
+          createdConversationId = conversationId;
 
           const body: MessagesPostData["body"] = {
             conversationId,
@@ -445,11 +449,6 @@ export function useResearchRunner(): UseResearchRunner {
 
           if (isStale()) return;
           setState((s) => ({ ...s, status: "done" }));
-          // The research conversation is a throwaway side channel; archive +
-          // invalidate so the sidebar that mounts on handoff never shows
-          // "Getting to know X". Best-effort, after delivery — never blocks.
-          await archiveResearchConversation(assistantId, conversationId);
-          void invalidateConversationQueries(queryClient, assistantId);
         } catch (err) {
           if (isStale()) return;
           captureError(err, { context: "research_onboarding_runner" });
@@ -459,6 +458,17 @@ export function useResearchRunner(): UseResearchRunner {
           // a stale bail-out, or a reply that never emitted a `plugins` array) so
           // `awaitPluginInstalls` can never hang.
           resolvePluginsReady();
+          // Archive the throwaway research conversation on every exit path (settled,
+          // errored, or superseded by a newer run) once it has been created, so the
+          // side channel never lingers in the sidebar on handoff. Best-effort +
+          // idempotent; awaiting lets the cache invalidation reflect the archived state.
+          if (resolvedAssistantId && createdConversationId) {
+            await archiveResearchConversation(
+              resolvedAssistantId,
+              createdConversationId,
+            );
+            void invalidateConversationQueries(queryClient, resolvedAssistantId);
+          }
         }
       })();
     },

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -21,6 +21,8 @@
 
 import { useCallback, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import {
   conversationsPost,
   messagesGet,
@@ -28,6 +30,8 @@ import {
   pluginsInstallPost,
   pluginsSearchGet,
 } from "@/generated/daemon/sdk.gen";
+import { archiveResearchConversation } from "@/domains/onboarding/archive-research-conversation";
+import { invalidateConversationQueries } from "@/utils/conversation-cache";
 import type {
   MessagesGetResponses,
   MessagesPostData,
@@ -292,6 +296,7 @@ export function useResearchRunner(): UseResearchRunner {
   // so ordinary clicks (plugins disabled / none picked / already installed)
   // aren't frozen until the whole reply settles.
   const pluginsReadyRef = useRef<Promise<void>>(Promise.resolve());
+  const queryClient = useQueryClient();
 
   const start = useCallback(
     ({ awaitAssistantId, subject, conversationTitle }: StartResearchOptions) => {
@@ -440,6 +445,11 @@ export function useResearchRunner(): UseResearchRunner {
 
           if (isStale()) return;
           setState((s) => ({ ...s, status: "done" }));
+          // The research conversation is a throwaway side channel; archive +
+          // invalidate so the sidebar that mounts on handoff never shows
+          // "Getting to know X". Best-effort, after delivery — never blocks.
+          await archiveResearchConversation(assistantId, conversationId);
+          void invalidateConversationQueries(queryClient, assistantId);
         } catch (err) {
           if (isStale()) return;
           captureError(err, { context: "research_onboarding_runner" });
@@ -452,7 +462,7 @@ export function useResearchRunner(): UseResearchRunner {
         }
       })();
     },
-    [],
+    [queryClient],
   );
 
   const awaitPluginInstalls = useCallback(async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- Add best-effort `archiveResearchConversation` helper (mirrors checkin-scheduler) that archives the dedicated 'Getting to know X' research conversation via the daemon.
- Call it from `useResearchRunner` right after the research turn settles, then invalidate the conversation cache so the sidebar never shows the throwaway side conversation on handoff.

Part of plan: research-onboarding-handoff.md (PR 1 of 2)