### PR TITLE
feat(research-onboarding): collapse the chat side panel when handing off into the workspace

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -128,6 +128,10 @@ export function ChatLayout() {
   // toggles — otherwise a suggestion click's navigate + `?prompt=` auto-send
   // gets raced by the remount and the message is lost.
   const isFocused = useOnboardingFocusStore.use.focused();
+  const sidebarCollapseRequested =
+    useOnboardingFocusStore.use.sidebarCollapseRequested();
+  const consumeSidebarCollapse =
+    useOnboardingFocusStore.use.consumeSidebarCollapse();
 
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantStateKind = useAssistantLifecycleStore(
@@ -259,6 +263,14 @@ export function ChatLayout() {
   useEffect(() => {
     setLocalBool(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed);
   }, [collapsed]);
+
+  useEffect(() => {
+    if (!sidebarCollapseRequested) return;
+    // One-shot: research-onboarding asked us to open collapsed. Honor it on
+    // desktop (mobile uses the drawer, which is already closed), then clear.
+    if (!window.matchMedia(MOBILE_MEDIA_QUERY).matches) setCollapsed(true);
+    consumeSidebarCollapse();
+  }, [sidebarCollapseRequested, consumeSidebarCollapse]);
 
   const handleSidebarWidthChange = useCallback((width: number) => {
     setSidebarWidth(width);

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -74,6 +74,8 @@ export function ResearchOnboardingRoute() {
   const exitFocus = useOnboardingFocusStore.use.exitFocus();
   const setPendingAvatarTraits =
     useOnboardingFocusStore.use.setPendingAvatarTraits();
+  const requestSidebarCollapse =
+    useOnboardingFocusStore.use.requestSidebarCollapse();
   // Belt-and-suspenders gate: the spike lives at a dedicated path AND behind
   // this flag (off by default; enable locally via the feature-flags panel).
   const enabled = useClientFeatureFlagStore.use.researchOnboarding();
@@ -237,6 +239,8 @@ export function ResearchOnboardingRoute() {
     if (isResearch) enterFocus();
     // No auto-sent first message when skipping, so don't arm the expectation.
     if (!skip) lifecycleService.markExpectingFirstMessage();
+    // Collapse the side panel so the workspace opens focused on the new chat.
+    requestSidebarCollapse();
     // Pin the refresh to the background-hatched assistant so the handoff targets
     // it (not a previously-selected one) and doesn't trigger a second hatch.
     void lifecycleService

--- a/clients/web/src/stores/onboarding-focus-store.test.ts
+++ b/clients/web/src/stores/onboarding-focus-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
+
+beforeEach(() => {
+  useOnboardingFocusStore.setState({
+    sidebarCollapseRequested: false,
+    focused: false,
+  });
+});
+
+describe("useOnboardingFocusStore — sidebar collapse one-shot signal", () => {
+  test("requestSidebarCollapse arms the signal", () => {
+    useOnboardingFocusStore.getState().requestSidebarCollapse();
+    expect(useOnboardingFocusStore.getState().sidebarCollapseRequested).toBe(
+      true,
+    );
+  });
+
+  test("consumeSidebarCollapse clears the signal", () => {
+    useOnboardingFocusStore.getState().requestSidebarCollapse();
+    useOnboardingFocusStore.getState().consumeSidebarCollapse();
+    expect(useOnboardingFocusStore.getState().sidebarCollapseRequested).toBe(
+      false,
+    );
+  });
+
+  test("exitFocus also clears a stale armed signal", () => {
+    useOnboardingFocusStore.getState().requestSidebarCollapse();
+    useOnboardingFocusStore.getState().exitFocus();
+    expect(useOnboardingFocusStore.getState().sidebarCollapseRequested).toBe(
+      false,
+    );
+  });
+});

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -64,6 +64,14 @@ interface OnboardingFocusState {
   checkinUserName: string | null;
   beginCheckin: (userName?: string) => void;
   endCheckin: () => void;
+  /**
+   * Set by the onboarding handoff so the chat side panel opens collapsed for a
+   * focused first impression; consumed (cleared) once by `ChatLayout`. A
+   * one-shot signal, not a persistent preference.
+   */
+  sidebarCollapseRequested: boolean;
+  requestSidebarCollapse: () => void;
+  consumeSidebarCollapse: () => void;
 }
 
 const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
@@ -75,6 +83,7 @@ const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
       pendingFollowupMessage: null,
       checkinPending: false,
       pendingAvatarTraits: null,
+      sidebarCollapseRequested: false,
     }),
   pendingAvatarTraits: null,
   setPendingAvatarTraits: (traits) => set({ pendingAvatarTraits: traits }),
@@ -86,6 +95,9 @@ const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
   beginCheckin: (userName) =>
     set({ checkinPending: true, checkinUserName: userName ?? null }),
   endCheckin: () => set({ checkinPending: false }),
+  sidebarCollapseRequested: false,
+  requestSidebarCollapse: () => set({ sidebarCollapseRequested: true }),
+  consumeSidebarCollapse: () => set({ sidebarCollapseRequested: false }),
 }));
 
 export const useOnboardingFocusStore = createSelectors(


### PR DESCRIPTION
## Summary
- Add a one-shot `sidebarCollapseRequested` signal to the cross-domain onboarding-focus store.
- Fire it from the research-onboarding handoff (`enterAssistant`, covering both suggestion-click and Skip to Chat); `ChatLayout` consumes it once on entry to collapse the side panel on desktop.

Part of plan: research-onboarding-handoff.md (PR 2 of 2)