### PR TITLE
fix: prune seeded call-site defaults

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -98,6 +98,64 @@ function writeConfig(obj: unknown): void {
   writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
 }
 
+function latencySeed(): Record<string, unknown> {
+  return {
+    model: "claude-haiku-4-5-20251001",
+    effort: "low",
+    thinking: { enabled: false },
+  };
+}
+
+function fullSeededCallSites(): Record<string, Record<string, unknown>> {
+  return {
+    guardianQuestionCopy: latencySeed(),
+    interactionClassifier: latencySeed(),
+    skillCategoryInference: latencySeed(),
+    inviteInstructionGenerator: latencySeed(),
+    notificationDecision: latencySeed(),
+    preferenceExtraction: latencySeed(),
+    commitMessage: {
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 120,
+      temperature: 0.2,
+      effort: "low",
+      thinking: { enabled: false },
+    },
+    conversationStarters: latencySeed(),
+    conversationSummarization: {
+      model: "claude-opus-4-7",
+      effort: "low",
+      thinking: { enabled: false },
+    },
+    recall: {
+      profile: "cost-optimized",
+      maxTokens: 4096,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      temperature: 0,
+      disableCache: true,
+    },
+    heartbeatAgent: {
+      profile: "cost-optimized",
+      maxTokens: 2048,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 16000 },
+    },
+    replySuggestion: {
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+      thinking: { enabled: false },
+      disableCache: true,
+    },
+    memoryRouter: {
+      profile: "cost-optimized",
+      contextWindow: { maxInputTokens: 1_000_000 },
+    },
+  };
+}
+
 function mergeDefaultConfigAndSeedInferenceProfiles(db?: DrizzleDb): void {
   const defaultConfigMerge = mergeDefaultWorkspaceConfig();
   seedInferenceProfiles({
@@ -370,6 +428,56 @@ describe("loadConfig startup behavior", () => {
     const config = getConfig();
 
     expect(config.memory.v2.bm25_b).toBe(0.4);
+  });
+
+  test("default workspace config merge prunes exact seeded call-site defaults", () => {
+    const seededCallSites = fullSeededCallSites();
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          gateway: {
+            unmappedPolicy: "default",
+            defaultAssistantId: "self",
+          },
+          llm: {
+            activeProfile: "balanced",
+            advisorProfile: "frontier",
+            callSites: {
+              ...seededCallSites,
+              recall: {
+                ...seededCallSites.recall,
+                disableCache: false,
+              },
+              customSite: { profile: "frontier" },
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    const result = mergeDefaultWorkspaceConfig();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8")) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const llm = raw.llm as Record<string, unknown>;
+    const callSites = llm.callSites as Record<string, Record<string, unknown>>;
+
+    expect(result.hadOverlay).toBe(true);
+    expect(raw.gateway).toEqual({
+      unmappedPolicy: "default",
+      defaultAssistantId: "self",
+    });
+    expect(llm.activeProfile).toBe("balanced");
+    expect(llm.advisorProfile).toBe("frontier");
+    expect(Object.keys(callSites).sort()).toEqual(["customSite", "recall"]);
+    expect(callSites.recall?.disableCache).toBe(false);
+    expect(callSites.customSite).toEqual({ profile: "frontier" });
   });
 
   test("reloads cached config when config.json is updated externally", () => {

--- a/assistant/src/__tests__/workspace-migration-111-prune-seeded-callsite-defaults.test.ts
+++ b/assistant/src/__tests__/workspace-migration-111-prune-seeded-callsite-defaults.test.ts
@@ -1,0 +1,208 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { pruneSeededCallsiteDefaultsMigration } from "../workspace/migrations/111-prune-seeded-callsite-defaults.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+let workspaceDir: string;
+let previousOverlayPath: string | undefined;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readLlm(): Record<string, unknown> | undefined {
+  return readConfig().llm as Record<string, unknown> | undefined;
+}
+
+function latencySeed(): Record<string, unknown> {
+  return {
+    model: "claude-haiku-4-5-20251001",
+    effort: "low",
+    thinking: { enabled: false },
+  };
+}
+
+function fullSeededCallSites(): Record<string, Record<string, unknown>> {
+  return {
+    guardianQuestionCopy: latencySeed(),
+    interactionClassifier: latencySeed(),
+    skillCategoryInference: latencySeed(),
+    inviteInstructionGenerator: latencySeed(),
+    notificationDecision: latencySeed(),
+    preferenceExtraction: latencySeed(),
+    commitMessage: {
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 120,
+      temperature: 0.2,
+      effort: "low",
+      thinking: { enabled: false },
+    },
+    conversationStarters: latencySeed(),
+    conversationSummarization: {
+      model: "claude-opus-4-7",
+      effort: "low",
+      thinking: { enabled: false },
+    },
+    recall: {
+      profile: "cost-optimized",
+      maxTokens: 4096,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      temperature: 0,
+      disableCache: true,
+    },
+    heartbeatAgent: {
+      profile: "cost-optimized",
+      maxTokens: 2048,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 16000 },
+    },
+    replySuggestion: {
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+      thinking: { enabled: false },
+      disableCache: true,
+    },
+    memoryRouter: {
+      profile: "cost-optimized",
+      contextWindow: { maxInputTokens: 1_000_000 },
+    },
+  };
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-111-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+  previousOverlayPath = process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  if (previousOverlayPath === undefined) {
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  } else {
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = previousOverlayPath;
+  }
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("111-prune-seeded-callsite-defaults migration", () => {
+  test("is registered last", () => {
+    expect(WORKSPACE_MIGRATIONS.at(-1)).toBe(
+      pruneSeededCallsiteDefaultsMigration,
+    );
+  });
+
+  test("no-op when config.json does not exist", () => {
+    pruneSeededCallsiteDefaultsMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    pruneSeededCallsiteDefaultsMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("removes exact system-owned call-site default materializations", () => {
+    writeConfig({
+      llm: {
+        activeProfile: "balanced",
+        advisorProfile: "frontier",
+        callSites: fullSeededCallSites(),
+      },
+    });
+
+    pruneSeededCallsiteDefaultsMigration.run(workspaceDir);
+
+    expect(readLlm()?.activeProfile).toBe("balanced");
+    expect(readLlm()?.advisorProfile).toBe("frontier");
+    expect(readLlm()?.callSites).toBeUndefined();
+  });
+
+  test("preserves user-customized call-site entries", () => {
+    writeConfig({
+      llm: {
+        callSites: {
+          ...fullSeededCallSites(),
+          commitMessage: {
+            model: "claude-haiku-4-5-20251001",
+            maxTokens: 256,
+            temperature: 0.2,
+            effort: "low",
+            thinking: { enabled: false },
+          },
+          recall: {
+            profile: "cost-optimized",
+            maxTokens: 4096,
+            effort: "low",
+            thinking: { enabled: false, streamThinking: false },
+            temperature: 0,
+            disableCache: false,
+          },
+          customSite: { profile: "frontier" },
+        },
+      },
+    });
+
+    pruneSeededCallsiteDefaultsMigration.run(workspaceDir);
+
+    const callSites = readLlm()?.callSites as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(Object.keys(callSites).sort()).toEqual([
+      "commitMessage",
+      "customSite",
+      "recall",
+    ]);
+    expect(callSites.commitMessage?.maxTokens).toBe(256);
+    expect(callSites.recall?.disableCache).toBe(false);
+    expect(callSites.customSite).toEqual({ profile: "frontier" });
+  });
+
+  test("platform-style config keeps gateway settings while pruning seeded call sites", () => {
+    writeConfig({
+      gateway: {
+        unmappedPolicy: "default",
+        defaultAssistantId: "self",
+      },
+      llm: {
+        callSites: fullSeededCallSites(),
+      },
+    });
+
+    pruneSeededCallsiteDefaultsMigration.run(workspaceDir);
+
+    expect(readConfig().gateway).toEqual({
+      unmappedPolicy: "default",
+      defaultAssistantId: "self",
+    });
+    expect(readLlm()?.callSites).toBeUndefined();
+  });
+});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -14,6 +14,7 @@ import {
   getConfigQuarantineNoticePath,
   getWorkspaceConfigPath,
 } from "../util/platform.js";
+import { pruneSeededCallsiteDefaultsFromConfig } from "./prune-seeded-callsite-defaults.js";
 import { AssistantConfigSchema } from "./schema.js";
 import type { AssistantConfig } from "./types.js";
 
@@ -629,6 +630,7 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
   }
 
   deepMergeOverwrite(existing, defaults as Record<string, unknown>);
+  pruneSeededCallsiteDefaultsFromConfig(existing);
 
   const dir = dirname(configPath);
   if (!existsSync(dir)) {

--- a/assistant/src/config/prune-seeded-callsite-defaults.ts
+++ b/assistant/src/config/prune-seeded-callsite-defaults.ts
@@ -1,0 +1,110 @@
+// Exact system-owned default materializations. These are resolved through
+// shipped call-site defaults rather than persisted as user overrides.
+const SEEDED_CALL_SITES: Record<string, Record<string, unknown>> = {
+  guardianQuestionCopy: latencySeed(),
+  interactionClassifier: latencySeed(),
+  skillCategoryInference: latencySeed(),
+  inviteInstructionGenerator: latencySeed(),
+  notificationDecision: latencySeed(),
+  preferenceExtraction: latencySeed(),
+  commitMessage: {
+    model: "claude-haiku-4-5-20251001",
+    maxTokens: 120,
+    temperature: 0.2,
+    effort: "low",
+    thinking: { enabled: false },
+  },
+  conversationStarters: latencySeed(),
+  conversationSummarization: {
+    model: "claude-opus-4-7",
+    effort: "low",
+    thinking: { enabled: false },
+  },
+  recall: {
+    profile: "cost-optimized",
+    maxTokens: 4096,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+    temperature: 0,
+    disableCache: true,
+  },
+  heartbeatAgent: {
+    profile: "cost-optimized",
+    maxTokens: 2048,
+    effort: "low",
+    temperature: 0,
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: { maxInputTokens: 16000 },
+  },
+  replySuggestion: {
+    model: "claude-haiku-4-5-20251001",
+    effort: "low",
+    thinking: { enabled: false },
+    disableCache: true,
+  },
+  memoryRouter: {
+    profile: "cost-optimized",
+    contextWindow: { maxInputTokens: 1_000_000 },
+  },
+};
+
+export function pruneSeededCallsiteDefaultsFromConfig(
+  config: Record<string, unknown>,
+): boolean {
+  const llm = readObject(config.llm);
+  if (llm === null) return false;
+
+  const callSites = readObject(llm.callSites);
+  if (callSites === null) return false;
+
+  let changed = false;
+  for (const [callSite, seed] of Object.entries(SEEDED_CALL_SITES)) {
+    if (deepEqual(callSites[callSite], seed)) {
+      delete callSites[callSite];
+      changed = true;
+    }
+  }
+  if (!changed) return false;
+
+  if (Object.keys(callSites).length === 0) {
+    delete llm.callSites;
+  } else {
+    llm.callSites = callSites;
+  }
+  config.llm = llm;
+  return true;
+}
+
+function latencySeed(): Record<string, unknown> {
+  return {
+    model: "claude-haiku-4-5-20251001",
+    effort: "low",
+    thinking: { enabled: false },
+  };
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) || Array.isArray(b)) return false;
+
+  const aRecord = a as Record<string, unknown>;
+  const bRecord = b as Record<string, unknown>;
+  const aKeys = Object.keys(aRecord);
+  const bKeys = Object.keys(bRecord);
+  if (aKeys.length !== bKeys.length) return false;
+
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bRecord, key)) return false;
+    if (!deepEqual(aRecord[key], bRecord[key])) return false;
+  }
+  return true;
+}

--- a/assistant/src/workspace/migrations/111-prune-seeded-callsite-defaults.ts
+++ b/assistant/src/workspace/migrations/111-prune-seeded-callsite-defaults.ts
@@ -1,0 +1,134 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Exact system-owned default materializations. These are not user overrides, so
+// matching entries are pruned and resolved through shipped call-site defaults.
+const SEEDED_CALL_SITES: Record<string, Record<string, unknown>> = {
+  guardianQuestionCopy: latencySeed(),
+  interactionClassifier: latencySeed(),
+  skillCategoryInference: latencySeed(),
+  inviteInstructionGenerator: latencySeed(),
+  notificationDecision: latencySeed(),
+  preferenceExtraction: latencySeed(),
+  commitMessage: {
+    model: "claude-haiku-4-5-20251001",
+    maxTokens: 120,
+    temperature: 0.2,
+    effort: "low",
+    thinking: { enabled: false },
+  },
+  conversationStarters: latencySeed(),
+  conversationSummarization: {
+    model: "claude-opus-4-7",
+    effort: "low",
+    thinking: { enabled: false },
+  },
+  recall: {
+    profile: "cost-optimized",
+    maxTokens: 4096,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+    temperature: 0,
+    disableCache: true,
+  },
+  heartbeatAgent: {
+    profile: "cost-optimized",
+    maxTokens: 2048,
+    effort: "low",
+    temperature: 0,
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: { maxInputTokens: 16000 },
+  },
+  replySuggestion: {
+    model: "claude-haiku-4-5-20251001",
+    effort: "low",
+    thinking: { enabled: false },
+    disableCache: true,
+  },
+  memoryRouter: {
+    profile: "cost-optimized",
+    contextWindow: { maxInputTokens: 1_000_000 },
+  },
+};
+
+export const pruneSeededCallsiteDefaultsMigration: WorkspaceMigration = {
+  id: "111-prune-seeded-callsite-defaults",
+  description:
+    "Remove seeded LLM call-site default materializations so fresh workspaces show no overrides",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const callSites = readObject(llm.callSites);
+    if (callSites === null) return;
+
+    let changed = false;
+    for (const [callSite, seed] of Object.entries(SEEDED_CALL_SITES)) {
+      if (deepEqual(callSites[callSite], seed)) {
+        delete callSites[callSite];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+
+    if (Object.keys(callSites).length === 0) {
+      delete llm.callSites;
+    } else {
+      llm.callSites = callSites;
+    }
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: restoring these entries would make defaults appear as
+    // user-visible overrides again.
+  },
+};
+
+function latencySeed(): Record<string, unknown> {
+  return {
+    model: "claude-haiku-4-5-20251001",
+    effort: "low",
+    thinking: { enabled: false },
+  };
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) || Array.isArray(b)) return false;
+
+  const aRecord = a as Record<string, unknown>;
+  const bRecord = b as Record<string, unknown>;
+  const aKeys = Object.keys(aRecord);
+  const bKeys = Object.keys(bRecord);
+  if (aKeys.length !== bKeys.length) return false;
+
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bRecord, key)) return false;
+    if (!deepEqual(aRecord[key], bRecord[key])) return false;
+  }
+  return true;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -108,6 +108,7 @@ import { dropSendDiagnosticsMigration } from "./107-drop-send-diagnostics.js";
 import { dropBalancedEconomyProfileMigration } from "./108-drop-balanced-economy-profile.js";
 import { swapQualityProfileToGlm52Migration } from "./109-swap-quality-profile-to-glm-5p2.js";
 import { flipBalancedProfileToTogetherMigration } from "./110-flip-balanced-profile-to-together.js";
+import { pruneSeededCallsiteDefaultsMigration } from "./111-prune-seeded-callsite-defaults.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -227,4 +228,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropBalancedEconomyProfileMigration,
   swapQualityProfileToGlm52Migration,
   flipBalancedProfileToTogetherMigration,
+  pruneSeededCallsiteDefaultsMigration,
 ];


### PR DESCRIPTION
## Summary
- Add workspace migration `111-prune-seeded-callsite-defaults` to remove exact system-owned LLM call-site default materializations from `config.json`.
- Preserve user-customized call-site entries, unknown call sites, profile settings, and platform gateway settings.
- Register the migration and cover the fresh-cloud-assistant case with focused tests.

## Why
Fresh platform workspaces can materialize shipped call-site defaults into persisted `llm.callSites`, which makes the UI count them as user-visible overrides. These exact seeded entries should resolve through the default resolver instead of living in workspace config.

## Verification
- `bun test src/__tests__/workspace-migration-111-prune-seeded-callsite-defaults.test.ts`
- `bun run lint src/__tests__/workspace-migration-111-prune-seeded-callsite-defaults.test.ts src/workspace/migrations/111-prune-seeded-callsite-defaults.ts src/workspace/migrations/registry.ts`
- `bunx tsc --noEmit`
- pre-commit formatting/lint checks passed
- pre-push assistant typecheck/lint checks passed
