### PR TITLE
docs(web): present-tense MAX_VISIBLE_SUBAGENT_AVATARS comment (AGENTS.md Code Comments)

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
@@ -16,11 +16,9 @@ import { Typography } from "@vellumai/design-library";
  * Number of subagent avatars shown before collapsing the remainder into a
  * `+N` overflow chip.
  *
- * Intentionally 6, matching the Figma mock (`6063:148462`), which shows 6
- * avatars followed by a "+6" chip — the mock is the authoritative spec here.
- * The requester's earlier "more than 4" wording was loose and is superseded by
- * the mock; 6 is deliberate, not a bug. Exposed as a named constant so the
- * threshold stays trivially tunable if product later confirms a different cap.
+ * Set to 6 to match the Figma spec (`6063:148462`), which shows 6 avatars
+ * followed by a `+6` chip. Exposed as a named constant so the threshold stays
+ * tunable.
  */
 export const MAX_VISIBLE_SUBAGENT_AVATARS = 6;
 


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for spawning-subagents-ui-redesign.md.

**Gap:** The MAX_VISIBLE_SUBAGENT_AVATARS doc comment narrated review history ('was loose', 'superseded', 'not a bug'), violating the root AGENTS.md Code Comments rule.
**Fix:** Trimmed the comment to present-tense rationale (6 matches the Figma spec; named constant keeps it tunable). The constant value is unchanged.