### PR TITLE
feat(subagent): add synchronous spawnAndAwait that returns the child's final text

### DIFF
--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for `SubagentManager.spawnAndAwait` — the synchronous run primitive.
+ *
+ * Unlike fire-and-forget `spawn` (covered elsewhere), `spawnAndAwait` awaits
+ * the child's run, resolves to its final assistant text, forwards streaming
+ * deltas via `onText`, supports external abort via `signal`, and MUST NOT
+ * trigger the terminal parent-injection that the fire-and-forget path uses.
+ *
+ * The harness mocks `Conversation` + bootstrap + provider registry + config
+ * (same pattern as subagent-call-site-routing.test.ts) so the manager runs
+ * its real setUpSubagent → runSubagent path against a controllable fake
+ * Conversation without touching SQLite or a real provider.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { Message } from "../providers/types.js";
+
+// ── Fake Conversation ───────────────────────────────────────────────────────
+
+interface FakeConversationConfig {
+  /** Final in-memory messages exposed after runAgentLoop resolves. */
+  messages?: Message[];
+  /** When set, runAgentLoop rejects with this error. */
+  runError?: Error;
+  /**
+   * When true, runAgentLoop blocks until `abort()` is called, then rejects.
+   * Used to exercise the external-signal abort path.
+   */
+  waitForAbort?: boolean;
+  /** Deltas to emit through sendToClient before runAgentLoop resolves. */
+  emitDeltas?: ServerMessage[];
+}
+
+let nextConversationConfig: FakeConversationConfig = {};
+
+class FakeConversation {
+  messages: Message[];
+  usageStats = { inputTokens: 10, outputTokens: 5, estimatedCost: 0.001 };
+  conversationType = "background";
+  hasSystemPromptOverride = false;
+
+  private sendToClient: (msg: ServerMessage) => void;
+  private readonly cfg: FakeConversationConfig;
+  private aborted = false;
+  private resolveAbort?: () => void;
+
+  constructor(
+    _id: string,
+    _provider: unknown,
+    _systemPrompt: string,
+    sendToClient: (msg: ServerMessage) => void,
+    _workingDir: string,
+    _options?: unknown,
+  ) {
+    this.sendToClient = sendToClient;
+    this.cfg = nextConversationConfig;
+    this.messages = this.cfg.messages ?? [];
+  }
+
+  updateClient(sendToClient: (msg: ServerMessage) => void) {
+    // The manager re-points sendToClient via updateClient; honor it so the
+    // wrappedSendToClient tap is the one the deltas flow through.
+    this.sendToClient = sendToClient;
+  }
+  setIsSubagent() {}
+  setTrustContext() {}
+  setAuthContext() {}
+  getAuthContext() {
+    return undefined;
+  }
+  setAssistantId() {}
+  setSubagentAllowedTools() {}
+  setPreactivatedSkillIds() {}
+  getCurrentSystemPrompt() {
+    return "system";
+  }
+  injectInheritedContext() {}
+
+  persistUserMessage() {
+    return { id: "msg-id", deduplicated: false };
+  }
+
+  async runAgentLoop() {
+    for (const delta of this.cfg.emitDeltas ?? []) {
+      this.sendToClient(delta);
+    }
+    if (this.cfg.waitForAbort) {
+      // Reject promptly if abort already fired (already-aborted signal), else
+      // block until abort() resolves the gate.
+      if (!this.aborted) {
+        await new Promise<void>((resolve) => {
+          this.resolveAbort = resolve;
+        });
+      }
+      throw new Error("aborted");
+    }
+    if (this.cfg.runError) {
+      throw this.cfg.runError;
+    }
+  }
+
+  abort() {
+    this.aborted = true;
+    this.resolveAbort?.();
+  }
+  dispose() {}
+}
+
+mock.module("../daemon/conversation.js", () => ({
+  Conversation: FakeConversation,
+}));
+
+mock.module("../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: () => ({ id: `conv-${Math.random()}` }),
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+  buildSubagentSystemPrompt: () => "subagent system",
+}));
+
+const anthropicStub = { name: "anthropic" };
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => anthropicStub,
+  resolveProviderFromConnection: async () => anthropicStub,
+  clearConnectionProviderCache: () => {},
+  listProviders: () => ["anthropic"],
+}));
+
+mock.module("../providers/connection-resolution.js", () => ({
+  resolveDefaultProvider: async () => anthropicStub,
+}));
+
+mock.module("../providers/call-site-routing.js", () => ({
+  wrapWithCallSiteRouting: (provider: unknown) => provider,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: {
+      default: {
+        provider: "anthropic",
+        provider_connection: "anthropic-conn",
+        model: "claude-opus-4-7",
+      },
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+mock.module("../config/llm-resolver.js", () => ({
+  resolveCallSiteConfig: () => ({
+    provider: "anthropic",
+    provider_connection: "anthropic-conn",
+    maxTokens: 4096,
+  }),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────
+
+import {
+  clearConversations,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { SubagentManager } from "../subagent/manager.js";
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    parentConversationId: `parent-${Math.random()}`,
+    label: "test",
+    objective: "do the thing",
+    ...overrides,
+  };
+}
+
+/** A fake parent conversation that records injected (enqueued) messages. */
+function registerFakeParent(parentConversationId: string): {
+  enqueuedCount: () => number;
+} {
+  let enqueued = 0;
+  setConversation(parentConversationId, {
+    // Accessors read by setUpSubagent when copying trust/auth context.
+    trustContext: undefined,
+    getAuthContext: () => undefined,
+    assistantId: undefined,
+    enqueueMessage: () => {
+      enqueued += 1;
+      return { rejected: false, queued: true };
+    },
+  } as never);
+  return { enqueuedCount: () => enqueued };
+}
+
+describe("SubagentManager.spawnAndAwait", () => {
+  test("resolves to the child's final assistant text", async () => {
+    nextConversationConfig = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "do the thing" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Final " },
+            { type: "text", text: "answer." },
+          ],
+        },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    const text = await manager.spawnAndAwait(makeConfig(), () => {});
+
+    expect(text).toBe("Final answer.");
+  });
+
+  test("returns empty string when the final assistant message has no text", async () => {
+    nextConversationConfig = {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "noop", input: {} }],
+        },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    const text = await manager.spawnAndAwait(makeConfig(), () => {});
+
+    expect(text).toBe("");
+  });
+
+  test("does NOT inject a terminal notification into the parent (synchronous path)", async () => {
+    clearConversations();
+    const cfg = makeConfig();
+    const parent = registerFakeParent(cfg.parentConversationId);
+
+    nextConversationConfig = {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "result" }],
+        },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(cfg, () => {});
+
+    expect(parent.enqueuedCount()).toBe(0);
+    clearConversations();
+  });
+
+  test("forwards streaming text/thinking deltas via onText", async () => {
+    nextConversationConfig = {
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "done" }] },
+      ],
+      emitDeltas: [
+        { type: "assistant_text_delta", text: "Hello " } as ServerMessage,
+        {
+          type: "assistant_thinking_delta",
+          thinking: "(pondering) ",
+        } as ServerMessage,
+        { type: "assistant_text_delta", text: "world" } as ServerMessage,
+        // Non-delta events must not be forwarded to onText.
+        { type: "subagent_status_changed" } as ServerMessage,
+      ],
+    };
+
+    const chunks: string[] = [];
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(makeConfig(), () => {}, {
+      onText: (chunk) => chunks.push(chunk),
+    });
+
+    expect(chunks).toEqual(["Hello ", "(pondering) ", "world"]);
+  });
+
+  test("aborting the provided signal rejects the run", async () => {
+    nextConversationConfig = { waitForAbort: true };
+
+    const controller = new AbortController();
+    const manager = new SubagentManager();
+    const promise = manager.spawnAndAwait(makeConfig(), () => {}, {
+      signal: controller.signal,
+    });
+
+    // Abort on the next tick so the run is in flight.
+    queueMicrotask(() => controller.abort());
+
+    await expect(promise).rejects.toThrow();
+  });
+
+  test("an already-aborted signal aborts the run immediately", async () => {
+    nextConversationConfig = { waitForAbort: true };
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const manager = new SubagentManager();
+    await expect(
+      manager.spawnAndAwait(makeConfig(), () => {}, {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("a failing run rejects (does not silently resolve)", async () => {
+    nextConversationConfig = { runError: new Error("boom") };
+
+    const manager = new SubagentManager();
+    await expect(manager.spawnAndAwait(makeConfig(), () => {})).rejects.toThrow(
+      "boom",
+    );
+  });
+});
+
+describe("SubagentManager.spawn (fire-and-forget) — unaffected", () => {
+  test("spawn returns the subagent id synchronously and does not throw on a normal run", async () => {
+    nextConversationConfig = {
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    const id = await manager.spawn(makeConfig(), () => {});
+
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  test("spawn still injects a terminal notification into the parent", async () => {
+    clearConversations();
+    const cfg = makeConfig();
+    const parent = registerFakeParent(cfg.parentConversationId);
+
+    nextConversationConfig = {
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    await manager.spawn(cfg, () => {});
+
+    // The run kicks off asynchronously; let the microtask/macrotask queue drain.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(parent.enqueuedCount()).toBeGreaterThan(0);
+    clearConversations();
+  });
+});

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -28,11 +28,20 @@ interface FakeConversationConfig {
    * Used to exercise the external-signal abort path.
    */
   waitForAbort?: boolean;
+  /**
+   * When true, runAgentLoop blocks until `abort()` is called, then RESOLVES
+   * normally (does not throw). Simulates the real `runAgentLoop`, which
+   * consumes the cancellation internally and resolves — the case where a
+   * timed-out run would otherwise reach the success branch.
+   */
+  resolveOnAbort?: boolean;
   /** Deltas to emit through sendToClient before runAgentLoop resolves. */
   emitDeltas?: ServerMessage[];
 }
 
 let nextConversationConfig: FakeConversationConfig = {};
+/** Set true when any FakeConversation's runAgentLoop is invoked. */
+let runLoopInvoked = false;
 
 class FakeConversation {
   messages: Message[];
@@ -82,17 +91,20 @@ class FakeConversation {
   }
 
   async runAgentLoop() {
+    runLoopInvoked = true;
     for (const delta of this.cfg.emitDeltas ?? []) {
       this.sendToClient(delta);
     }
-    if (this.cfg.waitForAbort) {
-      // Reject promptly if abort already fired (already-aborted signal), else
-      // block until abort() resolves the gate.
+    if (this.cfg.waitForAbort || this.cfg.resolveOnAbort) {
+      // Block until abort() resolves the gate (unless abort already fired, e.g.
+      // an already-aborted signal). resolveOnAbort RESOLVES normally to mimic
+      // the real runAgentLoop consuming the cancellation; waitForAbort throws.
       if (!this.aborted) {
         await new Promise<void>((resolve) => {
           this.resolveAbort = resolve;
         });
       }
+      if (this.cfg.resolveOnAbort) return;
       throw new Error("aborted");
     }
     if (this.cfg.runError) {
@@ -178,6 +190,13 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
     objective: "do the thing",
     ...overrides,
   };
+}
+
+/** Statuses broadcast to the parent via `subagent_status_changed` events. */
+function broadcastStatuses(events: ServerMessage[]): string[] {
+  return events
+    .filter((m) => m.type === "subagent_status_changed")
+    .map((m) => (m as { status: string }).status);
 }
 
 /** A fake parent conversation that records injected (enqueued) messages. */
@@ -309,6 +328,56 @@ describe("SubagentManager.spawnAndAwait", () => {
         signal: controller.signal,
       }),
     ).rejects.toThrow();
+  });
+
+  test("a live-signal abort records status 'aborted', never broadcasts 'completed'", async () => {
+    // runAgentLoop RESOLVES normally on abort (the real loop consumes the
+    // cancellation). Before the fix, runSubagent's success branch then
+    // recorded the run as "completed"; the manager-routed abort must mark it
+    // terminal first so this is recorded and broadcast as "aborted".
+    nextConversationConfig = { resolveOnAbort: true };
+
+    const events: ServerMessage[] = [];
+    const controller = new AbortController();
+    const manager = new SubagentManager();
+    const promise = manager.spawnAndAwait(
+      makeConfig(),
+      (msg) => events.push(msg),
+      { signal: controller.signal },
+    );
+
+    // Abort once the run is in flight (runAgentLoop is awaiting the gate).
+    queueMicrotask(() => controller.abort());
+
+    await expect(promise).rejects.toThrow();
+
+    const statuses = broadcastStatuses(events);
+    expect(statuses).toContain("aborted");
+    expect(statuses).not.toContain("completed");
+  });
+
+  test("an already-aborted signal does not run the agent loop", async () => {
+    nextConversationConfig = { resolveOnAbort: true };
+    runLoopInvoked = false;
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const events: ServerMessage[] = [];
+    const manager = new SubagentManager();
+    await expect(
+      manager.spawnAndAwait(makeConfig(), (msg) => events.push(msg), {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+
+    // The early-return guard fires before setStatus("running") and before the
+    // agent loop starts: no loop invocation, no "running"/"completed" broadcast.
+    expect(runLoopInvoked).toBe(false);
+    const statuses = broadcastStatuses(events);
+    expect(statuses).not.toContain("running");
+    expect(statuses).not.toContain("completed");
+    expect(statuses).toContain("aborted");
   });
 
   test("a failing run rejects (does not silently resolve)", async () => {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -24,6 +24,7 @@ import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import { resolveDefaultProvider } from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { listProviders } from "../providers/registry.js";
+import type { Message, TextContent } from "../providers/types.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
@@ -56,6 +57,38 @@ export function mergeSkillIds(
   configSkillIds?: string[],
 ): string[] {
   return [...new Set([...roleSkillIds, ...(configSkillIds ?? [])])];
+}
+
+// ── Final-text extraction helper ────────────────────────────────────────
+
+/**
+ * Concatenate the `text` blocks of the conversation's trailing assistant
+ * message. Used by `spawnAndAwait` to return the child's final synthesis to
+ * the awaiting caller. Returns an empty string when the conversation has no
+ * assistant message or the final assistant message carries no text blocks
+ * (e.g. it ended on a tool_use).
+ */
+function extractFinalAssistantText(messages: Message[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== "assistant") continue;
+    return message.content
+      .filter((block): block is TextContent => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+  }
+  return "";
+}
+
+/**
+ * Pull the user-visible text out of a streaming delta event, or null for any
+ * other event type. Used by the synchronous `onText` tap to forward
+ * `assistant_text_delta` / `assistant_thinking_delta` chunks to the caller.
+ */
+function extractDeltaText(msg: ServerMessage): string | null {
+  if (msg.type === "assistant_text_delta") return msg.text;
+  if (msg.type === "assistant_thinking_delta") return msg.thinking;
+  return null;
 }
 
 // ── Default subagent system prompt ──────────────────────────────────────
@@ -110,6 +143,19 @@ interface ManagedSubagent {
    * the release to the TTL sweep rather than tearing down mid-drain.
    */
   hadEnqueuedMessages?: boolean;
+  /**
+   * Set on the synchronous `spawnAndAwait` path. When true, `runSubagent`
+   * skips the terminal parent-injection (`notifyParentTerminal`) — the awaiting
+   * caller receives the child's final text directly, so re-injecting a
+   * "read the result" notification into the parent would be redundant noise.
+   */
+  synchronous?: boolean;
+  /**
+   * Optional text tap for the synchronous path. When set, `wrappedSendToClient`
+   * forwards each `assistant_text_delta` / `assistant_thinking_delta` chunk to
+   * this callback IN ADDITION to the normal `subagent_event` envelope.
+   */
+  onText?: (chunk: string) => void;
 }
 
 export interface SubagentNotificationInfo {
@@ -145,6 +191,30 @@ export class SubagentManager {
     config: Omit<SubagentConfig, "id">,
     parentSendToClient: (msg: ServerMessage) => void,
   ): Promise<string> {
+    const { subagentId } = await this.setUpSubagent(config, parentSendToClient);
+
+    // ── Kick off the agent loop (fire-and-forget) ───────────────────
+    this.runSubagent(subagentId, config.objective).catch((err) => {
+      log.error({ subagentId, err }, "Subagent run failed unexpectedly");
+    });
+
+    return subagentId;
+  }
+
+  // ── Internal: shared spawn setup ──────────────────────────────────────
+
+  /**
+   * Perform all spawn-time setup shared by `spawn` and `spawnAndAwait`:
+   * enforce the depth limit, resolve role/provider/system prompt, construct
+   * the child Conversation, register it, and emit the `subagent_spawned`
+   * event. Does NOT start the agent loop — the caller decides whether to run
+   * fire-and-forget (`spawn`) or awaited (`spawnAndAwait`).
+   */
+  private async setUpSubagent(
+    config: Omit<SubagentConfig, "id">,
+    parentSendToClient: (msg: ServerMessage) => void,
+    opts?: { synchronous?: boolean; onText?: (chunk: string) => void },
+  ): Promise<{ subagentId: string; managed: ManagedSubagent }> {
     // ── Limit checks ────────────────────────────────────────────────
 
     // Depth check: prevent subagents from spawning nested subagents.
@@ -279,11 +349,20 @@ export class SubagentManager {
       conversation: null! as Conversation,
       state,
       parentSendToClient,
+      ...(opts?.synchronous ? { synchronous: true } : {}),
+      ...(opts?.onText ? { onText: opts.onText } : {}),
     };
 
     // Wrap sendToClient to envelope all events with the subagent ID.
     // Reads from managed.parentSendToClient so reconnects are picked up.
     const wrappedSendToClient = (msg: ServerMessage): void => {
+      // Tap streaming text/thinking deltas for the synchronous caller (if any),
+      // in addition to the normal envelope below. Reads from managed.onText so
+      // the synchronous path can forward chunks without altering event routing.
+      if (managed.onText) {
+        const text = extractDeltaText(msg);
+        if (text) managed.onText(text);
+      }
       managed.parentSendToClient({
         type: "subagent_event",
         subagentId,
@@ -393,12 +472,60 @@ export class SubagentManager {
       "Subagent spawned",
     );
 
-    // ── Kick off the agent loop (fire-and-forget) ───────────────────
-    this.runSubagent(subagentId, config.objective).catch((err) => {
-      log.error({ subagentId, err }, "Subagent run failed unexpectedly");
-    });
+    return { subagentId, managed };
+  }
 
-    return subagentId;
+  // ── Spawn and await (synchronous) ─────────────────────────────────────
+
+  /**
+   * Spawn a subagent and AWAIT its run, resolving to the child's final
+   * assistant text. Unlike `spawn` (fire-and-forget), the caller blocks until
+   * the child reaches a terminal state and receives the text directly — so the
+   * terminal parent-injection (`notifyParentTerminal`) is skipped on this path.
+   *
+   * `opts.signal` aborts the underlying run when triggered (e.g. an external
+   * timeout). `opts.onText` receives each streaming text/thinking chunk in
+   * addition to the normal `subagent_event` envelope.
+   */
+  async spawnAndAwait(
+    config: Omit<SubagentConfig, "id">,
+    parentSendToClient: (msg: ServerMessage) => void,
+    opts?: { signal?: AbortSignal; onText?: (chunk: string) => void },
+  ): Promise<string> {
+    const { subagentId, managed } = await this.setUpSubagent(
+      config,
+      parentSendToClient,
+      { synchronous: true, ...(opts?.onText ? { onText: opts.onText } : {}) },
+    );
+
+    // Wire the external signal to abort the child conversation. If the signal
+    // is already aborted, abort immediately so the run rejects promptly.
+    const signal = opts?.signal;
+    const onAbort = (): void => {
+      managed.conversation?.abort(
+        createAbortReason(
+          "subagent_aborted",
+          "SubagentManager.spawnAndAwait",
+          managed.state.conversationId,
+        ),
+      );
+    };
+    if (signal) {
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    try {
+      const finalText = await this.runSubagent(subagentId, config.objective);
+      // Surface aborts as a rejection so the caller's timeout path is observable
+      // rather than silently resolving to whatever partial text exists.
+      if (signal?.aborted) {
+        throw new Error("Subagent run aborted before completion.");
+      }
+      return finalText;
+    } finally {
+      signal?.removeEventListener("abort", onAbort);
+    }
   }
 
   // ── Internal: run the subagent ────────────────────────────────────────
@@ -406,13 +533,19 @@ export class SubagentManager {
   private async runSubagent(
     subagentId: string,
     objective: string,
-  ): Promise<void> {
+  ): Promise<string> {
     const managed = this.subagents.get(subagentId);
-    if (!managed) return;
+    if (!managed) return "";
 
     // Capture the live conversation — it is non-null at this point because
     // spawn() sets it before firing runSubagent.
     const conversation = managed.conversation!;
+
+    // The child's trailing assistant text, captured after runAgentLoop resolves
+    // (before the `finally` releases the conversation). Returned to the
+    // synchronous `spawnAndAwait` caller; the fire-and-forget `spawn` caller
+    // ignores it.
+    let finalText = "";
 
     // Read the current parent sender so reconnects are picked up.
     const getSender = () => managed.parentSendToClient;
@@ -466,6 +599,9 @@ export class SubagentManager {
       });
 
       // Agent loop completed successfully.
+      // Capture the trailing assistant text before any release nulls the
+      // conversation reference. The fire-and-forget caller ignores the return.
+      finalText = extractFinalAssistantText(conversation.messages);
       // Copy usage stats from the conversation before sending status (which includes usage).
       managed.state.usage = { ...conversation.usageStats };
       // Only update state + notify if still non-terminal (guards against abort race).
@@ -476,7 +612,12 @@ export class SubagentManager {
         log.info({ subagentId }, "Subagent completed");
 
         // Notify the parent conversation so the LLM can call subagent_read.
-        this.notifyParentTerminal(managed, "completed");
+        // Skipped on the synchronous path — the awaiting caller receives the
+        // final text directly, so re-injecting a "read the result" prompt
+        // would be redundant noise in the parent.
+        if (!managed.synchronous) {
+          this.notifyParentTerminal(managed, "completed");
+        }
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
@@ -489,10 +630,22 @@ export class SubagentManager {
       // Only update status if not already terminal (e.g. aborted).
       if (!TERMINAL_STATUSES.has(managed.state.status)) {
         this.setStatus(subagentId, "failed", getSender(), errorMsg);
-        this.notifyParentTerminal(managed, "failed");
+        // Skip terminal parent-injection on the synchronous path — the failure
+        // surfaces to the awaiting caller as a rejected promise instead.
+        if (!managed.synchronous) {
+          this.notifyParentTerminal(managed, "failed");
+        }
       }
 
       log.error({ subagentId, err }, "Subagent failed");
+
+      // Surface the failure to the synchronous caller. The fire-and-forget
+      // path has no awaiter, so re-throwing there only feeds the `.catch()`
+      // logger in `spawn` — harmless but noisy — so it is confined to the
+      // synchronous path.
+      if (managed.synchronous) {
+        throw err;
+      }
     } finally {
       // Release the heavyweight Conversation — output is already persisted in DB.
       // drainQueue is async: it awaits buildPassthroughBatch (which awaits
@@ -516,6 +669,8 @@ export class SubagentManager {
         this.releaseConversation(managed);
       }
     }
+
+    return finalText;
   }
 
   // ── Abort ─────────────────────────────────────────────────────────────

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -502,13 +502,16 @@ export class SubagentManager {
     // is already aborted, abort immediately so the run rejects promptly.
     const signal = opts?.signal;
     const onAbort = (): void => {
-      managed.conversation?.abort(
-        createAbortReason(
-          "subagent_aborted",
-          "SubagentManager.spawnAndAwait",
-          managed.state.conversationId,
-        ),
-      );
+      // Route through the manager abort path so the subagent is marked terminal
+      // ("aborted") and broadcast as such. A bare conversation.abort() leaves
+      // status non-terminal, so runSubagent's success branch would record the
+      // run as "completed" once runAgentLoop resolves the consumed cancellation.
+      // Suppress the parent notification: the awaiting caller observes the abort
+      // as a thrown rejection, so a "do NOT re-spawn" injection would be
+      // redundant noise.
+      this.abort(subagentId, managed.parentSendToClient, undefined, {
+        suppressNotification: true,
+      });
     };
     if (signal) {
       if (signal.aborted) onAbort();
@@ -546,6 +549,13 @@ export class SubagentManager {
     // synchronous `spawnAndAwait` caller; the fire-and-forget `spawn` caller
     // ignores it.
     let finalText = "";
+
+    // Aborted before the run started (e.g. an already-aborted signal on the
+    // synchronous spawnAndAwait path): the subagent is already terminal. Do not
+    // start the agent loop or reset status back to "running".
+    if (TERMINAL_STATUSES.has(managed.state.status)) {
+      return finalText;
+    }
 
     // Read the current parent sender so reconnects are picked up.
     const getSender = () => managed.parentSendToClient;


### PR DESCRIPTION
## Summary
- Refactor runSubagent to return the child's final assistant text (backward-compatible).
- Add SubagentManager.spawnAndAwait that awaits the run, returns the text, and skips terminal parent-injection; supports signal + onText.

Part of plan: advisor-as-subagent-role.md (PR 2 of 9)