### PR TITLE
feat(onboarding): deterministic plugin floor for research-onboarding

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-plugin-affinity.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-plugin-affinity.test.ts
@@ -68,6 +68,31 @@ describe("pluginsForRole", () => {
     expect(pluginsForRole("Architect")).toEqual([]); // building architect, not software
   });
 
+  test("non-software engineering disciplines do NOT get git-workflow", () => {
+    // The bare "engineer"/"software" tokens used to over-match these.
+    for (const role of [
+      "Mechanical Engineer",
+      "Civil Engineer",
+      "Biomedical Engineer",
+      "Electrical Engineer",
+      "Chemical Engineer",
+      "Aerospace Engineer",
+    ]) {
+      expect(pluginsForRole(role)).not.toContain("git-workflow");
+    }
+  });
+
+  test("'software' as a qualifier on a non-eng title does not fire git-workflow", () => {
+    // "Software Product Manager" must stay a PM (unmapped), not match on "software".
+    expect(pluginsForRole("Software Product Manager")).toEqual([]);
+  });
+
+  test("Sales Engineer is treated as sales, not a git user", () => {
+    const result = pluginsForRole("Sales Engineer");
+    expect(result).toContain("marketing-expert");
+    expect(result).not.toContain("git-workflow");
+  });
+
   test("git-adjacent non-engineering roles are left to the model", () => {
     expect(pluginsForRole("Data Scientist")).toEqual([]);
     expect(pluginsForRole("Product Manager")).toEqual([]);

--- a/clients/web/src/domains/onboarding/onboarding-plugin-affinity.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-plugin-affinity.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the deterministic plugin floor: the always-install baseline and the
+ * role-keyword affinity map. The contract that matters: admin-copilot installs
+ * for everyone, a founder/CEO gets marketing, an engineer gets git tooling,
+ * matching is whole-token (no false fires inside words), and everything is
+ * narrowed to the live catalog.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ALWAYS_INSTALL_PLUGINS,
+  pluginsForRole,
+  resolveDeterministicPlugins,
+} from "@/domains/onboarding/onboarding-plugin-affinity";
+
+/** Stand-in for the full Vellum-owned onboarding catalog. */
+const FULL_CATALOG = new Set([
+  "admin-copilot",
+  "marketing-expert",
+  "git-workflow",
+]);
+
+describe("ALWAYS_INSTALL_PLUGINS", () => {
+  test("admin-copilot is the universal baseline", () => {
+    expect(ALWAYS_INSTALL_PLUGINS).toContain("admin-copilot");
+  });
+});
+
+describe("pluginsForRole", () => {
+  test("founder / CEO → marketing-expert", () => {
+    expect(pluginsForRole("Founder / CEO")).toContain("marketing-expert");
+  });
+
+  test("marketing and growth roles → marketing-expert", () => {
+    for (const role of [
+      "Marketing Manager",
+      "Growth Marketer",
+      "Content Writer",
+      "Head of Brand",
+      "Sales Representative",
+      "Account Executive",
+      "Entrepreneur",
+    ]) {
+      expect(pluginsForRole(role)).toContain("marketing-expert");
+    }
+  });
+
+  test("engineering roles → git-workflow", () => {
+    for (const role of [
+      "Software Engineer",
+      "Senior Developer",
+      "DevOps Engineer",
+      "Machine Learning Engineer",
+      "Backend Developer",
+      "Full Stack Engineer",
+      "SRE",
+      "CTO",
+    ]) {
+      expect(pluginsForRole(role)).toContain("git-workflow");
+    }
+  });
+
+  test("whole-token matching: 'dev' does not fire inside 'developer'", () => {
+    // "developer" must be matched by its own keyword, never by a bare "dev".
+    // Negative control: a role with neither maps to nothing.
+    expect(pluginsForRole("Veterinarian")).toEqual([]);
+    expect(pluginsForRole("Architect")).toEqual([]); // building architect, not software
+  });
+
+  test("git-adjacent non-engineering roles are left to the model", () => {
+    expect(pluginsForRole("Data Scientist")).toEqual([]);
+    expect(pluginsForRole("Product Manager")).toEqual([]);
+  });
+
+  test("a technical founder can match both buckets", () => {
+    const result = pluginsForRole("Founder and Software Engineer");
+    expect(result).toContain("marketing-expert");
+    expect(result).toContain("git-workflow");
+  });
+
+  test("blank role → no affinity matches", () => {
+    expect(pluginsForRole("")).toEqual([]);
+    expect(pluginsForRole("   ")).toEqual([]);
+  });
+});
+
+describe("resolveDeterministicPlugins", () => {
+  test("baseline first, then role matches, deduped", () => {
+    expect(resolveDeterministicPlugins("Founder / CEO", FULL_CATALOG)).toEqual([
+      "admin-copilot",
+      "marketing-expert",
+    ]);
+  });
+
+  test("always includes the baseline even for an unmapped role", () => {
+    expect(resolveDeterministicPlugins("Teacher", FULL_CATALOG)).toEqual([
+      "admin-copilot",
+    ]);
+  });
+
+  test("narrows to the live catalog — absent names are dropped", () => {
+    // marketing-expert not in the catalog (filtered out / not published) → skipped.
+    const partial = new Set(["admin-copilot", "git-workflow"]);
+    expect(resolveDeterministicPlugins("Marketing Manager", partial)).toEqual([
+      "admin-copilot",
+    ]);
+  });
+
+  test("empty catalog → nothing installable, even the baseline", () => {
+    expect(resolveDeterministicPlugins("Founder / CEO", new Set())).toEqual([]);
+  });
+
+  test("no duplicates when a role also matches a baseline plugin", () => {
+    const result = resolveDeterministicPlugins(
+      "Founder and Software Engineer",
+      FULL_CATALOG,
+    );
+    expect(result).toEqual([
+      "admin-copilot",
+      "marketing-expert",
+      "git-workflow",
+    ]);
+    expect(new Set(result).size).toBe(result.length);
+  });
+});

--- a/clients/web/src/domains/onboarding/onboarding-plugin-affinity.ts
+++ b/clients/web/src/domains/onboarding/onboarding-plugin-affinity.ts
@@ -1,0 +1,155 @@
+/**
+ * Deterministic plugin floor for research-onboarding.
+ *
+ * The research turn asks the model to pick capabilities that fit the person (a
+ * top-level `plugins` array), but the prompt biases toward fewer picks — so
+ * cases we want to happen *reliably* (admin-copilot for everyone; marketing for
+ * a founder; git tooling for an engineer) lose to that bias. This module is the
+ * deterministic complement: an always-install baseline plus a role-keyword
+ * affinity map, both narrowed to the live catalog by the runner. The model layer
+ * still covers the long tail of roles not enumerated here.
+ *
+ * Lives in the onboarding domain on purpose: a role → capability affinity is
+ * onboarding's own concern, not knowledge reached in from the chat/plugin domain.
+ * Keep the keyword lists lean and high-precision; a false match silently installs
+ * an off-topic plugin for a new user, which is worse than a miss the model can
+ * still catch.
+ */
+
+/**
+ * Capabilities installed for every new user, regardless of role — a universal
+ * baseline that should never be left to the model's discretion. Still gated by
+ * the runner against the live catalog (owner/enabled checks), so a name absent
+ * from the marketplace is simply skipped.
+ */
+export const ALWAYS_INSTALL_PLUGINS: readonly string[] = ["admin-copilot"];
+
+/**
+ * Role-keyword → capability affinity. A capability is selected when any of its
+ * keywords appears as a whole token (or contiguous token phrase) in the person's
+ * stated role. Matching is whole-token by construction (see `matchesKeyword`), so
+ * "dev" never fires on "developer" and "architect" phrases stay scoped — list the
+ * exact forms you mean.
+ */
+interface PluginAffinity {
+  plugin: string;
+  keywords: readonly string[];
+}
+
+const PLUGIN_AFFINITIES: readonly PluginAffinity[] = [
+  {
+    // Founders/execs do their own GTM, and the marketing roles are direct hits.
+    // marketing-expert spans positioning, demand, content, funnel, and sales
+    // motion, so the sales/creator roles fold in here too.
+    plugin: "marketing-expert",
+    keywords: [
+      "founder",
+      "cofounder",
+      "co founder",
+      "ceo",
+      "cmo",
+      "chief executive",
+      "chief marketing",
+      "entrepreneur",
+      "marketing",
+      "marketer",
+      "growth",
+      "brand",
+      "content",
+      "copywriter",
+      "copywriting",
+      "seo",
+      "demand gen",
+      "demand generation",
+      "sales",
+      "account executive",
+      "business development",
+      "creator",
+      "social media",
+      "community manager",
+    ],
+  },
+  {
+    // Software-engineering roles. Keep to roles that live in git day-to-day;
+    // git-adjacent roles (data scientist, analyst) are left to the model so we
+    // don't push code tooling on someone who doesn't ship code.
+    plugin: "git-workflow",
+    keywords: [
+      "engineer",
+      "engineering",
+      "developer",
+      "swe",
+      "software",
+      "programmer",
+      "coder",
+      "devops",
+      "sre",
+      "backend",
+      "back end",
+      "frontend",
+      "front end",
+      "full stack",
+      "fullstack",
+      "platform engineer",
+      "infrastructure",
+      "solutions architect",
+      "software architect",
+      "tech lead",
+      "cto",
+    ],
+  },
+];
+
+/**
+ * Normalize a free-text role to a space-padded, alphanumeric-token string so
+ * keyword tests are whole-token: every run of non-alphanumerics collapses to a
+ * single space and the whole string is wrapped in spaces. "Founder / CEO" →
+ * " founder ceo ", so `includes(" ceo ")` matches but `includes(" dev ")` can't
+ * match inside "developer".
+ */
+function normalizeRole(role: string): string {
+  return ` ${role.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim()} `;
+}
+
+/** Whether a keyword (single token or token phrase) appears whole in the role. */
+function matchesKeyword(normalizedRole: string, keyword: string): boolean {
+  return normalizedRole.includes(` ${keyword} `);
+}
+
+/**
+ * Plugins implied by a role on its own (excludes the always-install baseline),
+ * before any catalog narrowing. Order follows `PLUGIN_AFFINITIES`; deduped.
+ * Exported for unit tests; the runner uses {@link resolveDeterministicPlugins}.
+ */
+export function pluginsForRole(role: string): string[] {
+  const normalized = normalizeRole(role);
+  const matched: string[] = [];
+  for (const { plugin, keywords } of PLUGIN_AFFINITIES) {
+    if (keywords.some((kw) => matchesKeyword(normalized, kw))) {
+      matched.push(plugin);
+    }
+  }
+  return matched;
+}
+
+/**
+ * The deterministic install set for a run: the always-install baseline unioned
+ * with the role's affinity matches, narrowed to capabilities actually present in
+ * the fetched catalog (`validNames`) so a name the marketplace doesn't carry —
+ * or that's filtered out (non-Vellum, infra) — never hits the install route.
+ * Baseline first, then role matches; deduped, order-stable.
+ */
+export function resolveDeterministicPlugins(
+  role: string,
+  validNames: Set<string>,
+): string[] {
+  const ordered = [...ALWAYS_INSTALL_PLUGINS, ...pluginsForRole(role)];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const name of ordered) {
+    if (!validNames.has(name) || seen.has(name)) continue;
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}

--- a/clients/web/src/domains/onboarding/onboarding-plugin-affinity.ts
+++ b/clients/web/src/domains/onboarding/onboarding-plugin-affinity.ts
@@ -14,6 +14,17 @@
  * Keep the keyword lists lean and high-precision; a false match silently installs
  * an off-topic plugin for a new user, which is worse than a miss the model can
  * still catch.
+ *
+ * INTENTIONAL EXCEPTION to the "Assistant-Driven Judgement" rule in the root
+ * AGENTS.md (judgement calls route through the daemon, not client heuristics).
+ * This is a stakeholder-agreed deterministic FLOOR layered under the model's own
+ * picks, not a replacement for them: the research turn already asks the assistant
+ * to judge fit, but its prompt biases toward fewer picks, so the cases we require
+ * to be reliable (admin-copilot for everyone; marketing for a founder) kept
+ * getting dropped. The always-install baseline is a product POLICY, not a
+ * judgement; the role map is a narrow, high-precision safety net for the obvious
+ * hits while the model continues to cover the long tail. Prefer a miss (let the
+ * model decide) over a loose keyword that mis-installs.
  */
 
 /**
@@ -70,31 +81,51 @@ const PLUGIN_AFFINITIES: readonly PluginAffinity[] = [
     ],
   },
   {
-    // Software-engineering roles. Keep to roles that live in git day-to-day;
-    // git-adjacent roles (data scientist, analyst) are left to the model so we
-    // don't push code tooling on someone who doesn't ship code.
+    // Software-engineering roles only. Deliberately NO bare "engineer" or
+    // "software" token — those over-match the non-software engineering
+    // disciplines ("Mechanical Engineer", "Civil Engineer") and adjacent titles
+    // ("Software Product Manager"), silently installing code tooling for someone
+    // who doesn't ship code. Match the qualified phrases instead; "developer"
+    // stays bare since its dominant occupational sense is software (the rare
+    // "real estate developer" is an acceptable miss). Genuinely git-adjacent
+    // roles (data scientist, analyst, PM) are left to the model.
     plugin: "git-workflow",
     keywords: [
-      "engineer",
-      "engineering",
       "developer",
       "swe",
-      "software",
       "programmer",
       "coder",
       "devops",
+      "dev ops",
       "sre",
-      "backend",
-      "back end",
-      "frontend",
-      "front end",
-      "full stack",
-      "fullstack",
-      "platform engineer",
-      "infrastructure",
-      "solutions architect",
+      "site reliability",
+      "software engineer",
       "software architect",
+      "backend engineer",
+      "back end engineer",
+      "frontend engineer",
+      "front end engineer",
+      "full stack engineer",
+      "fullstack engineer",
+      "platform engineer",
+      "infrastructure engineer",
+      "data engineer",
+      "machine learning engineer",
+      "ml engineer",
+      "qa engineer",
+      "embedded engineer",
+      "security engineer",
+      "staff engineer",
+      "principal engineer",
+      "solutions architect",
       "tech lead",
+      "technical lead",
+      "engineering manager",
+      "engineering lead",
+      "head of engineering",
+      "director of engineering",
+      "vp of engineering",
+      "vp engineering",
       "cto",
     ],
   },

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -39,6 +39,7 @@ import {
   type AvailableCapability,
   type ResearchSubject,
 } from "@/domains/onboarding/research-prompt";
+import { resolveDeterministicPlugins } from "@/domains/onboarding/onboarding-plugin-affinity";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {
   parseResearchResultStreaming,
@@ -184,10 +185,11 @@ export interface ResearchRunnerState {
   claims: ResearchFact[];
   suggestions: ResearchSuggestion[];
   /**
-   * Capabilities being installed for the assistant this run — the model's
-   * top-level `plugins` picks, narrowed to names present in the fetched catalog.
-   * Persona-level (not tied to a suggestion); surfaced so the UI can confirm
-   * what was set up. Empty when plugins are disabled or nothing fit.
+   * Capabilities being installed for the assistant this run — the deterministic
+   * floor (always-install baseline + role affinity) unioned with the model's
+   * top-level `plugins` picks, each narrowed to names present in the fetched
+   * catalog. Persona-level (not tied to a suggestion); surfaced so the UI can
+   * confirm what was set up. Empty when plugins are disabled or nothing fit.
    */
   installedPlugins: string[];
 }
@@ -337,6 +339,29 @@ export function useResearchRunner(): UseResearchRunner {
           // click gate now so suggestion clicks never wait on the research turn.
           if (validNames.size === 0) resolvePluginsReady();
 
+          // Tracks every install fired this run (deterministic floor + the model's
+          // later picks), keyed by name so the suggestion click can await them and
+          // a name is never installed twice.
+          const installs = installPromisesRef.current;
+          // Deterministic floor: the always-install baseline plus the role's
+          // affinity matches, narrowed to the live catalog. Fired here — right
+          // after the catalog fetch, before the model has replied — so these
+          // materialize while the research turn is still streaming. The model's
+          // `plugins` picks (handled in the poll loop) union on top for the long
+          // tail of roles this map doesn't enumerate.
+          const deterministicPlugins = resolveDeterministicPlugins(
+            subject.occupation,
+            validNames,
+          );
+          for (const name of deterministicPlugins) {
+            if (!installs.has(name)) {
+              installs.set(name, installCapabilityBestEffort(assistantId, name));
+            }
+          }
+          if (deterministicPlugins.length > 0) {
+            setState((s) => ({ ...s, installedPlugins: deterministicPlugins }));
+          }
+
           const conversation = await conversationsPost({
             path: { assistant_id: assistantId },
             body: {
@@ -385,13 +410,10 @@ export function useResearchRunner(): UseResearchRunner {
           const deadline = Date.now() + MAX_POLL_MS;
           let lastText = "";
           let stableReads = 0;
-          // Installs fire as soon as the model's `plugins` array closes — emitted
+          // The model's `plugins` picks fire as soon as its array closes — emitted
           // first in the reply, so this lands early while claims/suggestions are
-          // still streaming, overlapping the user's results-review screens so the
-          // capabilities are materialized before the click opens the chat. Tracked
-          // by promise so the click can await still-running ones. Idempotent, so
-          // racing the same name is fine.
-          const installs = installPromisesRef.current;
+          // still streaming. These union on top of the deterministic floor already
+          // installing (see above); idempotent, so racing the same name is fine.
           while (Date.now() < deadline) {
             await sleep(POLL_INTERVAL_MS);
             if (isStale()) return;
@@ -425,7 +447,11 @@ export function useResearchRunner(): UseResearchRunner {
                 status: "running",
                 claims,
                 suggestions,
-                installedPlugins: validPlugins,
+                // Surface the full set actually installing: the deterministic
+                // floor plus the model's picks, deduped, baseline first.
+                installedPlugins: [
+                  ...new Set([...deterministicPlugins, ...validPlugins]),
+                ],
               });
               stableReads = text === lastText ? stableReads + 1 : 0;
               lastText = text;


### PR DESCRIPTION
## Problem

Plugin auto-install during research-onboarding is **100% model-driven**: the runner injects the catalog into the research prompt and installs whatever the model returns in its top-level `plugins` array. But the prompt actively biases *against* a second pick — "the **1-2** capabilities," "**prefer fewer over forcing a match**." So anything we want to happen *reliably* loses to that bias:

- **admin-copilot** (universal chief-of-staff) wasn't guaranteed
- **marketing-expert** was consistently missed for founders — report: *"I selected Founder/CEO and the marketing plugin wasn't installed"* (the model picks admin-copilot as the obvious chief-of-staff fit, then "prefer fewer" tells it to stop)

## Change

Add a **deterministic floor** that complements (doesn't replace) the model layer:

- **Always-install baseline** — `admin-copilot` for every new user.
- **Role-keyword affinity map** — founder/CEO, marketing, growth, sales, content, creator → `marketing-expert`; software-engineering roles (engineer, developer, devops, SRE, …) → `git-workflow`.
- Both are **narrowed to the live catalog** (`validNames`) so an absent/filtered name never hits the install route, and **fired early** — right after the catalog fetch, before the model replies — so they materialize while the research turn streams.
- The model's `plugins` picks still **union on top** for the long tail of roles the map doesn't enumerate.

Only three plugins are actually installable in onboarding (the owner filter is strict `vellum-ai`, and `ai-hero-engineer-kit` is owned by `marinatrajk`): `admin-copilot`, `marketing-expert`, `git-workflow` — so those three are the full mapping surface.

Whole-token keyword matching (normalize → space-pad → `includes(" kw ")`) avoids false fires inside words: `dev` never matches `developer`, and a bare `architect` (building architect) stays unmapped.

## Files

- `onboarding-plugin-affinity.ts` (new) — baseline + affinity table + `resolveDeterministicPlugins()`
- `onboarding-plugin-affinity.test.ts` (new) — 13 tests
- `research-runner.ts` — fire the deterministic floor early; union into the displayed install set

## Testing

- `onboarding-plugin-affinity.test.ts`: 13 pass
- `research-runner.test.ts`: 4 pass
- `tsc --noEmit` clean, eslint clean

## Notes

- No Linear ticket (per request) — won't auto-link/close.
- Deliberately **not** included: the prompt nudge to soften the "prefer fewer" bias (separate, model-side lever for the tail).
- Affinity map is hardcoded in the onboarding domain for now; declaring onboarding affinity in `marketplace.json` metadata is a reasonable future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)