### PR TITLE
fix(research-onboarding): archive the research conversation even when a run is superseded mid-create

### DIFF
--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -353,13 +353,17 @@ export function useResearchRunner(): UseResearchRunner {
             },
             throwOnError: false,
           });
+          // Capture the created conversation id BEFORE the stale check so a
+          // superseded run still archives its throwaway side conversation in the
+          // finally block. The finally already guards on truthiness, so an
+          // undefined id here is harmless.
+          createdConversationId = conversation.data?.id;
           if (isStale()) return;
           const conversationId = conversation.data?.id;
           if (!conversation.response?.ok || !conversationId) {
             setState((s) => ({ ...s, status: "error" }));
             return;
           }
-          createdConversationId = conversationId;
 
           const body: MessagesPostData["body"] = {
             conversationId,


### PR DESCRIPTION
## Summary
Fixes a review gap for plan research-onboarding-handoff.md.

**Gap:** the created research conversation id was recorded after the post-create `isStale()` check, so a resubmit that superseded the run mid-`conversationsPost` left the throwaway 'Getting to know…' conversation un-archived. Now the id is captured immediately after the await, before the stale check, so the finally-block cleanup archives it on every path.