### PR TITLE
docs(research-onboarding): correct the one-shot sidebar-collapse persistence comments

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -268,6 +268,9 @@ export function ChatLayout() {
     if (!sidebarCollapseRequested) return;
     // One-shot: research-onboarding asked us to open collapsed. Honor it on
     // desktop (mobile uses the drawer, which is already closed), then clear.
+    // `setCollapsed(true)` flows through the persistence effect above, so this
+    // intentionally sets the user's persisted collapsed preference (it is not a
+    // transient/visual-only collapse).
     if (!window.matchMedia(MOBILE_MEDIA_QUERY).matches) setCollapsed(true);
     consumeSidebarCollapse();
   }, [sidebarCollapseRequested, consumeSidebarCollapse]);

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -66,8 +66,11 @@ interface OnboardingFocusState {
   endCheckin: () => void;
   /**
    * Set by the onboarding handoff so the chat side panel opens collapsed for a
-   * focused first impression; consumed (cleared) once by `ChatLayout`. A
-   * one-shot signal, not a persistent preference.
+   * focused first impression; consumed (cleared) once by `ChatLayout`. The
+   * signal is one-shot — set once at handoff and consumed on the next
+   * `ChatLayout` mount; honoring it flips the chat's ordinary persisted
+   * `collapsed` state, so the user lands collapsed and it remains their default
+   * until they expand it.
    */
   sidebarCollapseRequested: boolean;
   requestSidebarCollapse: () => void;


### PR DESCRIPTION
## Summary
Fixes a review gap for plan research-onboarding-handoff.md.

**Gap:** the `sidebarCollapseRequested` field comment claimed the collapse was 'not a persistent preference', but honoring it calls `setCollapsed(true)`, which flows through the existing localStorage persistence effect — so the collapse does persist (intentionally, for a focused first impression). Comments corrected to match behavior; no logic change.