### PR TITLE
Research-onboarding → chat handoff: archive research conversation + auto-collapse side panel

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -268,6 +268,9 @@ export function ChatLayout() {
     if (!sidebarCollapseRequested) return;
     // One-shot: research-onboarding asked us to open collapsed. Honor it on
     // desktop (mobile uses the drawer, which is already closed), then clear.
+    // `setCollapsed(true)` flows through the persistence effect above, so this
+    // intentionally sets the user's persisted collapsed preference (it is not a
+    // transient/visual-only collapse).
     if (!window.matchMedia(MOBILE_MEDIA_QUERY).matches) setCollapsed(true);
     consumeSidebarCollapse();
   }, [sidebarCollapseRequested, consumeSidebarCollapse]);

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -128,6 +128,10 @@ export function ChatLayout() {
   // toggles — otherwise a suggestion click's navigate + `?prompt=` auto-send
   // gets raced by the remount and the message is lost.
   const isFocused = useOnboardingFocusStore.use.focused();
+  const sidebarCollapseRequested =
+    useOnboardingFocusStore.use.sidebarCollapseRequested();
+  const consumeSidebarCollapse =
+    useOnboardingFocusStore.use.consumeSidebarCollapse();
 
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantStateKind = useAssistantLifecycleStore(
@@ -259,6 +263,14 @@ export function ChatLayout() {
   useEffect(() => {
     setLocalBool(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed);
   }, [collapsed]);
+
+  useEffect(() => {
+    if (!sidebarCollapseRequested) return;
+    // One-shot: research-onboarding asked us to open collapsed. Honor it on
+    // desktop (mobile uses the drawer, which is already closed), then clear.
+    if (!window.matchMedia(MOBILE_MEDIA_QUERY).matches) setCollapsed(true);
+    consumeSidebarCollapse();
+  }, [sidebarCollapseRequested, consumeSidebarCollapse]);
 
   const handleSidebarWidthChange = useCallback((width: number) => {
     setSidebarWidth(width);

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -264,17 +264,6 @@ export function ChatLayout() {
     setLocalBool(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed);
   }, [collapsed]);
 
-  useEffect(() => {
-    if (!sidebarCollapseRequested) return;
-    // One-shot: research-onboarding asked us to open collapsed. Honor it on
-    // desktop (mobile uses the drawer, which is already closed), then clear.
-    // `setCollapsed(true)` flows through the persistence effect above, so this
-    // intentionally sets the user's persisted collapsed preference (it is not a
-    // transient/visual-only collapse).
-    if (!window.matchMedia(MOBILE_MEDIA_QUERY).matches) setCollapsed(true);
-    consumeSidebarCollapse();
-  }, [sidebarCollapseRequested, consumeSidebarCollapse]);
-
   const handleSidebarWidthChange = useCallback((width: number) => {
     setSidebarWidth(width);
     setLocalNumber(SIDEBAR_WIDTH_STORAGE_KEY, Math.round(width));
@@ -286,6 +275,18 @@ export function ChatLayout() {
   useEffect(() => {
     if (!isMobile) setDrawerOpen(false);
   }, [isMobile]);
+
+  useEffect(() => {
+    if (!sidebarCollapseRequested) return;
+    // One-shot: research-onboarding asked us to open with the side panel
+    // collapsed across the whole web experience (not just desktop). Collapse
+    // the desktop sidebar — `setCollapsed(true)` flows through the persistence
+    // effect above, so this intentionally sets the user's persisted collapsed
+    // preference — AND close the mobile drawer, then clear the signal.
+    setCollapsed(true);
+    setDrawerOpen(false);
+    consumeSidebarCollapse();
+  }, [sidebarCollapseRequested, consumeSidebarCollapse]);
 
   const drawerVisible = isMobile && drawerOpen;
 

--- a/clients/web/src/domains/onboarding/archive-research-conversation.test.ts
+++ b/clients/web/src/domains/onboarding/archive-research-conversation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for archiveResearchConversation's best-effort contract: it must call
+ * the archive endpoint with the right path + `throwOnError: false`, and swallow
+ * every failure mode (a thrown SDK call, a non-ok response) so the
+ * research-onboarding handoff is never blocked.
+ *
+ * NOTE: `bun mock.module` can leak across files — run this file singly:
+ *   bun test src/domains/onboarding/archive-research-conversation.test.ts
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+interface ArchiveCall {
+  path: { assistant_id: string; id: string };
+  throwOnError: false;
+}
+
+let calls: ArchiveCall[] = [];
+let responseOk = true;
+let responseStatus = 200;
+let shouldThrow = false;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  conversationsByIdArchivePost: (opts: ArchiveCall) => {
+    calls.push(opts);
+    if (shouldThrow) {
+      return Promise.reject(new Error("network blew up"));
+    }
+    return Promise.resolve({
+      data: {},
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
+}));
+
+const { archiveResearchConversation } = await import(
+  "./archive-research-conversation"
+);
+
+afterEach(() => {
+  calls = [];
+  responseOk = true;
+  responseStatus = 200;
+  shouldThrow = false;
+});
+
+describe("archiveResearchConversation", () => {
+  test("archives with the assistant + conversation path and throwOnError: false", async () => {
+    await archiveResearchConversation("a1", "c1");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toEqual({ assistant_id: "a1", id: "c1" });
+    expect(calls[0]?.throwOnError).toBe(false);
+  });
+
+  test("swallows a thrown SDK call without rejecting", async () => {
+    shouldThrow = true;
+
+    await expect(
+      archiveResearchConversation("a1", "c1"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("does not throw on a non-ok response", async () => {
+    responseOk = false;
+    responseStatus = 500;
+
+    await expect(
+      archiveResearchConversation("a1", "c1"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/onboarding/archive-research-conversation.ts
+++ b/clients/web/src/domains/onboarding/archive-research-conversation.ts
@@ -1,0 +1,37 @@
+/**
+ * Archives the dedicated "Getting to know X" side conversation the
+ * research-onboarding flow mints to run its behind-the-scenes research turn.
+ *
+ * That conversation is a throwaway side channel: it exists only to drive the
+ * research prompt whose claims/suggestions the in-flow result steps render. It
+ * must never surface in the user's chat sidebar when they land in their
+ * workspace, so once the research response has settled we archive it — the
+ * sidebar's `group-conversations.ts` drops `archivedAt != null` rows, so an
+ * archived conversation simply disappears from the list.
+ *
+ * Best-effort: this runs after the response is delivered, so a failure here
+ * must never block or surface in the flow. Every error is swallowed (reported
+ * to Sentry) and never rethrown, mirroring `checkin-scheduler.ts`.
+ */
+
+import { conversationsByIdArchivePost } from "@/generated/daemon/sdk.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+
+/**
+ * Archive the research-onboarding side conversation so it never appears in the
+ * chat sidebar. Best-effort and fire-and-forget: resolves regardless of outcome
+ * and never throws.
+ */
+export async function archiveResearchConversation(
+  assistantId: string,
+  conversationId: string,
+): Promise<void> {
+  try {
+    await conversationsByIdArchivePost({
+      path: { assistant_id: assistantId, id: conversationId },
+      throwOnError: false,
+    });
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_archive" });
+  }
+}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -74,6 +74,8 @@ export function ResearchOnboardingRoute() {
   const exitFocus = useOnboardingFocusStore.use.exitFocus();
   const setPendingAvatarTraits =
     useOnboardingFocusStore.use.setPendingAvatarTraits();
+  const requestSidebarCollapse =
+    useOnboardingFocusStore.use.requestSidebarCollapse();
   // Belt-and-suspenders gate: the spike lives at a dedicated path AND behind
   // this flag (off by default; enable locally via the feature-flags panel).
   const enabled = useClientFeatureFlagStore.use.researchOnboarding();
@@ -237,6 +239,8 @@ export function ResearchOnboardingRoute() {
     if (isResearch) enterFocus();
     // No auto-sent first message when skipping, so don't arm the expectation.
     if (!skip) lifecycleService.markExpectingFirstMessage();
+    // Collapse the side panel so the workspace opens focused on the new chat.
+    requestSidebarCollapse();
     // Pin the refresh to the background-hatched assistant so the handoff targets
     // it (not a previously-selected one) and doesn't trigger a second hatch.
     void lifecycleService

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -21,6 +21,8 @@
 
 import { useCallback, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import {
   conversationsPost,
   messagesGet,
@@ -28,6 +30,8 @@ import {
   pluginsInstallPost,
   pluginsSearchGet,
 } from "@/generated/daemon/sdk.gen";
+import { archiveResearchConversation } from "@/domains/onboarding/archive-research-conversation";
+import { invalidateConversationQueries } from "@/utils/conversation-cache";
 import type {
   MessagesGetResponses,
   MessagesPostData,
@@ -292,6 +296,7 @@ export function useResearchRunner(): UseResearchRunner {
   // so ordinary clicks (plugins disabled / none picked / already installed)
   // aren't frozen until the whole reply settles.
   const pluginsReadyRef = useRef<Promise<void>>(Promise.resolve());
+  const queryClient = useQueryClient();
 
   const start = useCallback(
     ({ awaitAssistantId, subject, conversationTitle }: StartResearchOptions) => {
@@ -317,8 +322,11 @@ export function useResearchRunner(): UseResearchRunner {
       });
 
       void (async () => {
+        let resolvedAssistantId: string | undefined;
+        let createdConversationId: string | undefined;
         try {
           const assistantId = await awaitAssistantId();
+          resolvedAssistantId = assistantId;
           if (isStale()) return;
 
           // Advertise the live marketplace catalog to the research turn so it can
@@ -351,6 +359,7 @@ export function useResearchRunner(): UseResearchRunner {
             setState((s) => ({ ...s, status: "error" }));
             return;
           }
+          createdConversationId = conversationId;
 
           const body: MessagesPostData["body"] = {
             conversationId,
@@ -449,10 +458,21 @@ export function useResearchRunner(): UseResearchRunner {
           // a stale bail-out, or a reply that never emitted a `plugins` array) so
           // `awaitPluginInstalls` can never hang.
           resolvePluginsReady();
+          // Archive the throwaway research conversation on every exit path (settled,
+          // errored, or superseded by a newer run) once it has been created, so the
+          // side channel never lingers in the sidebar on handoff. Best-effort +
+          // idempotent; awaiting lets the cache invalidation reflect the archived state.
+          if (resolvedAssistantId && createdConversationId) {
+            await archiveResearchConversation(
+              resolvedAssistantId,
+              createdConversationId,
+            );
+            void invalidateConversationQueries(queryClient, resolvedAssistantId);
+          }
         }
       })();
     },
-    [],
+    [queryClient],
   );
 
   const awaitPluginInstalls = useCallback(async (): Promise<void> => {

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -353,13 +353,17 @@ export function useResearchRunner(): UseResearchRunner {
             },
             throwOnError: false,
           });
+          // Capture the created conversation id BEFORE the stale check so a
+          // superseded run still archives its throwaway side conversation in the
+          // finally block. The finally already guards on truthiness, so an
+          // undefined id here is harmless.
+          createdConversationId = conversation.data?.id;
           if (isStale()) return;
           const conversationId = conversation.data?.id;
           if (!conversation.response?.ok || !conversationId) {
             setState((s) => ({ ...s, status: "error" }));
             return;
           }
-          createdConversationId = conversationId;
 
           const body: MessagesPostData["body"] = {
             conversationId,

--- a/clients/web/src/stores/onboarding-focus-store.test.ts
+++ b/clients/web/src/stores/onboarding-focus-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
+
+beforeEach(() => {
+  useOnboardingFocusStore.setState({
+    sidebarCollapseRequested: false,
+    focused: false,
+  });
+});
+
+describe("useOnboardingFocusStore — sidebar collapse one-shot signal", () => {
+  test("requestSidebarCollapse arms the signal", () => {
+    useOnboardingFocusStore.getState().requestSidebarCollapse();
+    expect(useOnboardingFocusStore.getState().sidebarCollapseRequested).toBe(
+      true,
+    );
+  });
+
+  test("consumeSidebarCollapse clears the signal", () => {
+    useOnboardingFocusStore.getState().requestSidebarCollapse();
+    useOnboardingFocusStore.getState().consumeSidebarCollapse();
+    expect(useOnboardingFocusStore.getState().sidebarCollapseRequested).toBe(
+      false,
+    );
+  });
+
+  test("exitFocus also clears a stale armed signal", () => {
+    useOnboardingFocusStore.getState().requestSidebarCollapse();
+    useOnboardingFocusStore.getState().exitFocus();
+    expect(useOnboardingFocusStore.getState().sidebarCollapseRequested).toBe(
+      false,
+    );
+  });
+});

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -66,8 +66,11 @@ interface OnboardingFocusState {
   endCheckin: () => void;
   /**
    * Set by the onboarding handoff so the chat side panel opens collapsed for a
-   * focused first impression; consumed (cleared) once by `ChatLayout`. A
-   * one-shot signal, not a persistent preference.
+   * focused first impression; consumed (cleared) once by `ChatLayout`. The
+   * signal is one-shot — set once at handoff and consumed on the next
+   * `ChatLayout` mount; honoring it flips the chat's ordinary persisted
+   * `collapsed` state, so the user lands collapsed and it remains their default
+   * until they expand it.
    */
   sidebarCollapseRequested: boolean;
   requestSidebarCollapse: () => void;

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -64,6 +64,14 @@ interface OnboardingFocusState {
   checkinUserName: string | null;
   beginCheckin: (userName?: string) => void;
   endCheckin: () => void;
+  /**
+   * Set by the onboarding handoff so the chat side panel opens collapsed for a
+   * focused first impression; consumed (cleared) once by `ChatLayout`. A
+   * one-shot signal, not a persistent preference.
+   */
+  sidebarCollapseRequested: boolean;
+  requestSidebarCollapse: () => void;
+  consumeSidebarCollapse: () => void;
 }
 
 const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
@@ -75,6 +83,7 @@ const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
       pendingFollowupMessage: null,
       checkinPending: false,
       pendingAvatarTraits: null,
+      sidebarCollapseRequested: false,
     }),
   pendingAvatarTraits: null,
   setPendingAvatarTraits: (traits) => set({ pendingAvatarTraits: traits }),
@@ -86,6 +95,9 @@ const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
   beginCheckin: (userName) =>
     set({ checkinPending: true, checkinUserName: userName ?? null }),
   endCheckin: () => set({ checkinPending: false }),
+  sidebarCollapseRequested: false,
+  requestSidebarCollapse: () => set({ sidebarCollapseRequested: true }),
+  consumeSidebarCollapse: () => set({ sidebarCollapseRequested: false }),
 }));
 
 export const useOnboardingFocusStore = createSelectors(


### PR DESCRIPTION
## Summary
Two polish changes to the research-onboarding → chat handoff:
1. **Archive the behind-the-scenes "Getting to know X" research conversation** once its turn settles (best-effort, from the run loop's `finally` so it covers done/error/superseded paths), so the throwaway side conversation never shows up in the chat sidebar after the user lands in their workspace.
2. **Auto-collapse the chat side panel** when the user crosses from research-onboarding into chat via a suggestion click or "Skip to Chat", for a focused first impression. Implemented as a one-shot signal on the cross-domain onboarding-focus store, consumed once by `ChatLayout` (desktop only).

## Self-review result
PASS — 2 gaps found and fixed across 2 fix PRs (archive-on-all-exit-paths race; corrected persistence comments). Round-2 re-review across all four passes returned PASS with no remaining gaps.

## PRs merged into feature branch
- #35963: feat(research-onboarding): collapse the chat side panel on handoff into the workspace
- #35962: fix(research-onboarding): archive the behind-the-scenes research conversation after it settles

### Fix PRs
- #35973: fix(research-onboarding): capture research conversation id before the stale check so superseded runs still archive it
- #35974: docs(research-onboarding): clarify that the one-shot sidebar collapse sets the persisted preference

Part of plan: research-onboarding-handoff.md