### PR TITLE
fix: self-review remediation for investigator read-only (ATL-864)

### DIFF
--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -146,6 +146,48 @@ describe("codeSearchTool", () => {
     expect(result.content).toBe("a.ts:2: const needle = 2;");
   });
 
+  test("an oversized explicit-file root returns an error, not a false 'No matches'", async () => {
+    const dir = makeTempDir();
+    // A single-file root larger than MAX_FILE_BYTES (8 MiB) was never searched,
+    // so reporting "No matches found" would be a silent false negative. Surface
+    // a hard error instead.
+    const oversize = 8 * 1024 * 1024 + 1;
+    writeFileSync(join(dir, "huge.txt"), "x".repeat(oversize));
+
+    const result = await codeSearchTool.execute(
+      { pattern: "x", path: "huge.txt", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("file too large to search");
+    expect(result.content).not.toContain("No matches found");
+  });
+
+  test("a single >4 MiB matching line yields a truncated result that acknowledges the match", async () => {
+    const dir = makeTempDir();
+    // One matching line whose output alone exceeds MAX_OUTPUT_BYTES (4 MiB) but
+    // whose file stays under MAX_FILE_BYTES (8 MiB) so it isn't skipped. The
+    // match must be counted and the truncation attributed to the output budget,
+    // not reported as "no matches / scan cap".
+    const lineLen = 5 * 1024 * 1024;
+    writeFileSync(join(dir, "wide.txt"), "needle" + "z".repeat(lineLen) + "\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", path: "wide.txt", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    // The match was found: the output budget message, not the scan-cap or
+    // no-match message.
+    expect(result.content).toContain("Output capped");
+    expect(result.content).not.toContain("No matches found");
+    expect(result.content).not.toContain("scan cap");
+    expect(result.content).toContain("wide.txt:1:");
+  });
+
   test("single-file search still honors the denied-basename guard", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "backup.key"), "supersecret token\n");

--- a/assistant/src/__tests__/exploration-drift-hook.test.ts
+++ b/assistant/src/__tests__/exploration-drift-hook.test.ts
@@ -225,10 +225,11 @@ describe("exploration-drift post-tool-use hook — long-dig trigger", () => {
     expect(ctx.toolResponse.content).toBe(BASE_CONTENT);
   });
 
-  test("counts file_read and file_list as exploration tools", async () => {
+  test("counts code_search, file_read, and file_list as exploration tools", async () => {
+    const explorationNames = ["code_search", "file_read", "file_list"];
     const messages: Message[] = [];
     for (let i = 0; i < EXPLORATION_NUDGE_THRESHOLD - 1; i++) {
-      const name = i % 2 === 0 ? "file_read" : "file_list";
+      const name = explorationNames[i % explorationNames.length];
       const id = `${name}-${i}`;
       messages.push(toolUseTurn(id, name, { path: `/tmp/file-${i}` }));
       messages.push(toolResultTurn(id));

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -1,6 +1,6 @@
 /**
  * Default `post-tool-use` hook: when a turn's exploration tool calls (bash,
- * file_read, file_list) show drift — a long unbroken run with no text sent to
+ * code_search, file_read, file_list) show drift — a long unbroken run with no text sent to
  * the user, or the model re-issuing the exact same call — surface a notice
  * via `additionalContext` that coaches it to (a) give the user a brief
  * progress summary and (b) delegate the rest of the investigation to an
@@ -105,6 +105,7 @@ const LOOP_PRONE_MODEL_PATTERN = /kimi-k2[p.]6|minimax-m3/i;
 /** Read-only exploration tools whose unbroken runs indicate inline drift. */
 const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
   "bash",
+  "code_search",
   "file_read",
   "file_list",
 ]);

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -265,6 +265,11 @@ export const codeSearchTool = {
           truncated = true;
           return;
         }
+        // Count the match before emitting its lines: a single match whose output
+        // alone exceeds the output-byte budget would otherwise leave matchCount
+        // at 0, making the zero-match branch report a false "no matches / scan
+        // cap" instead of a truncated result that acknowledges the match.
+        matchCount++;
         const lineNo = i + 1;
         if (contextLines > 0) {
           const start = Math.max(0, i - contextLines);
@@ -277,7 +282,6 @@ export const codeSearchTool = {
         } else {
           if (!pushLine(`${display}:${lineNo}: ${fileLines[i]}`)) return;
         }
-        matchCount++;
       }
     };
 
@@ -305,7 +309,16 @@ export const codeSearchTool = {
     if (rootStat.isDirectory()) {
       walk(root);
     } else if (rootStat.isFile()) {
-      // A regular-file root is a valid single-file search.
+      // A regular-file root is a valid single-file search. Unlike an oversized
+      // file skipped mid-walk (where other files may still match), an oversized
+      // explicit root means nothing was searched at all — surface a hard error
+      // instead of falling through to a false "No matches found".
+      if (rootStat.size > MAX_FILE_BYTES) {
+        return {
+          content: `Error: file too large to search (${rootStat.size} bytes): ${rawPath}`,
+          isError: true,
+        };
+      }
       scanFile(root);
     } else {
       return {

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -148,10 +148,7 @@ export function sandboxPolicy(
 
   // Check both the logical path and the symlink-resolved path so a symlink
   // with a non-denied name pointing at a denied file is still caught.
-  if (
-    DENIED_BASENAMES.has(basename(resolved)) ||
-    DENIED_BASENAMES.has(basename(realResolved))
-  ) {
+  if (isDeniedBasename(resolved) || isDeniedBasename(realResolved)) {
     return {
       ok: false,
       reason: "denied",
@@ -178,7 +175,7 @@ export function hostPolicy(rawPath: string): PathResult {
       error: `path must be absolute for host file access: ${rawPath}`,
     };
   }
-  if (DENIED_BASENAMES.has(basename(rawPath))) {
+  if (isDeniedBasename(rawPath)) {
     return {
       ok: false,
       reason: "denied",


### PR DESCRIPTION
## Summary
Addresses four findings from plan self-review:
- Add `code_search` to `EXPLORATION_TOOL_NAMES` so search-based investigation still triggers the investigator-delegation nudge (integration).
- Return an explicit error for an oversized explicit-file search root instead of a silent "No matches" (correctness).
- Account for a match and correctly attribute truncation to the output budget when a >4 MiB matching line trips `MAX_OUTPUT_BYTES` (correctness).
- Finish the `isDeniedBasename` extraction: `sandboxPolicy`/`hostPolicy` now call the shared helper (consistency).

Part of plan: investigator-readonly-tools.md (self-review remediation)