### PR TITLE
Investigator subagent: structural read-only — drop bash, add read-only code_search (ATL-864)

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -38,6 +38,7 @@
         "playwright": "1.58.2",
         "postgres": "3.4.8",
         "quickjs-emscripten": "0.32.0",
+        "re2js": "2.8.3",
         "rrule": "2.8.1",
         "semver": "7.8.0",
         "stemmer": "2.0.1",
@@ -1039,6 +1040,8 @@
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "re2js": ["re2js@2.8.3", "", {}, "sha512-lUKeXVwMqU302DM/WaOm33XF2hhzjGUZ8CbLg4zSAMpW2PPkJ2+is25AROevNiw+DytFmKU5gsQ92cB1Kxy+fA=="],
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -66,6 +66,7 @@
     "playwright": "1.58.2",
     "postgres": "3.4.8",
     "quickjs-emscripten": "0.32.0",
+    "re2js": "2.8.3",
     "rrule": "2.8.1",
     "semver": "7.8.0",
     "stemmer": "2.0.1",

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -164,6 +164,45 @@ describe("codeSearchTool", () => {
     expect(result.content).not.toContain("No matches found");
   });
 
+  test("an oversized file skipped mid-walk keeps scanning others but flags the result incomplete", async () => {
+    const dir = makeTempDir();
+    // A directory search must keep scanning sibling files when it hits an
+    // oversized one (so a smaller file still matches), yet flag the overall
+    // result incomplete since the skipped file could have contained the pattern.
+    const oversize = 8 * 1024 * 1024 + 1;
+    writeFileSync(join(dir, "huge.txt"), "needle " + "x".repeat(oversize));
+    writeFileSync(join(dir, "small.txt"), "needle here\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    // The walk wasn't aborted by the skip — the small file still matched...
+    expect(result.content).toContain("small.txt");
+    // ...and the result is flagged incomplete with a size-limit note.
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("size limit");
+  });
+
+  test("a directory whose only candidate is oversized reports incompleteness, not a clean miss", async () => {
+    const dir = makeTempDir();
+    const oversize = 8 * 1024 * 1024 + 1;
+    writeFileSync(join(dir, "huge.txt"), "needle " + "x".repeat(oversize));
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    // Zero matches because the only file was skipped — but the result must say
+    // it's incomplete (status truncated + size-limit note), not a definitive miss.
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("size limit");
+  });
+
   test("a single >4 MiB matching line yields a truncated result that acknowledges the match", async () => {
     const dir = makeTempDir();
     // One matching line whose output alone exceeds MAX_OUTPUT_BYTES (4 MiB) but

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -146,6 +146,48 @@ describe("codeSearchTool", () => {
     expect(result.content).toBe("a.ts:2: const needle = 2;");
   });
 
+  test("an oversized explicit-file root returns an error, not a false 'No matches'", async () => {
+    const dir = makeTempDir();
+    // A single-file root larger than MAX_FILE_BYTES (8 MiB) was never searched,
+    // so reporting "No matches found" would be a silent false negative. Surface
+    // a hard error instead.
+    const oversize = 8 * 1024 * 1024 + 1;
+    writeFileSync(join(dir, "huge.txt"), "x".repeat(oversize));
+
+    const result = await codeSearchTool.execute(
+      { pattern: "x", path: "huge.txt", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("file too large to search");
+    expect(result.content).not.toContain("No matches found");
+  });
+
+  test("a single >4 MiB matching line yields a truncated result that acknowledges the match", async () => {
+    const dir = makeTempDir();
+    // One matching line whose output alone exceeds MAX_OUTPUT_BYTES (4 MiB) but
+    // whose file stays under MAX_FILE_BYTES (8 MiB) so it isn't skipped. The
+    // match must be counted and the truncation attributed to the output budget,
+    // not reported as "no matches / scan cap".
+    const lineLen = 5 * 1024 * 1024;
+    writeFileSync(join(dir, "wide.txt"), "needle" + "z".repeat(lineLen) + "\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", path: "wide.txt", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    // The match was found: the output budget message, not the scan-cap or
+    // no-match message.
+    expect(result.content).toContain("Output capped");
+    expect(result.content).not.toContain("No matches found");
+    expect(result.content).not.toContain("scan cap");
+    expect(result.content).toContain("wide.txt:1:");
+  });
+
   test("single-file search still honors the denied-basename guard", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "backup.key"), "supersecret token\n");

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -368,17 +368,19 @@ describe("codeSearchTool", () => {
   });
 
   test(
-    "a catastrophic-backtracking pattern over many lines terminates",
+    "a catastrophic-backtracking pattern returns near-instantly (linear-time RE2)",
     async () => {
       const dir = makeTempDir();
-      // A classic catastrophic-backtracking pattern against crafted lines that
-      // never match. Each individual line is small enough to backtrack quickly,
-      // but the file has many of them — the wall-clock deadline is checked once
-      // per line, so the scan must terminate (it does not block indefinitely).
-      // Kept deterministically fast: the whole file scans well under the
-      // deadline, so we assert it returns a clean result rather than hanging.
-      const evilLine = "a".repeat(20) + "!"; // forces backtracking, no match
-      const body = Array.from({ length: 50 }, () => evilLine).join("\n");
+      // The classic ReDoS proof: `(a+)+$` against many non-matching lines of the
+      // form `'a'.repeat(50) + '!'`. Under V8's backtracking RegExp a single
+      // `regex.test()` on one such line blocks the event loop for seconds, and
+      // the synchronous scan never yields so neither the wall-clock deadline nor
+      // the promise timeout can interrupt it — the call would hang. With the
+      // linear-time RE2 engine the whole file scans in milliseconds and returns
+      // a clean, non-truncated "No matches found". The small per-call timeout
+      // below would trip if matching ever fell back to backtracking.
+      const evilLine = "a".repeat(50) + "!"; // forces backtracking, no match
+      const body = Array.from({ length: 200 }, () => evilLine).join("\n");
       writeFileSync(join(dir, "evil.txt"), body + "\n");
 
       const result = await codeSearchTool.execute(
@@ -386,18 +388,30 @@ describe("codeSearchTool", () => {
         makeToolContext(dir),
       );
 
-      // It must terminate gracefully. Depending on host speed it either
-      // finishes under the deadline (clean "No matches found") or trips the
-      // deadline (truncated/timed-out) — both are acceptable; hanging is not.
       expect(result.isError).toBe(false);
-      if (result.status === "truncated") {
-        expect(result.content).toContain("timed out");
-      } else {
-        expect(result.content).toContain("No matches found");
-      }
+      // Linear-time matching completes well within the deadline, so this is a
+      // definitive miss, not a timed-out/truncated result.
+      expect(result.status).toBeUndefined();
+      expect(result.content).toContain("No matches found");
     },
-    30_000,
+    5_000,
   );
+
+  test("an unsupported pattern (backreference) returns a clean error, not a throw", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "aa\n");
+
+    // RE2 does not support backreferences (or lookarounds). The pattern must be
+    // rejected at compile time and surfaced as an isError result rather than
+    // throwing out of execute().
+    const result = await codeSearchTool.execute(
+      { pattern: "(a)\\1", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("invalid or unsupported pattern");
+  });
 
   test("does not return contents of denied-basename files", async () => {
     const dir = makeTempDir();

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -203,12 +203,13 @@ describe("codeSearchTool", () => {
     expect(result.content).toContain("size limit");
   });
 
-  test("a single >4 MiB matching line yields a truncated result that acknowledges the match", async () => {
+  test("a single multi-MiB matching line is found but its printed output is display-bounded", async () => {
     const dir = makeTempDir();
-    // One matching line whose output alone exceeds MAX_OUTPUT_BYTES (4 MiB) but
-    // whose file stays under MAX_FILE_BYTES (8 MiB) so it isn't skipped. The
-    // match must be counted and the truncation attributed to the output budget,
-    // not reported as "no matches / scan cap".
+    // One matching line many megabytes wide whose file stays under MAX_FILE_BYTES
+    // (8 MiB) so it isn't skipped. The match is on the full line (so it's found),
+    // but the EMITTED line is truncated to the display cap — so a single wide
+    // line cannot, by itself, blow the output-byte budget anymore. The result is
+    // a clean single match, not truncated, with the printed line bounded.
     const lineLen = 5 * 1024 * 1024;
     writeFileSync(join(dir, "wide.txt"), "needle" + "z".repeat(lineLen) + "\n");
 
@@ -218,13 +219,17 @@ describe("codeSearchTool", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.status).toBe("truncated");
-    // The match was found: the output budget message, not the scan-cap or
-    // no-match message.
-    expect(result.content).toContain("Output capped");
+    // Found on the full line — never a false "No matches" or scan-cap message.
     expect(result.content).not.toContain("No matches found");
     expect(result.content).not.toContain("scan cap");
     expect(result.content).toContain("wide.txt:1:");
+    // The printed line is display-truncated, so the output stays tiny and the
+    // output budget is never hit — single match => not truncated.
+    expect(result.content).toContain("…[line truncated]");
+    expect(result.status).toBeUndefined();
+    expect(result.content).not.toContain("Output capped");
+    // The multi-MiB body never reaches the emitted output.
+    expect(Buffer.byteLength(result.content, "utf8")).toBeLessThan(64 * 1024);
   });
 
   test("single-file search still honors the denied-basename guard", async () => {
@@ -276,12 +281,13 @@ describe("codeSearchTool", () => {
     expect(result.content).toContain("a.txt:3- after");
   });
 
-  test("bounds the regex to the leading slice of very long lines", async () => {
+  test("matches a token past the display cap on a long line, truncating only the printed output", async () => {
     const dir = makeTempDir();
-    // A line far longer than MAX_MATCH_LINE_LENGTH (2000). The matchable token
-    // sits well beyond the cap, so the bounded regex slice must not see it,
-    // while a token inside the cap on the same file is still found. This also
-    // exercises that a huge line is handled without throwing/hanging.
+    // A line far longer than MAX_DISPLAY_LINE_LENGTH (2000) whose matchable token
+    // sits well beyond column 2000. With RE2's linear-time matching the pattern
+    // is run against the FULL line, so the token MUST be found — but the emitted
+    // line is truncated for display with a clear marker. This also exercises that
+    // a huge line is handled without throwing/hanging.
     const prefix = "x".repeat(5000);
     writeFileSync(
       join(dir, "huge.txt"),
@@ -293,8 +299,17 @@ describe("codeSearchTool", () => {
       makeToolContext(dir),
     );
     expect(beyond.isError).toBe(false);
-    // The token only appears past the bounded slice, so it must not match.
-    expect(beyond.content).toContain("No matches found");
+    // The token appears past column 2000, but matching runs against the full
+    // line, so it IS found (correct grep behavior — no false "No matches").
+    expect(beyond.content).not.toContain("No matches found");
+    expect(beyond.content).toContain("huge.txt:1:");
+    // The displayed line is truncated with a marker, so the multi-kilobyte line
+    // never balloons the output...
+    expect(beyond.content).toContain("…[line truncated]");
+    // ...and the matched token (which sits beyond the display cap) is NOT echoed
+    // back in the bounded output even though the match was found.
+    expect(beyond.content).not.toContain("BEYOND_CAP_TOKEN\n");
+    expect(beyond.content.length).toBeLessThan(prefix.length);
 
     const inside = await codeSearchTool.execute(
       { pattern: "INSIDE_CAP_TOKEN", activity: "search" },
@@ -302,6 +317,9 @@ describe("codeSearchTool", () => {
     );
     expect(inside.isError).toBe(false);
     expect(inside.content).toContain("huge.txt:2:");
+    // A short line is emitted verbatim — no truncation marker.
+    expect(inside.content).toContain("inside INSIDE_CAP_TOKEN here");
+    expect(inside.content).not.toContain("…[line truncated]");
   });
 
   test("caps output via the byte budget when many matches have context", async () => {
@@ -367,35 +385,63 @@ describe("codeSearchTool", () => {
     expect(result.content).not.toContain("No matches found");
   });
 
-  test(
-    "a catastrophic-backtracking pattern returns near-instantly (linear-time RE2)",
-    async () => {
-      const dir = makeTempDir();
-      // The classic ReDoS proof: `(a+)+$` against many non-matching lines of the
-      // form `'a'.repeat(50) + '!'`. Under V8's backtracking RegExp a single
-      // `regex.test()` on one such line blocks the event loop for seconds, and
-      // the synchronous scan never yields so neither the wall-clock deadline nor
-      // the promise timeout can interrupt it — the call would hang. With the
-      // linear-time RE2 engine the whole file scans in milliseconds and returns
-      // a clean, non-truncated "No matches found". The small per-call timeout
-      // below would trip if matching ever fell back to backtracking.
-      const evilLine = "a".repeat(50) + "!"; // forces backtracking, no match
-      const body = Array.from({ length: 200 }, () => evilLine).join("\n");
-      writeFileSync(join(dir, "evil.txt"), body + "\n");
+  test("an already-aborted signal stops the directory traversal, not just per-line scanning", async () => {
+    const dir = makeTempDir();
+    // Build a small tree of subdirectories and files. The traversal deadline /
+    // abort check now lives at the top of walk() and inside its per-entry loop
+    // (shared with the per-line checkpoint), so an already-aborted signal must
+    // stop the walk before it descends/scans the whole tree, returning a
+    // truncated/timed-out result rather than scanning everything.
+    for (let d = 0; d < 5; d++) {
+      const sub = join(dir, `sub${d}`);
+      mkdirSync(sub);
+      for (let f = 0; f < 5; f++) {
+        writeFileSync(join(sub, `f${f}.txt`), "needle here\n");
+      }
+    }
 
-      const result = await codeSearchTool.execute(
-        { pattern: "(a+)+$", activity: "search" },
-        makeToolContext(dir),
-      );
+    const controller = new AbortController();
+    controller.abort();
+    const context = { ...makeToolContext(dir), signal: controller.signal };
 
-      expect(result.isError).toBe(false);
-      // Linear-time matching completes well within the deadline, so this is a
-      // definitive miss, not a timed-out/truncated result.
-      expect(result.status).toBeUndefined();
-      expect(result.content).toContain("No matches found");
-    },
-    5_000,
-  );
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", activity: "search" },
+      context,
+    );
+
+    // The traversal honored the abort: stopped promptly with a timed-out /
+    // incomplete result instead of a definitive miss or full scan.
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("timed out");
+    expect(result.content).not.toContain("No matches found");
+  });
+
+  test("a catastrophic-backtracking pattern returns near-instantly (linear-time RE2)", async () => {
+    const dir = makeTempDir();
+    // The classic ReDoS proof: `(a+)+$` against many non-matching lines of the
+    // form `'a'.repeat(50) + '!'`. Under V8's backtracking RegExp a single
+    // `regex.test()` on one such line blocks the event loop for seconds, and
+    // the synchronous scan never yields so neither the wall-clock deadline nor
+    // the promise timeout can interrupt it — the call would hang. With the
+    // linear-time RE2 engine the whole file scans in milliseconds and returns
+    // a clean, non-truncated "No matches found". The small per-call timeout
+    // below would trip if matching ever fell back to backtracking.
+    const evilLine = "a".repeat(50) + "!"; // forces backtracking, no match
+    const body = Array.from({ length: 200 }, () => evilLine).join("\n");
+    writeFileSync(join(dir, "evil.txt"), body + "\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "(a+)+$", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    // Linear-time matching completes well within the deadline, so this is a
+    // definitive miss, not a timed-out/truncated result.
+    expect(result.status).toBeUndefined();
+    expect(result.content).toContain("No matches found");
+  }, 5_000);
 
   test("an unsupported pattern (backreference) returns a clean error, not a throw", async () => {
     const dir = makeTempDir();

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -162,6 +163,31 @@ describe("codeSearchTool", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("file too large to search");
     expect(result.content).not.toContain("No matches found");
+  });
+
+  test("an unreadable explicit file root surfaces a read error, not a false 'No matches'", async () => {
+    const dir = makeTempDir();
+    const f = join(dir, "secret.txt");
+    writeFileSync(f, "needle here\n");
+    chmodSync(f, 0o000);
+    // When the suite runs as root (e.g. CI in Docker), chmod 000 does not block
+    // reads, so EACCES can't be simulated — skip the assertion in that case.
+    let readable = true;
+    try {
+      readFileSync(f);
+    } catch {
+      readable = false;
+    }
+    if (!readable) {
+      const result = await codeSearchTool.execute(
+        { pattern: "needle", path: "secret.txt", activity: "search" },
+        makeToolContext(dir),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("failed to read file");
+      expect(result.content).not.toContain("No matches found");
+    }
+    chmodSync(f, 0o644);
   });
 
   test("an oversized file skipped mid-walk keeps scanning others but flags the result incomplete", async () => {

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -2,6 +2,7 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -188,6 +189,33 @@ describe("codeSearchTool", () => {
       expect(result.content).not.toContain("No matches found");
     }
     chmodSync(f, 0o644);
+  });
+
+  test("an unreadable explicit directory root surfaces a read error, not a false 'No matches'", async () => {
+    const dir = makeTempDir();
+    const subdir = join(dir, "locked");
+    mkdirSync(subdir);
+    writeFileSync(join(subdir, "a.ts"), "needle here\n");
+    chmodSync(subdir, 0o000);
+    // When the suite runs as root (e.g. CI in Docker), chmod 000 does not block
+    // reads, so EACCES can't be simulated — probe readdir and skip the assertion
+    // in that case.
+    let readable = true;
+    try {
+      readdirSync(subdir);
+    } catch {
+      readable = false;
+    }
+    if (!readable) {
+      const result = await codeSearchTool.execute(
+        { pattern: "needle", path: "locked", activity: "search" },
+        makeToolContext(dir),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("failed to read directory");
+      expect(result.content).not.toContain("No matches found");
+    }
+    chmodSync(subdir, 0o755);
   });
 
   test("an oversized file skipped mid-walk keeps scanning others but flags the result incomplete", async () => {

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -1,0 +1,332 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { SUBAGENT_ONLY_TOOL_NAMES } from "../daemon/conversation-tool-setup.js";
+import { codeSearchTool } from "../tools/filesystem/search.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "code-search-test-")));
+  testDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeToolContext(workingDir: string): ToolContext {
+  return {
+    workingDir,
+    conversationId: "test-conv",
+    trustClass: "guardian",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// code_search
+// ---------------------------------------------------------------------------
+
+describe("codeSearchTool", () => {
+  test("finds a known pattern with correct file:line", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.ts"), "const foo = 1;\nconst bar = 2;\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "bar", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("a.ts:2: const bar = 2;");
+  });
+
+  test("respects glob filter", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "match.ts"), "needle here\n");
+    writeFileSync(join(dir, "skip.md"), "needle here too\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", glob: "*.ts", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("match.ts:1:");
+    expect(result.content).not.toContain("skip.md");
+  });
+
+  test("rejects a path escaping the workspace root", async () => {
+    const dir = makeTempDir();
+
+    const result = await codeSearchTool.execute(
+      { pattern: "anything", path: "../../../etc", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside the working directory");
+  });
+
+  test("case_insensitive matching", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "Hello WORLD\n");
+
+    const sensitive = await codeSearchTool.execute(
+      { pattern: "world", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(sensitive.content).toContain("No matches found");
+
+    const insensitive = await codeSearchTool.execute(
+      { pattern: "world", case_insensitive: true, activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(insensitive.isError).toBe(false);
+    expect(insensitive.content).toBe("a.txt:1: Hello WORLD");
+  });
+
+  test("no match returns a clear empty result", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "nothing relevant\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "absent-token", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("No matches found");
+  });
+
+  test("non-existent root path returns a path error, not a false 'No matches'", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.ts"), "needle\n");
+
+    // A typo'd subdirectory (e.g. "srcc") must surface an actionable path error
+    // rather than being swallowed and reported as a successful empty search.
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", path: "srcc", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("path not found");
+    expect(result.content).not.toContain("No matches found");
+  });
+
+  test("searches a single file when the root resolves to a regular file", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.ts"), "const foo = 1;\nconst needle = 2;\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", path: "a.ts", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("a.ts:2: const needle = 2;");
+  });
+
+  test("single-file search still honors the denied-basename guard", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "backup.key"), "supersecret token\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "supersecret", path: "backup.key", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    // The denied basename is rejected by the sandbox policy before any read,
+    // so the secret never surfaces in the result.
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("supersecret");
+  });
+
+  test("max_results truncates and reports it", async () => {
+    const dir = makeTempDir();
+    const body = Array.from({ length: 10 }, () => "match").join("\n");
+    writeFileSync(join(dir, "a.txt"), body + "\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "match", max_results: 3, activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("truncated at 3 matches");
+    const matchLines = result.content
+      .split("\n")
+      .filter((l) => l.startsWith("a.txt:"));
+    expect(matchLines.length).toBe(3);
+  });
+
+  test("includes context lines when requested", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "before\nTARGET\nafter\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "TARGET", context_lines: 1, activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("a.txt:1- before");
+    expect(result.content).toContain("a.txt:2: TARGET");
+    expect(result.content).toContain("a.txt:3- after");
+  });
+
+  test("bounds the regex to the leading slice of very long lines", async () => {
+    const dir = makeTempDir();
+    // A line far longer than MAX_MATCH_LINE_LENGTH (2000). The matchable token
+    // sits well beyond the cap, so the bounded regex slice must not see it,
+    // while a token inside the cap on the same file is still found. This also
+    // exercises that a huge line is handled without throwing/hanging.
+    const prefix = "x".repeat(5000);
+    writeFileSync(
+      join(dir, "huge.txt"),
+      `${prefix}BEYOND_CAP_TOKEN\ninside INSIDE_CAP_TOKEN here\n`,
+    );
+
+    const beyond = await codeSearchTool.execute(
+      { pattern: "BEYOND_CAP_TOKEN", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(beyond.isError).toBe(false);
+    // The token only appears past the bounded slice, so it must not match.
+    expect(beyond.content).toContain("No matches found");
+
+    const inside = await codeSearchTool.execute(
+      { pattern: "INSIDE_CAP_TOKEN", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(inside.isError).toBe(false);
+    expect(inside.content).toContain("huge.txt:2:");
+  });
+
+  test("caps output via the byte budget when many matches have context", async () => {
+    const dir = makeTempDir();
+    // Many matches with context lines. Even though context_lines is requested
+    // far above the clamp (MAX_CONTEXT_LINES = 20), the clamp plus the
+    // output-byte budget must produce a truncated result rather than an
+    // unbounded one. The source file stays under MAX_FILE_BYTES (8 MiB) so it
+    // isn't skipped, but because every line both matches and is re-emitted as
+    // context for ~41 nearby matches, the accumulated output crosses the 4 MiB
+    // budget.
+    const filler = "y".repeat(200);
+    const lineCount = 20_000;
+    const body = Array.from(
+      { length: lineCount },
+      () => `match ${filler}`,
+    ).join("\n");
+    writeFileSync(join(dir, "big.txt"), body + "\n");
+
+    const result = await codeSearchTool.execute(
+      {
+        pattern: "match",
+        context_lines: 1000,
+        max_results: 1_000_000,
+        activity: "search",
+      },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("Output capped");
+    // The accumulated output must stay near the budget, not balloon to the full
+    // file size (~20 MiB of body * surrounding context).
+    expect(Buffer.byteLength(result.content, "utf8")).toBeLessThan(
+      8 * 1024 * 1024,
+    );
+  });
+
+  test("does not return contents of denied-basename files", async () => {
+    const dir = makeTempDir();
+    // A denied file (forbidden to file_read/file_write) that contains the
+    // search pattern must never surface in code_search results.
+    writeFileSync(join(dir, ".backup.key"), "supersecret token\n");
+    writeFileSync(join(dir, "backup.key"), "another supersecret\n");
+    writeFileSync(join(dir, "ok.txt"), "supersecret in a normal file\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "supersecret", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("ok.txt:1:");
+    expect(result.content).not.toContain(".backup.key");
+    expect(result.content).not.toContain("backup.key");
+  });
+
+  test("ignores node_modules and .git", async () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "node_modules"));
+    writeFileSync(join(dir, "node_modules", "dep.js"), "secret\n");
+    writeFileSync(join(dir, "src.js"), "secret\n");
+
+    const result = await codeSearchTool.execute(
+      { pattern: "secret", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(result.content).toContain("src.js:1:");
+    expect(result.content).not.toContain("node_modules");
+  });
+
+  test("requires a non-empty pattern", async () => {
+    const dir = makeTempDir();
+    const result = await codeSearchTool.execute(
+      { pattern: "", activity: "search" },
+      makeToolContext(dir),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("pattern is required");
+  });
+
+  test("is read-only: directory is unchanged after a search", async () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, "a.txt");
+    writeFileSync(filePath, "hello search\n");
+    const before = readFileSync(filePath, "utf8");
+    const mtimeBefore = statSync(filePath).mtimeMs;
+
+    await codeSearchTool.execute(
+      { pattern: "search", activity: "search" },
+      makeToolContext(dir),
+    );
+
+    expect(readFileSync(filePath, "utf8")).toBe(before);
+    expect(statSync(filePath).mtimeMs).toBe(mtimeBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subagent-only visibility
+// ---------------------------------------------------------------------------
+
+describe("code_search subagent visibility", () => {
+  test("code_search is in SUBAGENT_ONLY_TOOL_NAMES", () => {
+    expect(SUBAGENT_ONLY_TOOL_NAMES.has("code_search")).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/code-search-tool.test.ts
+++ b/assistant/src/__tests__/code-search-tool.test.ts
@@ -302,6 +302,64 @@ describe("codeSearchTool", () => {
     );
   });
 
+  test("an already-aborted signal stops the scan and reports a timed-out result", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "a.txt"), "needle here\nneedle there\n");
+
+    // The wall-clock deadline (MAX_SEARCH_MS) and the abort signal are checked
+    // at the same per-line checkpoint. MAX_SEARCH_MS is a 10s const that isn't
+    // injectable, so we exercise the shared stop path deterministically via an
+    // already-aborted signal: the scan must stop at the first line check and
+    // return a truncated/timed-out result instead of running the regex.
+    const controller = new AbortController();
+    controller.abort();
+    const context = { ...makeToolContext(dir), signal: controller.signal };
+
+    const result = await codeSearchTool.execute(
+      { pattern: "needle", activity: "search" },
+      context,
+    );
+
+    // Aborted before any match was emitted, so this is the zero-match
+    // timed-out branch (incomplete), not a definitive "No matches found".
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("truncated");
+    expect(result.content).toContain("timed out");
+    expect(result.content).not.toContain("No matches found");
+  });
+
+  test(
+    "a catastrophic-backtracking pattern over many lines terminates",
+    async () => {
+      const dir = makeTempDir();
+      // A classic catastrophic-backtracking pattern against crafted lines that
+      // never match. Each individual line is small enough to backtrack quickly,
+      // but the file has many of them — the wall-clock deadline is checked once
+      // per line, so the scan must terminate (it does not block indefinitely).
+      // Kept deterministically fast: the whole file scans well under the
+      // deadline, so we assert it returns a clean result rather than hanging.
+      const evilLine = "a".repeat(20) + "!"; // forces backtracking, no match
+      const body = Array.from({ length: 50 }, () => evilLine).join("\n");
+      writeFileSync(join(dir, "evil.txt"), body + "\n");
+
+      const result = await codeSearchTool.execute(
+        { pattern: "(a+)+$", activity: "search" },
+        makeToolContext(dir),
+      );
+
+      // It must terminate gracefully. Depending on host speed it either
+      // finishes under the deadline (clean "No matches found") or trips the
+      // deadline (truncated/timed-out) — both are acceptable; hanging is not.
+      expect(result.isError).toBe(false);
+      if (result.status === "truncated") {
+        expect(result.content).toContain("timed out");
+      } else {
+        expect(result.content).toContain("No matches found");
+      }
+    },
+    30_000,
+  );
+
   test("does not return contents of denied-basename files", async () => {
     const dir = makeTempDir();
     // A denied file (forbidden to file_read/file_write) that contains the

--- a/assistant/src/__tests__/exploration-drift-hook.test.ts
+++ b/assistant/src/__tests__/exploration-drift-hook.test.ts
@@ -225,10 +225,11 @@ describe("exploration-drift post-tool-use hook — long-dig trigger", () => {
     expect(ctx.toolResponse.content).toBe(BASE_CONTENT);
   });
 
-  test("counts file_read and file_list as exploration tools", async () => {
+  test("counts code_search, file_read, and file_list as exploration tools", async () => {
+    const explorationNames = ["code_search", "file_read", "file_list"];
     const messages: Message[] = [];
     for (let i = 0; i < EXPLORATION_NUDGE_THRESHOLD - 1; i++) {
-      const name = i % 2 === 0 ? "file_read" : "file_list";
+      const name = explorationNames[i % explorationNames.length];
       const id = `${name}-${i}`;
       messages.push(toolUseTurn(id, name, { path: `/tmp/file-${i}` }));
       messages.push(toolResultTurn(id));

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -111,7 +111,7 @@ describe("tool registry dynamic-tools tools", () => {
 
 describe("tool manifest", () => {
   test("eager module tool names list contains expected count", () => {
-    expect(eagerModuleToolNames.length).toBe(11);
+    expect(eagerModuleToolNames.length).toBe(12);
   });
 
   test("explicit tools list includes memory tools", () => {

--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -70,8 +70,11 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     expect(SUBAGENT_ROLE_REGISTRY.planner.allowedTools!).toContain("recall");
   });
 
-  test('investigator includes "bash" for grep/find-based code and log investigation', () => {
-    expect(SUBAGENT_ROLE_REGISTRY.investigator.allowedTools!).toContain("bash");
+  test("investigator is shell-free and uses code_search for code/log investigation", () => {
+    const tools = SUBAGENT_ROLE_REGISTRY.investigator.allowedTools!;
+    expect(tools).not.toContain("bash");
+    expect(tools).not.toContain("host_bash");
+    expect(tools).toContain("code_search");
   });
 
   test("investigator excludes file write tools (read-only investigation)", () => {
@@ -85,6 +88,8 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     expect(preamble).toContain("Root cause");
     expect(preamble).toContain("Evidence");
     expect(preamble).toContain("notify_parent");
+    expect(preamble).not.toContain("shell access");
+    expect(preamble).toContain("code_search");
   });
 
   test("no role references the old memory_recall tool name", () => {

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -39,7 +39,7 @@ Each subagent is spawned with a role that determines its tool access. Choose the
 | `researcher` | `web_search`, `web_fetch`, `file_read`, `file_list`, `recall`, `notify_parent` | Information gathering, web research, codebase exploration, reading documentation |
 | `coder` | `bash`, `file_read`, `file_write`, `file_edit`, `web_search`, `recall`, `notify_parent` | Code changes, file editing, running commands, build/test tasks |
 | `planner` | `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Analysis, planning, synthesizing information, reviewing approaches |
-| `investigator` | `bash`, `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Root-cause analysis: debugging, log forensics, tracing behavior across many files. Shell access is for read-only investigation (grep/find/reading logs); returns a compact root-cause report |
+| `investigator` | `code_search`, `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Root-cause analysis: debugging, log forensics, tracing behavior across many files. Read-only search/read tools only (no shell): use `code_search` to grep file contents across directories, `file_list` to enumerate paths, `file_read` to read whole files and logs; returns a compact root-cause report |
 
 All specialized roles (`researcher`, `coder`, `planner`) include `notify_parent` for mid-run communication with the parent.
 

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -38,7 +38,7 @@
               "planner",
               "investigator"
             ],
-            "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'investigator': root-cause analysis — debugging, log forensics, tracing behavior across many files; has bash for read-only investigation (grep/find/log inspection) and returns a compact root-cause report. 'general': full access (default). Ignored when fork: true (forks always use general)."
+            "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'investigator': root-cause analysis — debugging, log forensics, tracing behavior across many files; uses read-only search/read tools (code_search, file_read, file_list) with no shell access and returns a compact root-cause report. 'general': full access (default). Ignored when fork: true (forks always use general)."
           },
           "inference_profile": {
             "type": "string",

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -515,6 +515,7 @@ const PLATFORM_TOOL_NAMES = new Set(["request_system_permission"]);
  */
 export const SUBAGENT_ONLY_TOOL_NAMES = new Set<string>([
   "file_list",
+  "code_search",
   "notify_parent",
 ]);
 

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -1,6 +1,6 @@
 /**
  * Default `post-tool-use` hook: when a turn's exploration tool calls (bash,
- * file_read, file_list) show drift — a long unbroken run with no text sent to
+ * code_search, file_read, file_list) show drift — a long unbroken run with no text sent to
  * the user, or the model re-issuing the exact same call — surface a notice
  * via `additionalContext` that coaches it to (a) give the user a brief
  * progress summary and (b) delegate the rest of the investigation to an
@@ -105,6 +105,7 @@ const LOOP_PRONE_MODEL_PATTERN = /kimi-k2[p.]6|minimax-m3/i;
 /** Read-only exploration tools whose unbroken runs indicate inline drift. */
 const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
   "bash",
+  "code_search",
   "file_read",
   "file_list",
 ]);

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -180,7 +180,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
     },
     investigator: {
       allowedTools: [
-        "bash",
+        "code_search",
         "file_read",
         "file_list",
         "web_search",
@@ -191,8 +191,8 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
       skillIds: [],
       systemPromptPreamble: [
         "You are an investigation-focused subagent for root-cause analysis: debugging, log forensics, and tracing behavior across code.",
-        "Your shell access is for read-only investigation (grep, find, reading files and logs) — do not modify files or system state.",
-        "Working method: read whole files instead of many small line-range slices; prefer broad searches (e.g. grep -rn across a directory) over one-symbol-at-a-time queries.",
+        "You have read-only investigation tools only — there is no shell. Use code_search to search file contents across directories, file_list to enumerate paths, and file_read to read whole files and logs. You cannot modify files or system state.",
+        "Working method: read whole files instead of many small line-range slices; prefer broad code_search queries across a directory over one-symbol-at-a-time queries.",
         "Send notify_parent (urgency 'important') as soon as each finding is confirmed, so progress survives interruption.",
         "Your final message must be a compact root-cause report with these sections: Symptom, Root cause, Evidence (file:line references), Suggested fix, Open questions.",
         "If you approach context limits, stop investigating and produce the report from what you have — a partial report delivered is worth more than a complete investigation lost.",

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -41,6 +41,14 @@ const MAX_MATCH_LINE_LENGTH = 2000;
 // report the result as truncated.
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024; // 4 MiB
 
+// Wall-clock deadline for the whole search. Even with the per-line slice bound
+// above, a catastrophic-backtracking regex can take ~1s on a single 2000-char
+// slice, so a file with many such lines could block the event loop for a long
+// time — long enough that the promise-based tool timeout / abort signal can't
+// fire (nothing yields). Checking this deadline every line bounds the total
+// event-loop block to roughly MAX_SEARCH_MS plus one line's worst case.
+const MAX_SEARCH_MS = 10_000; // 10 s
+
 const DEFAULT_MAX_RESULTS = 200;
 const DEFAULT_CONTEXT_LINES = 0;
 // Clamp `context_lines` so a single match cannot request unbounded surrounding
@@ -171,12 +179,21 @@ export const codeSearchTool = {
       };
     }
 
+    // Start the wall-clock deadline before walking so a pathological regex
+    // (or an external abort) can stop the synchronous scan mid-flight instead
+    // of blocking the event loop until the whole tree is exhausted.
+    const searchStart = Date.now();
+
     const lines: string[] = [];
     let matchCount = 0;
     let truncated = false;
     // Set when the output-byte budget (not the max-results cap) stopped the
     // accumulation, so the truncation note can explain why.
     let outputBudgetHit = false;
+    // Set when the wall-clock deadline (or an abort signal) stopped the scan,
+    // so the result can report that the search timed out and is incomplete —
+    // distinct from the scan-cap and output-budget truncation notes.
+    let timedOut = false;
     let filesScanned = 0;
     let totalBytes = 0;
     // Running size of the accumulated output (lines joined by "\n") so we can
@@ -249,6 +266,16 @@ export const codeSearchTool = {
       const display = rel.length > 0 ? rel : basename(full);
       const fileLines = buf.toString("utf8").split("\n");
       for (let i = 0; i < fileLines.length; i++) {
+        // Bound the total event-loop block: check the wall-clock deadline and
+        // the abort signal before every regex test (the per-line Date.now() and
+        // .aborted reads are negligible next to a catastrophic-backtracking
+        // test). When either trips, mark the search timed out / aborted and
+        // stop the whole walk so partial results are still reported.
+        if (Date.now() - searchStart > MAX_SEARCH_MS || context.signal?.aborted) {
+          truncated = true;
+          timedOut = true;
+          return;
+        }
         // Only run the regex against the leading slice of each line so a single
         // pathological line can't monopolize the event loop via catastrophic
         // backtracking. Normal code/log lines are well under the cap.
@@ -329,9 +356,16 @@ export const codeSearchTool = {
 
     if (matchCount === 0) {
       // With zero matches, `truncated` can only have been set by a scan cap
-      // (MAX_FILES_SCANNED / MAX_TOTAL_BYTES), never the max-results path. In
-      // that case the tree was only partially scanned, so a definitive "No
-      // matches found" would be a false negative.
+      // (MAX_FILES_SCANNED / MAX_TOTAL_BYTES) or the wall-clock deadline, never
+      // the max-results path. In either case the tree was only partially
+      // scanned, so a definitive "No matches found" would be a false negative.
+      if (timedOut) {
+        return {
+          content: `Search timed out after ${MAX_SEARCH_MS / 1000}s before finding any match for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}. Results are incomplete — narrow your pattern, glob, or path and search again.`,
+          isError: false,
+          status: "truncated",
+        };
+      }
       if (truncated) {
         return {
           content: `Search stopped early after hitting a scan cap before finding any match for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}. Results are incomplete — narrow your glob or path and search again.`,
@@ -347,9 +381,13 @@ export const codeSearchTool = {
 
     let content = lines.join("\n");
     if (truncated) {
-      content += outputBudgetHit
-        ? `\n\n[Output capped at ${Math.round(MAX_OUTPUT_BYTES / (1024 * 1024))} MiB. Narrow your pattern, glob, or path, or reduce context_lines, to see more.]`
-        : `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
+      if (timedOut) {
+        content += `\n\n[Search timed out after ${MAX_SEARCH_MS / 1000}s. Results are incomplete. Narrow your pattern, glob, or path to see more.]`;
+      } else {
+        content += outputBudgetHit
+          ? `\n\n[Output capped at ${Math.round(MAX_OUTPUT_BYTES / (1024 * 1024))} MiB. Narrow your pattern, glob, or path, or reduce context_lines, to see more.]`
+          : `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
+      }
     }
 
     return {

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -224,6 +224,11 @@ export const codeSearchTool = {
     // bounded by MAX_ENTRIES_TRAVERSED so a pathological tree can't run the
     // synchronous readdir/stat work unbounded even when no file is ever read.
     let entriesTraversed = 0;
+    // Set when an EXPLICIT file root (not a child discovered mid-walk) can't be
+    // read — e.g. EACCES/EPERM. A child file's read failure is optional and
+    // silently skipped, but an unreadable explicit root means nothing was
+    // searched, so we surface it as an error instead of a false "No matches".
+    let rootReadError: string | null = null;
     // Running size of the accumulated output (lines joined by "\n") so we can
     // stop before allocating an unbounded result. Each pushed line contributes
     // its UTF-8 byte length plus one byte for the joining newline.
@@ -253,7 +258,7 @@ export const codeSearchTool = {
 
     // Scan a single regular file for matches. Applies the denied-basename guard
     // and per-file size caps. Returns nothing; mutates the shared accumulators.
-    const scanFile = (full: string): void => {
+    const scanFile = (full: string, isExplicitRoot = false): void => {
       if (truncated) return;
 
       // Honor the wall-clock deadline / abort signal before doing any stat/size
@@ -309,7 +314,14 @@ export const codeSearchTool = {
       let buf: Buffer;
       try {
         buf = readFileSync(full);
-      } catch {
+      } catch (err) {
+        // A child file discovered mid-walk is optional — skip it silently. But
+        // an explicit file root that can't be read was never searched, so record
+        // the failure for the caller to surface as an error.
+        if (isExplicitRoot) {
+          const code = (err as NodeJS.ErrnoException)?.code;
+          rootReadError = `Error: failed to read file (${code ?? "unreadable"}): ${rawPath}`;
+        }
         return;
       }
       filesScanned++;
@@ -434,7 +446,10 @@ export const codeSearchTool = {
           isError: true,
         };
       }
-      scanFile(root);
+      scanFile(root, true);
+      if (rootReadError) {
+        return { content: rootReadError, isError: true };
+      }
     } else {
       return {
         content: `Error: path not found: ${rawPath}`,

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -26,11 +26,21 @@ const MAX_FILES_SCANNED = 20_000;
 const MAX_TOTAL_BYTES = 256 * 1024 * 1024; // 256 MiB
 const MAX_FILE_BYTES = 8 * 1024 * 1024; // skip files larger than 8 MiB
 
-// Per-line work/output cap (ripgrep-style long-line bound). The pattern is run
-// against only the leading slice of each line, so a single pathological line
-// (e.g. a minified bundle on one line) can't dominate matching time or emit a
-// multi-megabyte match line. Normal code/log lines are well under the cap.
-const MAX_MATCH_LINE_LENGTH = 2000;
+// Hard cap on directory entries visited during the walk, independent of
+// wall-clock time. `MAX_FILES_SCANNED`/`MAX_TOTAL_BYTES` only count files that
+// are actually READ, so a pathological tree full of oversized, unreadable,
+// permission-denied, or glob-filtered files (which never increment those
+// counters) could otherwise traverse unbounded. This bounds the readdir/stat
+// work even when every individual operation is fast.
+const MAX_ENTRIES_TRAVERSED = 200_000;
+
+// Display-only cap on emitted output lines (ripgrep-style long-line bound). The
+// pattern is matched against the FULL line, so a token anywhere on a long line
+// is found; this cap only bounds the PRINTED line text (matched and context
+// lines) so a single pathological line (e.g. a minified bundle on one line)
+// can't emit a multi-megabyte output line. Normal code/log lines are well under
+// the cap and print verbatim.
+const MAX_DISPLAY_LINE_LENGTH = 2000;
 
 // Output-byte budget: when `context_lines` is large and many nearby lines
 // match, the surrounding block is appended for every match, so a single large
@@ -74,7 +84,8 @@ export const codeSearchTool = {
     properties: {
       pattern: {
         type: "string",
-        description: "Regular-expression pattern to search for in file contents",
+        description:
+          "Regular-expression pattern to search for in file contents",
       },
       path: {
         type: "string",
@@ -143,7 +154,10 @@ export const codeSearchTool = {
     // clean error below.
     let regex: RE2JS;
     try {
-      regex = RE2JS.compile(pattern, caseInsensitive ? RE2JS.CASE_INSENSITIVE : 0);
+      regex = RE2JS.compile(
+        pattern,
+        caseInsensitive ? RE2JS.CASE_INSENSITIVE : 0,
+      );
     } catch (err) {
       return {
         content: `Error: invalid or unsupported pattern "${pattern}": ${
@@ -206,10 +220,23 @@ export const codeSearchTool = {
     let skippedLargeFile = false;
     let filesScanned = 0;
     let totalBytes = 0;
+    // Number of directory entries visited during the walk (files + subdirs),
+    // bounded by MAX_ENTRIES_TRAVERSED so a pathological tree can't run the
+    // synchronous readdir/stat work unbounded even when no file is ever read.
+    let entriesTraversed = 0;
     // Running size of the accumulated output (lines joined by "\n") so we can
     // stop before allocating an unbounded result. Each pushed line contributes
     // its UTF-8 byte length plus one byte for the joining newline.
     let outputBytes = 0;
+
+    // Bound a single emitted line's length for display only. Matching always
+    // runs against the full line; this just keeps the PRINTED text readable and
+    // prevents one pathological line (minified bundle, huge JSON/log line) from
+    // emitting a multi-megabyte output line. Normal lines pass through verbatim.
+    const truncateForDisplay = (text: string): string =>
+      text.length > MAX_DISPLAY_LINE_LENGTH
+        ? `${text.slice(0, MAX_DISPLAY_LINE_LENGTH)} …[line truncated]`
+        : text;
 
     // Append an output line, tracking its byte cost. Returns false once the
     // output-byte budget is exhausted so callers can stop accumulating.
@@ -229,6 +256,16 @@ export const codeSearchTool = {
     const scanFile = (full: string): void => {
       if (truncated) return;
 
+      // Honor the wall-clock deadline / abort signal before doing any stat/size
+      // work, not just inside the per-line loop. A tree full of oversized or
+      // unreadable files (which never reach the per-line loop) could otherwise
+      // run far past the advertised deadline.
+      if (Date.now() - searchStart > MAX_SEARCH_MS || context.signal?.aborted) {
+        truncated = true;
+        timedOut = true;
+        return;
+      }
+
       // Never read files the assistant is forbidden from touching, even if a
       // broad pattern would otherwise match them. Reuses the same denylist as
       // file_read/file_write so the policies stay in sync.
@@ -240,7 +277,10 @@ export const codeSearchTool = {
       // relative path. dot so dotfiles aren't silently excluded. When the root
       // is a single file, `rel` is empty, so match against the basename.
       const globTarget = rel.length > 0 ? rel : basename(full);
-      if (glob && !minimatch(globTarget, glob, { matchBase: true, dot: true })) {
+      if (
+        glob &&
+        !minimatch(globTarget, glob, { matchBase: true, dot: true })
+      ) {
         return;
       }
 
@@ -286,23 +326,22 @@ export const codeSearchTool = {
         // .aborted reads are negligible next to a catastrophic-backtracking
         // test). When either trips, mark the search timed out / aborted and
         // stop the whole walk so partial results are still reported.
-        if (Date.now() - searchStart > MAX_SEARCH_MS || context.signal?.aborted) {
+        if (
+          Date.now() - searchStart > MAX_SEARCH_MS ||
+          context.signal?.aborted
+        ) {
           truncated = true;
           timedOut = true;
           return;
         }
-        // Only run the pattern against the leading slice of each line so a
-        // single very long line (e.g. a minified bundle) can't dominate match
-        // time or emit a huge match line. Normal code/log lines are well under
-        // the cap.
+        // Match against the FULL line so a token that appears past any display
+        // cap (e.g. after column 2000 on a long log/JSON/minified line) is still
+        // found. RE2's linear-time matching makes this safe — there is no
+        // backtracking blowup to bound, so no need to slice before matching.
         const line = fileLines[i];
-        const probe =
-          line.length > MAX_MATCH_LINE_LENGTH
-            ? line.slice(0, MAX_MATCH_LINE_LENGTH)
-            : line;
-        // Unanchored partial match anywhere in the slice — the RE2 equivalent of
+        // Unanchored partial match anywhere in the line — the RE2 equivalent of
         // RegExp.prototype.test(). The compiled pattern is stateless per call.
-        if (!regex.test(probe)) continue;
+        if (!regex.test(line)) continue;
         if (matchCount >= maxResults) {
           truncated = true;
           return;
@@ -318,17 +357,35 @@ export const codeSearchTool = {
           const end = Math.min(fileLines.length - 1, i + contextLines);
           for (let j = start; j <= end; j++) {
             const sep = j === i ? ":" : "-";
-            if (!pushLine(`${display}:${j + 1}${sep} ${fileLines[j]}`)) return;
+            if (
+              !pushLine(
+                `${display}:${j + 1}${sep} ${truncateForDisplay(fileLines[j])}`,
+              )
+            )
+              return;
           }
           if (!pushLine("--")) return;
         } else {
-          if (!pushLine(`${display}:${lineNo}: ${fileLines[i]}`)) return;
+          if (
+            !pushLine(
+              `${display}:${lineNo}: ${truncateForDisplay(fileLines[i])}`,
+            )
+          )
+            return;
         }
       }
     };
 
     const walk = (dir: string): void => {
       if (truncated) return;
+      // Bound the traversal itself, not just file reads: a deep/wide tree of
+      // directories (or many entries that never get read) could otherwise run
+      // the synchronous readdir/stat work far past the advertised deadline.
+      if (Date.now() - searchStart > MAX_SEARCH_MS || context.signal?.aborted) {
+        truncated = true;
+        timedOut = true;
+        return;
+      }
       let entries: import("node:fs").Dirent[];
       try {
         entries = readdirSync(dir, { withFileTypes: true });
@@ -337,6 +394,22 @@ export const codeSearchTool = {
       }
       for (const entry of entries) {
         if (truncated) return;
+        // Per-entry deadline/abort check (the Date.now()/.aborted reads are
+        // negligible) plus a hard entry cap independent of wall-clock time so a
+        // pathological tree is bounded even when every operation is fast.
+        if (
+          Date.now() - searchStart > MAX_SEARCH_MS ||
+          context.signal?.aborted
+        ) {
+          truncated = true;
+          timedOut = true;
+          return;
+        }
+        entriesTraversed++;
+        if (entriesTraversed > MAX_ENTRIES_TRAVERSED) {
+          truncated = true;
+          return;
+        }
         const full = join(dir, entry.name);
         if (entry.isDirectory()) {
           if (IGNORED_DIRS.has(entry.name)) continue;
@@ -371,9 +444,10 @@ export const codeSearchTool = {
 
     if (matchCount === 0) {
       // With zero matches, `truncated` can only have been set by a scan cap
-      // (MAX_FILES_SCANNED / MAX_TOTAL_BYTES) or the wall-clock deadline, never
-      // the max-results path. In either case the tree was only partially
-      // scanned, so a definitive "No matches found" would be a false negative.
+      // (MAX_FILES_SCANNED / MAX_TOTAL_BYTES / MAX_ENTRIES_TRAVERSED) or the
+      // wall-clock deadline, never the max-results path. In either case the tree
+      // was only partially scanned, so a definitive "No matches found" would be
+      // a false negative.
       if (timedOut) {
         return {
           content: `Search timed out after ${MAX_SEARCH_MS / 1000}s before finding any match for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}. Results are incomplete — narrow your pattern, glob, or path and search again.`,

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join, relative } from "node:path";
 
 import { minimatch } from "minimatch";
+import { RE2JS } from "re2js";
 
 import { RiskLevel } from "../../permissions/types.js";
 import { registerTool } from "../registry.js";
@@ -25,13 +26,10 @@ const MAX_FILES_SCANNED = 20_000;
 const MAX_TOTAL_BYTES = 256 * 1024 * 1024; // 256 MiB
 const MAX_FILE_BYTES = 8 * 1024 * 1024; // skip files larger than 8 MiB
 
-// A user-supplied pattern is run synchronously against every line. A
-// catastrophic-backtracking regex against a very long line can monopolize the
-// event loop, which prevents the tool's promise timeout from ever firing
-// (nothing yields). Bounding the slice the regex sees caps worst-case
-// backtracking per line while still covering normal code/log lines. A future
-// enhancement could run matching in an interruptible worker for full isolation;
-// the prefix bound is the pragmatic guard here.
+// Per-line work/output cap (ripgrep-style long-line bound). The pattern is run
+// against only the leading slice of each line, so a single pathological line
+// (e.g. a minified bundle on one line) can't dominate matching time or emit a
+// multi-megabyte match line. Normal code/log lines are well under the cap.
 const MAX_MATCH_LINE_LENGTH = 2000;
 
 // Output-byte budget: when `context_lines` is large and many nearby lines
@@ -41,12 +39,11 @@ const MAX_MATCH_LINE_LENGTH = 2000;
 // report the result as truncated.
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024; // 4 MiB
 
-// Wall-clock deadline for the whole search. Even with the per-line slice bound
-// above, a catastrophic-backtracking regex can take ~1s on a single 2000-char
-// slice, so a file with many such lines could block the event loop for a long
-// time — long enough that the promise-based tool timeout / abort signal can't
-// fire (nothing yields). Checking this deadline every line bounds the total
-// event-loop block to roughly MAX_SEARCH_MS plus one line's worst case.
+// Wall-clock deadline for the whole search. The synchronous scan never yields,
+// so the promise-based tool timeout / abort signal can't fire mid-scan. Checking
+// this deadline (and the abort signal) once per line bounds how long a search
+// over a very large tree can block the event loop and lets an external abort
+// stop the walk promptly.
 const MAX_SEARCH_MS = 10_000; // 10 s
 
 const DEFAULT_MAX_RESULTS = 200;
@@ -138,14 +135,20 @@ export const codeSearchTool = {
     const root = pathCheck.resolved;
 
     const caseInsensitive = input.case_insensitive === true;
-    let regex: RegExp;
+    // Match with the linear-time RE2 engine (via re2js) instead of V8's
+    // backtracking RegExp. RE2 guarantees linear-time matching, so a
+    // user/subagent-supplied pattern cannot trigger catastrophic backtracking
+    // and block the synchronous scan. The trade-off is that RE2 rejects
+    // backreferences and lookarounds; compile() throws on those, surfaced as a
+    // clean error below.
+    let regex: RE2JS;
     try {
-      regex = new RegExp(pattern, caseInsensitive ? "i" : "");
+      regex = RE2JS.compile(pattern, caseInsensitive ? RE2JS.CASE_INSENSITIVE : 0);
     } catch (err) {
       return {
-        content: `Error: invalid pattern "${pattern}": ${
+        content: `Error: invalid or unsupported pattern "${pattern}": ${
           err instanceof Error ? err.message : String(err)
-        }`,
+        }. The RE2 engine does not support backreferences or lookarounds.`,
         isError: true,
       };
     }
@@ -288,17 +291,17 @@ export const codeSearchTool = {
           timedOut = true;
           return;
         }
-        // Only run the regex against the leading slice of each line so a single
-        // pathological line can't monopolize the event loop via catastrophic
-        // backtracking. Normal code/log lines are well under the cap.
+        // Only run the pattern against the leading slice of each line so a
+        // single very long line (e.g. a minified bundle) can't dominate match
+        // time or emit a huge match line. Normal code/log lines are well under
+        // the cap.
         const line = fileLines[i];
         const probe =
           line.length > MAX_MATCH_LINE_LENGTH
             ? line.slice(0, MAX_MATCH_LINE_LENGTH)
             : line;
-        // Reset lastIndex defensively in case a future change adds the global
-        // flag; with a fresh slice each iteration this is otherwise a no-op.
-        regex.lastIndex = 0;
+        // Unanchored partial match anywhere in the slice — the RE2 equivalent of
+        // RegExp.prototype.test(). The compiled pattern is stateless per call.
         if (!regex.test(probe)) continue;
         if (matchCount >= maxResults) {
           truncated = true;

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -211,6 +211,11 @@ export const codeSearchTool = {
     // so the result can report that the search timed out and is incomplete —
     // distinct from the scan-cap and output-budget truncation notes.
     let timedOut = false;
+    // Set when the search stopped because it reached the `max_results` cap (as
+    // opposed to a scan/traversal cap). Only this cause is helped by raising
+    // `max_results`, so the matched-branch truncation note keys off this flag to
+    // avoid suggesting a larger `max_results` when a scan cap stopped the walk.
+    let maxResultsHit = false;
     // Set when a file was skipped mid-walk because it exceeds MAX_FILE_BYTES.
     // Unlike the truncation flags this does NOT halt the walk — other files may
     // still match — but it does mark the overall result incomplete, since the
@@ -356,6 +361,7 @@ export const codeSearchTool = {
         if (!regex.test(line)) continue;
         if (matchCount >= maxResults) {
           truncated = true;
+          maxResultsHit = true;
           return;
         }
         // Count the match before emitting its lines: a single match whose output
@@ -388,7 +394,7 @@ export const codeSearchTool = {
       }
     };
 
-    const walk = (dir: string): void => {
+    const walk = (dir: string, isExplicitRoot = false): void => {
       if (truncated) return;
       // Bound the traversal itself, not just file reads: a deep/wide tree of
       // directories (or many entries that never get read) could otherwise run
@@ -401,7 +407,15 @@ export const codeSearchTool = {
       let entries: import("node:fs").Dirent[];
       try {
         entries = readdirSync(dir, { withFileTypes: true });
-      } catch {
+      } catch (err) {
+        // A child directory discovered mid-walk is optional — skip it silently.
+        // But an explicit directory root that can't be read (e.g. EACCES/EPERM)
+        // was never searched, so record the failure for the caller to surface
+        // as an error instead of a false "No matches found".
+        if (isExplicitRoot) {
+          const code = (err as NodeJS.ErrnoException)?.code;
+          rootReadError = `Error: failed to read directory (${code ?? "unreadable"}): ${rawPath}`;
+        }
         return;
       }
       for (const entry of entries) {
@@ -434,7 +448,13 @@ export const codeSearchTool = {
     };
 
     if (rootStat.isDirectory()) {
-      walk(root);
+      walk(root, true);
+      // An explicit directory root that statSync sees but readdirSync can't read
+      // (EACCES/EPERM) was never searched — surface a hard error instead of a
+      // false "No matches found", mirroring the unreadable explicit-file root.
+      if (rootReadError) {
+        return { content: rootReadError, isError: true };
+      }
     } else if (rootStat.isFile()) {
       // A regular-file root is a valid single-file search. Unlike an oversized
       // file skipped mid-walk (where other files may still match), an oversized
@@ -492,12 +512,18 @@ export const codeSearchTool = {
 
     let content = lines.join("\n");
     if (truncated) {
+      // Distinguish the truncation cause in priority order so the note doesn't
+      // mislead. Only `maxResultsHit` is helped by raising `max_results`; a
+      // scan/traversal cap (MAX_FILES_SCANNED / MAX_TOTAL_BYTES /
+      // MAX_ENTRIES_TRAVERSED) is not, so it gets its own note.
       if (timedOut) {
         content += `\n\n[Search timed out after ${MAX_SEARCH_MS / 1000}s. Results are incomplete. Narrow your pattern, glob, or path to see more.]`;
+      } else if (outputBudgetHit) {
+        content += `\n\n[Output capped at ${Math.round(MAX_OUTPUT_BYTES / (1024 * 1024))} MiB. Narrow your pattern, glob, or path, or reduce context_lines, to see more.]`;
+      } else if (maxResultsHit) {
+        content += `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
       } else {
-        content += outputBudgetHit
-          ? `\n\n[Output capped at ${Math.round(MAX_OUTPUT_BYTES / (1024 * 1024))} MiB. Narrow your pattern, glob, or path, or reduce context_lines, to see more.]`
-          : `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
+        content += `\n\n[Search stopped early after hitting a scan/traversal cap — some files weren't searched. Narrow your glob or path (raising max_results won't help).]`;
       }
     }
     if (skippedLargeFile) {

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -1,0 +1,350 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+
+import { minimatch } from "minimatch";
+
+import { RiskLevel } from "../../permissions/types.js";
+import { registerTool } from "../registry.js";
+import {
+  isDeniedBasename,
+  sandboxPolicy,
+} from "../shared/filesystem/path-policy.js";
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "../types.js";
+
+// Directory names that are never worth searching and would otherwise dominate
+// the file budget (dependencies, VCS metadata).
+const IGNORED_DIRS = new Set(["node_modules", ".git"]);
+
+// Defensive caps so a search over a huge tree cannot read the whole disk into
+// memory. These bound the walk regardless of `max_results`.
+const MAX_FILES_SCANNED = 20_000;
+const MAX_TOTAL_BYTES = 256 * 1024 * 1024; // 256 MiB
+const MAX_FILE_BYTES = 8 * 1024 * 1024; // skip files larger than 8 MiB
+
+// A user-supplied pattern is run synchronously against every line. A
+// catastrophic-backtracking regex against a very long line can monopolize the
+// event loop, which prevents the tool's promise timeout from ever firing
+// (nothing yields). Bounding the slice the regex sees caps worst-case
+// backtracking per line while still covering normal code/log lines. A future
+// enhancement could run matching in an interruptible worker for full isolation;
+// the prefix bound is the pragmatic guard here.
+const MAX_MATCH_LINE_LENGTH = 2000;
+
+// Output-byte budget: when `context_lines` is large and many nearby lines
+// match, the surrounding block is appended for every match, so a single large
+// file with many matches could allocate hundreds of MB before the post-tool
+// truncation hook runs. Stop accumulating once this budget is exceeded and
+// report the result as truncated.
+const MAX_OUTPUT_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+const DEFAULT_MAX_RESULTS = 200;
+const DEFAULT_CONTEXT_LINES = 0;
+// Clamp `context_lines` so a single match cannot request unbounded surrounding
+// context (which would blow past the output budget on its own).
+const MAX_CONTEXT_LINES = 20;
+
+/** Heuristic binary-file detection: a NUL byte in the leading bytes. */
+function looksBinary(buf: Buffer): boolean {
+  const len = Math.min(buf.length, 8000);
+  for (let i = 0; i < len; i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+}
+
+export const codeSearchTool = {
+  name: "code_search",
+  description:
+    "Search file contents for a regular-expression pattern across a directory tree on your own machine, returning matching `path:line: text` lines. Read-only — never modifies files. Skips node_modules, .git, and binary files. Use this to grep across files without a shell.",
+  category: "filesystem",
+  executionTarget: "sandbox",
+  defaultRiskLevel: RiskLevel.Low,
+
+  input_schema: {
+    type: "object",
+    properties: {
+      pattern: {
+        type: "string",
+        description: "Regular-expression pattern to search for in file contents",
+      },
+      path: {
+        type: "string",
+        description:
+          "Directory to search under (defaults to the working directory)",
+      },
+      glob: {
+        type: "string",
+        description:
+          "Only search files whose path (relative to the search root) matches this glob, e.g. '*.ts' or 'src/**'",
+      },
+      case_insensitive: {
+        type: "boolean",
+        description: "Match the pattern case-insensitively",
+      },
+      context_lines: {
+        type: "number",
+        description:
+          "Number of lines of context to include before and after each match (default 0)",
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum number of matches to return (default 200)",
+      },
+      activity: {
+        type: "string",
+        description:
+          "Brief non-technical explanation of what you are doing and why, shown as a status update.",
+      },
+    },
+    required: ["pattern", "activity"],
+  },
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const pattern = input.pattern;
+    if (!pattern || typeof pattern !== "string") {
+      return {
+        content: "Error: pattern is required and must be a non-empty string",
+        isError: true,
+      };
+    }
+
+    const rawPath =
+      typeof input.path === "string" && input.path.length > 0
+        ? input.path
+        : context.workingDir;
+
+    const pathCheck = sandboxPolicy(rawPath, context.workingDir);
+    if (!pathCheck.ok) {
+      return {
+        content: `Error: ${pathCheck.error}. To search outside the workspace, use the host_bash tool instead.`,
+        isError: true,
+      };
+    }
+    const root = pathCheck.resolved;
+
+    const caseInsensitive = input.case_insensitive === true;
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern, caseInsensitive ? "i" : "");
+    } catch (err) {
+      return {
+        content: `Error: invalid pattern "${pattern}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        isError: true,
+      };
+    }
+
+    const glob =
+      typeof input.glob === "string" && input.glob.length > 0
+        ? input.glob
+        : undefined;
+
+    const contextLines =
+      typeof input.context_lines === "number" && input.context_lines > 0
+        ? Math.min(Math.floor(input.context_lines), MAX_CONTEXT_LINES)
+        : DEFAULT_CONTEXT_LINES;
+
+    const maxResults =
+      typeof input.max_results === "number" && input.max_results > 0
+        ? Math.floor(input.max_results)
+        : DEFAULT_MAX_RESULTS;
+
+    // Validate the search root before walking so a missing/unreadable/typo'd
+    // path surfaces a hard error instead of being swallowed like an unreadable
+    // child directory and returning a false "No matches found". Mirrors the
+    // NOT_FOUND / NOT_A_DIRECTORY reporting in file_list.
+    let rootStat: import("node:fs").Stats;
+    try {
+      rootStat = statSync(root);
+    } catch {
+      return {
+        content: `Error: path not found: ${rawPath}`,
+        isError: true,
+      };
+    }
+
+    const lines: string[] = [];
+    let matchCount = 0;
+    let truncated = false;
+    // Set when the output-byte budget (not the max-results cap) stopped the
+    // accumulation, so the truncation note can explain why.
+    let outputBudgetHit = false;
+    let filesScanned = 0;
+    let totalBytes = 0;
+    // Running size of the accumulated output (lines joined by "\n") so we can
+    // stop before allocating an unbounded result. Each pushed line contributes
+    // its UTF-8 byte length plus one byte for the joining newline.
+    let outputBytes = 0;
+
+    // Append an output line, tracking its byte cost. Returns false once the
+    // output-byte budget is exhausted so callers can stop accumulating.
+    const pushLine = (line: string): boolean => {
+      outputBytes += Buffer.byteLength(line, "utf8") + 1;
+      lines.push(line);
+      if (outputBytes > MAX_OUTPUT_BYTES) {
+        truncated = true;
+        outputBudgetHit = true;
+        return false;
+      }
+      return true;
+    };
+
+    // Scan a single regular file for matches. Applies the denied-basename guard
+    // and per-file size caps. Returns nothing; mutates the shared accumulators.
+    const scanFile = (full: string): void => {
+      if (truncated) return;
+
+      // Never read files the assistant is forbidden from touching, even if a
+      // broad pattern would otherwise match them. Reuses the same denylist as
+      // file_read/file_write so the policies stay in sync.
+      if (isDeniedBasename(full)) return;
+
+      const rel = relative(root, full);
+      // matchBase lets a slash-free pattern like "*.ts" match files at any
+      // depth (against the basename); patterns with slashes match the full
+      // relative path. dot so dotfiles aren't silently excluded. When the root
+      // is a single file, `rel` is empty, so match against the basename.
+      const globTarget = rel.length > 0 ? rel : basename(full);
+      if (glob && !minimatch(globTarget, glob, { matchBase: true, dot: true })) {
+        return;
+      }
+
+      if (filesScanned >= MAX_FILES_SCANNED) {
+        truncated = true;
+        return;
+      }
+
+      let size: number;
+      try {
+        size = statSync(full).size;
+      } catch {
+        return;
+      }
+      if (size > MAX_FILE_BYTES) return;
+      if (totalBytes + size > MAX_TOTAL_BYTES) {
+        truncated = true;
+        return;
+      }
+
+      let buf: Buffer;
+      try {
+        buf = readFileSync(full);
+      } catch {
+        return;
+      }
+      filesScanned++;
+      totalBytes += buf.length;
+      if (looksBinary(buf)) return;
+
+      // Display path: when searching a single file at the root, `rel` is empty;
+      // fall back to the basename so output stays readable.
+      const display = rel.length > 0 ? rel : basename(full);
+      const fileLines = buf.toString("utf8").split("\n");
+      for (let i = 0; i < fileLines.length; i++) {
+        // Only run the regex against the leading slice of each line so a single
+        // pathological line can't monopolize the event loop via catastrophic
+        // backtracking. Normal code/log lines are well under the cap.
+        const line = fileLines[i];
+        const probe =
+          line.length > MAX_MATCH_LINE_LENGTH
+            ? line.slice(0, MAX_MATCH_LINE_LENGTH)
+            : line;
+        // Reset lastIndex defensively in case a future change adds the global
+        // flag; with a fresh slice each iteration this is otherwise a no-op.
+        regex.lastIndex = 0;
+        if (!regex.test(probe)) continue;
+        if (matchCount >= maxResults) {
+          truncated = true;
+          return;
+        }
+        const lineNo = i + 1;
+        if (contextLines > 0) {
+          const start = Math.max(0, i - contextLines);
+          const end = Math.min(fileLines.length - 1, i + contextLines);
+          for (let j = start; j <= end; j++) {
+            const sep = j === i ? ":" : "-";
+            if (!pushLine(`${display}:${j + 1}${sep} ${fileLines[j]}`)) return;
+          }
+          if (!pushLine("--")) return;
+        } else {
+          if (!pushLine(`${display}:${lineNo}: ${fileLines[i]}`)) return;
+        }
+        matchCount++;
+      }
+    };
+
+    const walk = (dir: string): void => {
+      if (truncated) return;
+      let entries: import("node:fs").Dirent[];
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (truncated) return;
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (IGNORED_DIRS.has(entry.name)) continue;
+          walk(full);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        scanFile(full);
+      }
+    };
+
+    if (rootStat.isDirectory()) {
+      walk(root);
+    } else if (rootStat.isFile()) {
+      // A regular-file root is a valid single-file search.
+      scanFile(root);
+    } else {
+      return {
+        content: `Error: path not found: ${rawPath}`,
+        isError: true,
+      };
+    }
+
+    if (matchCount === 0) {
+      // With zero matches, `truncated` can only have been set by a scan cap
+      // (MAX_FILES_SCANNED / MAX_TOTAL_BYTES), never the max-results path. In
+      // that case the tree was only partially scanned, so a definitive "No
+      // matches found" would be a false negative.
+      if (truncated) {
+        return {
+          content: `Search stopped early after hitting a scan cap before finding any match for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}. Results are incomplete — narrow your glob or path and search again.`,
+          isError: false,
+          status: "truncated",
+        };
+      }
+      return {
+        content: `No matches found for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}`,
+        isError: false,
+      };
+    }
+
+    let content = lines.join("\n");
+    if (truncated) {
+      content += outputBudgetHit
+        ? `\n\n[Output capped at ${Math.round(MAX_OUTPUT_BYTES / (1024 * 1024))} MiB. Narrow your pattern, glob, or path, or reduce context_lines, to see more.]`
+        : `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
+    }
+
+    return {
+      content,
+      isError: false,
+      ...(truncated ? { status: "truncated" } : {}),
+    };
+  },
+} satisfies ToolDefinition;
+
+registerTool(codeSearchTool);

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -194,6 +194,13 @@ export const codeSearchTool = {
     // so the result can report that the search timed out and is incomplete —
     // distinct from the scan-cap and output-budget truncation notes.
     let timedOut = false;
+    // Set when a file was skipped mid-walk because it exceeds MAX_FILE_BYTES.
+    // Unlike the truncation flags this does NOT halt the walk — other files may
+    // still match — but it does mark the overall result incomplete, since the
+    // skipped file could have contained the pattern. Kept separate from
+    // `truncated` so the zero-match invariant ("truncated => scan cap/timeout")
+    // stays intact.
+    let skippedLargeFile = false;
     let filesScanned = 0;
     let totalBytes = 0;
     // Running size of the accumulated output (lines joined by "\n") so we can
@@ -245,7 +252,12 @@ export const codeSearchTool = {
       } catch {
         return;
       }
-      if (size > MAX_FILE_BYTES) return;
+      if (size > MAX_FILE_BYTES) {
+        // Skip just this file (others may still match), but record that the
+        // search is incomplete so the result doesn't read as a definitive miss.
+        skippedLargeFile = true;
+        return;
+      }
       if (totalBytes + size > MAX_TOTAL_BYTES) {
         truncated = true;
         return;
@@ -373,6 +385,13 @@ export const codeSearchTool = {
           status: "truncated",
         };
       }
+      if (skippedLargeFile) {
+        return {
+          content: `No matches found for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}, but one or more files were skipped because they exceed the ${Math.round(MAX_FILE_BYTES / (1024 * 1024))} MiB per-file size limit, so results may be incomplete.`,
+          isError: false,
+          status: "truncated",
+        };
+      }
       return {
         content: `No matches found for /${pattern}/${caseInsensitive ? "i" : ""} under ${basename(root)}`,
         isError: false,
@@ -389,11 +408,16 @@ export const codeSearchTool = {
           : `\n\n[Results truncated at ${maxResults} matches. Narrow your pattern, glob, or path to see more.]`;
       }
     }
+    if (skippedLargeFile) {
+      // Independent of the truncation reasons above: note any files skipped for
+      // exceeding the per-file size limit so the result isn't read as complete.
+      content += `\n\n[One or more files were skipped because they exceed the ${Math.round(MAX_FILE_BYTES / (1024 * 1024))} MiB per-file size limit. Results may be incomplete.]`;
+    }
 
     return {
       content,
       isError: false,
-      ...(truncated ? { status: "truncated" } : {}),
+      ...(truncated || skippedLargeFile ? { status: "truncated" } : {}),
     };
   },
 } satisfies ToolDefinition;

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -265,6 +265,11 @@ export const codeSearchTool = {
           truncated = true;
           return;
         }
+        // Count the match before emitting its lines: a single match whose output
+        // alone exceeds the output-byte budget would otherwise leave matchCount
+        // at 0, making the zero-match branch report a false "no matches / scan
+        // cap" instead of a truncated result that acknowledges the match.
+        matchCount++;
         const lineNo = i + 1;
         if (contextLines > 0) {
           const start = Math.max(0, i - contextLines);
@@ -277,7 +282,6 @@ export const codeSearchTool = {
         } else {
           if (!pushLine(`${display}:${lineNo}: ${fileLines[i]}`)) return;
         }
-        matchCount++;
       }
     };
 
@@ -305,7 +309,16 @@ export const codeSearchTool = {
     if (rootStat.isDirectory()) {
       walk(root);
     } else if (rootStat.isFile()) {
-      // A regular-file root is a valid single-file search.
+      // A regular-file root is a valid single-file search. Unlike an oversized
+      // file skipped mid-walk (where other files may still match), an oversized
+      // explicit root means nothing was searched at all — surface a hard error
+      // instead of falling through to a false "No matches found".
+      if (rootStat.size > MAX_FILE_BYTES) {
+        return {
+          content: `Error: file too large to search (${rootStat.size} bytes): ${rawPath}`,
+          isError: true,
+        };
+      }
       scanFile(root);
     } else {
       return {

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -148,10 +148,7 @@ export function sandboxPolicy(
 
   // Check both the logical path and the symlink-resolved path so a symlink
   // with a non-denied name pointing at a denied file is still caught.
-  if (
-    DENIED_BASENAMES.has(basename(resolved)) ||
-    DENIED_BASENAMES.has(basename(realResolved))
-  ) {
+  if (isDeniedBasename(resolved) || isDeniedBasename(realResolved)) {
     return {
       ok: false,
       reason: "denied",
@@ -178,7 +175,7 @@ export function hostPolicy(rawPath: string): PathResult {
       error: `path must be absolute for host file access: ${rawPath}`,
     };
   }
-  if (DENIED_BASENAMES.has(basename(rawPath))) {
+  if (isDeniedBasename(rawPath)) {
     return {
       ok: false,
       reason: "denied",

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -20,6 +20,16 @@ export type PathFailureReason = "not_absolute" | "out_of_bounds" | "denied";
  */
 const DENIED_BASENAMES = new Set([".backup.key", "backup.key"]);
 
+/**
+ * Whether a path's basename is on the denylist of files the assistant must
+ * never read or write. Shared so callers that walk the filesystem (e.g.
+ * `code_search`) apply the same denylist as `sandboxPolicy`/`hostPolicy`,
+ * keeping the three in sync.
+ */
+export function isDeniedBasename(path: string): boolean {
+  return DENIED_BASENAMES.has(basename(path));
+}
+
 export type PathResult =
   | { ok: true; resolved: string }
   | { ok: false; reason: PathFailureReason; error: string };

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,6 +18,7 @@ import { runAuthenticatedCommandTool } from "./credential-execution/run-authenti
 import { fileEditTool } from "./filesystem/edit.js";
 import { fileListTool } from "./filesystem/list.js";
 import { fileReadTool } from "./filesystem/read.js";
+import { codeSearchTool } from "./filesystem/search.js";
 import { fileWriteTool } from "./filesystem/write.js";
 import { recallTool, rememberTool } from "./memory/register.js";
 import { webFetchTool } from "./network/web-fetch.js";
@@ -59,6 +60,7 @@ export const eagerModuleToolNames: string[] = [
   "file_write",
   "file_edit",
   "file_list",
+  "code_search",
   "web_search",
   "web_fetch",
   "skill_execute",
@@ -81,6 +83,7 @@ export const explicitTools: ToolDefinition[] = [
   fileWriteTool,
   fileEditTool,
   fileListTool,
+  codeSearchTool,
   webFetchTool,
   webSearchTool,
   skillExecuteTool,


### PR DESCRIPTION
## Summary
Makes the `investigator` subagent role's "read-only" guarantee **structural** instead of prompt-only. Previously the role held unrestricted `bash` while only being *told* to stay read-only (and platform-hosted guardian sessions auto-approve bash) — so `rm`, `chmod`, `sed -i`, redirection, and secret exfiltration were all reachable. This is **Option A** for ATL-864: remove `bash` from the role and give it a real, enforced read-only `code_search` tool instead (vs. PR #35898's command-string-parsing gate, which is bypassable).

## What changed (3 PRs merged into this branch)
- **#35951** — Add read-only `code_search` content-search tool: pure-JS recursive grep-across-files (no shell, no process exec, no FS writes), sandbox-scoped via `sandboxPolicy`, denied-basename guard, ReDoS line bound, output-byte budget, registered subagent-only. Core-team approved as a security exception per `assistant/src/tools/AGENTS.md`.
- **#35968** — Make the investigator role read-only: remove `bash` from `allowedTools`, add `code_search`; update preamble, `TOOLS.json`, and `SKILL.md` to "read-only search/read tools, no shell"; update role-registry tests.
- **#35976** — Self-review remediation: add `code_search` to the exploration-drift `EXPLORATION_TOOL_NAMES` nudge; error on oversized explicit-file search roots; correct match accounting when a >4 MiB line trips the output budget; finish the `isDeniedBasename` extraction.

## Review
- Each PR went through a Codex/Devin review gate before merging (Codex raised 5 real issues on the tool — denied-basename enforcement, root validation, ReDoS, output cap, truncated-scan reporting — all fixed; Devin/Codex caught a stale `SKILL.md` reference, fixed).
- A fresh-eyes self-review (plan-faithfulness, repo-integration, slop/reuse, external-feedback) found 4 gaps, all remediated in #35976; a re-review confirmed PASS with the test suite green.

## Not included
- **PR 3** (drop `web_fetch`/`web_search` from the investigator to close a cross-tool exfil path) was left as an explicit, optional, decision-gated follow-up — not required to close ATL-864.

Part of plan: investigator-readonly-tools.md