### PR TITLE
feat(subagent): run the `advisor` role as a synchronous, context-inheriting, stronger-model consult

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -11,7 +11,12 @@ const mockProfiles = {
   "cost-optimized": {},
   disabled: { status: "disabled" },
   "quality-optimized": {},
+  frontier: {},
 };
+// The advisor consult defaults to `llm.advisorProfile`. Set here so the
+// advisor tests can assert the default and an explicit `inference_profile`
+// override against the same shared config.
+const mockAdvisorProfile = "frontier";
 mock.module("../config/loader.js", () => ({
   getConfigReadOnly: () => ({
     llm: { profiles: mockProfiles },
@@ -24,13 +29,30 @@ mock.module("../config/loader.js", () => ({
         model: "claude-opus-4-7",
       },
       profiles: mockProfiles,
+      advisorProfile: mockAdvisorProfile,
     },
     rateLimit: { maxRequestsPerMinute: 0 },
+    tools: { exclude: [] },
+    memory: { enabled: true },
   }),
 }));
+
+// Mock the conversation registry so the advisor consult can resolve a fake
+// parent conversation (snapshot messages + system prompt) without a live
+// Conversation. Other executors in this suite never call `findConversation`.
+let mockFindConversation: (conversationId: string) =>
+  | {
+      messages: Array<{ role: string; content: unknown[] }>;
+      getCurrentSystemPrompt: () => string;
+    }
+  | undefined = () => undefined;
+mock.module("../daemon/conversation-registry.js", () => ({
+  findConversation: (conversationId: string) =>
+    mockFindConversation(conversationId),
+}));
 mock.module("../memory/conversation-crud.js", () => ({
-    setConversationProcessingStartedAt: () => {},
-    isConversationProcessing: () => false,
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
@@ -1568,5 +1590,316 @@ describe("Subagent role-based spawn", () => {
     ]);
     // role is not required
     expect(def.input_schema.required).not.toContain("role");
+  });
+});
+
+// ── Advisor-role consult ────────────────────────────────────────────
+
+describe("Subagent advisor-role consult", () => {
+  type Block = { type: string; [k: string]: unknown };
+  type CapturedAwait = {
+    config: Record<string, unknown>;
+    opts?: { signal?: AbortSignal; onText?: (chunk: string) => void };
+  };
+
+  /**
+   * Stub `manager.spawnAndAwait` to capture the config + opts and resolve to
+   * `advice`. Restores the original on cleanup. Returns the captured-call ref.
+   */
+  function stubAwait(advice: string | (() => Promise<string>)): {
+    captured: { current?: CapturedAwait };
+    restore: () => void;
+  } {
+    const manager = getSubagentManager();
+    const original = manager.spawnAndAwait.bind(manager);
+    const captured: { current?: CapturedAwait } = {};
+    manager.spawnAndAwait = (async (
+      config: Record<string, unknown>,
+      _send: unknown,
+      opts?: CapturedAwait["opts"],
+    ) => {
+      captured.current = { config, opts };
+      return typeof advice === "function" ? await advice() : advice;
+    }) as typeof manager.spawnAndAwait;
+    return {
+      captured,
+      restore: () => {
+        manager.spawnAndAwait = original;
+      },
+    };
+  }
+
+  test("advisor role returns guidance synchronously as the tool result", async () => {
+    mockFindConversation = () => ({
+      messages: [{ role: "user", content: [{ type: "text", text: "Help" }] }],
+      getCurrentSystemPrompt: () => "PARENT SYSTEM PROMPT",
+    });
+    const { captured, restore } = stubAwait("Here is my advice.");
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Consult",
+          objective: "advise me",
+          role: "advisor",
+        },
+        makeContext("advisor-sess-1", { sendToClient: () => {} }),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Here is my advice.");
+      // Ran synchronously through spawnAndAwait, not fire-and-forget spawn.
+      expect(captured.current).toBeDefined();
+      expect(captured.current!.config.fork).toBe(true);
+      expect(captured.current!.config.role).toBe("advisor");
+      // Framing embeds the executor prompt as advisor system prompt context.
+      expect(captured.current!.config.systemPromptOverride).toContain(
+        "PARENT SYSTEM PROMPT",
+      );
+    } finally {
+      restore();
+      mockFindConversation = () => undefined;
+    }
+  });
+
+  test("advisor inherits and sanitizes the parent transcript", async () => {
+    // Parent in-memory history carries a thinking block (must be stripped) and
+    // a completed tool_use/tool_result pair (must be preserved).
+    mockFindConversation = () => ({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Do the task" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "secret reasoning" },
+            { type: "text", text: "Working on it" },
+            { type: "tool_use", id: "t1", name: "bash", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }],
+        },
+      ],
+      getCurrentSystemPrompt: () => "SYS",
+    });
+    const { captured, restore } = stubAwait("advice");
+    try {
+      await executeSubagentSpawn(
+        { label: "Consult", objective: "x", role: "advisor" },
+        makeContext("advisor-sess-2", { sendToClient: () => {} }),
+      );
+      const msgs = captured.current!.config.parentMessages as Array<{
+        role: string;
+        content: Block[];
+      }>;
+      const allBlocks = msgs.flatMap((m) => m.content);
+      // Thinking is stripped; the completed tool_use/tool_result pair survives.
+      expect(allBlocks.some((b) => b.type === "thinking")).toBe(false);
+      expect(allBlocks.some((b) => b.type === "tool_use")).toBe(true);
+      expect(allBlocks.some((b) => b.type === "tool_result")).toBe(true);
+    } finally {
+      restore();
+      mockFindConversation = () => undefined;
+    }
+  });
+
+  test("in-flight plan is visible to the advisor with no dangling tool_use", async () => {
+    // The in-memory snapshot ends on the user turn — the in-flight assistant
+    // turn (this turn's plan + the pending advisor tool_use) lives only in the
+    // DB at consult time. It must be appended, and its dangling tool_use stripped.
+    mockFindConversation = () => ({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Plan the work" }] },
+      ],
+      getCurrentSystemPrompt: () => "SYS",
+    });
+    mockGetMessages = (convId: string) => {
+      if (convId !== "advisor-sess-3") return null;
+      return [
+        {
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: "Plan the work" }]),
+        },
+        {
+          role: "assistant",
+          content: JSON.stringify([
+            { type: "text", text: "My plan: step 1, step 2." },
+            {
+              type: "tool_use",
+              id: "adv-1",
+              name: "subagent_spawn",
+              input: {},
+            },
+          ]),
+        },
+      ];
+    };
+    const { captured, restore } = stubAwait("advice");
+    try {
+      await executeSubagentSpawn(
+        { label: "Consult", objective: "x", role: "advisor" },
+        makeContext("advisor-sess-3", { sendToClient: () => {} }),
+      );
+      const msgs = captured.current!.config.parentMessages as Array<{
+        role: string;
+        content: Block[];
+      }>;
+      const allBlocks = msgs.flatMap((m) => m.content);
+      // The plan text the model wrote this turn is present in the consult.
+      expect(
+        allBlocks.some(
+          (b) => b.type === "text" && b.text === "My plan: step 1, step 2.",
+        ),
+      ).toBe(true);
+      // No dangling tool_use is sent.
+      expect(allBlocks.some((b) => b.type === "tool_use")).toBe(false);
+    } finally {
+      restore();
+      mockFindConversation = () => undefined;
+      mockGetMessages = () => null;
+    }
+  });
+
+  test("advisor defaults to llm.advisorProfile (forced)", async () => {
+    mockFindConversation = () => ({
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      getCurrentSystemPrompt: () => "SYS",
+    });
+    const { captured, restore } = stubAwait("advice");
+    try {
+      await executeSubagentSpawn(
+        { label: "Consult", objective: "x", role: "advisor" },
+        makeContext("advisor-sess-4", { sendToClient: () => {} }),
+      );
+      expect(captured.current!.config.overrideProfile).toBe("frontier");
+      expect(captured.current!.config.forceOverrideProfile).toBe(true);
+    } finally {
+      restore();
+      mockFindConversation = () => undefined;
+    }
+  });
+
+  test("advisor respects an explicit inference_profile over advisorProfile", async () => {
+    mockFindConversation = () => ({
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      getCurrentSystemPrompt: () => "SYS",
+    });
+    const { captured, restore } = stubAwait("advice");
+    try {
+      await executeSubagentSpawn(
+        {
+          label: "Consult",
+          objective: "x",
+          role: "advisor",
+          inference_profile: "quality-optimized",
+        },
+        makeContext("advisor-sess-5", { sendToClient: () => {} }),
+      );
+      expect(captured.current!.config.overrideProfile).toBe(
+        "quality-optimized",
+      );
+      expect(captured.current!.config.forceOverrideProfile).toBe(true);
+    } finally {
+      restore();
+      mockFindConversation = () => undefined;
+    }
+  });
+
+  test("advisor forwards the tool's onOutput as the streaming onText sink", async () => {
+    mockFindConversation = () => ({
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      getCurrentSystemPrompt: () => "SYS",
+    });
+    const { captured, restore } = stubAwait("advice");
+    const onOutput = () => {};
+    try {
+      await executeSubagentSpawn(
+        { label: "Consult", objective: "x", role: "advisor" },
+        makeContext("advisor-sess-6", { sendToClient: () => {}, onOutput }),
+      );
+      expect(captured.current!.opts?.onText).toBe(onOutput);
+      expect(captured.current!.opts?.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      restore();
+      mockFindConversation = () => undefined;
+    }
+  });
+
+  test("advisor degrades benignly when the consult throws (incl. depth limit)", async () => {
+    mockFindConversation = () => ({
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      getCurrentSystemPrompt: () => "SYS",
+    });
+    const { restore } = stubAwait(async () => {
+      throw new Error(
+        "Cannot spawn subagent: parent is itself a subagent (max depth 1).",
+      );
+    });
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Consult", objective: "x", role: "advisor" },
+        makeContext("advisor-sess-7", { sendToClient: () => {} }),
+      );
+      // Never fail the turn — benign non-error notice.
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("advisor unavailable");
+      expect(result.content).toContain("parent is itself a subagent");
+    } finally {
+      restore();
+      mockFindConversation = () => undefined;
+    }
+  });
+
+  test("advisor degrades benignly when no client is connected", async () => {
+    // No sendToClient → the shared client guard fires before the advisor branch.
+    const result = await executeSubagentSpawn(
+      { label: "Consult", objective: "x", role: "advisor" },
+      makeContext("advisor-sess-8"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No client connected");
+  });
+});
+
+// ── Advisor role tool-less enforcement ──────────────────────────────
+
+describe("Advisor role is tool-less", () => {
+  test("the advisor role's empty allowlist yields zero tools (not 'no filter')", async () => {
+    // An empty allowlist must mean ZERO tools, not "no restriction". Build a
+    // resolveTools callback with the advisor's empty allowlist and confirm no
+    // tool survives — including a fake skill tool the projection would add.
+    const { createResolveToolsCallback } =
+      await import("../daemon/conversation-tool-setup.js");
+    const { SUBAGENT_ROLE_REGISTRY } = await import("../subagent/types.js");
+    const advisorAllowed = SUBAGENT_ROLE_REGISTRY.advisor.allowedTools;
+    expect(advisorAllowed).toEqual([]);
+
+    const toolDefs = [
+      { name: "bash", description: "", input_schema: { type: "object" } },
+      { name: "file_read", description: "", input_schema: { type: "object" } },
+    ];
+    const ctx = {
+      skillProjectionState: new Map<string, string>(),
+      skillProjectionCache: new Map(),
+      coreToolNames: new Set(toolDefs.map((d) => d.name)),
+      toolsDisabledDepth: 0,
+      // The advisor role applies `new Set(allowedTools)` — empty Set here.
+      subagentAllowedTools: new Set<string>(advisorAllowed),
+      // Default (absent) gate mode is "wire": the allowlist filters the wire
+      // tool list, so an empty Set leaves nothing.
+      isSubagent: true,
+    } as unknown as Parameters<typeof createResolveToolsCallback>[1];
+
+    const resolve = createResolveToolsCallback(
+      toolDefs as unknown as Parameters<typeof createResolveToolsCallback>[0],
+      ctx,
+    );
+    expect(resolve).toBeDefined();
+    const resolved = resolve!([]);
+    expect(resolved).toEqual([]);
+    // The per-turn execution gate is likewise empty.
+    expect(
+      (ctx as unknown as { allowedToolNames?: Set<string> }).allowedToolNames
+        ?.size ?? 0,
+    ).toBe(0);
   });
 });

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -2,11 +2,26 @@ import { validateInferenceProfileKey } from "../../config/inference-profile-vali
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
-import { getConversationOverrideProfile } from "../../memory/conversation-crud.js";
-import type { Message } from "../../providers/types.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import {
+  getConversationOverrideProfile,
+  getMessages,
+} from "../../memory/conversation-crud.js";
+import type { ContentBlock, Message } from "../../providers/types.js";
+import {
+  advisorRequestText,
+  buildAdvisorSystem,
+} from "../../subagent/consult-prompt.js";
+import { sanitizeConsultTranscript } from "../../subagent/consult-transcript.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import type { SubagentRole } from "../../subagent/types.js";
+import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("subagent-spawn");
+
+/** Hard ceiling on a single advisor consult — mirrors the old advisor plugin. */
+const ADVISOR_TIMEOUT_MS = 60_000;
 
 export async function executeSubagentSpawn(
   input: Record<string, unknown>,
@@ -61,6 +76,18 @@ export async function executeSubagentSpawn(
       content: "No client connected - cannot spawn subagent.",
       isError: true,
     };
+  }
+
+  // ── Advisor role: synchronous, tool-less, stronger-model consult ──
+  // Branch before the fire-and-forget path: the advisor blocks on the run and
+  // returns its guidance as the tool result in the same turn.
+  if (role === "advisor") {
+    return runAdvisorConsult({
+      context,
+      label,
+      sendToClient: sendToClient as (msg: ServerMessage) => void,
+      requestedOverrideProfile,
+    });
   }
 
   // ── Fork mode: resolve parent context ────────────────────────────
@@ -167,4 +194,147 @@ export async function executeSubagentSpawn(
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Failed to spawn subagent: ${msg}`, isError: true };
   }
+}
+
+// ── Advisor consult ──────────────────────────────────────────────────
+
+/**
+ * Run the `advisor` role as a synchronous, context-inheriting, stronger-model
+ * consult and return its guidance as the tool result.
+ *
+ * Inherits the parent transcript (sanitized), frames it as advice via
+ * `buildAdvisorSystem`, runs tool-less on `llm.advisorProfile` (unless the
+ * caller passed an explicit `inference_profile`), bounded by a 60s timeout, and
+ * degrades to a benign non-error notice on any failure (including the
+ * depth-limit rejection when a subagent itself calls the advisor).
+ */
+async function runAdvisorConsult(args: {
+  context: ToolContext;
+  label: string;
+  sendToClient: (msg: ServerMessage) => void;
+  requestedOverrideProfile: string | undefined;
+}): Promise<ToolExecutionResult> {
+  const { context, label, sendToClient, requestedOverrideProfile } = args;
+
+  try {
+    const parentConversation = findConversation(context.conversationId);
+    if (!parentConversation) {
+      return {
+        content:
+          "(advisor unavailable: parent conversation could not be resolved)",
+        isError: false,
+      };
+    }
+
+    // Snapshot the parent's in-memory transcript and system prompt, then append
+    // the in-flight assistant turn (the plan/text the model wrote THIS turn,
+    // before calling the advisor). The in-memory array does not yet hold that
+    // turn — the agent loop only writes it back to `conversation.messages` after
+    // the turn settles — but it is already persisted to the DB (the assistant
+    // row is finalized at `message_complete`, which fires before tool execution).
+    // `sanitizeConsultTranscript` then strips the dangling advisor `tool_use`
+    // off that final assistant turn so the inherited transcript is provider-safe.
+    const parentSystemPrompt = parentConversation.getCurrentSystemPrompt();
+    const withInFlight = appendInFlightAssistantTurn(
+      [...parentConversation.messages],
+      context.conversationId,
+    );
+    const sanitizedMessages = sanitizeConsultTranscript(withInFlight);
+
+    // Default to the stronger advisor profile when the caller did not pin one;
+    // an explicit `inference_profile` wins (already forced upstream).
+    const advisorProfile = getConfig().llm.advisorProfile;
+    const overrideProfile = requestedOverrideProfile ?? advisorProfile;
+    const forceOverrideProfile = overrideProfile !== undefined;
+
+    // Combine the caller's signal with a hard 60s ceiling.
+    const timeout = AbortSignal.timeout(ADVISOR_TIMEOUT_MS);
+    const signal = context.signal
+      ? AbortSignal.any([context.signal, timeout])
+      : timeout;
+
+    const advice = await getSubagentManager().spawnAndAwait(
+      {
+        parentConversationId: context.conversationId,
+        label,
+        objective: advisorRequestText(),
+        sendResultToUser: false,
+        role: "advisor",
+        fork: true,
+        parentMessages: sanitizedMessages,
+        parentSystemPrompt,
+        systemPromptOverride: buildAdvisorSystem(parentSystemPrompt),
+        ...(overrideProfile ? { overrideProfile } : {}),
+        ...(forceOverrideProfile ? { forceOverrideProfile: true } : {}),
+        ...(context.toolUseId ? { parentToolUseId: context.toolUseId } : {}),
+      },
+      sendToClient,
+      {
+        signal,
+        ...(context.onOutput ? { onText: context.onOutput } : {}),
+      },
+    );
+
+    const trimmed = advice.trim();
+    return {
+      content: trimmed.length > 0 ? trimmed : "(advisor returned no guidance)",
+      isError: false,
+    };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { err, conversationId: context.conversationId },
+      "Advisor consult failed",
+    );
+    // Never fail the turn — the advisor is advice, not a blocker.
+    return { content: `(advisor unavailable: ${reason})`, isError: false };
+  }
+}
+
+/**
+ * Append the in-flight assistant turn (persisted this turn before the advisor
+ * tool ran) to an in-memory message snapshot, unless the snapshot already ends
+ * with it. The latest persisted assistant row carries the plan/text the model
+ * wrote immediately before calling the advisor plus the dangling advisor
+ * `tool_use`; `sanitizeConsultTranscript` strips the dangling call.
+ *
+ * Best-effort: a malformed or missing row leaves the snapshot unchanged so the
+ * consult still runs over the in-memory history.
+ */
+function appendInFlightAssistantTurn(
+  messages: Message[],
+  conversationId: string,
+): Message[] {
+  // When the snapshot already ends on an assistant turn, the in-flight turn is
+  // present (or there is none to add) — appending the latest row would duplicate it.
+  if (messages[messages.length - 1]?.role === "assistant") return messages;
+
+  let rows;
+  try {
+    rows = getMessages(conversationId);
+  } catch {
+    return messages;
+  }
+  if (!rows || rows.length === 0) return messages;
+
+  const lastRow = rows[rows.length - 1];
+  if (lastRow.role !== "assistant") return messages;
+
+  let blocks: ContentBlock[];
+  try {
+    const parsed = JSON.parse(lastRow.content);
+    if (Array.isArray(parsed)) {
+      blocks = parsed as ContentBlock[];
+    } else if (typeof parsed === "string") {
+      blocks = [{ type: "text", text: parsed }];
+    } else {
+      return messages;
+    }
+  } catch {
+    // Plain-text content (no JSON envelope).
+    blocks = [{ type: "text", text: lastRow.content }];
+  }
+
+  if (blocks.length === 0) return messages;
+  return [...messages, { role: "assistant", content: blocks }];
 }


### PR DESCRIPTION
## Summary
- role: advisor → synchronous spawnAndAwait consult: inherits + sanitizes the parent transcript, advice-framed system prompt embedding the executor prompt, defaults to llm.advisorProfile, tool-less, 60s timeout, benign degradation (incl. depth limit).
- Closes two Codex review items deferred from PR 4/PR 5 (sanitizer wired incl. in-flight dangling tool_use; advisor role delivers the advertised synchronous/full-context/stronger-profile semantics).

Part of plan: advisor-as-subagent-role.md (PR 6 of 10)