### PR TITLE
Extract sidebar conversation rows/sections into components (LUM-2572)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -16,28 +16,26 @@ import { useCommandPaletteStore } from "@/stores/command-palette-store";
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
 import { CollapsedGroupIcon, getGroupIndicatorState } from "@/domains/chat/components/collapsed-group-icon";
 import {
-    ConversationActionsMenu,
-    renderConversationMenuItems,
-    type ConversationMenuItemsProps,
-} from "@/domains/chat/components/conversation-actions-menu";
+    ConversationListProvider,
+    type ConversationListContextValue,
+} from "@/domains/chat/components/conversation-list-context";
+import {
+    ConversationNavSection,
+    ConversationRowList,
+} from "@/domains/chat/components/conversation-nav-section";
+import { CollapsedGroupFlyout } from "@/domains/chat/components/conversation-rail-flyout";
 import { GroupActionsMenu, renderGroupMenuItems } from "@/domains/chat/components/group-actions-menu";
-import { ThreadPinToggle } from "@/domains/chat/components/thread-pin-toggle";
 import { useDragReorder } from "@/domains/chat/hooks/use-drag-reorder";
-import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type PaginatedSection, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
-import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
-import { isConversationPinned } from "@/domains/chat/utils/group-conversations";
+import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
 import { channelSectionKey } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { Conversation } from "@/types/conversation-types";
-import { canMarkRead, canMarkUnread } from "@/utils/conversation-predicates";
 import { getChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
 import {
     Button,
     ContextMenu,
-    PanelItem,
     SideMenu,
 } from "@vellumai/design-library";
-import { cn } from "@vellumai/design-library/utils/cn";
 
 /** @deprecated Use {@link SIDEBAR_CONVERSATION_LIMIT} from `use-sidebar-state.ts` */
 export const ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT = SIDEBAR_CONVERSATION_LIMIT;
@@ -68,7 +66,7 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
    * Persist a drag-reorder within a section. Receives the section's full
    * conversation list in its new order. When omitted, rows aren't draggable.
    * Only sections that honor `displayOrder` (Pinned, custom groups) offer
-   * drag-reordering — Recents and Slack stay recency-sorted.
+   * drag-reordering — Recents and channel sections stay recency-sorted.
    */
   onReorderConversations?: (conversations: Conversation[]) => void;
   onRenameConversation?: (conversation: Conversation) => void;
@@ -119,10 +117,17 @@ function SearchButton({ onClose }: { onClose?: () => void }) {
  *     • thread …       — recent conversations inline
  *     • …
  *     • Show more/less — page through recent conversations
- *     • Slack ▾        — collapsible category when Slack conversations exist
+ *     • Channel ▾      — one collapsible section per origin channel
+ *                        (Slack, Telegram, WhatsApp, …)
  *   Footer
  *     • ───────────────
  *     • caller-provided action (PreferencesMenu)
+ *
+ * The conversation rows, row lists, and collapsible sections are
+ * components ({@link ConversationRow} / {@link ConversationRowList} /
+ * {@link ConversationNavSection}); their shared action callbacks and state
+ * flow through {@link ConversationListProvider} rather than being threaded
+ * as props.
  */
 export function AssistantSideMenu({
   assistantId,
@@ -182,114 +187,8 @@ export function AssistantSideMenu({
     onReorder: (_section, ordered) => onReorderConversations?.(ordered),
   });
 
-  const buildDragProps = (
-    section: string | undefined,
-    items: Conversation[],
-    conversation: Conversation,
-  ) => {
-    if (!section || !onReorderConversations || items.length < 2) return {};
-    const { draggingId, dropIndicator } = dragReorder;
-    const edge =
-      dropIndicator?.section === section &&
-      dropIndicator.itemId === conversation.conversationId
-        ? dropIndicator.edge
-        : null;
-    return {
-      ...dragReorder.getItemProps(section, items, conversation),
-      className: cn(
-        draggingId === conversation.conversationId && "opacity-50",
-        edge === "before" && "shadow-[inset_0_2px_0_0_var(--primary-base)]",
-        edge === "after" && "shadow-[inset_0_-2px_0_0_var(--primary-base)]",
-      ),
-    };
-  };
-
-  // --- Render helpers (action wiring, context menu, pin toggle) ---
-
-  const renderThreadPinToggle = (conversation: Conversation): ReactNode => {
-    const isProcessing =
-      conversation.conversationId === activeConversationId
-        ? activeConversationProcessing ?? false
-        : processingConversationIds?.has(conversation.conversationId) ?? false;
-    const needsAttention = attentionConversationIds?.has(conversation.conversationId) ?? false;
-    return (
-      <ThreadPinToggle
-        conversation={conversation}
-        isProcessing={isProcessing}
-        needsAttention={needsAttention}
-        onPinToggle={
-          onPinConversation ? () => onPinConversation(conversation) : undefined
-        }
-      />
-    );
-  };
-
-  const buildConversationMenuProps = (
-    conversation: Conversation,
-  ): ConversationMenuItemsProps => {
-    const isChannel = isChannelConversation(conversation);
-    return {
-      isPinned: isConversationPinned(conversation),
-      isArchived: conversation.archivedAt != null,
-      isReadonly: isChannel,
-      onPinToggle: onPinConversation
-        ? () => onPinConversation(conversation)
-        : undefined,
-      onRename: onRenameConversation
-        ? () => onRenameConversation(conversation)
-        : undefined,
-      onArchive: onArchiveConversation
-        ? () => onArchiveConversation(conversation)
-        : undefined,
-      onUnarchive: onUnarchiveConversation
-        ? () => onUnarchiveConversation(conversation)
-        : undefined,
-      onMarkRead:
-        onMarkConversationRead && canMarkRead(conversation)
-          ? () => onMarkConversationRead(conversation)
-          : undefined,
-      onMarkUnread:
-        onMarkConversationUnread && !canMarkRead(conversation)
-          ? () => onMarkConversationUnread(conversation)
-          : undefined,
-      isMarkUnreadDisabled: !canMarkUnread(conversation),
-      onAnalyze:
-        onAnalyze && conversation.conversationId != null && !isChannel
-          ? () => onAnalyze(conversation)
-          : undefined,
-      onOpenInNewWindow:
-        onOpenInNewWindow && conversation.conversationId != null
-          ? () => onOpenInNewWindow(conversation)
-          : undefined,
-      onShareFeedback,
-      onInspect:
-        onInspect && conversation.conversationId != null
-          ? () => onInspect(conversation)
-          : undefined,
-    };
-  };
-
-  const renderThreadActions = (conversation: Conversation): ReactNode => (
-    <ConversationActionsMenu {...buildConversationMenuProps(conversation)} />
-  );
-
-  const renderThreadRow = (
-    conversation: Conversation,
-    panelItem: ReactNode,
-  ): ReactNode => {
-    const menuProps = buildConversationMenuProps(conversation);
-    return (
-      <ContextMenu.Root key={conversation.conversationId}>
-        <ContextMenu.Trigger>{panelItem}</ContextMenu.Trigger>
-        <ContextMenu.Content
-          onClick={(event) => event.stopPropagation()}
-        >
-          {renderConversationMenuItems({ Primitive: ContextMenu, ...menuProps })}
-        </ContextMenu.Content>
-      </ContextMenu.Root>
-    );
-  };
-
+  // Context menu content for a section header (channel section / custom
+  // group). Returns undefined when no group-level action is available.
   const buildGroupContextMenu = (
     groupName: string,
     conversations: Conversation[],
@@ -321,6 +220,30 @@ export function AssistantSideMenu({
     [onSelectConversation, onClose],
   );
 
+  // Shared context for every conversation row (Pinned, Recents, channel
+  // sections, custom groups, rail flyout) — lifts the action callbacks,
+  // active/processing/attention state, and drag controller out of the
+  // per-row closures this component used to carry.
+  const listContext: ConversationListContextValue = {
+    activeConversationId,
+    activeConversationProcessing,
+    processingConversationIds,
+    attentionConversationIds,
+    onSelect: selectAndClose,
+    onPin: onPinConversation,
+    onRename: onRenameConversation,
+    onArchive: onArchiveConversation,
+    onUnarchive: onUnarchiveConversation,
+    onMarkRead: onMarkConversationRead,
+    onMarkUnread: onMarkConversationUnread,
+    onAnalyze,
+    onOpenInNewWindow,
+    onShareFeedback,
+    onInspect,
+    dragReorder,
+    canReorder: !!onReorderConversations,
+  };
+
   // --- Header actions ---
   // A plain icon button that starts a new conversation on click.
 
@@ -339,297 +262,232 @@ export function AssistantSideMenu({
     />
   ) : null;
 
-  // --- Flat conversation list renderer ---
-
-  const renderFlatList = (
-    items: Conversation[],
-    pagination?: Pick<
-      PaginatedSection,
-      "showMore" | "onShowMore" | "showLess" | "onShowLess"
-    >,
-    reorderSection?: string,
-  ): ReactNode => (
-    <SideMenu.SubList>
-      {items.map((c) =>
-        renderThreadRow(
-          c,
-          <PanelItem
-            leadingSlot={renderThreadPinToggle(c)}
-            label={c.title ?? "Untitled"}
-            marqueeOnHover
-            active={c.conversationId === activeConversationId}
-            onSelect={() => selectAndClose(c.conversationId)}
-            trailingAction={renderThreadActions(c)}
-            {...buildDragProps(reorderSection, items, c)}
-          />,
-        ),
-      )}
-      {pagination?.showMore ? (
-        <SideMenu.Item
-          label="Show more"
-          size="compact"
-          indent
-          emphasized
-          onSelect={pagination.onShowMore}
-        />
-      ) : null}
-      {pagination?.showLess ? (
-        <SideMenu.Item
-          label="Show less"
-          size="compact"
-          indent
-          emphasized
-          onSelect={pagination.onShowLess}
-        />
-      ) : null}
-    </SideMenu.SubList>
-  );
-
-  // --- Collapsed-rail popover content renderer ---
-
-  const renderCollapsedGroupContent = (title: string, conversations: Conversation[], closePopover?: () => void, emptyState?: ReactNode): ReactNode => (
-    <div className="pb-1">
-      <div className="flex items-center justify-between px-4 py-1">
-        <span className="text-body-small-default text-[var(--content-tertiary)]">{title}</span>
-      </div>
-      <div className="px-2">
-        {conversations.length === 0 ? emptyState : null}
-        {conversations.map((c) => (
-          <PanelItem
-            key={c.conversationId}
-            leadingSlot={renderThreadPinToggle(c)}
-            label={c.title ?? "Untitled"}
-            active={c.conversationId === activeConversationId}
-            onSelect={() => { closePopover?.(); selectAndClose(c.conversationId); }}
-            trailingAction={renderThreadActions(c)}
-          />
-        ))}
-      </div>
-    </div>
-  );
-
   // --- JSX ---
 
   return (
-    <SideMenu
-      ariaLabel="Assistant navigation"
-      collapsed={collapsed}
-      variant={variant}
-      width={width}
-      onWidthChange={onWidthChange}
-      className="h-full"
-    >
-      <SideMenu.Header>
-        {variant === "overlay" ? (
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                iconOnly={<X />}
-                aria-label="Close navigation"
-                onClick={() => onClose?.()}
-              />
-              <SearchButton onClose={onClose} />
+    <ConversationListProvider value={listContext}>
+      <SideMenu
+        ariaLabel="Assistant navigation"
+        collapsed={collapsed}
+        variant={variant}
+        width={width}
+        onWidthChange={onWidthChange}
+        className="h-full"
+      >
+        <SideMenu.Header>
+          {variant === "overlay" ? (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  iconOnly={<X />}
+                  aria-label="Close navigation"
+                  onClick={() => onClose?.()}
+                />
+                <SearchButton onClose={onClose} />
+              </div>
+              <div className="flex items-center gap-2">{headerActions}</div>
             </div>
-            <div className="flex items-center gap-2">{headerActions}</div>
-          </div>
-        ) : null}
-        {/* 2px row gap to match the conversation list. */}
-        <div className="flex flex-col gap-[2px]">
-          <SideMenu.Item
-            icon={Brain}
-            label={assistantName || "Your Assistant"}
-            showCollapsedTooltip
-            active={isIntelligenceActive}
-            onSelect={onOpenIntelligence ? () => { onOpenIntelligence(); onClose?.(); } : undefined}
-          />
-          {onOpenLibrary ? (
-            <SideMenu.Item
-              icon={LayoutGrid}
-              label="Library"
-              showCollapsedTooltip
-              active={isLibraryActive}
-              onSelect={onOpenLibrary ? () => { onOpenLibrary(); onClose?.(); } : undefined}
-            />
           ) : null}
-          {onOpenHome ? (
+          {/* 2px row gap to match the conversation list. */}
+          <div className="flex flex-col gap-[2px]">
             <SideMenu.Item
-              icon={Calendar}
-              label="Activity"
+              icon={Brain}
+              label={assistantName || "Your Assistant"}
               showCollapsedTooltip
-              active={isHomeActive}
-              badge={
-                hasUnreadHome && !isHomeActive ? (
-                  <span
-                    className="h-2 w-2 rounded-full bg-[var(--system-negative-strong)]"
-                    aria-hidden="true"
-                  />
-                ) : undefined
-              }
-              onSelect={onOpenHome ? () => { onOpenHome(); onClose?.(); } : undefined}
+              active={isIntelligenceActive}
+              onSelect={onOpenIntelligence ? () => { onOpenIntelligence(); onClose?.(); } : undefined}
             />
-          ) : null}
-          {pinnedApps.map((app) => (
-            <SideMenu.Item
-              key={app.appId}
-              // Apps source their icon as an emoji string on the manifest
-              // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
-              // apps still get a leading icon in the rail.
-              icon={app.icon ?? Rocket}
-              label={app.name}
-              showCollapsedTooltip
-              active={activeAppId === app.appId}
-              onSelect={onOpenApp ? () => { onOpenApp(app.appId); onClose?.(); } : undefined}
-            />
-          ))}
-        </div>
-        <SideMenu.Separator />
-      </SideMenu.Header>
-
-      <SideMenu.Body className="gap-1 pt-3 max-md:pt-4">
-        {collapsed && variant === "rail" ? (
-          <div className="flex flex-col items-center gap-1">
-            {headerActions}
-            {sidebar.pinned.length > 0 ? (
-              <CollapsedGroupIcon
-                icon={Pin}
-                label="Pinned"
-                indicatorState={getGroupIndicatorState(sidebar.pinned, processingConversationIds, attentionConversationIds)}
-              >
-                {(close) => renderCollapsedGroupContent("Pinned", sidebar.pinned, close)}
-              </CollapsedGroupIcon>
+            {onOpenLibrary ? (
+              <SideMenu.Item
+                icon={LayoutGrid}
+                label="Library"
+                showCollapsedTooltip
+                active={isLibraryActive}
+                onSelect={onOpenLibrary ? () => { onOpenLibrary(); onClose?.(); } : undefined}
+              />
             ) : null}
-            <CollapsedGroupIcon
-              icon={Clock}
-              label="Recents"
-              disabled={sidebar.recents.all.length === 0}
-              indicatorState={getGroupIndicatorState(sidebar.recents.all, processingConversationIds, attentionConversationIds)}
-            >
-              {(close) => renderCollapsedGroupContent("Recents", sidebar.recents.all, close)}
-            </CollapsedGroupIcon>
-            {sidebar.channelSections.map((section) => (
-              <CollapsedGroupIcon
-                key={section.channelId}
-                icon={getChannelIcon(section.channelId)}
-                label={getChannelLabel(section.channelId)}
-                disabled={section.totalCount === 0}
-                indicatorState={getGroupIndicatorState(section.all, processingConversationIds, attentionConversationIds)}
-              >
-                {(close) => renderCollapsedGroupContent(getChannelLabel(section.channelId), section.all, close)}
-              </CollapsedGroupIcon>
+            {onOpenHome ? (
+              <SideMenu.Item
+                icon={Calendar}
+                label="Activity"
+                showCollapsedTooltip
+                active={isHomeActive}
+                badge={
+                  hasUnreadHome && !isHomeActive ? (
+                    <span
+                      className="h-2 w-2 rounded-full bg-[var(--system-negative-strong)]"
+                      aria-hidden="true"
+                    />
+                  ) : undefined
+                }
+                onSelect={onOpenHome ? () => { onOpenHome(); onClose?.(); } : undefined}
+              />
+            ) : null}
+            {pinnedApps.map((app) => (
+              <SideMenu.Item
+                key={app.appId}
+                // Apps source their icon as an emoji string on the manifest
+                // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
+                // apps still get a leading icon in the rail.
+                icon={app.icon ?? Rocket}
+                label={app.name}
+                showCollapsedTooltip
+                active={activeAppId === app.appId}
+                onSelect={onOpenApp ? () => { onOpenApp(app.appId); onClose?.(); } : undefined}
+              />
             ))}
           </div>
-        ) : (
-          <>
-            {sidebar.pinned.length > 0 ? (
-              <SideMenu.Section title="Pinned">
-                {renderFlatList(sidebar.pinned, undefined, "pinned")}
-              </SideMenu.Section>
-            ) : null}
-
-            <SideMenu.Section
-              title="Conversations"
-              className="gap-1"
-              actions={variant === "overlay" ? undefined : headerActions}
-            >
-              {renderFlatList(sidebar.recents.items, sidebar.recents)}
-
-              <CollapsibleNavSection.Root
-                type="multiple"
-                className="gap-1"
-                value={sidebar.effectiveOpenCategories}
-                onValueChange={sidebar.onOpenCategoriesChange}
-              >
-                {sidebar.channelSections.map((section) => {
-                  const label = getChannelLabel(section.channelId);
-                  return (
-                    <CollapsibleNavSection.Section
-                      key={section.channelId}
-                      value={channelSectionKey(section.channelId)}
-                      icon={getChannelIcon(section.channelId)}
-                      label={label}
-                      contextMenuContent={buildGroupContextMenu(label, section.all)}
-                    >
-                      {renderFlatList(section.items, section)}
-                    </CollapsibleNavSection.Section>
-                  );
-                })}
-              </CollapsibleNavSection.Root>
-
-              {sidebar.customGroups.length > 0 ? (
-                <>
-                  <SideMenu.Separator />
-                  <SideMenu.Section title="Your Groups">
-                    <CollapsibleNavSection.Root
-                      type="multiple"
-                      className="gap-1"
-                      value={sidebar.effectiveOpenCustomGroups}
-                      onValueChange={sidebar.onOpenCustomGroupsChange}
-                    >
-                      {sidebar.customGroups.map((group) => (
-                        <CollapsibleNavSection.Section
-                          key={group.id}
-                          value={group.id}
-                          label={group.name}
-                          trailing={
-                            onRenameGroup || onDeleteGroup ? (
-                              <GroupActionsMenu
-                                groupId={group.id}
-                                onRename={onRenameGroup}
-                                onDelete={onDeleteGroup}
-                              />
-                            ) : null
-                          }
-                          contextMenuContent={buildGroupContextMenu(
-                            group.name,
-                            group.conversations,
-                            {
-                              onRename: onRenameGroup
-                                ? () => onRenameGroup(group.id)
-                                : undefined,
-                              onDelete: onDeleteGroup
-                                ? () => onDeleteGroup(group.id)
-                                : undefined,
-                            },
-                          )}
-                        >
-                          <SideMenu.SubList>
-                            {group.conversations.map((c) =>
-                              renderThreadRow(
-                                c,
-                                <PanelItem
-                                  leadingSlot={renderThreadPinToggle(c)}
-                                  label={c.title ?? "Untitled"}
-                                  marqueeOnHover
-                                  active={c.conversationId === activeConversationId}
-                                  onSelect={() => selectAndClose(c.conversationId)}
-                                  trailingAction={renderThreadActions(c)}
-                                  {...buildDragProps(
-                                    `group:${group.id}`,
-                                    group.conversations,
-                                    c,
-                                  )}
-                                />,
-                              ),
-                            )}
-                          </SideMenu.SubList>
-                        </CollapsibleNavSection.Section>
-                      ))}
-                    </CollapsibleNavSection.Root>
-                  </SideMenu.Section>
-                </>
-              ) : null}
-            </SideMenu.Section>
-          </>
-        )}
-      </SideMenu.Body>
-
-      {footerAction ? (
-        <SideMenu.Footer>
           <SideMenu.Separator />
-          {footerAction}
-        </SideMenu.Footer>
-      ) : null}
-    </SideMenu>
+        </SideMenu.Header>
+
+        <SideMenu.Body className="gap-1 pt-3 max-md:pt-4">
+          {collapsed && variant === "rail" ? (
+            <div className="flex flex-col items-center gap-1">
+              {headerActions}
+              {sidebar.pinned.length > 0 ? (
+                <CollapsedGroupIcon
+                  icon={Pin}
+                  label="Pinned"
+                  indicatorState={getGroupIndicatorState(sidebar.pinned, processingConversationIds, attentionConversationIds)}
+                >
+                  {(close) => (
+                    <CollapsedGroupFlyout
+                      title="Pinned"
+                      conversations={sidebar.pinned}
+                      onClosePopover={close}
+                    />
+                  )}
+                </CollapsedGroupIcon>
+              ) : null}
+              <CollapsedGroupIcon
+                icon={Clock}
+                label="Recents"
+                disabled={sidebar.recents.all.length === 0}
+                indicatorState={getGroupIndicatorState(sidebar.recents.all, processingConversationIds, attentionConversationIds)}
+              >
+                {(close) => (
+                  <CollapsedGroupFlyout
+                    title="Recents"
+                    conversations={sidebar.recents.all}
+                    onClosePopover={close}
+                  />
+                )}
+              </CollapsedGroupIcon>
+              {sidebar.channelSections.map((section) => (
+                <CollapsedGroupIcon
+                  key={section.channelId}
+                  icon={getChannelIcon(section.channelId)}
+                  label={getChannelLabel(section.channelId)}
+                  disabled={section.totalCount === 0}
+                  indicatorState={getGroupIndicatorState(section.all, processingConversationIds, attentionConversationIds)}
+                >
+                  {(close) => (
+                    <CollapsedGroupFlyout
+                      title={getChannelLabel(section.channelId)}
+                      conversations={section.all}
+                      onClosePopover={close}
+                    />
+                  )}
+                </CollapsedGroupIcon>
+              ))}
+            </div>
+          ) : (
+            <>
+              {sidebar.pinned.length > 0 ? (
+                <SideMenu.Section title="Pinned">
+                  <ConversationRowList items={sidebar.pinned} dragSection="pinned" />
+                </SideMenu.Section>
+              ) : null}
+
+              <SideMenu.Section
+                title="Conversations"
+                className="gap-1"
+                actions={variant === "overlay" ? undefined : headerActions}
+              >
+                <ConversationRowList
+                  items={sidebar.recents.items}
+                  pagination={sidebar.recents}
+                />
+
+                <CollapsibleNavSection.Root
+                  type="multiple"
+                  className="gap-1"
+                  value={sidebar.effectiveOpenCategories}
+                  onValueChange={sidebar.onOpenCategoriesChange}
+                >
+                  {sidebar.channelSections.map((section) => {
+                    const label = getChannelLabel(section.channelId);
+                    return (
+                      <ConversationNavSection
+                        key={section.channelId}
+                        value={channelSectionKey(section.channelId)}
+                        icon={getChannelIcon(section.channelId)}
+                        label={label}
+                        contextMenuContent={buildGroupContextMenu(label, section.all)}
+                        items={section.items}
+                        pagination={section}
+                      />
+                    );
+                  })}
+                </CollapsibleNavSection.Root>
+
+                {sidebar.customGroups.length > 0 ? (
+                  <>
+                    <SideMenu.Separator />
+                    <SideMenu.Section title="Your Groups">
+                      <CollapsibleNavSection.Root
+                        type="multiple"
+                        className="gap-1"
+                        value={sidebar.effectiveOpenCustomGroups}
+                        onValueChange={sidebar.onOpenCustomGroupsChange}
+                      >
+                        {sidebar.customGroups.map((group) => (
+                          <ConversationNavSection
+                            key={group.id}
+                            value={group.id}
+                            label={group.name}
+                            trailing={
+                              onRenameGroup || onDeleteGroup ? (
+                                <GroupActionsMenu
+                                  groupId={group.id}
+                                  onRename={onRenameGroup}
+                                  onDelete={onDeleteGroup}
+                                />
+                              ) : null
+                            }
+                            contextMenuContent={buildGroupContextMenu(
+                              group.name,
+                              group.conversations,
+                              {
+                                onRename: onRenameGroup
+                                  ? () => onRenameGroup(group.id)
+                                  : undefined,
+                                onDelete: onDeleteGroup
+                                  ? () => onDeleteGroup(group.id)
+                                  : undefined,
+                              },
+                            )}
+                            items={group.conversations}
+                            dragSection={`group:${group.id}`}
+                          />
+                        ))}
+                      </CollapsibleNavSection.Root>
+                    </SideMenu.Section>
+                  </>
+                ) : null}
+              </SideMenu.Section>
+            </>
+          )}
+        </SideMenu.Body>
+
+        {footerAction ? (
+          <SideMenu.Footer>
+            <SideMenu.Separator />
+            {footerAction}
+          </SideMenu.Footer>
+        ) : null}
+      </SideMenu>
+    </ConversationListProvider>
   );
 }

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -126,8 +126,7 @@ function SearchButton({ onClose }: { onClose?: () => void }) {
  * The conversation rows, row lists, and collapsible sections are
  * components ({@link ConversationRow} / {@link ConversationRowList} /
  * {@link ConversationNavSection}); their shared action callbacks and state
- * flow through {@link ConversationListProvider} rather than being threaded
- * as props.
+ * flow through {@link ConversationListProvider}.
  */
 export function AssistantSideMenu({
   assistantId,
@@ -221,9 +220,8 @@ export function AssistantSideMenu({
   );
 
   // Shared context for every conversation row (Pinned, Recents, channel
-  // sections, custom groups, rail flyout) — lifts the action callbacks,
-  // active/processing/attention state, and drag controller out of the
-  // per-row closures this component used to carry.
+  // sections, custom groups, rail flyout): the action callbacks,
+  // active/processing/attention state, and drag controller the rows read.
   const listContext: ConversationListContextValue = {
     activeConversationId,
     activeConversationProcessing,

--- a/clients/web/src/domains/chat/components/conversation-list-context.tsx
+++ b/clients/web/src/domains/chat/components/conversation-list-context.tsx
@@ -1,0 +1,62 @@
+/**
+ * Shared context for the assistant sidebar's conversation rows.
+ *
+ * Every conversation row (in Pinned, Recents, a channel section, a custom
+ * group, or the collapsed-rail flyout) needs the same ~12 action callbacks
+ * plus the active/processing/attention state and the drag-reorder
+ * controller. Threading all of that through section → list → row as props
+ * is what kept the rendering as inline closures inside `AssistantSideMenu`.
+ *
+ * Lifting it into a context lets {@link ConversationRow} read what it needs
+ * directly, so the row/list/section pieces become real components instead
+ * of parent-bound render closures.
+ */
+
+import { createContext, useContext } from "react";
+
+import type { UseDragReorderResult } from "@/domains/chat/hooks/use-drag-reorder";
+import type { Conversation } from "@/types/conversation-types";
+
+export interface ConversationListContextValue {
+  activeConversationId?: string;
+  /** Whether the *active* conversation is mid-turn (its row shows a spinner). */
+  activeConversationProcessing?: boolean;
+  /** Conversation ids currently processing (non-active rows). */
+  processingConversationIds?: Set<string>;
+  /** Conversation ids that need attention (unseen assistant message). */
+  attentionConversationIds?: Set<string>;
+
+  /** Select a conversation (and close the overlay sidebar on mobile). */
+  onSelect: (conversationId: string) => void;
+
+  onPin?: (conversation: Conversation) => void;
+  onRename?: (conversation: Conversation) => void;
+  onArchive?: (conversation: Conversation) => void;
+  onUnarchive?: (conversation: Conversation) => void;
+  onMarkRead?: (conversation: Conversation) => void;
+  onMarkUnread?: (conversation: Conversation) => void;
+  onAnalyze?: (conversation: Conversation) => void;
+  onOpenInNewWindow?: (conversation: Conversation) => void;
+  onShareFeedback?: () => void;
+  onInspect?: (conversation: Conversation) => void;
+
+  /** Drag-reorder controller; rows derive their own drag props from it. */
+  dragReorder: UseDragReorderResult<Conversation>;
+  /** True when reordering is wired (an `onReorder` handler exists). */
+  canReorder: boolean;
+}
+
+const ConversationListContext =
+  createContext<ConversationListContextValue | null>(null);
+
+export const ConversationListProvider = ConversationListContext.Provider;
+
+export function useConversationListContext(): ConversationListContextValue {
+  const ctx = useContext(ConversationListContext);
+  if (!ctx) {
+    throw new Error(
+      "useConversationListContext must be used within a ConversationListProvider",
+    );
+  }
+  return ctx;
+}

--- a/clients/web/src/domains/chat/components/conversation-list-context.tsx
+++ b/clients/web/src/domains/chat/components/conversation-list-context.tsx
@@ -4,12 +4,9 @@
  * Every conversation row (in Pinned, Recents, a channel section, a custom
  * group, or the collapsed-rail flyout) needs the same ~12 action callbacks
  * plus the active/processing/attention state and the drag-reorder
- * controller. Threading all of that through section → list → row as props
- * is what kept the rendering as inline closures inside `AssistantSideMenu`.
- *
- * Lifting it into a context lets {@link ConversationRow} read what it needs
- * directly, so the row/list/section pieces become real components instead
- * of parent-bound render closures.
+ * controller. Providing them through context lets {@link ConversationRow}
+ * read what it needs directly, so the row, list, and section components
+ * don't each take a dozen props.
  */
 
 import { createContext, useContext } from "react";

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -9,8 +9,8 @@
  *   shell (icon + label + trailing + context menu) wrapping a
  *   `ConversationRowList`. Used by channel sections and custom groups.
  *
- * Both read row callbacks/state from {@link useConversationListContext}
- * via `ConversationRow`, so neither needs the row wiring threaded through.
+ * Row callbacks and state come from {@link useConversationListContext}
+ * (via `ConversationRow`), so neither takes them as props.
  */
 
 import { type ReactNode } from "react";

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -1,0 +1,112 @@
+/**
+ * The two list-shaped pieces of the sidebar conversation list:
+ *
+ * - {@link ConversationRowList} — a `SideMenu.SubList` of
+ *   {@link ConversationRow}s with optional "Show more / Show less"
+ *   pagination. Used directly by Pinned and Recents, and inside every
+ *   collapsible section.
+ * - {@link ConversationNavSection} — a `CollapsibleNavSection.Section`
+ *   shell (icon + label + trailing + context menu) wrapping a
+ *   `ConversationRowList`. Used by channel sections and custom groups.
+ *
+ * Both read row callbacks/state from {@link useConversationListContext}
+ * via `ConversationRow`, so neither needs the row wiring threaded through.
+ */
+
+import { type ReactNode } from "react";
+
+import { type LucideIcon } from "lucide-react";
+
+import { SideMenu } from "@vellumai/design-library";
+
+import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
+import { ConversationRow } from "@/domains/chat/components/conversation-row";
+import type { PaginatedSection } from "@/domains/chat/use-sidebar-state";
+import type { Conversation } from "@/types/conversation-types";
+
+type PaginationControls = Pick<
+  PaginatedSection,
+  "showMore" | "onShowMore" | "showLess" | "onShowLess"
+>;
+
+export interface ConversationRowListProps {
+  items: Conversation[];
+  /** Drag-reorder section key; omit for non-reorderable lists. */
+  dragSection?: string;
+  /**
+   * Full ordered list for drag math. Defaults to `items` — pass explicitly
+   * only when the visible `items` are a paginated subset (drag operates on
+   * the whole section).
+   */
+  dragSiblings?: Conversation[];
+  /** Show-more/less controls; omit for non-paginated lists (Pinned, groups). */
+  pagination?: PaginationControls;
+}
+
+export function ConversationRowList({
+  items,
+  dragSection,
+  dragSiblings,
+  pagination,
+}: ConversationRowListProps) {
+  return (
+    <SideMenu.SubList>
+      {items.map((conversation) => (
+        <ConversationRow
+          key={conversation.conversationId}
+          conversation={conversation}
+          dragSection={dragSection}
+          dragSiblings={dragSiblings ?? items}
+        />
+      ))}
+      {pagination?.showMore ? (
+        <SideMenu.Item
+          label="Show more"
+          size="compact"
+          indent
+          emphasized
+          onSelect={pagination.onShowMore}
+        />
+      ) : null}
+      {pagination?.showLess ? (
+        <SideMenu.Item
+          label="Show less"
+          size="compact"
+          indent
+          emphasized
+          onSelect={pagination.onShowLess}
+        />
+      ) : null}
+    </SideMenu.SubList>
+  );
+}
+
+export interface ConversationNavSectionProps extends ConversationRowListProps {
+  /** Collapse/expand key (matches the controlling `CollapsibleNavSection.Root`). */
+  value: string;
+  label: string;
+  icon?: LucideIcon;
+  trailing?: ReactNode;
+  contextMenuContent?: ReactNode;
+}
+
+export function ConversationNavSection({
+  value,
+  label,
+  icon,
+  trailing,
+  contextMenuContent,
+  ...listProps
+}: ConversationNavSectionProps) {
+  return (
+    <CollapsibleNavSection.Section
+      value={value}
+      icon={icon}
+      label={label}
+      trailing={trailing}
+      contextMenuContent={contextMenuContent}
+    >
+      <ConversationRowList {...listProps} />
+    </CollapsibleNavSection.Section>
+  );
+}

--- a/clients/web/src/domains/chat/components/conversation-rail-flyout.tsx
+++ b/clients/web/src/domains/chat/components/conversation-rail-flyout.tsx
@@ -1,0 +1,50 @@
+/**
+ * Flyout body shown when a collapsed-rail group icon is opened.
+ *
+ * Rows here are deliberately lighter than the full sidebar: no right-click
+ * context menu, no hover marquee, no drag — but they keep the trailing
+ * actions menu. Selecting a row closes the flyout popover and then runs the
+ * normal select (which also closes the overlay sidebar on mobile).
+ */
+
+import { useConversationListContext } from "@/domains/chat/components/conversation-list-context";
+import { ConversationRow } from "@/domains/chat/components/conversation-row";
+import type { Conversation } from "@/types/conversation-types";
+
+export interface CollapsedGroupFlyoutProps {
+  title: string;
+  conversations: Conversation[];
+  /** Close the rail flyout popover (in addition to selecting). */
+  onClosePopover?: () => void;
+}
+
+export function CollapsedGroupFlyout({
+  title,
+  conversations,
+  onClosePopover,
+}: CollapsedGroupFlyoutProps) {
+  const ctx = useConversationListContext();
+  return (
+    <div className="pb-1">
+      <div className="flex items-center justify-between px-4 py-1">
+        <span className="text-body-small-default text-[var(--content-tertiary)]">
+          {title}
+        </span>
+      </div>
+      <div className="px-2">
+        {conversations.map((conversation) => (
+          <ConversationRow
+            key={conversation.conversationId}
+            conversation={conversation}
+            withContextMenu={false}
+            marquee={false}
+            onSelect={(id) => {
+              onClosePopover?.();
+              ctx.onSelect(id);
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/conversation-row.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildDragProps,
+  buildMenuProps,
+} from "@/domains/chat/components/conversation-row";
+import type { ConversationListContextValue } from "@/domains/chat/components/conversation-list-context";
+import type { UseDragReorderResult } from "@/domains/chat/hooks/use-drag-reorder";
+import type { Conversation } from "@/types/conversation-types";
+
+const stubDragReorder: UseDragReorderResult<Conversation> = {
+  getItemProps: () => ({
+    draggable: true,
+    onDragStart: () => {},
+    onDragOver: () => {},
+    onDragLeave: () => {},
+    onDrop: () => {},
+    onDragEnd: () => {},
+  }),
+  draggingId: null,
+  dropIndicator: null,
+};
+
+function makeCtx(
+  overrides: Partial<ConversationListContextValue> = {},
+): ConversationListContextValue {
+  return {
+    onSelect: () => {},
+    dragReorder: stubDragReorder,
+    canReorder: false,
+    ...overrides,
+  };
+}
+
+function conv(overrides: Partial<Conversation> = {}): Conversation {
+  return { conversationId: overrides.conversationId ?? "c1", ...overrides };
+}
+
+describe("buildMenuProps", () => {
+  test("marks channel conversations read-only and omits analyze", () => {
+    const props = buildMenuProps(
+      makeCtx({ onAnalyze: () => {} }),
+      conv({ originChannel: "telegram" }),
+    );
+    expect(props.isReadonly).toBe(true);
+    expect(props.onAnalyze).toBeUndefined();
+  });
+
+  test("wires analyze for native conversations", () => {
+    const props = buildMenuProps(
+      makeCtx({ onAnalyze: () => {} }),
+      conv({ originChannel: "vellum" }),
+    );
+    expect(props.isReadonly).toBe(false);
+    expect(typeof props.onAnalyze).toBe("function");
+  });
+
+  test("only wires callbacks the context provides", () => {
+    const bare = buildMenuProps(makeCtx(), conv());
+    expect(bare.onRename).toBeUndefined();
+    expect(bare.onArchive).toBeUndefined();
+
+    const wired = buildMenuProps(
+      makeCtx({ onRename: () => {}, onArchive: () => {} }),
+      conv(),
+    );
+    expect(typeof wired.onRename).toBe("function");
+    expect(typeof wired.onArchive).toBe("function");
+  });
+
+  test("offers mark-read for unread rows and mark-unread for read rows", () => {
+    const ctx = makeCtx({ onMarkRead: () => {}, onMarkUnread: () => {} });
+
+    const unread = buildMenuProps(
+      ctx,
+      conv({ hasUnseenLatestAssistantMessage: true }),
+    );
+    expect(typeof unread.onMarkRead).toBe("function");
+    expect(unread.onMarkUnread).toBeUndefined();
+
+    const read = buildMenuProps(
+      ctx,
+      conv({ hasUnseenLatestAssistantMessage: false }),
+    );
+    expect(read.onMarkRead).toBeUndefined();
+    expect(typeof read.onMarkUnread).toBe("function");
+  });
+});
+
+describe("buildDragProps", () => {
+  const a = conv({ conversationId: "a" });
+  const b = conv({ conversationId: "b" });
+
+  test("returns nothing when reordering is disabled", () => {
+    expect(buildDragProps(makeCtx({ canReorder: false }), a, "pinned", [a, b])).toEqual(
+      {},
+    );
+  });
+
+  test("returns nothing without a section or with fewer than two siblings", () => {
+    const ctx = makeCtx({ canReorder: true });
+    expect(buildDragProps(ctx, a, undefined, [a, b])).toEqual({});
+    expect(buildDragProps(ctx, a, "pinned", [a])).toEqual({});
+  });
+
+  test("dims the row currently being dragged", () => {
+    const ctx = makeCtx({
+      canReorder: true,
+      dragReorder: { ...stubDragReorder, draggingId: "a" },
+    });
+    const props = buildDragProps(ctx, a, "pinned", [a, b]);
+    expect(props.draggable).toBe(true);
+    expect(props.className).toContain("opacity-50");
+  });
+
+  test("draws the drop line on the hovered edge within the same section", () => {
+    const ctx = makeCtx({
+      canReorder: true,
+      dragReorder: {
+        ...stubDragReorder,
+        dropIndicator: { section: "pinned", itemId: "b", edge: "before" },
+      },
+    });
+    const props = buildDragProps(ctx, b, "pinned", [a, b]);
+    expect(props.className).toContain(
+      "shadow-[inset_0_2px_0_0_var(--primary-base)]",
+    );
+  });
+
+  test("ignores a drop indicator from another section", () => {
+    const ctx = makeCtx({
+      canReorder: true,
+      dragReorder: {
+        ...stubDragReorder,
+        dropIndicator: { section: "group:x", itemId: "b", edge: "after" },
+      },
+    });
+    const props = buildDragProps(ctx, b, "pinned", [a, b]);
+    expect(props.className).not.toContain("shadow-");
+  });
+});

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -1,13 +1,12 @@
 /**
- * A single conversation row in the assistant sidebar.
+ * A single conversation row in the assistant sidebar: a pin/processing
+ * toggle, the title, an actions menu, an optional right-click context
+ * menu, and optional drag-reorder. Action callbacks, active/processing
+ * state, and the drag controller come from
+ * {@link useConversationListContext}.
  *
- * Replaces the parent-bound `renderThreadRow` / `renderThreadPinToggle` /
- * `renderThreadActions` / `buildConversationMenuProps` / `buildDragProps`
- * closures: each row now reads its action callbacks, active/processing
- * state, and the drag controller from {@link useConversationListContext}.
- *
- * Used by every list surface — Pinned, Recents, channel sections, custom
- * groups, and the collapsed-rail flyout. The flyout passes
+ * Rendered in every list surface — Pinned, Recents, channel sections,
+ * custom groups, and the collapsed-rail flyout. The flyout passes
  * `withContextMenu={false}` (no right-click menu) and `marquee={false}`.
  */
 

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -1,0 +1,165 @@
+/**
+ * A single conversation row in the assistant sidebar.
+ *
+ * Replaces the parent-bound `renderThreadRow` / `renderThreadPinToggle` /
+ * `renderThreadActions` / `buildConversationMenuProps` / `buildDragProps`
+ * closures: each row now reads its action callbacks, active/processing
+ * state, and the drag controller from {@link useConversationListContext}.
+ *
+ * Used by every list surface — Pinned, Recents, channel sections, custom
+ * groups, and the collapsed-rail flyout. The flyout passes
+ * `withContextMenu={false}` (no right-click menu) and `marquee={false}`.
+ */
+
+import { ContextMenu, PanelItem } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library/utils/cn";
+
+import {
+  ConversationActionsMenu,
+  renderConversationMenuItems,
+  type ConversationMenuItemsProps,
+} from "@/domains/chat/components/conversation-actions-menu";
+import { ThreadPinToggle } from "@/domains/chat/components/thread-pin-toggle";
+import type { DragReorderItemProps } from "@/domains/chat/hooks/use-drag-reorder";
+import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
+import { isConversationPinned } from "@/domains/chat/utils/group-conversations";
+import type { Conversation } from "@/types/conversation-types";
+import { canMarkRead, canMarkUnread } from "@/utils/conversation-predicates";
+
+import {
+  type ConversationListContextValue,
+  useConversationListContext,
+} from "./conversation-list-context";
+
+export interface ConversationRowProps {
+  conversation: Conversation;
+  /**
+   * Drag-reorder section key. Omit for non-reorderable lists (Recents,
+   * channel sections) — only Pinned and custom groups reorder.
+   */
+  dragSection?: string;
+  /** The section's full ordered list, for drag math. Defaults to nothing. */
+  dragSiblings?: Conversation[];
+  /** Wrap in a right-click context menu. Default true; false in the rail flyout. */
+  withContextMenu?: boolean;
+  /** Marquee the title on hover. Default true; false in the rail flyout. */
+  marquee?: boolean;
+  /** Override the select handler (the rail flyout also closes the popover). */
+  onSelect?: (conversationId: string) => void;
+}
+
+export function buildMenuProps(
+  ctx: ConversationListContextValue,
+  conversation: Conversation,
+): ConversationMenuItemsProps {
+  const isChannel = isChannelConversation(conversation);
+  const hasId = conversation.conversationId != null;
+  return {
+    isPinned: isConversationPinned(conversation),
+    isArchived: conversation.archivedAt != null,
+    isReadonly: isChannel,
+    onPinToggle: ctx.onPin ? () => ctx.onPin?.(conversation) : undefined,
+    onRename: ctx.onRename ? () => ctx.onRename?.(conversation) : undefined,
+    onArchive: ctx.onArchive ? () => ctx.onArchive?.(conversation) : undefined,
+    onUnarchive: ctx.onUnarchive
+      ? () => ctx.onUnarchive?.(conversation)
+      : undefined,
+    onMarkRead:
+      ctx.onMarkRead && canMarkRead(conversation)
+        ? () => ctx.onMarkRead?.(conversation)
+        : undefined,
+    onMarkUnread:
+      ctx.onMarkUnread && !canMarkRead(conversation)
+        ? () => ctx.onMarkUnread?.(conversation)
+        : undefined,
+    isMarkUnreadDisabled: !canMarkUnread(conversation),
+    onAnalyze:
+      ctx.onAnalyze && hasId && !isChannel
+        ? () => ctx.onAnalyze?.(conversation)
+        : undefined,
+    onOpenInNewWindow:
+      ctx.onOpenInNewWindow && hasId
+        ? () => ctx.onOpenInNewWindow?.(conversation)
+        : undefined,
+    onShareFeedback: ctx.onShareFeedback,
+    onInspect:
+      ctx.onInspect && hasId ? () => ctx.onInspect?.(conversation) : undefined,
+  };
+}
+
+export function buildDragProps(
+  ctx: ConversationListContextValue,
+  conversation: Conversation,
+  dragSection: string | undefined,
+  dragSiblings: Conversation[] | undefined,
+): Partial<DragReorderItemProps> & { className?: string } {
+  if (!dragSection || !ctx.canReorder || !dragSiblings || dragSiblings.length < 2) {
+    return {};
+  }
+  const { draggingId, dropIndicator } = ctx.dragReorder;
+  const edge =
+    dropIndicator?.section === dragSection &&
+    dropIndicator.itemId === conversation.conversationId
+      ? dropIndicator.edge
+      : null;
+  return {
+    ...ctx.dragReorder.getItemProps(dragSection, dragSiblings, conversation),
+    className: cn(
+      draggingId === conversation.conversationId && "opacity-50",
+      edge === "before" && "shadow-[inset_0_2px_0_0_var(--primary-base)]",
+      edge === "after" && "shadow-[inset_0_-2px_0_0_var(--primary-base)]",
+    ),
+  };
+}
+
+export function ConversationRow({
+  conversation,
+  dragSection,
+  dragSiblings,
+  withContextMenu = true,
+  marquee = true,
+  onSelect,
+}: ConversationRowProps) {
+  const ctx = useConversationListContext();
+  const { conversationId } = conversation;
+
+  const isProcessing =
+    conversationId === ctx.activeConversationId
+      ? ctx.activeConversationProcessing ?? false
+      : ctx.processingConversationIds?.has(conversationId) ?? false;
+  const needsAttention =
+    ctx.attentionConversationIds?.has(conversationId) ?? false;
+
+  const menuProps = buildMenuProps(ctx, conversation);
+  const select = onSelect ?? ctx.onSelect;
+
+  const panelItem = (
+    <PanelItem
+      leadingSlot={
+        <ThreadPinToggle
+          conversation={conversation}
+          isProcessing={isProcessing}
+          needsAttention={needsAttention}
+          onPinToggle={ctx.onPin ? () => ctx.onPin?.(conversation) : undefined}
+        />
+      }
+      label={conversation.title ?? "Untitled"}
+      marqueeOnHover={marquee}
+      active={conversationId === ctx.activeConversationId}
+      onSelect={() => select(conversationId)}
+      trailingAction={<ConversationActionsMenu {...menuProps} />}
+      {...buildDragProps(ctx, conversation, dragSection, dragSiblings)}
+    />
+  );
+
+  if (!withContextMenu) return panelItem;
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>{panelItem}</ContextMenu.Trigger>
+      <ContextMenu.Content onClick={(event) => event.stopPropagation()}>
+        {renderConversationMenuItems({ Primitive: ContextMenu, ...menuProps })}
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  );
+}

--- a/clients/web/src/utils/channel-presentation.tsx
+++ b/clients/web/src/utils/channel-presentation.tsx
@@ -46,7 +46,6 @@ const REPLYABLE_CHANNELS = new Set([
   "telegram",
   "whatsapp",
   "email",
-  "discord",
 ]);
 
 const CHANNEL_ICONS: Record<string, LucideIcon> = {


### PR DESCRIPTION
## What & why

Follow-up to #35945 (LUM-2571), the deferred refactor tracked as **LUM-2572**.

`AssistantSideMenu` rendered the entire conversation list through a stack of **parent-bound render closures** — `renderFlatList`, `renderThreadRow`, `renderThreadPinToggle`, `renderThreadActions`, `buildConversationMenuProps`, `buildDragProps`, `renderCollapsedGroupContent` — each closing over the same ~12 action callbacks plus active/processing/attention state and the drag controller, duplicated across Pinned, Recents, channel sections, custom groups, and the collapsed rail. Adding the per-channel sections in #35945 made the pattern more visible, and per CONVENTIONS.md ("extract sub-components by responsibility") it should be components, not closures.

## Changes (behavior-preserving)

- **`ConversationListProvider` / `useConversationListContext`** — lifts the shared row callbacks, active/processing/attention state, and drag controller into a context, so rows read what they need instead of being threaded 12 props deep. This is the "earns its place" justification for context: ~6 render sites × ~12 values.
- **`ConversationRow`** — one row (pin toggle + `PanelItem` + actions menu + optional right-click menu + optional drag), reading from context. Its menu-prop and drag-prop derivation are exported as **pure functions and unit-tested**.
- **`ConversationRowList` / `ConversationNavSection`** — the `SubList` (+ show more/less) and the collapsible-section shell, shared by every section type.
- **`CollapsedGroupFlyout`** — the collapsed-rail flyout body (and drops its never-passed `emptyState` param — dead per "no speculative generality").
- **`AssistantSideMenu`** keeps only section-level wiring (drag controller, group context menu, header actions) and renders the components. ~250 lines of closures → component usage.

Also folds in a 1-line cleanup that lost a race with the #35945 merge: **drop speculative `"discord"` from `REPLYABLE_CHANNELS`** (not a real inbound channel; flagged by review on #35945).

## Notes
- **No manual memoization** — the codebase is on the React-Compiler trajectory (compiler-aligned `react-hooks` lint rules, `preserve-manual-memoization` disabled); the context value matches the file's existing non-memoized render cadence.
- **Behavior preserved**: the existing `assistant-side-menu.test.tsx` (14 tests, SSR markup) passes unchanged — it exercises Pinned/Recents/channel/custom-group rendering through the new components. Drag semantics (which sections reorder, sibling lists), the collapsed-rail flyout's lighter rows (no right-click/marquee/drag), and the channel-vs-group context menus are all preserved.

## Test plan
- `bun test` — 14 integration tests unchanged + 9 new `ConversationRow` logic tests (menu-prop gating: channel read-only, analyze/mark-read/unread; drag-prop derivation: disabled/no-section/<2-siblings/dragging/drop-edge/cross-section). All green.
- `tsc --noEmit` clean; `eslint` clean on all touched files.

Closes LUM-2572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_