### PR TITLE
Reword research-onboarding check-in step copy

### DIFF
--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx
@@ -74,11 +74,11 @@ describe("LetsChatTomorrowStep", () => {
     ]);
   });
 
-  test("hides the re-prompt and shows 'Set it up' by default", () => {
+  test("hides the re-prompt and shows the connect CTA by default", () => {
     renderStep({ missingCalendarScope: false });
 
     expect(screen.queryByText(RE_PROMPT)).toBeNull();
-    expect(screen.getByText("Set it up")).toBeDefined();
+    expect(screen.getByText("Connect Calendar →")).toBeDefined();
   });
 
   test("shows the re-prompt and 'Try again' when the scope is missing", () => {

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -79,12 +79,12 @@ export function LetsChatTomorrowStep({
         >
           {missingCalendarScope
             ? "Access not enabled"
-            : "I’ll also check in with you"}
+            : "Let me make this easy"}
         </h1>
         <p className="text-[16px]" style={{ color: tone.fgMuted }}>
           {missingCalendarScope
             ? "Check the box next to the Google Calendar permission so I can book the check-in."
-            : "Add a quick check-in to your calendar to follow up tomorrow."}
+            : "Connect your Google Calendar so I can find time to check in and start helping."}
         </p>
 
         <div className="mt-6 flex w-[234px] flex-col items-center gap-4">
@@ -106,7 +106,7 @@ export function LetsChatTomorrowStep({
             ) : missingCalendarScope ? (
               "Try again"
             ) : (
-              "Set it up"
+              "Connect Calendar →"
             )}
           </button>
           {/* Skip sits directly under the connect button. */}


### PR DESCRIPTION
## What

Reword the research-onboarding Day-2 check-in step to frame it around connecting Google Calendar directly.

| | Before | After |
|---|---|---|
| Heading | I'll also check in with you | Let me make this easy |
| Body | Add a quick check-in to your calendar to follow up tomorrow. | Connect your Google Calendar so I can find time to check in and start helping. |
| CTA | Set it up | Connect Calendar → |

The `missingCalendarScope` error-state copy and "Skip for now" are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)