### PR TITLE
feat(memory): add proc-candidate registry table + store module

### DIFF
--- a/assistant/src/memory/migrations/302-create-proc-candidates.ts
+++ b/assistant/src/memory/migrations/302-create-proc-candidates.ts
@@ -1,0 +1,32 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Adds `proc_candidates`, the procedural-memory candidate registry: one row per
+ * recurrence cluster of related notes tracked toward a distilled procedure.
+ * `member_note_slugs` is a JSON array of the note slugs that have joined the
+ * cluster, `count` is the observed recurrence tally, and `status` walks
+ * `observing → ready → distilled` as a cluster accumulates evidence and is
+ * eventually distilled into a procedure. `explicit` flags clusters seeded by a
+ * direct user request rather than passive observation.
+ *
+ * Idempotent — re-running is a no-op once the table and index exist.
+ */
+export function createProcCandidatesTable(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS proc_candidates (
+      cluster_id TEXT PRIMARY KEY,
+      goal TEXT NOT NULL,
+      member_note_slugs TEXT NOT NULL,
+      count INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'observing',
+      explicit INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_proc_candidates_status
+      ON proc_candidates (status)
+  `);
+}

--- a/assistant/src/memory/steps.ts
+++ b/assistant/src/memory/steps.ts
@@ -252,6 +252,7 @@ import { migrateMoveMemoryJobsToMemoryDb } from "./migrations/298-move-memory-jo
 import { migrateCanonicalGuardianDeliveriesConversationIndex } from "./migrations/299-canonical-guardian-deliveries-conversation-index.js";
 import { migrateAddProcessingStartedAt } from "./migrations/300-add-processing-started-at.js";
 import { createWatchdogEventsTable } from "./migrations/301-create-watchdog-events.js";
+import { createProcCandidatesTable } from "./migrations/302-create-proc-candidates.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -569,5 +570,6 @@ export const migrationSteps: MigrationStep[] = [
     migrateMoveMemoryJobsToMemoryDb,
     migrateCanonicalGuardianDeliveriesConversationIndex,
     migrateAddProcessingStartedAt,
-    createWatchdogEventsTable
+    createWatchdogEventsTable,
+    createProcCandidatesTable
 ];

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-candidate-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-candidate-store.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for `proc-candidate-store.ts` — the procedural-memory candidate
+ * registry (migration 302):
+ *   - upsert/get round-trip, including member-slug and explicit fields;
+ *   - upsert conflict path refreshing fields while preserving `created_at`;
+ *   - `incrementCandidate` bumping the recurrence tally;
+ *   - `listCandidatesByStatus` filtering to one lifecycle status;
+ *   - `markCandidateStatus` walking the lifecycle;
+ *   - `addMemberNote` set semantics (dedup, no-op for unknown clusters);
+ *   - migration idempotence (run twice).
+ *
+ * `mock.module` is process-global and leaks into sibling files in a directory
+ * run, so the db-connection stub DELEGATES to the real implementation unless
+ * this test is actively running (`storeMockActive`, toggled in
+ * beforeEach/afterAll). Mirrors `ever-injected-store.test.ts`.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { createProcCandidatesTable } from "../../../../memory/migrations/302-create-proc-candidates.js";
+import * as schema from "../../../../memory/schema.js";
+
+const realDb = { ...(await import("../../../../memory/db-connection.js")) };
+
+let storeMockActive = false;
+
+let testSqlite: Database;
+let testDb = makeDb();
+function makeDb() {
+  testSqlite = new Database(":memory:");
+  const db = drizzle(testSqlite, { schema });
+  createProcCandidatesTable(db);
+  return db;
+}
+
+mock.module("../../../../memory/db-connection.js", () => ({
+  ...realDb,
+  getDb: () => (storeMockActive ? testDb : realDb.getDb()),
+  getSqliteFrom: (db: unknown) =>
+    storeMockActive
+      ? testSqlite
+      : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+}));
+
+const {
+  addMemberNote,
+  getCandidate,
+  incrementCandidate,
+  listCandidatesByStatus,
+  markCandidateStatus,
+  upsertCandidate,
+} = await import("../proc-candidate-store.js");
+
+beforeEach(() => {
+  storeMockActive = true;
+  testDb = makeDb();
+});
+
+afterAll(() => {
+  storeMockActive = false;
+});
+
+describe("upsertCandidate / getCandidate", () => {
+  test("round-trips a candidate cluster", () => {
+    upsertCandidate(
+      {
+        clusterId: "cluster-1",
+        goal: "draft the weekly status email",
+        memberNoteSlugs: ["notes/a", "notes/b"],
+        count: 2,
+        status: "observing",
+        explicit: true,
+      },
+      1_000,
+    );
+
+    expect(getCandidate("cluster-1")).toEqual({
+      clusterId: "cluster-1",
+      goal: "draft the weekly status email",
+      memberNoteSlugs: ["notes/a", "notes/b"],
+      count: 2,
+      status: "observing",
+      explicit: true,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    });
+    expect(getCandidate("cluster-unknown")).toBeNull();
+  });
+
+  test("defaults member slugs, count, status, and explicit", () => {
+    upsertCandidate({ clusterId: "cluster-1", goal: "do the thing" }, 1_000);
+    expect(getCandidate("cluster-1")).toEqual({
+      clusterId: "cluster-1",
+      goal: "do the thing",
+      memberNoteSlugs: [],
+      count: 0,
+      status: "observing",
+      explicit: false,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    });
+  });
+
+  test("re-upserting refreshes fields and updated_at but preserves created_at", () => {
+    upsertCandidate({ clusterId: "cluster-1", goal: "first" }, 1_000);
+    upsertCandidate(
+      {
+        clusterId: "cluster-1",
+        goal: "second",
+        memberNoteSlugs: ["notes/a"],
+        count: 5,
+        status: "ready",
+      },
+      2_000,
+    );
+
+    expect(getCandidate("cluster-1")).toEqual({
+      clusterId: "cluster-1",
+      goal: "second",
+      memberNoteSlugs: ["notes/a"],
+      count: 5,
+      status: "ready",
+      explicit: false,
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    });
+  });
+});
+
+describe("incrementCandidate", () => {
+  test("bumps the recurrence tally and stamps updated_at", () => {
+    upsertCandidate({ clusterId: "cluster-1", goal: "g", count: 1 }, 1_000);
+    incrementCandidate("cluster-1", 2_000);
+    incrementCandidate("cluster-1", 3_000);
+
+    const candidate = getCandidate("cluster-1");
+    expect(candidate?.count).toBe(3);
+    expect(candidate?.updatedAt).toBe(3_000);
+  });
+});
+
+describe("listCandidatesByStatus", () => {
+  test("filters to the requested status, newest update first", () => {
+    upsertCandidate(
+      { clusterId: "observing-1", goal: "g", status: "observing" },
+      1_000,
+    );
+    upsertCandidate(
+      { clusterId: "ready-1", goal: "g", status: "ready" },
+      2_000,
+    );
+    upsertCandidate(
+      { clusterId: "ready-2", goal: "g", status: "ready" },
+      3_000,
+    );
+    upsertCandidate(
+      { clusterId: "distilled-1", goal: "g", status: "distilled" },
+      4_000,
+    );
+
+    expect(listCandidatesByStatus("ready").map((c) => c.clusterId)).toEqual([
+      "ready-2",
+      "ready-1",
+    ]);
+    expect(listCandidatesByStatus("observing").map((c) => c.clusterId)).toEqual(
+      ["observing-1"],
+    );
+    expect(listCandidatesByStatus("distilled")).toHaveLength(1);
+  });
+
+  test("returns an empty list when no cluster has the status", () => {
+    upsertCandidate(
+      { clusterId: "cluster-1", goal: "g", status: "observing" },
+      1_000,
+    );
+    expect(listCandidatesByStatus("ready")).toEqual([]);
+  });
+});
+
+describe("markCandidateStatus", () => {
+  test("walks a cluster through the lifecycle", () => {
+    upsertCandidate({ clusterId: "cluster-1", goal: "g" }, 1_000);
+
+    markCandidateStatus("cluster-1", "ready", 2_000);
+    expect(getCandidate("cluster-1")?.status).toBe("ready");
+    expect(listCandidatesByStatus("ready").map((c) => c.clusterId)).toEqual([
+      "cluster-1",
+    ]);
+
+    markCandidateStatus("cluster-1", "distilled", 3_000);
+    expect(getCandidate("cluster-1")?.status).toBe("distilled");
+    expect(getCandidate("cluster-1")?.updatedAt).toBe(3_000);
+    expect(listCandidatesByStatus("ready")).toEqual([]);
+  });
+});
+
+describe("addMemberNote", () => {
+  test("appends a slug, dedups, and is a no-op for unknown clusters", () => {
+    upsertCandidate(
+      { clusterId: "cluster-1", goal: "g", memberNoteSlugs: ["notes/a"] },
+      1_000,
+    );
+
+    addMemberNote("cluster-1", "notes/b", 2_000);
+    expect(getCandidate("cluster-1")?.memberNoteSlugs).toEqual([
+      "notes/a",
+      "notes/b",
+    ]);
+    expect(getCandidate("cluster-1")?.updatedAt).toBe(2_000);
+
+    // Re-adding an existing slug is a no-op (set semantics, no updated_at bump).
+    addMemberNote("cluster-1", "notes/a", 3_000);
+    expect(getCandidate("cluster-1")?.memberNoteSlugs).toEqual([
+      "notes/a",
+      "notes/b",
+    ]);
+    expect(getCandidate("cluster-1")?.updatedAt).toBe(2_000);
+
+    // Unknown cluster: no row is created.
+    addMemberNote("cluster-unknown", "notes/x", 4_000);
+    expect(getCandidate("cluster-unknown")).toBeNull();
+  });
+});
+
+describe("migration", () => {
+  test("is idempotent — running twice leaves a usable table", () => {
+    // makeDb() already ran the migration once; run it again.
+    createProcCandidatesTable(testDb);
+
+    upsertCandidate({ clusterId: "cluster-1", goal: "g" }, 1_000);
+    expect(getCandidate("cluster-1")?.goal).toBe("g");
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-candidate-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-candidate-store.test.ts
@@ -2,7 +2,8 @@
  * Tests for `proc-candidate-store.ts` — the procedural-memory candidate
  * registry (migration 302):
  *   - upsert/get round-trip, including member-slug and explicit fields;
- *   - upsert conflict path refreshing fields while preserving `created_at`;
+ *   - upsert conflict path refreshing only `goal`/`updated_at` while preserving
+ *     `created_at` and the accumulated members/count/status/explicit fields;
  *   - `incrementCandidate` bumping the recurrence tally;
  *   - `listCandidatesByStatus` filtering to one lifecycle status;
  *   - `markCandidateStatus` walking the lifecycle;
@@ -104,26 +105,48 @@ describe("upsertCandidate / getCandidate", () => {
     });
   });
 
-  test("re-upserting refreshes fields and updated_at but preserves created_at", () => {
+  test("re-upserting refreshes goal and updated_at but preserves created_at", () => {
     upsertCandidate({ clusterId: "cluster-1", goal: "first" }, 1_000);
-    upsertCandidate(
-      {
-        clusterId: "cluster-1",
-        goal: "second",
-        memberNoteSlugs: ["notes/a"],
-        count: 5,
-        status: "ready",
-      },
-      2_000,
-    );
+    upsertCandidate({ clusterId: "cluster-1", goal: "second" }, 2_000);
 
     expect(getCandidate("cluster-1")).toEqual({
       clusterId: "cluster-1",
       goal: "second",
-      memberNoteSlugs: ["notes/a"],
+      memberNoteSlugs: [],
+      count: 0,
+      status: "observing",
+      explicit: false,
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    });
+  });
+
+  test("re-upserting preserves accumulated members, count, status, and explicit", () => {
+    // Seed a cluster that has accumulated evidence via the dedicated mutators.
+    upsertCandidate(
+      {
+        clusterId: "cluster-1",
+        goal: "first",
+        memberNoteSlugs: ["notes/a", "notes/b"],
+        count: 5,
+        status: "ready",
+        explicit: true,
+      },
+      1_000,
+    );
+
+    // A bare refresh-upsert (only the required fields) must not clobber the
+    // accumulated member slugs, recurrence count, lifecycle status, or the
+    // explicit flag — those are owned by the dedicated mutators.
+    upsertCandidate({ clusterId: "cluster-1", goal: "second" }, 2_000);
+
+    expect(getCandidate("cluster-1")).toEqual({
+      clusterId: "cluster-1",
+      goal: "second",
+      memberNoteSlugs: ["notes/a", "notes/b"],
       count: 5,
       status: "ready",
-      explicit: false,
+      explicit: true,
       createdAt: 1_000,
       updatedAt: 2_000,
     });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/proc-candidate-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/proc-candidate-store.ts
@@ -1,0 +1,199 @@
+/**
+ * Procedural-memory candidate registry (migration 302).
+ *
+ * Backed by `proc_candidates`: one row per recurrence cluster of related notes
+ * tracked toward a distilled procedure. `memberNoteSlugs` is a set of the note
+ * slugs that have joined the cluster (persisted as a JSON array), `count` is
+ * the observed recurrence tally, and `status` walks `observing → ready →
+ * distilled` as a cluster accumulates evidence. `explicit` flags clusters
+ * seeded by a direct user request rather than passive observation.
+ */
+
+import {
+  type DrizzleDb,
+  getDb,
+  getSqliteFrom,
+} from "../../../memory/db-connection.js";
+
+export type ProcCandidateStatus = "observing" | "ready" | "distilled";
+
+export interface ProcCandidate {
+  clusterId: string;
+  goal: string;
+  memberNoteSlugs: string[];
+  count: number;
+  status: ProcCandidateStatus;
+  explicit: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface ProcCandidateRow {
+  clusterId: string;
+  goal: string;
+  memberNoteSlugs: string;
+  count: number;
+  status: ProcCandidateStatus;
+  explicit: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function rowToCandidate(row: ProcCandidateRow): ProcCandidate {
+  return {
+    clusterId: row.clusterId,
+    goal: row.goal,
+    memberNoteSlugs: JSON.parse(row.memberNoteSlugs) as string[],
+    count: row.count,
+    status: row.status,
+    explicit: row.explicit !== 0,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export interface UpsertCandidateInput {
+  clusterId: string;
+  goal: string;
+  memberNoteSlugs?: string[];
+  count?: number;
+  status?: ProcCandidateStatus;
+  explicit?: boolean;
+}
+
+/**
+ * Insert a candidate cluster, or refresh `goal`/`status`/`explicit` and stamp
+ * `updated_at` when one already exists. The `created_at` of an existing row is
+ * preserved.
+ */
+export function upsertCandidate(
+  input: UpsertCandidateInput,
+  at: number = Date.now(),
+): void {
+  getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      INSERT INTO proc_candidates
+        (cluster_id, goal, member_note_slugs, count, status, explicit, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(cluster_id) DO UPDATE SET
+        goal = excluded.goal,
+        member_note_slugs = excluded.member_note_slugs,
+        count = excluded.count,
+        status = excluded.status,
+        explicit = excluded.explicit,
+        updated_at = excluded.updated_at
+    `,
+    )
+    .run(
+      input.clusterId,
+      input.goal,
+      JSON.stringify(input.memberNoteSlugs ?? []),
+      input.count ?? 0,
+      input.status ?? "observing",
+      input.explicit ? 1 : 0,
+      at,
+      at,
+    );
+}
+
+/** Bump a cluster's recurrence tally by one and stamp `updated_at`. */
+export function incrementCandidate(
+  clusterId: string,
+  at: number = Date.now(),
+): void {
+  getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      UPDATE proc_candidates SET count = count + 1, updated_at = ?
+      WHERE cluster_id = ?
+    `,
+    )
+    .run(at, clusterId);
+}
+
+/** Fetch a single cluster, or `null` when it is not registered. */
+export function getCandidate(clusterId: string): ProcCandidate | null {
+  const row = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT
+        cluster_id AS clusterId,
+        goal,
+        member_note_slugs AS memberNoteSlugs,
+        count,
+        status,
+        explicit,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM proc_candidates
+      WHERE cluster_id = ?
+    `,
+    )
+    .get(clusterId) as ProcCandidateRow | null;
+  return row ? rowToCandidate(row) : null;
+}
+
+/** All clusters in the given lifecycle status, newest update first. */
+export function listCandidatesByStatus(
+  status: ProcCandidateStatus,
+): ProcCandidate[] {
+  const rows = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT
+        cluster_id AS clusterId,
+        goal,
+        member_note_slugs AS memberNoteSlugs,
+        count,
+        status,
+        explicit,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM proc_candidates
+      WHERE status = ?
+      ORDER BY updated_at DESC
+    `,
+    )
+    .all(status) as ProcCandidateRow[];
+  return rows.map(rowToCandidate);
+}
+
+/** Move a cluster to a new lifecycle status and stamp `updated_at`. */
+export function markCandidateStatus(
+  clusterId: string,
+  status: ProcCandidateStatus,
+  at: number = Date.now(),
+): void {
+  getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      UPDATE proc_candidates SET status = ?, updated_at = ?
+      WHERE cluster_id = ?
+    `,
+    )
+    .run(status, at, clusterId);
+}
+
+/**
+ * Add a note slug to a cluster's member set (no-op when already present) and
+ * stamp `updated_at`. No-op when the cluster is not registered.
+ */
+export function addMemberNote(
+  clusterId: string,
+  slug: string,
+  at: number = Date.now(),
+): void {
+  const existing = getCandidate(clusterId);
+  if (!existing) return;
+  if (existing.memberNoteSlugs.includes(slug)) return;
+  const next = [...existing.memberNoteSlugs, slug];
+  getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      UPDATE proc_candidates SET member_note_slugs = ?, updated_at = ?
+      WHERE cluster_id = ?
+    `,
+    )
+    .run(JSON.stringify(next), at, clusterId);
+}

--- a/assistant/src/plugins/defaults/memory-v3-shadow/proc-candidate-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/proc-candidate-store.ts
@@ -9,11 +9,7 @@
  * seeded by a direct user request rather than passive observation.
  */
 
-import {
-  type DrizzleDb,
-  getDb,
-  getSqliteFrom,
-} from "../../../memory/db-connection.js";
+import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
 
 export type ProcCandidateStatus = "observing" | "ready" | "distilled";
 
@@ -62,9 +58,12 @@ export interface UpsertCandidateInput {
 }
 
 /**
- * Insert a candidate cluster, or refresh `goal`/`status`/`explicit` and stamp
- * `updated_at` when one already exists. The `created_at` of an existing row is
- * preserved.
+ * Insert a candidate cluster, or refresh `goal` and stamp `updated_at` when one
+ * already exists. The accumulated fields — `member_note_slugs`, `count`,
+ * `status`, `explicit`, and `created_at` — are PRESERVED on conflict; they are
+ * owned by the dedicated mutators (`incrementCandidate`, `addMemberNote`,
+ * `markCandidateStatus`), so re-upserting with only the required fields never
+ * clobbers accumulated evidence.
  */
 export function upsertCandidate(
   input: UpsertCandidateInput,
@@ -78,10 +77,6 @@ export function upsertCandidate(
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(cluster_id) DO UPDATE SET
         goal = excluded.goal,
-        member_note_slugs = excluded.member_note_slugs,
-        count = excluded.count,
-        status = excluded.status,
-        explicit = excluded.explicit,
         updated_at = excluded.updated_at
     `,
     )


### PR DESCRIPTION
## Summary
- Add `proc_candidates` table (migration 302) for recurrence tracking
- Add a store module (CRUD) mirroring ever-injected-store

Part of plan: procedural-memory-as-skills.md (PR 3 of 9)