### PR TITLE
feat(memory): add procedural-memory-as-skills feature flag + recurrence config

### DIFF
--- a/assistant/src/config/__tests__/proc-to-skills.test.ts
+++ b/assistant/src/config/__tests__/proc-to-skills.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { isProcToSkillsEnabled } from "../memory-v3-gate.js";
+import type { AssistantConfig } from "../schema.js";
+import { MemoryConfigSchema } from "../schemas/memory.js";
+
+const PROC_TO_SKILLS_FLAG = "procedural-memory-as-skills";
+
+beforeEach(() => {
+  setOverridesForTesting({});
+});
+
+afterEach(() => {
+  setOverridesForTesting({});
+});
+
+describe("memory.procToSkills config", () => {
+  test("defaults minRecurrence to 2 when unset", () => {
+    const parsed = MemoryConfigSchema.parse({});
+    expect(parsed.procToSkills).toEqual({ minRecurrence: 2 });
+  });
+
+  test("accepts an explicit minRecurrence override", () => {
+    const parsed = MemoryConfigSchema.parse({
+      procToSkills: { minRecurrence: 3 },
+    });
+    expect(parsed.procToSkills.minRecurrence).toBe(3);
+  });
+
+  test("rejects a minRecurrence below 1 or non-integer", () => {
+    expect(() =>
+      MemoryConfigSchema.parse({ procToSkills: { minRecurrence: 0 } }),
+    ).toThrow();
+    expect(() =>
+      MemoryConfigSchema.parse({ procToSkills: { minRecurrence: 1.5 } }),
+    ).toThrow();
+  });
+});
+
+describe("isProcToSkillsEnabled", () => {
+  const config = {} as AssistantConfig;
+
+  test("returns false by default (flag off)", () => {
+    expect(isProcToSkillsEnabled(config)).toBe(false);
+  });
+
+  test("returns true when the flag is enabled", () => {
+    setOverridesForTesting({ [PROC_TO_SKILLS_FLAG]: true });
+    expect(isProcToSkillsEnabled(config)).toBe(true);
+  });
+});

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -1,3 +1,4 @@
+import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import type { AssistantConfig } from "./schema.js";
 
 /**
@@ -8,4 +9,14 @@ import type { AssistantConfig } from "./schema.js";
  */
 export function isMemoryV3Live(config: AssistantConfig): boolean {
   return config.memory?.v3?.live === true;
+}
+
+/**
+ * Whether the procedural-memory-as-skills behavior is enabled. Gated by the
+ * `procedural-memory-as-skills` assistant feature flag (default off). Routes
+ * procedures to candidate notes and procedural knowledge to skill-linked facts,
+ * and distills recurring procedures into managed skills.
+ */
+export function isProcToSkillsEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled("procedural-memory-as-skills", config);
 }

--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -21,6 +21,23 @@ import {
 import { MemoryV2ConfigSchema } from "./memory-v2.js";
 import { MemoryV3ConfigSchema } from "./memory-v3.js";
 
+/**
+ * Procedural-memory-as-skills tuning: a recurring procedure is captured as a
+ * candidate note and distilled into a managed skill once it recurs.
+ */
+export const MemoryProcToSkillsConfigSchema = z
+  .object({
+    minRecurrence: z
+      .number({ error: "memory.procToSkills.minRecurrence must be a number" })
+      .int("memory.procToSkills.minRecurrence must be an integer")
+      .min(1, "memory.procToSkills.minRecurrence must be at least 1")
+      .default(2)
+      .describe(
+        "Number of recurrences of the same procedure before a candidate is distilled into a skill. An explicitly taught procedure distills immediately, bypassing this gate.",
+      ),
+  })
+  .describe("Procedural-memory-as-skills recurrence/distillation tuning.");
+
 export const MemoryConfigSchema = z
   .object({
     enabled: z
@@ -62,6 +79,9 @@ export const MemoryConfigSchema = z
     v3: MemoryV3ConfigSchema.default(MemoryV3ConfigSchema.parse({})),
     retrospective: MemoryRetrospectiveConfigSchema.default(
       MemoryRetrospectiveConfigSchema.parse({}),
+    ),
+    procToSkills: MemoryProcToSkillsConfigSchema.default(
+      MemoryProcToSkillsConfigSchema.parse({}),
     ),
   })
   .describe(

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -379,6 +379,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "procedural-memory-as-skills",
+      "scope": "assistant",
+      "key": "procedural-memory-as-skills",
+      "label": "Procedural Memory as Skills",
+      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Off by default.",
+      "defaultEnabled": false
+    },
+    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -379,6 +379,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "procedural-memory-as-skills",
+      "scope": "assistant",
+      "key": "procedural-memory-as-skills",
+      "label": "Procedural Memory as Skills",
+      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Off by default.",
+      "defaultEnabled": false
+    },
+    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",


### PR DESCRIPTION
## Summary
- Register `procedural-memory-as-skills` feature flag (default off)
- Add `memory.procToSkills.minRecurrence` config (default 2) + `isProcToSkillsEnabled` gate

Part of plan: procedural-memory-as-skills.md (PR 1 of 9)