### PR TITLE
feat(memory): add `skill:` frontmatter field and derive fact→skills/<id> edge

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -227,6 +227,27 @@ describe("writePage + readPage round-trip", () => {
     expect(read!.frontmatter.skill).toBe("deploy-preview");
   });
 
+  test("tolerates a non-string skill: value — page still parses, skill coerces to undefined", async () => {
+    // A legacy page whose `skill:` is a non-string (e.g. a YAML list that
+    // predates the typed field and previously passed through via `.passthrough`)
+    // must NOT fail the whole-page parse. `.catch(undefined)` coerces the bad
+    // value to `undefined` so the page survives index/retrieval rather than being
+    // silently dropped — the loss-of-page regression #34800 guards against.
+    const slug = "legacy-list-skill";
+    const raw =
+      "---\nedges: []\nref_files: []\nskill:\n  - deploy-preview\n  - rollback\n---\nbody\n";
+    writeFileSync(
+      join(workspaceDir, "memory", "concepts", `${slug}.md`),
+      raw,
+      "utf-8",
+    );
+
+    const read = await readPage(workspaceDir, slug);
+    expect(read).not.toBeNull();
+    expect(read!.frontmatter.skill).toBeUndefined();
+    expect(read!.body).toBe("body\n");
+  });
+
   test("accepts and round-trips the v3 wiki-article frontmatter fields", async () => {
     // The full shape CONSOLIDATION_PROMPT_V3 teaches and migrated corpora
     // arrive in. readPage() throws on schema failure and one invalid page in

--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -208,6 +208,25 @@ describe("writePage + readPage round-trip", () => {
     ]);
   });
 
+  test("round-trips the skill: frontmatter link (procedural-knowledge fact)", async () => {
+    const page = makePage({
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        ref_urls: [],
+        skill: "deploy-preview",
+      },
+    });
+    await writePage(workspaceDir, page);
+
+    // The `skill:` link must survive the render → read round-trip so the edge
+    // graph can derive the `fact → skills/<id>` edge by reading it back from the
+    // rendered frontmatter.
+    const read = await readPage(workspaceDir, page.slug);
+    expect(read).not.toBeNull();
+    expect(read!.frontmatter.skill).toBe("deploy-preview");
+  });
+
   test("accepts and round-trips the v3 wiki-article frontmatter fields", async () => {
     // The full shape CONSOLIDATION_PROMPT_V3 teaches and migrated corpora
     // arrive in. readPage() throws on schema failure and one invalid page in

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -54,7 +54,15 @@ export const ConceptPageFrontmatterSchema = z
     // `renderPageContent` round-trips it — the edge graph derives the
     // `fact → skills/<id>` edge by reading this field back from the rendered
     // frontmatter.
-    skill: z.string().optional(),
+    //
+    // `.catch(undefined)`: a non-string value (e.g. a legacy YAML list/object
+    // that predates this field and previously passed through via `.passthrough`)
+    // must NOT fail the whole-page `.parse()` — that would drop the page from the
+    // index and section lane entirely, the same loss-of-page regression #34800
+    // moved to `.passthrough` to avoid. A non-string coerces to `undefined`
+    // (no edge derived — `buildEdgeGraph` already gates on a non-empty string),
+    // while valid string values still round-trip via `renderPageContent`.
+    skill: z.string().optional().catch(undefined),
     // The memory-v3 wiki-article fields — the shape CONSOLIDATION_PROMPT_V3
     // teaches and migrated corpora arrive in. Declared (not just tolerated by
     // the catchall) so `renderPageContent` round-trips them — a programmatic

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -47,6 +47,14 @@ export const ConceptPageFrontmatterSchema = z
     // `renderPageContent` round-trips the field (the edge graph reads it back
     // from the rendered frontmatter).
     links: z.array(z.string()).optional(),
+    // Optional link to the one skill this page is procedural knowledge about
+    // (`skills/<skill>` capability page). Present only on the subset of memories
+    // that are facts about a skill; most pages carry none. Declared (not left to
+    // the `.passthrough()` catchall below) so it carries a real type and
+    // `renderPageContent` round-trips it — the edge graph derives the
+    // `fact → skills/<id>` edge by reading this field back from the rendered
+    // frontmatter.
+    skill: z.string().optional(),
     // The memory-v3 wiki-article fields — the shape CONSOLIDATION_PROMPT_V3
     // teaches and migrated corpora arrive in. Declared (not just tolerated by
     // the catchall) so `renderPageContent` round-trips them — a programmatic

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/edge.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/edge.test.ts
@@ -20,6 +20,11 @@ function withLinks(links: string[], body = "body"): string {
   return `---\ntitle: x\nlinks:\n${block}\n---\n\n${body}`;
 }
 
+/** Frontmatter helper: a page with a `skill:` link and an optional body. */
+function withSkill(skill: string, body = "body"): string {
+  return `---\ntitle: x\nskill: "${skill}"\n---\n\n${body}`;
+}
+
 describe("buildEdgeGraph — links: frontmatter", () => {
   test("parses target + description split on the first ' — '", async () => {
     const articles = [entry(1, "page-a"), entry(2, "page-b")];
@@ -71,6 +76,38 @@ describe("buildEdgeGraph — links: frontmatter", () => {
     // No curated descriptions on wikilink/numeric edges.
     expect(out.get("page-b")).toBeUndefined();
     expect(out.get("topic-x")).toBeUndefined();
+  });
+});
+
+describe("buildEdgeGraph — skill: frontmatter", () => {
+  test("derives a fact → skills/<id> edge when the skill page exists", async () => {
+    const articles = [entry(1, "a-fact"), entry(2, "skills/foo")];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({ "a-fact": withSkill("foo") }),
+    );
+    const out = graph.adjacency.get("a-fact")!;
+    expect(out.has("skills/foo")).toBe(true);
+    expect(out.get("skills/foo")).toBe("procedural knowledge for this skill");
+  });
+
+  test("drops the edge when the skill page is absent from the corpus", async () => {
+    const articles = [entry(1, "a-fact")];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({ "a-fact": withSkill("foo") }),
+    );
+    // No skills/foo in the corpus → no adjacency entry at all.
+    expect(graph.adjacency.get("a-fact")).toBeUndefined();
+  });
+
+  test("ignores an empty/whitespace skill value", async () => {
+    const articles = [entry(1, "a-fact"), entry(2, "skills/")];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({ "a-fact": withSkill("   ") }),
+    );
+    expect(graph.adjacency.get("a-fact")).toBeUndefined();
   });
 });
 
@@ -229,6 +266,55 @@ describe("edgeExpand", () => {
     });
     expect(out.find((n) => n.article === "page-c")).toBeUndefined();
     expect(out.find((n) => n.article === "page-b")).toBeDefined();
+  });
+
+  test("exempts a popular capability target from the hub filter", async () => {
+    // skills/foo receives 3 inbound fact edges; with hubDegree=2 it is a hub.
+    // A plain hub would be filtered out of expansion, but a capability target
+    // (skills/ prefix) is exempt so it still co-surfaces with its facts.
+    const articles = [
+      entry(1, "fact-a"),
+      entry(2, "fact-b"),
+      entry(3, "fact-c"),
+      entry(4, "skills/foo"),
+    ];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "fact-a": withSkill("foo"),
+        "fact-b": withSkill("foo"),
+        "fact-c": withSkill("foo"),
+      }),
+      { hubDegree: 2 },
+    );
+    // It is still recorded as a hub by in-degree...
+    expect(graph.hubs.has("skills/foo")).toBe(true);
+    // ...but expansion from a linking fact still surfaces it.
+    const out = edgeExpand(graph, ["fact-a"]);
+    expect(out.find((n) => n.article === "skills/foo")).toBeDefined();
+  });
+
+  test("a non-capability hub is still filtered out", async () => {
+    // Same shape as above but the popular target is an ordinary page, so the
+    // hub filter still excludes it — the exemption is capability-only.
+    const articles = [
+      entry(1, "fact-a"),
+      entry(2, "fact-b"),
+      entry(3, "fact-c"),
+      entry(4, "plain-hub"),
+    ];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "fact-a": withLinks(["plain-hub — to hub"]),
+        "fact-b": withLinks(["plain-hub — to hub"]),
+        "fact-c": withLinks(["plain-hub — to hub"]),
+      }),
+      { hubDegree: 2 },
+    );
+    expect(graph.hubs.has("plain-hub")).toBe(true);
+    const out = edgeExpand(graph, ["fact-a"]);
+    expect(out.find((n) => n.article === "plain-hub")).toBeUndefined();
   });
 
   test("does not surface the seeds themselves", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
@@ -42,6 +42,18 @@ const LINK_SEPARATOR = " — ";
  * display-text or `#section` anchor. */
 const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
 
+/** Slug prefixes for capability pages (skills, CLI commands). These are the
+ * targets of derived `fact → skills/<id>` edges; a popular capability linked by
+ * many facts would otherwise be flagged a hub and filtered out of expansion, so
+ * it is exempt from the hub filter — a skill should still co-surface with its
+ * facts no matter how many link to it. */
+const CAPABILITY_TARGET_PREFIXES = ["skills/", "cli-commands/"] as const;
+
+/** Whether `slug` names a capability page exempt from the hub filter. */
+function isCapabilityTarget(slug: Slug): boolean {
+  return CAPABILITY_TARGET_PREFIXES.some((prefix) => slug.startsWith(prefix));
+}
+
 /**
  * The directed link-graph. `adjacency` maps each source slug to its outbound
  * edges (target slug → curated description, or `undefined` when the edge came
@@ -181,6 +193,15 @@ export async function buildEdgeGraph(
       }
     }
 
+    // (a′) the `skill:` frontmatter link — derives a `fact → skills/<id>` edge
+    // so a fact about a skill co-surfaces with the skill's capability page via
+    // the edge lane. `addEdge` drops the edge when `skills/<id>` is absent from
+    // the corpus, so a skill with no capability page is a safe no-op.
+    const skill = parsed?.fields.skill;
+    if (typeof skill === "string" && skill.trim() !== "") {
+      addEdge(source, `skills/${skill}`, "procedural knowledge for this skill");
+    }
+
     // (b) inline `[[wikilink]]` targets from the body. `parsed.body` strips
     // the frontmatter; a page without frontmatter has `parsed === null`, so
     // the whole raw text is the body.
@@ -209,9 +230,11 @@ export async function buildEdgeGraph(
 /**
  * Expand `seeds` outward along the graph. For each of the top `seedCount`
  * seeds (in input order), surface up to `perSeed` non-hub, `alive`-passing
- * neighbours, capped at `cap` total distinct articles. Seeds themselves are
- * not surfaced (they are already in the pool). Each surfaced article carries
- * the curated `links` description of the traversed edge when it had one.
+ * neighbours, capped at `cap` total distinct articles. Capability targets
+ * (`skills/` / `cli-commands/`) are exempt from the hub filter so a popular
+ * skill still co-surfaces with its facts. Seeds themselves are not surfaced
+ * (they are already in the pool). Each surfaced article carries the curated
+ * `links` description of the traversed edge when it had one.
  *
  * Deterministic given the input seed order and the graph's insertion order.
  */
@@ -238,7 +261,9 @@ export function edgeExpand(
       if (surfaced.size >= cap) break;
       if (seedSet.has(target)) continue; // already in the pool
       if (surfaced.has(target)) continue; // already surfaced via another seed
-      if (graph.hubs.has(target)) continue; // hubs excluded
+      // Hubs are too-generic to surface — except capability targets, which a
+      // popular skill must still co-surface with its facts through.
+      if (graph.hubs.has(target) && !isCapabilityTarget(target)) continue;
       if (alive && !alive(target)) continue;
       surfaced.set(target, description);
       added++;


### PR DESCRIPTION
## Summary
- Add optional `skill:` field to concept-page frontmatter schema
- Derive a `fact → skills/<id>` edge from it in buildEdgeGraph; exempt capability targets from the hub filter

Part of plan: procedural-memory-as-skills.md (PR 2 of 9)