### PR TITLE
feat(permissions): allow background consolidation to scaffold skills non-interactively

### DIFF
--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -606,6 +606,135 @@ describe("Permission Checker (gateway IPC)", () => {
       );
       expect(result.decision).toBe("prompt");
     });
+
+    // ── Memory-consolidation skill-authoring auto-grant ─────────────────────
+    // The background consolidation guardian session (sourceChannel "vellum",
+    // trustClass "guardian", origin "memory_consolidation") cannot answer
+    // interactive prompts, so `scaffold_managed_skill` and
+    // `skill_load skill-management` resolve to allow without prompting. The
+    // grant is scoped to that origin + those two tools only.
+
+    const consolidationContext = {
+      requestOrigin: "memory_consolidation",
+      trustClass: "guardian",
+      sourceChannel: "vellum",
+      executionContext: "background" as const,
+    };
+
+    test("allows scaffold_managed_skill for the consolidation origin without prompting", async () => {
+      // High risk would normally force a prompt — the grant short-circuits
+      // before classification, so no IPC result is needed.
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        consolidationContext,
+      );
+      expect(result.decision).toBe("allow");
+    });
+
+    test("allows skill_load skill-management for the consolidation origin without prompting", async () => {
+      const result = await check(
+        "skill_load",
+        { skill: "skill-management" },
+        "/home/user/project",
+        consolidationContext,
+      );
+      expect(result.decision).toBe("allow");
+    });
+
+    test("does not grant skill_load for a non skill-management skill", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Dynamic skill load",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const result = await check(
+        "skill_load",
+        { skill: "some-other-skill" },
+        "/home/user/project",
+        consolidationContext,
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("does not grant for tools outside the scaffold/skill_load pair", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Managed skill delete",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const result = await check(
+        "delete_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        consolidationContext,
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("does not grant scaffold for an interactive (non-background) session", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      // A normal interactive turn carries no consolidation origin signals.
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        { executionContext: "conversation" },
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("does not grant scaffold for a different background origin", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      // Same guardian/vellum background trust, but a different origin (e.g.
+      // the memory sweep job) must not inherit the consolidation grant.
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        {
+          requestOrigin: "schedule",
+          trustClass: "guardian",
+          sourceChannel: "vellum",
+          executionContext: "background",
+        },
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("does not grant scaffold when trust is not guardian", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        {
+          requestOrigin: "memory_consolidation",
+          trustClass: "unknown",
+          sourceChannel: "vellum",
+          executionContext: "background",
+        },
+      );
+      expect(result.decision).toBe("prompt");
+    });
   });
 
   // ── generateAllowlistOptions ──────────────────────────────────────────────

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -671,6 +671,46 @@ export async function classifyRisk(
   return result;
 }
 
+// ── Background memory-consolidation skill-authoring auto-grant ────────────────
+// Skill scaffolding (`scaffold_managed_skill`, risk: high + allowlist-gated) and
+// loading the `skill-management` skill (`skill_load skill-management`, which
+// exposes that tool) require an interactive approval. The memory-consolidation
+// background job runs without any connected client, so it can never answer that
+// prompt. When a turn is the consolidation background source — guardian trust,
+// `vellum` source channel, `memory_consolidation` origin (set in
+// consolidation-job.ts) — these two tools resolve to ALLOW non-interactively.
+//
+// The grant is intentionally narrow: it matches exactly these two tools AND the
+// consolidation origin, so no interactive session or other origin is affected.
+// It is inert until a later PR actually drives `scaffold_managed_skill` from
+// consolidation; no current caller sets `requestOrigin` to this origin. Once the
+// `isProcToSkillsEnabled` flag helper lands (sibling PR), this grant can also be
+// gated on that flag.
+const MEMORY_CONSOLIDATION_ORIGIN = "memory_consolidation";
+const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
+
+function isMemoryConsolidationSkillAuthoringGrant(
+  toolName: string,
+  input: Record<string, unknown>,
+  policyContext?: PolicyContext,
+): boolean {
+  if (
+    policyContext?.requestOrigin !== MEMORY_CONSOLIDATION_ORIGIN ||
+    policyContext.trustClass !== "guardian" ||
+    policyContext.sourceChannel !== "vellum"
+  ) {
+    return false;
+  }
+  if (toolName === "scaffold_managed_skill") return true;
+  if (toolName === "skill_load") {
+    return (
+      getStringField(input, "skill", "skill_id").trim() ===
+      SKILL_MANAGEMENT_SKILL_ID
+    );
+  }
+  return false;
+}
+
 export async function check(
   toolName: string,
   input: Record<string, unknown>,
@@ -680,6 +720,16 @@ export async function check(
   signal?: AbortSignal,
 ): Promise<PermissionCheckResult> {
   signal?.throwIfAborted();
+
+  if (
+    isMemoryConsolidationSkillAuthoringGrant(toolName, input, policyContext)
+  ) {
+    return {
+      decision: "allow",
+      reason:
+        "Memory consolidation background session: skill authoring auto-approved",
+    };
+  }
 
   const classification = await classifyRisk(
     toolName,

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -74,4 +74,17 @@ export interface PolicyContext {
   executionContext?: "conversation" | "background" | "headless";
   /** Conversation ID for per-conversation threshold overrides. */
   conversationId?: string;
+  /**
+   * Origin tag of the turn driving this permission check (the conversation's
+   * `TitleOrigin`, e.g. "memory_consolidation"). Background jobs cannot answer
+   * interactive approval prompts, so the checker uses this — together with
+   * {@link trustClass} / {@link sourceChannel} — to scope narrow non-interactive
+   * auto-grants to a specific internal origin without broadening any other
+   * session.
+   */
+  requestOrigin?: string;
+  /** Trust classification of the actor driving the turn (e.g. "guardian"). */
+  trustClass?: string;
+  /** Source channel the turn arrived on (e.g. "vellum" for internal jobs). */
+  sourceChannel?: string;
 }


### PR DESCRIPTION
## Summary
- Narrow auto-grant so the memory-consolidation background guardian context can run `skill_load skill-management` + `scaffold_managed_skill` without an interactive prompt
- Scoped to the consolidation origin + those two tools only

Part of plan: procedural-memory-as-skills.md (PR 4 of 9)