### PR TITLE
fix(contacts): gateway-read bridge for invite gate-status fallback

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -76,6 +76,9 @@ mock.module("../ipc/gateway-client.js", () => ({
     params?: Record<string, unknown>,
   ) => {
     gatewayIpcCalls.push({ method, params });
+    if (method === "contacts_get_rich") {
+      return richContactForId(params?.contactId as string);
+    }
     if (method === "record_invite_redemption") {
       return { ok: true, updated: true, mirrored: true };
     }
@@ -86,8 +89,46 @@ mock.module("../ipc/gateway-client.js", () => ({
   },
 }));
 
+// Serves contacts_get_rich (the gateway ACL read backing the gate-status
+// fallback) from the seeded local contact, so gate resolution sources status
+// from the gateway path rather than the local channel column.
+function richContactForId(contactId: string | undefined) {
+  if (!contactId) return undefined;
+  const contact = getContact(contactId);
+  if (!contact) return undefined;
+  return {
+    ok: true,
+    contact: {
+      id: contact.id,
+      displayName: contact.displayName,
+      role: contact.role,
+      interactionCount: contact.interactionCount,
+      createdAt: contact.createdAt,
+      updatedAt: contact.updatedAt,
+      channels: contact.channels.map((c) => ({
+        id: c.id,
+        contactId: c.contactId,
+        type: c.type,
+        address: c.address,
+        isPrimary: c.isPrimary,
+        externalUserId: c.externalChatId,
+        status: c.status,
+        policy: c.policy,
+        verifiedAt: c.verifiedAt,
+        verifiedVia: c.verifiedVia,
+        lastSeenAt: c.lastSeenAt,
+        interactionCount: c.interactionCount,
+        lastInteraction: c.lastInteraction,
+        revokedReason: c.revokedReason,
+        blockedReason: c.blockedReason,
+      })),
+    },
+  };
+}
+
 import {
   findContactChannel,
+  getContact,
   upsertContact,
 } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -37,6 +37,12 @@ const gatewayIpc = {
     mirrored: boolean;
   },
   claimThrows: false,
+  // When set, contacts_get_rich throws (gateway read unreachable) so the
+  // gate-status fallback must fail open.
+  richThrows: false,
+  // When set, overrides the contacts_get_rich response (e.g. a gateway row
+  // under a divergent UUID for the same (type,address)).
+  richOverride: null as ((contactId: string | undefined) => unknown) | null,
   // Drives the upsert_verified_channel relay verdict. When false the gateway
   // refuses the actor (blocked/revoked) and the activation is refused.
   activationVerified: true,
@@ -53,6 +59,10 @@ mock.module("../ipc/gateway-client.js", () => ({
   ) => {
     gatewayIpc.calls.push({ method, params });
     if (method === "contacts_get_rich") {
+      if (gatewayIpc.richThrows) throw new Error("gateway read unreachable");
+      if (gatewayIpc.richOverride) {
+        return gatewayIpc.richOverride(params?.contactId as string);
+      }
       return richContactForId(params?.contactId as string);
     }
     if (method === "record_invite_redemption") {
@@ -129,6 +139,8 @@ let onGatewayClaim: (() => void) | null = null;
 function resetGatewayIpc() {
   gatewayIpc.claim = { ok: true, updated: true, mirrored: true };
   gatewayIpc.claimThrows = false;
+  gatewayIpc.richThrows = false;
+  gatewayIpc.richOverride = null;
   gatewayIpc.activationVerified = true;
   gatewayIpc.activationChannelId = "gw-channel-id";
   gatewayIpc.calls = [];
@@ -421,6 +433,142 @@ describe("invite-redemption-service", () => {
     });
 
     expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  test("matches an active member by (type,address) when the gateway row has a divergent uuid", async () => {
+    const member = upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "divergent-user",
+      status: "active",
+    });
+
+    // The gateway row for the same (type,address) carries a DIFFERENT id, as a
+    // reconcile divergence would produce. Matching by id alone would miss it.
+    gatewayIpc.richOverride = () => ({
+      ok: true,
+      contact: {
+        id: member!.contact.id,
+        displayName: member!.contact.displayName,
+        role: member!.contact.role,
+        interactionCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        channels: [
+          {
+            id: "gateway-divergent-uuid",
+            contactId: member!.contact.id,
+            type: "telegram",
+            address: "divergent-user",
+            isPrimary: false,
+            externalUserId: null,
+            status: "active",
+            policy: "allow",
+            verifiedAt: 1,
+            verifiedVia: "invite",
+            lastSeenAt: null,
+            interactionCount: 0,
+            lastInteraction: null,
+            revokedReason: null,
+            blockedReason: null,
+          },
+        ],
+      },
+    });
+
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: member!.contact.id,
+      maxUses: 5,
+    });
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "divergent-user",
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect((outcome as { type: string }).type).toBe("already_member");
+  });
+
+  test("blocks via the (type,address) match when the gateway row has a divergent uuid", async () => {
+    const member = upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "divergent-blocked",
+      status: "blocked",
+    });
+
+    gatewayIpc.richOverride = () => ({
+      ok: true,
+      contact: {
+        id: member!.contact.id,
+        displayName: member!.contact.displayName,
+        role: member!.contact.role,
+        interactionCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        channels: [
+          {
+            id: "gateway-divergent-blocked-uuid",
+            contactId: member!.contact.id,
+            type: "telegram",
+            // Case-divergent address must still match (COLLATE NOCASE).
+            address: "DIVERGENT-BLOCKED",
+            isPrimary: false,
+            externalUserId: null,
+            status: "blocked",
+            policy: "deny",
+            verifiedAt: null,
+            verifiedVia: null,
+            lastSeenAt: null,
+            interactionCount: 0,
+            lastInteraction: null,
+            revokedReason: null,
+            blockedReason: "guardian blocked",
+          },
+        ],
+      },
+    });
+
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: member!.contact.id,
+      maxUses: 5,
+    });
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "divergent-blocked",
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  test("fails open (no throw) when the gateway gate-status read is unreachable", async () => {
+    // No verdict member and an unreachable gateway read must degrade to the
+    // fail-open path: redemption still resolves rather than throwing.
+    const member = upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "readfail-user",
+      status: "revoked",
+    });
+
+    gatewayIpc.richThrows = true;
+
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: member!.contact.id,
+      maxUses: 1,
+    });
+
+    const outcome = await redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "readfail-user",
+    });
+
+    expect(outcome.ok).toBe(true);
   });
 
   test("binds redeemer to the invite's target contact, not the guardian", async () => {

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -52,6 +52,9 @@ mock.module("../ipc/gateway-client.js", () => ({
     params?: Record<string, unknown>,
   ) => {
     gatewayIpc.calls.push({ method, params });
+    if (method === "contacts_get_rich") {
+      return richContactForId(params?.contactId as string);
+    }
     if (method === "record_invite_redemption") {
       if (gatewayIpc.claimThrows) throw new Error("gateway unreachable");
       onGatewayClaim?.();
@@ -80,6 +83,43 @@ mock.module("../ipc/gateway-client.js", () => ({
     return undefined;
   },
 }));
+
+// Serves contacts_get_rich (the gateway ACL read backing the gate-status
+// fallback) from the seeded local contact, so gate resolution sources status
+// from the gateway path rather than the local channel column.
+function richContactForId(contactId: string | undefined) {
+  if (!contactId) return undefined;
+  const contact = getContact(contactId);
+  if (!contact) return undefined;
+  return {
+    ok: true,
+    contact: {
+      id: contact.id,
+      displayName: contact.displayName,
+      role: contact.role,
+      interactionCount: contact.interactionCount,
+      createdAt: contact.createdAt,
+      updatedAt: contact.updatedAt,
+      channels: contact.channels.map((c) => ({
+        id: c.id,
+        contactId: c.contactId,
+        type: c.type,
+        address: c.address,
+        isPrimary: c.isPrimary,
+        externalUserId: c.externalChatId,
+        status: c.status,
+        policy: c.policy,
+        verifiedAt: c.verifiedAt,
+        verifiedVia: c.verifiedVia,
+        lastSeenAt: c.lastSeenAt,
+        interactionCount: c.interactionCount,
+        lastInteraction: c.lastInteraction,
+        revokedReason: c.revokedReason,
+        blockedReason: c.blockedReason,
+      })),
+    },
+  };
+}
 
 // Lets a test inject a side-effect into the gateway claim — runs after the
 // service's pre-validation but before the assistant use-bump, so it can race a

--- a/assistant/src/__tests__/invite-service-ipc.test.ts
+++ b/assistant/src/__tests__/invite-service-ipc.test.ts
@@ -19,7 +19,13 @@ mock.module("../security/secure-keys.js", () => ({
 // mutating. Default the claim to consumed (updated:true) so these assistant-side
 // handler tests exercise the happy redemption path.
 mock.module("../ipc/gateway-client.js", () => ({
-  ipcCallPersistent: async (method: string) => {
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    if (method === "contacts_get_rich") {
+      return richContactForId(params?.contactId as string);
+    }
     if (method === "record_invite_redemption") {
       return { ok: true, updated: true, mirrored: true };
     }
@@ -27,7 +33,44 @@ mock.module("../ipc/gateway-client.js", () => ({
   },
 }));
 
-import { upsertContact } from "../contacts/contact-store.js";
+// Serves contacts_get_rich (the gateway ACL read backing the gate-status
+// fallback) from the seeded local contact, so the already_member gate resolves
+// via the gateway path rather than the dropped local channel column.
+function richContactForId(contactId: string | undefined) {
+  if (!contactId) return undefined;
+  const contact = getContact(contactId);
+  if (!contact) return undefined;
+  return {
+    ok: true,
+    contact: {
+      id: contact.id,
+      displayName: contact.displayName,
+      role: contact.role,
+      interactionCount: contact.interactionCount,
+      createdAt: contact.createdAt,
+      updatedAt: contact.updatedAt,
+      channels: contact.channels.map((c) => ({
+        id: c.id,
+        contactId: c.contactId,
+        type: c.type,
+        address: c.address,
+        isPrimary: c.isPrimary,
+        externalUserId: c.externalChatId,
+        status: c.status,
+        policy: c.policy,
+        verifiedAt: c.verifiedAt,
+        verifiedVia: c.verifiedVia,
+        lastSeenAt: c.lastSeenAt,
+        interactionCount: c.interactionCount,
+        lastInteraction: c.lastInteraction,
+        revokedReason: c.revokedReason,
+        blockedReason: c.blockedReason,
+      })),
+    },
+  };
+}
+
+import { getContact, upsertContact } from "../contacts/contact-store.js";
 import { handleMintInvite } from "../ipc/routes/invite-ipc-routes.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -25,6 +25,9 @@ mock.module("../ipc/gateway-client.js", () => ({
     params?: Record<string, unknown>,
   ) => {
     gatewayIpc.calls.push({ method, params });
+    if (method === "contacts_get_rich") {
+      return richContactForId(params?.contactId as string);
+    }
     if (method === "record_invite_redemption") {
       if (gatewayIpc.claimThrows) throw new Error("gateway unreachable");
       return gatewayIpc.claim;
@@ -38,6 +41,43 @@ mock.module("../ipc/gateway-client.js", () => ({
     return undefined;
   },
 }));
+
+// Serves contacts_get_rich (the gateway ACL read backing the gate-status
+// fallback) from the seeded local contact, so gate resolution sources status
+// from the gateway path rather than the local channel column.
+function richContactForId(contactId: string | undefined) {
+  if (!contactId) return undefined;
+  const contact = getContact(contactId);
+  if (!contact) return undefined;
+  return {
+    ok: true,
+    contact: {
+      id: contact.id,
+      displayName: contact.displayName,
+      role: contact.role,
+      interactionCount: contact.interactionCount,
+      createdAt: contact.createdAt,
+      updatedAt: contact.updatedAt,
+      channels: contact.channels.map((c) => ({
+        id: c.id,
+        contactId: c.contactId,
+        type: c.type,
+        address: c.address,
+        isPrimary: c.isPrimary,
+        externalUserId: c.externalChatId,
+        status: c.status,
+        policy: c.policy,
+        verifiedAt: c.verifiedAt,
+        verifiedVia: c.verifiedVia,
+        lastSeenAt: c.lastSeenAt,
+        interactionCount: c.interactionCount,
+        lastInteraction: c.lastInteraction,
+        revokedReason: c.revokedReason,
+        blockedReason: c.blockedReason,
+      })),
+    },
+  };
+}
 
 function resetGatewayIpc() {
   gatewayIpc.claim = { ok: true, updated: true, mirrored: true };

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -14,6 +14,12 @@ const gatewayIpc = {
     mirrored: boolean;
   },
   claimThrows: false,
+  // When set, contacts_get_rich throws (gateway read unreachable) so the
+  // gate-status fallback must fail open.
+  richThrows: false,
+  // When set, overrides the contacts_get_rich response (e.g. a gateway row
+  // under a divergent UUID for the same (type,address)).
+  richOverride: null as ((contactId: string | undefined) => unknown) | null,
   // Drives the upsert_verified_channel relay verdict; false refuses the actor.
   activationVerified: true,
   calls: [] as { method: string; params?: Record<string, unknown> }[],
@@ -26,6 +32,10 @@ mock.module("../ipc/gateway-client.js", () => ({
   ) => {
     gatewayIpc.calls.push({ method, params });
     if (method === "contacts_get_rich") {
+      if (gatewayIpc.richThrows) throw new Error("gateway read unreachable");
+      if (gatewayIpc.richOverride) {
+        return gatewayIpc.richOverride(params?.contactId as string);
+      }
       return richContactForId(params?.contactId as string);
     }
     if (method === "record_invite_redemption") {
@@ -82,6 +92,8 @@ function richContactForId(contactId: string | undefined) {
 function resetGatewayIpc() {
   gatewayIpc.claim = { ok: true, updated: true, mirrored: true };
   gatewayIpc.claimThrows = false;
+  gatewayIpc.richThrows = false;
+  gatewayIpc.richOverride = null;
   gatewayIpc.activationVerified = true;
   gatewayIpc.calls = [];
 }
@@ -330,6 +342,83 @@ describe("redeemVoiceInviteCode", () => {
     expect(
       findContactChannel({ channelType: "phone", address: phone }),
     ).not.toBeNull();
+  });
+
+  test("matches an active member by (type,address) when the gateway row has a divergent uuid", async () => {
+    const phone = "+15551234567";
+    const member = upsertContactChannel({
+      sourceChannel: "phone",
+      externalUserId: phone,
+      status: "active",
+    });
+    const { code } = createVoiceInvite({
+      callerPhone: phone,
+      contactId: member!.contact.id,
+    });
+
+    // Gateway row for the same (type,address) under a DIFFERENT id.
+    gatewayIpc.richOverride = () => ({
+      ok: true,
+      contact: {
+        id: member!.contact.id,
+        displayName: member!.contact.displayName,
+        role: member!.contact.role,
+        interactionCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        channels: [
+          {
+            id: "gateway-divergent-uuid",
+            contactId: member!.contact.id,
+            type: "phone",
+            address: phone,
+            isPrimary: false,
+            externalUserId: null,
+            status: "active",
+            policy: "allow",
+            verifiedAt: 1,
+            verifiedVia: "invite",
+            lastSeenAt: null,
+            interactionCount: 0,
+            lastInteraction: null,
+            revokedReason: null,
+            blockedReason: null,
+          },
+        ],
+      },
+    });
+
+    const result = await redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: "phone",
+      code,
+    });
+
+    expect(result.ok).toBe(true);
+    expect((result as { type: string }).type).toBe("already_member");
+  });
+
+  test("fails open (no throw) when the gateway gate-status read is unreachable", async () => {
+    const phone = "+15551234567";
+    const member = upsertContactChannel({
+      sourceChannel: "phone",
+      externalUserId: phone,
+      status: "revoked",
+    });
+    const { code } = createVoiceInvite({
+      callerPhone: phone,
+      contactId: member!.contact.id,
+    });
+
+    gatewayIpc.richThrows = true;
+
+    const result = await redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: "phone",
+      code,
+    });
+
+    expect(result.ok).toBe(true);
   });
 
   test("marks channel as verified via invite on voice redemption", async () => {

--- a/assistant/src/contacts/gateway-channel-read.ts
+++ b/assistant/src/contacts/gateway-channel-read.ts
@@ -1,23 +1,51 @@
 import { GetContactIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
+import { getLogger } from "../util/logger.js";
 import type { ContactChannel } from "./types.js";
+
+const log = getLogger("gateway-channel-read");
 
 /**
  * Read a contact channel's verified state from the gateway contact-channel read
  * (ACL source of truth). Covers all contacts, not just guardian deliveries.
- * Returns `undefined` when the gateway is unreachable or has no such channel.
+ *
+ * Matches the gateway row by logical identity — `(type, address)`,
+ * case-insensitive — not by id, so a reconcile-divergent row that the gateway
+ * write helpers re-keyed under a different UUID is still found.
+ *
+ * Returns `undefined` for unreachable reads (gateway down, IPC timeout, schema
+ * mismatch) or when no such channel exists, so callers fail open.
  */
 export async function gatewayContactChannelState(
-  channel: Pick<ContactChannel, "id" | "contactId">,
+  channel: Pick<ContactChannel, "contactId" | "type" | "address">,
 ): Promise<{ status: string; verifiedAt: number | null } | undefined> {
-  const result = await ipcCallPersistent("contacts_get_rich", {
-    contactId: channel.contactId,
-  });
+  let result: unknown;
+  try {
+    result = await ipcCallPersistent("contacts_get_rich", {
+      contactId: channel.contactId,
+    });
+  } catch (err) {
+    log.warn(
+      { err, contactId: channel.contactId },
+      "contacts_get_rich unreachable — failing open",
+    );
+    return undefined;
+  }
   if (!result || (result as { contact?: unknown }).contact == null) {
     return undefined;
   }
-  const { contact } = GetContactIpcResponseSchema.parse(result);
-  const ch = contact.channels.find((c) => c.id === channel.id);
+  const parsed = GetContactIpcResponseSchema.safeParse(result);
+  if (!parsed.success) {
+    log.warn(
+      { err: parsed.error, contactId: channel.contactId },
+      "contacts_get_rich response failed schema parse — failing open",
+    );
+    return undefined;
+  }
+  const address = channel.address.toLowerCase();
+  const ch = parsed.data.contact.channels.find(
+    (c) => c.type === channel.type && c.address.toLowerCase() === address,
+  );
   return ch ? { status: ch.status, verifiedAt: ch.verifiedAt } : undefined;
 }

--- a/assistant/src/contacts/gateway-channel-read.ts
+++ b/assistant/src/contacts/gateway-channel-read.ts
@@ -1,0 +1,23 @@
+import { GetContactIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import { ipcCallPersistent } from "../ipc/gateway-client.js";
+import type { ContactChannel } from "./types.js";
+
+/**
+ * Read a contact channel's verified state from the gateway contact-channel read
+ * (ACL source of truth). Covers all contacts, not just guardian deliveries.
+ * Returns `undefined` when the gateway is unreachable or has no such channel.
+ */
+export async function gatewayContactChannelState(
+  channel: Pick<ContactChannel, "id" | "contactId">,
+): Promise<{ status: string; verifiedAt: number | null } | undefined> {
+  const result = await ipcCallPersistent("contacts_get_rich", {
+    contactId: channel.contactId,
+  });
+  if (!result || (result as { contact?: unknown }).contact == null) {
+    return undefined;
+  }
+  const { contact } = GetContactIpcResponseSchema.parse(result);
+  const ch = contact.channels.find((c) => c.id === channel.id);
+  return ch ? { status: ch.status, verifiedAt: ch.verifiedAt } : undefined;
+}

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,14 +1,12 @@
 import { createHash, randomBytes } from "node:crypto";
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";
-import {
-  GetContactIpcResponseSchema,
-  MarkChannelRevokedIpcResponseSchema,
-} from "@vellumai/gateway-client/gateway-ipc-contracts";
+import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { startVerificationCall } from "../../calls/call-domain.js";
 import type { ChannelId } from "../../channels/types.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
+import { gatewayContactChannelState } from "../../contacts/gateway-channel-read.js";
 import {
   findContactChannel,
   findGuardianForChannel,
@@ -103,25 +101,6 @@ async function deliveryForChannel(
         (channel.externalChatId != null &&
           g.externalChatId === channel.externalChatId)),
   );
-}
-
-/**
- * Read a contact channel's verified state from the gateway contact-channel read
- * (ACL source of truth). Covers all contacts, not just guardian deliveries.
- * Returns `undefined` when the gateway is unreachable or has no such channel.
- */
-async function gatewayContactChannelState(
-  channel: Pick<ContactChannel, "id" | "contactId">,
-): Promise<{ status: string; verifiedAt: number | null } | undefined> {
-  const result = await ipcCallPersistent("contacts_get_rich", {
-    contactId: channel.contactId,
-  });
-  if (!result || (result as { contact?: unknown }).contact == null) {
-    return undefined;
-  }
-  const { contact } = GetContactIpcResponseSchema.parse(result);
-  const ch = contact.channels.find((c) => c.id === channel.id);
-  return ch ? { status: ch.status, verifiedAt: ch.verifiedAt } : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -6,13 +6,13 @@ import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/ga
 import { startVerificationCall } from "../../calls/call-domain.js";
 import type { ChannelId } from "../../channels/types.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
-import { gatewayContactChannelState } from "../../contacts/gateway-channel-read.js";
 import {
   findContactChannel,
   findGuardianForChannel,
   getChannelById,
   getContact,
 } from "../../contacts/contact-store.js";
+import { gatewayContactChannelState } from "../../contacts/gateway-channel-read.js";
 import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
 import type { ContactChannel } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -56,7 +56,7 @@ export async function resolveMemberGateStatus(
  * local column.
  */
 async function gatewayFallbackStatus(
-  channel: Pick<ContactChannel, "id" | "contactId"> | null,
+  channel: Pick<ContactChannel, "contactId" | "type" | "address"> | null,
 ): Promise<ChannelStatus | null> {
   if (!channel) return null;
   const state = await gatewayContactChannelState(channel);

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -13,8 +13,9 @@ import {
 } from "../calls/inbound-trust-reader.js";
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel, getContact } from "../contacts/contact-store.js";
+import { gatewayContactChannelState } from "../contacts/gateway-channel-read.js";
 import { activateMemberChannel } from "../contacts/member-write-relay.js";
-import type { ChannelStatus } from "../contacts/types.js";
+import type { ChannelStatus, ContactChannel } from "../contacts/types.js";
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
 import {
   findActiveVoiceInvites,
@@ -33,19 +34,33 @@ const log = getLogger("invite-redemption-service");
 
 /**
  * Resolve the sender's existing member status for the already_member/blocked
- * gate from the gateway trust verdict. Falls back to the local channel status
- * when the verdict is absent or carries no resolvable member status (e.g. an
- * externalChatId-only match or a resolutionFailed verdict), so a locally
- * blocked contact can't bypass the gate.
+ * gate from the gateway trust verdict. Falls back to the gateway-sourced channel
+ * status when the verdict is absent or carries no resolvable member status (e.g.
+ * an externalChatId-only match or a resolutionFailed verdict), so a blocked
+ * contact can't bypass the gate.
  */
 export async function resolveMemberGateStatus(
   verdict: Awaited<ReturnType<typeof getInboundTrustVerdict>>,
-  localChannelStatus: ChannelStatus | null,
+  fallbackStatus: ChannelStatus | null,
 ): Promise<ChannelStatus | null> {
   const memberStatus = verdict
     ? verdictMemberFromVerdict(verdict)?.status
     : null;
-  return memberStatus ?? localChannelStatus;
+  return memberStatus ?? fallbackStatus;
+}
+
+/**
+ * Gateway-sourced status for an existing local channel, used as the gate-status
+ * fallback when the verdict resolves no member. The local row is only located by
+ * identity; its status is read from the gateway (ACL source of truth), never the
+ * local column.
+ */
+async function gatewayFallbackStatus(
+  channel: Pick<ContactChannel, "id" | "contactId"> | null,
+): Promise<ChannelStatus | null> {
+  if (!channel) return null;
+  const state = await gatewayContactChannelState(channel);
+  return (state?.status as ChannelStatus | undefined) ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -245,7 +260,7 @@ export async function redeemInvite(params: {
       channelType: sourceChannel as ChannelId,
       actorExternalId: canonicalUserId,
     }),
-    existingChannel?.status ?? null,
+    await gatewayFallbackStatus(existingChannel),
   );
 
   if (existingChannel && gateStatus === "active" && !targetMismatch) {
@@ -481,7 +496,7 @@ export async function redeemVoiceInviteCode(params: {
 
   const gateStatus = await resolveMemberGateStatus(
     await getPhoneCallerVerdict(canonicalCallerId),
-    existingVoiceChannel?.status ?? null,
+    await gatewayFallbackStatus(existingVoiceChannel),
   );
 
   if (existingVoiceChannel && gateStatus === "active" && !targetMismatch) {
@@ -657,7 +672,7 @@ export async function redeemInviteByCode(params: {
       channelType: sourceChannel as ChannelId,
       actorExternalId: canonicalUserId,
     }),
-    existingChannel?.status ?? null,
+    await gatewayFallbackStatus(existingChannel),
   );
 
   if (existingChannel && gateStatus === "active" && !targetMismatch) {


### PR DESCRIPTION
## Summary
- Extract gatewayContactChannelState into a shared assistant/src/contacts/gateway-channel-read.ts
- resolveMemberGateStatus fallback now sources channel status from the gateway, not the local DB column

Part of plan: combo11-phase-b2-drop-acl-columns.md (PR 2 of 11)