### PR TITLE
refactor(contacts): replace resolvedMemberFromVerdict with the narrow verdict member

### DIFF
--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -404,8 +404,8 @@ function makeVerdict(overrides: Partial<TrustVerdict> = {}): TrustVerdict {
 }
 
 // A verdict carrying a fully-resolvable member ACL (contactId/channelId + valid
-// known status·policy enums). The REAL `resolvedMemberFromVerdict` synthesizes
-// a memberRecord from these, so the verdict path enforces blocked/revoked/deny.
+// known status·policy enums). The verdict path builds a memberRecord from
+// these, so it enforces blocked/revoked/deny.
 function makeMemberVerdict(
   trustClass: TrustVerdict["trustClass"],
   channel: { status: string; policy?: string },

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -11,7 +11,6 @@ import type { ActorTrustContext } from "../actor-trust-resolver.js";
 import { toTrustContext } from "../actor-trust-resolver.js";
 import {
   actorTrustContextFromVerdict,
-  resolvedMemberFromVerdict,
   trustContextFromVerdict,
   verdictHasMemberIdentity,
   verdictMemberFromVerdict,
@@ -292,6 +291,77 @@ describe("actorTrustContextFromVerdict", () => {
     expect(ctx.memberRecord!.channel.policy).toBe("deny");
   });
 
+  test("memberRecord surfaces channel ACL/identity, info fields null", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      type: "slack",
+      address: "u-1",
+      status: "active",
+      policy: "allow",
+      externalChatId: "chat-1",
+      verifiedAt: 1700000000,
+      verifiedVia: "code",
+      memberDisplayName: "Dora",
+    } satisfies TrustVerdict;
+
+    const { memberRecord } = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+    expect(memberRecord!.channel.status).toBe("active");
+    expect(memberRecord!.channel.policy).toBe("allow");
+    expect(memberRecord!.channel.verifiedAt).toBe(1700000000);
+    expect(memberRecord!.channel.verifiedVia).toBe("code");
+    expect(memberRecord!.channel.externalChatId).toBe("chat-1");
+
+    expect(memberRecord!.contact.displayName).toBe("Dora");
+    expect(memberRecord!.contact.role).toBe("contact");
+    // INFO fields must be null/default placeholders.
+    expect(memberRecord!.contact.notes).toBeNull();
+    expect(memberRecord!.contact.userFile).toBeNull();
+    expect(memberRecord!.contact.interactionCount).toBe(0);
+    expect(memberRecord!.contact.lastInteraction).toBeNull();
+  });
+
+  test("guardian member verdict maps role guardian + principalId", () => {
+    const verdict = {
+      trustClass: "guardian",
+      canonicalSenderId: "u-g",
+      contactId: "contact-g",
+      channelId: "channel-g",
+      guardianPrincipalId: "vellum-principal-g",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const { memberRecord } = actorTrustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+    expect(memberRecord!.contact.role).toBe("guardian");
+    expect(memberRecord!.contact.principalId).toBe("vellum-principal-g");
+  });
+
+  test("memberRecord null when status missing (fail-closed)", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-4",
+      contactId: "contact-4",
+      channelId: "channel-4",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    expect(
+      actorTrustContextFromVerdict(verdict, {
+        sourceChannel: "slack",
+        conversationExternalId: CONV,
+      }).memberRecord,
+    ).toBeNull();
+  });
+
   test("stranger verdict (no contactId/channelId) leaves memberRecord null", () => {
     const verdict = {
       trustClass: "unknown",
@@ -347,11 +417,11 @@ describe("actorTrustContextFromVerdict", () => {
       actorTrustContextFromVerdict(verdict, input),
       input.conversationExternalId,
     );
-    const member = resolvedMemberFromVerdict(verdict);
+    const member = verdictMemberFromVerdict(verdict);
     expect(member).not.toBeNull();
-    expected.requesterContactId = member!.contact.id;
-    expected.memberStatus = channelStatusToMemberStatus(member!.channel.status);
-    expected.memberPolicy = member!.channel.policy;
+    expected.requesterContactId = member!.contactId;
+    expected.memberStatus = channelStatusToMemberStatus(member!.status);
+    expected.memberPolicy = member!.policy;
 
     expect(trustContextFromVerdict(verdict, input)).toEqual(expected);
   });
@@ -463,151 +533,6 @@ describe("toTrustContext member grounding", () => {
   });
 });
 
-describe("resolvedMemberFromVerdict", () => {
-  test("member verdict surfaces channel ACL/identity, info fields null", () => {
-    const verdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "u-1",
-      contactId: "contact-1",
-      channelId: "channel-1",
-      type: "slack",
-      address: "u-1",
-      status: "active",
-      policy: "allow",
-      externalChatId: "chat-1",
-      verifiedAt: 1700000000,
-      verifiedVia: "code",
-      memberDisplayName: "Dora",
-    } satisfies TrustVerdict;
-
-    const member = resolvedMemberFromVerdict(verdict);
-    expect(member).not.toBeNull();
-    expect(member!.channel.id).toBe("channel-1");
-    expect(member!.channel.status).toBe("active");
-    expect(member!.channel.policy).toBe("allow");
-    expect(member!.channel.verifiedAt).toBe(1700000000);
-    expect(member!.channel.verifiedVia).toBe("code");
-    expect(member!.channel.externalChatId).toBe("chat-1");
-
-    expect(member!.contact.id).toBe("contact-1");
-    expect(member!.contact.displayName).toBe("Dora");
-    expect(member!.contact.role).toBe("contact");
-    // INFO fields must be null/default placeholders.
-    expect(member!.contact.notes).toBeNull();
-    expect(member!.contact.userFile).toBeNull();
-    expect(member!.contact.interactionCount).toBe(0);
-    expect(member!.contact.lastInteraction).toBeNull();
-  });
-
-  test("guardian member verdict maps role guardian + principalId", () => {
-    const verdict = {
-      trustClass: "guardian",
-      canonicalSenderId: "u-g",
-      contactId: "contact-g",
-      channelId: "channel-g",
-      guardianPrincipalId: "vellum-principal-g",
-      status: "active",
-      policy: "allow",
-    } satisfies TrustVerdict;
-
-    const member = resolvedMemberFromVerdict(verdict);
-    expect(member!.contact.role).toBe("guardian");
-    expect(member!.contact.principalId).toBe("vellum-principal-g");
-  });
-
-  test("memberless verdict (no contactId) returns null", () => {
-    const verdict = {
-      trustClass: "unknown",
-      canonicalSenderId: "u-2",
-    } satisfies TrustVerdict;
-
-    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
-  });
-
-  test("member verdict missing status returns null (fail-closed)", () => {
-    const verdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "u-4",
-      contactId: "contact-4",
-      channelId: "channel-4",
-      policy: "allow",
-    } satisfies TrustVerdict;
-
-    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
-  });
-
-  test("member verdict missing policy returns null (fail-closed)", () => {
-    const verdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "u-5",
-      contactId: "contact-5",
-      channelId: "channel-5",
-      status: "active",
-    } satisfies TrustVerdict;
-
-    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
-  });
-
-  test("member verdict with unknown policy returns null (fail-closed)", () => {
-    const verdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "u-6",
-      contactId: "contact-6",
-      channelId: "channel-6",
-      status: "active",
-      policy: "bogus",
-    } satisfies TrustVerdict;
-
-    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
-  });
-
-  test("member verdict with unknown status returns null (fail-closed)", () => {
-    const verdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "u-7",
-      contactId: "contact-7",
-      channelId: "channel-7",
-      status: "quarantined",
-      policy: "allow",
-    } satisfies TrustVerdict;
-
-    expect(resolvedMemberFromVerdict(verdict)).toBeNull();
-  });
-
-  test("member verdict with valid known status+policy returns a member", () => {
-    const verdict = {
-      trustClass: "trusted_contact",
-      canonicalSenderId: "u-8",
-      contactId: "contact-8",
-      channelId: "channel-8",
-      status: "active",
-      policy: "allow",
-    } satisfies TrustVerdict;
-
-    const member = resolvedMemberFromVerdict(verdict);
-    expect(member).not.toBeNull();
-    expect(member!.channel.status).toBe("active");
-    expect(member!.channel.policy).toBe("allow");
-  });
-
-  test("blocked/revoked verdict surfaces channel.status verbatim", () => {
-    for (const status of ["blocked", "revoked"] as const) {
-      const verdict = {
-        trustClass: "unknown",
-        canonicalSenderId: "u-3",
-        contactId: "contact-3",
-        channelId: "channel-3",
-        status,
-        policy: "deny",
-      } satisfies TrustVerdict;
-
-      const member = resolvedMemberFromVerdict(verdict);
-      expect(member!.channel.status).toBe(status);
-      expect(member!.channel.policy).toBe("deny");
-    }
-  });
-});
-
 describe("verdictMemberFromVerdict", () => {
   test("active member verdict yields the narrow ACL view", () => {
     const verdict = {
@@ -681,6 +606,27 @@ describe("verdictMemberFromVerdict", () => {
         channelId: "channel-6",
         status: "active",
         policy: "bogus",
+      } satisfies TrustVerdict),
+    ).toBeNull();
+  });
+
+  test("missing status or policy returns null (fail-closed)", () => {
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-4",
+        contactId: "contact-4",
+        channelId: "channel-4",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toBeNull();
+    expect(
+      verdictMemberFromVerdict({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-5",
+        contactId: "contact-5",
+        channelId: "channel-5",
+        status: "active",
       } satisfies TrustVerdict),
     ).toBeNull();
   });

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -4,10 +4,9 @@
  *
  * The gateway resolves a per-actor verdict from its ACL DB and stamps it onto
  * inbound `sourceMetadata`. These pure mappers turn that verdict into the same
- * {@link TrustContext} / {@link ResolvedMember} the local resolver would have
- * produced — ACL + identity only. INFO fields (notes, userFile, contactType,
- * interactionCount) are never carried on the wire; the consumer re-joins them
- * locally by contactId.
+ * {@link TrustContext} the local resolver would have produced — ACL + identity
+ * only. INFO fields (notes, userFile, contactType, interactionCount) are never
+ * carried on the wire; the consumer re-joins them locally by contactId.
  */
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
@@ -23,7 +22,6 @@ import type {
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ActorTrustContext } from "./actor-trust-resolver.js";
 import { toTrustContext } from "./actor-trust-resolver.js";
-import type { ResolvedMember } from "./routes/inbound-stages/acl-enforcement.js";
 
 export interface TrustVerdictTransport {
   sourceChannel: ChannelId;
@@ -66,7 +64,7 @@ export function actorTrustContextFromVerdict(
     // deny/escalate. Null for memberless verdicts. Text path is unaffected:
     // toTrustContext derives the same member fields trustContextFromVerdict
     // already stamps.
-    memberRecord: resolvedMemberFromVerdict(verdict),
+    memberRecord: memberRecordFromVerdict(verdict),
     trustClass: verdict.trustClass,
     actorMetadata: {
       identifier,
@@ -99,11 +97,11 @@ export function trustContextFromVerdict(
   // Stamp the verdict's ACL member fields onto the context so downstream turn
   // assembly reads member status/policy from the verdict rather than a local
   // re-resolution. The contact ID anchors the local info-only join.
-  const member = resolvedMemberFromVerdict(verdict);
+  const member = verdictMemberFromVerdict(verdict);
   if (member) {
-    context.requesterContactId = member.contact.id;
-    context.memberStatus = channelStatusToMemberStatus(member.channel.status);
-    context.memberPolicy = member.channel.policy;
+    context.requesterContactId = member.contactId;
+    context.memberStatus = channelStatusToMemberStatus(member.status);
+    context.memberPolicy = member.policy;
   }
 
   return context;
@@ -111,7 +109,7 @@ export function trustContextFromVerdict(
 
 /**
  * True when the verdict carries a member identity (contactId or channelId),
- * regardless of whether that member resolves to a usable {@link ResolvedMember}.
+ * regardless of whether that member resolves to a usable {@link VerdictMember}.
  */
 export function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
   return !!(verdict.contactId || verdict.channelId);
@@ -119,13 +117,13 @@ export function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
 
 /**
  * True when the verdict claims a member identity but that member can't be
- * synthesized (partial/mixed-version verdict). Such a verdict is unusable —
+ * resolved (partial/mixed-version verdict). Such a verdict is unusable —
  * callers fall back to local resolution.
  */
 export function verdictMemberUnresolvable(verdict: TrustVerdict): boolean {
   return (
     verdictHasMemberIdentity(verdict) &&
-    resolvedMemberFromVerdict(verdict) === null
+    verdictMemberFromVerdict(verdict) === null
   );
 }
 
@@ -167,8 +165,8 @@ export interface VerdictMember {
 /**
  * Extract the narrow {@link VerdictMember} ACL view from a gateway verdict.
  *
- * Mirrors {@link resolvedMemberFromVerdict}'s guards (contactId/channelId
- * present + known status/policy enums), failing closed to null otherwise.
+ * Guards on contactId/channelId presence + known status/policy enums, failing
+ * closed to null otherwise.
  */
 export function verdictMemberFromVerdict(
   verdict: TrustVerdict,
@@ -190,34 +188,28 @@ export function verdictMemberFromVerdict(
 }
 
 /**
- * Build a synthetic {@link ResolvedMember} from a gateway verdict.
+ * Build the voice-path {@link ActorTrustContext.memberRecord} from a gateway
+ * verdict's narrow ACL view.
  *
  * ACL + identity only; info fields are placeholders, re-joined locally by
- * contactId. Returns null for memberless verdicts.
+ * contactId. Returns null for memberless/unresolvable verdicts.
  */
-export function resolvedMemberFromVerdict(
+function memberRecordFromVerdict(
   verdict: TrustVerdict,
-): ResolvedMember | null {
-  if (!verdict.contactId || !verdict.channelId) return null;
-  // Member verdict requires valid known status+policy enums, else null
-  // (fail-closed): a partial/mixed-version verdict (absent OR
-  // present-but-unknown ACL value) must not synthesize an active/allow channel
-  // that would skip ingress ACL gates.
-  if (!verdict.status || !verdict.policy) return null;
-  if (!isChannelStatus(verdict.status) || !isChannelPolicy(verdict.policy)) {
-    return null;
-  }
+): ActorTrustContext["memberRecord"] {
+  const member = verdictMemberFromVerdict(verdict);
+  if (!member) return null;
 
   const channel: ContactChannel = {
-    id: verdict.channelId,
-    contactId: verdict.contactId,
+    id: member.channelId,
+    contactId: member.contactId,
     type: verdict.type ?? "",
     address: verdict.address ?? "",
     isPrimary: false,
     externalChatId: verdict.externalChatId ?? null,
-    status: verdict.status,
-    policy: verdict.policy,
-    verifiedAt: verdict.verifiedAt ?? null,
+    status: member.status,
+    policy: member.policy,
+    verifiedAt: member.verifiedAt,
     verifiedVia: verdict.verifiedVia ?? null,
     inviteId: null,
     revokedReason: null,
@@ -230,8 +222,8 @@ export function resolvedMemberFromVerdict(
   };
 
   const contact: ContactWithChannels = {
-    id: verdict.contactId,
-    displayName: verdict.memberDisplayName ?? "",
+    id: member.contactId,
+    displayName: member.displayName ?? "",
     notes: null,
     lastInteraction: null,
     interactionCount: 0,


### PR DESCRIPTION
## Summary
- Replace resolvedMemberFromVerdict callers with verdictMemberFromVerdict
- Delete the Contact/ContactChannel synthesizer that fabricated soon-dropped ACL fields

Part of plan: combo11-phase-b2-drop-acl-columns.md (PR 3 of 11)