### PR TITLE
refactor(contacts): remove #35806 transitional local principalId fallbacks

### DIFF
--- a/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
+++ b/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
@@ -70,11 +70,10 @@ describe("healGuardianBindingDrift", () => {
     expect(guardian!.channel.address).toBe("vellum-principal-old-uuid");
   });
 
-  test("repairs the stale local mirror even when the gateway already matches the JWT", async () => {
-    // Gateway binding already matches the incoming JWT principal, but the
-    // local mirror is stale — the gateway-source-of-truth drift mode. The
-    // /v1/messages trust path still reads the local mirror in this plan, so
-    // a stale row must be repaired or the actor stays classified `unknown`.
+  test("repairs the local mirror toward the JWT when the gateway diverges", async () => {
+    // Gateway principal diverges from the incoming JWT — the drift signal. The
+    // /v1/messages trust path still reads the local mirror in this plan, so the
+    // mirror is repaired toward the JWT or the actor stays `unknown`.
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "vellum-principal-stale-local",
@@ -82,7 +81,7 @@ describe("healGuardianBindingDrift", () => {
       guardianPrincipalId: "vellum-principal-stale-local",
       verifiedVia: "startup-migration",
     });
-    mockGuardians = [gatewayGuardian("vellum-principal-jwt")];
+    mockGuardians = [gatewayGuardian("vellum-principal-gateway")];
 
     const healed = await healGuardianBindingDrift("vellum-principal-jwt");
     expect(healed).toBe(true);
@@ -127,7 +126,7 @@ describe("healGuardianBindingDrift", () => {
     expect(guardian!.contact.principalId).toBe("vellum-principal-aaa");
   });
 
-  test("refuses to heal when stored principal lacks vellum-principal- prefix", async () => {
+  test("refuses to heal when the gateway principal lacks vellum-principal- prefix", async () => {
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "verified-phone-guardian",

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -551,10 +551,14 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("telegram");
   });
 
-  test("notifyGuardianOfAccessRequest falls back to local source-channel binding when gateway delivery is empty", async () => {
-    // Gateway delivery read yields nothing (restart/timeout/malformed IPC).
-    gatewayGuardians = [];
-    // Local dual-written mirror still has the vellum anchor + telegram binding.
+  test("notifyGuardianOfAccessRequest resolves the source-channel guardian from the gateway delivery", async () => {
+    // Gateway delivery serves a telegram guardian matching the vellum anchor.
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-tg",
+      externalChatId: "tg-chat",
+      principalId: anchorPrincipalId,
+    });
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-tg",
@@ -578,7 +582,7 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
-    // Request is decidable: local read supplied the principal + source binding.
+    // Request is decidable: gateway delivery supplied the principal + source binding.
     expect(pending[0].guardianPrincipalId).toBe(anchorPrincipalId);
     expect(pending[0].guardianExternalUserId).toBe("guardian-tg");
 
@@ -589,10 +593,8 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("telegram");
   });
 
-  test("notifyGuardianOfAccessRequest falls back to local vellum anchor when gateway delivery is empty", async () => {
-    // Gateway empty; only the local vellum anchor from resetState remains.
-    gatewayGuardians = [];
-
+  test("notifyGuardianOfAccessRequest resolves the vellum anchor from the gateway delivery", async () => {
+    // Only the vellum anchor (seeded in resetState) is served by the gateway.
     const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
       sourceChannel: "telegram",
@@ -608,7 +610,7 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
-    // Decidable via the local vellum anchor principal.
+    // Decidable via the gateway-served vellum anchor principal.
     expect(pending[0].guardianPrincipalId).toBe(anchorPrincipalId);
 
     const payload = emitSignalCalls[0].contextPayload as Record<
@@ -618,9 +620,9 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("vellum");
   });
 
-  test("notifyGuardianOfAccessRequest does not create a decisionable request when both gateway and local reads are empty", async () => {
-    // Genuinely unbound assistant: gateway empty AND no local binding. Prior
-    // behavior rejects creation of a decisionable request without a principal.
+  test("notifyGuardianOfAccessRequest does not create a decisionable request when the gateway delivery is empty", async () => {
+    // Genuinely unbound assistant: gateway serves no guardian. The guard
+    // rejects creation of a decisionable request without a principal.
     gatewayGuardians = [];
     const db = getDb();
     db.run("DELETE FROM contact_channels");

--- a/assistant/src/__tests__/sse-actor-principal-guardian-source.test.ts
+++ b/assistant/src/__tests__/sse-actor-principal-guardian-source.test.ts
@@ -2,18 +2,16 @@
  * Regression: the SSE subscribe path must resolve the actor principal from the
  * SAME guardian source as the send/result routes.
  *
- * The send/result routes resolve the actor principal via the async,
- * gateway-first `findLocalGuardianPrincipalId`. The SSE eager-subscribe path
- * cannot await and uses the sync `findLocalGuardianPrincipalIdFromStore`. When
- * the gateway binding is canonical but the local contact row is stale/missing
- * (after a guardian reset or gateway-owned binding update), the sync path must
- * still land on the gateway principal — otherwise the event hub registers the
- * SSE client under a DIFFERENT principal than the turn/result paths use, and
- * targeted result submissions 403.
+ * The send/result routes resolve the actor principal via the async
+ * `findLocalGuardianPrincipalId`. The SSE eager-subscribe path cannot await and
+ * uses the sync `findLocalGuardianPrincipalIdFromStore`. Both read the
+ * gateway-owned guardian binding — async via the cached IPC read, sync via the
+ * IO-free cache snapshot — so the event hub registers the SSE client under the
+ * SAME principal the turn/result paths use; otherwise targeted result
+ * submissions 403.
  *
- * These tests pin the invariant by priming the gateway-delivery cache with a
- * principal that differs from the stale local store and asserting both
- * resolvers agree; and that a cold cache falls back to the local store.
+ * These tests pin the invariant by priming the gateway-delivery cache and
+ * asserting both resolvers agree; and that a cold cache yields no principal.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -28,17 +26,6 @@ mock.module("../ipc/gateway-client.js", () => ({
   ipcCall: async () => ({ guardians: ipcGuardians }),
   ipcCallPersistent: async () => undefined,
   resetPersistentClient: () => {},
-}));
-
-// ── Local store mock (the stale fallback source) ─────────────────────────────
-
-let storePrincipalId: string | undefined;
-
-mock.module("../contacts/contact-store.js", () => ({
-  findGuardianForChannel: (channelType: string) =>
-    storePrincipalId && channelType === "vellum"
-      ? { contact: { principalId: storePrincipalId }, channel: {} }
-      : null,
 }));
 
 import {
@@ -62,31 +49,21 @@ describe("SSE actor principal resolves from the same guardian source as send/res
   beforeEach(() => {
     __resetGuardianDeliveryCacheForTest();
     ipcGuardians = [];
-    storePrincipalId = undefined;
   });
 
-  test("warm gateway cache: sync (SSE) and async (send/result) resolve the SAME principal despite a stale local store", async () => {
-    // Gateway binding is canonical; local store row is stale (different id).
+  test("warm gateway cache: sync (SSE) and async (send/result) resolve the SAME principal", async () => {
     ipcGuardians = [gatewayVellumGuardian];
-    storePrincipalId = "guardian-stale-local";
 
     // Prime the cache the way the async hot paths do.
     const asyncPrincipalId = await findLocalGuardianPrincipalId();
     expect(asyncPrincipalId).toBe("guardian-from-gateway");
 
-    // SSE's sync resolver reads the same cached gateway snapshot, NOT the
-    // stale store — so the principals match and host-proxy targeting works.
+    // SSE's sync resolver reads the same cached gateway snapshot — so the
+    // principals match and host-proxy targeting works.
     expect(findLocalGuardianPrincipalIdFromStore()).toBe(asyncPrincipalId);
   });
 
-  test("cold cache: sync resolver falls back to the local store as before", () => {
-    // Nothing primed the cache; only the local store has a binding.
-    storePrincipalId = "guardian-stale-local";
-
-    expect(findLocalGuardianPrincipalIdFromStore()).toBe("guardian-stale-local");
-  });
-
-  test("cold cache with no store binding: sync resolver returns undefined", () => {
+  test("cold cache: sync resolver returns undefined", () => {
     expect(findLocalGuardianPrincipalIdFromStore()).toBeUndefined();
   });
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -74,6 +74,7 @@ import {
   resolveSigningKey,
 } from "../runtime/auth/token-service.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
+import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
 import {
@@ -824,6 +825,16 @@ export async function runDaemon(): Promise<void> {
 
     await server.start();
     log.info("Daemon startup: DaemonServer started");
+
+    // Warm the gateway guardian-delivery cache so the SSE eager-subscribe path
+    // (sync, IO-free) resolves the local actor principal on the FIRST client
+    // registration. Without this, a cold cache regresses host-proxy same-user
+    // targeting until a later reconnect. Non-blocking: failures aren't cached
+    // and the async hot paths re-warm on their next read.
+    void warmLocalGuardianPrincipalCache().catch((err) =>
+      log.warn({ err }, "Guardian principal cache warm failed — continuing"),
+    );
+
     startDiskPressureGuardForLifecycle();
     startOrphanReaper();
     startEventLoopWatchdog();

--- a/assistant/src/notifications/__tests__/destination-resolver.test.ts
+++ b/assistant/src/notifications/__tests__/destination-resolver.test.ts
@@ -1,10 +1,10 @@
 /**
  * Verifies resolveDestinations resolves guardian delivery endpoints from the
- * gateway-provided guardian list, with shapes identical to the local read, and
- * falls back to the local contacts read when the list is null.
+ * gateway-provided guardian list, and omits a channel when the list is
+ * null/empty or carries no entry for it.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";
 
@@ -13,15 +13,6 @@ mock.module("../../util/logger.js", () => ({
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
-}));
-
-// Local fallback read; mocked so the null-list path is deterministic.
-let localGuardian:
-  | { contact: { principalId?: string }; channel: { address: string; externalChatId?: string } }
-  | null = null;
-
-mock.module("../../contacts/contact-store.js", () => ({
-  findGuardianForChannel: (_channelType: string) => localGuardian,
 }));
 
 const { resolveDestinations } = await import("../destination-resolver.js");
@@ -37,10 +28,6 @@ function guardian(
 }
 
 describe("resolveDestinations — gateway guardian list", () => {
-  beforeEach(() => {
-    localGuardian = null;
-  });
-
   test("vellum carries guardianPrincipalId from the gateway list", () => {
     const list = [
       guardian({ channelType: "vellum", address: "user@example.com", principalId: "prin-1" }),
@@ -137,120 +124,28 @@ describe("resolveDestinations — gateway guardian list", () => {
   });
 });
 
-describe("resolveDestinations — null list falls back to local read", () => {
-  beforeEach(() => {
-    localGuardian = null;
-  });
-
-  test("telegram resolves from the local contacts read", () => {
-    localGuardian = {
-      contact: {},
-      channel: { address: "tg-user", externalChatId: "12345" },
-    };
+describe("resolveDestinations — gateway empty or missing channel", () => {
+  test("null gateway list omits telegram", () => {
     const result = resolveDestinations(["telegram"], null);
-    expect(result.get("telegram")).toEqual({
-      channel: "telegram",
-      endpoint: "12345",
-      metadata: { externalUserId: "tg-user" },
-      bindingContext: {
-        sourceChannel: "telegram",
-        externalChatId: "12345",
-        externalUserId: "tg-user",
-      },
-    });
+    expect(result.has("telegram")).toBe(false);
   });
 
-  test("slack DM resolves from the local contacts read", () => {
-    localGuardian = {
-      contact: {},
-      channel: { address: "slack-user", externalChatId: "D123" },
-    };
-    const result = resolveDestinations(["slack"], null);
-    expect(result.get("slack")).toEqual({
-      channel: "slack",
-      endpoint: "D123",
-      metadata: { externalUserId: "slack-user" },
-      bindingContext: {
-        sourceChannel: "slack",
-        externalChatId: "D123",
-        externalUserId: "slack-user",
-      },
-    });
-  });
-
-  test("vellum carries principalId from the local contacts read", () => {
-    localGuardian = {
-      contact: { principalId: "prin-1" },
-      channel: { address: "user@example.com" },
-    };
+  test("null gateway list omits vellum principalId metadata", () => {
     const result = resolveDestinations(["vellum"], null);
-    expect(result.get("vellum")).toEqual({
-      channel: "vellum",
-      metadata: { guardianPrincipalId: "prin-1" },
-    });
-  });
-});
-
-describe("resolveDestinations — gateway yields no channel match falls back to local", () => {
-  beforeEach(() => {
-    localGuardian = null;
+    expect(result.get("vellum")).toEqual({ channel: "vellum" });
   });
 
-  test("empty gateway list falls back to local telegram binding", () => {
-    localGuardian = {
-      contact: {},
-      channel: { address: "tg-user", externalChatId: "12345" },
-    };
+  test("empty gateway list omits telegram", () => {
     const result = resolveDestinations(["telegram"], []);
-    expect(result.get("telegram")).toEqual({
-      channel: "telegram",
-      endpoint: "12345",
-      metadata: { externalUserId: "tg-user" },
-      bindingContext: {
-        sourceChannel: "telegram",
-        externalChatId: "12345",
-        externalUserId: "tg-user",
-      },
-    });
+    expect(result.has("telegram")).toBe(false);
   });
 
-  test("gateway list missing the channel falls back to local slack DM", () => {
-    localGuardian = {
-      contact: {},
-      channel: { address: "slack-user", externalChatId: "D123" },
-    };
+  test("gateway list missing the channel omits slack", () => {
     // Gateway returns a telegram guardian but no slack entry.
     const list = [
       guardian({ channelType: "telegram", address: "tg", externalChatId: "999" }),
     ];
     const result = resolveDestinations(["slack"], list);
-    expect(result.get("slack")).toEqual({
-      channel: "slack",
-      endpoint: "D123",
-      metadata: { externalUserId: "slack-user" },
-      bindingContext: {
-        sourceChannel: "slack",
-        externalChatId: "D123",
-        externalUserId: "slack-user",
-      },
-    });
-  });
-
-  test("empty gateway list falls back to local vellum principalId", () => {
-    localGuardian = {
-      contact: { principalId: "prin-1" },
-      channel: { address: "user@example.com" },
-    };
-    const result = resolveDestinations(["vellum"], []);
-    expect(result.get("vellum")).toEqual({
-      channel: "vellum",
-      metadata: { guardianPrincipalId: "prin-1" },
-    });
-  });
-
-  test("empty gateway list with no local binding omits telegram", () => {
-    localGuardian = null;
-    const result = resolveDestinations(["telegram"], []);
-    expect(result.has("telegram")).toBe(false);
+    expect(result.has("slack")).toBe(false);
   });
 });

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -15,7 +15,6 @@ import type { GuardianDelivery } from "@vellumai/gateway-client";
 
 import { isNotificationDeliverable } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { guardianForChannel } from "../contacts/guardian-delivery-reader.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDestination, NotificationChannel } from "./types.js";
@@ -29,13 +28,7 @@ interface ResolvedGuardian {
   externalChatId?: string;
 }
 
-/**
- * Resolve the guardian delivery endpoint for a channel: gateway list first,
- * else the local contacts read. The local read is the transitional
- * dual-written mirror and covers a transient gateway failure (null list) or a
- * gateway list missing this channel, so a soft-failed gateway read does not
- * drop a binding the local store still holds. Removed in Combo 11.
- */
+/** Resolve the guardian delivery endpoint for a channel from the gateway list. */
 function resolveGuardian(
   guardians: GuardianDelivery[] | null,
   channelType: string,
@@ -43,19 +36,11 @@ function resolveGuardian(
   const g = guardians
     ? guardianForChannel(guardians, channelType)
     : undefined;
-  if (g) {
-    return {
-      principalId: g.principalId ?? undefined,
-      address: g.address,
-      externalChatId: g.externalChatId ?? undefined,
-    };
-  }
-  const local = findGuardianForChannel(channelType);
-  if (!local) return undefined;
+  if (!g) return undefined;
   return {
-    principalId: local.contact.principalId ?? undefined,
-    address: local.channel.address,
-    externalChatId: local.channel.externalChatId ?? undefined,
+    principalId: g.principalId ?? undefined,
+    address: g.address,
+    externalChatId: g.externalChatId ?? undefined,
   };
 }
 
@@ -67,9 +52,8 @@ function resolveGuardian(
  * Returns a map keyed by `NotificationChannel`. Channels that cannot be
  * resolved (e.g. no Telegram binding configured) are omitted from the result.
  *
- * `guardians` is the gateway-resolved guardian list; per channel, a missing
- * match (null list or no entry for the channel) falls back to the local
- * contacts read for this release.
+ * `guardians` is the gateway-resolved guardian list; a channel with no entry
+ * in the list is omitted from the result.
  */
 export function resolveDestinations(
   channels: readonly (ChannelId | NotificationChannel)[],

--- a/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
@@ -3,11 +3,12 @@
  * `reResolveTrustOnResetDrift`.
  *
  * The real helper runs against mocked leaf deps: the gateway guardian read
- * (`getGuardianDelivery`/`guardianForChannel`), the local-mirror heal
- * (`findGuardianForChannel`/`updateContactPrincipalAndChannel`, which the real
- * `healGuardianBindingDrift` drives), and the local trust resolver
- * (`resolveTrustContext`). Heal invocations are observed via the contact-store
- * write mock.
+ * (`getGuardianDelivery`/`guardianForChannel`) supplies the authoritative
+ * principal, the local-mirror heal target is resolved via
+ * `findGuardianForChannel` and written via `updateContactPrincipalAndChannel`
+ * (the real `healGuardianBindingDrift` drives this), and the local trust
+ * resolver (`resolveTrustContext`) closes the loop. Heal invocations are
+ * observed via the contact-store write mock.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -26,10 +27,10 @@ mock.module("../../contacts/guardian-delivery-reader.js", () => ({
   ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
-// Local mirror the real heal reads/writes. `findGuardianForChannel` returns the
-// stored guardian; `updateContactPrincipalAndChannel` records heal writes.
+// Local mirror the real heal repairs. `findGuardianForChannel` returns the
+// heal target; `updateContactPrincipalAndChannel` records heal writes.
 let mockLocalGuardian: {
-  contact: { id: string; principalId: string };
+  contact: { id: string };
   channel: { id: string };
 } | null = null;
 const healWrites: Array<{ principalId: string }> = [];
@@ -74,9 +75,9 @@ function gatewayGuardian(principalId: string): Record<string, unknown> {
   };
 }
 
-function localGuardian(principalId: string) {
+function localGuardian() {
   return {
-    contact: { id: "contact-1", principalId },
+    contact: { id: "contact-1" },
     channel: { id: "channel-1" },
   };
 }
@@ -89,10 +90,10 @@ describe("reResolveTrustOnResetDrift", () => {
   });
 
   test("reset drift: heals and returns the re-resolved guardian ctx", async () => {
-    // Stale local mirror still holds the pre-reset principal; the incoming JWT
-    // carries the old one. Heal repairs the mirror toward the incoming actor.
+    // Gateway principal diverges from the incoming JWT; heal repairs the local
+    // mirror toward the incoming actor.
     mockGuardianList = [gatewayGuardian("vellum-principal-new")];
-    mockLocalGuardian = localGuardian("vellum-principal-stale");
+    mockLocalGuardian = localGuardian();
 
     const ctx = await reResolveTrustOnResetDrift(
       "vellum-principal-old",
@@ -103,11 +104,11 @@ describe("reResolveTrustOnResetDrift", () => {
     expect(healWrites).toEqual([{ principalId: "vellum-principal-old" }]);
   });
 
-  test("repeat drift where heal no-ops still returns the guardian ctx", async () => {
-    // Local mirror already matches the incoming principal, so heal's write is
-    // skipped, but the gate still passes and the re-resolve yields guardian.
+  test("no local mirror to repair still returns the guardian ctx", async () => {
+    // The gate passes and the re-resolve yields guardian even when there is no
+    // local mirror row for heal to write.
     mockGuardianList = [gatewayGuardian("vellum-principal-new")];
-    mockLocalGuardian = localGuardian("vellum-principal-old");
+    mockLocalGuardian = null;
 
     const ctx = await reResolveTrustOnResetDrift(
       "vellum-principal-old",
@@ -120,7 +121,7 @@ describe("reResolveTrustOnResetDrift", () => {
 
   test("gateway unreachable (null): returns null, heal not called", async () => {
     mockGuardianList = null;
-    mockLocalGuardian = localGuardian("vellum-principal-old");
+    mockLocalGuardian = localGuardian();
 
     const ctx = await reResolveTrustOnResetDrift(
       "vellum-principal-old",
@@ -133,7 +134,7 @@ describe("reResolveTrustOnResetDrift", () => {
 
   test("empty/revoked gateway (no active guardian): returns null, heal not called", async () => {
     mockGuardianList = [];
-    mockLocalGuardian = localGuardian("vellum-principal-old");
+    mockLocalGuardian = localGuardian();
 
     const ctx = await reResolveTrustOnResetDrift(
       "vellum-principal-old",
@@ -146,7 +147,7 @@ describe("reResolveTrustOnResetDrift", () => {
 
   test("gateway guardian is a real (non vellum-principal-*) id: returns null", async () => {
     mockGuardianList = [gatewayGuardian("user@example.com")];
-    mockLocalGuardian = localGuardian("vellum-principal-old");
+    mockLocalGuardian = localGuardian();
 
     const ctx = await reResolveTrustOnResetDrift(
       "vellum-principal-old",
@@ -159,7 +160,7 @@ describe("reResolveTrustOnResetDrift", () => {
 
   test("incoming principal is not vellum-principal-*: returns null", async () => {
     mockGuardianList = [gatewayGuardian("vellum-principal-new")];
-    mockLocalGuardian = localGuardian("vellum-principal-old");
+    mockLocalGuardian = localGuardian();
 
     const ctx = await reResolveTrustOnResetDrift("user@example.com", "vellum");
 
@@ -169,7 +170,7 @@ describe("reResolveTrustOnResetDrift", () => {
 
   test("threads sourceChannel into the returned ctx", async () => {
     mockGuardianList = [gatewayGuardian("vellum-principal-new")];
-    mockLocalGuardian = localGuardian("vellum-principal-old");
+    mockLocalGuardian = localGuardian();
 
     const ctx = await reResolveTrustOnResetDrift(
       "vellum-principal-old",

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -97,11 +97,10 @@ export async function notifyGuardianOfAccessRequest(
 
   // Resolve guardian identity with the assistant-anchored strategy (gateway
   // source-channel match validated against the vellum anchor, else the vellum
-  // anchor), with a LOCAL-store fallback when the gateway read is empty.
+  // anchor).
   const anchored = resolveAnchoredGuardian({
     guardians: await getGuardianDelivery(),
     sourceChannel,
-    useLocalFallback: true,
   });
   const guardianExternalUserId = anchored?.address ?? null;
   const guardianPrincipalId = anchored?.principalId ?? null;

--- a/assistant/src/runtime/anchored-guardian.test.ts
+++ b/assistant/src/runtime/anchored-guardian.test.ts
@@ -2,24 +2,14 @@
  * Unit tests for `resolveAnchoredGuardian`.
  *
  * Covers the gateway arms (source-channel match validated against the vellum
- * anchor, vellum-anchor fallback), the LOCAL-store fallback when the gateway
- * list is empty, and the cosmetic `requireAnchorPrincipal` guard.
+ * anchor, vellum-anchor fallback) and the cosmetic `requireAnchorPrincipal`
+ * guard.
  */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";
 
-// Local store fallback is mocked so we can drive both arms deterministically.
-let localGuardians: Record<
-  string,
-  { contact: { principalId: string | null; displayName: string }; channel: { address: string; type: string } } | null
-> = {};
-mock.module("../contacts/contact-store.js", () => ({
-  findGuardianForChannel: (channelType: string) =>
-    localGuardians[channelType] ?? null,
-}));
-
-const { resolveAnchoredGuardian } = await import("./anchored-guardian.js");
+import { resolveAnchoredGuardian } from "./anchored-guardian.js";
 
 function gw(g: Partial<GuardianDelivery> & { channelType: string; address: string }): GuardianDelivery {
   return {
@@ -28,10 +18,6 @@ function gw(g: Partial<GuardianDelivery> & { channelType: string; address: strin
     ...g,
   };
 }
-
-afterEach(() => {
-  localGuardians = {};
-});
 
 describe("resolveAnchoredGuardian — gateway arm", () => {
   test("source-channel guardian matching the anchor wins", () => {
@@ -80,40 +66,8 @@ describe("resolveAnchoredGuardian — gateway arm", () => {
   });
 });
 
-describe("resolveAnchoredGuardian — local fallback", () => {
-  test("gateway empty + local source-channel match returns the local record", () => {
-    localGuardians = {
-      vellum: { contact: { principalId: "p-local", displayName: "LocalVellum" }, channel: { address: "lv-addr", type: "vellum" } },
-      telegram: { contact: { principalId: "p-local", displayName: "LocalAlice" }, channel: { address: "ltg-addr", type: "telegram" } },
-    };
-    const result = resolveAnchoredGuardian({
-      guardians: null,
-      sourceChannel: "telegram",
-      useLocalFallback: true,
-    });
-    expect(result).toEqual({
-      principalId: "p-local",
-      address: "ltg-addr",
-      displayName: "LocalAlice",
-      channelType: "telegram",
-      source: "source-channel-contact",
-    });
-  });
-
-  test("gateway empty + only local vellum returns the local vellum-anchor", () => {
-    localGuardians = {
-      vellum: { contact: { principalId: "p-local", displayName: "LocalVellum" }, channel: { address: "lv-addr", type: "vellum" } },
-    };
-    const result = resolveAnchoredGuardian({
-      guardians: null,
-      sourceChannel: "telegram",
-      useLocalFallback: true,
-    });
-    expect(result?.source).toBe("vellum-anchor");
-    expect(result?.address).toBe("lv-addr");
-  });
-
-  test("gateway empty + no local + fallback disabled returns null", () => {
+describe("resolveAnchoredGuardian — gateway empty", () => {
+  test("null gateway list returns null", () => {
     const result = resolveAnchoredGuardian({
       guardians: null,
       sourceChannel: "telegram",
@@ -121,11 +75,10 @@ describe("resolveAnchoredGuardian — local fallback", () => {
     expect(result).toBeNull();
   });
 
-  test("nothing anywhere returns null", () => {
+  test("empty gateway list returns null", () => {
     const result = resolveAnchoredGuardian({
       guardians: [],
       sourceChannel: "telegram",
-      useLocalFallback: true,
     });
     expect(result).toBeNull();
   });

--- a/assistant/src/runtime/anchored-guardian.ts
+++ b/assistant/src/runtime/anchored-guardian.ts
@@ -7,16 +7,13 @@
  * anchor identity is used. This blocks stale or cross-assistant contacts from
  * being bound to a request.
  *
- * Gateway-first: resolves from the gateway delivery list, then falls back to
- * the LOCAL dual-written binding when the gateway read is empty/unavailable
- * (restart, timeout, malformed IPC). The local fallback is transitional and is
- * removed in a later step.
+ * Resolves from the gateway delivery list, the source of truth for guardian
+ * principals.
  */
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { guardianForChannel } from "../contacts/guardian-delivery-reader.js";
 import type { GuardianResolutionSource } from "../notifications/signal.js";
 
@@ -34,13 +31,6 @@ export interface ResolveAnchoredGuardianInput {
   guardians: GuardianDelivery[] | null;
   sourceChannel: ChannelId;
   /**
-   * Fall back to the LOCAL dual-written binding when the gateway arm resolves
-   * nothing. Access-request enables this to avoid an undecidable request; the
-   * cosmetic guardian-label path leaves it off so a missing gateway read
-   * degrades gracefully to the default reference.
-   */
-  useLocalFallback?: boolean;
-  /**
    * Require a non-null anchor principal for the vellum-anchor arm. When the
    * vellum guardian has no principal, return `null` instead of a vellum-anchor
    * record. Matches the cosmetic label path, which degrades to the default
@@ -52,12 +42,12 @@ export interface ResolveAnchoredGuardianInput {
 /**
  * Resolve the anchored guardian for `sourceChannel`, or `null` when none can be
  * resolved. Gateway source-channel match → that record; gateway anchor-only →
- * vellum-anchor; gateway empty + local has it → local fallback record.
+ * vellum-anchor.
  */
 export function resolveAnchoredGuardian(
   input: ResolveAnchoredGuardianInput,
 ): AnchoredGuardian | null {
-  const { sourceChannel, useLocalFallback, requireAnchorPrincipal } = input;
+  const { sourceChannel, requireAnchorPrincipal } = input;
   const guardians = input.guardians ?? [];
 
   const vellumGuardian = guardianForChannel(guardians, "vellum");
@@ -87,45 +77,6 @@ export function resolveAnchoredGuardian(
       principalId: anchorPrincipalId ?? null,
       address: vellumGuardian.address,
       displayName: vellumGuardian.displayName ?? null,
-      channelType: "vellum",
-      source: "vellum-anchor",
-    };
-  }
-
-  // Gateway resolved a principal — done.
-  if (resolved?.principalId) {
-    return resolved;
-  }
-
-  if (!useLocalFallback) {
-    return resolved;
-  }
-
-  // Fallback: gateway read was empty/unavailable (or carried no principal), so
-  // resolve from the LOCAL dual-written binding to avoid an undecidable
-  // request. A local match overwrites the principal-less gateway record; with
-  // no local match the gateway record (if any) is retained.
-  const localVellum = findGuardianForChannel("vellum");
-  const localAnchorPrincipalId = localVellum?.contact.principalId;
-  const localSource = findGuardianForChannel(sourceChannel);
-  if (
-    localAnchorPrincipalId &&
-    localSource &&
-    localSource.contact.principalId === localAnchorPrincipalId
-  ) {
-    return {
-      principalId: localSource.contact.principalId,
-      address: localSource.channel.address,
-      displayName: localSource.contact.displayName,
-      channelType: localSource.channel.type,
-      source: "source-channel-contact",
-    };
-  }
-  if (localVellum) {
-    return {
-      principalId: localAnchorPrincipalId ?? null,
-      address: localVellum.channel.address,
-      displayName: localVellum.contact.displayName,
       channelType: "vellum",
       source: "vellum-anchor",
     };

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -44,8 +44,7 @@ const log = getLogger("guardian-vellum-migration");
  * Returns true if healing occurred, false otherwise.
  *
  * The gateway binding supplies the authoritative principal; the local
- * assistant-mirror row is repaired whenever it diverges from the JWT
- * principal — even when the gateway binding already matches — because the
+ * assistant-mirror row is repaired to match the JWT principal because the
  * /v1/messages trust path still resolves against the local mirror in this
  * plan. A stale mirror must be repaired or valid guardians stay `unknown`.
  */
@@ -62,17 +61,15 @@ export async function healGuardianBindingDrift(
   if (!guardian) return false;
 
   const currentPrincipalId = guardian.principalId;
+  // Only repair auto-generated principals — never overwrite a real one.
   if (!currentPrincipalId?.startsWith("vellum-principal-")) return false;
+  // No-op when the principal already matches the JWT principal.
+  if (currentPrincipalId === incomingPrincipalId) return false;
 
-  // Resolve the assistant-mirror row whose principal drives local trust.
+  // Resolve the assistant-mirror row to repair so local trust resolution
+  // converges on the JWT principal.
   const guardianResult = findGuardianForChannel("vellum");
   if (!guardianResult) return false;
-
-  const localPrincipalId = guardianResult.contact.principalId;
-  // Only repair auto-generated local principals — never overwrite a real one.
-  if (!localPrincipalId?.startsWith("vellum-principal-")) return false;
-  // No-op when the local mirror already matches the JWT principal.
-  if (localPrincipalId === incomingPrincipalId) return false;
 
   const updated = updateContactPrincipalAndChannel(
     guardianResult.contact.id,
@@ -83,7 +80,7 @@ export async function healGuardianBindingDrift(
   if (!updated) {
     log.warn(
       {
-        oldPrincipalId: localPrincipalId,
+        oldPrincipalId: currentPrincipalId,
         newPrincipalId: incomingPrincipalId,
       },
       "Skipped guardian binding drift heal — address collision on contact_channels",
@@ -93,7 +90,7 @@ export async function healGuardianBindingDrift(
 
   log.info(
     {
-      oldPrincipalId: localPrincipalId,
+      oldPrincipalId: currentPrincipalId,
       newPrincipalId: incomingPrincipalId,
     },
     "Healed vellum guardian binding drift — updated local mirror principalId to match JWT actor",

--- a/assistant/src/runtime/local-actor-identity.test.ts
+++ b/assistant/src/runtime/local-actor-identity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the local-actor-identity cache-warm path.
+ *
+ * The SSE eager-subscribe path resolves the local actor principal
+ * synchronously from the IO-free guardian-delivery cache snapshot. A cold
+ * cache returns undefined, so the daemon warms it at startup
+ * (`warmLocalGuardianPrincipalCache`) before clients register. These tests pin
+ * that the sync read is cold before the warm and resolves the gateway-owned
+ * principal after it.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+// ── Controllable IPC mock ──────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+const ipcHandlers = new Map<string, IpcHandler>();
+
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCall: async (method: string, params?: Record<string, unknown>) => {
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+let httpAuthDisabled = false;
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => httpAuthDisabled,
+}));
+
+import { __resetGuardianDeliveryCacheForTest } from "../contacts/guardian-delivery-reader.js";
+import {
+  findLocalGuardianPrincipalIdFromStore,
+  resolveActorPrincipalIdForLocalGuardianSync,
+  warmLocalGuardianPrincipalCache,
+} from "./local-actor-identity.js";
+
+const METHOD = "resolve_guardian_delivery";
+
+const vellumGuardian: GuardianDelivery = {
+  channelType: "vellum",
+  contactId: "contact-1",
+  address: "self",
+  status: "active",
+  principalId: "principal-abc",
+};
+
+describe("warmLocalGuardianPrincipalCache", () => {
+  beforeEach(() => {
+    __resetGuardianDeliveryCacheForTest();
+    ipcHandlers.clear();
+    httpAuthDisabled = false;
+  });
+
+  afterEach(() => {
+    __resetGuardianDeliveryCacheForTest();
+  });
+
+  test("sync read is cold before warming", () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [vellumGuardian] }));
+
+    // No warm yet — the cache snapshot is empty.
+    expect(findLocalGuardianPrincipalIdFromStore()).toBeUndefined();
+  });
+
+  test("warming populates the cache for the sync read", async () => {
+    ipcHandlers.set(METHOD, () => ({ guardians: [vellumGuardian] }));
+
+    await warmLocalGuardianPrincipalCache();
+
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe("principal-abc");
+  });
+
+  test("cold-start SSE registration resolves the principal after warm", async () => {
+    httpAuthDisabled = true;
+    ipcHandlers.set(METHOD, () => ({ guardians: [vellumGuardian] }));
+
+    // Cold cache: dev-bypass header resolves to no principal.
+    expect(
+      resolveActorPrincipalIdForLocalGuardianSync("dev-bypass"),
+    ).toBeUndefined();
+
+    await warmLocalGuardianPrincipalCache();
+
+    // Warmed: the SSE sync path now resolves the gateway-owned principal.
+    expect(resolveActorPrincipalIdForLocalGuardianSync("dev-bypass")).toBe(
+      "principal-abc",
+    );
+  });
+
+  test("warm tolerates an unreachable gateway without caching a failure", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("gateway down");
+    });
+
+    await warmLocalGuardianPrincipalCache();
+
+    // Failure not cached; a later successful read warms the cache.
+    expect(findLocalGuardianPrincipalIdFromStore()).toBeUndefined();
+    ipcHandlers.set(METHOD, () => ({ guardians: [vellumGuardian] }));
+    await warmLocalGuardianPrincipalCache();
+    expect(findLocalGuardianPrincipalIdFromStore()).toBe("principal-abc");
+  });
+});

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -68,6 +68,25 @@ export async function findLocalGuardianPrincipalId(): Promise<
 }
 
 /**
+ * Eagerly warm the gateway guardian-delivery cache for the vellum channel.
+ *
+ * The SSE eager-subscribe path resolves the actor principal synchronously via
+ * {@link findLocalGuardianPrincipalIdFromStore}, which reads only the IO-free
+ * cache snapshot. On a cold cache (auth-disabled / local startup, before any
+ * async `getGuardianDelivery` has run) it returns undefined, so the FIRST SSE
+ * registration would carry no `actorPrincipalId` and host-proxy same-user
+ * targeting would regress until a later reconnect warms the cache.
+ *
+ * Called during daemon startup (after the gateway IPC is reachable) so the
+ * cache is populated before clients register. Best-effort: a cold gateway
+ * leaves the cache empty (failures aren't cached), and the async hot paths
+ * warm it on their next read.
+ */
+export async function warmLocalGuardianPrincipalCache(): Promise<void> {
+  await findLocalGuardianPrincipalId();
+}
+
+/**
  * Synchronous read of the vellum guardian's principalId for paths that cannot
  * await {@link findLocalGuardianPrincipalId} — namely the SSE eager-subscribe
  * path (`events-routes`), which registers before the stream is created.

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -13,7 +13,6 @@
 
 import type { ChannelId } from "../channels/types.js";
 import { isHttpAuthDisabled } from "../config/env.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
 import {
   getGuardianDelivery,
   guardianForChannel,
@@ -54,24 +53,18 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
  *
  * The gateway owns guardian binding; this reads it through the cached
  * `getGuardianDelivery` reader (PR-3 TTL + single-flight) so hot paths don't
- * storm the IPC. Falls back to the local contacts table for the bootstrap /
- * first-run window where the gateway has no guardian yet or is unreachable
- * (the reader returns `null`).
+ * storm the IPC.
  *
- * Returns `undefined` when no vellum guardian binding exists in either source
- * (e.g. fresh install before bootstrap). Callers should treat that case as
- * "not yet available" and either fall back or proceed without a principalId.
+ * Returns `undefined` when no vellum guardian binding exists (e.g. fresh
+ * install before bootstrap, or the gateway is unreachable). Callers should
+ * treat that case as "not yet available" and proceed without a principalId.
  */
 export async function findLocalGuardianPrincipalId(): Promise<
   string | undefined
 > {
   const list = await getGuardianDelivery({ channelTypes: ["vellum"] });
-  if (list) {
-    const principalId = guardianForChannel(list, "vellum")?.principalId;
-    if (principalId) return principalId;
-  }
-
-  return findLocalGuardianPrincipalIdFromStore();
+  if (!list) return undefined;
+  return guardianForChannel(list, "vellum")?.principalId ?? undefined;
 }
 
 /**
@@ -82,17 +75,12 @@ export async function findLocalGuardianPrincipalId(): Promise<
  * Reads the same gateway-owned binding as the async path via a sync, IO-free
  * snapshot of the guardian-delivery cache (kept fresh by the async hot paths
  * and event-driven invalidation), so SSE registers the SAME principal the
- * send/result routes resolve. Falls back to the local store when the cache is
- * cold — the same fallback the async path lands on during bootstrap.
+ * send/result routes resolve.
  */
 export function findLocalGuardianPrincipalIdFromStore(): string | undefined {
   const cached = peekCachedGuardianDelivery({ channelTypes: ["vellum"] });
-  if (cached) {
-    const principalId = guardianForChannel(cached, "vellum")?.principalId;
-    if (principalId) return principalId;
-  }
-
-  return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
+  if (!cached) return undefined;
+  return guardianForChannel(cached, "vellum")?.principalId ?? undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove the local contact.principalId fallbacks in anchored-guardian, destination-resolver, local-actor-identity, guardian-vellum-migration
- Guardian principal now sourced solely from the gateway delivery

Part of plan: combo11-phase-b2-drop-acl-columns.md (PR 4 of 11)