### PR TITLE
feat(subagent): give the advisor consult provider-native web search when supported

### DIFF
--- a/assistant/src/agent/loop-native-web-search.test.ts
+++ b/assistant/src/agent/loop-native-web-search.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Verifies the agent loop's provider-native web-search gate (used by the
+ * tool-less advisor consult): when `enableNativeWebSearch` is set, the loop
+ * appends a `web_search`-named SERVER tool to the outbound request and forces
+ * `tool_choice: auto` — but ONLY when the resolved provider reports
+ * `supportsNativeWebSearch === true`. A non-native provider gets nothing, and
+ * the consult stays tool-less (no client `web_search` tool surfaced). Drives the
+ * REAL loop, mocking only the provider boundary.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { createMockProvider } from "../__tests__/helpers/mock-provider.js";
+import type { Provider, ProviderResponse } from "../providers/types.js";
+import { AgentLoop } from "./loop.js";
+
+const endTurn = (text: string): ProviderResponse => ({
+  content: [{ type: "text", text }],
+  model: "mock-model",
+  usage: { inputTokens: 1, outputTokens: 1 },
+  stopReason: "end_turn",
+});
+
+const baseRun = {
+  requestId: "req-web",
+  onEvent: () => {},
+  callSite: "subagentSpawn" as const,
+  trust: { sourceChannel: "vellum" as const, trustClass: "unknown" as const },
+};
+
+const userMessages = [
+  {
+    role: "user" as const,
+    content: [{ type: "text" as const, text: "advise" }],
+  },
+];
+
+/** Build a tool-less loop (mirrors the advisor consult) with the given flag. */
+function buildAdvisorLoop(
+  provider: Provider,
+  enableNativeWebSearch: boolean,
+): AgentLoop {
+  return new AgentLoop({
+    provider,
+    systemPrompt: "advisor system",
+    conversationId: "advisor-1",
+    // Tool-less for client tools — exactly the advisor role's empty allowlist.
+    config: { enableNativeWebSearch },
+  });
+}
+
+describe("AgentLoop — provider-native web search gate", () => {
+  test("attaches the native web_search server tool when the provider supports it", async () => {
+    const { provider, calls } = createMockProvider([endTurn("guidance")]);
+    (
+      provider as { supportsNativeWebSearch?: boolean }
+    ).supportsNativeWebSearch = true;
+
+    const loop = buildAdvisorLoop(provider, true);
+    await loop.run({ ...baseRun, messages: userMessages });
+
+    expect(calls).toHaveLength(1);
+    const sent = calls[0];
+    // The native web_search SERVER tool is the only tool surfaced.
+    expect(sent.tools?.map((t) => t.name)).toEqual(["web_search"]);
+    // tool_choice is forced to auto so the model may invoke the search.
+    expect(sent.options?.config?.tool_choice).toEqual({ type: "auto" });
+  });
+
+  test("attaches nothing on a non-native provider (consult stays tool-less)", async () => {
+    const { provider, calls } = createMockProvider([endTurn("guidance")]);
+    // supportsNativeWebSearch is absent (falsy) — a non-native provider.
+
+    const loop = buildAdvisorLoop(provider, true);
+    await loop.run({ ...baseRun, messages: userMessages });
+
+    expect(calls).toHaveLength(1);
+    const sent = calls[0];
+    // No web_search tool surfaced — no client tool the one-shot consult can't run.
+    expect(sent.tools).toBeUndefined();
+    // No tool_choice forced when nothing is attached.
+    expect(sent.options?.config?.tool_choice).toBeUndefined();
+  });
+
+  test("attaches nothing when the flag is off, even on a native provider", async () => {
+    const { provider, calls } = createMockProvider([endTurn("guidance")]);
+    (
+      provider as { supportsNativeWebSearch?: boolean }
+    ).supportsNativeWebSearch = true;
+
+    const loop = buildAdvisorLoop(provider, false);
+    await loop.run({ ...baseRun, messages: userMessages });
+
+    expect(calls).toHaveLength(1);
+    const sent = calls[0];
+    expect(sent.tools).toBeUndefined();
+    expect(sent.options?.config?.tool_choice).toBeUndefined();
+  });
+
+  test("does not duplicate web_search when a tool of that name is already present", async () => {
+    const { provider, calls } = createMockProvider([endTurn("guidance")]);
+    (
+      provider as { supportsNativeWebSearch?: boolean }
+    ).supportsNativeWebSearch = true;
+
+    // A loop that already exposes a `web_search` client tool (e.g. researcher
+    // role). The gate must not append a second `web_search` entry.
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "sys",
+      conversationId: "advisor-dup",
+      config: { enableNativeWebSearch: true },
+      tools: [
+        {
+          name: "web_search",
+          description: "",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+    await loop.run({ ...baseRun, messages: userMessages });
+
+    const sent = calls[0];
+    expect(sent.tools?.filter((t) => t.name === "web_search")).toHaveLength(1);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -95,7 +95,44 @@ export interface AgentLoopConfig {
   minTurnIntervalMs?: number;
   /** Override the default prompt cache TTL sent to the provider (e.g. "5m" for short-lived subagents). */
   cacheTtl?: "5m" | "1h";
+  /**
+   * Give every LLM call provider-native (server-side) web search, gated on the
+   * resolved provider's {@link Provider.supportsNativeWebSearch} capability.
+   * When both are true, the loop appends a `web_search`-named tool to the
+   * outbound request — which Anthropic/OpenAI substitute for their server-side
+   * search tool, running the search inline and returning results without a
+   * client tool round-trip — and forces `tool_choice: auto` so the model may
+   * call it. Non-native providers get nothing.
+   *
+   * This is a SERVER tool the provider runs itself, distinct from the client
+   * tool list (`tools` / `resolveTools`): it is never executed by
+   * {@link AgentLoopConstructorOptions.toolExecutor} and does not require any
+   * client-tool allowlist entry. Used by the tool-less advisor consult to
+   * ground its guidance with live web access while staying one-shot for client
+   * tools. Defaults to false — existing behavior.
+   */
+  enableNativeWebSearch?: boolean;
 }
+
+/**
+ * The `web_search`-named tool the loop appends when
+ * {@link AgentLoopConfig.enableNativeWebSearch} is set on a native provider.
+ * Anthropic/OpenAI intercept a tool with this name and substitute their own
+ * server-side web search (run inline, no client execution), so the exact
+ * `input_schema` is informational — the provider supplies the real schema.
+ */
+const NATIVE_WEB_SEARCH_TOOL: ToolDefinition = {
+  name: "web_search",
+  description:
+    "Search the web for current information to ground your response.",
+  input_schema: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "The search query." },
+    },
+    required: ["query"],
+  },
+};
 
 export interface CheckpointInfo {
   turnIndex: number;
@@ -1240,9 +1277,25 @@ export class AgentLoop {
 
         // Resolve tools for this turn: use the dynamic resolver if provided,
         // otherwise fall back to the static tool list.
-        const currentTools = this.resolveTools
+        const resolvedTools = this.resolveTools
           ? this.resolveTools(history)
           : this.tools;
+
+        // Provider-native web search: append a `web_search`-named tool that the
+        // provider substitutes for its server-side search (run inline, no client
+        // execution), gated STRICTLY on the resolved provider's capability so a
+        // non-native provider never sees an unexecutable client tool. This is a
+        // SERVER tool — it bypasses the client allowlist and the tool executor —
+        // so the tool-less advisor consult can ground its guidance with live web
+        // access while staying one-shot for client tools. Skip when a
+        // `web_search` tool is already present so we never duplicate the name.
+        const attachNativeWebSearch =
+          this.config.enableNativeWebSearch === true &&
+          this.provider.supportsNativeWebSearch === true &&
+          !resolvedTools.some((t) => t.name === NATIVE_WEB_SEARCH_TOOL.name);
+        const currentTools = attachNativeWebSearch
+          ? [...resolvedTools, NATIVE_WEB_SEARCH_TOOL]
+          : resolvedTools;
 
         // Field precedence (highest wins):
         //   1. Per-run explicit (`runModel`)
@@ -1286,6 +1339,11 @@ export class AgentLoop {
 
         if (this.config.toolChoice) {
           providerConfig.tool_choice = this.config.toolChoice;
+        } else if (attachNativeWebSearch) {
+          // The native web-search tool is the only tool on this turn (the
+          // advisor consult is otherwise tool-less). Let the model decide
+          // whether to search rather than forcing it.
+          providerConfig.tool_choice = { type: "auto" };
         }
 
         if (this.config.cacheTtl) {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -243,6 +243,14 @@ export interface ConversationConstructorOptions {
   speedOverride?: Speed;
   cacheTtl?: "5m" | "1h";
   modelOverride?: string;
+  /**
+   * Give this conversation's LLM calls provider-native (server-side) web
+   * search when the resolved provider supports it (see
+   * {@link AgentLoopConfig.enableNativeWebSearch}). Set by the subagent manager
+   * for the tool-less advisor consult so it can ground guidance with live web
+   * access; non-native providers get nothing. Defaults to false.
+   */
+  enableNativeWebSearch?: boolean;
 }
 
 export class Conversation {
@@ -592,6 +600,7 @@ export class Conversation {
     options?: ConversationConstructorOptions,
   ) {
     const { maxTokens, speedOverride, cacheTtl, modelOverride } = options ?? {};
+    const enableNativeWebSearch = options?.enableNativeWebSearch ?? false;
     this.conversationId = conversationId;
     this.systemPrompt = systemPrompt;
     this.provider = provider;
@@ -690,6 +699,7 @@ export class Conversation {
         ? { speed: resolvedSpeed }
         : {}),
       ...(cacheTtl ? { cacheTtl } : {}),
+      ...(enableNativeWebSearch ? { enableNativeWebSearch: true } : {}),
     };
     if (configuredMaxTokens !== undefined) {
       agentLoopConfig.maxTokens = configuredMaxTokens;

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -382,7 +382,16 @@ export class SubagentManager {
       systemPrompt,
       wrappedSendToClient,
       workingDir,
-      { maxTokens, cacheTtl: "5m" },
+      {
+        maxTokens,
+        cacheTtl: "5m",
+        // The advisor consult runs tool-less for CLIENT tools but should ground
+        // its guidance with provider-native web search when the resolved
+        // provider supports it. This is a server tool the provider runs itself,
+        // so it stays one-shot — no client tool surfaced, allowlist unchanged.
+        // Other roles keep the default (no native search appended).
+        ...(role === "advisor" ? { enableNativeWebSearch: true } : {}),
+      },
     );
 
     // Mark conversation as having no direct client — it routes through parent.


### PR DESCRIPTION
## Summary
- Attach a provider-native web_search server tool to the advisor consult's send only when supportsNativeWebSearch is true; advisor stays tool-less for client tools.

Part of plan: advisor-as-subagent-role.md (PR 10 of 10)