### PR TITLE
feat(memory): candidate-identity matcher (existing-skill + embedding tiers)

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for `candidate-match.ts` — the procedural-memory candidate-identity
+ * matcher (Tier 0 existing-skill + Tier 1 candidate-cluster).
+ *
+ * The matcher's ANN/embedding seam and its catalog/registry reads are
+ * dependency-injected via `MatchCandidateOptions`, so these tests exercise the
+ * pure tier logic with a fake scorer + fake catalog/candidate sets — no Qdrant,
+ * no embedding backend. Coverage:
+ *   - Tier 0: a goal scoring at/above the existing-skill threshold against a
+ *     skill capability page resolves to `existing-skill` (and short-circuits
+ *     Tier 1).
+ *   - Tier 1: a goal scoring at/above the cluster threshold against a candidate
+ *     note resolves to `cluster` with that note's slug as the clusterId.
+ *   - Novel: a goal below the gray band against everything resolves to `new`.
+ *   - Gray band: a goal whose best candidate match lands in
+ *     `[GRAY_BAND_THRESHOLD, CLUSTER_MATCH_THRESHOLD)` resolves to `gray` (the
+ *     Tier-2 judge is the caller's job, never invoked here).
+ *   - Threshold precedence (Tier 0 beats Tier 1) + read-only invariant (no
+ *     writes, default registry reader only SELECTs).
+ *
+ * The logger is stubbed so the default-scorer failure path stays quiet; the
+ * tier-logic tests never reach it because they inject a fake scorer.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
+import type { ScoredSlug } from "../candidate-match.js";
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+const {
+  matchCandidate,
+  EXISTING_SKILL_THRESHOLD,
+  CLUSTER_MATCH_THRESHOLD,
+  GRAY_BAND_THRESHOLD,
+} = await import("../candidate-match.js");
+
+// ---------------------------------------------------------------------------
+// Test helpers — a fake scorer driven by a slug→score table, plus fake catalog
+// and candidate-note sources. The scorer only returns hits for the slugs it was
+// restricted to, mirroring `hybridQueryConceptPages`'s server-side filter.
+// ---------------------------------------------------------------------------
+
+function fakeScorer(scores: Record<string, number>) {
+  const calls: string[][] = [];
+  const fn = async (
+    _goal: string,
+    restrictToSlugs: readonly string[],
+  ): Promise<ScoredSlug[]> => {
+    calls.push([...restrictToSlugs]);
+    return restrictToSlugs
+      .filter((slug) => slug in scores)
+      .map((slug) => ({ slug, score: scores[slug]! }));
+  };
+  return { fn, calls };
+}
+
+const catalog =
+  (...ids: string[]) =>
+  () =>
+    ids.map((id) => ({ id }));
+const candidateNotes =
+  (...slugs: string[]) =>
+  () =>
+    slugs;
+
+describe("matchCandidate — Tier 0 (existing skill)", () => {
+  test("a goal matching a skill capability page → existing-skill", async () => {
+    const { fn } = fakeScorer({ "skills/deploy-web": 0.91 });
+
+    const result = await matchCandidate("ship the web app to prod", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("deploy-web", "rotate-secrets"),
+      listCandidateNoteSlugs: candidateNotes("proc/something-else"),
+    });
+
+    expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
+  });
+
+  test("Tier 0 short-circuits before Tier 1 is even queried", async () => {
+    const { fn, calls } = fakeScorer({
+      "skills/deploy-web": EXISTING_SKILL_THRESHOLD,
+      // A candidate note that would ALSO match — but Tier 1 must never run.
+      "proc/deploy-candidate": 0.99,
+    });
+
+    const result = await matchCandidate("deploy the app", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("deploy-web"),
+      listCandidateNoteSlugs: candidateNotes("proc/deploy-candidate"),
+    });
+
+    expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
+    // Only the Tier-0 (skill) restriction was scored.
+    expect(calls).toEqual([["skills/deploy-web"]]);
+  });
+
+  test("a skill hit just below the threshold does NOT match Tier 0", async () => {
+    const { fn } = fakeScorer({
+      "skills/deploy-web": EXISTING_SKILL_THRESHOLD - 0.01,
+    });
+
+    const result = await matchCandidate("deploy the app", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("deploy-web"),
+      listCandidateNoteSlugs: candidateNotes(),
+    });
+
+    // Falls through Tier 0 and Tier 1 (no candidates) → new.
+    expect(result).toEqual({ kind: "new" });
+  });
+});
+
+describe("matchCandidate — Tier 1 (candidate cluster)", () => {
+  test("a goal matching a candidate note → cluster with that slug", async () => {
+    const { fn } = fakeScorer({
+      "skills/unrelated": 0.1,
+      "proc/cleanup-disk": 0.85,
+    });
+
+    const result = await matchCandidate("clear out the disk", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("unrelated"),
+      listCandidateNoteSlugs: candidateNotes("proc/cleanup-disk", "proc/other"),
+    });
+
+    expect(result).toEqual({ kind: "cluster", clusterId: "proc/cleanup-disk" });
+  });
+
+  test("the highest-scoring candidate wins when several match", async () => {
+    const { fn } = fakeScorer({
+      "proc/a": CLUSTER_MATCH_THRESHOLD + 0.01,
+      "proc/b": CLUSTER_MATCH_THRESHOLD + 0.1,
+      "proc/c": CLUSTER_MATCH_THRESHOLD + 0.05,
+    });
+
+    const result = await matchCandidate("do the thing", {
+      scoreSlugs: fn,
+      loadCatalog: catalog(),
+      listCandidateNoteSlugs: candidateNotes("proc/a", "proc/b", "proc/c"),
+    });
+
+    expect(result).toEqual({ kind: "cluster", clusterId: "proc/b" });
+  });
+
+  test("a candidate exactly at the cluster threshold matches (inclusive)", async () => {
+    const { fn } = fakeScorer({ "proc/edge": CLUSTER_MATCH_THRESHOLD });
+
+    const result = await matchCandidate("boundary goal", {
+      scoreSlugs: fn,
+      loadCatalog: catalog(),
+      listCandidateNoteSlugs: candidateNotes("proc/edge"),
+    });
+
+    expect(result).toEqual({ kind: "cluster", clusterId: "proc/edge" });
+  });
+});
+
+describe("matchCandidate — novel goal", () => {
+  test("nothing close enough → new", async () => {
+    const { fn } = fakeScorer({
+      "skills/deploy-web": 0.2,
+      "proc/cleanup-disk": GRAY_BAND_THRESHOLD - 0.01,
+    });
+
+    const result = await matchCandidate("a totally unrelated brand-new task", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("deploy-web"),
+      listCandidateNoteSlugs: candidateNotes("proc/cleanup-disk"),
+    });
+
+    expect(result).toEqual({ kind: "new" });
+  });
+
+  test("empty catalog + empty candidate pool → new", async () => {
+    const { fn, calls } = fakeScorer({});
+
+    const result = await matchCandidate("anything", {
+      scoreSlugs: fn,
+      loadCatalog: catalog(),
+      listCandidateNoteSlugs: candidateNotes(),
+    });
+
+    expect(result).toEqual({ kind: "new" });
+    // No slugs to restrict to → scorer is never called (empty-set short-circuit).
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("matchCandidate — gray band (deferred to caller's Tier-2 judge)", () => {
+  test("a borderline candidate → gray carrying the clusterId", async () => {
+    const { fn } = fakeScorer({
+      "proc/deploy-preview":
+        (GRAY_BAND_THRESHOLD + CLUSTER_MATCH_THRESHOLD) / 2,
+    });
+
+    const result = await matchCandidate("deploy to production", {
+      scoreSlugs: fn,
+      loadCatalog: catalog(),
+      listCandidateNoteSlugs: candidateNotes("proc/deploy-preview"),
+    });
+
+    expect(result).toEqual({ kind: "gray", clusterId: "proc/deploy-preview" });
+  });
+
+  test("a candidate exactly at the gray-band floor → gray (inclusive)", async () => {
+    const { fn } = fakeScorer({ "proc/edge": GRAY_BAND_THRESHOLD });
+
+    const result = await matchCandidate("boundary goal", {
+      scoreSlugs: fn,
+      loadCatalog: catalog(),
+      listCandidateNoteSlugs: candidateNotes("proc/edge"),
+    });
+
+    expect(result).toEqual({ kind: "gray", clusterId: "proc/edge" });
+  });
+
+  test("just below the gray-band floor → new, not gray", async () => {
+    const { fn } = fakeScorer({ "proc/edge": GRAY_BAND_THRESHOLD - 0.001 });
+
+    const result = await matchCandidate("boundary goal", {
+      scoreSlugs: fn,
+      loadCatalog: catalog(),
+      listCandidateNoteSlugs: candidateNotes("proc/edge"),
+    });
+
+    expect(result).toEqual({ kind: "new" });
+  });
+});
+
+describe("matchCandidate — thresholds are ordered for precision bias", () => {
+  test("gray floor < cluster bar < existing-skill bar", () => {
+    expect(GRAY_BAND_THRESHOLD).toBeLessThan(CLUSTER_MATCH_THRESHOLD);
+    expect(CLUSTER_MATCH_THRESHOLD).toBeLessThanOrEqual(
+      EXISTING_SKILL_THRESHOLD,
+    );
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
@@ -10,11 +10,13 @@
  *     skill capability page resolves to `existing-skill` (and short-circuits
  *     Tier 1).
  *   - Tier 1: a goal scoring at/above the cluster threshold against a candidate
- *     note resolves to `cluster` with that note's slug as the clusterId.
+ *     member note resolves to `cluster` carrying the OWNING cluster's id — not
+ *     the matched note slug (the store keys every mutator on `cluster_id`).
  *   - Novel: a goal below the gray band against everything resolves to `new`.
  *   - Gray band: a goal whose best candidate match lands in
- *     `[GRAY_BAND_THRESHOLD, CLUSTER_MATCH_THRESHOLD)` resolves to `gray` (the
- *     Tier-2 judge is the caller's job, never invoked here).
+ *     `[GRAY_BAND_THRESHOLD, CLUSTER_MATCH_THRESHOLD)` resolves to `gray`
+ *     carrying the owning cluster id (the Tier-2 judge is the caller's job,
+ *     never invoked here).
  *   - Threshold precedence (Tier 0 beats Tier 1) + read-only invariant (no
  *     writes, default registry reader only SELECTs).
  *
@@ -25,7 +27,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
-import type { ScoredSlug } from "../candidate-match.js";
+import type { CandidateClusterRef, ScoredSlug } from "../candidate-match.js";
 
 mock.module("../../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
@@ -62,10 +64,20 @@ const catalog =
   (...ids: string[]) =>
   () =>
     ids.map((id) => ({ id }));
-const candidateNotes =
-  (...slugs: string[]) =>
+
+// A Tier-1 candidate-cluster source. Each cluster carries its own `clusterId`
+// plus the member-note slugs that are actually embedded; the matcher ANN-scores
+// the slugs but must report the owning clusterId. Fixtures deliberately give
+// clusters a `clusterId` that DIFFERS from any member-note slug so a test fails
+// if the matcher leaks a note slug as the clusterId.
+const clusters =
+  (...refs: CandidateClusterRef[]) =>
   () =>
-    slugs;
+    refs;
+const cluster = (
+  clusterId: string,
+  ...memberNoteSlugs: string[]
+): CandidateClusterRef => ({ clusterId, memberNoteSlugs });
 
 describe("matchCandidate — Tier 0 (existing skill)", () => {
   test("a goal matching a skill capability page → existing-skill", async () => {
@@ -74,7 +86,9 @@ describe("matchCandidate — Tier 0 (existing skill)", () => {
     const result = await matchCandidate("ship the web app to prod", {
       scoreSlugs: fn,
       loadCatalog: catalog("deploy-web", "rotate-secrets"),
-      listCandidateNoteSlugs: candidateNotes("proc/something-else"),
+      listCandidateClusters: clusters(
+        cluster("cluster/other", "proc/something-else"),
+      ),
     });
 
     expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
@@ -90,7 +104,9 @@ describe("matchCandidate — Tier 0 (existing skill)", () => {
     const result = await matchCandidate("deploy the app", {
       scoreSlugs: fn,
       loadCatalog: catalog("deploy-web"),
-      listCandidateNoteSlugs: candidateNotes("proc/deploy-candidate"),
+      listCandidateClusters: clusters(
+        cluster("cluster/deploy", "proc/deploy-candidate"),
+      ),
     });
 
     expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
@@ -106,7 +122,7 @@ describe("matchCandidate — Tier 0 (existing skill)", () => {
     const result = await matchCandidate("deploy the app", {
       scoreSlugs: fn,
       loadCatalog: catalog("deploy-web"),
-      listCandidateNoteSlugs: candidateNotes(),
+      listCandidateClusters: clusters(),
     });
 
     // Falls through Tier 0 and Tier 1 (no candidates) → new.
@@ -115,35 +131,53 @@ describe("matchCandidate — Tier 0 (existing skill)", () => {
 });
 
 describe("matchCandidate — Tier 1 (candidate cluster)", () => {
-  test("a goal matching a candidate note → cluster with that slug", async () => {
+  test("a goal matching a member note → cluster carrying the OWNING clusterId (not the note slug)", async () => {
     const { fn } = fakeScorer({
       "skills/unrelated": 0.1,
       "proc/cleanup-disk": 0.85,
     });
 
+    // The owning cluster's id DIFFERS from the matched member-note slug. The
+    // matcher must report the clusterId — the store keys every mutator on it.
     const result = await matchCandidate("clear out the disk", {
       scoreSlugs: fn,
       loadCatalog: catalog("unrelated"),
-      listCandidateNoteSlugs: candidateNotes("proc/cleanup-disk", "proc/other"),
+      listCandidateClusters: clusters(
+        cluster("cluster/disk-housekeeping", "proc/cleanup-disk", "proc/other"),
+      ),
     });
 
-    expect(result).toEqual({ kind: "cluster", clusterId: "proc/cleanup-disk" });
+    expect(result).toEqual({
+      kind: "cluster",
+      clusterId: "cluster/disk-housekeeping",
+    });
+    // Regression guard: the matched note slug must NOT leak out as the clusterId.
+    expect(result).not.toEqual({
+      kind: "cluster",
+      clusterId: "proc/cleanup-disk",
+    });
   });
 
-  test("the highest-scoring candidate wins when several match", async () => {
+  test("the highest-scoring candidate wins, reported as its owning clusterId", async () => {
     const { fn } = fakeScorer({
       "proc/a": CLUSTER_MATCH_THRESHOLD + 0.01,
       "proc/b": CLUSTER_MATCH_THRESHOLD + 0.1,
       "proc/c": CLUSTER_MATCH_THRESHOLD + 0.05,
     });
 
+    // Each note lives in a distinct cluster whose id differs from the note slug.
     const result = await matchCandidate("do the thing", {
       scoreSlugs: fn,
       loadCatalog: catalog(),
-      listCandidateNoteSlugs: candidateNotes("proc/a", "proc/b", "proc/c"),
+      listCandidateClusters: clusters(
+        cluster("cluster/a", "proc/a"),
+        cluster("cluster/b", "proc/b"),
+        cluster("cluster/c", "proc/c"),
+      ),
     });
 
-    expect(result).toEqual({ kind: "cluster", clusterId: "proc/b" });
+    // Winner is proc/b's score → its owning cluster, not the note slug.
+    expect(result).toEqual({ kind: "cluster", clusterId: "cluster/b" });
   });
 
   test("a candidate exactly at the cluster threshold matches (inclusive)", async () => {
@@ -152,10 +186,10 @@ describe("matchCandidate — Tier 1 (candidate cluster)", () => {
     const result = await matchCandidate("boundary goal", {
       scoreSlugs: fn,
       loadCatalog: catalog(),
-      listCandidateNoteSlugs: candidateNotes("proc/edge"),
+      listCandidateClusters: clusters(cluster("cluster/edge", "proc/edge")),
     });
 
-    expect(result).toEqual({ kind: "cluster", clusterId: "proc/edge" });
+    expect(result).toEqual({ kind: "cluster", clusterId: "cluster/edge" });
   });
 });
 
@@ -169,7 +203,9 @@ describe("matchCandidate — novel goal", () => {
     const result = await matchCandidate("a totally unrelated brand-new task", {
       scoreSlugs: fn,
       loadCatalog: catalog("deploy-web"),
-      listCandidateNoteSlugs: candidateNotes("proc/cleanup-disk"),
+      listCandidateClusters: clusters(
+        cluster("cluster/disk-housekeeping", "proc/cleanup-disk"),
+      ),
     });
 
     expect(result).toEqual({ kind: "new" });
@@ -181,7 +217,7 @@ describe("matchCandidate — novel goal", () => {
     const result = await matchCandidate("anything", {
       scoreSlugs: fn,
       loadCatalog: catalog(),
-      listCandidateNoteSlugs: candidateNotes(),
+      listCandidateClusters: clusters(),
     });
 
     expect(result).toEqual({ kind: "new" });
@@ -191,19 +227,31 @@ describe("matchCandidate — novel goal", () => {
 });
 
 describe("matchCandidate — gray band (deferred to caller's Tier-2 judge)", () => {
-  test("a borderline candidate → gray carrying the clusterId", async () => {
+  test("a borderline member note → gray carrying the OWNING clusterId (not the note slug)", async () => {
     const { fn } = fakeScorer({
       "proc/deploy-preview":
         (GRAY_BAND_THRESHOLD + CLUSTER_MATCH_THRESHOLD) / 2,
     });
 
+    // The owning cluster's id DIFFERS from the matched member-note slug; the
+    // gray result must hand the Tier-2 judge the clusterId, not the note slug.
     const result = await matchCandidate("deploy to production", {
       scoreSlugs: fn,
       loadCatalog: catalog(),
-      listCandidateNoteSlugs: candidateNotes("proc/deploy-preview"),
+      listCandidateClusters: clusters(
+        cluster("cluster/deploy-rituals", "proc/deploy-preview"),
+      ),
     });
 
-    expect(result).toEqual({ kind: "gray", clusterId: "proc/deploy-preview" });
+    expect(result).toEqual({
+      kind: "gray",
+      clusterId: "cluster/deploy-rituals",
+    });
+    // Regression guard: the matched note slug must NOT leak out as the clusterId.
+    expect(result).not.toEqual({
+      kind: "gray",
+      clusterId: "proc/deploy-preview",
+    });
   });
 
   test("a candidate exactly at the gray-band floor → gray (inclusive)", async () => {
@@ -212,10 +260,10 @@ describe("matchCandidate — gray band (deferred to caller's Tier-2 judge)", () 
     const result = await matchCandidate("boundary goal", {
       scoreSlugs: fn,
       loadCatalog: catalog(),
-      listCandidateNoteSlugs: candidateNotes("proc/edge"),
+      listCandidateClusters: clusters(cluster("cluster/edge", "proc/edge")),
     });
 
-    expect(result).toEqual({ kind: "gray", clusterId: "proc/edge" });
+    expect(result).toEqual({ kind: "gray", clusterId: "cluster/edge" });
   });
 
   test("just below the gray-band floor → new, not gray", async () => {
@@ -224,7 +272,7 @@ describe("matchCandidate — gray band (deferred to caller's Tier-2 judge)", () 
     const result = await matchCandidate("boundary goal", {
       scoreSlugs: fn,
       loadCatalog: catalog(),
-      listCandidateNoteSlugs: candidateNotes("proc/edge"),
+      listCandidateClusters: clusters(cluster("cluster/edge", "proc/edge")),
     });
 
     expect(result).toEqual({ kind: "new" });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
@@ -102,6 +102,18 @@ export type ScoreSlugsFn = (
   restrictToSlugs: readonly string[],
 ) => Promise<ScoredSlug[]>;
 
+/**
+ * A registered candidate cluster reduced to what Tier 1 needs: its identity
+ * (`clusterId` — the registry/store key) and the member-note slugs embedded for
+ * it. The matcher restricts the ANN to the member-note slugs but always reports
+ * the OWNING `clusterId`, never a note slug — the store keys every mutator
+ * (`getCandidate`/`incrementCandidate`/`addMemberNote`) on `cluster_id`.
+ */
+export interface CandidateClusterRef {
+  clusterId: string;
+  memberNoteSlugs: readonly string[];
+}
+
 export interface MatchCandidateOptions {
   /** Config used for embedding + fusion weights. Defaults to `getConfig()`. */
   config?: AssistantConfig;
@@ -110,10 +122,12 @@ export interface MatchCandidateOptions {
   /** Live skill catalog (Tier 0 targets). Defaults to `loadSkillCatalog()`. */
   loadCatalog?: () => { id: string }[];
   /**
-   * Member-note slugs of existing candidate clusters (Tier 1 targets).
-   * Defaults to the union of every registered cluster's `memberNoteSlugs`.
+   * Existing candidate clusters (Tier 1 targets), each carrying its `clusterId`
+   * and its embedded member-note slugs. The matcher ANN-restricts to the union
+   * of member-note slugs but maps any hit back to its owning `clusterId`.
+   * Defaults to every registered cluster across the tracked statuses.
    */
-  listCandidateNoteSlugs?: () => string[];
+  listCandidateClusters?: () => CandidateClusterRef[];
 }
 
 /** The matcher's verdict — which tier (if any) claimed the goal. */
@@ -147,8 +161,8 @@ export async function matchCandidate(
   const scoreSlugs =
     opts.scoreSlugs ?? ((g, slugs) => scoreSlugsWithQdrant(config, g, slugs));
   const loadCatalog = opts.loadCatalog ?? (() => loadSkillCatalog());
-  const listCandidateNoteSlugs =
-    opts.listCandidateNoteSlugs ?? defaultCandidateNoteSlugs;
+  const listCandidateClusters =
+    opts.listCandidateClusters ?? defaultCandidateClusters;
 
   // ── Tier 0 — existing skill. ───────────────────────────────────────────────
   // Map each skill id to its capability-page slug, score them, and resolve the
@@ -166,19 +180,29 @@ export async function matchCandidate(
   }
 
   // ── Tier 1 — candidate cluster. ────────────────────────────────────────────
-  // The candidate-note slug IS the clusterId in the registry contract used by
-  // the caller's distillation job; carry it straight through.
-  const candidateBest = await bestHit(
-    scoreSlugs,
-    goal,
-    listCandidateNoteSlugs(),
-  );
-  if (candidateBest) {
-    if (candidateBest.score >= CLUSTER_MATCH_THRESHOLD) {
-      return { kind: "cluster", clusterId: candidateBest.slug };
+  // Member-note slugs are EMBEDDED, so the ANN must run against them — but a
+  // note slug is NOT a clusterId. Build a `memberNoteSlug → clusterId` map so a
+  // hit resolves back to the OWNING cluster's store key; the caller keys every
+  // mutator (`incrementCandidate`/`addMemberNote`) on `cluster_id`, so returning
+  // a note slug would update zero rows or fork a duplicate cluster.
+  const slugToClusterId = new Map<string, string>();
+  for (const cluster of listCandidateClusters()) {
+    for (const slug of cluster.memberNoteSlugs) {
+      slugToClusterId.set(slug, cluster.clusterId);
     }
-    if (candidateBest.score >= GRAY_BAND_THRESHOLD) {
-      return { kind: "gray", clusterId: candidateBest.slug };
+  }
+  const candidateBest = await bestHit(scoreSlugs, goal, [
+    ...slugToClusterId.keys(),
+  ]);
+  if (candidateBest) {
+    const clusterId = slugToClusterId.get(candidateBest.slug);
+    if (clusterId) {
+      if (candidateBest.score >= CLUSTER_MATCH_THRESHOLD) {
+        return { kind: "cluster", clusterId };
+      }
+      if (candidateBest.score >= GRAY_BAND_THRESHOLD) {
+        return { kind: "gray", clusterId };
+      }
     }
   }
 
@@ -201,8 +225,9 @@ async function bestHit(
 }
 
 /**
- * Default Tier-1 target set: every member-note slug across every registered
- * candidate cluster, deduped. Read-only — `listCandidatesByStatus` only SELECTs.
+ * Default Tier-1 target set: every registered candidate cluster across the
+ * tracked statuses, each carrying its `clusterId` and embedded member-note
+ * slugs. Read-only — `listCandidatesByStatus` only SELECTs.
  */
 const CANDIDATE_STATUSES: ProcCandidateStatus[] = [
   "observing",
@@ -210,14 +235,17 @@ const CANDIDATE_STATUSES: ProcCandidateStatus[] = [
   "distilled",
 ];
 
-function defaultCandidateNoteSlugs(): string[] {
-  const slugs = new Set<string>();
+function defaultCandidateClusters(): CandidateClusterRef[] {
+  const clusters: CandidateClusterRef[] = [];
   for (const status of CANDIDATE_STATUSES) {
     for (const candidate of listCandidatesByStatus(status)) {
-      for (const slug of candidate.memberNoteSlugs) slugs.add(slug);
+      clusters.push({
+        clusterId: candidate.clusterId,
+        memberNoteSlugs: candidate.memberNoteSlugs,
+      });
     }
   }
-  return [...slugs];
+  return clusters;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
@@ -1,0 +1,298 @@
+// ---------------------------------------------------------------------------
+// Procedural-memory candidate-identity matcher (Tier 0 + Tier 1)
+// ---------------------------------------------------------------------------
+//
+// Recurrence-gating needs to recognize that a freshly-captured procedure is
+// *the same procedure* as one we have seen before, so it can count toward the
+// distillation threshold. Identity keys on the procedure's **goal/intent**, not
+// its step sequence — two runs of one procedure routinely differ in steps (one
+// hit a retry), and averaging out that noise is the whole point of waiting for
+// recurrence.
+//
+// The matcher is tiered, cheap → expensive, riding existing memory infra (no
+// new substrate):
+//
+//   Tier 0 — existing skill. ANN the goal against the **skill catalog** first.
+//     A high-similarity hit means this is a *run of an existing skill*, not a
+//     new candidate — the caller routes any knowledge to a `skill:`-linked
+//     fact rather than opening a cluster.
+//   Tier 1 — candidate cluster. ANN the goal against the **candidate-note pool**
+//     (member-note slugs already embedded as ordinary memory). A high hit means
+//     it is provisionally the same procedure → join that cluster. A gray-band
+//     hit is ambiguous → defer to the caller's Tier-2 LLM judge (a later PR).
+//     Below the gray band → a genuinely new procedure.
+//
+// This module is a **pure, read-only matcher**: it embeds + queries but never
+// writes, never touches the registry except to read member slugs, and never
+// calls an LLM (the Tier-2 judge is the caller's job). The ANN/embedding seam
+// and the catalog/registry reads are dependency-injected so tests exercise the
+// tier logic without standing up Qdrant.
+
+import { getConfig } from "../../../config/loader.js";
+import { loadSkillCatalog } from "../../../config/skills.js";
+import type { AssistantConfig } from "../../../config/types.js";
+import { embedWithRetry } from "../../../memory/embed.js";
+import { hybridQueryConceptPages } from "../../../memory/v2/qdrant.js";
+import { fuseHalf } from "../../../memory/v2/sim.js";
+import { generateBm25QueryEmbedding } from "../../../memory/v2/sparse-bm25.js";
+import { getLogger } from "../../../util/logger.js";
+import {
+  listCandidatesByStatus,
+  type ProcCandidateStatus,
+} from "./proc-candidate-store.js";
+
+const log = getLogger("memory-v3-candidate-match");
+
+// ─── Thresholds ──────────────────────────────────────────────────────────────
+//
+// Bias precision over recall (per the design doc). Over-merging ships a skill
+// that conflates two procedures — a permanent bad catalog entry, the exact
+// pollution we are killing. Under-merging just delays a promotion, nearly free.
+// So both bars are HIGH, and the gray band between them is narrow.
+
+/**
+ * Tier 0 — a goal at or above this fused similarity to a skill capability page
+ * is treated as a *run of that existing skill*. High, since a false positive
+ * here silently suppresses a legitimately new procedure.
+ */
+export const EXISTING_SKILL_THRESHOLD = 0.82;
+
+/**
+ * Tier 1 — a goal at or above this fused similarity to a candidate note joins
+ * that note's cluster. Deliberately high: over-merging two distinct procedures
+ * is the costly failure, so the bar to declare "same procedure" is strict.
+ */
+export const CLUSTER_MATCH_THRESHOLD = 0.78;
+
+/**
+ * Tier 1 gray band — a goal whose best candidate similarity falls in
+ * `[GRAY_BAND_THRESHOLD, CLUSTER_MATCH_THRESHOLD)` is ambiguous (a borderline
+ * match or a dangerous near-miss like "deploy preview" vs "deploy production").
+ * The matcher reports `gray` and the caller's Tier-2 LLM judge breaks the tie
+ * — toward "different" — in a later PR.
+ */
+export const GRAY_BAND_THRESHOLD = 0.7;
+
+/**
+ * Per-channel ANN fetch limit. The candidate/skill pools are small (tens to low
+ * thousands of pages), and we only ever read the single best hit, so a modest
+ * limit is plenty of headroom while keeping each Qdrant round-trip cheap.
+ */
+const ANN_LIMIT = 32;
+
+/** Prefix under which a skill `<id>` is embedded as a capability page. */
+function skillSlug(id: string): string {
+  return `skills/${id}`;
+}
+
+/** A scored ANN hit: a corpus slug and its fused dense+sparse similarity. */
+export interface ScoredSlug {
+  slug: string;
+  score: number;
+}
+
+/**
+ * The injectable scoring seam. Given the embedded goal and a slug restriction,
+ * return each restricted slug's fused dense+sparse similarity to the goal.
+ * Defaults to a real Qdrant-backed query (`scoreSlugsWithQdrant`); tests pass a
+ * fake so the tier logic runs without a live collection.
+ */
+export type ScoreSlugsFn = (
+  goal: string,
+  restrictToSlugs: readonly string[],
+) => Promise<ScoredSlug[]>;
+
+export interface MatchCandidateOptions {
+  /** Config used for embedding + fusion weights. Defaults to `getConfig()`. */
+  config?: AssistantConfig;
+  /** ANN scorer (Tier 0 + Tier 1). Defaults to the Qdrant-backed scorer. */
+  scoreSlugs?: ScoreSlugsFn;
+  /** Live skill catalog (Tier 0 targets). Defaults to `loadSkillCatalog()`. */
+  loadCatalog?: () => { id: string }[];
+  /**
+   * Member-note slugs of existing candidate clusters (Tier 1 targets).
+   * Defaults to the union of every registered cluster's `memberNoteSlugs`.
+   */
+  listCandidateNoteSlugs?: () => string[];
+}
+
+/** The matcher's verdict — which tier (if any) claimed the goal. */
+export type MatchResult =
+  | { kind: "existing-skill"; skillId: string }
+  | { kind: "cluster"; clusterId: string }
+  | { kind: "gray"; clusterId: string }
+  | { kind: "new" };
+
+/**
+ * Classify a captured procedure's `goal` against existing skills (Tier 0) and
+ * candidate clusters (Tier 1).
+ *
+ *   - `existing-skill` — the goal matches a live skill at/above
+ *     {@link EXISTING_SKILL_THRESHOLD}; it is a run of that skill, not a new
+ *     candidate.
+ *   - `cluster` — the goal matches a candidate note at/above
+ *     {@link CLUSTER_MATCH_THRESHOLD}; it joins that note's cluster.
+ *   - `gray` — the best candidate match is in the gray band; ambiguous, deferred
+ *     to the caller's Tier-2 judge. Carries the borderline `clusterId` so the
+ *     judge knows which cluster it is weighing the goal against.
+ *   - `new` — no skill or candidate is close enough; a genuinely new procedure.
+ *
+ * Pure and read-only: no writes, no LLM call.
+ */
+export async function matchCandidate(
+  goal: string,
+  opts: MatchCandidateOptions = {},
+): Promise<MatchResult> {
+  const config = opts.config ?? getConfig();
+  const scoreSlugs =
+    opts.scoreSlugs ?? ((g, slugs) => scoreSlugsWithQdrant(config, g, slugs));
+  const loadCatalog = opts.loadCatalog ?? (() => loadSkillCatalog());
+  const listCandidateNoteSlugs =
+    opts.listCandidateNoteSlugs ?? defaultCandidateNoteSlugs;
+
+  // ── Tier 0 — existing skill. ───────────────────────────────────────────────
+  // Map each skill id to its capability-page slug, score them, and resolve the
+  // best back to its id.
+  const slugToSkillId = new Map<string, string>();
+  for (const skill of loadCatalog()) {
+    slugToSkillId.set(skillSlug(skill.id), skill.id);
+  }
+  const skillBest = await bestHit(scoreSlugs, goal, [...slugToSkillId.keys()]);
+  if (skillBest && skillBest.score >= EXISTING_SKILL_THRESHOLD) {
+    const skillId = slugToSkillId.get(skillBest.slug);
+    if (skillId) {
+      return { kind: "existing-skill", skillId };
+    }
+  }
+
+  // ── Tier 1 — candidate cluster. ────────────────────────────────────────────
+  // The candidate-note slug IS the clusterId in the registry contract used by
+  // the caller's distillation job; carry it straight through.
+  const candidateBest = await bestHit(
+    scoreSlugs,
+    goal,
+    listCandidateNoteSlugs(),
+  );
+  if (candidateBest) {
+    if (candidateBest.score >= CLUSTER_MATCH_THRESHOLD) {
+      return { kind: "cluster", clusterId: candidateBest.slug };
+    }
+    if (candidateBest.score >= GRAY_BAND_THRESHOLD) {
+      return { kind: "gray", clusterId: candidateBest.slug };
+    }
+  }
+
+  return { kind: "new" };
+}
+
+/** Score a slug restriction and return its single best (highest-scoring) hit. */
+async function bestHit(
+  scoreSlugs: ScoreSlugsFn,
+  goal: string,
+  restrictToSlugs: readonly string[],
+): Promise<ScoredSlug | null> {
+  if (restrictToSlugs.length === 0) return null;
+  const scored = await scoreSlugs(goal, restrictToSlugs);
+  let best: ScoredSlug | null = null;
+  for (const hit of scored) {
+    if (!best || hit.score > best.score) best = hit;
+  }
+  return best;
+}
+
+/**
+ * Default Tier-1 target set: every member-note slug across every registered
+ * candidate cluster, deduped. Read-only — `listCandidatesByStatus` only SELECTs.
+ */
+const CANDIDATE_STATUSES: ProcCandidateStatus[] = [
+  "observing",
+  "ready",
+  "distilled",
+];
+
+function defaultCandidateNoteSlugs(): string[] {
+  const slugs = new Set<string>();
+  for (const status of CANDIDATE_STATUSES) {
+    for (const candidate of listCandidatesByStatus(status)) {
+      for (const slug of candidate.memberNoteSlugs) slugs.add(slug);
+    }
+  }
+  return [...slugs];
+}
+
+/**
+ * Default scorer: embed `goal` (dense via `embedWithRetry`, sparse via
+ * `generateBm25QueryEmbedding` — the same pair `sources/memory-v2.ts` builds),
+ * run a slug-restricted hybrid query, and fuse each hit's dense+sparse channels
+ * into one similarity via `fuseHalf` with the configured `dense_weight` /
+ * `sparse_weight`. Body and summary halves are fused independently and the max
+ * is taken per slug, exactly as the recall source does. Returns `[]` on any
+ * embedding/Qdrant failure (logged at warn) so a matcher outage degrades to
+ * "treat as new" rather than throwing.
+ */
+async function scoreSlugsWithQdrant(
+  config: AssistantConfig,
+  goal: string,
+  restrictToSlugs: readonly string[],
+): Promise<ScoredSlug[]> {
+  const trimmed = goal.trim();
+  if (trimmed.length === 0 || restrictToSlugs.length === 0) return [];
+
+  try {
+    const denseResult = await embedWithRetry(config, [trimmed]);
+    const denseVector = denseResult.vectors[0] ?? [];
+    const sparseVector = generateBm25QueryEmbedding(trimmed);
+
+    const hits = await hybridQueryConceptPages(
+      denseVector,
+      sparseVector,
+      ANN_LIMIT,
+      restrictToSlugs,
+    );
+    if (hits.length === 0) return [];
+
+    const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
+      config.memory.v2;
+
+    // Normalize each sparse channel against its own per-batch max, mirroring
+    // sim.ts / the v2 recall source so scores are comparable to the thresholds.
+    let maxBodySparse = 0;
+    let maxSummarySparse = 0;
+    for (const hit of hits) {
+      if (hit.sparseScore !== undefined && hit.sparseScore > maxBodySparse) {
+        maxBodySparse = hit.sparseScore;
+      }
+      if (
+        hit.summarySparseScore !== undefined &&
+        hit.summarySparseScore > maxSummarySparse
+      ) {
+        maxSummarySparse = hit.summarySparseScore;
+      }
+    }
+
+    return hits.map((hit) => {
+      const bodyScore = fuseHalf(
+        hit.denseScore,
+        hit.sparseScore,
+        maxBodySparse,
+        denseWeight,
+        sparseWeight,
+      );
+      const summaryScore = fuseHalf(
+        hit.summaryDenseScore,
+        hit.summarySparseScore,
+        maxSummarySparse,
+        denseWeight,
+        sparseWeight,
+      );
+      const score = Math.max(bodyScore ?? 0, summaryScore ?? bodyScore ?? 0);
+      return { slug: hit.slug, score };
+    });
+  } catch (err) {
+    log.warn(
+      { err },
+      "candidate-match scorer failed; degrading to no hits (treat as new)",
+    );
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- Add matchCandidate: Tier 0 existing-skill check + Tier 1 candidate-cluster ANN; gray cases deferred to caller

Part of plan: procedural-memory-as-skills.md (PR 5 of 9)