### PR TITLE
feat(memory): validate fact `skill:` links against the skill catalog in maintain

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -96,6 +96,10 @@ describe("maintainJob", () => {
       // Core-validation stage off by default: empty core set ⇒ nothing to
       // check. The dedicated core tests below override this.
       loadCoreSet: () => [],
+      // Skill-validation stage off by default: empty skill catalog ⇒ nothing to
+      // check. The dedicated skill-link tests below override these.
+      loadSkillIds: () => [],
+      readPageSkillLink: async () => undefined,
       invalidateLanes: () => {
         calls.invalidate += 1;
       },
@@ -410,6 +414,70 @@ describe("maintainJob", () => {
     // Never replace good points with a blank: no delete, no upsert.
     expect(calls.deleted).toEqual([]);
     expect(calls.upserted).toEqual([]);
+  });
+
+  test("a fact linking a live skill reports no orphan", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      loadSkillIds: () => ["meet-join"],
+      listIndexedSlugs: async () => ["fact-a"],
+      readPageSkillLink: async (slug) =>
+        slug === "fact-a" ? "meet-join" : undefined,
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.orphanSkillSlugs).toEqual([]);
+    expect(outcome.failures).toEqual([]);
+    // Report-only and read-only: no dense-store mutation.
+    expect(calls.deleted).toEqual([]);
+    expect(calls.upserted).toEqual([]);
+    expect(calls.invalidate).toBe(1);
+  });
+
+  test("a fact linking a removed skill is reported as an orphan", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    // Two facts: one links a live skill, the other a removed/renamed one. A
+    // synthetic capability row carries no `skill:` link and is skipped. Only the
+    // dangling fact is reported.
+    const { deps: d, calls } = deps({
+      loadSkillIds: () => ["meet-join"],
+      listIndexedSlugs: async () => [
+        "fact-live",
+        "fact-gone",
+        "skills/example",
+      ],
+      // The capability row is already in the store, so the reconcile stage
+      // no-ops here and this test exercises skill-validation in isolation.
+      listSectionArticles: async () => ["skills/example"],
+      readPageSkillLink: async (slug) => {
+        if (slug === "fact-live") return "meet-join";
+        if (slug === "fact-gone") return "removed-skill";
+        return undefined;
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.orphanSkillSlugs).toEqual(["fact-gone"]);
+    expect(outcome.failures).toEqual([]);
+    // Report-only: the dangling link triggered no mutation.
+    expect(calls.deleted).toEqual([]);
+    expect(calls.upserted).toEqual([]);
+    expect(calls.invalidate).toBe(1);
+  });
+
+  test("a thrown skill-validation stage is contained and does not abort lane invalidation", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      loadSkillIds: () => {
+        throw new Error("skill boom");
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.failures).toContain("skill-validate");
+    expect(outcome.orphanSkillSlugs).toEqual([]);
+    expect(calls.invalidate).toBe(1);
+    expect(outcome.invalidated).toBe(true);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -96,9 +96,10 @@ describe("maintainJob", () => {
       // Core-validation stage off by default: empty core set ⇒ nothing to
       // check. The dedicated core tests below override this.
       loadCoreSet: () => [],
-      // Skill-validation stage off by default: empty skill catalog ⇒ nothing to
-      // check. The dedicated skill-link tests below override these.
-      loadSkillIds: () => [],
+      // Skill-validation stage off by default: empty catalog AND no indexed
+      // `skills/<id>` rows ⇒ nothing to check. The dedicated skill-link tests
+      // below override these.
+      loadValidSkillIds: () => [],
       readPageSkillLink: async () => undefined,
       invalidateLanes: () => {
         calls.invalidate += 1;
@@ -334,8 +335,10 @@ describe("maintainJob", () => {
     const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.danglingCoreSlugs).toEqual([]);
     // The reconcile and prune stages each read the index once; the empty core
-    // stage adds no further read.
-    expect(indexReads).toBe(2);
+    // stage adds no further read. The skill-link stage always reads the index to
+    // derive the indexed `skills/<id>` capability set (its valid-skill source of
+    // truth), so it adds one read even when the local catalog is empty.
+    expect(indexReads).toBe(3);
   });
 
   test("a thrown core-validation stage is contained and does not abort lane invalidation", async () => {
@@ -416,10 +419,10 @@ describe("maintainJob", () => {
     expect(calls.upserted).toEqual([]);
   });
 
-  test("a fact linking a live skill reports no orphan", async () => {
+  test("a fact linking a live catalog skill reports no orphan", async () => {
     setOverridesForTesting({ [FLAG_SHADOW]: true });
     const { deps: d, calls } = deps({
-      loadSkillIds: () => ["meet-join"],
+      loadValidSkillIds: () => ["meet-join"],
       listIndexedSlugs: async () => ["fact-a"],
       readPageSkillLink: async (slug) =>
         slug === "fact-a" ? "meet-join" : undefined,
@@ -440,7 +443,7 @@ describe("maintainJob", () => {
     // synthetic capability row carries no `skill:` link and is skipped. Only the
     // dangling fact is reported.
     const { deps: d, calls } = deps({
-      loadSkillIds: () => ["meet-join"],
+      loadValidSkillIds: () => ["meet-join"],
       listIndexedSlugs: async () => [
         "fact-live",
         "fact-gone",
@@ -465,10 +468,56 @@ describe("maintainJob", () => {
     expect(calls.invalidate).toBe(1);
   });
 
+  test("a fact linking an uninstalled catalog skill with an indexed capability row is NOT an orphan", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    // `meet-join` is absent from the local catalog (`loadValidSkillIds` empty)
+    // but IS seeded into the corpus as a live `skills/meet-join` capability row
+    // — exactly the uninstalled-first-party-catalog case. The edge derivation
+    // resolves `fact → skills/meet-join` against that indexed row, so the fact
+    // must NOT be false-flagged.
+    const { deps: d, calls } = deps({
+      loadValidSkillIds: () => [],
+      listIndexedSlugs: async () => ["fact-a", "skills/meet-join"],
+      // The capability row is already stored, so the reconcile stage no-ops.
+      listSectionArticles: async () => ["skills/meet-join"],
+      readPageSkillLink: async (slug) =>
+        slug === "fact-a" ? "meet-join" : undefined,
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.orphanSkillSlugs).toEqual([]);
+    expect(outcome.failures).toEqual([]);
+    // Report-only and read-only: no dense-store mutation.
+    expect(calls.deleted).toEqual([]);
+    expect(calls.upserted).toEqual([]);
+    expect(calls.invalidate).toBe(1);
+  });
+
+  test("a fact linking a skill absent from the indexed capability set is an orphan", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    // `removed-skill` backs no `skills/<id>` capability row and is not in the
+    // local catalog either, so the edge lane drops `fact → skills/removed-skill`
+    // — the fact is a genuine orphan and must be flagged.
+    const { deps: d, calls } = deps({
+      loadValidSkillIds: () => [],
+      listIndexedSlugs: async () => ["fact-gone", "skills/meet-join"],
+      listSectionArticles: async () => ["skills/meet-join"],
+      readPageSkillLink: async (slug) =>
+        slug === "fact-gone" ? "removed-skill" : undefined,
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.orphanSkillSlugs).toEqual(["fact-gone"]);
+    expect(outcome.failures).toEqual([]);
+    expect(calls.deleted).toEqual([]);
+    expect(calls.upserted).toEqual([]);
+    expect(calls.invalidate).toBe(1);
+  });
+
   test("a thrown skill-validation stage is contained and does not abort lane invalidation", async () => {
     setOverridesForTesting({ [FLAG_SHADOW]: true });
     const { deps: d, calls } = deps({
-      loadSkillIds: () => {
+      loadValidSkillIds: () => {
         throw new Error("skill boom");
       },
     });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -35,9 +35,13 @@
  *      maintainer-owned, so this stage NEVER edits it — the maintainer fixes
  *      dangling entries at the next consolidation pass.
  *   5. **Skill-link validation** — read each indexed concept page's `skill:`
- *      frontmatter and report pages whose link points at a skill id no longer in
- *      the catalog (removed or renamed) via the log + outcome. Report-only like
- *      core-set validation — the pages are never auto-edited.
+ *      frontmatter and report pages whose link points at a skill that backs no
+ *      `skills/<id>` capability row (removed or renamed) via the log + outcome.
+ *      The valid set is the indexed `skills/<id>` capability slugs — the same
+ *      set the edge derivation resolves `fact → skills/<id>` edges against — so
+ *      an uninstalled first-party catalog skill with a live capability row is not
+ *      false-flagged. Report-only like core-set validation — the pages are never
+ *      auto-edited.
  *   6. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
@@ -71,6 +75,10 @@ import { EmbeddingBillingBlockError } from "../../../memory/embedding-billing-br
 import type { MemoryJob } from "../../../memory/jobs-store.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
 import { readPage } from "../../../memory/v2/page-store.js";
+import {
+  isSkillSlug,
+  SKILL_SLUG_PREFIX,
+} from "../../../memory/v2/skill-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import { capabilityOrDiskBody, isCapabilitySlug } from "./capabilities.js";
@@ -163,11 +171,17 @@ export interface MaintainJobDeps {
    */
   loadCoreSet: () => Slug[];
   /**
-   * The live skill ids from the skill catalog. The skill-link validation stage
-   * diffs each indexed page's `skill:` frontmatter against this set to find
-   * facts whose `skill:` points at a removed or renamed skill.
+   * Extra valid skill ids beyond the indexed `skills/<id>` capability set — the
+   * local skill catalog. The skill-link validation stage treats a fact's
+   * `skill: <id>` as orphaned ONLY when `skills/<id>` is absent from the indexed
+   * capability rows (the set the edge derivation resolves against; see
+   * {@link addEdge}), UNIONED with these ids as belt-and-suspenders. The indexed
+   * set is the source of truth: uninstalled first-party catalog skills are
+   * seeded as live `skills/<id>` rows even though they are not in the local
+   * catalog, so validating against the catalog alone false-flags a fact that
+   * validly links such a skill.
    */
-  loadSkillIds: () => string[];
+  loadValidSkillIds: () => string[];
   /**
    * A page's `skill:` frontmatter value (a bare skill id) or `undefined` when
    * the page carries no `skill:` link. Reads through the page store rather than
@@ -264,9 +278,11 @@ export interface MaintainOutcome {
    */
   danglingCoreSlugs: Slug[];
   /**
-   * Indexed concept pages whose `skill:` frontmatter link points at a skill id
-   * no longer in the catalog (removed or renamed). Reported for review — the
-   * pages themselves are never mutated.
+   * Indexed concept pages whose `skill:` frontmatter link points at a skill that
+   * backs no `skills/<id>` capability row in the index (removed or renamed).
+   * Validated against the indexed capability set (the edge-target source of
+   * truth), not just the local catalog. Reported for review — the pages
+   * themselves are never mutated.
    */
   orphanSkillSlugs: Slug[];
   /** Whether the in-memory lanes were invalidated. */
@@ -381,7 +397,7 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     listSectionArticles: () => realListSectionArticles(config),
     listIndexedSlugs: () => selectAllPagesFromWorkspace(workspaceDir),
     loadCoreSet: () => realLoadCoreSet(workspaceDir),
-    loadSkillIds: () => loadSkillCatalog().map((s) => s.id),
+    loadValidSkillIds: () => loadSkillCatalog().map((s) => s.id),
     readPageSkillLink: (slug) =>
       readPageSkillLinkFromWorkspace(workspaceDir, slug),
     invalidateLanes: realInvalidateLanes,
@@ -803,27 +819,46 @@ export async function maintainJob(
     );
   }
 
-  // Stage 5: validate fact `skill:` links against the live skill catalog. Read
-  // each indexed concept page's `skill:` frontmatter and REPORT pages whose link
-  // points at a skill id no longer in the catalog (removed or renamed) through
-  // the log + outcome. Synthetic capability rows carry no `skill:` link, so they
+  // Stage 5: validate fact `skill:` links against the indexed `skills/<id>`
+  // capability set. Read each indexed concept page's `skill:` frontmatter and
+  // REPORT pages whose link points at a skill that backs no `skills/<id>`
+  // capability row (removed or renamed) through the log + outcome.
+  //
+  // The valid-skill set is the `skills/<id>` slugs present in the page index
+  // (prefix stripped), NOT just `loadValidSkillIds()` (the local catalog). This
+  // is the exact set the edge derivation resolves a `fact → skills/<id>` edge
+  // against (see `edge.ts` `addEdge`): uninstalled first-party catalog skills are
+  // seeded into the corpus as live `skills/<id>` rows even though they are absent
+  // from the local catalog, so validating against the catalog alone would
+  // false-flag a fact that validly links such a skill. The catalog ids are
+  // unioned in as belt-and-suspenders, but the indexed capability set is the
+  // source of truth. Synthetic capability rows carry no `skill:` link, so they
   // are skipped. Report-only, mirroring core-set validation: the pages are never
   // auto-edited; the maintainer fixes a dangling link at the next consolidation.
   try {
-    const skillIds = deps.loadSkillIds();
-    if (skillIds.length > 0) {
-      const liveSkills = new Set(skillIds);
+    const indexedSlugs = await deps.listIndexedSlugs();
+    // The set the edge lane actually resolves `skills/<id>` targets against:
+    // every `skills/<id>` capability row in the index, by bare id.
+    const validSkills = new Set<string>(
+      indexedSlugs
+        .filter((slug) => isSkillSlug(slug))
+        .map((slug) => slug.slice(SKILL_SLUG_PREFIX.length)),
+    );
+    // Union the local catalog ids as belt-and-suspenders.
+    for (const id of deps.loadValidSkillIds()) validSkills.add(id);
+
+    if (validSkills.size > 0) {
       const orphans: Slug[] = [];
-      for (const slug of await deps.listIndexedSlugs()) {
+      for (const slug of indexedSlugs) {
         if (isCapabilitySlug(slug)) continue;
         const skill = await deps.readPageSkillLink(slug);
-        if (skill && !liveSkills.has(skill)) orphans.push(slug);
+        if (skill && !validSkills.has(skill)) orphans.push(slug);
       }
       outcome.orphanSkillSlugs = orphans;
       if (orphans.length > 0) {
         log.warn(
           { orphans },
-          "memory-v3 maintain: pages link a `skill:` missing from the catalog — review the links at the next consolidation",
+          "memory-v3 maintain: pages link a `skill:` with no indexed capability row — review the links at the next consolidation",
         );
       }
     }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -2,7 +2,7 @@
  * Memory v3 — `memory_v3_maintain` job handler.
  *
  * A flag-gated, best-effort self-maintenance pass over the v3 section dense
- * store and the in-memory lanes. It runs five independent stages, in order:
+ * store and the in-memory lanes. It runs six independent stages, in order:
  *
  *   1. **Section re-embed** — diff the page index by `modifiedAt` against the
  *      last successful pass (the high-water mark below), and for every page that
@@ -34,7 +34,11 @@
  *      in the page index (dangling slugs) via the log + outcome. The file is
  *      maintainer-owned, so this stage NEVER edits it — the maintainer fixes
  *      dangling entries at the next consolidation pass.
- *   5. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
+ *   5. **Skill-link validation** — read each indexed concept page's `skill:`
+ *      frontmatter and report pages whose link points at a skill id no longer in
+ *      the catalog (removed or renamed) via the log + outcome. Report-only like
+ *      core-set validation — the pages are never auto-edited.
+ *   6. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
  *
@@ -53,6 +57,7 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
+import { loadSkillCatalog } from "../../../config/skills.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import {
   getMemoryCheckpoint,
@@ -157,6 +162,18 @@ export interface MaintainJobDeps {
    * entries only — the file is maintainer-owned and is never edited here.
    */
   loadCoreSet: () => Slug[];
+  /**
+   * The live skill ids from the skill catalog. The skill-link validation stage
+   * diffs each indexed page's `skill:` frontmatter against this set to find
+   * facts whose `skill:` points at a removed or renamed skill.
+   */
+  loadSkillIds: () => string[];
+  /**
+   * A page's `skill:` frontmatter value (a bare skill id) or `undefined` when
+   * the page carries no `skill:` link. Reads through the page store rather than
+   * Qdrant; missing/unreadable pages degrade to `undefined`.
+   */
+  readPageSkillLink: (slug: Slug) => Promise<string | undefined>;
   /** Drop the memoized v3 lanes so the next turn rebuilds them. */
   invalidateLanes: () => void;
   /** Active assistant config (for the dense-store/embedding calls). */
@@ -246,6 +263,12 @@ export interface MaintainOutcome {
    * consolidation pass — the file itself is never mutated.
    */
   danglingCoreSlugs: Slug[];
+  /**
+   * Indexed concept pages whose `skill:` frontmatter link points at a skill id
+   * no longer in the catalog (removed or renamed). Reported for review — the
+   * pages themselves are never mutated.
+   */
+  orphanSkillSlugs: Slug[];
   /** Whether the in-memory lanes were invalidated. */
   invalidated: boolean;
   /** Stages that threw (and were contained). */
@@ -307,6 +330,19 @@ async function readPageBodyFromWorkspace(
   }
 }
 
+/** Read a page's `skill:` frontmatter link; missing/failed reads degrade to undefined. */
+async function readPageSkillLinkFromWorkspace(
+  workspaceDir: string,
+  slug: Slug,
+): Promise<string | undefined> {
+  try {
+    const page = await readPage(workspaceDir, slug);
+    return page?.frontmatter.skill;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Capability-aware page-body reader for the full backfill: synthetic skill/CLI
  * slugs have no on-disk page, so they contribute their rendered capability
@@ -345,6 +381,9 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     listSectionArticles: () => realListSectionArticles(config),
     listIndexedSlugs: () => selectAllPagesFromWorkspace(workspaceDir),
     loadCoreSet: () => realLoadCoreSet(workspaceDir),
+    loadSkillIds: () => loadSkillCatalog().map((s) => s.id),
+    readPageSkillLink: (slug) =>
+      readPageSkillLinkFromWorkspace(workspaceDir, slug),
     invalidateLanes: realInvalidateLanes,
     config,
   };
@@ -652,6 +691,7 @@ export async function maintainJob(
     pruned: 0,
     pruneFailures: 0,
     danglingCoreSlugs: [],
+    orphanSkillSlugs: [],
     invalidated: false,
     failures: [],
   };
@@ -763,7 +803,39 @@ export async function maintainJob(
     );
   }
 
-  // Stage 5: rebuild section index + needle + edge graph on the next turn.
+  // Stage 5: validate fact `skill:` links against the live skill catalog. Read
+  // each indexed concept page's `skill:` frontmatter and REPORT pages whose link
+  // points at a skill id no longer in the catalog (removed or renamed) through
+  // the log + outcome. Synthetic capability rows carry no `skill:` link, so they
+  // are skipped. Report-only, mirroring core-set validation: the pages are never
+  // auto-edited; the maintainer fixes a dangling link at the next consolidation.
+  try {
+    const skillIds = deps.loadSkillIds();
+    if (skillIds.length > 0) {
+      const liveSkills = new Set(skillIds);
+      const orphans: Slug[] = [];
+      for (const slug of await deps.listIndexedSlugs()) {
+        if (isCapabilitySlug(slug)) continue;
+        const skill = await deps.readPageSkillLink(slug);
+        if (skill && !liveSkills.has(skill)) orphans.push(slug);
+      }
+      outcome.orphanSkillSlugs = orphans;
+      if (orphans.length > 0) {
+        log.warn(
+          { orphans },
+          "memory-v3 maintain: pages link a `skill:` missing from the catalog — review the links at the next consolidation",
+        );
+      }
+    }
+  } catch (err) {
+    outcome.failures.push("skill-validate");
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3 maintain: skill-link validation failed (non-fatal)",
+    );
+  }
+
+  // Stage 6: rebuild section index + needle + edge graph on the next turn.
   try {
     deps.invalidateLanes();
     outcome.invalidated = true;
@@ -784,6 +856,7 @@ export async function maintainJob(
       pruned: outcome.pruned,
       pruneFailures: outcome.pruneFailures,
       danglingCoreSlugs: outcome.danglingCoreSlugs,
+      orphanSkillSlugs: outcome.orphanSkillSlugs,
       invalidated: outcome.invalidated,
       failures: outcome.failures,
     },


### PR DESCRIPTION
## Summary
- Add a read-only maintain stage reporting facts whose `skill:` link is dangling (orphanSkillSlugs)

Part of plan: procedural-memory-as-skills.md (PR 7 of 9)