### PR TITLE
refactor(config): remove the advisor LLM call site and advisorEnabled; repurpose advisorProfile

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29606,12 +29606,6 @@ components:
                 - $ref: "#/components/schemas/ProfileStatus"
                 - type: "null"
             - type: "null"
-        advisorEnabled:
-          anyOf:
-            - anyOf:
-                - type: boolean
-                - type: "null"
-            - type: "null"
         mix:
           anyOf:
             - minItems: 2
@@ -30338,10 +30332,6 @@ components:
         status:
           anyOf:
             - $ref: "#/components/schemas/ProfileStatus"
-            - type: "null"
-        advisorEnabled:
-          anyOf:
-            - type: boolean
             - type: "null"
         mix:
           minItems: 2

--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -234,7 +234,7 @@ describe("native web-search capability survives the wrapper chain", () => {
     // UsageTracking → leaf. The advisor consult reads the flag off the top.
     const wrapped = new CallSiteConfiguredProvider(
       new UsageTrackingProvider(leaf(true)),
-      "advisor",
+      "subagentSpawn",
     );
     expect(wrapped.supportsNativeWebSearch).toBe(true);
   });

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -149,7 +149,6 @@ describe("reconcileFlagGatedProfiles", () => {
     const raw = readConfig();
     raw.llm.profiles["os-beta"]!.label = "My OS Beta";
     raw.llm.profiles["os-beta"]!.status = "disabled";
-    raw.llm.profiles["os-beta"]!.advisorEnabled = true;
     writeConfig(raw);
     invalidateConfigCache();
 
@@ -158,7 +157,6 @@ describe("reconcileFlagGatedProfiles", () => {
     const after = readConfig().llm.profiles["os-beta"]!;
     expect(after.label).toBe("My OS Beta");
     expect(after.status).toBe("disabled");
-    expect(after.advisorEnabled).toBe(true);
     expect(after.model).toBe("accounts/fireworks/models/glm-5p2");
   });
 
@@ -316,7 +314,7 @@ describe("reconcileFlagGatedProfiles", () => {
 
     const raw = readConfig();
     (raw.llm as Record<string, unknown>).callSites = {
-      advisor: { profile: "os-beta", temperature: 0.3 },
+      inference: { profile: "os-beta", temperature: 0.3 },
     };
     writeConfig(raw);
     invalidateConfigCache();
@@ -325,14 +323,14 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(reconcileFlagGatedProfiles()).toBe(true);
 
     const after = readConfig();
-    const advisor = (
+    const inference = (
       after.llm as unknown as Record<
         string,
         Record<string, Record<string, unknown>>
       >
-    ).callSites.advisor;
-    expect(advisor.profile).toBeUndefined();
-    expect(advisor.temperature).toBe(0.3);
+    ).callSites.inference;
+    expect(inference.profile).toBeUndefined();
+    expect(inference.temperature).toBe(0.3);
 
     expect(LLMSchema.safeParse(after.llm).success).toBe(true);
   });

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -69,12 +69,6 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   meetConsentMonitor: { profile: "cost-optimized" },
   meetChatOpportunity: { profile: "cost-optimized" },
   inference: { profile: "cost-optimized" },
-  // The advisor consults the strongest managed profile (`frontier`, Opus),
-  // which seeding writes into `llm.advisorProfile` on boot and floats above this
-  // layer. This static fallback — used only when no `advisorProfile` resolves —
-  // stays on the always-reserved `quality-optimized` so it can never resolve to
-  // a user-owned profile that happens to be named `frontier`.
-  advisor: { profile: "quality-optimized" },
   // Vision captioning for the image-fallback plugin. No pinned profile — the
   // plugin resolves a vision-capable profile itself via `doesSupportVision` and
   // passes it as an `overrideProfile`, so the call-site default is a fallback

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -497,9 +497,6 @@ function profileConfigFragment(profile: ProfileEntry): Mergeable {
     // lower-precedence (e.g. active) profile into one that merely inherited it.
     // `RetryProvider` resolves it from the applied profile, not the merge.
     logitBias: _logitBias,
-    // Per-profile advisor toggle is profile identity, not inheritable model
-    // config — strip it so it can't leak into the merged `LLMConfigBase`.
-    advisorEnabled: _advisorEnabled,
     // `temperature`/`top_p` are provider-coupled: only the winning profile
     // contributes them (tracked via `samplingRef`, applied post-merge), so a
     // shadowed profile's sampling can never reach a different provider through

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -300,13 +300,6 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "General-purpose LLM inference call site for skill use.",
     domain: "skills",
   },
-  advisor: {
-    id: "advisor",
-    displayName: "Advisor",
-    description:
-      "Stronger reviewer model consulted mid-task to shape or pressure-test the plan.",
-    domain: "skills",
-  },
   vision: {
     id: "vision",
     displayName: "Vision",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -79,7 +79,6 @@ export const LLMCallSiteEnum = z.enum([
   "meetConsentMonitor",
   "meetChatOpportunity",
   "inference",
-  "advisor",
   "vision",
   "trustRuleSuggestion",
   "homeGreeting",
@@ -443,13 +442,6 @@ export const ProfileEntry = LLMConfigFragment.extend({
    */
   status: ProfileStatusSchema.nullable().optional(),
   /**
-   * Whether the advisor is active while this profile is the chat profile.
-   * Absent/null means enabled (default on); only an explicit `false` disables
-   * it. `.nullable()` matches `status`/`label` so the PUT route's "send null
-   * to clear" sentinel resets it back to the default-on state.
-   */
-  advisorEnabled: z.boolean().nullable().optional(),
-  /**
    * When present, this profile is a "mix": it carries no model config and
    * instead references a weighted list of standard profiles. The resolver
    * expands a mix by a seeded weighted pick (see `resolveCallSiteConfig`).
@@ -492,10 +484,9 @@ export const LLMSchema = z
     // schema level, so `LLMSchema.parse({})` yields an empty map.
     callSites: z.partialRecord(LLMCallSiteEnum, LLMCallSiteConfig).default({}),
     activeProfile: z.string().min(1).optional(),
-    // The profile the advisor consults (chosen under Models & Services). It is
-    // excluded from the chat-profile pickers so it can't be selected as the
-    // assistant's chat model. Absent falls back to the `advisor` call-site
-    // default (`quality-optimized`).
+    // The profile the advisor role consults when spawned as a subagent (chosen
+    // under Models & Services). It is excluded from the chat-profile pickers so
+    // it can't be selected as the assistant's chat model.
     advisorProfile: z.string().min(1).optional(),
     // TTL bounds for inference profile sessions. `defaultTtlSeconds` is read by
     // the CLI to apply when `--ttl` is omitted; the daemon handler itself only

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -84,9 +84,6 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-    // This is the advisor's own (strongest) profile: when it's also the chat
-    // profile there's nothing stronger to consult, so the advisor defaults off.
-    advisorEnabled: false,
   },
   // Served by DeepSeek V4 Flash on Fireworks via managed platform inference: a
   // fast, low-cost open model. `model` is pinned explicitly rather than
@@ -223,11 +220,9 @@ export type SeedInferenceProfilesOptions = {
  *    `cost-optimized`): reconciled from the code templates on every boot —
  *    on-platform and off-platform alike — so Vellum can push model/config
  *    updates to customers in a release without a workspace migration. The
- *    templates own all profile content; `label`, `status`, `advisorEnabled`,
- *    and `topP` are user overrides that survive reseeds. Of those, only
- *    `label`, `status`, and `topP` are editable through the managed PUT route
- *    allowlist; `advisorEnabled` is edited via the generic config path but is
- *    still preserved here so it survives reboots.
+ *    templates own all profile content; `label`, `status`, and `topP` are user
+ *    overrides that survive reseeds and are editable through the managed PUT
+ *    route allowlist.
  *    Platform overlays (`preserveProfileNames`) take precedence for the boot
  *    they are supplied.
  *
@@ -282,14 +277,11 @@ export function seedInferenceProfiles(
   //    as usual.
   //
   //    A whitelist of user-editable fields survives the reconcile: `label`
-  //    (display rename), `status` (active/disabled toggle), `advisorEnabled`
-  //    (per-profile advisor toggle), and `topP` (sampling override) — the only
-  //    fields a user may override. The managed PUT route
-  //    `/v1/config/llm/profiles/:name` lets users patch `label`, `status`, and
-  //    `topP` on managed profiles without duplicating (its editable allowlist,
-  //    `MANAGED_PROFILE_EDITABLE_KEYS`, deliberately excludes `advisorEnabled`,
-  //    which is set through the generic config path). We honor every one of
-  //    these overrides across reseeds or they'd silently revert on every boot.
+  //    (display rename), `status` (active/disabled toggle), and `topP`
+  //    (sampling override) — the only fields a user may override. The managed
+  //    PUT route `/v1/config/llm/profiles/:name` lets users patch these on
+  //    managed profiles without duplicating. We honor every one of these
+  //    overrides across reseeds or they'd silently revert on every boot.
   //    Carry by key-presence rather than truthiness so an explicit `null` (user
   //    cleared the field) survives too.
   //
@@ -361,12 +353,6 @@ export function seedInferenceProfiles(
             : previous.label;
       }
       if ("status" in previous) next.status = previous.status;
-      // The per-profile advisor toggle is a user override — preserve it across
-      // reseeds so a user's choice survives reboots (the template value only
-      // seeds the initial default, e.g. off for quality-optimized).
-      if ("advisorEnabled" in previous) {
-        next.advisorEnabled = previous.advisorEnabled;
-      }
       // `topP` is user-editable on managed profiles (see the managed-profile
       // editable allowlist on the PUT route) — preserve a user override across
       // reseeds, including an explicit `null` clear, or it would silently revert

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -119,9 +119,6 @@ function enableProfile(
     // by key-presence so an explicit null (user cleared it) survives too.
     if ("label" in previous) next.label = previous.label;
     if ("status" in previous) next.status = previous.status;
-    if ("advisorEnabled" in previous) {
-      next.advisorEnabled = previous.advisorEnabled;
-    }
   }
 
   let changed = false;

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -196,10 +196,6 @@ function ProfileEditorModalInner({
   const [status, setStatus] = useState<ProfileStatus>(
     initialValues?.status ?? "active",
   );
-  // Per-profile advisor toggle. Absent/null means ENABLED (default on); only an
-  // explicit `false` disables — so coalesce nil to `true`.
-  const initialAdvisorEnabled = initialValues?.advisorEnabled ?? true;
-  const [advisorEnabled, setAdvisorEnabled] = useState(initialAdvisorEnabled);
   // Connections created inline this session, before the parent's `connections`
   // prop has refetched. Unioned into the available-connections set so a
   // just-created binding is treated as valid immediately — otherwise
@@ -247,7 +243,7 @@ function ProfileEditorModalInner({
 
   // Advanced params — top P. Top P is editable in view mode (managed
   // profiles), so capture its initial enabled flag + value as the baseline
-  // `hasViewModeChanges` compares against — mirroring `initialAdvisorEnabled`.
+  // `hasViewModeChanges` compares against.
   const initialTopPEnabled = typeof initialValues?.topP === "number";
   const initialTopP =
     typeof initialValues?.topP === "number" ? initialValues.topP : 0.95;
@@ -255,15 +251,14 @@ function ProfileEditorModalInner({
   const [topP, setTopP] = useState<number>(initialTopP);
 
   // True when in view mode and the user has touched one of the fields that
-  // view mode permits editing (label, status, advisor, Top P). Drives the
-  // view-mode Save button's enabled state and the partial-update save path.
-  // Top P is compared on both the enabled flag and the value so flipping the
-  // toggle or dragging the slider both arm Save.
+  // view mode permits editing (label, status, Top P). Drives the view-mode
+  // Save button's enabled state and the partial-update save path. Top P is
+  // compared on both the enabled flag and the value so flipping the toggle or
+  // dragging the slider both arm Save.
   const hasViewModeChanges =
     isReadOnly &&
     (label !== initialLabel ||
       status !== initialStatus ||
-      advisorEnabled !== initialAdvisorEnabled ||
       topPEnabled !== initialTopPEnabled ||
       (topPEnabled && topP !== initialTopP));
 
@@ -519,7 +514,6 @@ function ProfileEditorModalInner({
         const entry: ProfileEntry = {
           label: label.trim() || null,
           status,
-          advisorEnabled,
         };
         // Top P is the one advanced param managed profiles may override.
         // Mirror the create/edit build-entry logic: enabled → number,
@@ -624,13 +618,6 @@ function ProfileEditorModalInner({
       } else if (status !== "active") {
         entry.status = status;
       }
-      // Advisor toggle — always include in edit mode; omit in create when
-      // enabled (absent/null already means enabled, so the default round-trips).
-      if (effectiveMode === "edit") {
-        entry.advisorEnabled = advisorEnabled;
-      } else if (!advisorEnabled) {
-        entry.advisorEnabled = advisorEnabled;
-      }
       // Do NOT include source or name
       await onSave(keyTrimmed, entry);
     } catch {
@@ -717,15 +704,6 @@ function ProfileEditorModalInner({
       checked={status === "active"}
       onChange={(v) => setStatus(v ? "active" : "disabled")}
       label="Active"
-    />
-  );
-
-  const advisorToggle = (
-    <Toggle
-      checked={advisorEnabled}
-      onChange={setAdvisorEnabled}
-      label="Advisor"
-      helperText="Let the model consult a stronger advisor model while using this profile."
     />
   );
 
@@ -920,7 +898,6 @@ function ProfileEditorModalInner({
             {keyField}
             {descriptionField}
             {activeToggle}
-            {advisorToggle}
 
             {/* Advanced params — collapsed by default in create mode. */}
             {createAdvancedDisclosure}
@@ -936,7 +913,6 @@ function ProfileEditorModalInner({
             {descriptionField}
             {keyField}
             {activeToggle}
-            {advisorToggle}
 
             <ProfileEditorProviderSection
               provider={provider}


### PR DESCRIPTION
## Summary
- Remove the now-unused advisor LLM call site and per-profile advisorEnabled (advisor is a subagent role now).
- Keep llm.advisorProfile, repurposed as the advisor role's default consult profile; web keeps the Advisor Profile picker, drops the per-profile toggle.

Part of plan: advisor-as-subagent-role.md (PR 9 of 10)