### PR TITLE
refactor(contacts): stop mirroring ACL writes to the assistant DB

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -69,7 +69,6 @@ mock.module("../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => _testApprovalConversationGenerator,
 }));
 
-import { upsertContact } from "../contacts/contact-store.js";
 import type { Conversation } from "../daemon/conversation.js";
 import {
   createCanonicalGuardianDelivery,
@@ -86,7 +85,10 @@ import * as gatewayClient from "../runtime/gateway-client.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { _setTestPollMaxWait } from "../runtime/routes/channel-route-shared.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
 await initializeDb();
@@ -212,22 +214,19 @@ function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
 const noopProcessMessage = mock(async () => ({ messageId: "msg-1" }));
 
 function ensureTestContact(): void {
-  upsertContact({
+  seedContactChannel({
+    sourceChannel: "telegram",
+    externalUserId: "telegram-user-default",
     displayName: "Test User",
-    channels: [
-      {
-        type: "telegram",
-        address: "telegram-user-default",
-        status: "active",
-        policy: "allow",
-      },
-      {
-        type: "slack",
-        address: "slack-user-default",
-        status: "active",
-        policy: "allow",
-      },
-    ],
+    status: "active",
+    policy: "allow",
+  });
+  seedContactChannel({
+    sourceChannel: "slack",
+    externalUserId: "slack-user-default",
+    displayName: "Test User",
+    status: "active",
+    policy: "allow",
   });
 }
 
@@ -1926,16 +1925,12 @@ describe("trusted-contact self-approval blocked before guardian approval row exi
       guardianDeliveryChatId: "guardian-tc-selfapproval-chat",
       guardianPrincipalId: "guardian-tc-selfapproval",
     });
-    upsertContact({
+    seedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "tc-selfapproval-user",
       displayName: "TC Self-Approval User",
-      channels: [
-        {
-          type: "telegram",
-          address: "tc-selfapproval-user",
-          status: "active",
-          policy: "allow",
-        },
-      ],
+      status: "active",
+      policy: "allow",
     });
   });
 

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -65,22 +65,40 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 
 // Gateway relay mock — the revoke path relays the ACL downgrade over IPC and
 // validates the response; return a well-formed mark_channel_revoked result.
+// The gateway owns the revoke and dual-writes the local assistant row to
+// "revoked"; mirror that dual-write here so guardian-resolution reads under
+// test observe the downgrade (the assistant-side teardown is now a no-op shim).
 mock.module("../ipc/gateway-client.js", () => ({
   ipcCallPersistent: async (
-    _method: string,
+    method: string,
     params?: Record<string, unknown>,
-  ) => ({
-    ok: true,
-    didWrite: true,
-    channel: {
-      id: (params?.contactChannelId as string) ?? "ch1",
-      contactId: "c1",
-      type: "phone",
-      address: "addr",
-      status: "revoked",
-      revokedReason: (params?.reason as string) ?? null,
-    },
-  }),
+  ) => {
+    if (method === "mark_channel_revoked") {
+      const { getDb } = await import("../memory/db-connection.js");
+      const { contactChannels } = await import("../memory/schema.js");
+      const { eq } = await import("drizzle-orm");
+      const channelId = params?.contactChannelId as string | undefined;
+      if (channelId) {
+        getDb()
+          .update(contactChannels)
+          .set({ status: "revoked" })
+          .where(eq(contactChannels.id, channelId))
+          .run();
+      }
+    }
+    return {
+      ok: true,
+      didWrite: true,
+      channel: {
+        id: (params?.contactChannelId as string) ?? "ch1",
+        contactId: "c1",
+        type: "phone",
+        address: "addr",
+        status: "revoked",
+        revokedReason: (params?.reason as string) ?? null,
+      },
+    };
+  },
 }));
 
 // Guardian-delivery reader mock — the inbound challenge guard reads guardian
@@ -147,6 +165,7 @@ import {
 } from "../memory/guardian-rate-limits.js";
 import {
   channelVerificationSessions,
+  contactChannels,
   conversations,
 } from "../memory/schema.js";
 import {
@@ -190,6 +209,19 @@ function resetTables(): void {
   telegramDeliverCalls.length = 0;
   voiceCallInitCalls.length = 0;
   mockBotUsername = "test_bot";
+}
+
+/**
+ * Revoke a guardian channel's local ACL state directly. The production revoke
+ * is gateway-owned (relayed via mark_channel_revoked); this stamps the local
+ * mirror so the guardian-resolution reads still under test see the downgrade.
+ */
+function revokeGuardianChannelLocally(channelType: string): void {
+  getDb()
+    .update(contactChannels)
+    .set({ status: "revoked" })
+    .where(eq(contactChannels.type, channelType))
+    .run();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -558,7 +590,7 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    serviceRevokeBinding("asst-1", "telegram");
+    revokeGuardianChannelLocally("telegram");
 
     expect(await isGuardian("asst-1", "telegram", "user-42")).toBe(false);
   });
@@ -595,7 +627,7 @@ describe("guardian identity check", () => {
     expect(await isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
   });
 
-  test("serviceRevokeBinding revokes the active binding", async () => {
+  test("guardian binding read reflects a gateway-owned revoke", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -603,8 +635,10 @@ describe("guardian identity check", () => {
       guardianDeliveryChatId: "chat-42",
     });
 
-    const result = serviceRevokeBinding("asst-1", "telegram");
-    expect(result).toBe(true);
+    // The revoke is gateway-owned; serviceRevokeBinding's local teardown is a
+    // no-op shim. Stamp the local downgrade and assert the read reflects it.
+    serviceRevokeBinding("asst-1", "telegram");
+    revokeGuardianChannelLocally("telegram");
     expect(await getGuardianBinding("asst-1", "telegram")).toBeNull();
   });
 });
@@ -958,7 +992,7 @@ describe("channel-scoped guardian resolution", () => {
       guardianDeliveryChatId: "chat-beta",
     });
 
-    serviceRevokeBinding("self", "telegram");
+    revokeGuardianChannelLocally("telegram");
 
     expect(await getGuardianBinding("self", "telegram")).toBeNull();
     expect(await getGuardianBinding("self", "phone")).not.toBeNull();
@@ -1472,8 +1506,10 @@ describe("voice guardian identity and revocation", () => {
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    const result = serviceRevokeBinding("asst-1", "phone");
-    expect(result).toBe(true);
+    // The revoke is gateway-owned; serviceRevokeBinding's local teardown is a
+    // no-op shim. Stamp the local downgrade and assert the read reflects it.
+    serviceRevokeBinding("asst-1", "phone");
+    revokeGuardianChannelLocally("phone");
     expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
   });
 
@@ -1491,7 +1527,7 @@ describe("voice guardian identity and revocation", () => {
       guardianDeliveryChatId: "tg-chat-1",
     });
 
-    serviceRevokeBinding("asst-1", "phone");
+    revokeGuardianChannelLocally("phone");
 
     expect(await getGuardianBinding("asst-1", "phone")).toBeNull();
     expect(await getGuardianBinding("asst-1", "telegram")).not.toBeNull();

--- a/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
+++ b/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
@@ -59,7 +59,6 @@ mock.module("../daemon/disk-pressure-guard.js", () => ({
     diskPressureStatusSequence?.shift() ?? diskPressureStatus,
 }));
 
-import { upsertContact } from "../contacts/contact-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import * as deliveryCrud from "../memory/delivery-crud.js";
@@ -71,6 +70,7 @@ import {
 import { sweepFailedEvents } from "../runtime/channel-retry-sweep.js";
 import {
   handleChannelInbound,
+  seedContactChannel,
   setAdapterProcessMessage,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
@@ -90,16 +90,12 @@ function resetTables(): void {
 }
 
 function seedTrustedContact(policy: "allow" | "escalate" = "allow"): void {
-  upsertContact({
+  seedContactChannel({
+    sourceChannel: "telegram",
+    externalUserId: "telegram-user-1",
     displayName: "Example User",
-    channels: [
-      {
-        type: "telegram",
-        address: "telegram-user-1",
-        status: "active",
-        policy,
-      },
-    ],
+    status: "active",
+    policy,
   });
 }
 
@@ -236,16 +232,12 @@ describe("channel inbound disk pressure gate", () => {
   });
 
   test("blocks non-guardian Slack reactions silently (no reply) before persistence while locked", async () => {
-    upsertContact({
+    seedContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "slack-user-1",
       displayName: "Example Slack User",
-      channels: [
-        {
-          type: "slack",
-          address: "slack-user-1",
-          status: "active",
-          policy: "allow",
-        },
-      ],
+      status: "active",
+      policy: "allow",
     });
     const processMessage = mock(async () => {
       throw new Error("processMessage should not run");

--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -70,7 +70,6 @@ describe("upsertContact user_file selection", () => {
     const primary = upsertContact({
       displayName: "Chris",
       role: "guardian",
-      principalId: "principal-abc",
       channels: [
         {
           type: "vellum",
@@ -78,6 +77,12 @@ describe("upsertContact user_file selection", () => {
         },
       ],
     });
+    // principalId is gateway-owned and no longer written by upsertContact; stamp
+    // it directly so the (still-present) sibling lookup resolves it.
+    getSqlite().run("UPDATE contacts SET principal_id = ? WHERE id = ?", [
+      "principal-abc",
+      primary.id,
+    ]);
     expect(primary.userFile).toBe("chris.md");
 
     // Second contact for the same principal on Slack — must inherit the

--- a/assistant/src/__tests__/contacts-write.test.ts
+++ b/assistant/src/__tests__/contacts-write.test.ts
@@ -63,8 +63,6 @@ describe("guardian persona seeding and trust-cache invariants", () => {
       externalUserId: "Bob",
       externalChatId: "chat-bob",
       displayName: "Bob",
-      role: "contact",
-      status: "active",
     });
 
     expect(result).not.toBeNull();

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -31,7 +31,6 @@ mock.module("../daemon/handlers/shared.js", () => ({
 
 import { eq } from "drizzle-orm";
 
-import { upsertContact } from "../contacts/contact-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import * as deliveryChannels from "../memory/delivery-channels.js";
@@ -39,7 +38,10 @@ import { resetTestTables } from "../memory/raw-query.js";
 import { attachments, conversationAttentionEvents } from "../memory/schema.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 
 await initializeDb();
 
@@ -69,16 +71,12 @@ function resetTables(): void {
 }
 
 function ensureTestContact(): void {
-  upsertContact({
+  seedContactChannel({
+    sourceChannel: "telegram",
+    externalUserId: "telegram-user-default",
     displayName: "Test User",
-    channels: [
-      {
-        type: "telegram",
-        address: "telegram-user-default",
-        status: "active",
-        policy: "allow",
-      },
-    ],
+    status: "active",
+    policy: "allow",
   });
 }
 

--- a/assistant/src/__tests__/delete-propagation.test.ts
+++ b/assistant/src/__tests__/delete-propagation.test.ts
@@ -23,7 +23,6 @@ mock.module("../config/env.js", () => ({
 
 import { eq } from "drizzle-orm";
 
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { linkMessage, recordInbound } from "../memory/delivery-crud.js";
@@ -33,7 +32,10 @@ import {
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import { _setDeleteLookupConfigForTests } from "../runtime/routes/inbound-message-handler.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 
 await initializeDb();
 
@@ -56,7 +58,7 @@ function resetState(): void {
 }
 
 function seedActiveDeleteActor(externalChatId: string): void {
-  upsertContactChannel({
+  seedContactChannel({
     sourceChannel: "slack",
     externalUserId: SLACK_DELETE_ACTOR_ID,
     externalChatId,

--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -78,7 +78,6 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../config/loader.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { messages } from "../memory/schema/conversations.js";
@@ -86,7 +85,10 @@ import {
   readSlackMetadata,
   type SlackMessageMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 
 await initializeDb();
 
@@ -117,7 +119,7 @@ function setConfiguredSlackBotUserId(botUserId: string): void {
 }
 
 function seedActiveMember(): void {
-  upsertContactChannel({
+  seedContactChannel({
     sourceChannel: "slack",
     externalUserId: SLACK_DM_USER_ID,
     externalChatId: SLACK_DM_CHANNEL_ID,
@@ -128,7 +130,7 @@ function seedActiveMember(): void {
 }
 
 function seedSlackGuardian(): void {
-  upsertContactChannel({
+  seedContactChannel({
     sourceChannel: "slack",
     externalUserId: SLACK_DM_USER_ID,
     externalChatId: SLACK_DM_CHANNEL_ID,

--- a/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
+++ b/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
@@ -63,10 +63,10 @@ describe("healGuardianBindingDrift", () => {
     const healed = await healGuardianBindingDrift("vellum-principal-old-uuid");
     expect(healed).toBe(true);
 
-    // Guardian binding now matches the old JWT
+    // The heal repairs the channel identity address to match the JWT. The
+    // principalId column is gateway-owned and no longer written locally.
     const guardian = findGuardianForChannel("vellum");
     expect(guardian).not.toBeNull();
-    expect(guardian!.contact.principalId).toBe("vellum-principal-old-uuid");
     expect(guardian!.channel.address).toBe("vellum-principal-old-uuid");
   });
 
@@ -87,10 +87,10 @@ describe("healGuardianBindingDrift", () => {
     const healed = await healGuardianBindingDrift("vellum-principal-jwt");
     expect(healed).toBe(true);
 
-    // Local mirror now matches the JWT, so a subsequent local trust
-    // resolution classifies the actor as guardian rather than unknown.
+    // The local mirror's identity address now matches the JWT, so a subsequent
+    // local trust resolution classifies the actor as guardian rather than
+    // unknown. The principalId column is gateway-owned and not written locally.
     const guardian = findGuardianForChannel("vellum");
-    expect(guardian!.contact.principalId).toBe("vellum-principal-jwt");
     expect(guardian!.channel.address).toBe("vellum-principal-jwt");
   });
 

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -14,7 +14,6 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { upsertContact } from "../contacts/contact-store.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
@@ -27,6 +26,7 @@ import {
 } from "../runtime/trust-context-resolver.js";
 import {
   handleChannelInbound,
+  seedContactChannel,
   setAdapterProcessMessage,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
@@ -155,16 +155,12 @@ describe("inbound-message-handler trusted-contact interactivity", () => {
     resetTables();
     setAdapterProcessMessage(undefined);
     // Insert a test contact so the contacts-based ACL lookup passes
-    upsertContact({
+    seedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "telegram-user-default",
       displayName: "Test User",
-      channels: [
-        {
-          type: "telegram",
-          address: "telegram-user-default",
-          status: "active",
-          policy: "allow",
-        },
-      ],
+      status: "active",
+      policy: "allow",
     });
   });
 

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -207,6 +207,8 @@ export function resolveLocalTrustVerdict(input: {
   return verdict;
 }
 
+export { seedContactChannel } from "./seed-contact-channel.js";
+
 // ---------------------------------------------------------------------------
 // handleDeleteConversation adapter
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/helpers/create-guardian-binding.ts
+++ b/assistant/src/__tests__/helpers/create-guardian-binding.ts
@@ -4,11 +4,10 @@
  * path was moved to the gateway.
  */
 
-import type { ChannelId } from "../../channels/types.js";
-import { upsertContact } from "../../contacts/contact-store.js";
+import { getContact } from "../../contacts/contact-store.js";
 import type { GuardianBinding } from "../../memory/channel-verification-sessions.js";
 import { ensureGuardianPersonaFile } from "../../prompts/persona-resolver.js";
-import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
+import { seedContactChannel } from "./seed-contact-channel.js";
 
 function parseDisplayNameFromMetadata(
   metadataJson: string | null | undefined,
@@ -36,37 +35,30 @@ export function createGuardianBinding(params: {
   verifiedVia?: string;
   metadataJson?: string | null;
 }): GuardianBinding {
-  const canonicalId =
-    canonicalizeInboundIdentity(
-      params.channel as ChannelId,
-      params.guardianExternalUserId,
-    ) ?? params.guardianExternalUserId;
-
   const displayName =
     parseDisplayNameFromMetadata(params.metadataJson) ??
     params.guardianExternalUserId;
 
-  const contact = upsertContact({
+  // The production identity upsert no longer writes ACL columns (gateway-owned);
+  // seedContactChannel stamps the guardian ACL state directly so the local
+  // guardian-resolution reads still under test resolve this binding.
+  const { contactId } = seedContactChannel({
+    sourceChannel: params.channel,
+    externalUserId: params.guardianExternalUserId,
+    externalChatId: params.guardianDeliveryChatId,
     displayName,
     role: "guardian",
-    notes: "guardian",
     principalId: params.guardianPrincipalId,
-    channels: [
-      {
-        type: params.channel,
-        address: canonicalId,
-        externalChatId: params.guardianDeliveryChatId,
-        status: "active",
-        verifiedAt: Date.now(),
-        verifiedVia: params.verifiedVia ?? "challenge",
-      },
-    ],
+    status: "active",
+    verifiedAt: Date.now(),
+    verifiedVia: params.verifiedVia ?? "challenge",
   });
 
   // Seed persona file (mirrors gateway's production behavior)
-  if (contact.userFile) {
+  const userFile = getContact(contactId)?.userFile;
+  if (userFile) {
     try {
-      ensureGuardianPersonaFile(contact.userFile);
+      ensureGuardianPersonaFile(userFile);
     } catch {
       // Tolerate filesystem failures in tests
     }

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -1,0 +1,77 @@
+/**
+ * Test-only member seeding.
+ *
+ * Production identity upserts no longer write ACL columns (gateway-owned).
+ * Tests that simulate gateway-resolved members stamp the ACL columns directly
+ * so local verdict synthesis and the redemption service's local fallback
+ * resolve the intended trust.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { upsertContact } from "../../contacts/contact-store.js";
+import type { ChannelStatus, ContactRole } from "../../contacts/types.js";
+import { getDb } from "../../memory/db-connection.js";
+import { contactChannels, contacts } from "../../memory/schema.js";
+
+export function seedContactChannel(params: {
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  contactId?: string;
+  role?: ContactRole;
+  status?: ChannelStatus;
+  policy?: string;
+  verifiedAt?: number | null;
+  verifiedVia?: string | null;
+  inviteId?: string | null;
+  revokedReason?: string | null;
+  blockedReason?: string | null;
+  principalId?: string | null;
+}): { contactId: string; channelId: string } {
+  const address = params.externalUserId ?? params.externalChatId;
+  if (!address) throw new Error("seedContactChannel requires an address");
+
+  const contact = upsertContact({
+    id: params.contactId,
+    displayName: params.displayName ?? address,
+    channels: [
+      {
+        type: params.sourceChannel,
+        address,
+        externalChatId: params.externalChatId ?? null,
+        inviteId: params.inviteId ?? null,
+      },
+    ],
+    reassignConflictingChannels: !!params.contactId,
+  });
+
+  const db = getDb();
+  if (params.role !== undefined || params.principalId !== undefined) {
+    const set: Record<string, unknown> = {};
+    if (params.role !== undefined) set.role = params.role;
+    if (params.principalId !== undefined) set.principalId = params.principalId;
+    db.update(contacts).set(set).where(eq(contacts.id, contact.id)).run();
+  }
+
+  const channel = contact.channels.find(
+    (ch) => ch.type === params.sourceChannel,
+  )!;
+  const aclSet: Record<string, unknown> = { updatedAt: Date.now() };
+  if (params.status !== undefined) aclSet.status = params.status;
+  if (params.policy !== undefined) aclSet.policy = params.policy;
+  if (params.verifiedAt !== undefined) aclSet.verifiedAt = params.verifiedAt;
+  if (params.verifiedVia !== undefined) aclSet.verifiedVia = params.verifiedVia;
+  if (params.revokedReason !== undefined)
+    aclSet.revokedReason = params.revokedReason;
+  if (params.blockedReason !== undefined)
+    aclSet.blockedReason = params.blockedReason;
+  db.update(contactChannels)
+    .set(aclSet)
+    .where(eq(contactChannels.id, channel.id))
+    .run();
+
+  return { contactId: contact.id, channelId: channel.id };
+}

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -90,11 +90,13 @@ import {
   findContactChannel,
   upsertContact,
 } from "../contacts/contact-store.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 
 await initializeDb();
 
@@ -192,13 +194,13 @@ describe("inbound invite redemption intercept", () => {
     expect(json.memberId).toEqual(expect.any(String));
     expect(json.denied).toBeUndefined();
 
-    // Verify the user is now an active member
+    // The local mirror persists the member identity row; the gateway owns the
+    // active ACL verdict.
     const result = findContactChannel({
       channelType: "telegram",
       address: "user-invite-123",
     });
     expect(result).not.toBeNull();
-    expect(result!.channel.status).toBe("active");
 
     // The activation is written to the gateway via upsert_verified_channel.
     expect(
@@ -337,7 +339,7 @@ describe("inbound invite redemption intercept", () => {
 
   test("existing active member sending normal message is unaffected", async () => {
     // Pre-create an active member
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-active-member",
       externalChatId: "chat-active",
@@ -391,7 +393,7 @@ describe("inbound invite redemption intercept", () => {
     });
 
     // Pre-create an active member that will click the invite link
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-already-active",
       externalChatId: "chat-invite-test",
@@ -414,7 +416,7 @@ describe("inbound invite redemption intercept", () => {
   test("reactivation via invite preserves existing guardian-managed member display name", async () => {
     // Pre-create a revoked member named "Jeff" — the invite should preserve
     // that guardian-assigned name rather than overwriting with the Telegram name.
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-invite-123",
       externalChatId: "chat-invite-test",
@@ -423,7 +425,7 @@ describe("inbound invite redemption intercept", () => {
       displayName: "Jeff",
     });
 
-    // Look up the contact that upsertContactChannel created so we can use
+    // Look up the contact that the seed created so we can use
     // its ID as the invite's contactId (satisfies the FK constraint).
     const existing = findContactChannel({
       channelType: "telegram",
@@ -453,7 +455,8 @@ describe("inbound invite redemption intercept", () => {
       externalChatId: "chat-invite-test",
     });
     expect(result).not.toBeNull();
-    expect(result!.channel.status).toBe("active");
+    // The gateway owns reactivation; the local mirror preserves the
+    // guardian-assigned display name rather than the raw platform identity.
     expect(result!.contact.displayName).toBe("Jeff");
   });
 });

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -102,7 +102,6 @@ import {
   getContact,
   upsertContact,
 } from "../contacts/contact-store.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
@@ -116,6 +115,7 @@ import {
   resolveMemberGateStatus,
 } from "../runtime/invite-redemption-service.js";
 import { hashVoiceCode } from "../util/voice-code.js";
+import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
 
@@ -181,15 +181,16 @@ describe("invite-redemption-service", () => {
 
     expect(outcome.ok).toBe(true);
 
+    // The gateway owns the verified ACL verdict (relayed via
+    // upsert_verified_channel); the local mirror persists identity only.
     const result = findContactChannel({
       channelType: "telegram",
       address: "user-1",
     });
-
     expect(result).not.toBeNull();
-    expect(result!.channel.verifiedAt).toBeGreaterThan(0);
-    expect(result!.channel.verifiedVia).toBe("invite");
-    expect(result!.channel.status).toBe("active");
+    expect(
+      gatewayIpc.calls.some((c) => c.method === "upsert_verified_channel"),
+    ).toBe(true);
   });
 
   test("marks channel as verified via invite on 6-digit code redemption", async () => {
@@ -210,15 +211,15 @@ describe("invite-redemption-service", () => {
 
     expect(outcome.ok).toBe(true);
 
+    // The gateway owns the verified ACL verdict; the local mirror is identity-only.
     const result = findContactChannel({
       channelType: "telegram",
       address: "code-user-1",
     });
-
     expect(result).not.toBeNull();
-    expect(result!.channel.verifiedAt).toBeGreaterThan(0);
-    expect(result!.channel.verifiedVia).toBe("invite");
-    expect(result!.channel.status).toBe("active");
+    expect(
+      gatewayIpc.calls.some((c) => c.method === "upsert_verified_channel"),
+    ).toBe(true);
   });
 
   test("returns invalid_token for a bogus token", async () => {
@@ -329,7 +330,7 @@ describe("invite-redemption-service", () => {
 
   test("returns already_member when user is already an active member", async () => {
     // Pre-create an active member and find their contact
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "existing-user",
       status: "active",
@@ -338,7 +339,7 @@ describe("invite-redemption-service", () => {
     // Create an invite targeting the same contact that owns the channel
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: member!.contact.id,
+      contactId: member.contactId,
       maxUses: 5,
     });
 
@@ -361,7 +362,7 @@ describe("invite-redemption-service", () => {
 
   test("returns invalid_token for a blocked member to avoid leaking membership status", async () => {
     // Pre-create a blocked member and find their contact
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "blocked-user",
       status: "blocked",
@@ -370,7 +371,7 @@ describe("invite-redemption-service", () => {
     // Create an invite targeting the same contact that owns the channel
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: member!.contact.id,
+      contactId: member.contactId,
       maxUses: 5,
     });
 
@@ -385,16 +386,12 @@ describe("invite-redemption-service", () => {
 
   test("binds redeemer to the invite's target contact, not the guardian", async () => {
     // Pre-create a guardian contact with a revoked telegram channel
-    const guardianContact = upsertContact({
+    const guardianSeed = seedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "guardian-tg-id",
       displayName: "Guardian",
       role: "guardian",
-      channels: [
-        {
-          type: "telegram",
-          address: "guardian-tg-id",
-          status: "revoked",
-        },
-      ],
+      status: "revoked",
     });
 
     // Create a separate target contact "Mom"
@@ -440,32 +437,27 @@ describe("invite-redemption-service", () => {
     });
     expect(result).not.toBeNull();
     expect(result!.contact.id).toBe(momContact.id);
-    expect(result!.channel.status).toBe("active");
 
     // Verify the original guardian contact was NOT modified
-    const guardian = getContact(guardianContact.id);
+    const guardian = getContact(guardianSeed.contactId);
     expect(guardian).not.toBeNull();
     expect(guardian!.role).toBe("guardian");
   });
 
   test("downgrades guardian to contact when redeeming invite targeting own contact", async () => {
     // Create a guardian contact with a revoked channel
-    const guardianContact = upsertContact({
+    const guardianSeed = seedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "guardian-own-id",
       displayName: "Guardian",
       role: "guardian",
-      channels: [
-        {
-          type: "telegram",
-          address: "guardian-own-id",
-          status: "revoked",
-        },
-      ],
+      status: "revoked",
     });
 
     // Create invite targeting the guardian's own contact
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: guardianContact.id,
+      contactId: guardianSeed.contactId,
       maxUses: 5,
     });
 
@@ -477,23 +469,23 @@ describe("invite-redemption-service", () => {
 
     expect(outcome.ok).toBe(true);
 
-    // The guardian should now be downgraded to "contact"
-    const updated = getContact(guardianContact.id);
-    expect(updated!.role).toBe("contact");
+    // The role downgrade is gateway-owned; redemption relays the activation for
+    // the guardian's own contact rather than mutating the local role.
+    expect(
+      gatewayIpc.calls.some((c) => c.method === "upsert_verified_channel"),
+    ).toBe(true);
+    const updated = getContact(guardianSeed.contactId);
+    expect(updated).not.toBeNull();
   });
 
   test("binds redeemer to the invite's target contact via 6-digit code, not the guardian", async () => {
     // Pre-create a guardian contact with a revoked telegram channel
-    const guardianContact = upsertContact({
+    const guardianSeed = seedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "guardian-code-id",
       displayName: "Guardian",
       role: "guardian",
-      channels: [
-        {
-          type: "telegram",
-          address: "guardian-code-id",
-          status: "revoked",
-        },
-      ],
+      status: "revoked",
     });
 
     // Create a separate target contact "Mom"
@@ -530,10 +522,9 @@ describe("invite-redemption-service", () => {
     });
     expect(result).not.toBeNull();
     expect(result!.contact.id).toBe(momContact.id);
-    expect(result!.channel.status).toBe("active");
 
     // Verify the original guardian contact was NOT modified
-    const guardian = getContact(guardianContact.id);
+    const guardian = getContact(guardianSeed.contactId);
     expect(guardian).not.toBeNull();
     expect(guardian!.role).toBe("guardian");
   });
@@ -547,12 +538,11 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create a revoked member
-    const member = upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "revoked-user",
       status: "revoked",
     });
-    expect(member!.channel.status).toBe("revoked");
 
     const outcome = await redeemInvite({
       rawToken,
@@ -605,7 +595,7 @@ describe("invite-redemption-service", () => {
 
   test("returns invalid_token for an active member with a bogus token (no membership probing)", async () => {
     // Pre-create an active member
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "probed-user",
       status: "active",
@@ -632,7 +622,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "expired-token-user",
       status: "active",
@@ -658,7 +648,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member on telegram
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "cross-channel-user",
       status: "active",
@@ -821,7 +811,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Seed an already-active member bound to the invite's target contact.
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "already-member-user",
       role: "contact",

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -437,7 +437,7 @@ describe("invite-redemption-service", () => {
   });
 
   test("matches an active member by (type,address) when the gateway row has a divergent uuid", async () => {
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "divergent-user",
       status: "active",
@@ -448,16 +448,16 @@ describe("invite-redemption-service", () => {
     gatewayIpc.richOverride = () => ({
       ok: true,
       contact: {
-        id: member!.contact.id,
-        displayName: member!.contact.displayName,
-        role: member!.contact.role,
+        id: member.contactId,
+        displayName: "divergent-user",
+        role: "contact",
         interactionCount: 0,
         createdAt: 1,
         updatedAt: 1,
         channels: [
           {
             id: "gateway-divergent-uuid",
-            contactId: member!.contact.id,
+            contactId: member.contactId,
             type: "telegram",
             address: "divergent-user",
             isPrimary: false,
@@ -478,7 +478,7 @@ describe("invite-redemption-service", () => {
 
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: member!.contact.id,
+      contactId: member.contactId,
       maxUses: 5,
     });
 
@@ -493,7 +493,7 @@ describe("invite-redemption-service", () => {
   });
 
   test("blocks via the (type,address) match when the gateway row has a divergent uuid", async () => {
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "divergent-blocked",
       status: "blocked",
@@ -502,16 +502,16 @@ describe("invite-redemption-service", () => {
     gatewayIpc.richOverride = () => ({
       ok: true,
       contact: {
-        id: member!.contact.id,
-        displayName: member!.contact.displayName,
-        role: member!.contact.role,
+        id: member.contactId,
+        displayName: "divergent-blocked",
+        role: "contact",
         interactionCount: 0,
         createdAt: 1,
         updatedAt: 1,
         channels: [
           {
             id: "gateway-divergent-blocked-uuid",
-            contactId: member!.contact.id,
+            contactId: member.contactId,
             type: "telegram",
             // Case-divergent address must still match (COLLATE NOCASE).
             address: "DIVERGENT-BLOCKED",
@@ -533,7 +533,7 @@ describe("invite-redemption-service", () => {
 
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: member!.contact.id,
+      contactId: member.contactId,
       maxUses: 5,
     });
 
@@ -549,7 +549,7 @@ describe("invite-redemption-service", () => {
   test("fails open (no throw) when the gateway gate-status read is unreachable", async () => {
     // No verdict member and an unreachable gateway read must degrade to the
     // fail-open path: redemption still resolves rather than throwing.
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "readfail-user",
       status: "revoked",
@@ -559,7 +559,7 @@ describe("invite-redemption-service", () => {
 
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: member!.contact.id,
+      contactId: member.contactId,
       maxUses: 1,
     });
 

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -34,6 +34,40 @@ mock.module("../calls/call-domain.js", () => ({
   startInviteCall: async () => mockStartInviteCallResult,
 }));
 
+// Model the gateway: the redemption claim (record_invite_redemption) and the
+// gateway-owned activation (upsert_verified_channel) are both relayed. The
+// activation write fails closed in production, so the mock must serve a
+// verified upsert for the legitimate-success redemption paths.
+const gatewayIpc = {
+  claim: { ok: true, updated: true, mirrored: true },
+  activationVerified: true,
+};
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    if (method === "record_invite_redemption") return gatewayIpc.claim;
+    if (method === "upsert_verified_channel") {
+      if (!gatewayIpc.activationVerified) return { ok: true, verified: false };
+      return {
+        ok: true,
+        verified: true,
+        channel: {
+          id: "gw-channel-id",
+          contactId: (params?.contactId as string) ?? "gw-contact",
+          type: (params?.type as string) ?? "telegram",
+          address: (params?.address as string) ?? "gw-addr",
+          status: "active",
+          verifiedAt: 1,
+          verifiedVia: (params?.verifiedVia as string) ?? "invite",
+        },
+      };
+    }
+    return undefined;
+  },
+}));
+
 import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";

--- a/assistant/src/__tests__/invite-service-ipc.test.ts
+++ b/assistant/src/__tests__/invite-service-ipc.test.ts
@@ -29,13 +29,31 @@ mock.module("../ipc/gateway-client.js", () => ({
     if (method === "record_invite_redemption") {
       return { ok: true, updated: true, mirrored: true };
     }
+    if (method === "upsert_verified_channel") {
+      // Gateway-as-SoT activation: return a verified channel so the gateway-first
+      // relay lands its write before mirroring identity locally.
+      return {
+        ok: true,
+        verified: true,
+        channel: {
+          id: "gw-channel-1",
+          contactId: (params?.contactId as string) ?? "gw-contact-1",
+          type: (params?.type as string) ?? "telegram",
+          address: (params?.address as string) ?? "",
+          status: "active",
+          verifiedAt: Date.now(),
+          verifiedVia: (params?.verifiedVia as string) ?? "invite",
+        },
+      };
+    }
     return undefined;
   },
 }));
 
 // Serves contacts_get_rich (the gateway ACL read backing the gate-status
-// fallback) from the seeded local contact, so the already_member gate resolves
-// via the gateway path rather than the dropped local channel column.
+// fallback) from the seeded local contact identity. Channel ACL state is
+// gateway-owned, so a contact with a mirrored channel reports "active" here —
+// the local status column is drained and never consulted.
 function richContactForId(contactId: string | undefined) {
   if (!contactId) return undefined;
   const contact = getContact(contactId);
@@ -56,7 +74,7 @@ function richContactForId(contactId: string | undefined) {
         address: c.address,
         isPrimary: c.isPrimary,
         externalUserId: c.externalChatId,
-        status: c.status,
+        status: "active",
         policy: c.policy,
         verifiedAt: c.verifiedAt,
         verifiedVia: c.verifiedVia,

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -44,7 +44,6 @@ mock.module("../runtime/gateway-client.js", () => ({
 
 import { eq } from "drizzle-orm";
 
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import type { Conversation } from "../daemon/conversation.js";
 import {
   createCanonicalGuardianDelivery,
@@ -60,7 +59,10 @@ import {
   isSlackReactionEvent,
   parseSlackReactionCallbackData,
 } from "../runtime/routes/inbound-stages/reaction-intercept.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
 await initializeDb();
@@ -84,7 +86,7 @@ function resetState(): void {
 }
 
 function seedActiveMember(): void {
-  upsertContactChannel({
+  seedContactChannel({
     sourceChannel: "slack",
     externalUserId: SLACK_USER_ID,
     externalChatId: SLACK_CHANNEL_ID,
@@ -655,7 +657,7 @@ describe("reaction access control (no verification handshake)", () => {
     // A pending contact classifies as `unverified_contact` — a known tier, so
     // its reactions are recorded. On a real message it would be re-challenged,
     // but a reaction must not trigger that.
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "slack",
       externalUserId: CONTACT_USER_ID,
       externalChatId: SLACK_CHANNEL_ID,

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -388,7 +388,6 @@ import {
 } from "../calls/relay-server.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { upsertContact } from "../contacts/contact-store.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import {
   listCanonicalGuardianRequests,
   resolveCanonicalGuardianRequest,
@@ -410,6 +409,7 @@ import {
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
 
@@ -500,7 +500,7 @@ function createTargetContact(displayName = "Test Contact"): string {
 }
 
 function addTrustedVoiceContact(phoneNumber: string): void {
-  upsertContactChannel({
+  seedContactChannel({
     sourceChannel: "phone",
     externalUserId: phoneNumber,
     externalChatId: phoneNumber,
@@ -2811,7 +2811,7 @@ describe("relay-server", () => {
       toNumber: "+15551111111",
     });
 
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "phone",
       externalUserId: "+15558886666",
       externalChatId: "+15558886666",
@@ -2874,7 +2874,7 @@ describe("relay-server", () => {
       toNumber: "+15551111111",
     });
 
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "phone",
       externalUserId: "+15558887777",
       externalChatId: "+15558887777",
@@ -3173,7 +3173,7 @@ describe("relay-server", () => {
     });
 
     // Create a blocked member
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "phone",
       externalUserId: "+15558881111",
       externalChatId: "+15558881111",

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -50,11 +50,31 @@ let inviteClaimCalls = 0;
 let inviteClaimGate: Promise<void> | null = null;
 mock.module("../ipc/gateway-client.js", () => ({
   ipcCall: async () => undefined,
-  ipcCallPersistent: async (method: string) => {
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
     if (method === "record_invite_redemption") {
       inviteClaimCalls += 1;
       if (inviteClaimGate) await inviteClaimGate;
       return { ok: true, updated: true, mirrored: true };
+    }
+    // The gateway owns the ACL verdict; activation fails closed when the relay
+    // does not land, so model a verified upsert for the redemption paths.
+    if (method === "upsert_verified_channel") {
+      return {
+        ok: true,
+        verified: true,
+        channel: {
+          id: "gw-channel-id",
+          contactId: (params?.contactId as string) ?? "gw-contact",
+          type: (params?.type as string) ?? "phone",
+          address: (params?.address as string) ?? "gw-addr",
+          status: "active",
+          verifiedAt: 1,
+          verifiedVia: (params?.verifiedVia as string) ?? "invite",
+        },
+      };
     }
     return undefined;
   },

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -44,7 +44,6 @@ mock.module("../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => undefined,
 }));
 
-import { upsertContact } from "../contacts/contact-store.js";
 import {
   linkAttachmentToMessage,
   uploadAttachment,
@@ -58,7 +57,10 @@ import { resetTestTables } from "../memory/raw-query.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
-import { resolveLocalTrustVerdict } from "./helpers/channel-test-adapter.js";
+import {
+  resolveLocalTrustVerdict,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 
 await initializeDb();
 
@@ -251,16 +253,12 @@ describe("WhatsApp channel ingress attachment resolution", () => {
   }
 
   function ensureWhatsAppContact(): void {
-    upsertContact({
+    seedContactChannel({
+      sourceChannel: "whatsapp",
+      externalUserId: WHATSAPP_USER_ID,
       displayName: "WhatsApp Test User",
-      channels: [
-        {
-          type: "whatsapp",
-          address: WHATSAPP_USER_ID,
-          status: "active",
-          policy: "allow",
-        },
-      ],
+      status: "active",
+      policy: "allow",
     });
   }
 

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -98,7 +98,6 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../config/loader.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import {
   type ChannelCapabilities,
   loadSlackChronologicalContext,
@@ -121,6 +120,7 @@ import {
 } from "../runtime/routes/inbound-message-handler.js";
 import {
   handleChannelInbound,
+  seedContactChannel,
   setAdapterProcessMessage,
 } from "./helpers/channel-test-adapter.js";
 
@@ -1902,7 +1902,7 @@ function resetHttpState(): void {
 }
 
 function seedHttpActiveMember(chatId = HTTP_SLACK_CHANNEL_ID): void {
-  upsertContactChannel({
+  seedContactChannel({
     sourceChannel: "slack",
     externalUserId: HTTP_SLACK_USER_ID,
     externalChatId: chatId,
@@ -1913,7 +1913,7 @@ function seedHttpActiveMember(chatId = HTTP_SLACK_CHANNEL_ID): void {
 }
 
 function seedHttpGuardianMember(chatId = HTTP_SLACK_CHANNEL_ID): void {
-  upsertContactChannel({
+  seedContactChannel({
     sourceChannel: "slack",
     externalUserId: HTTP_SLACK_USER_ID,
     externalChatId: chatId,

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -158,7 +158,6 @@ import { applyCanonicalGuardianDecision } from "../approvals/guardian-decision-p
 import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
 import { getResolver } from "../approvals/guardian-request-resolvers.js";
 import type { TrustContext } from "../daemon/trust-context.js";
-import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 import {
   createCanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -176,6 +175,7 @@ import {
   waitForInlineGrant,
 } from "../tools/tool-approval-handler.js";
 import type { ToolContext, ToolLifecycleEvent } from "../tools/types.js";
+import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
 

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -157,8 +157,8 @@ mock.module("../config/env.js", () => ({
 import { applyCanonicalGuardianDecision } from "../approvals/guardian-decision-primitive.js";
 import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
 import { getResolver } from "../approvals/guardian-request-resolvers.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import type { TrustContext } from "../daemon/trust-context.js";
+import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 import {
   createCanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -1352,7 +1352,7 @@ describe("(g) access_request resolver: requester code delivery", () => {
 
   test("guardian-facing reply uses the requester's display name, not the raw ID", async () => {
     // Seed a contact so the resolver can resolve a display name.
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "slack",
       externalUserId: REQUESTER_UID,
       displayName: "Alice",

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -65,11 +65,13 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 }));
 
 import { getResolver } from "../approvals/guardian-request-resolvers.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { createCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
 await initializeDb();
@@ -140,7 +142,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -150,7 +152,7 @@ describe("trusted contact lifecycle notification signals", () => {
     });
 
     // Set up requester contact with a display name so payloads are enriched
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
       externalChatId: "requester-chat-456",
@@ -234,7 +236,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -244,7 +246,7 @@ describe("trusted contact lifecycle notification signals", () => {
     });
 
     // Set up requester contact with a display name
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
       externalChatId: "requester-chat-456",
@@ -322,7 +324,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertContactChannel({
+    seedContactChannel({
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -73,14 +73,16 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 }));
 
 import { findContactChannel } from "../contacts/contact-store.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   createOutboundSession,
   validateAndConsumeVerification,
 } from "../runtime/channel-verification-service.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+} from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
 await initializeDb();
@@ -253,7 +255,7 @@ for (const config of CHANNEL_CONFIGS) {
         expect(challengeResult.verificationType).toBe("trusted_contact");
       }
 
-      upsertContactChannel({
+      seedContactChannel({
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,
         externalChatId: config.externalChatId,
@@ -276,7 +278,7 @@ for (const config of CHANNEL_CONFIGS) {
 
     test("no cross-channel leakage between member records", () => {
       // Create a member for this channel
-      upsertContactChannel({
+      seedContactChannel({
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,
         externalChatId: config.externalChatId,

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -88,26 +88,24 @@ describe("trusted contact verification → member activation", () => {
       expect(result.verificationType).toBe("trusted_contact");
     }
 
-    // Simulate the member upsert that inbound-message-handler performs on success
+    // Simulate the member upsert that inbound-message-handler performs on
+    // success. The local mirror persists identity only; the gateway owns the
+    // ACL verdict, so the channel lands at the schema-default status.
     upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-123",
       externalChatId: "requester-chat-123",
-      status: "active",
-      policy: "allow",
       displayName: "Requester Name",
       username: "requester_username",
     });
 
-    // Verify: active member record exists
+    // Verify: member identity record exists
     const contactResult = findContactChannel({
       channelType: "telegram",
       address: "requester-user-123",
     });
 
     expect(contactResult).not.toBeNull();
-    expect(contactResult!.channel.status).toBe("active");
-    expect(contactResult!.channel.policy).toBe("allow");
     expect(contactResult!.channel.address).toBe("requester-user-123");
     expect(contactResult!.channel.externalChatId).toBe("requester-chat-123");
     expect(contactResult!.contact.displayName).toBe("Requester Name");
@@ -119,8 +117,6 @@ describe("trusted contact verification → member activation", () => {
       sourceChannel: "telegram",
       externalUserId: "requester-user-jeff",
       externalChatId: "requester-chat-jeff",
-      status: "active",
-      policy: "allow",
       displayName: "Jeff",
       username: "jeff_handle",
     });
@@ -132,7 +128,9 @@ describe("trusted contact verification → member activation", () => {
       actorExternalId: "requester-user-jeff",
     });
 
-    expect(trust.trustClass).toBe("trusted_contact");
+    // The local mirror persists identity only; the schema-default status places
+    // the contact in the unverified_contact tier (gateway owns elevation).
+    expect(trust.trustClass).toBe("unverified_contact");
     expect(trust.actorMetadata.displayName).toBe("Jeff");
     expect(trust.actorMetadata.senderDisplayName).toBeUndefined();
     expect(trust.actorMetadata.memberDisplayName).toBe("Jeff");
@@ -147,8 +145,6 @@ describe("trusted contact verification → member activation", () => {
       sourceChannel: "telegram",
       externalUserId: "requester-user-jeff-priority",
       externalChatId: "requester-chat-jeff-priority",
-      status: "active",
-      policy: "allow",
       displayName: "Jeff",
       username: "jeff_handle",
     });
@@ -162,7 +158,7 @@ describe("trusted contact verification → member activation", () => {
       actorDisplayName: "Jeffrey",
     });
 
-    expect(trust.trustClass).toBe("trusted_contact");
+    expect(trust.trustClass).toBe("unverified_contact");
     expect(trust.actorMetadata.displayName).toBe("Jeff");
     expect(trust.actorMetadata.senderDisplayName).toBe("Jeffrey");
     expect(trust.actorMetadata.memberDisplayName).toBe("Jeff");
@@ -179,8 +175,6 @@ describe("trusted contact verification → member activation", () => {
       sourceChannel: "telegram",
       externalUserId: "other-user-in-group",
       externalChatId: "shared-group-chat",
-      status: "active",
-      policy: "allow",
       displayName: "Other User",
       username: "other_handle",
     });
@@ -229,20 +223,17 @@ describe("trusted contact verification → member activation", () => {
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
       externalChatId: "requester-chat-456",
-      status: "active",
-      policy: "allow",
     });
 
-    // Simulate the ACL check that inbound-message-handler performs
+    // The local mirror persists the member identity; the gateway owns the ACL
+    // verdict the inbound handler enforces.
     const contactResult = findContactChannel({
       channelType: "telegram",
       address: "requester-user-456",
     });
 
     expect(contactResult).not.toBeNull();
-    expect(contactResult!.channel.status).toBe("active");
-    expect(contactResult!.channel.policy).toBe("allow");
-    // ACL check passes: member exists, is active, and has allow policy
+    expect(contactResult!.channel.address).toBe("requester-user-456");
   });
 
   test("member lookup is scoped by channel type", () => {
@@ -267,8 +258,6 @@ describe("trusted contact verification → member activation", () => {
       sourceChannel: "telegram",
       externalUserId: "user-cross-test",
       externalChatId: "chat-cross-test",
-      status: "active",
-      policy: "allow",
     });
 
     // Member should be found via contacts
@@ -277,7 +266,7 @@ describe("trusted contact verification → member activation", () => {
       address: "user-cross-test",
     });
     expect(contactResult).not.toBeNull();
-    expect(contactResult!.channel.status).toBe("active");
+    expect(contactResult!.channel.address).toBe("user-cross-test");
 
     // Member should NOT be found for a different channel type
     const otherChannel = findContactChannel({
@@ -287,31 +276,22 @@ describe("trusted contact verification → member activation", () => {
     expect(otherChannel).toBeNull();
   });
 
-  test("re-verification of previously revoked member reactivates them", () => {
-    // Create and activate a member
+  test("revokeMember resolves the member identity without mutating local ACL", () => {
+    // Create a member identity row.
     const member = upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-revoked",
       externalChatId: "chat-revoked",
-      status: "active",
-      policy: "allow",
       displayName: "Revoked User",
     });
 
-    // Revoke the member
-    const revoked = revokeMember(member!.channel.id, "testing revocation");
+    // The local revoke is a pure resolver now — the gateway owns the ACL
+    // downgrade; revokeMember returns the resolved native contact/channel.
+    const revoked = revokeMember(member!.channel.id);
     expect(revoked).not.toBeNull();
-    expect(revoked!.channel.status).toBe("revoked");
+    expect(revoked!.channel.id).toBe(member!.channel.id);
 
-    // Verify the member is indeed revoked (ACL would reject)
-    const revokedResult = findContactChannel({
-      channelType: "telegram",
-      address: "user-revoked",
-    });
-    expect(revokedResult).not.toBeNull();
-    expect(revokedResult!.channel.status).toBe("revoked");
-
-    // Guardian re-approves, new outbound session created
+    // Re-upsert on the same identity is idempotent on the identity row.
     const session = createOutboundSession({
       channel: "telegram",
       expectedExternalUserId: "user-revoked",
@@ -321,7 +301,6 @@ describe("trusted contact verification → member activation", () => {
       verificationPurpose: "trusted_contact",
     });
 
-    // Requester enters the new code
     const result = validateAndConsumeVerification(
       "telegram",
       session.secret,
@@ -333,23 +312,18 @@ describe("trusted contact verification → member activation", () => {
       expect(result.verificationType).toBe("trusted_contact");
     }
 
-    // upsertContactChannel reactivates the existing record
     upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-revoked",
       externalChatId: "chat-revoked",
-      status: "active",
-      policy: "allow",
     });
 
-    // Verify: member is now active again
-    const reactivatedResult = findContactChannel({
+    const reResolved = findContactChannel({
       channelType: "telegram",
       address: "user-revoked",
     });
-    expect(reactivatedResult).not.toBeNull();
-    expect(reactivatedResult!.channel.status).toBe("active");
-    expect(reactivatedResult!.channel.policy).toBe("allow");
+    expect(reResolved).not.toBeNull();
+    expect(reResolved!.channel.id).toBe(member!.channel.id);
   });
 
   test("trusted contact verification does NOT create a guardian binding", () => {

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -51,12 +51,12 @@ import {
   getContact,
   upsertContact,
 } from "../contacts/contact-store.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
+import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
 
@@ -304,15 +304,12 @@ describe("redeemVoiceInviteCode", () => {
 
     expect(result.ok).toBe(true);
 
+    // The gateway owns the verified ACL verdict; the local mirror is identity-only.
     const channelResult = findContactChannel({
       channelType: "phone",
       address: phone,
     });
-
     expect(channelResult).not.toBeNull();
-    expect(channelResult!.channel.verifiedAt).toBeGreaterThan(0);
-    expect(channelResult!.channel.verifiedVia).toBe("invite");
-    expect(channelResult!.channel.status).toBe("active");
   });
 
   test("wrong caller identity fails with generic error", async () => {
@@ -420,7 +417,7 @@ describe("redeemVoiceInviteCode", () => {
     const phone = "+15551234567";
 
     // Pre-create an active member for this phone on voice channel
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "phone",
       externalUserId: phone,
       status: "active",
@@ -430,7 +427,7 @@ describe("redeemVoiceInviteCode", () => {
     // Create a voice invite targeting the same contact that owns the channel
     const { code } = createVoiceInvite({
       callerPhone: phone,
-      contactId: member!.contact.id,
+      contactId: member.contactId,
     });
 
     const result = await redeemVoiceInviteCode({
@@ -456,7 +453,7 @@ describe("redeemVoiceInviteCode", () => {
     const phone = "+15551234567";
 
     // Pre-create a blocked member and find their contact
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "phone",
       externalUserId: phone,
       status: "blocked",
@@ -466,7 +463,7 @@ describe("redeemVoiceInviteCode", () => {
     // Create a voice invite targeting the same contact that owns the channel
     const { code } = createVoiceInvite({
       callerPhone: phone,
-      contactId: member!.contact.id,
+      contactId: member.contactId,
     });
 
     const result = await redeemVoiceInviteCode({
@@ -492,16 +489,12 @@ describe("redeemVoiceInviteCode", () => {
     const phone = "+15559998888";
 
     // Pre-create a guardian contact with a revoked phone channel
-    const guardianContact = upsertContact({
+    const guardianSeed = seedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: phone,
       displayName: "Guardian",
       role: "guardian",
-      channels: [
-        {
-          type: "phone",
-          address: phone,
-          status: "revoked",
-        },
-      ],
+      status: "revoked",
     });
 
     // Create a separate target contact "Mom"
@@ -533,10 +526,9 @@ describe("redeemVoiceInviteCode", () => {
     });
     expect(contactResult).not.toBeNull();
     expect(contactResult!.contact.id).toBe(momContact.id);
-    expect(contactResult!.channel.status).toBe("active");
 
     // Verify the original guardian contact was NOT modified
-    const guardian = getContact(guardianContact.id);
+    const guardian = getContact(guardianSeed.contactId);
     expect(guardian).not.toBeNull();
     expect(guardian!.role).toBe("guardian");
   });

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -346,30 +346,30 @@ describe("redeemVoiceInviteCode", () => {
 
   test("matches an active member by (type,address) when the gateway row has a divergent uuid", async () => {
     const phone = "+15551234567";
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "phone",
       externalUserId: phone,
       status: "active",
     });
     const { code } = createVoiceInvite({
       callerPhone: phone,
-      contactId: member!.contact.id,
+      contactId: member.contactId,
     });
 
     // Gateway row for the same (type,address) under a DIFFERENT id.
     gatewayIpc.richOverride = () => ({
       ok: true,
       contact: {
-        id: member!.contact.id,
-        displayName: member!.contact.displayName,
-        role: member!.contact.role,
+        id: member.contactId,
+        displayName: phone,
+        role: "contact",
         interactionCount: 0,
         createdAt: 1,
         updatedAt: 1,
         channels: [
           {
             id: "gateway-divergent-uuid",
-            contactId: member!.contact.id,
+            contactId: member.contactId,
             type: "phone",
             address: phone,
             isPrimary: false,
@@ -400,14 +400,14 @@ describe("redeemVoiceInviteCode", () => {
 
   test("fails open (no throw) when the gateway gate-status read is unreachable", async () => {
     const phone = "+15551234567";
-    const member = upsertContactChannel({
+    const member = seedContactChannel({
       sourceChannel: "phone",
       externalUserId: phone,
       status: "revoked",
     });
     const { code } = createVoiceInvite({
       callerPhone: phone,
-      contactId: member!.contact.id,
+      contactId: member.contactId,
     });
 
     gatewayIpc.richThrows = true;

--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -42,6 +42,7 @@ mock.module("../../util/logger.js", () => ({
 // the a2a.enabled flag. We use the real config system backed by initializeDb's
 // workspace directory.
 
+import { seedContactChannel } from "../../__tests__/helpers/seed-contact-channel.js";
 import {
   invalidateConfigCache,
   loadRawConfig,
@@ -59,7 +60,6 @@ import {
 } from "../../daemon/handlers/config-a2a.js";
 import { getSqlite } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
-import { seedContactChannel } from "../../__tests__/helpers/seed-contact-channel.js";
 import type { A2AMessage, Artifact } from "../protocol-types.js";
 import {
   completeWithArtifacts,

--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -59,6 +59,7 @@ import {
 } from "../../daemon/handlers/config-a2a.js";
 import { getSqlite } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
+import { seedContactChannel } from "../../__tests__/helpers/seed-contact-channel.js";
 import type { A2AMessage, Artifact } from "../protocol-types.js";
 import {
   completeWithArtifacts,
@@ -164,17 +165,16 @@ describe("e2e: trusted contact setup", () => {
         {
           type: "a2a",
           address: "assistant-b",
-          status: "active",
-          policy: "allow",
         },
       ],
     });
 
+    // upsertContact persists the a2a channel identity; the gateway owns the ACL
+    // status verdict.
     const contact = findContactByAddress("a2a", "assistant-b");
     expect(contact).not.toBeNull();
     expect(contact!.channels.some((ch) => ch.type === "a2a")).toBe(true);
     const a2aChannel = contact!.channels.find((ch) => ch.type === "a2a");
-    expect(a2aChannel!.status).toBe("active");
     expect(a2aChannel!.address).toBe("assistant-b");
   });
 });
@@ -355,21 +355,13 @@ describe("e2e: unknown sender blocked (ACL enforcement)", () => {
   });
 
   test("trusted contact exists with active a2a channel — ACL passes", async () => {
-    const { upsertContact } = await import("../../contacts/contact-store.js");
-
     // Pre-create a trusted contact for the sender
-    upsertContact({
+    seedContactChannel({
+      sourceChannel: "a2a",
+      externalUserId: "trusted-assistant",
       displayName: "Trusted Bot",
-      contactType: "assistant",
-      role: "contact",
-      channels: [
-        {
-          type: "a2a",
-          address: "trusted-assistant",
-          status: "active",
-          policy: "allow",
-        },
-      ],
+      status: "active",
+      policy: "allow",
     });
 
     // Verify the contact exists (the ACL check the runtime performs)
@@ -391,20 +383,12 @@ describe("e2e: unknown sender blocked (ACL enforcement)", () => {
   });
 
   test("contact exists but channel is blocked — ACL would reject", async () => {
-    const { upsertContact } = await import("../../contacts/contact-store.js");
-
-    upsertContact({
+    seedContactChannel({
+      sourceChannel: "a2a",
+      externalUserId: "blocked-assistant",
       displayName: "Blocked Bot",
-      contactType: "assistant",
-      role: "contact",
-      channels: [
-        {
-          type: "a2a",
-          address: "blocked-assistant",
-          status: "blocked",
-          policy: "deny",
-        },
-      ],
+      status: "blocked",
+      policy: "deny",
     });
 
     const contact = findContactByAddress("a2a", "blocked-assistant");
@@ -507,18 +491,12 @@ describe("e2e: full A2A round-trip", () => {
     setConfigEnabled(true);
 
     // Step 1: Create trusted contact for Assistant B (platform-mediated)
-    upsertContact({
+    seedContactChannel({
+      sourceChannel: "a2a",
+      externalUserId: "assistant-b",
       displayName: "Assistant B",
-      contactType: "assistant",
-      role: "contact",
-      channels: [
-        {
-          type: "a2a",
-          address: "assistant-b",
-          status: "active",
-          policy: "allow",
-        },
-      ],
+      status: "active",
+      policy: "allow",
     });
 
     // Step 2: Verify trusted contact was created

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -13,7 +13,7 @@
 
 import { answerCall } from "../calls/call-domain.js";
 import { findContactChannel } from "../contacts/contact-store.js";
-import { upsertContactChannel } from "../contacts/contacts-write.js";
+import { activateMemberChannel } from "../contacts/member-write-relay.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import {
   type CanonicalGuardianRequest,
@@ -603,12 +603,12 @@ const accessRequestResolver: GuardianRequestResolver = {
     // relay server's in-call wait loop will detect the approved status.
     if (channel === "phone") {
       try {
-        upsertContactChannel({
+        // Gateway-first activation: the gateway owns the ACL verdict, the local
+        // mirror persists the caller's contact/channel identity.
+        await activateMemberChannel({
           sourceChannel: "phone",
           externalUserId: requesterExternalUserId,
           externalChatId: requesterChatId,
-          status: "active",
-          policy: "allow",
         });
       } catch (err) {
         log.error(

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -602,10 +602,11 @@ const accessRequestResolver: GuardianRequestResolver = {
     // a verification session. The caller is already on the line and the
     // relay server's in-call wait loop will detect the approved status.
     if (channel === "phone") {
+      let activation: Awaited<ReturnType<typeof activateMemberChannel>>;
       try {
         // Gateway-first activation: the gateway owns the ACL verdict, the local
         // mirror persists the caller's contact/channel identity.
-        await activateMemberChannel({
+        activation = await activateMemberChannel({
           sourceChannel: "phone",
           externalUserId: requesterExternalUserId,
           externalChatId: requesterChatId,
@@ -615,6 +616,17 @@ const accessRequestResolver: GuardianRequestResolver = {
           { err, requesterExternalUserId },
           "Access request resolver: failed to activate voice caller as trusted contact",
         );
+        return { ok: false, reason: "voice_activation_failed" };
+      }
+
+      // Fail-closed: a refused activation did not land on the gateway source of
+      // truth, so the caller is not actually trusted — do not report success.
+      if (activation.status === "refused") {
+        log.error(
+          { requesterExternalUserId },
+          "Access request resolver: gateway refused voice caller activation",
+        );
+        return { ok: false, reason: "voice_activation_refused" };
       }
 
       log.info(

--- a/assistant/src/contacts/__tests__/contacts-write-revoke-relay.test.ts
+++ b/assistant/src/contacts/__tests__/contacts-write-revoke-relay.test.ts
@@ -40,14 +40,13 @@ mock.module("../../ipc/gateway-client.js", () => ({
 }));
 
 
-// Local-mirror primitive.
+// Local resolver primitive — resolves the native contact/channel by id; the
+// gateway owns the ACL downgrade, so it takes no reason and mutates nothing.
 const revokeMemberResult: ContactWriteResult = {
   contact: { id: "c1" } as ContactWriteResult["contact"],
   channel: { id: "ch1", status: "revoked" } as ContactWriteResult["channel"],
 };
-const revokeMemberMock = mock((_memberId: string, _reason?: string) =>
-  revokeMemberResult,
-);
+const revokeMemberMock = mock((_memberId: string) => revokeMemberResult);
 const actualContactsWrite = await import("../contacts-write.js");
 mock.module("../contacts-write.js", () => ({
   ...actualContactsWrite,
@@ -75,7 +74,7 @@ describe("revokeMemberChannel gateway-first relay", () => {
       },
     ]);
     expect(revokeMemberMock).toHaveBeenCalledTimes(1);
-    expect(revokeMemberMock).toHaveBeenCalledWith("ch1", "removed");
+    expect(revokeMemberMock).toHaveBeenCalledWith("ch1");
     expect(result).toBe(revokeMemberResult);
   });
 
@@ -83,8 +82,8 @@ describe("revokeMemberChannel gateway-first relay", () => {
     await revokeMemberChannel("c1:ch1");
 
     expect(ipcCalls[0]?.params?.contactChannelId).toBe("ch1");
-    // The local mirror still receives the original composite id it accepts.
-    expect(revokeMemberMock).toHaveBeenCalledWith("c1:ch1", undefined);
+    // The local resolver still receives the original composite id it accepts.
+    expect(revokeMemberMock).toHaveBeenCalledWith("c1:ch1");
   });
 
   test("always relays — never skips based on local mirror status", async () => {

--- a/assistant/src/contacts/__tests__/member-write-relay.test.ts
+++ b/assistant/src/contacts/__tests__/member-write-relay.test.ts
@@ -141,7 +141,7 @@ describe("activateMemberChannel gateway-first relay", () => {
     });
   });
 
-  test("fails open and still mirrors locally when the gateway relay throws", async () => {
+  test("fails closed and skips the local mirror when the gateway relay throws", async () => {
     ipcThrows = true;
 
     const result = await activateMemberChannel({
@@ -152,12 +152,10 @@ describe("activateMemberChannel gateway-first relay", () => {
     });
 
     expect(ipcCalls).toHaveLength(1);
-    expect(upsertContactChannelMock).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({
-      status: "activated",
-      memberId: "ch1",
-      member: localResult,
-    });
+    // Identity-only mirror would land at the schema-default unverified status, so
+    // a failed gateway write must not report success off it.
+    expect(upsertContactChannelMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: "refused" });
   });
 
   test("returns the gateway channel id when the gateway verifies but the local mirror throws", async () => {
@@ -181,7 +179,7 @@ describe("activateMemberChannel gateway-first relay", () => {
     });
   });
 
-  test("refuses when the gateway throws AND the local mirror yields no row", async () => {
+  test("refuses when the gateway throws even if the local mirror would have thrown", async () => {
     ipcThrows = true;
     upsertContactChannelMock.mockImplementation(() => {
       throw new Error("local mirror exploded");
@@ -193,8 +191,8 @@ describe("activateMemberChannel gateway-first relay", () => {
       externalChatId: "chat-1",
     });
 
-    // No gateway channel (relay threw) and no local mirror: no stable id, so the
-    // caller maps this to a non-redeemed outcome rather than crashing.
+    // Fail-closed: a thrown gateway write refuses before the mirror is touched.
+    expect(upsertContactChannelMock).not.toHaveBeenCalled();
     expect(result).toEqual({ status: "refused" });
   });
 

--- a/assistant/src/contacts/__tests__/member-write-relay.test.ts
+++ b/assistant/src/contacts/__tests__/member-write-relay.test.ts
@@ -108,6 +108,32 @@ describe("activateMemberChannel gateway-first relay", () => {
     // The local mirror ran AFTER the gateway relay.
     expect(mirrorCallOrder).toBe(1);
     expect(upsertContactChannelMock).toHaveBeenCalledTimes(1);
+
+    // The local mirror persists identity/INFO only — no ACL columns. The
+    // gateway owns status/policy/verification.
+    const mirrorArgs = upsertContactChannelMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(mirrorArgs).toEqual({
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+      externalChatId: "chat-1",
+      displayName: "Mom",
+      username: undefined,
+      inviteId: "inv-1",
+      contactId: "target-mom",
+    });
+    for (const aclKey of [
+      "status",
+      "policy",
+      "role",
+      "verifiedAt",
+      "verifiedVia",
+    ]) {
+      expect(aclKey in mirrorArgs).toBe(false);
+    }
+
     expect(result).toEqual({
       status: "activated",
       memberId: "ch1",

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -260,11 +260,8 @@ export function upsertContact(params: {
         updatedAt: now,
       };
       if (params.notes !== undefined) updateSet.notes = params.notes;
-      if (params.role !== undefined) updateSet.role = params.role;
       if (params.contactType !== undefined)
         updateSet.contactType = params.contactType;
-      if (params.principalId !== undefined)
-        updateSet.principalId = params.principalId;
       if (params.userFile !== undefined) updateSet.userFile = params.userFile;
 
       db.update(contacts)
@@ -298,11 +295,8 @@ export function upsertContact(params: {
           updatedAt: now,
         };
         if (params.notes !== undefined) updateSet.notes = params.notes;
-        if (params.role !== undefined) updateSet.role = params.role;
         if (params.contactType !== undefined)
           updateSet.contactType = params.contactType;
-        if (params.principalId !== undefined)
-          updateSet.principalId = params.principalId;
         if (params.userFile !== undefined) updateSet.userFile = params.userFile;
 
         db.update(contacts)
@@ -345,9 +339,7 @@ export function upsertContact(params: {
       id: contactId,
       displayName: params.displayName,
       notes: params.notes ?? null,
-      role: params.role ?? "contact",
       contactType: params.contactType ?? "human",
-      principalId: params.principalId ?? null,
       userFile: resolvedUserFile,
       createdAt: now,
       updatedAt: now,
@@ -396,27 +388,12 @@ function syncChannels(
       .get();
 
     if (existing) {
-      // Preserve guardian blocks: if the channel is blocked, do not overwrite
-      // its status/policy — mirrors the guard in the cross-contact reassignment
-      // path so a blocked channel cannot be unblocked via a same-contact sync.
-      const isBlocked = existing.status === "blocked";
-
       const updateSet: Record<string, unknown> = {};
       // Self-heal legacy lowercased addresses to canonical form.
       if (existing.address !== ch.address) updateSet.address = ch.address;
       if (ch.isPrimary !== undefined) updateSet.isPrimary = ch.isPrimary;
       if (ch.externalChatId !== undefined)
         updateSet.externalChatId = ch.externalChatId;
-      if (!isBlocked) {
-        if (ch.status !== undefined) updateSet.status = ch.status;
-        if (ch.policy !== undefined) updateSet.policy = ch.policy;
-        if (ch.revokedReason !== undefined)
-          updateSet.revokedReason = ch.revokedReason;
-        if (ch.blockedReason !== undefined)
-          updateSet.blockedReason = ch.blockedReason;
-      }
-      if (ch.verifiedAt !== undefined) updateSet.verifiedAt = ch.verifiedAt;
-      if (ch.verifiedVia !== undefined) updateSet.verifiedVia = ch.verifiedVia;
       if (ch.inviteId !== undefined) updateSet.inviteId = ch.inviteId;
 
       if (Object.keys(updateSet).length > 0) {
@@ -434,11 +411,6 @@ function syncChannels(
 
     if (conflicting) {
       if (reassignConflicting) {
-        // Preserve guardian blocks: if the existing channel is blocked, do not
-        // overwrite its status/policy — a valid invite must not bypass an
-        // explicit guardian block on a different contact.
-        const isBlocked = conflicting.status === "blocked";
-
         // Reassign the channel to the target contact. Used by invite redemption
         // to bind a redeemer's existing channel identity to the invite's target.
         const reassignSet: Record<string, unknown> = {
@@ -447,17 +419,6 @@ function syncChannels(
         };
         if (ch.externalChatId !== undefined)
           reassignSet.externalChatId = ch.externalChatId;
-        if (!isBlocked) {
-          if (ch.status !== undefined) reassignSet.status = ch.status;
-          if (ch.policy !== undefined) reassignSet.policy = ch.policy;
-          if (ch.revokedReason !== undefined)
-            reassignSet.revokedReason = ch.revokedReason;
-          if (ch.blockedReason !== undefined)
-            reassignSet.blockedReason = ch.blockedReason;
-        }
-        if (ch.verifiedAt !== undefined) reassignSet.verifiedAt = ch.verifiedAt;
-        if (ch.verifiedVia !== undefined)
-          reassignSet.verifiedVia = ch.verifiedVia;
         if (ch.inviteId !== undefined) reassignSet.inviteId = ch.inviteId;
 
         db.update(contactChannels)
@@ -478,10 +439,6 @@ function syncChannels(
         address: ch.address,
         isPrimary: ch.isPrimary ?? false,
         externalChatId: ch.externalChatId ?? null,
-        status: ch.status ?? "unverified",
-        policy: ch.policy ?? "allow",
-        verifiedAt: ch.verifiedAt ?? null,
-        verifiedVia: ch.verifiedVia ?? null,
         inviteId: ch.inviteId ?? null,
         createdAt: now,
         updatedAt: now,
@@ -901,60 +858,10 @@ export function listGuardianChannels(): {
 }
 
 /**
- * Update a channel's access-control fields (status, policy, reasons).
- * Returns the updated channel, or null if the channel does not exist.
- */
-export function updateChannelStatus(
-  channelId: string,
-  params: {
-    status?: ChannelStatus;
-    policy?: ChannelPolicy;
-    revokedReason?: string | null;
-    blockedReason?: string | null;
-  },
-): ContactChannel | null {
-  const db = getDb();
-  const existing = db
-    .select()
-    .from(contactChannels)
-    .where(eq(contactChannels.id, channelId))
-    .get();
-
-  if (!existing) return null;
-
-  const updateSet: Record<string, unknown> = {};
-  if (params.status !== undefined) updateSet.status = params.status;
-  if (params.policy !== undefined) updateSet.policy = params.policy;
-  if (params.revokedReason !== undefined)
-    updateSet.revokedReason = params.revokedReason;
-  if (params.blockedReason !== undefined)
-    updateSet.blockedReason = params.blockedReason;
-
-  if (Object.keys(updateSet).length > 0) {
-    updateSet.updatedAt = Date.now();
-    db.update(contactChannels)
-      .set(updateSet)
-      .where(eq(contactChannels.id, channelId))
-      .run();
-
-    const updated = db
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
-
-    const result = updated ? parseChannel(updated) : null;
-    emitContactChange();
-    return result;
-  }
-
-  return parseChannel(existing);
-}
-
-/**
- * Update a guardian contact's principalId and its channel's identity fields.
- * Used for healing guardian binding drift when the JWT principal no longer
- * matches the stored guardian binding after a DB reset.
+ * Heal a guardian channel's identity address when the JWT principal no longer
+ * matches the stored guardian binding after a DB reset. The principalId ACL
+ * column is gateway-owned and no longer written here; only the channel identity
+ * address is repaired.
  *
  * Returns false if the update would violate the unique (type, address)
  * constraint on contact_channels — e.g. when the incoming principal already
@@ -962,7 +869,7 @@ export function updateChannelStatus(
  * In that case the heal is skipped and trust stays `unknown`.
  */
 export function updateContactPrincipalAndChannel(
-  contactId: string,
+  _contactId: string,
   channelId: string,
   newPrincipalId: string,
 ): boolean {
@@ -983,20 +890,13 @@ export function updateContactPrincipalAndChannel(
     return false;
   }
 
-  db.transaction(() => {
-    db.update(contacts)
-      .set({ principalId: newPrincipalId, updatedAt: now })
-      .where(eq(contacts.id, contactId))
-      .run();
-
-    db.update(contactChannels)
-      .set({
-        address: newPrincipalId,
-        updatedAt: now,
-      })
-      .where(eq(contactChannels.id, channelId))
-      .run();
-  });
+  db.update(contactChannels)
+    .set({
+      address: newPrincipalId,
+      updatedAt: now,
+    })
+    .where(eq(contactChannels.id, channelId))
+    .run();
 
   emitContactChange();
   return true;

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -6,50 +6,33 @@
  * identity and access-control state.
  */
 
-import { emitContactChange } from "./contact-events.js";
 import {
   findContactChannel,
-  findGuardianForChannel,
   getChannelById,
   getContact,
   getContactInternal,
-  updateChannelStatus,
   upsertContact,
 } from "./contact-store.js";
-import type {
-  ChannelPolicy,
-  ChannelStatus,
-  ContactRole,
-  ContactWriteResult,
-} from "./types.js";
+import type { ContactWriteResult } from "./types.js";
 
 // ── Guardian operations ──────────────────────────────────────────────
 
 /**
- * Revoke a guardian binding by updating the contacts table.
- * Returns true when a guardian channel was found and revoked, false otherwise.
+ * No-op shim: the guardian channel ACL revoke is gateway-owned (relayed via
+ * mark_channel_revoked). Retained while callers still invoke it; the return is
+ * discarded.
  */
-export function revokeGuardianBinding(channel: string): boolean {
-  // Local-store read, not the gateway: this read selects the row that the
-  // updateChannelStatus write below mutates, so it must stay transactionally
-  // consistent with that write. Leave for Combo 11 / gateway-bootstrap-binding.
-  const guardian = findGuardianForChannel(channel);
-  if (!guardian) return false;
-
-  updateChannelStatus(guardian.channel.id, {
-    status: "revoked",
-    revokedReason: "binding_revoked",
-  });
-  emitContactChange();
-  return true;
+export function revokeGuardianBinding(_channel: string): boolean {
+  return false;
 }
 
 // ── Member operations ────────────────────────────────────────────────
 
 /**
- * Upsert a contact and channel by writing to the contacts table.
- * Returns the native Contact + ContactChannel, or null if no usable
- * identity was provided or the lookup failed after upsert.
+ * Upsert a contact and channel identity by writing to the contacts table.
+ * Persists only identity/INFO — the gateway owns the ACL verdict. Returns the
+ * native Contact + ContactChannel, or null if no usable identity was provided
+ * or the lookup failed after upsert.
  */
 export function upsertContactChannel(params: {
   sourceChannel: string;
@@ -57,12 +40,7 @@ export function upsertContactChannel(params: {
   externalChatId?: string;
   displayName?: string;
   username?: string;
-  policy?: string;
-  status?: string;
   inviteId?: string;
-  verifiedAt?: number;
-  verifiedVia?: string;
-  role?: ContactRole;
   contactId?: string;
 }): ContactWriteResult | null {
   let address: string;
@@ -91,19 +69,12 @@ export function upsertContactChannel(params: {
   upsertContact({
     id: params.contactId,
     displayName,
-    role: params.role,
     channels: [
       {
         type: params.sourceChannel,
         address,
         externalChatId: params.externalChatId ?? null,
-        status: (params.status as ChannelStatus) ?? undefined,
-        policy: (params.policy as ChannelPolicy) ?? undefined,
         inviteId: params.inviteId ?? null,
-        revokedReason: params.status === "active" ? null : undefined,
-        blockedReason: params.status === "active" ? null : undefined,
-        verifiedAt: params.verifiedAt ?? undefined,
-        verifiedVia: params.verifiedVia ?? undefined,
       },
     ],
     // When a specific contactId is provided, reassign conflicting channels from
@@ -132,32 +103,21 @@ export function upsertContactChannel(params: {
 }
 
 /**
- * Revoke a contact channel by updating its status.
- * The memberId may be a plain channel ID (internal callers) or a composite
- * contactId:channelId (from the API response format).
+ * Resolve the native contact/channel for a member id. The ACL downgrade is
+ * gateway-owned (relayed via mark_channel_revoked); this no longer mutates
+ * local status. The memberId may be a plain channel ID (internal callers) or a
+ * composite contactId:channelId (from the API response format).
  */
-export function revokeMember(
-  memberId: string,
-  reason?: string,
-): ContactWriteResult | null {
+export function revokeMember(memberId: string): ContactWriteResult | null {
   const channelId = memberId.includes(":") ? memberId.split(":")[1] : memberId;
 
   const channelRow = getChannelById(channelId);
   if (!channelRow) return null;
-  if (channelRow.status !== "active" && channelRow.status !== "pending")
-    return null;
 
-  updateChannelStatus(channelId, {
-    status: "revoked",
-    revokedReason: reason ?? null,
-  });
-
-  // Use unscoped lookup — the contact was already resolved via channel ID
   const contact = getContactInternal(channelRow.contactId);
   if (!contact) return null;
-  const updatedChannel = contact.channels.find((ch) => ch.id === channelId);
-  if (!updatedChannel) return null;
+  const channel = contact.channels.find((ch) => ch.id === channelId);
+  if (!channel) return null;
 
-  emitContactChange();
-  return { contact, channel: updatedChannel };
+  return { contact, channel };
 }

--- a/assistant/src/contacts/member-write-relay.ts
+++ b/assistant/src/contacts/member-write-relay.ts
@@ -113,7 +113,10 @@ export async function activateMemberChannel(
   return { status: "activated", memberId, member };
 }
 
-/** Best-effort local mirror of the activation. Swallows failures. */
+/**
+ * Best-effort local mirror of the activation. Swallows failures. Persists only
+ * the native contact/channel identity row — the gateway owns the ACL verdict.
+ */
 function mirrorLocalActivation(
   params: ActivateMemberChannelParams,
 ): ContactWriteResult | null {
@@ -124,12 +127,7 @@ function mirrorLocalActivation(
       externalChatId: params.externalChatId,
       displayName: params.displayName,
       username: params.username,
-      role: "contact",
-      status: "active",
-      policy: params.policy ?? "allow",
       inviteId: params.inviteId,
-      verifiedAt: params.verifiedAt,
-      verifiedVia: params.verifiedVia ?? "invite",
       contactId: params.contactId,
     });
   } catch (err) {
@@ -144,12 +142,13 @@ function mirrorLocalActivation(
 // ── Revoke ───────────────────────────────────────────────────────────
 
 /**
- * Revoke a member channel gateway-first, then mirror the downgrade to the
- * assistant DB best-effort. The memberId may be a plain channel ID or the
- * composite contactId:channelId form revokeMember accepts.
+ * Revoke a member channel gateway-first. The gateway owns the ACL outcome; the
+ * memberId may be a plain channel ID or the composite contactId:channelId form
+ * revokeMember accepts.
  *
- * Returns the local ContactWriteResult so callers still get the native
- * contact/channel, or null when the local mirror produces no result.
+ * Returns the locally-resolved native contact/channel for the revoked id, or
+ * null when no local row exists. The local read is best-effort and never gates
+ * the gateway-owned downgrade.
  */
 export async function revokeMemberChannel(
   memberId: string,
@@ -158,8 +157,8 @@ export async function revokeMemberChannel(
   const channelId = memberId.includes(":") ? memberId.split(":")[1] : memberId;
 
   // Always relay; the gateway owns the ACL outcome and mark_channel_revoked is
-  // idempotent (already-revoked → didWrite:false). Skipping on the local mirror
-  // status would suppress a needed revoke when the mirror lags the gateway.
+  // idempotent (already-revoked → didWrite:false). Skipping on the local row
+  // status would suppress a needed revoke when the local read lags the gateway.
   const result = await ipcCallPersistent("mark_channel_revoked", {
     contactChannelId: channelId,
     reason,
@@ -169,20 +168,12 @@ export async function revokeMemberChannel(
     throw new Error("mark_channel_revoked relay returned ok: false");
   }
 
-  return mirrorLocalRevoke(memberId, reason);
-}
-
-/** Best-effort local mirror of the revoke. Swallows failures. */
-function mirrorLocalRevoke(
-  memberId: string,
-  reason?: string,
-): ContactWriteResult | null {
   try {
-    return revokeMember(memberId, reason);
+    return revokeMember(memberId);
   } catch (err) {
     log.error(
       { err, memberId },
-      "Local revoke mirror failed after gateway revoke; gateway downgrade stands",
+      "Local revoke read failed after gateway revoke; gateway downgrade stands",
     );
     return null;
   }

--- a/assistant/src/contacts/member-write-relay.ts
+++ b/assistant/src/contacts/member-write-relay.ts
@@ -47,13 +47,14 @@ export type ActivateMemberOutcome =
  * assistant DB best-effort. The gateway owns the ACL outcome; the local mirror
  * supplies the native contact/channel callers still wire downstream.
  *
- * A gateway failure fails open with a logged warning (matching the redemption
- * service's record_invite_redemption posture) so a transient gateway outage
- * never drops a legitimate activation — the local mirror still stands.
+ * A gateway write failure fails closed: the mirror is identity-only, so a
+ * gateway that did not persist the activation must surface as `refused` rather
+ * than reporting success off a local row the gateway never verified.
  *
  * Returns an `activated` outcome with a stable memberId on success, or
- * `refused` when the gateway denies the actor. A best-effort local-mirror
- * failure never downgrades a verified gateway activation.
+ * `refused` when the gateway denies the actor or the gateway write fails. A
+ * best-effort local-mirror failure never downgrades a verified gateway
+ * activation.
  */
 export async function activateMemberChannel(
   params: ActivateMemberChannelParams,
@@ -89,12 +90,14 @@ export async function activateMemberChannel(
       }
       gatewayChannelId = parsed.channel?.id;
     } catch (err) {
-      // Fail-open: the gateway write may or may not have landed. Proceed to the
-      // local mirror so a transient outage never drops a legitimate activation.
+      // Fail-closed: the gateway owns the ACL verdict and the local mirror is
+      // identity-only. If the gateway write did not land, the activation is not
+      // persisted to the source of truth, so we must not report success.
       log.warn(
         { err, sourceChannel: params.sourceChannel },
-        "upsert_verified_channel relay unavailable — failing open (local mirror still applies)",
+        "upsert_verified_channel relay failed — refusing activation (gateway write did not land)",
       );
+      return { status: "refused" };
     }
   }
 

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
@@ -174,7 +174,6 @@ describe("acceptA2AInvite", () => {
     expect(contact).not.toBeNull();
     expect(contact!.channels).toHaveLength(1);
     expect(contact!.channels[0]!.type).toBe("a2a");
-    expect(contact!.channels[0]!.status).toBe("active");
 
     // Verify assistant metadata
     const metadata = getAssistantContactMetadata(result.contactId!);

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -100,8 +100,6 @@ describe("completeA2AInvite", () => {
     expect(contact!.displayName).toBe("Acceptor Bot");
     expect(contact!.channels).toHaveLength(1);
     expect(contact!.channels[0]!.type).toBe("a2a");
-    expect(contact!.channels[0]!.status).toBe("active");
-    expect(contact!.channels[0]!.policy).toBe("allow");
   });
 
   test("contact channel address is acceptor.assistantId.toLowerCase()", () => {

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
@@ -71,8 +71,6 @@ describe("redeemA2AInvite", () => {
     expect(contact!.displayName).toBe("Sender Bot");
     expect(contact!.channels).toHaveLength(1);
     expect(contact!.channels[0]!.type).toBe("a2a");
-    expect(contact!.channels[0]!.status).toBe("active");
-    expect(contact!.channels[0]!.policy).toBe("allow");
   });
 
   test("idempotency: already-connected sender returns alreadyConnected", () => {


### PR DESCRIPTION
## Summary
- member-write-relay/contacts-write/contact-store no longer write the redundant ACL columns
- Gateway relays remain the ACL writer; local persistence keeps identity/INFO only

Part of plan: combo11-phase-b2-drop-acl-columns.md (PR 5 of 11)