### PR TITLE
[codex] Fix research onboarding readiness handoffs

### DIFF
--- a/clients/web/src/components/onboarding-avatar-applier.test.tsx
+++ b/clients/web/src/components/onboarding-avatar-applier.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CharacterTraits } from "@/types/avatar";
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+const TRAITS: CharacterTraits = {
+  bodyShape: "round",
+  eyeStyle: "dot",
+  color: "green",
+};
+
+let saveCharacterTraitsImpl: (
+  assistantId: string,
+  traits: CharacterTraits,
+) => Promise<boolean> = async () => true;
+const saveCharacterTraitsMock = mock(
+  async (assistantId: string, traits: CharacterTraits) =>
+    saveCharacterTraitsImpl(assistantId, traits),
+);
+
+mock.module("@/assistant/avatar-api", () => ({
+  saveCharacterTraits: saveCharacterTraitsMock,
+}));
+
+const { OnboardingAvatarApplier } = await import(
+  "@/components/onboarding-avatar-applier"
+);
+
+describe("OnboardingAvatarApplier", () => {
+  beforeEach(() => {
+    saveCharacterTraitsImpl = async () => true;
+    saveCharacterTraitsMock.mockClear();
+    useOnboardingFocusStore.setState({ pendingAvatarTraits: null });
+    useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  });
+
+  afterEach(cleanup);
+
+  test("clears staged traits after a successful save", async () => {
+    useOnboardingFocusStore.getState().setPendingAvatarTraits(TRAITS);
+    useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
+
+    render(<OnboardingAvatarApplier />);
+
+    await waitFor(() =>
+      expect(saveCharacterTraitsMock).toHaveBeenCalledWith("asst-1", TRAITS),
+    );
+    await waitFor(() =>
+      expect(useOnboardingFocusStore.getState().pendingAvatarTraits).toBeNull(),
+    );
+  });
+
+  test("keeps staged traits queued when the save reports failure", async () => {
+    saveCharacterTraitsImpl = async () => false;
+    useOnboardingFocusStore.getState().setPendingAvatarTraits(TRAITS);
+    useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
+
+    render(<OnboardingAvatarApplier />);
+
+    await waitFor(() =>
+      expect(saveCharacterTraitsMock).toHaveBeenCalledWith("asst-1", TRAITS),
+    );
+    expect(useOnboardingFocusStore.getState().pendingAvatarTraits).toEqual(
+      TRAITS,
+    );
+  });
+});

--- a/clients/web/src/components/onboarding-avatar-applier.tsx
+++ b/clients/web/src/components/onboarding-avatar-applier.tsx
@@ -6,15 +6,18 @@
  * The chosen avatar traits aren't part of the pre-chat handoff context, so they
  * can't be set during hatch. This invisible component (mounted in `ChatLayout`)
  * watches for the staged `pendingAvatarTraits` and the active assistant id, then
- * persists the traits via `saveCharacterTraits` exactly once — the moment the
- * freshly-hatched assistant becomes reachable — and clears the staged value.
+ * persists the traits via `saveCharacterTraits`. Transient save failures keep
+ * the staged value queued for a retry; the value clears only after a successful
+ * save.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { saveCharacterTraits } from "@/assistant/avatar-api";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+const AVATAR_APPLY_RETRY_MS = 1_500;
 
 export function OnboardingAvatarApplier() {
   const pendingAvatarTraits =
@@ -22,17 +25,36 @@ export function OnboardingAvatarApplier() {
   const setPendingAvatarTraits =
     useOnboardingFocusStore.use.setPendingAvatarTraits();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  // Guards against a double-apply if this re-renders before the clear lands.
-  const appliedRef = useRef(false);
+  const savingRef = useRef(false);
+  const [retryNonce, setRetryNonce] = useState(0);
 
   useEffect(() => {
-    if (!pendingAvatarTraits || !assistantId || appliedRef.current) return;
-    appliedRef.current = true;
+    if (!pendingAvatarTraits || !assistantId || savingRef.current) return;
+    savingRef.current = true;
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
     const traits = pendingAvatarTraits;
-    void saveCharacterTraits(assistantId, traits).finally(() => {
-      setPendingAvatarTraits(null);
-    });
-  }, [pendingAvatarTraits, assistantId, setPendingAvatarTraits]);
+    void saveCharacterTraits(assistantId, traits)
+      .then((saved) => {
+        if (!saved) throw new Error("Avatar traits were not saved");
+        if (!cancelled) setPendingAvatarTraits(null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        retryTimer = setTimeout(() => {
+          setRetryNonce((nonce) => nonce + 1);
+        }, AVATAR_APPLY_RETRY_MS);
+      })
+      .finally(() => {
+        if (!cancelled) savingRef.current = false;
+      });
+
+    return () => {
+      cancelled = true;
+      savingRef.current = false;
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [pendingAvatarTraits, assistantId, retryNonce, setPendingAvatarTraits]);
 
   return null;
 }

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -26,6 +26,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { routes } from "@/utils/routes";
 import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
 import {
+  setPendingAssistantName,
   setPendingPreChatContext,
   type PreChatOnboardingContext,
 } from "@/domains/onboarding/prechat";
@@ -168,8 +169,9 @@ export function ResearchOnboardingRoute() {
   // provision + poll an assistant before being bounced away.
   useEffect(() => {
     exitFocus();
+    setPendingAvatarTraits(null);
     if (enabled && flagsHydrated) startHatch();
-  }, [exitFocus, startHatch, enabled, flagsHydrated]);
+  }, [exitFocus, setPendingAvatarTraits, startHatch, enabled, flagsHydrated]);
 
   // If we're sitting on the results step when the research turn resolves empty
   // (it was still streaming when we arrived), skip ahead to the suggestions.
@@ -236,6 +238,8 @@ export function ResearchOnboardingRoute() {
     };
 
     setPendingPreChatContext(context);
+    const assistantName = face?.name?.trim();
+    if (assistantName) setPendingAssistantName(assistantName);
 
     // Stage the chosen avatar traits; OnboardingAvatarApplier applies them once
     // the assistant is hatched (they're not part of the pre-chat context).

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -8,7 +8,10 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { selectRecommendableCapabilities } from "@/domains/onboarding/research-runner";
+import {
+  selectRecommendableCapabilities,
+  shouldSettleResearchPoll,
+} from "@/domains/onboarding/research-runner";
 
 type Match = Parameters<typeof selectRecommendableCapabilities>[0][number];
 
@@ -71,5 +74,25 @@ describe("selectRecommendableCapabilities", () => {
     expect(capabilities[0]?.description).toBe(
       "Acts as a full-stack marketing expert for any business.",
     );
+  });
+});
+
+describe("shouldSettleResearchPoll", () => {
+  test("does not settle an incomplete response even after repeated identical polls", () => {
+    expect(
+      shouldSettleResearchPoll({ complete: false, stableReads: 20 }),
+    ).toBe(false);
+  });
+
+  test("settles a complete response after the stable-read threshold", () => {
+    expect(
+      shouldSettleResearchPoll({ complete: true, stableReads: 2 }),
+    ).toBe(true);
+  });
+
+  test("waits for the complete response to stabilize", () => {
+    expect(
+      shouldSettleResearchPoll({ complete: true, stableReads: 1 }),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -61,15 +61,16 @@ const MAX_POLL_MS = 120_000;
  * message incrementally or only on completion.
  */
 const STABLE_READS_TO_SETTLE = 2;
-/**
- * Higher stable-read bar used while the reply has NOT yet parsed as a complete
- * payload — a still-open (or malformed) `suggestions` array. This stops us
- * settling on a partial array during a generation pause (which would render
- * only the first card or two); a genuinely finished-but-malformed reply still
- * settles here, well before `MAX_POLL_MS`, rather than hanging to the deadline.
- */
-const STABLE_READS_TO_SETTLE_INCOMPLETE = 6;
 
+export function shouldSettleResearchPoll({
+  complete,
+  stableReads,
+}: {
+  complete: boolean;
+  stableReads: number;
+}): boolean {
+  return complete && stableReads >= STABLE_READS_TO_SETTLE;
+}
 /**
  * Org that owns first-party, reviewed Vellum plugins. Onboarding only ever
  * surfaces and installs plugins from this owner — never third-party/external
@@ -468,12 +469,10 @@ export function useResearchRunner(): UseResearchRunner {
               });
               stableReads = text === lastText ? stableReads + 1 : 0;
               lastText = text;
-              // Prefer to settle only once the payload is complete, so a pause
-              // mid-`suggestions` doesn't freeze the result on a partial array.
-              const settleAt = complete
-                ? STABLE_READS_TO_SETTLE
-                : STABLE_READS_TO_SETTLE_INCOMPLETE;
-              if (stableReads >= settleAt) break;
+              // Only a complete payload can settle early. A partial JSON object
+              // can pause between claim/suggestion objects for long enough to
+              // look stable, but it may still be mid-response.
+              if (shouldSettleResearchPoll({ complete, stableReads })) break;
             }
           }
 

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx
@@ -45,7 +45,7 @@ function renderStep(props: Partial<Parameters<typeof LetsChatTomorrowStep>[0]>) 
   return render(
     <LetsChatTomorrowStep
       assistantId="asst-1"
-      assistantReady
+      assistantReady={true}
       onConnected={() => {}}
       onSkip={() => {}}
       onBack={() => {}}
@@ -96,5 +96,24 @@ describe("LetsChatTomorrowStep", () => {
 
     expect(onRetry).toHaveBeenCalledTimes(1);
     expect(handleConnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("explains why calendar setup is disabled while the assistant starts", () => {
+    renderStep({ assistantReady: false });
+
+    expect(screen.getByText("Almost ready")).toBeDefined();
+    expect(
+      screen.getByText(
+        "Your assistant is still getting ready. Calendar setup will be available in a moment.",
+      ),
+    ).toBeDefined();
+    const button = screen.getByRole("button", {
+      name: /Starting assistant/,
+    });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(button);
+
+    expect(handleConnectMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -66,7 +66,8 @@ export function LetsChatTomorrowStep({
   };
   // Wait for full readiness (not just an id): the post-OAuth `scheduleCheckin`
   // hits the daemon, which may not be reachable until healthz passes.
-  const connectDisabled = !assistantId || !assistantReady || oauthInProgress;
+  const waitingForAssistant = !assistantId || !assistantReady;
+  const connectDisabled = waitingForAssistant || oauthInProgress;
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
@@ -77,14 +78,18 @@ export function LetsChatTomorrowStep({
           className="text-[2.6rem] leading-tight"
           style={{ fontFamily: "var(--font-serif)" }}
         >
-          {missingCalendarScope
-            ? "Access not enabled"
-            : "Let me make this easy"}
+          {waitingForAssistant
+            ? "Almost ready"
+            : missingCalendarScope
+              ? "Access not enabled"
+              : "Let me make this easy"}
         </h1>
         <p className="text-[16px]" style={{ color: tone.fgMuted }}>
-          {missingCalendarScope
-            ? "Check the box next to the Google Calendar permission so I can book the check-in."
-            : "Connect your Google Calendar so I can find time to check in and start helping."}
+          {waitingForAssistant
+            ? "Your assistant is still getting ready. Calendar setup will be available in a moment."
+            : missingCalendarScope
+              ? "Check the box next to the Google Calendar permission so I can book the check-in."
+              : "Connect your Google Calendar so I can find time to check in and start helping."}
         </p>
 
         <div className="mt-6 flex w-[234px] flex-col items-center gap-4">
@@ -92,13 +97,18 @@ export function LetsChatTomorrowStep({
             type="button"
             onClick={handleConnectClick}
             disabled={connectDisabled}
-            className="flex h-11 w-full items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97] disabled:opacity-60"
+            className="flex h-11 w-full items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
             style={{
               backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
               color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
             }}
           >
-            {oauthInProgress ? (
+            {waitingForAssistant ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Starting assistant…
+              </>
+            ) : oauthInProgress ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
                 Waiting for authorization…

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -291,6 +291,7 @@ export function ResearchResultsStep({
   const [removed, setRemoved] = useState<Set<string>>(() => new Set());
   const visible = claims.filter((c) => !removed.has(c.claim));
   const hasClaims = visible.length > 0;
+  const canContinue = !loading;
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
@@ -305,7 +306,9 @@ export function ResearchResultsStep({
         </div>
         <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
           {hasClaims
-            ? "I searched the web. Feel free to remove anything that isn’t true"
+            ? loading
+              ? "Still checking the rest. You can review these as they come in."
+              : "I searched the web. Feel free to remove anything that isn’t true"
             : loading
               ? "Still putting this together…"
               : "I didn’t turn up much — we can fill it in as we chat."}
@@ -347,14 +350,15 @@ export function ResearchResultsStep({
         <button
           type="button"
           onClick={onContinue}
-          className="mt-8 flex h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
+          disabled={!canContinue}
+          className="mt-8 flex h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
           style={{
             backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
             color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
           }}
         >
-          Continue
-          <ArrowRight className="h-4 w-4" />
+          {canContinue ? "Continue" : "Still searching…"}
+          {canContinue && <ArrowRight className="h-4 w-4" />}
         </button>
       </div>
     </div>

--- a/clients/web/src/stores/onboarding-focus-store.test.ts
+++ b/clients/web/src/stores/onboarding-focus-store.test.ts
@@ -6,6 +6,7 @@ beforeEach(() => {
   useOnboardingFocusStore.setState({
     sidebarCollapseRequested: false,
     focused: false,
+    pendingAvatarTraits: null,
   });
 });
 
@@ -30,6 +31,17 @@ describe("useOnboardingFocusStore — sidebar collapse one-shot signal", () => {
     useOnboardingFocusStore.getState().exitFocus();
     expect(useOnboardingFocusStore.getState().sidebarCollapseRequested).toBe(
       false,
+    );
+  });
+
+  test("exitFocus preserves staged avatar traits for the handoff applier", () => {
+    const traits = { bodyShape: "round", eyeStyle: "dot", color: "green" };
+    useOnboardingFocusStore.getState().setPendingAvatarTraits(traits);
+
+    useOnboardingFocusStore.getState().exitFocus();
+
+    expect(useOnboardingFocusStore.getState().pendingAvatarTraits).toEqual(
+      traits,
     );
   });
 });

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -22,6 +22,7 @@
  *
  * Lifetime: `enterFocus()` on submit of the research form, `exitFocus()` when
  * the user clicks "Continue" out of the focused chat (or remounts the form).
+ * Avatar traits are handoff state and clear through their own setter.
  */
 
 import { create } from "zustand";
@@ -37,7 +38,8 @@ interface OnboardingFocusState {
   /**
    * Avatar traits chosen on the "Give me a face" picker, staged at handoff and
    * applied to the assistant once it's hatched (the avatar isn't part of the
-   * pre-chat context, so it's a post-hatch call). Cleared after it's applied.
+   * pre-chat context, so it's a post-hatch call). Cleared after a successful
+   * apply or when a new research-onboarding form mounts.
    */
   pendingAvatarTraits: CharacterTraits | null;
   setPendingAvatarTraits: (traits: CharacterTraits | null) => void;
@@ -85,7 +87,6 @@ const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
       focused: false,
       pendingFollowupMessage: null,
       checkinPending: false,
-      pendingAvatarTraits: null,
       sidebarCollapseRequested: false,
     }),
   pendingAvatarTraits: null,


### PR DESCRIPTION
## Summary

Fixes the slow-hatch and partial-research paths in research onboarding:

- only settles research polling once the parsed payload is complete, so a paused partial stream cannot freeze the UI at one claim and trigger fallback suggestions
- disables the research results Continue CTA while research is still loading, with explicit in-progress copy
- preserves selected avatar traits until they actually save, retrying transient failures instead of clearing the queued handoff
- carries the selected assistant name through the optimistic name handoff used by the existing pre-chat flow
- keeps check-in creation gated on assistant readiness, but explains the disabled CTA with an "Almost ready" state

## Root Cause

The research poller could treat repeated identical incomplete JSON as settled. Separately, avatar traits were cleared in a `finally` even when the post-hatch save failed or returned `false`, and `exitFocus()` also cleared the staged avatar handoff state.

## Validation

- `cd clients/web && bun test src/components/onboarding-avatar-applier.test.tsx`
- `cd clients/web && bun test src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx`
- `cd clients/web && bun test src/stores/onboarding-focus-store.test.ts`
- `cd clients/web && bun test src/domains/onboarding/research-runner.test.ts`
- `cd clients/web && bun test src/utils/research-facts.test.ts`
- `cd clients/web && bun run typecheck`
- `cd clients/web && bun run lint src/components/onboarding-avatar-applier.tsx src/components/onboarding-avatar-applier.test.tsx src/stores/onboarding-focus-store.ts src/stores/onboarding-focus-store.test.ts src/domains/onboarding/pages/research-onboarding-route.tsx src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx src/domains/onboarding/screens/lets-chat-tomorrow-step.test.tsx src/domains/onboarding/research-runner.ts src/domains/onboarding/research-runner.test.ts src/domains/onboarding/screens/research-result-steps.tsx`

## Rebase

Rebased onto current `origin/main` to resolve the PR conflict. The PR is now a single commit on top of `main`.