### PR TITLE
refactor(subagent): drop unused runtimeContext param from buildAdvisorSystem

### DIFF
--- a/assistant/src/subagent/__tests__/consult-prompt.test.ts
+++ b/assistant/src/subagent/__tests__/consult-prompt.test.ts
@@ -19,20 +19,6 @@ describe("buildAdvisorSystem", () => {
     const prompt = buildAdvisorSystem(null);
     expect(prompt).not.toContain("<agent_system_prompt>");
   });
-
-  test("embeds the runtime context inside <agent_runtime_context> when provided", () => {
-    const prompt = buildAdvisorSystem(
-      "You are a coding agent.",
-      "## Available tools\n- bash — run commands",
-    );
-    expect(prompt).toContain("<agent_runtime_context>");
-    expect(prompt).toContain("- bash — run commands");
-  });
-
-  test("omits the <agent_runtime_context> block when no runtime context is given", () => {
-    const prompt = buildAdvisorSystem("You are a coding agent.");
-    expect(prompt).not.toContain("<agent_runtime_context>");
-  });
 });
 
 describe("advisorRequestText", () => {

--- a/assistant/src/subagent/consult-prompt.ts
+++ b/assistant/src/subagent/consult-prompt.ts
@@ -1,8 +1,7 @@
 /**
  * Advice-framing prompt fragments for the advisor consult:
  *  - `buildAdvisorSystem` — the advisor-facing system prompt; frames the role and,
- *    for context, embeds the executor's own system prompt (and optional runtime
- *    context).
+ *    for context, embeds the executor's own system prompt.
  *  - `advisorRequestText` — the final user turn appended to the transcript asking
  *    for guidance.
  */
@@ -11,15 +10,9 @@
  * System prompt for the advisor sub-call. Frames the advisor's role and, for
  * context, quotes the executor's own system prompt (as the advisor tool does —
  * the advisor sees the system prompt as context about the executor's task).
- *
- * `runtimeContext`, when present, carries the agent's situational context that
- * lives outside its system prompt — available tools and skills, workspace /
- * project context, and recalled memory — so the advisor can ground its
- * recommendations in what the agent can actually do.
  */
 export function buildAdvisorSystem(
   originalSystemPrompt: string | null,
-  runtimeContext?: string | null,
 ): string {
   const base = `You are a senior advisor consulted by another AI agent working on a task — most often at the planning stage, before it starts building, but sometimes partway through. The entire conversation above is the agent's working context: its task or goal, every tool call it has made, and every result it has seen. The agent has paused to consult you because you bring a second, independent perspective it cannot get from inside its own reasoning loop. Your job is to maximize its odds of completing the task correctly and efficiently.
 
@@ -41,9 +34,6 @@ Write as much as the guidance genuinely needs, and no more.`;
   let prompt = base;
   if (originalSystemPrompt) {
     prompt += `\n\nFor context, the agent is operating under this system prompt:\n<agent_system_prompt>\n${originalSystemPrompt}\n</agent_system_prompt>`;
-  }
-  if (runtimeContext) {
-    prompt += `\n\nThe agent's runtime context — the tools and skills available to it, the loaded workspace/project context, and relevant memory — follows. Ground your recommendations in what the agent can actually do and what is around it; reference specific tools, skills, files, or memory where relevant.\n<agent_runtime_context>\n${runtimeContext}\n</agent_runtime_context>`;
   }
   return prompt;
 }


### PR DESCRIPTION
## Summary
- Remove the speculative, unconsumed runtimeContext parameter (+ its <agent_runtime_context> branch and the two tests that only exercised it) from buildAdvisorSystem. The sole caller passes one arg.

Self-review remediation for plan: advisor-as-subagent-role.md