### PR TITLE
feat(migrations): strip removed advisor call-site override from saved config

### DIFF
--- a/assistant/src/__tests__/workspace-migration-111-remove-advisor-callsite-override.test.ts
+++ b/assistant/src/__tests__/workspace-migration-111-remove-advisor-callsite-override.test.ts
@@ -1,0 +1,170 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { removeAdvisorCallsiteOverrideMigration } from "../workspace/migrations/111-remove-advisor-callsite-override.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-111-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("111-remove-advisor-callsite-override migration", () => {
+  test("has correct migration id and description", () => {
+    expect(removeAdvisorCallsiteOverrideMigration.id).toBe(
+      "111-remove-advisor-callsite-override",
+    );
+    expect(removeAdvisorCallsiteOverrideMigration.description).toBe(
+      "Remove the stale advisor entry from llm.callSites (advisor call site removed)",
+    );
+  });
+
+  // ─── No-op cases ────────────────────────────────────────────────────────
+
+  test("no-op when config.json does not exist", () => {
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("no-op when config has no llm.callSites", () => {
+    const original = { llm: { default: { provider: "anthropic" } } };
+    writeConfig(original);
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("no-op when llm.callSites has no advisor key", () => {
+    const original = {
+      llm: {
+        callSites: {
+          mainAgent: { profile: "quality-optimized" },
+          memoryRouter: { profile: "latency-optimized" },
+        },
+      },
+    };
+    writeConfig(original);
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles non-object llm / callSites shapes", () => {
+    const original = { llm: { callSites: 42 } };
+    writeConfig(original);
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  // ─── Removal ────────────────────────────────────────────────────────────
+
+  test("removes advisor and prunes the now-empty callSites map", () => {
+    writeConfig({
+      llm: {
+        callSites: {
+          advisor: { profile: "quality-optimized" },
+        },
+        advisorProfile: "frontier",
+      },
+    });
+
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, unknown>;
+    expect("callSites" in llm).toBe(false);
+    // The unrelated top-level advisor profile selection is untouched.
+    expect(llm.advisorProfile).toBe("frontier");
+  });
+
+  test("removes advisor but preserves other callSites keys", () => {
+    writeConfig({
+      llm: {
+        callSites: {
+          advisor: { profile: "quality-optimized" },
+          mainAgent: { profile: "opus" },
+          memoryRouter: { profile: "latency-optimized" },
+        },
+      },
+    });
+
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+
+    const callSites = (readConfig().llm as Record<string, unknown>)
+      .callSites as Record<string, unknown>;
+    expect("advisor" in callSites).toBe(false);
+    expect(callSites.mainAgent).toEqual({ profile: "opus" });
+    expect(callSites.memoryRouter).toEqual({ profile: "latency-optimized" });
+  });
+
+  // ─── Idempotency ────────────────────────────────────────────────────────
+
+  test("idempotency: re-running yields no further mutation", () => {
+    writeConfig({
+      llm: {
+        callSites: {
+          advisor: { profile: "quality-optimized" },
+          mainAgent: { profile: "opus" },
+        },
+      },
+    });
+
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+    const afterFirst = readConfig();
+
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  test("idempotency: writes nothing on a config without the advisor key", () => {
+    writeConfig({
+      llm: { callSites: { mainAgent: { profile: "opus" } } },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+
+    removeAdvisorCallsiteOverrideMigration.run(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/workspace/migrations/111-remove-advisor-callsite-override.ts
+++ b/assistant/src/workspace/migrations/111-remove-advisor-callsite-override.ts
@@ -4,17 +4,15 @@ import { join } from "node:path";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
- * Remove a persisted `llm.callSites.advisor` entry from existing config files.
+ * Strip a persisted `llm.callSites.advisor` entry from existing config files.
  *
- * `advisor` was a real, user-facing LLM call site (catalog entry + seeded
- * default), so a workspace could have saved `llm.callSites.advisor.profile`
- * via the config UI/API. It has since been removed from `LLMCallSiteEnum`.
- * Because `callSites` is a `z.partialRecord(LLMCallSiteEnum, ...)`, the stale
- * `advisor` key is now an invalid enum key and is *rejected* on parse — the
- * loader recovers (logs `Invalid config at "llm.callSites.advisor"...`,
- * deletes the key, re-parses), so it is not a crash, but the warning is logged
- * on every boot and `GET /config` serves the raw file so the web "Overrides"
- * badge keeps counting the dead key with no reset path.
+ * `advisor` is not a valid `LLMCallSiteEnum` key, so a saved
+ * `llm.callSites.advisor.profile` is rejected on parse by the
+ * `z.partialRecord(LLMCallSiteEnum, ...)` schema. The loader recovers (logs
+ * `Invalid config at "llm.callSites.advisor"...`, deletes the key, re-parses),
+ * so it is not a crash — but the warning is logged on every boot, and because
+ * `GET /config` serves the raw file the web "Overrides" badge keeps counting
+ * the invalid key with no reset path.
  *
  * This migration strips the key once. The now-empty `llm.callSites` object is
  * pruned if `advisor` was its only key (the schema defaults `callSites` to

--- a/assistant/src/workspace/migrations/111-remove-advisor-callsite-override.ts
+++ b/assistant/src/workspace/migrations/111-remove-advisor-callsite-override.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Remove a persisted `llm.callSites.advisor` entry from existing config files.
+ *
+ * `advisor` was a real, user-facing LLM call site (catalog entry + seeded
+ * default), so a workspace could have saved `llm.callSites.advisor.profile`
+ * via the config UI/API. It has since been removed from `LLMCallSiteEnum`.
+ * Because `callSites` is a `z.partialRecord(LLMCallSiteEnum, ...)`, the stale
+ * `advisor` key is now an invalid enum key and is *rejected* on parse — the
+ * loader recovers (logs `Invalid config at "llm.callSites.advisor"...`,
+ * deletes the key, re-parses), so it is not a crash, but the warning is logged
+ * on every boot and `GET /config` serves the raw file so the web "Overrides"
+ * badge keeps counting the dead key with no reset path.
+ *
+ * This migration strips the key once. The now-empty `llm.callSites` object is
+ * pruned if `advisor` was its only key (the schema defaults `callSites` to
+ * `{}`, so an absent key is equivalent to an empty map). Other call-site keys
+ * and the unrelated top-level `llm.advisorProfile` selection are left intact.
+ *
+ * No-op for configs that never had the key. Idempotent.
+ */
+export const removeAdvisorCallsiteOverrideMigration: WorkspaceMigration = {
+  id: "111-remove-advisor-callsite-override",
+  description:
+    "Remove the stale advisor entry from llm.callSites (advisor call site removed)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = config.llm;
+    if (!llm || typeof llm !== "object" || Array.isArray(llm)) return;
+
+    const callSites = (llm as Record<string, unknown>).callSites;
+    if (!callSites || typeof callSites !== "object" || Array.isArray(callSites))
+      return;
+
+    const sites = callSites as Record<string, unknown>;
+    if (!("advisor" in sites)) return;
+
+    delete sites.advisor;
+
+    // Prune the now-empty callSites map; an absent key is equivalent to the
+    // schema's `{}` default.
+    if (Object.keys(sites).length === 0) {
+      delete (llm as Record<string, unknown>).callSites;
+    }
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only — the advisor call site no longer exists.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -108,6 +108,7 @@ import { dropSendDiagnosticsMigration } from "./107-drop-send-diagnostics.js";
 import { dropBalancedEconomyProfileMigration } from "./108-drop-balanced-economy-profile.js";
 import { swapQualityProfileToGlm52Migration } from "./109-swap-quality-profile-to-glm-5p2.js";
 import { flipBalancedProfileToTogetherMigration } from "./110-flip-balanced-profile-to-together.js";
+import { removeAdvisorCallsiteOverrideMigration } from "./111-remove-advisor-callsite-override.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -227,4 +228,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropBalancedEconomyProfileMigration,
   swapQualityProfileToGlm52Migration,
   flipBalancedProfileToTogetherMigration,
+  removeAdvisorCallsiteOverrideMigration,
 ];


### PR DESCRIPTION
## Summary
- Add a workspace migration deleting a persisted llm.callSites.advisor entry (and pruning empty llm.callSites), so configs that saved an advisor call-site override are cleaned once instead of logging an invalid-key warning every boot.

Self-review remediation for plan: advisor-as-subagent-role.md