### PR TITLE
fix(surfaces): normalize file_upload acceptedTypes to a string[] (LUM-2574)

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -340,9 +340,8 @@ describe("task_progress surface compatibility", () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);
 
-    // The model sometimes emits acceptedTypes as a string instead of string[];
-    // the renderer calls `.join`/`.some` on it (LUM-2574), so the daemon must
-    // hand the client a clean array.
+    // The model may emit acceptedTypes as a comma-joined string; the renderer
+    // calls `.join`/`.some` on it, so the daemon hands the client a clean array.
     const result = await surfaceProxyResolver(ctx, "ui_show", {
       surface_type: "file_upload",
       title: "Upload a receipt",

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -336,6 +336,36 @@ describe("task_progress surface compatibility", () => {
     });
   });
 
+  test("ui_show file_upload normalizes a comma-joined acceptedTypes string", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // The model sometimes emits acceptedTypes as a string instead of string[];
+    // the renderer calls `.join`/`.some` on it (LUM-2574), so the daemon must
+    // hand the client a clean array.
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "file_upload",
+      title: "Upload a receipt",
+      data: {
+        prompt: "Share the receipt",
+        acceptedTypes: "image/*, application/pdf",
+      },
+    });
+
+    expect(result.isError).toBe(false);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "file_upload") return;
+
+    expect(showMessage.data.acceptedTypes).toEqual([
+      "image/*",
+      "application/pdf",
+    ]);
+  });
+
   test("ui_show dynamic_page uses data.html when properly nested", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);

--- a/assistant/src/__tests__/ui-file-upload-surface.test.ts
+++ b/assistant/src/__tests__/ui-file-upload-surface.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { FileUploadSurfaceDataSchema } from "../api/surfaces.js";
 import type {
   FileUploadSurfaceData,
   UiSurfaceShowFileUpload,
@@ -101,5 +102,91 @@ describe("UI surface tool registration", () => {
       "ui_update",
       "ui_dismiss",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileUploadSurfaceDataSchema coercion (LUM-2574)
+// ---------------------------------------------------------------------------
+//
+// `acceptedTypes` is contractually a string[], but the model frequently emits a
+// comma-joined string or a bare string. The renderer calls `.join`/`.some` on
+// it, so a non-array used to throw `acceptedTypes.join is not a function` and
+// crash the surface. The schema coerces every shape back to the array contract.
+
+describe("FileUploadSurfaceDataSchema coercion", () => {
+  test("passes a well-formed payload through unchanged", () => {
+    expect(
+      FileUploadSurfaceDataSchema.parse({
+        prompt: "Share the receipt PDF",
+        acceptedTypes: ["image/*", "application/pdf"],
+        maxFiles: 3,
+      }),
+    ).toEqual({
+      prompt: "Share the receipt PDF",
+      acceptedTypes: ["image/*", "application/pdf"],
+      maxFiles: 3,
+    });
+  });
+
+  test("coerces a comma-joined acceptedTypes string into an array", () => {
+    expect(
+      FileUploadSurfaceDataSchema.parse({
+        prompt: "p",
+        acceptedTypes: "image/*, application/pdf",
+      }).acceptedTypes,
+    ).toEqual(["image/*", "application/pdf"]);
+  });
+
+  test("wraps a single acceptedTypes string into a one-element array", () => {
+    expect(
+      FileUploadSurfaceDataSchema.parse({ acceptedTypes: "application/pdf" })
+        .acceptedTypes,
+    ).toEqual(["application/pdf"]);
+  });
+
+  test("the parsed acceptedTypes always supports .join (the crash site)", () => {
+    const parsed = FileUploadSurfaceDataSchema.parse({
+      acceptedTypes: "image/*,application/pdf",
+    });
+    // This call is exactly what threw in production before the fix.
+    expect(parsed.acceptedTypes?.join(",")).toBe("image/*,application/pdf");
+  });
+
+  test("drops blanks and non-string entries from an array", () => {
+    expect(
+      FileUploadSurfaceDataSchema.parse({
+        acceptedTypes: [" application/pdf ", "", null, 42, {}],
+      }).acceptedTypes,
+    ).toEqual(["application/pdf", "42"]);
+  });
+
+  test("treats a non-string, non-array acceptedTypes as absent", () => {
+    expect(
+      FileUploadSurfaceDataSchema.parse({ acceptedTypes: { pdf: true } })
+        .acceptedTypes,
+    ).toBeUndefined();
+    expect(
+      FileUploadSurfaceDataSchema.parse({ acceptedTypes: null }).acceptedTypes,
+    ).toBeUndefined();
+  });
+
+  test("coerces numeric-string maxFiles and drops invalid numbers", () => {
+    const parsed = FileUploadSurfaceDataSchema.parse({
+      maxFiles: "2",
+      maxSizeBytes: "not-a-number",
+    });
+    expect(parsed.maxFiles).toBe(2);
+    expect(parsed.maxSizeBytes).toBeUndefined();
+  });
+
+  test("never rejects a fully malformed payload", () => {
+    expect(
+      FileUploadSurfaceDataSchema.safeParse({
+        prompt: 5,
+        acceptedTypes: 99,
+        maxFiles: -1,
+      }).success,
+    ).toBe(true);
   });
 });

--- a/assistant/src/__tests__/ui-file-upload-surface.test.ts
+++ b/assistant/src/__tests__/ui-file-upload-surface.test.ts
@@ -106,13 +106,12 @@ describe("UI surface tool registration", () => {
 });
 
 // ---------------------------------------------------------------------------
-// FileUploadSurfaceDataSchema coercion (LUM-2574)
+// FileUploadSurfaceDataSchema coercion
 // ---------------------------------------------------------------------------
 //
 // `acceptedTypes` is contractually a string[], but the model frequently emits a
 // comma-joined string or a bare string. The renderer calls `.join`/`.some` on
-// it, so a non-array used to throw `acceptedTypes.join is not a function` and
-// crash the surface. The schema coerces every shape back to the array contract.
+// it, so the schema coerces every shape to the array contract.
 
 describe("FileUploadSurfaceDataSchema coercion", () => {
   test("passes a well-formed payload through unchanged", () => {
@@ -145,11 +144,11 @@ describe("FileUploadSurfaceDataSchema coercion", () => {
     ).toEqual(["application/pdf"]);
   });
 
-  test("the parsed acceptedTypes always supports .join (the crash site)", () => {
+  test("the parsed acceptedTypes always supports .join", () => {
     const parsed = FileUploadSurfaceDataSchema.parse({
       acceptedTypes: "image/*,application/pdf",
     });
-    // This call is exactly what threw in production before the fix.
+    // `.join` is the call the renderer makes on `acceptedTypes`.
     expect(parsed.acceptedTypes?.join(",")).toBe("image/*,application/pdf");
   });
 

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -477,7 +477,12 @@ export {
   type WorkflowLeaf,
   WorkflowLeafSchema,
 } from "./responses/workflow-journal.js";
-export { type CardSurfaceData, CardSurfaceDataSchema } from "./surfaces.js";
+export {
+  type CardSurfaceData,
+  CardSurfaceDataSchema,
+  type FileUploadSurfaceData,
+  FileUploadSurfaceDataSchema,
+} from "./surfaces.js";
 
 /**
  * Canonical SSE event schema for the assistant runtime.

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -11,9 +11,9 @@
  * normalizer *supports* — anything the model sends outside these fields is
  * dropped (and logged) there, which is how we learn the shapes to recover.
  *
- * Card is the first surface type migrated to a canonical schema; the remaining
- * types still live as hand-written interfaces in
- * `daemon/message-types/surfaces.ts` pending migration.
+ * Card and file_upload are migrated to canonical schemas; the remaining types
+ * still live as hand-written interfaces in `daemon/message-types/surfaces.ts`
+ * pending migration.
  */
 
 import { z } from "zod";
@@ -31,3 +31,41 @@ export const CardSurfaceDataSchema = z.object({
   templateData: z.record(z.string(), z.unknown()).optional(),
 });
 export type CardSurfaceData = z.infer<typeof CardSurfaceDataSchema>;
+
+/**
+ * Accepted MIME-type / extension patterns for a `file_upload` surface.
+ *
+ * The contract is `string[]`, but the model frequently emits a single
+ * comma-joined string ("image/*, application/pdf") or a bare string instead.
+ * The renderer calls `.join`/`.some`/`.length` on this value, so a non-array
+ * here throws `acceptedTypes.join is not a function` and crashes the surface
+ * (LUM-2574) — `?.` guards nullish, not a wrong type. Coerce every shape to a
+ * clean `string[]` so the array contract the renderer relies on always holds:
+ * a string is split on commas; array entries are stringified and trimmed;
+ * blanks and anything non-array collapse to `undefined` (no restriction).
+ */
+const FileUploadAcceptedTypesSchema = z.preprocess((value) => {
+  const items =
+    typeof value === "string"
+      ? value.split(",")
+      : Array.isArray(value)
+        ? value
+        : [];
+  const cleaned = items
+    .map((item) =>
+      typeof item === "string" || typeof item === "number"
+        ? String(item).trim()
+        : "",
+    )
+    .filter((item) => item.length > 0);
+  return cleaned.length > 0 ? cleaned : undefined;
+}, z.array(z.string()).optional());
+
+export const FileUploadSurfaceDataSchema = z.object({
+  prompt: z.coerce.string().optional(),
+  acceptedTypes: FileUploadAcceptedTypesSchema,
+  /** A non-positive or non-numeric value is dropped rather than rejecting the surface. */
+  maxFiles: z.coerce.number().int().positive().optional().catch(undefined),
+  maxSizeBytes: z.coerce.number().positive().optional().catch(undefined),
+});
+export type FileUploadSurfaceData = z.infer<typeof FileUploadSurfaceDataSchema>;

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -11,9 +11,9 @@
  * normalizer *supports* — anything the model sends outside these fields is
  * dropped (and logged) there, which is how we learn the shapes to recover.
  *
- * Card and file_upload are migrated to canonical schemas; the remaining types
- * still live as hand-written interfaces in `daemon/message-types/surfaces.ts`
- * pending migration.
+ * Card and file_upload use canonical schemas; the remaining types are
+ * hand-written interfaces in `daemon/message-types/surfaces.ts` pending
+ * migration.
  */
 
 import { z } from "zod";
@@ -35,14 +35,12 @@ export type CardSurfaceData = z.infer<typeof CardSurfaceDataSchema>;
 /**
  * Accepted MIME-type / extension patterns for a `file_upload` surface.
  *
- * The contract is `string[]`, but the model frequently emits a single
- * comma-joined string ("image/*, application/pdf") or a bare string instead.
- * The renderer calls `.join`/`.some`/`.length` on this value, so a non-array
- * here throws `acceptedTypes.join is not a function` and crashes the surface
- * (LUM-2574) — `?.` guards nullish, not a wrong type. Coerce every shape to a
- * clean `string[]` so the array contract the renderer relies on always holds:
- * a string is split on commas; array entries are stringified and trimmed;
- * blanks and anything non-array collapse to `undefined` (no restriction).
+ * The renderer consumes this as a `string[]` — it calls `.join`/`.some`/
+ * `.length` on the value — but the model may emit a single comma-joined string
+ * ("image/*, application/pdf") or a bare string. Coercing every shape to a
+ * clean `string[]` keeps that array invariant intact: a string is split on
+ * commas; array entries are stringified and trimmed; blanks and any non-array
+ * value collapse to `undefined` (no restriction).
  */
 const FileUploadAcceptedTypesSchema = z.preprocess((value) => {
   const items =

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -863,12 +863,10 @@ function normalizeOAuthConnectShowData(
 function normalizeFileUploadShowData(
   rawData: Record<string, unknown>,
 ): FileUploadSurfaceData {
-  // The schema is tolerant (every field optional, coerced) and recovers the
-  // common malformed `acceptedTypes` shapes — a comma-joined string or a bare
-  // string the model sends instead of string[] — into the array the renderer
-  // requires, so a non-array can no longer reach `acceptedTypes.join` and crash
-  // the surface (LUM-2574). Parse, don't assert, so an unmodelled shape yields a
-  // renderable surface rather than a passthrough that throws downstream.
+  // Parse against the canonical schema so the surface carries the shape the
+  // renderer expects. The schema is tolerant (every field optional and coerced)
+  // and recovers the common malformed `acceptedTypes` shapes — a comma-joined or
+  // bare string — into the `string[]` the renderer requires.
   const parsed = FileUploadSurfaceDataSchema.safeParse(rawData);
   if (parsed.success) {
     return parsed.data;

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -3,7 +3,10 @@ import { v4 as uuid } from "uuid";
 import { z } from "zod";
 
 import { SurfaceActionSchema } from "../api/events/ui-surface-show.js";
-import { CardSurfaceDataSchema } from "../api/surfaces.js";
+import {
+  CardSurfaceDataSchema,
+  FileUploadSurfaceDataSchema,
+} from "../api/surfaces.js";
 import { isActivationSession } from "../memory/activation-session-store.js";
 import {
   addAppConversationId,
@@ -56,6 +59,7 @@ import type {
   ConfirmationSurfaceData,
   CopyBlockSurfaceData,
   DynamicPageSurfaceData,
+  FileUploadSurfaceData,
   FormSurfaceData,
   ListSurfaceData,
   OAuthConnectSurfaceData,
@@ -854,6 +858,26 @@ function normalizeOAuthConnectShowData(
       ? { logoUrl: rawData.logoUrl }
       : {}),
   };
+}
+
+function normalizeFileUploadShowData(
+  rawData: Record<string, unknown>,
+): FileUploadSurfaceData {
+  // The schema is tolerant (every field optional, coerced) and recovers the
+  // common malformed `acceptedTypes` shapes — a comma-joined string or a bare
+  // string the model sends instead of string[] — into the array the renderer
+  // requires, so a non-array can no longer reach `acceptedTypes.join` and crash
+  // the surface (LUM-2574). Parse, don't assert, so an unmodelled shape yields a
+  // renderable surface rather than a passthrough that throws downstream.
+  const parsed = FileUploadSurfaceDataSchema.safeParse(rawData);
+  if (parsed.success) {
+    return parsed.data;
+  }
+  log.warn(
+    { issues: parsed.error.issues },
+    "ui_show file_upload data failed FileUploadSurfaceDataSchema; rendering an empty file_upload surface",
+  );
+  return {};
 }
 
 function buildChoiceActions(data: ChoiceSurfaceData): Array<{
@@ -2922,7 +2946,9 @@ export async function surfaceProxyResolver(
               ? normalizeOAuthConnectShowData(rawData)
               : surfaceType === "dynamic_page"
                 ? normalizeDynamicPageShowData(input, rawData)
-                : (rawData as SurfaceData);
+                : surfaceType === "file_upload"
+                  ? normalizeFileUploadShowData(rawData)
+                  : (rawData as SurfaceData);
     // Parse actions through the schema instead of typecasting raw model output.
     // The model may place actions inside `data` instead of the top-level
     // `actions` param — recover them so they aren't silently dropped.

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -3,14 +3,21 @@
 import {
   type CardSurfaceData,
   CardSurfaceDataSchema,
+  type FileUploadSurfaceData,
+  FileUploadSurfaceDataSchema,
 } from "../../api/surfaces.js";
 
 // Surface `data` shapes are wire payloads owned by `@vellumai/assistant-api`.
-// Card is migrated (canonical Zod schema); the remaining types below are still
-// hand-written interfaces pending migration. Re-exported so the daemon's
-// surface protocol barrel (`message-protocol.ts`) keeps surfacing them to
-// daemon consumers under their canonical names.
-export { type CardSurfaceData, CardSurfaceDataSchema };
+// Card and file_upload are migrated (canonical Zod schemas); the remaining
+// types below are still hand-written interfaces pending migration. Re-exported
+// so the daemon's surface protocol barrel (`message-protocol.ts`) keeps
+// surfacing them to daemon consumers under their canonical names.
+export {
+  type CardSurfaceData,
+  CardSurfaceDataSchema,
+  type FileUploadSurfaceData,
+  FileUploadSurfaceDataSchema,
+};
 
 // === Surface type definitions ===
 
@@ -153,13 +160,6 @@ export interface DynamicPageSurfaceData {
   reloadGeneration?: number;
   status?: string;
   preview?: DynamicPagePreview;
-}
-
-export interface FileUploadSurfaceData {
-  prompt: string;
-  acceptedTypes?: string[];
-  maxFiles?: number;
-  maxSizeBytes?: number;
 }
 
 export interface TableColumn {

--- a/clients/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, File, Loader2, Upload, X } from "lucide-react";
 import { type ChangeEvent, type DragEvent, useCallback, useRef, useState } from "react";
 
 import { Button } from "@vellumai/design-library";
+import { FileUploadSurfaceDataSchema } from "@vellumai/assistant-api";
 import type { Surface } from "@/domains/chat/types/types";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
@@ -9,13 +10,6 @@ import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-mes
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface FileUploadSurfaceData {
-  prompt: string;
-  acceptedTypes?: string[];
-  maxFiles?: number;
-  maxSizeBytes?: number;
-}
 
 interface FileUploadSurfaceProps {
   surface: Surface;
@@ -101,7 +95,13 @@ function readFileAsBase64(file: File): Promise<string> {
 // ---------------------------------------------------------------------------
 
 export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps) {
-  const data = surface.data as unknown as FileUploadSurfaceData;
+  // The wire keeps surface `data` opaque; narrow it with the canonical schema
+  // (every field optional/coerced, so a real surface never fails to parse)
+  // rather than an unchecked cast. The schema also normalizes `acceptedTypes`
+  // into a string[], so a model-sent string can't reach `.join`/`.some` and
+  // crash the render (LUM-2574).
+  const parsed = FileUploadSurfaceDataSchema.safeParse(surface.data);
+  const data = parsed.success ? parsed.data : {};
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -266,7 +266,7 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
       )}
 
       <ChatMarkdownMessage
-        content={data.prompt}
+        content={data.prompt ?? ""}
         className="mb-3 text-body-medium-lighter text-[var(--content-strong)]"
       />
 

--- a/clients/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
@@ -96,10 +96,9 @@ function readFileAsBase64(file: File): Promise<string> {
 
 export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps) {
   // The wire keeps surface `data` opaque; narrow it with the canonical schema
-  // (every field optional/coerced, so a real surface never fails to parse)
-  // rather than an unchecked cast. The schema also normalizes `acceptedTypes`
-  // into a string[], so a model-sent string can't reach `.join`/`.some` and
-  // crash the render (LUM-2574).
+  // (every field optional/coerced, so a real surface never fails to parse). The
+  // schema also coerces `acceptedTypes` to a string[], the shape this
+  // component's `.join`/`.some` calls require.
   const parsed = FileUploadSurfaceDataSchema.safeParse(surface.data);
   const data = parsed.success ? parsed.data : {};
   const fileInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Summary

Fixes [LUM-2574](https://linear.app/vellum/issue/LUM-2574/typeerror-nacceptedtypesjoin-is-not-a-function) — `TypeError: n.acceptedTypes?.join is not a function`, a route-render crash reported from the macOS app (Sentry `VELLUM-ASSISTANT-MACOS-1RM`).

## Root cause

The `file_upload` surface renderer (`file-upload-surface.tsx`) trusts that `acceptedTypes` is a `string[]` and calls `.join` / `.some` / `.length` on it. But surface `data` is **LLM-produced** and the `ui_show` tool declares `data` as an opaque object with no inner validation. When the model emits `acceptedTypes` as a **string** (e.g. a comma-joined `"image/*, application/pdf"`, or a single MIME type), the optional chain `acceptedTypes?.join` still throws — `?.` guards **nullish, not a wrong type**. The malformed surface was persisted in conversation history, so it re-crashed on every load of that conversation (hence `boundary: route-render`).

Underlying gap: `file_upload` is one of the surface types that still flowed through **unvalidated**. `surfaces.ts` documents that Card was migrated to a canonical Zod schema (daemon normalizes on creation + client re-parses on render) and the rest are "pending migration." In the `ui_show` assembly, `card`/`choice`/`copy_block`/`oauth_connect`/`dynamic_page` each get a normalizer; `file_upload` fell to the raw passthrough.

## What changed

Migrates `file_upload` to the same canonical-schema pattern as Card — **defense in depth**, so both new and already-persisted payloads are safe:

- **`api/surfaces.ts`** — add a tolerant `FileUploadSurfaceDataSchema`. `acceptedTypes` is coerced to a clean `string[]`: a comma string is split, array entries are stringified/trimmed, blanks dropped, and anything non-array collapses to `undefined` (no restriction). `maxFiles`/`maxSizeBytes` are numeric-coerced with invalid values dropped.
- **`daemon/conversation-surfaces.ts`** — add `normalizeFileUploadShowData` and wire it into the `ui_show` assembly, so the persisted/broadcast wire payload is well-formed going forward (also benefits Slack/history/any non-web consumer).
- **`clients/web/.../file-upload-surface.tsx`** — replace the unchecked `as unknown as` cast with `FileUploadSurfaceDataSchema.safeParse(surface.data)`, mirroring `card-surface.tsx`. **This is what fixes the already-persisted crash.**
- **`api/index.ts`, `daemon/message-types/surfaces.ts`** — export the schema and make `FileUploadSurfaceData` the schema-inferred type (single source of truth); remove the hand-written interface.

## Test plan

- New schema coercion tests (`ui-file-upload-surface.test.ts`): comma string → array, single string → one-element array, junk-array cleanup, non-array → absent, numeric-string coercion, never-rejects. Includes a test asserting `parsed.acceptedTypes?.join(",")` works — exactly the call that threw.
- New daemon normalizer test (`conversation-surfaces-task-progress.test.ts`): a `ui_show` with a comma-joined `acceptedTypes` string is broadcast as an array. Existing clean-passthrough test still holds.
- ✅ `bun test` (file_upload + conversation-surfaces + card-surface suites), ✅ typecheck (assistant + web), ✅ eslint (assistant + web) — all green locally and via the pre-commit hook.

## Risk

Low. The schema is strictly additive tolerance — clean payloads pass through unchanged. `prompt` becomes optional in the inferred type (handled at the one render site); no daemon code constructs this type by hand. No new dependency (Zod already bundled for Card).

## Alternatives considered

- **Client-only `safeParse`** — fixes the crash but keeps persisting malformed data and diverges from the Card precedent.
- **Inline one-field coercion** — band-aid; doesn't establish a contract and contradicts the documented migration direction.
- **Per-surface React error boundary** — masks the symptom and would hide future shape bugs.
- **Hard-reject non-array in the tool schema** — makes a renderable surface vanish; tolerant normalize (Postel's law) matches how Card recovers.

Fixes VELLUM-ASSISTANT-MACOS-1RM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC31UT45yjNX9m1CtLkFbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EC31UT45yjNX9m1CtLkFbr)_