### PR TITLE
fix(subagent): advisor consult — route-aware web search, no fork framing, drop redundant parentSystemPrompt

### DIFF
--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -11,7 +11,7 @@
  * its real setUpSubagent → runSubagent path against a controllable fake
  * Conversation without touching SQLite or a real provider.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message } from "../providers/types.js";
@@ -42,6 +42,8 @@ interface FakeConversationConfig {
 let nextConversationConfig: FakeConversationConfig = {};
 /** Set true when any FakeConversation's runAgentLoop is invoked. */
 let runLoopInvoked = false;
+/** The first user message persisted by the most recent FakeConversation. */
+let lastPersistedUserMessage: string | undefined;
 
 class FakeConversation {
   messages: Message[];
@@ -86,7 +88,8 @@ class FakeConversation {
   }
   injectInheritedContext() {}
 
-  persistUserMessage() {
+  persistUserMessage(args: { content: string }) {
+    lastPersistedUserMessage = args.content;
     return { id: "msg-id", deduplicated: false };
   }
 
@@ -387,6 +390,79 @@ describe("SubagentManager.spawnAndAwait", () => {
     await expect(manager.spawnAndAwait(makeConfig(), () => {})).rejects.toThrow(
       "boom",
     );
+  });
+});
+
+describe("SubagentManager — first user message framing", () => {
+  const advisorTrailingText = {
+    messages: [
+      {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "advice" }],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    lastPersistedUserMessage = undefined;
+  });
+
+  test("advisor consult sends the bare advice request (no FORK TASK wrapper)", async () => {
+    nextConversationConfig = advisorTrailingText;
+
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(
+      makeConfig({
+        objective: "Please advise.",
+        fork: true,
+        role: "advisor",
+        // The advisor always supplies its own framing; setUpSubagent uses it
+        // verbatim and never falls back to parentSystemPrompt.
+        systemPromptOverride: "You are a senior advisor.",
+        parentMessages: [
+          { role: "user", content: [{ type: "text", text: "prior turn" }] },
+        ],
+      }),
+      () => {},
+    );
+
+    // The advisor's user turn is the bare advice request — the generic fork
+    // directive would fight the advisor system prompt.
+    expect(lastPersistedUserMessage).toBe("Please advise.");
+    expect(lastPersistedUserMessage).not.toContain("FORK TASK");
+  });
+
+  test("a non-advisor fork still wraps the objective in FORK TASK framing", async () => {
+    nextConversationConfig = advisorTrailingText;
+
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(
+      makeConfig({
+        objective: "Investigate the bug.",
+        fork: true,
+        parentSystemPrompt: "Parent prompt.",
+        parentMessages: [
+          { role: "user", content: [{ type: "text", text: "prior turn" }] },
+        ],
+      }),
+      () => {},
+    );
+
+    expect(lastPersistedUserMessage).toContain("FORK TASK");
+    expect(lastPersistedUserMessage).toContain("Investigate the bug.");
+  });
+
+  test("a non-fork subagent sends the bare objective (no FORK TASK wrapper)", async () => {
+    nextConversationConfig = advisorTrailingText;
+
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(
+      makeConfig({ objective: "Do the thing." }),
+      () => {},
+    );
+
+    expect(lastPersistedUserMessage).toBe("Do the thing.");
+    expect(lastPersistedUserMessage).not.toContain("FORK TASK");
   });
 });
 

--- a/assistant/src/agent/loop-native-web-search.test.ts
+++ b/assistant/src/agent/loop-native-web-search.test.ts
@@ -2,15 +2,26 @@
  * Verifies the agent loop's provider-native web-search gate (used by the
  * tool-less advisor consult): when `enableNativeWebSearch` is set, the loop
  * appends a `web_search`-named SERVER tool to the outbound request and forces
- * `tool_choice: auto` — but ONLY when the resolved provider reports
- * `supportsNativeWebSearch === true`. A non-native provider gets nothing, and
- * the consult stays tool-less (no client `web_search` tool surfaced). Drives the
- * REAL loop, mocking only the provider boundary.
+ * `tool_choice: auto` — but ONLY when the provider/model the call ACTUALLY
+ * routes to reports native-search support. A non-native target gets nothing,
+ * and the consult stays tool-less (no client `web_search` tool surfaced).
+ *
+ * The gate prefers the routing-aware `supportsNativeWebSearchFor(options)` (the
+ * routed (provider, model)'s capability) over the construction-time
+ * `supportsNativeWebSearch` snapshot. The advisor's `advisorProfile` can route
+ * `subagentSpawn` to a provider/model whose native-search support DIFFERS from
+ * the default, so the routed capability — not the default's — must drive the
+ * decision in both directions. Drives the REAL loop, mocking only the provider
+ * boundary.
  */
 import { describe, expect, test } from "bun:test";
 
 import { createMockProvider } from "../__tests__/helpers/mock-provider.js";
-import type { Provider, ProviderResponse } from "../providers/types.js";
+import type {
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
 import { AgentLoop } from "./loop.js";
 
 const endTurn = (text: string): ProviderResponse => ({
@@ -121,5 +132,69 @@ describe("AgentLoop — provider-native web search gate", () => {
 
     const sent = calls[0];
     expect(sent.tools?.filter((t) => t.name === "web_search")).toHaveLength(1);
+  });
+
+  // ── Routed capability drives the decision (not the static default) ────────
+
+  test("false positive: static flag is native but the ROUTED target is not — attaches nothing", async () => {
+    const { provider, calls } = createMockProvider([endTurn("guidance")]);
+    // The construction-time default supports native search…
+    (
+      provider as { supportsNativeWebSearch?: boolean }
+    ).supportsNativeWebSearch = true;
+    // …but the advisorProfile routes `subagentSpawn` to a provider/model that
+    // does NOT. The routing-aware probe wins, so no unexecutable client tool is
+    // surfaced to the otherwise tool-less advisor.
+    (
+      provider as {
+        supportsNativeWebSearchFor?: (o?: SendMessageOptions) => boolean;
+      }
+    ).supportsNativeWebSearchFor = () => false;
+
+    const loop = buildAdvisorLoop(provider, true);
+    await loop.run({ ...baseRun, messages: userMessages });
+
+    const sent = calls[0];
+    expect(sent.tools).toBeUndefined();
+    expect(sent.options?.config?.tool_choice).toBeUndefined();
+  });
+
+  test("false negative: static flag is non-native but the ROUTED target is — attaches the tool", async () => {
+    const { provider, calls } = createMockProvider([endTurn("guidance")]);
+    // The construction-time default lacks native search (flag absent/falsy)…
+    // …but the advisorProfile routes to a provider/model that has it.
+    (
+      provider as {
+        supportsNativeWebSearchFor?: (o?: SendMessageOptions) => boolean;
+      }
+    ).supportsNativeWebSearchFor = () => true;
+
+    const loop = buildAdvisorLoop(provider, true);
+    await loop.run({ ...baseRun, messages: userMessages });
+
+    const sent = calls[0];
+    expect(sent.tools?.map((t) => t.name)).toEqual(["web_search"]);
+    expect(sent.options?.config?.tool_choice).toEqual({ type: "auto" });
+  });
+
+  test("the routing probe receives the loop's callSite", async () => {
+    const { provider, calls } = createMockProvider([endTurn("guidance")]);
+    const probeOptions: (SendMessageOptions | undefined)[] = [];
+    (
+      provider as {
+        supportsNativeWebSearchFor?: (o?: SendMessageOptions) => boolean;
+      }
+    ).supportsNativeWebSearchFor = (o) => {
+      probeOptions.push(o);
+      return true;
+    };
+
+    const loop = buildAdvisorLoop(provider, true);
+    await loop.run({ ...baseRun, messages: userMessages });
+
+    expect(calls).toHaveLength(1);
+    // The probe is resolved against the same callSite the dispatch uses
+    // (`subagentSpawn` per `baseRun`), so the routed (provider, model) matches.
+    expect(probeOptions[0]?.config?.callSite).toBe("subagentSpawn");
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -97,7 +97,9 @@ export interface AgentLoopConfig {
   cacheTtl?: "5m" | "1h";
   /**
    * Give every LLM call provider-native (server-side) web search, gated on the
-   * resolved provider's {@link Provider.supportsNativeWebSearch} capability.
+   * native-search capability of the (provider, model) the call routes to —
+   * {@link Provider.supportsNativeWebSearchFor} when the provider exposes it,
+   * else the static {@link Provider.supportsNativeWebSearch} flag.
    * When both are true, the loop appends a `web_search`-named tool to the
    * outbound request — which Anthropic/OpenAI substitute for their server-side
    * search tool, running the search inline and returning results without a
@@ -133,6 +135,35 @@ const NATIVE_WEB_SEARCH_TOOL: ToolDefinition = {
     required: ["query"],
   },
 };
+
+/**
+ * Build the minimal `SendMessageOptions` a routing-aware provider needs to
+ * report the native web-search capability of the (provider, model) THIS turn
+ * routes to. Mirrors the call-site fields the loop plumbs onto the actual send
+ * (`callSite` + `overrideProfile`/`forceOverrideProfile` + per-conversation
+ * `selectionSeed`) so the capability probe and the dispatch resolve the same
+ * arm. Returns `undefined` when there is no `callSite` (the legacy
+ * default-provider path); `selectionSeed` is omitted for standalone loops with
+ * no conversation id, matching the dispatch path's own guard.
+ */
+function buildNativeWebSearchProbeOptions(
+  callSite: LLMCallSite | undefined,
+  overrideProfile: string | undefined,
+  forceOverrideProfile: boolean,
+  conversationId: string | undefined,
+): SendMessageOptions | undefined {
+  if (!callSite) return undefined;
+  return {
+    config: {
+      callSite,
+      ...(overrideProfile ? { overrideProfile } : {}),
+      ...(overrideProfile && forceOverrideProfile
+        ? { forceOverrideProfile: true }
+        : {}),
+      ...(conversationId ? { selectionSeed: conversationId } : {}),
+    },
+  };
+}
 
 export interface CheckpointInfo {
   turnIndex: number;
@@ -1283,15 +1314,33 @@ export class AgentLoop {
 
         // Provider-native web search: append a `web_search`-named tool that the
         // provider substitutes for its server-side search (run inline, no client
-        // execution), gated STRICTLY on the resolved provider's capability so a
-        // non-native provider never sees an unexecutable client tool. This is a
-        // SERVER tool — it bypasses the client allowlist and the tool executor —
-        // so the tool-less advisor consult can ground its guidance with live web
-        // access while staying one-shot for client tools. Skip when a
-        // `web_search` tool is already present so we never duplicate the name.
+        // execution), gated STRICTLY on the capability of the provider/model
+        // this call ACTUALLY routes to so a non-native provider never sees an
+        // unexecutable client tool. The advisor consult's `advisorProfile` can
+        // route `subagentSpawn` to a provider/model whose native-search support
+        // differs from the construction-time default, so the gate resolves the
+        // routed target (callSite + overrideProfile) via
+        // `supportsNativeWebSearchFor` rather than the static
+        // `this.provider.supportsNativeWebSearch` snapshot; providers without
+        // the routing-aware probe fall back to the static flag. This is a SERVER
+        // tool — it bypasses the client allowlist and the tool executor — so the
+        // tool-less advisor consult can ground its guidance with live web access
+        // while staying one-shot for client tools. Skip when a `web_search` tool
+        // is already present so we never duplicate the name.
+        const supportsRoutedNativeWebSearch = this.provider
+          .supportsNativeWebSearchFor
+          ? this.provider.supportsNativeWebSearchFor(
+              buildNativeWebSearchProbeOptions(
+                callSite,
+                resolveEffectiveOverrideProfile(),
+                forceOverrideProfile,
+                this.conversationId,
+              ),
+            )
+          : this.provider.supportsNativeWebSearch === true;
         const attachNativeWebSearch =
           this.config.enableNativeWebSearch === true &&
-          this.provider.supportsNativeWebSearch === true &&
+          supportsRoutedNativeWebSearch &&
           !resolvedTools.some((t) => t.name === NATIVE_WEB_SEARCH_TOOL.name);
         const currentTools = attachNativeWebSearch
           ? [...resolvedTools, NATIVE_WEB_SEARCH_TOOL]

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -143,6 +143,16 @@ export class CallSiteRoutingProvider implements Provider {
    *
    * Falls back to the default provider's static flag when no `callSite` is set
    * (the legacy short-circuit `selectProvider` also takes).
+   *
+   * Known limitation: this reports the *resolved* target's capability and does
+   * not replay `selectProvider`'s async soft-credential fallback. If the routed
+   * connection has a transient credential failure at send time, `selectProvider`
+   * falls back to the default provider while this probe still reports the routed
+   * target — so a non-native default + native routed target with a credential
+   * blip can attach `web_search` to the fallback non-native provider. The probe
+   * stays sync (the loop assembles tools synchronously) and the worst case is
+   * bounded: the advisor consult that hits it degrades benignly (the unhandled
+   * tool surfaces as a caught failure → "(advisor unavailable)"), not a crash.
    */
   supportsNativeWebSearchFor(options?: SendMessageOptions): boolean {
     const callSite = options?.config?.callSite;

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -34,6 +34,7 @@ import {
 } from "./connection-resolution.js";
 import { listConnections } from "./inference/connections.js";
 import type { ProvidersConfig } from "./registry.js";
+import { shouldUseNativeWebSearch } from "./registry.js";
 import type {
   Message,
   Provider,
@@ -128,6 +129,36 @@ export class CallSiteRoutingProvider implements Provider {
     return isRouted
       ? this._activeProviderContext.run(target.name, doSend)
       : doSend();
+  }
+
+  /**
+   * Native web-search capability of the provider/model THIS call routes to.
+   *
+   * `selectProvider` picks the transport from the routed connection, but each
+   * leaf provider's static `supportsNativeWebSearch` was fixed to the DEFAULT
+   * (provider, model) at boot. Resolving the call-site here — same
+   * `resolveCallSiteConfig` inputs `selectProvider` uses — and recomputing
+   * `shouldUseNativeWebSearch(resolved.provider, resolved.model)` yields the
+   * capability of the routed target instead of the construction-time default.
+   *
+   * Falls back to the default provider's static flag when no `callSite` is set
+   * (the legacy short-circuit `selectProvider` also takes).
+   */
+  supportsNativeWebSearchFor(options?: SendMessageOptions): boolean {
+    const callSite = options?.config?.callSite;
+    if (!callSite) {
+      return this.defaultProvider.supportsNativeWebSearch === true;
+    }
+    const resolved = resolveCallSiteConfig(callSite, getConfig().llm, {
+      overrideProfile: options?.config?.overrideProfile,
+      forceOverrideProfile: options?.config?.forceOverrideProfile,
+      selectionSeed: options?.config?.selectionSeed,
+    });
+    return shouldUseNativeWebSearch(
+      getConfig(),
+      resolved.provider,
+      resolved.model,
+    );
   }
 
   /**

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -58,6 +58,12 @@ export class CallSiteConfiguredProvider implements Provider {
     this.supportsNativeWebSearch = inner.supportsNativeWebSearch;
   }
 
+  supportsNativeWebSearchFor(options?: SendMessageOptions): boolean {
+    return this.inner.supportsNativeWebSearchFor
+      ? this.inner.supportsNativeWebSearchFor(options)
+      : this.inner.supportsNativeWebSearch === true;
+  }
+
   sendMessage(
     messages: Message[],
     options?: SendMessageOptions,

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -27,6 +27,12 @@ export class RateLimitProvider implements Provider {
     return this.inner.supportsNativeWebSearch;
   }
 
+  supportsNativeWebSearchFor(options?: SendMessageOptions): boolean {
+    return this.inner.supportsNativeWebSearchFor
+      ? this.inner.supportsNativeWebSearchFor(options)
+      : this.inner.supportsNativeWebSearch === true;
+  }
+
   private requestTimestamps: number[];
 
   // Forward the optional token-counting endpoint so the capability survives

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -118,7 +118,7 @@ export function isNativeWebSearchCapableProvider(
   return false;
 }
 
-function shouldUseNativeWebSearch(
+export function shouldUseNativeWebSearch(
   config: ProvidersConfig,
   providerName: string,
   model: string,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -622,6 +622,12 @@ export class RetryProvider implements Provider {
     return this.inner.supportsNativeWebSearch;
   }
 
+  supportsNativeWebSearchFor(options?: SendMessageOptions): boolean {
+    return this.inner.supportsNativeWebSearchFor
+      ? this.inner.supportsNativeWebSearchFor(options)
+      : this.inner.supportsNativeWebSearch === true;
+  }
+
   // Forward the optional token-counting endpoint so the capability survives
   // the wrapper chain (callers gate on its presence). Bound straight to the
   // inner provider — count_tokens is a cheap separate endpoint and its caller

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -274,6 +274,19 @@ export interface Provider {
    * unexecutable client tool call. Absent/false on providers without it.
    */
   supportsNativeWebSearch?: boolean;
+  /**
+   * Per-call native web-search capability for the provider/model this specific
+   * request will route to. Unlike the static {@link supportsNativeWebSearch}
+   * flag — fixed to the DEFAULT provider/model at construction — this consults
+   * the resolved call-site (`options.config.callSite` + `overrideProfile`) so a
+   * routing wrapper reports the ROUTED target's capability. Callers that gate a
+   * `web_search` server tool on a possibly-routed call (e.g. the advisor
+   * consult, whose `advisorProfile` may point at a different provider/model)
+   * must use this rather than the construction-time snapshot. Optional: wrappers
+   * forward it to their inner provider; leaf providers may omit it, in which
+   * case callers fall back to {@link supportsNativeWebSearch}.
+   */
+  supportsNativeWebSearchFor?(options?: SendMessageOptions): boolean;
   sendMessage(
     messages: Message[],
     options?: SendMessageOptions,

--- a/assistant/src/providers/usage-tracking.ts
+++ b/assistant/src/providers/usage-tracking.ts
@@ -35,6 +35,12 @@ export class UsageTrackingProvider implements Provider {
     }
   }
 
+  supportsNativeWebSearchFor(options?: SendMessageOptions): boolean {
+    return this.inner.supportsNativeWebSearchFor
+      ? this.inner.supportsNativeWebSearchFor(options)
+      : this.inner.supportsNativeWebSearch === true;
+  }
+
   async sendMessage(
     messages: Message[],
     options?: SendMessageOptions,

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -605,7 +605,16 @@ export class SubagentManager {
       // the fork tends to continue the parent conversation instead of
       // pivoting to the task — the inherited context is louder than a bare
       // objective buried after 100k+ tokens of chat history.
-      const message = managed.state.isFork
+      //
+      // The advisor consult is the exception: it is a fork, but its
+      // `systemPromptOverride` already frames the inherited context as advice
+      // ("you are a senior advisor … do not write its final deliverable"), so
+      // the generic "complete this task and return your findings" wrapper would
+      // fight that framing. The advisor's objective is already the bare advice
+      // request (`advisorRequestText()`), so it is sent uncontested.
+      const useForkFraming =
+        managed.state.isFork && managed.state.config.role !== "advisor";
+      const message = useForkFraming
         ? [
             "⎯⎯⎯ FORK TASK ⎯⎯⎯",
             "You have been forked from the parent conversation to execute a specific task.",

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -262,7 +262,6 @@ async function runAdvisorConsult(args: {
         role: "advisor",
         fork: true,
         parentMessages: sanitizedMessages,
-        parentSystemPrompt,
         systemPromptOverride: buildAdvisorSystem(parentSystemPrompt),
         ...(overrideProfile ? { overrideProfile } : {}),
         ...(forceOverrideProfile ? { forceOverrideProfile: true } : {}),


### PR DESCRIPTION
## Summary
- Gate native web search on the advisor-routed provider's capability (new Provider.supportsNativeWebSearchFor resolving callSite + overrideProfile), not the construction-time default — fixes false-positive (unexecutable client web_search surfaced to the tool-less advisor) and false-negative (search silently disabled) when advisorProfile routes to a different provider/model.
- Skip the generic FORK TASK framing for the advisor consult so its user turn (advisorRequestText) doesn't fight the advisor system prompt.
- Drop the redundant parentSystemPrompt field from the advisor spawnAndAwait config (systemPromptOverride already bakes it in).

Self-review remediation for plan: advisor-as-subagent-role.md (recovered after the implementing agent timed out post-implementation; tsc + targeted tests verified green before ship).