### PR TITLE
Use channel-presentation registry for contact channel icons (LUM-2575)

### DIFF
--- a/clients/web/src/domains/contacts/components/contact-channels-section.tsx
+++ b/clients/web/src/domains/contacts/components/contact-channels-section.tsx
@@ -1,14 +1,4 @@
-import {
-    Bot,
-    CheckCircle,
-    Hash,
-    HelpCircle,
-    Mail,
-    MessageSquare,
-    Phone,
-    Send,
-} from "lucide-react";
-import type { CSSProperties } from "react";
+import { CheckCircle } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
@@ -18,6 +8,7 @@ import type {
     ChannelInfo,
     ContactChannelPayload,
 } from "@/domains/contacts/types";
+import { ChannelIcon } from "@/utils/channel-presentation";
 
 const KNOWN_CHANNEL_IDS: ReadonlySet<string> = new Set<ChannelInfo["id"]>([
   "telegram",
@@ -121,33 +112,6 @@ interface ContactChannelsSectionProps {
   onSetupChannel?: (type: string) => void;
   onVerifyChannel?: (type: string) => void;
   onRevokeChannel?: (channelId: string, type: string) => void;
-}
-
-function ChannelIcon({
-  name,
-  className,
-  style,
-}: {
-  name: string;
-  className?: string;
-  style?: CSSProperties;
-}) {
-  switch (name) {
-    case "bot":
-      return <Bot className={className} style={style} />;
-    case "hash":
-      return <Hash className={className} style={style} />;
-    case "send":
-      return <Send className={className} style={style} />;
-    case "phone":
-      return <Phone className={className} style={style} />;
-    case "mail":
-      return <Mail className={className} style={style} />;
-    case "message-square":
-      return <MessageSquare className={className} style={style} />;
-    default:
-      return <HelpCircle className={className} style={style} />;
-  }
 }
 
 export function ContactChannelsSection({
@@ -292,9 +256,8 @@ function ChannelRow({
   return (
     <div className="flex items-center gap-3 py-4">
       <ChannelIcon
-        name={info.icon}
-        className="h-4 w-4 shrink-0"
-        style={{ color: "var(--content-secondary)" }}
+        channelId={info.id}
+        className="h-4 w-4 shrink-0 text-[var(--content-secondary)]"
       />
       <span
         className="text-body-medium-default"


### PR DESCRIPTION
Closes LUM-2575 (follow-up to LUM-2571/LUM-2572).

`contact-channels-section.tsx` carried its own icon-name → Lucide resolver (a local `ChannelIcon`, ~26 lines + 7 lucide imports) that duplicated the shared `channel-presentation` registry. This renders the channel icon by id through the registry instead — single source of truth for channel glyphs.

**Visible effect:** none for slack/telegram/phone (the registry maps them to the same glyphs). Unknown *contact* channels (anything beyond the assistant's own slack/telegram/phone) now show their real channel icon instead of a generic `help-circle` — a small consistency win with the sidebar/footer/header, which already use the registry.

**Deliberately scoped out — `assistant-channels-detail.tsx`:** the explorer flagged its `CHANNEL_META` too, but on inspection it's not a registry-consolidation target:
- its `Icon` is **unreachable** — `isExpandable` is hardcoded `true`, so a chevron always renders and `<meta.Icon>` never does (left alone rather than removed, since it reads as intentional scaffolding for future non-expandable rows);
- its labels are **contextual** ("Phone Calling", not the registry's "Phone"), so pulling labels from the registry would be a copy regression.

Net: −41/+4.

## Test plan
- `tsc --noEmit` clean, `eslint` clean. No colocated/importing tests for this component; the exported `getChannelActionState`/`buildVisibleChannels` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_