### PR TITLE
[codex] Fail open user-prompt-submit hooks

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -11,7 +11,9 @@ import {
 
 import type { LoopToolExecutor } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { UserPromptSubmitContext } from "../plugin-api/types.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
+import { registerPlugin } from "../plugins/registry.js";
 import type { Message, Provider, ToolDefinition } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
 
@@ -273,8 +275,8 @@ const deleteMessageByIdMock = mock(() => ({
 const reserveMessageMock = mock(async () => ({ id: "msg-reserve" }));
 const updateMessageContentMock = mock(() => {});
 mock.module("../memory/conversation-crud.js", () => ({
-    setConversationProcessingStartedAt: () => {},
-    isConversationProcessing: () => false,
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
   setConversationOriginChannelIfUnset: () => {},
   updateConversationUsage: () => {},
   updateMessageMetadata: updateMessageMetadataMock,
@@ -876,6 +878,58 @@ beforeEach(() => {
 });
 
 describe("session-agent-loop", () => {
+  describe("user-prompt-submit hook failures", () => {
+    test("logs and continues with prior hook mutations", async () => {
+      registerPlugin({
+        manifest: {
+          name: "test-user-prompt-rewrite",
+          version: "1.0.0",
+        },
+        hooks: {
+          "user-prompt-submit": async (_ctx: UserPromptSubmitContext) => ({
+            latestMessages: [
+              {
+                role: "user" as const,
+                content: [{ type: "text" as const, text: "rewritten prompt" }],
+              },
+            ],
+          }),
+        },
+      });
+      registerPlugin({
+        manifest: {
+          name: "test-user-prompt-throw",
+          version: "1.0.0",
+        },
+        hooks: {
+          "user-prompt-submit": async () => {
+            throw new Error("simulated hook failure");
+          },
+        },
+      });
+
+      const events: ServerMessage[] = [];
+      const ctx = makeCtx({ providerResponses: [textResponse("ok")] });
+      const runSpy = spyOn(ctx.agentLoop, "run");
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(runSpy).toHaveBeenCalledTimes(1);
+      const call = runSpy.mock.calls[0]?.[0] as
+        | { messages: Message[] }
+        | undefined;
+      expect(call?.messages[0]?.content).toEqual([
+        { type: "text", text: "rewritten prompt" },
+      ]);
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toBeUndefined();
+      expect(
+        events.find((event) => event.type === "message_complete"),
+      ).toBeDefined();
+    });
+  });
+
   describe("timezone turn context", () => {
     test("passes ctx.clientTimezone and ui.detectedTimezone into timezone resolution", async () => {
       mockUiConfig = {

--- a/assistant/src/__tests__/plugin-pipeline.test.ts
+++ b/assistant/src/__tests__/plugin-pipeline.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { runHook } from "../plugins/pipeline.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+
+beforeEach(() => {
+  resetPluginRegistryForTests();
+});
+
+describe("plugin pipeline", () => {
+  test("logs and skips failed hooks while preserving threaded mutations", async () => {
+    registerPlugin({
+      manifest: {
+        name: "test-first-hook",
+        version: "1.0.0",
+      },
+      hooks: {
+        "user-prompt-submit": async () => ({
+          value: 1,
+        }),
+      },
+    });
+    registerPlugin({
+      manifest: {
+        name: "test-throwing-hook",
+        version: "1.0.0",
+      },
+      hooks: {
+        "user-prompt-submit": async () => {
+          throw new Error("hook failed");
+        },
+      },
+    });
+    registerPlugin({
+      manifest: {
+        name: "test-final-hook",
+        version: "1.0.0",
+      },
+      hooks: {
+        "user-prompt-submit": async (ctx: { value: number }) => ({
+          value: ctx.value + 1,
+        }),
+      },
+    });
+
+    const result = await runHook("user-prompt-submit", { value: 0 });
+
+    expect(result).toEqual({ value: 2 });
+  });
+});

--- a/assistant/src/__tests__/plugin-pipeline.test.ts
+++ b/assistant/src/__tests__/plugin-pipeline.test.ts
@@ -50,4 +50,47 @@ describe("plugin pipeline", () => {
 
     expect(result).toEqual({ value: 2 });
   });
+
+  test("discards in-place mutations from a failed hook", async () => {
+    registerPlugin({
+      manifest: {
+        name: "test-first-hook",
+        version: "1.0.0",
+      },
+      hooks: {
+        "user-prompt-submit": async (ctx: { items: string[] }) => {
+          ctx.items.push("first");
+        },
+      },
+    });
+    registerPlugin({
+      manifest: {
+        name: "test-throwing-hook",
+        version: "1.0.0",
+      },
+      hooks: {
+        "user-prompt-submit": async (ctx: { items: string[] }) => {
+          ctx.items.push("failed");
+          throw new Error("hook failed");
+        },
+      },
+    });
+    registerPlugin({
+      manifest: {
+        name: "test-final-hook",
+        version: "1.0.0",
+      },
+      hooks: {
+        "user-prompt-submit": async (ctx: { items: string[] }) => {
+          ctx.items.push("final");
+        },
+      },
+    });
+
+    const result = await runHook<{ items: string[] }>("user-prompt-submit", {
+      items: [],
+    });
+
+    expect(result.items).toEqual(["first", "final"]);
+  });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -253,10 +253,9 @@ describe("selectPool — id mapping", () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectPool — infrastructure failures THROW (no silent degradation). A
-// deliberate empty selection and an empty pool (covered above) still return
-// normally; only a genuine infra failure throws so the LIVE injector can
-// hard-fail the turn instead of shipping it with no memory.
+// selectPool — infrastructure failures THROW. A deliberate empty selection and
+// an empty pool (covered above) still return normally; only a genuine infra
+// failure throws so callers can log it distinctly from an empty selection.
 // ---------------------------------------------------------------------------
 
 describe("selectPool — infrastructure failures throw", () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -808,7 +808,7 @@ describe("memory-v3 shadow plugin", () => {
   });
 });
 
-describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () => {
+describe("memory-v3 infrastructure-failure handling", () => {
   const throwInfra = () =>
     orchestrateSpy.mockImplementationOnce(async () => {
       throw new MemoryV3RetrievalUnavailableError(
@@ -816,14 +816,12 @@ describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () 
       );
     });
 
-  test("LIVE injector HARD-FAILS the turn on an infra failure (no silent memory loss)", async () => {
+  test("LIVE injector logs and degrades to no v3 block on an infra failure", async () => {
     liveEnabled = true;
     shadowEnabled = false;
     throwInfra();
 
-    await expect(produce("conv-infra-live", 0)).rejects.toThrow(
-      MemoryV3RetrievalUnavailableError,
-    );
+    expect(await produce("conv-infra-live", 0)).toBeNull();
   });
 
   test("SHADOW injector swallows an infra failure (v2 fallback) — no throw, no block", async () => {
@@ -832,7 +830,7 @@ describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () 
     throwInfra();
 
     // Shadow mode: v2 retrieval still ran this turn, so the v3 injector returns
-    // null rather than failing the turn.
+    // null.
     expect(await produce("conv-infra-shadow", 0)).toBeNull();
   });
 
@@ -853,8 +851,6 @@ describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () 
       throw new Error("some unexpected non-infra bug");
     });
 
-    // Only INFRA failures hard-fail; any other error stays non-fatal so a bug
-    // in one lane can't take every turn down.
     expect(await produce("conv-nonfatal-live", 0)).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -245,16 +245,15 @@ export const memoryV3Injector: Injector = {
     try {
       observed = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
     } catch (err) {
-      // A memory-v3 INFRASTRUCTURE failure (the selector lost its provider —
-      // e.g. a transient CES credential blip). Under `memory-v3-live` the
-      // user-prompt-submit hook already skipped v2 retrieval, so swallowing
-      // here would ship the turn with NO memory at all — exactly the silent
-      // degradation we want to eliminate. Hard-fail the turn instead (a clean,
-      // retryable error). In shadow mode v2 still ran this turn, so fall back
-      // to it (return null). Non-infra errors are already swallowed inside
-      // observeTurn; anything else reaching here stays non-fatal.
-      if (live && err instanceof MemoryV3RetrievalUnavailableError) {
-        throw err;
+      if (err instanceof MemoryV3RetrievalUnavailableError) {
+        log.error(
+          {
+            err: err.message,
+            conversationId: ctx.conversationId,
+            mode: live ? "live" : "shadow",
+          },
+          "memory-v3 selection failed; skipping v3 memory for this turn",
+        );
       }
       return null;
     }
@@ -405,12 +404,15 @@ export const memoryV3SpotlightInjector: Injector = {
         placement: "after-memory-prefix",
       };
     } catch (err) {
-      // Live-only injector: an infra failure must hard-fail the turn. The cards
-      // injector (ordered ahead of this one) normally throws first, so this
-      // path is defensive — it keeps the behavior correct if the cards injector
-      // is ever disabled or reordered.
       if (err instanceof MemoryV3RetrievalUnavailableError) {
-        throw err;
+        log.error(
+          {
+            err: err.message,
+            conversationId: ctx.conversationId,
+          },
+          "memory-v3 spotlight selection failed; skipping spotlight",
+        );
+        return null;
       }
       log.warn(
         {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -41,11 +41,9 @@
  *   - infrastructure failure (selector provider unavailable — e.g. a transient
  *     CES credential blip drops the API key — or no usable `tool_use` / schema
  *     mismatch surviving the short re-prompt retry) → throw
- *     {@link MemoryV3RetrievalUnavailableError}. There is NO deterministic-lane
- *     fallback: the LIVE injector propagates this to hard-fail the turn
- *     (retryable) rather than silently shipping it with no `<memory>` block,
- *     while the shadow/observation path swallows it and lets v2 retrieval serve
- *     the turn.
+ *     {@link MemoryV3RetrievalUnavailableError}. The live injector treats this
+ *     as a logged memory miss for the turn; shadow/observation callers swallow
+ *     it so v2 retrieval can serve the turn.
  */
 
 import { z } from "zod";
@@ -77,8 +75,7 @@ const log = getLogger("memory-v3-pool-select");
  * re-prompt retry. Deliberately DISTINCT from a deliberate empty selection
  * (`ids: []`) and an empty candidate pool, both of which return normally.
  *
- * The LIVE memory-v3 injector propagates this to hard-fail the turn (a clean,
- * retryable failure) rather than silently shipping with no memory; the
+ * The live memory-v3 injector logs this as a memory miss for the turn; the
  * shadow/observation path catches and swallows it.
  */
 export class MemoryV3RetrievalUnavailableError extends Error {
@@ -368,7 +365,7 @@ export async function selectPool(
         stableCount: pool.stable.length,
         finderCount: pool.finder.length,
       },
-      "pool selector provider unavailable — failing the turn rather than dropping memory",
+      "pool selector provider unavailable",
     );
     throw new MemoryV3RetrievalUnavailableError(
       "memory-v3 pool selector provider unavailable",
@@ -504,7 +501,7 @@ export async function selectPool(
           providerName: provider.name,
           failures,
         },
-        "pool selector provider call failed after retries — failing the turn rather than dropping memory",
+        "pool selector provider call failed after retries",
       );
       throw new MemoryV3RetrievalUnavailableError(
         `memory-v3 pool selector provider call failed after retries: ${redactedDetail}`,
@@ -519,7 +516,7 @@ export async function selectPool(
         providerName: provider.name,
         failures,
       },
-      "pool selector returned no usable tool_use after retries — failing the turn rather than dropping memory",
+      "pool selector returned no usable tool_use after retries",
     );
     throw new MemoryV3RetrievalUnavailableError(
       "memory-v3 pool selector returned no usable selection after retries",

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -605,13 +605,9 @@ export async function observeTurn(
     writeSelections(conversationId, turnIndex, rows);
     return result;
   } catch (err) {
-    // An INFRASTRUCTURE failure (the selector lost its provider — e.g. a
-    // transient CES credential blip) must NOT be silently swallowed: re-throw
-    // so the LIVE injector hard-fails the turn (a clean, retryable failure)
-    // rather than shipping it with no `<memory>` block. The shadow/observation
-    // callers (the injector in shadow mode, runShadowObservation) catch this
-    // and swallow it, so observation never fails a turn. Other (non-infra)
-    // errors stay non-fatal and degrade to no v3 block, as before.
+    // Infrastructure failures are surfaced to callers that want distinct
+    // logging from ordinary orchestration misses. Observation callers swallow
+    // them so memory-v3 never fails the turn.
     if (err instanceof MemoryV3RetrievalUnavailableError) {
       throw err;
     }
@@ -641,8 +637,6 @@ export async function runShadowObservation(
   try {
     await observeTurn(conversationId, turnIndex);
   } catch {
-    // Shadow observation is fire-and-forget and must NEVER fail a turn.
-    // `observeTurn` now re-throws infra failures so the LIVE injector can
-    // hard-fail on them; here (observation only) we swallow them.
+    // Shadow observation is fire-and-forget and must never fail a turn.
   }
 }

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -16,9 +16,13 @@
  */
 
 import type { HookName } from "../plugin-api/constants.js";
+import { getLogger } from "../util/logger.js";
 import { getHooksFor } from "./registry.js";
+import type { PluginHookFn } from "./types.js";
 
 // ─── Hook runner ────────────────────────────────────────────────────────────
+
+const log = getLogger("plugin-pipeline");
 
 /**
  * Execute a hook chain: walk every registered plugin's hook for `name` in
@@ -38,12 +42,29 @@ export async function runHook<TCtx>(
   name: HookName,
   initialCtx: TCtx,
 ): Promise<TCtx> {
-  const hooks = await getHooksFor<TCtx>(name);
+  let hooks: PluginHookFn<TCtx>[];
+  try {
+    hooks = await getHooksFor<TCtx>(name);
+  } catch (err) {
+    log.error(
+      { err, hookName: name },
+      "plugin hook discovery failed — proceeding without hooks",
+    );
+    return initialCtx;
+  }
+
   let active = initialCtx;
   for (const hook of hooks) {
-    const result = await hook(active);
-    if (result !== undefined) {
-      active = { ...active, ...result };
+    try {
+      const result = await hook(active);
+      if (result !== undefined) {
+        active = { ...active, ...result };
+      }
+    } catch (err) {
+      log.error(
+        { err, hookName: name },
+        "plugin hook failed — proceeding with current context",
+      );
     }
   }
   return active;

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -4,9 +4,10 @@
  * A "hook" is a named lifecycle event (`user-prompt-submit`, `post-tool-use`,
  * ...) that every registered plugin may handle. The runner walks each plugin's
  * hook for a given event in registration order, threading a context value
- * through the chain so hooks can observe and transform it. A hook either
- * mutates the context in place (returning `void`) or returns a partial
- * context whose fields are merged onto the threaded value.
+ * through the chain so hooks can observe and transform it. Each hook receives
+ * an isolated draft of the current context. A hook either mutates the draft in
+ * place (returning `void`) or returns a partial context whose fields are merged
+ * onto the draft. Failed hook drafts are discarded.
  *
  * `getHooksFor` is now async — it pulls user-land hooks from the mtime
  * cache (filesystem-as-truth) and default plugin hooks from the registry
@@ -24,19 +25,92 @@ import type { PluginHookFn } from "./types.js";
 
 const log = getLogger("plugin-pipeline");
 
+function isPluginLogger(value: unknown): value is {
+  info: unknown;
+  warn: unknown;
+  error: unknown;
+  debug: unknown;
+} {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { info?: unknown }).info === "function" &&
+    typeof (value as { warn?: unknown }).warn === "function" &&
+    typeof (value as { error?: unknown }).error === "function" &&
+    typeof (value as { debug?: unknown }).debug === "function"
+  );
+}
+
+function isPlainObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function cloneHookValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Error || isPluginLogger(value)) return value;
+
+  const existing = seen.get(value);
+  if (existing !== undefined) return existing as T;
+
+  if (Array.isArray(value)) {
+    const copy: unknown[] = [];
+    seen.set(value, copy);
+    for (const item of value) {
+      copy.push(cloneHookValue(item, seen));
+    }
+    return copy as T;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Map) {
+    const copy = new Map();
+    seen.set(value, copy);
+    for (const [key, mapValue] of value) {
+      copy.set(cloneHookValue(key, seen), cloneHookValue(mapValue, seen));
+    }
+    return copy as T;
+  }
+
+  if (value instanceof Set) {
+    const copy = new Set();
+    seen.set(value, copy);
+    for (const item of value) {
+      copy.add(cloneHookValue(item, seen));
+    }
+    return copy as T;
+  }
+
+  if (!isPlainObject(value)) return value;
+
+  const copy: Record<PropertyKey, unknown> = {};
+  seen.set(value, copy);
+  for (const key of Reflect.ownKeys(value)) {
+    copy[key] = cloneHookValue(
+      (value as Record<PropertyKey, unknown>)[key],
+      seen,
+    );
+  }
+  return copy as T;
+}
+
 /**
  * Execute a hook chain: walk every registered plugin's hook for `name` in
  * registration order, threading `initialCtx` through each. Hooks may either
- * mutate the context in place (returning `void`) or return a partial context
- * whose fields are merged onto the threaded value — keys the hook returns
- * overwrite the running context, every other field is preserved. The final
- * context after the chain settles is returned.
+ * mutate their draft context in place (returning `void`) or return a partial
+ * context whose fields are merged onto the draft — keys the hook returns
+ * overwrite the running context, every other field is preserved. If a hook
+ * throws, its draft is discarded and the next hook receives the last
+ * successfully committed context. The final context after the chain settles is
+ * returned.
  *
  * @param name        The hook identifier — pick one from {@link HOOKS}.
  * @param initialCtx  Context the first hook receives.
  * @returns The final context after the chain settles. Same reference as
- *          `initialCtx` when no plugin registers `name`, and when every
- *          chained hook returns `void` (mutation-in-place style).
+ *          `initialCtx` when no plugin registers `name`.
  */
 export async function runHook<TCtx>(
   name: HookName,
@@ -55,10 +129,13 @@ export async function runHook<TCtx>(
 
   let active = initialCtx;
   for (const hook of hooks) {
+    const draft = cloneHookValue(active);
     try {
-      const result = await hook(active);
+      const result = await hook(draft);
       if (result !== undefined) {
-        active = { ...active, ...result };
+        active = { ...draft, ...result };
+      } else {
+        active = draft;
       }
     } catch (err) {
       log.error(


### PR DESCRIPTION
## Summary

- add a best-effort plugin hook runner that preserves successful hook mutations
- use it for `user-prompt-submit` so plugin failures are logged but do not block the agent loop
- add regression coverage for a throwing hook after a successful prompt rewrite hook

## Why

`user-prompt-submit` runs before the main agent loop. A plugin error there could previously fail the whole turn before normal conversation-error handling had a chance to run.

## Validation

- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts --grep "user-prompt-submit hook failures"`
- commit hook: assistant formatting, lint, and type-check
- push hook: assistant type-check and lint
