### PR TITLE
[codex] Degrade memory-v3 retrieval failures

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -253,10 +253,9 @@ describe("selectPool — id mapping", () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectPool — infrastructure failures THROW (no silent degradation). A
-// deliberate empty selection and an empty pool (covered above) still return
-// normally; only a genuine infra failure throws so the LIVE injector can
-// hard-fail the turn instead of shipping it with no memory.
+// selectPool — infrastructure failures THROW. A deliberate empty selection and
+// an empty pool (covered above) still return normally; only a genuine infra
+// failure throws so callers can log it distinctly from an empty selection.
 // ---------------------------------------------------------------------------
 
 describe("selectPool — infrastructure failures throw", () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -808,7 +808,7 @@ describe("memory-v3 shadow plugin", () => {
   });
 });
 
-describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () => {
+describe("memory-v3 infrastructure-failure handling", () => {
   const throwInfra = () =>
     orchestrateSpy.mockImplementationOnce(async () => {
       throw new MemoryV3RetrievalUnavailableError(
@@ -816,14 +816,12 @@ describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () 
       );
     });
 
-  test("LIVE injector HARD-FAILS the turn on an infra failure (no silent memory loss)", async () => {
+  test("LIVE injector logs and degrades to no v3 block on an infra failure", async () => {
     liveEnabled = true;
     shadowEnabled = false;
     throwInfra();
 
-    await expect(produce("conv-infra-live", 0)).rejects.toThrow(
-      MemoryV3RetrievalUnavailableError,
-    );
+    expect(await produce("conv-infra-live", 0)).toBeNull();
   });
 
   test("SHADOW injector swallows an infra failure (v2 fallback) — no throw, no block", async () => {
@@ -832,7 +830,7 @@ describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () 
     throwInfra();
 
     // Shadow mode: v2 retrieval still ran this turn, so the v3 injector returns
-    // null rather than failing the turn.
+    // null.
     expect(await produce("conv-infra-shadow", 0)).toBeNull();
   });
 
@@ -853,8 +851,6 @@ describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () 
       throw new Error("some unexpected non-infra bug");
     });
 
-    // Only INFRA failures hard-fail; any other error stays non-fatal so a bug
-    // in one lane can't take every turn down.
     expect(await produce("conv-nonfatal-live", 0)).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -245,16 +245,15 @@ export const memoryV3Injector: Injector = {
     try {
       observed = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
     } catch (err) {
-      // A memory-v3 INFRASTRUCTURE failure (the selector lost its provider —
-      // e.g. a transient CES credential blip). Under `memory-v3-live` the
-      // user-prompt-submit hook already skipped v2 retrieval, so swallowing
-      // here would ship the turn with NO memory at all — exactly the silent
-      // degradation we want to eliminate. Hard-fail the turn instead (a clean,
-      // retryable error). In shadow mode v2 still ran this turn, so fall back
-      // to it (return null). Non-infra errors are already swallowed inside
-      // observeTurn; anything else reaching here stays non-fatal.
-      if (live && err instanceof MemoryV3RetrievalUnavailableError) {
-        throw err;
+      if (err instanceof MemoryV3RetrievalUnavailableError) {
+        log.error(
+          {
+            err: err.message,
+            conversationId: ctx.conversationId,
+            mode: live ? "live" : "shadow",
+          },
+          "memory-v3 selection failed; skipping v3 memory for this turn",
+        );
       }
       return null;
     }
@@ -405,12 +404,15 @@ export const memoryV3SpotlightInjector: Injector = {
         placement: "after-memory-prefix",
       };
     } catch (err) {
-      // Live-only injector: an infra failure must hard-fail the turn. The cards
-      // injector (ordered ahead of this one) normally throws first, so this
-      // path is defensive — it keeps the behavior correct if the cards injector
-      // is ever disabled or reordered.
       if (err instanceof MemoryV3RetrievalUnavailableError) {
-        throw err;
+        log.error(
+          {
+            err: err.message,
+            conversationId: ctx.conversationId,
+          },
+          "memory-v3 spotlight selection failed; skipping spotlight",
+        );
+        return null;
       }
       log.warn(
         {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -41,11 +41,9 @@
  *   - infrastructure failure (selector provider unavailable — e.g. a transient
  *     CES credential blip drops the API key — or no usable `tool_use` / schema
  *     mismatch surviving the short re-prompt retry) → throw
- *     {@link MemoryV3RetrievalUnavailableError}. There is NO deterministic-lane
- *     fallback: the LIVE injector propagates this to hard-fail the turn
- *     (retryable) rather than silently shipping it with no `<memory>` block,
- *     while the shadow/observation path swallows it and lets v2 retrieval serve
- *     the turn.
+ *     {@link MemoryV3RetrievalUnavailableError}. The live injector treats this
+ *     as a logged memory miss for the turn; shadow/observation callers swallow
+ *     it so v2 retrieval can serve the turn.
  */
 
 import { z } from "zod";
@@ -77,8 +75,7 @@ const log = getLogger("memory-v3-pool-select");
  * re-prompt retry. Deliberately DISTINCT from a deliberate empty selection
  * (`ids: []`) and an empty candidate pool, both of which return normally.
  *
- * The LIVE memory-v3 injector propagates this to hard-fail the turn (a clean,
- * retryable failure) rather than silently shipping with no memory; the
+ * The live memory-v3 injector logs this as a memory miss for the turn; the
  * shadow/observation path catches and swallows it.
  */
 export class MemoryV3RetrievalUnavailableError extends Error {
@@ -368,7 +365,7 @@ export async function selectPool(
         stableCount: pool.stable.length,
         finderCount: pool.finder.length,
       },
-      "pool selector provider unavailable — failing the turn rather than dropping memory",
+      "pool selector provider unavailable",
     );
     throw new MemoryV3RetrievalUnavailableError(
       "memory-v3 pool selector provider unavailable",
@@ -504,7 +501,7 @@ export async function selectPool(
           providerName: provider.name,
           failures,
         },
-        "pool selector provider call failed after retries — failing the turn rather than dropping memory",
+        "pool selector provider call failed after retries",
       );
       throw new MemoryV3RetrievalUnavailableError(
         `memory-v3 pool selector provider call failed after retries: ${redactedDetail}`,
@@ -519,7 +516,7 @@ export async function selectPool(
         providerName: provider.name,
         failures,
       },
-      "pool selector returned no usable tool_use after retries — failing the turn rather than dropping memory",
+      "pool selector returned no usable tool_use after retries",
     );
     throw new MemoryV3RetrievalUnavailableError(
       "memory-v3 pool selector returned no usable selection after retries",

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -605,13 +605,9 @@ export async function observeTurn(
     writeSelections(conversationId, turnIndex, rows);
     return result;
   } catch (err) {
-    // An INFRASTRUCTURE failure (the selector lost its provider — e.g. a
-    // transient CES credential blip) must NOT be silently swallowed: re-throw
-    // so the LIVE injector hard-fails the turn (a clean, retryable failure)
-    // rather than shipping it with no `<memory>` block. The shadow/observation
-    // callers (the injector in shadow mode, runShadowObservation) catch this
-    // and swallow it, so observation never fails a turn. Other (non-infra)
-    // errors stay non-fatal and degrade to no v3 block, as before.
+    // Infrastructure failures are surfaced to callers that want distinct
+    // logging from ordinary orchestration misses. Observation callers swallow
+    // them so memory-v3 never fails the turn.
     if (err instanceof MemoryV3RetrievalUnavailableError) {
       throw err;
     }
@@ -641,8 +637,6 @@ export async function runShadowObservation(
   try {
     await observeTurn(conversationId, turnIndex);
   } catch {
-    // Shadow observation is fire-and-forget and must NEVER fail a turn.
-    // `observeTurn` now re-throws infra failures so the LIVE injector can
-    // hard-fail on them; here (observation only) we swallow them.
+    // Shadow observation is fire-and-forget and must never fail a turn.
   }
 }


### PR DESCRIPTION
## Summary

- make live memory-v3 retrieval failures log and return no v3 injection for the turn
- keep shadow/observation behavior non-terminal
- update comments and tests to describe the new non-terminal behavior

## Stack

Base: #36009

## Why

Memory-v3 selector failures should not stop the main agent loop. The worst case is no v3 memory injection for that turn.

## Validation

- `cd assistant && bun test src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts --grep "infrastructure-failure handling"`
- commit hook: assistant formatting, lint, and type-check
- push hook: assistant type-check and lint
