### PR TITLE
[codex] Add non-terminal degradation notice events

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -10,6 +10,10 @@ import {
 } from "bun:test";
 
 import type { LoopToolExecutor } from "../agent/loop.js";
+import {
+  queueConversationNotice,
+  resetConversationNoticesForTests,
+} from "../daemon/conversation-notices.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { UserPromptSubmitContext } from "../plugin-api/types.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
@@ -870,6 +874,7 @@ beforeEach(() => {
   projectAssistantMessageMock.mockClear();
   publishSyncInvalidationMock.mockClear();
   mockMessageById = null;
+  resetConversationNoticesForTests();
   // The compaction pipeline runs through the plugin registry; reset and
   // re-register every default so it dispatches to middleware backed by the
   // mocked collaborators these tests install (`syncMessageToDisk`, etc.)
@@ -924,6 +929,38 @@ describe("session-agent-loop", () => {
       expect(
         events.find((event) => event.type === "conversation_error"),
       ).toBeUndefined();
+      expect(
+        events.find((event) => event.type === "message_complete"),
+      ).toBeDefined();
+    });
+  });
+
+  describe("conversation notices", () => {
+    test("emits queued billing notices after a successful turn", async () => {
+      const events: ServerMessage[] = [];
+      const ctx = makeCtx({ providerResponses: [textResponse("ok")] });
+      queueConversationNotice(ctx.conversationId, "memory-v3-test", {
+        source: "memory_v3",
+        code: "PROVIDER_BILLING",
+        userMessage: "You've run out of credits.",
+        errorCategory: "credits_exhausted",
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toBeUndefined();
+      expect(
+        events.find((event) => event.type === "conversation_notice"),
+      ).toEqual({
+        type: "conversation_notice",
+        conversationId: "test-conv",
+        source: "memory_v3",
+        code: "PROVIDER_BILLING",
+        userMessage: "You've run out of credits.",
+        errorCategory: "credits_exhausted",
+      });
       expect(
         events.find((event) => event.type === "message_complete"),
       ).toBeDefined();

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -873,6 +873,12 @@ beforeEach(() => {
   indexMessageNowMock.mockClear();
   projectAssistantMessageMock.mockClear();
   publishSyncInvalidationMock.mockClear();
+  resolveAssistantAttachmentsMock.mockClear();
+  resolveAssistantAttachmentsMock.mockImplementation(async () => ({
+    assistantAttachments: [],
+    emittedAttachments: [],
+    directiveWarnings: [],
+  }));
   mockMessageById = null;
   resetConversationNoticesForTests();
   // The compaction pipeline runs through the plugin registry; reset and
@@ -951,9 +957,16 @@ describe("session-agent-loop", () => {
       expect(
         events.find((event) => event.type === "conversation_error"),
       ).toBeUndefined();
-      expect(
-        events.find((event) => event.type === "conversation_notice"),
-      ).toEqual({
+      const messageCompleteIndex = events.findIndex(
+        (event) => event.type === "message_complete",
+      );
+      const conversationNoticeIndex = events.findIndex(
+        (event) => event.type === "conversation_notice",
+      );
+
+      expect(messageCompleteIndex).toBeGreaterThanOrEqual(0);
+      expect(conversationNoticeIndex).toBeGreaterThan(messageCompleteIndex);
+      expect(events[conversationNoticeIndex]).toEqual({
         type: "conversation_notice",
         conversationId: "test-conv",
         source: "memory_v3",
@@ -961,8 +974,31 @@ describe("session-agent-loop", () => {
         userMessage: "You've run out of credits.",
         errorCategory: "credits_exhausted",
       });
+    });
+
+    test("clears queued notices when post-loop success work fails", async () => {
+      resolveAssistantAttachmentsMock.mockImplementation(async () => {
+        throw new Error("attachment resolution failed");
+      });
+      const events: ServerMessage[] = [];
+      const ctx = makeCtx({ providerResponses: [textResponse("ok")] });
+      queueConversationNotice(ctx.conversationId, "memory-v3-test", {
+        source: "memory_v3",
+        code: "PROVIDER_BILLING",
+        userMessage: "You've run out of credits.",
+        errorCategory: "credits_exhausted",
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(
+        events.find((event) => event.type === "conversation_notice"),
+      ).toBeUndefined();
       expect(
         events.find((event) => event.type === "message_complete"),
+      ).toBeUndefined();
+      expect(
+        events.find((event) => event.type === "conversation_error"),
       ).toBeDefined();
     });
   });

--- a/assistant/src/api/events/conversation-notice.ts
+++ b/assistant/src/api/events/conversation-notice.ts
@@ -1,0 +1,26 @@
+/**
+ * `conversation_notice` SSE event.
+ *
+ * Non-terminal, conversation-scoped notice for actionable runtime conditions
+ * that should not mark the turn as failed. The client may render CTA UI from
+ * this event while preserving the current assistant response.
+ */
+
+import { z } from "zod";
+
+import { ConversationErrorCodeSchema } from "./conversation-error.js";
+
+export const ConversationNoticeSourceSchema = z.enum(["memory_v3"]);
+
+export const ConversationNoticeEventSchema = z.object({
+  type: z.literal("conversation_notice"),
+  conversationId: z.string(),
+  source: ConversationNoticeSourceSchema,
+  code: ConversationErrorCodeSchema,
+  userMessage: z.string(),
+  errorCategory: z.string().optional(),
+});
+
+export type ConversationNoticeEvent = z.infer<
+  typeof ConversationNoticeEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -11,6 +11,7 @@ import { ConfirmationRequestEventSchema } from "./events/confirmation-request.js
 import { ContactRequestEventSchema } from "./events/contact-request.js";
 import { ConversationErrorEventSchema } from "./events/conversation-error.js";
 import { ConversationListInvalidatedEventSchema } from "./events/conversation-list-invalidated.js";
+import { ConversationNoticeEventSchema } from "./events/conversation-notice.js";
 import { ConversationTitleUpdatedEventSchema } from "./events/conversation-title-updated.js";
 import { DiskPressureStatusChangedEventSchema } from "./events/disk-pressure-status-changed.js";
 import { DocumentCommentCreatedEventSchema } from "./events/document-comment-created.js";
@@ -138,6 +139,11 @@ export {
   type ConversationListInvalidatedReason,
   ConversationListInvalidatedReasonSchema,
 } from "./events/conversation-list-invalidated.js";
+export {
+  type ConversationNoticeEvent,
+  ConversationNoticeEventSchema,
+  ConversationNoticeSourceSchema,
+} from "./events/conversation-notice.js";
 export {
   type ConversationTitleUpdatedEvent,
   ConversationTitleUpdatedEventSchema,
@@ -509,6 +515,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   ContactRequestEventSchema,
   ConversationErrorEventSchema,
   ConversationListInvalidatedEventSchema,
+  ConversationNoticeEventSchema,
   ConversationTitleUpdatedEventSchema,
   DiskPressureStatusChangedEventSchema,
   DocumentCommentCreatedEventSchema,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1021,16 +1021,12 @@ export async function runAgentLoopImpl(
       );
     }
 
-    if (
+    const shouldEmitQueuedConversationNotices =
       !overflowTerminalReason &&
       !yieldedForHandoff &&
       !state.providerErrorUserMessage &&
-      !abortController.signal.aborted
-    ) {
-      for (const notice of drainConversationNotices(ctx.conversationId)) {
-        onEvent(notice);
-      }
-    } else {
+      !abortController.signal.aborted;
+    if (!shouldEmitQueuedConversationNotices) {
       clearConversationNotices(ctx.conversationId);
     }
 
@@ -1426,6 +1422,11 @@ export async function runAgentLoopImpl(
             ? { messageId: state.lastAssistantMessageId }
             : {}),
         });
+        if (shouldEmitQueuedConversationNotices) {
+          for (const notice of drainConversationNotices(ctx.conversationId)) {
+            onEvent(notice);
+          }
+        }
         publishLoopMessagesChanged();
       }
     }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -101,6 +101,10 @@ import {
 } from "./conversation-error.js";
 import { raceWithTimeout } from "./conversation-media-retry.js";
 import {
+  clearConversationNotices,
+  drainConversationNotices,
+} from "./conversation-notices.js";
+import {
   getSlackCompactionWatermarkForPrefix,
   loadSlackChronologicalContext,
   resolveTurnInboundActorContext,
@@ -1017,6 +1021,19 @@ export async function runAgentLoopImpl(
       );
     }
 
+    if (
+      !overflowTerminalReason &&
+      !yieldedForHandoff &&
+      !state.providerErrorUserMessage &&
+      !abortController.signal.aborted
+    ) {
+      for (const notice of drainConversationNotices(ctx.conversationId)) {
+        onEvent(notice);
+      }
+    } else {
+      clearConversationNotices(ctx.conversationId);
+    }
+
     // Flush remaining tool results. On a normal turn these drain at the next
     // `message_complete`; an aborted or yielded loop exits with them still
     // buffered, so finalize the (possibly already on-arrival-reserved) grouped
@@ -1413,6 +1430,7 @@ export async function runAgentLoopImpl(
       }
     }
   } catch (err) {
+    clearConversationNotices(ctx.conversationId);
     const errorCtx = {
       phase: "agent_loop" as const,
       aborted: abortController.signal.aborted,

--- a/assistant/src/daemon/conversation-notices.ts
+++ b/assistant/src/daemon/conversation-notices.ts
@@ -1,0 +1,60 @@
+import type { ConversationNoticeEvent } from "../api/events/conversation-notice.js";
+
+export type PendingConversationNotice = Omit<
+  ConversationNoticeEvent,
+  "type" | "conversationId"
+>;
+
+const MAX_TRACKED_CONVERSATIONS = 256;
+
+const pendingNotices = new Map<
+  string,
+  Map<string, PendingConversationNotice>
+>();
+
+function touchConversation(
+  conversationId: string,
+): Map<string, PendingConversationNotice> {
+  const existing = pendingNotices.get(conversationId);
+  if (existing) {
+    pendingNotices.delete(conversationId);
+    pendingNotices.set(conversationId, existing);
+    return existing;
+  }
+  if (pendingNotices.size >= MAX_TRACKED_CONVERSATIONS) {
+    const oldest = pendingNotices.keys().next().value;
+    if (oldest !== undefined) pendingNotices.delete(oldest);
+  }
+  const next = new Map<string, PendingConversationNotice>();
+  pendingNotices.set(conversationId, next);
+  return next;
+}
+
+export function queueConversationNotice(
+  conversationId: string,
+  key: string,
+  notice: PendingConversationNotice,
+): void {
+  touchConversation(conversationId).set(key, notice);
+}
+
+export function drainConversationNotices(
+  conversationId: string,
+): ConversationNoticeEvent[] {
+  const notices = pendingNotices.get(conversationId);
+  if (!notices) return [];
+  pendingNotices.delete(conversationId);
+  return Array.from(notices.values(), (notice) => ({
+    type: "conversation_notice" as const,
+    conversationId,
+    ...notice,
+  }));
+}
+
+export function clearConversationNotices(conversationId: string): void {
+  pendingNotices.delete(conversationId);
+}
+
+export function resetConversationNoticesForTests(): void {
+  pendingNotices.clear();
+}

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -4,6 +4,7 @@ import type { CompactionCircuitClosedEvent } from "../../api/events/compaction-c
 import type { CompactionCircuitOpenEvent } from "../../api/events/compaction-circuit-open.js";
 import type { ConversationErrorEvent } from "../../api/events/conversation-error.js";
 import type { ConversationListInvalidatedEvent } from "../../api/events/conversation-list-invalidated.js";
+import type { ConversationNoticeEvent } from "../../api/events/conversation-notice.js";
 import type { ConversationTitleUpdatedEvent } from "../../api/events/conversation-title-updated.js";
 import type { GenerationCancelledEvent } from "../../api/events/generation-cancelled.js";
 import type { GenerationHandoffEvent } from "../../api/events/generation-handoff.js";
@@ -543,6 +544,7 @@ export type _ConversationsServerMessages =
   | CompactionCircuitOpenEvent
   | CompactionCircuitClosedEvent
   | ConversationErrorEvent
+  | ConversationNoticeEvent
   | ConversationInfo
   | ConversationTitleUpdatedEvent
   | ConversationListResponse


### PR DESCRIPTION
## Summary

- add a schema for non-terminal `conversation_notice` SSE events
- add an in-memory pending notice queue keyed by conversation and caller-provided key
- drain notices only after successful turns; clear them on terminal/error paths
- add loop coverage for notice emission after a successful assistant response
- provide the generic backend path for user-facing warnings when memory or another pre-loop/background subsystem degrades without failing the turn

## Stack

Base: main

## Why

Some pre-loop/background failures need user-facing UI without marking the assistant response as failed. This provides the backend event path used by follow-up memory-v3 work to tell users when memory is degraded instead of only logging it.

## Validation

- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts --grep "conversation notices"`
- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts`
- `cd assistant && bun run lint src/__tests__/conversation-agent-loop.test.ts src/api/events/conversation-notice.ts src/api/index.ts src/daemon/conversation-agent-loop.ts src/daemon/conversation-notices.ts src/daemon/message-types/conversations.ts`
- `cd assistant && bunx tsc --noEmit`
- `git diff --check`
