### PR TITLE
[codex] Show memory-v3 degradation and billing notices

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -67,13 +67,17 @@ let pruneConfig: {
   maxResidentBytes: number;
   targetResidentBytes: number;
 } | null = null;
-/** Canned orchestrate result per turnIndex; `null` simulates a failed turn. */
-let turnResults = new Map<number, OrchestrateResult | null>();
+/** Canned orchestrate result per turnIndex; `null` simulates an ordinary miss. */
+let turnResults = new Map<number, OrchestrateResult | null | Error>();
 const observeTurnSpy = mock(
   async (
     _conversationId: string,
     turnIndex: number,
-  ): Promise<OrchestrateResult | null> => turnResults.get(turnIndex) ?? null,
+  ): Promise<OrchestrateResult | null> => {
+    const value = turnResults.get(turnIndex) ?? null;
+    if (value instanceof Error) throw value;
+    return value;
+  },
 );
 
 const logCalls: Array<{ data: unknown; msg: string }> = [];
@@ -199,6 +203,9 @@ const {
 } = await import("../ever-injected-store.js");
 const { V3_CARDS_INJECTION_HEADER } = await import("../render-injection.js");
 const { flushPruneValveForTests } = await import("../prune.js");
+const { drainConversationNotices, resetConversationNoticesForTests } =
+  await import("../../../../daemon/conversation-notices.js");
+const { MemoryV3RetrievalUnavailableError } = await import("../pool-select.js");
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -313,6 +320,7 @@ beforeEach(async () => {
   logCalls.length = 0;
   testDb = makeDb();
   resetMemoryV3InjectorStateForTests();
+  resetConversationNoticesForTests();
 });
 
 afterAll(async () => {
@@ -333,6 +341,28 @@ describe("memoryV3Injector — frozen net-new cards", () => {
     expect(await produceSpotlight("conv-1", 0)).toBeNull();
     expect(observeTurnSpy).not.toHaveBeenCalled();
     expect(getActiveSlugs("conv-1")).toEqual(new Set());
+  });
+
+  test("live retrieval failure queues a degraded-memory notice", async () => {
+    liveEnabled = true;
+    turnResults.set(
+      0,
+      new MemoryV3RetrievalUnavailableError("selector unavailable"),
+    );
+
+    await expect(produceCardsWithoutCommit("conv-1", 0)).resolves.toBeNull();
+
+    expect(drainConversationNotices("conv-1")).toEqual([
+      {
+        type: "conversation_notice",
+        conversationId: "conv-1",
+        source: "memory_v3",
+        code: "UNKNOWN",
+        userMessage:
+          "Memory is temporarily unavailable, so this response may not use your saved memories. You can retry in a moment.",
+        errorCategory: "memory_v3_degraded",
+      },
+    ]);
   });
 
   test("turn 1 renders cards; turn 2 re-selecting the same pages renders ZERO new cards", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -26,6 +26,7 @@
  * The provider is stubbed so no network calls fire; mirrors selector.test.ts.
  */
 
+import { createRequire } from "node:module";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
@@ -35,6 +36,7 @@ import type {
   SendMessageOptions,
   ToolUseContent,
 } from "../../../../providers/types.js";
+import { ProviderError } from "../../../../util/errors.js";
 import type { MemoryRoutingTurn } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -43,6 +45,11 @@ import type { MemoryRoutingTurn } from "../types.js";
 // ---------------------------------------------------------------------------
 
 let providerStub: Provider | null = null;
+const registryReal = {
+  ...(createRequire(import.meta.url)(
+    "../../../../providers/registry.js",
+  ) as Record<string, unknown>),
+};
 
 interface ProviderCall {
   messages: Message[];
@@ -55,6 +62,12 @@ mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => providerStub,
   extractToolUse: (response: ProviderResponse) =>
     response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+}));
+
+mock.module("../../../../providers/registry.js", () => ({
+  ...registryReal,
+  getProviderRoutingSource: (providerName: string) =>
+    providerName === "managed" ? "managed-proxy" : "user-key",
 }));
 
 mock.module("../../../../util/logger.js", () => ({
@@ -368,6 +381,38 @@ describe("selectPool — infrastructure failures throw", () => {
       expect.objectContaining({ attempt: 2 }),
       expect.objectContaining({ attempt: 3 }),
     ]);
+  });
+
+  test("managed provider 402 attaches a non-terminal credits notice", async () => {
+    providerStub = {
+      name: "managed",
+      sendMessage: async (messages, options) => {
+        providerCalls.push({ messages, options });
+        throw new ProviderError(
+          "Together AI API error (402): 402 status code (no body)",
+          "managed",
+          402,
+        );
+      },
+    };
+    let caught: unknown;
+    try {
+      await selectPool(makePool(), makeTurn("x"));
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(MemoryV3RetrievalUnavailableError);
+    const notice = (
+      caught as InstanceType<typeof MemoryV3RetrievalUnavailableError>
+    ).conversationNotice;
+    expect(notice).toEqual({
+      source: "memory_v3",
+      code: "PROVIDER_BILLING",
+      userMessage:
+        "You've run out of credits. Add funds to continue using the assistant.",
+      errorCategory: "credits_exhausted",
+    });
   });
 
   test("provider throw redacts sensitive message details in diagnostics", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -63,7 +63,10 @@
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
 import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
-import { queueConversationNotice } from "../../../daemon/conversation-notices.js";
+import {
+  type PendingConversationNotice,
+  queueConversationNotice,
+} from "../../../daemon/conversation-notices.js";
 import { isPersonalMemoryAllowed } from "../../../daemon/trust-context.js";
 import {
   wrapMemoryBlock,
@@ -126,11 +129,18 @@ function queueMemoryV3ConversationNotice(
   ctx: TurnContext,
   live: boolean,
 ): void {
-  if (!live || !err.conversationNotice) return;
+  if (!live) return;
+  const notice: PendingConversationNotice = err.conversationNotice ?? {
+    source: "memory_v3",
+    code: "UNKNOWN",
+    userMessage:
+      "Memory is temporarily unavailable, so this response may not use your saved memories. You can retry in a moment.",
+    errorCategory: "memory_v3_degraded",
+  };
   queueConversationNotice(
     ctx.conversationId,
-    `memory_v3:${ctx.turnIndex}:${err.conversationNotice.errorCategory ?? err.conversationNotice.code}`,
-    err.conversationNotice,
+    `memory_v3:${ctx.turnIndex}:${notice.errorCategory ?? notice.code}`,
+    notice,
   );
 }
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -63,6 +63,7 @@
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
 import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
+import { queueConversationNotice } from "../../../daemon/conversation-notices.js";
 import { isPersonalMemoryAllowed } from "../../../daemon/trust-context.js";
 import {
   wrapMemoryBlock,
@@ -118,6 +119,19 @@ function lruSet<V>(map: Map<string, V>, key: string, value: V): void {
     if (oldest !== undefined) map.delete(oldest);
   }
   map.set(key, value);
+}
+
+function queueMemoryV3ConversationNotice(
+  err: MemoryV3RetrievalUnavailableError,
+  ctx: TurnContext,
+  live: boolean,
+): void {
+  if (!live || !err.conversationNotice) return;
+  queueConversationNotice(
+    ctx.conversationId,
+    `memory_v3:${ctx.turnIndex}:${err.conversationNotice.errorCategory ?? err.conversationNotice.code}`,
+    err.conversationNotice,
+  );
 }
 
 // ─── shared per-turn orchestration memo ─────────────────────────────────────
@@ -246,6 +260,7 @@ export const memoryV3Injector: Injector = {
       observed = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
     } catch (err) {
       if (err instanceof MemoryV3RetrievalUnavailableError) {
+        queueMemoryV3ConversationNotice(err, ctx, live);
         log.error(
           {
             err: err.message,
@@ -405,6 +420,7 @@ export const memoryV3SpotlightInjector: Injector = {
       };
     } catch (err) {
       if (err instanceof MemoryV3RetrievalUnavailableError) {
+        queueMemoryV3ConversationNotice(err, ctx, true);
         log.error(
           {
             err: err.message,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -48,6 +48,8 @@
 
 import { z } from "zod";
 
+import { classifyConversationError } from "../../../daemon/conversation-error.js";
+import type { PendingConversationNotice } from "../../../daemon/conversation-notices.js";
 import { loadPromptOverride } from "../../../memory/prompt-override.js";
 import { cachedTextBlock } from "../../../providers/cache-control.js";
 import {
@@ -79,10 +81,37 @@ const log = getLogger("memory-v3-pool-select");
  * shadow/observation path catches and swallows it.
  */
 export class MemoryV3RetrievalUnavailableError extends Error {
-  constructor(message: string) {
-    super(message);
+  readonly conversationNotice?: PendingConversationNotice;
+
+  constructor(
+    message: string,
+    options?: {
+      cause?: unknown;
+      conversationNotice?: PendingConversationNotice;
+    },
+  ) {
+    super(
+      message,
+      options?.cause === undefined ? undefined : { cause: options.cause },
+    );
     this.name = "MemoryV3RetrievalUnavailableError";
+    this.conversationNotice = options?.conversationNotice;
   }
+}
+
+function providerBillingNoticeFromError(
+  error: unknown,
+): PendingConversationNotice | undefined {
+  const classified = classifyConversationError(error, {
+    phase: "agent_loop",
+  });
+  if (classified.code !== "PROVIDER_BILLING") return undefined;
+  return {
+    source: "memory_v3",
+    code: classified.code,
+    userMessage: classified.userMessage,
+    errorCategory: classified.errorCategory,
+  };
 }
 
 /** A dynamic-tail (finder) candidate: the slug plus the descriptor that
@@ -419,6 +448,12 @@ export async function selectPool(
   // (no usable tool_use, or tool input that fails the schema) re-prompts before
   // we give up. `null` from an attempt means "unusable, retry"; the provider
   // layer already backs off transient throws, so this loop adds no delay.
+  //
+  // `lastError` captures the most recent attempt's thrown provider error —
+  // `retryForResult` swallows attempt throws, so without this an infrastructure
+  // failure (e.g. an upstream HTTP 4xx/5xx) is indistinguishable from a 200 that
+  // carried no usable tool_use. It is cleared on every attempt that reaches a
+  // response, so it reflects the LAST attempt's failure mode.
   let lastError: unknown = null;
   const parsed = await retryForResult(async () => {
     attempt += 1;
@@ -505,6 +540,10 @@ export async function selectPool(
       );
       throw new MemoryV3RetrievalUnavailableError(
         `memory-v3 pool selector provider call failed after retries: ${redactedDetail}`,
+        {
+          cause: lastError,
+          conversationNotice: providerBillingNoticeFromError(lastError),
+        },
       );
     }
     log.warn(

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -53,6 +53,7 @@ export interface ChatSessionState {
   // cached history and this live turn (`selectTranscriptMessages`).
   liveTurn: DisplayMessage[];
   error: ChatError | null;
+  notice: ChatError | null;
   isLoadingHistory: boolean;
 
   // --- Pagination ---
@@ -113,6 +114,7 @@ export interface ChatSessionActions {
   // --- Setters ---
   setLiveTurn: (updater: DisplayMessage[] | ((prev: DisplayMessage[]) => DisplayMessage[])) => void;
   setError: (updater: ChatError | null | ((prev: ChatError | null) => ChatError | null)) => void;
+  setNotice: (updater: ChatError | null | ((prev: ChatError | null) => ChatError | null)) => void;
   setIsLoadingHistory: (value: boolean) => void;
   setTranscriptPagination: (
     updater:
@@ -195,6 +197,7 @@ function initialState(): ChatSessionState {
   return {
     liveTurn: [],
     error: null,
+    notice: null,
     isLoadingHistory: true,
     transcriptPagination: { ...INITIAL_PAGINATION },
     contextWindowUsage: null,
@@ -238,6 +241,9 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
 
   setError: (updater) =>
     set((s) => ({ error: applyUpdater(s.error, updater) })),
+
+  setNotice: (updater) =>
+    set((s) => ({ notice: applyUpdater(s.notice, updater) })),
 
   setIsLoadingHistory: (value) =>
     set({ isLoadingHistory: value }),
@@ -320,6 +326,7 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
       liveTurn: [],
       ephemeralMetaResults: [],
       error: shouldSuppressGenericChatErrorNotice(state.error) ? state.error : null,
+      notice: null,
       isLoadingHistory: true,
       transcriptPagination: { ...INITIAL_PAGINATION },
       contextWindowUsage:

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -66,11 +66,13 @@ mock.module("@vellumai/design-library", () => ({
   Notice: ({
     children,
     actions,
+    tone,
   }: {
     children?: ReactNode;
     actions?: ReactNode;
+    tone?: string;
   }) => (
-    <div data-testid="notice">
+    <div data-testid="notice" data-tone={tone}>
       {children}
       {actions ? <div data-testid="notice-actions">{actions}</div> : null}
     </div>
@@ -325,6 +327,23 @@ describe("ChatBody — generic chat error Notice (dismiss UX)", () => {
 
     expect(html).toContain("Go to Doctor");
     expect(html).toContain("Dismiss");
+  });
+
+  test("renders warning-tone generic notices as status banners", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          genericChatError: {
+            message: "Memory is temporarily unavailable.",
+            tone: "warning",
+          },
+          onDismissChatError: () => {},
+        })}
+      />,
+    );
+
+    expect(html).toContain("Memory is temporarily unavailable.");
+    expect(html).toContain('data-tone="warning"');
   });
 
   test("does NOT render the Dismiss button when onDismissChatError is omitted", () => {

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -10,7 +10,7 @@ import {
     RefreshFeedbackPill,
     type RefreshFeedback,
 } from "@/domains/chat/refresh-feedback-pill";
-import { Button, Notice } from "@vellumai/design-library";
+import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
 
 /**
  * Single composition of a chat panel: a scrollable messages/empty-state
@@ -93,8 +93,12 @@ export interface ChatBodyProps {
   /** Retry handler for {@link refreshFeedback}. */
   onRetryRefresh: () => void;
 
-  /** Generic chat error rendered above the composer, or `null` when none. */
-  genericChatError: { message: string; actions?: ReactNode } | null;
+  /** Generic chat notice rendered above the composer, or `null` when none. */
+  genericChatError: {
+    message: string;
+    actions?: ReactNode;
+    tone?: NoticeTone;
+  } | null;
   /**
    * Dismiss handler for {@link genericChatError}. When provided, the
    * banner renders a "Dismiss" button as a second action next to the
@@ -268,7 +272,7 @@ export function ChatBody({
           {genericChatError && (
             <div className="mb-2">
               <Notice
-                tone="error"
+                tone={genericChatError.tone ?? "error"}
                 actions={
                   <>
                     {genericChatError.actions}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -472,6 +472,7 @@ export function ChatMainPanel({
   const genericChatError = shouldShowGenericChatErrorNotice(error) && error
     ? {
         message: error.message,
+        tone: "error" as const,
         actions: showDoctorAction ? (
           <Button asChild variant="outlined" size="compact">
             <Link to={`${routes.settings.debug}?tab=doctor`}>
@@ -481,12 +482,25 @@ export function ChatMainPanel({
         ) : undefined,
       }
     : null;
+  const hasGenericChatError = genericChatError !== null;
+  const genericChatNotice =
+    shouldShowGenericChatErrorNotice(notice) && notice
+      ? {
+          message: notice.message,
+          tone: "warning" as const,
+        }
+      : null;
+  const genericChatBanner = genericChatError ?? genericChatNotice;
 
   const handleDismissChatError = useCallback(() => {
     // Clears the inline `genericChatError` Notice. The modal variant has
     // its own close handler because it also restores the draft input.
-    useChatSessionStore.getState().setError(null);
-  }, []);
+    if (hasGenericChatError) {
+      useChatSessionStore.getState().setError(null);
+    } else {
+      useChatSessionStore.getState().setNotice(null);
+    }
+  }, [hasGenericChatError]);
 
   const sendErrorModalNode =
     error?.displayAs === "modal" ? (
@@ -841,7 +855,7 @@ export function ChatMainPanel({
         refreshFeedback={refreshFeedback}
         onDismissRefreshFeedback={handleDismissRefreshFeedback}
         onRetryRefresh={handleRetryRefreshFromPill}
-        genericChatError={genericChatError}
+        genericChatError={genericChatBanner}
         onDismissChatError={handleDismissChatError}
         isChannelReadonly={isChannelReadonly}
         canStopGenerating={canStopGenerating}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -206,6 +206,7 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   const messages = useTranscriptMessages(assistantId, activeConversationId);
   const error = useChatSessionStore.use.error();
+  const notice = useChatSessionStore.use.notice();
   const isLoadingHistory = useChatSessionStore.use.isLoadingHistory();
   const contextWindowUsage = useChatSessionStore.use.contextWindowUsage();
   const compactionCircuitOpenUntil = useChatSessionStore.use.compactionCircuitOpenUntil();
@@ -680,7 +681,10 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   // Billing composer banner
   // -------------------------------------------------------------------------
-  const billingBannerDecision = getChatBillingBannerDecision(error);
+  const errorBillingBannerDecision = getChatBillingBannerDecision(error);
+  const noticeBillingBannerDecision = getChatBillingBannerDecision(notice);
+  const billingBannerDecision =
+    errorBillingBannerDecision ?? noticeBillingBannerDecision;
 
   // -------------------------------------------------------------------------
   // JSX construction

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -160,6 +160,7 @@ export function useSendMessage({
   const queryClient = useQueryClient();
   const setLiveTurn = useChatSessionStore.use.setLiveTurn();
   const setError = useChatSessionStore.use.setError();
+  const setNotice = useChatSessionStore.use.setNotice();
 
   // -------------------------------------------------------------------------
   // Server-mint in-flight gate
@@ -623,6 +624,7 @@ export function useSendMessage({
         return;
       }
       setError(null);
+      setNotice(null);
       // Local meta commands (/clean, /status, /commands, /models) never start a
       // turn: resolve them via the daemon and render an ephemeral card.
       if (isLocalMetaCommand(content)) {

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -28,6 +28,7 @@ import {
 import {
   handleStreamError,
   handleConversationErrorEvent,
+  handleConversationNoticeEvent,
 } from "@/domains/chat/utils/stream-handlers/error-handlers";
 import {
   handleSecretRequest,
@@ -232,6 +233,7 @@ export function useStreamEventHandler(
         getTurnState: () => useTurnStore.getState(),
         endTurn,
         setError: store.setError,
+        setNotice: store.setNotice,
         cancelAndClearStream: useStreamStore.getState().cancelAndClearStream,
         cancelReconciliation,
         startReconciliationLoop,
@@ -287,6 +289,9 @@ export function useStreamEventHandler(
           break;
         case "conversation_error":
           handleConversationErrorEvent(event, ctx);
+          break;
+        case "conversation_notice":
+          handleConversationNoticeEvent(event, ctx);
           break;
         case "generation_cancelled":
           handleGenerationCancelled(event, ctx);

--- a/clients/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
@@ -4,6 +4,7 @@ import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import {
   handleStreamError,
   handleConversationErrorEvent,
+  handleConversationNoticeEvent,
 } from "@/domains/chat/utils/stream-handlers/error-handlers";
 
 describe("handleStreamError", () => {
@@ -62,5 +63,31 @@ describe("handleConversationErrorEvent", () => {
       conversationId: "conv-from-event",
       reason: "error",
     });
+  });
+});
+
+describe("handleConversationNoticeEvent", () => {
+  it("sets a non-terminal notice without ending the turn", () => {
+    const ctx = makeCtx();
+    handleConversationNoticeEvent(
+      {
+        type: "conversation_notice",
+        conversationId: "conv-1",
+        source: "memory_v3",
+        code: "PROVIDER_BILLING",
+        userMessage: "You've run out of credits.",
+        errorCategory: "credits_exhausted",
+      },
+      ctx,
+    );
+
+    expect(ctx.setNotice).toHaveBeenCalledWith({
+      message: "You've run out of credits.",
+      code: "PROVIDER_BILLING",
+      errorCategory: "credits_exhausted",
+    });
+    expect(ctx.endTurn).not.toHaveBeenCalled();
+    expect(ctx.cancelAndClearStream).not.toHaveBeenCalled();
+    expect(ctx.setError).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/error-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/error-handlers.ts
@@ -5,6 +5,7 @@ import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/
 import { patchConversation } from "@/utils/conversation-cache";
 import type {
   ConversationErrorEvent,
+  ConversationNoticeEvent,
   ErrorEvent,
 } from "@vellumai/assistant-api";
 
@@ -65,4 +66,15 @@ export function handleConversationErrorEvent(
   if (!isBannerError) {
     ctx.cancelAndClearStream();
   }
+}
+
+export function handleConversationNoticeEvent(
+  event: ConversationNoticeEvent,
+  ctx: StreamHandlerContext,
+): void {
+  ctx.setNotice({
+    message: event.userMessage,
+    code: event.code,
+    errorCategory: event.errorCategory,
+  });
 }

--- a/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -73,6 +73,7 @@ export function makeCtx(
     getTurnState: () => ({ ...INITIAL_TURN_STATE }) as TurnState,
     endTurn: mock(() => {}),
     setError: mock(() => {}),
+    setNotice: mock(() => {}),
     cancelAndClearStream: mock(() => {}),
     cancelReconciliation: mock(() => {}),
     startReconciliationLoop: mock(() => {}),

--- a/clients/web/src/domains/chat/utils/stream-handlers/types.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/types.ts
@@ -58,6 +58,7 @@ export interface StreamHandlerContext {
 
   // --- Error & stream lifecycle ---
   setError: Dispatch<SetStateAction<ChatError | null>>;
+  setNotice: Dispatch<SetStateAction<ChatError | null>>;
   /** Cancel the active SSE stream and clear the store's stream state. */
   cancelAndClearStream: () => void;
 

--- a/clients/web/src/lib/streaming/event-parser.test.ts
+++ b/clients/web/src/lib/streaming/event-parser.test.ts
@@ -1097,6 +1097,29 @@ describe("parseAssistantEvent", () => {
     });
   });
 
+  // ---------------------------------------------------------------------
+  // conversation_notice (schema-validated)
+  // ---------------------------------------------------------------------
+
+  test("parses conversation_notice with billing fields", () => {
+    const event = parseEvent({
+      type: "conversation_notice",
+      conversationId: "conv-1",
+      source: "memory_v3",
+      code: "PROVIDER_BILLING",
+      userMessage: "You've run out of credits.",
+      errorCategory: "credits_exhausted",
+    });
+    expect(event).toEqual({
+      type: "conversation_notice",
+      conversationId: "conv-1",
+      source: "memory_v3",
+      code: "PROVIDER_BILLING",
+      userMessage: "You've run out of credits.",
+      errorCategory: "credits_exhausted",
+    });
+  });
+
   test("parses interaction_resolved with explicit conversationId", () => {
     const event = parseEvent({
       type: "interaction_resolved",


### PR DESCRIPTION
## Summary

- classify managed memory-v3 selector provider billing failures into pending conversation notices
- queue live memory-v3 degradation notices while still skipping memory for the turn so the assistant can answer
- handle `conversation_notice` on the web client without ending the turn
- reuse the existing billing banner CTA for managed billing notices from either terminal `error` or non-terminal `notice`
- show a generic user-facing warning when memory-v3 retrieval is degraded for non-billing reasons

## Stack

Base: #36011

## Why

When the main agent uses BYOK/local/another working profile but memory-v3 uses a managed profile that is out of credits, the assistant can still answer. This PR lets the UI show the billing CTA for that non-terminal managed-memory failure.

It also covers the broader degraded-memory concern: if live memory-v3 retrieval fails for another retrieval-unavailable reason, the user gets a non-blocking warning that the response may not use saved memories instead of silently losing memory for the turn.

## Validation

- `cd assistant && bun test src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts`
- `cd assistant && bun test src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts`
- `cd clients/web && bun test src/domains/chat/components/chat-body.test.tsx src/domains/chat/utils/stream-handlers/error-handlers.test.ts src/lib/streaming/event-parser.test.ts`
- `cd clients/web && bun test src/domains/settings/mcp/mcp-page.test.tsx`
- `cd assistant && bun run lint src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts src/plugins/defaults/memory-v3-shadow/injector.ts src/plugins/defaults/memory-v3-shadow/pool-select.ts`
- `cd clients/web && bun run lint <touched chat/event files>`
- `cd clients/web && bun run lint src/domains/settings/mcp/mcp-page.test.tsx`
- `cd assistant && bunx tsc --noEmit`
- `cd clients/web && bun run typecheck`
- `git diff --check`
