### PR TITLE
feat(telemetry): capture browser client metadata in turn telemetry

### DIFF
--- a/assistant/src/__tests__/client-os-metadata-persistence.test.ts
+++ b/assistant/src/__tests__/client-os-metadata-persistence.test.ts
@@ -163,4 +163,18 @@ describe("client OS surface metadata persistence", () => {
       interface_version: "1.2.3",
     });
   });
+
+  test("transport os fills in when the caller bag omits it", async () => {
+    const ctx = createWebTurnContext("ios");
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-merge",
+      metadata: { client: { browser_family: "safari" } },
+    });
+
+    expect(lastUserMetadata().client).toEqual({
+      os: "ios",
+      browser_family: "safari",
+    });
+  });
 });

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -304,13 +304,18 @@ function makeConversation(overrides: Record<string, unknown> = {}) {
 }
 
 // ── Helper: create an HTTP request to POST /v1/messages ────────────────────
-function makeRequest(content: string, extra: Record<string, unknown> = {}) {
+function makeRequest(
+  content: string,
+  extra: Record<string, unknown> = {},
+  headers: Record<string, string> = {},
+) {
   return new Request("http://localhost/v1/messages", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "x-vellum-actor-principal-id": "test-user",
       "x-vellum-principal-type": "actor",
+      ...headers,
     },
     body: JSON.stringify({
       conversationKey: "parity-test-key",
@@ -332,6 +337,7 @@ async function sendMessage(
       conversationId: string,
       opts?: Record<string, unknown>,
     ) => void;
+    headers?: Record<string, string>;
   } = {},
 ) {
   return callHandler(
@@ -349,7 +355,7 @@ async function sendMessage(
           resolveAttachments: () => [],
         },
       }),
-    makeRequest(content, extra),
+    makeRequest(content, extra, options.headers ?? {}),
     undefined,
     202,
   );
@@ -523,6 +529,152 @@ describe("HTTP POST /v1/messages clientTimezone transport metadata", () => {
     });
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// CLIENT METADATA — sanitized x-vellum-* headers persisted under
+// metadata.client for turn analytics
+// ============================================================================
+describe("HTTP POST /v1/messages client metadata headers", () => {
+  beforeEach(() => {
+    routeGuardianReplyMock.mockClear();
+    listPendingByDestinationMock.mockClear();
+    listCanonicalMock.mockClear();
+    addMessageMock.mockClear();
+  });
+
+  const clientMetadataHeaders = {
+    "x-vellum-browser-family": "safari",
+    "x-vellum-browser-version": "17",
+    "x-vellum-client-os": "ios",
+    "x-vellum-interface-version": "1.2.3",
+  };
+
+  test("persists client metadata on immediate user messages", async () => {
+    const persistUserMessage = mock(
+      async (_options: { metadata?: Record<string, unknown> }) => ({
+        id: "persisted-msg-id",
+        deduplicated: false,
+      }),
+    );
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+
+    const res = await sendMessage(
+      "hello",
+      conversation,
+      {},
+      {
+        headers: clientMetadataHeaders,
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    const persistCall = persistUserMessage.mock.calls[0];
+    expect(persistCall).toBeDefined();
+    const [persistOptions] = persistCall as unknown as [
+      { metadata?: Record<string, unknown> },
+    ];
+    expect(persistOptions.metadata).toEqual({
+      client: {
+        browser_family: "safari",
+        browser_version: "17",
+        os: "ios",
+        interface_version: "1.2.3",
+      },
+    });
+  });
+
+  test("persists client metadata on queued user messages", async () => {
+    const enqueueMessage = mock(
+      (_options: { metadata?: Record<string, unknown> }) => ({
+        queued: true,
+        requestId: "queued-id",
+      }),
+    );
+    const conversation = makeConversation({
+      isProcessing: () => true,
+      enqueueMessage,
+    });
+
+    const res = await sendMessage(
+      "hello",
+      conversation,
+      {},
+      {
+        headers: clientMetadataHeaders,
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    const enqueueCall = enqueueMessage.mock.calls[0];
+    expect(enqueueCall).toBeDefined();
+    const [enqueueOptions] = enqueueCall as unknown as [
+      { metadata?: Record<string, unknown> },
+    ];
+    expect(enqueueOptions.metadata).toMatchObject({
+      client: {
+        browser_family: "safari",
+        browser_version: "17",
+        os: "ios",
+        interface_version: "1.2.3",
+      },
+    });
+  });
+
+  test("malformed header values are dropped, valid ones kept", async () => {
+    const persistUserMessage = mock(
+      async (_options: { metadata?: Record<string, unknown> }) => ({
+        id: "persisted-msg-id",
+        deduplicated: false,
+      }),
+    );
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+
+    const res = await sendMessage(
+      "hello",
+      conversation,
+      {},
+      {
+        headers: {
+          // Uppercase + space + disallowed chars → normalized or dropped.
+          "x-vellum-browser-family": "  SAFARI  ",
+          "x-vellum-browser-version": "not allowed!",
+          "x-vellum-client-os": "a".repeat(65),
+        },
+      },
+    );
+
+    expect(res.status).toBe(202);
+    const [persistOptions] = persistUserMessage.mock.calls[0] as unknown as [
+      { metadata?: Record<string, unknown> },
+    ];
+    expect(persistOptions.metadata).toEqual({
+      client: { browser_family: "safari" },
+    });
+  });
+
+  test("no client metadata headers → metadata unchanged", async () => {
+    const persistUserMessage = mock(
+      async (_options: { metadata?: Record<string, unknown> }) => ({
+        id: "persisted-msg-id",
+        deduplicated: false,
+      }),
+    );
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+
+    const res = await sendMessage("hello", conversation);
+
+    expect(res.status).toBe(202);
+    const [persistOptions] = persistUserMessage.mock.calls[0] as unknown as [
+      { metadata?: Record<string, unknown> },
+    ];
+    expect(persistOptions.metadata).toBeUndefined();
   });
 });
 

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -522,16 +522,26 @@ export async function persistQueuedMessageBody(
       turnChannel: turnCtx?.userMessageChannel,
     });
 
-    // OS-surface attribution for turn telemetry. The client-reported OS is
-    // validated through `parseClientOs` and stored under the `client`
-    // metadata bag (`$.client.os`), which `turn-events-store` forwards onto
-    // `TurnTelemetryEvent.client`. Caller-supplied `client` metadata wins —
-    // this only fills the key when absent.
+    // Client attribution for turn telemetry, stored under the `client`
+    // metadata bag which `turn-events-store` forwards onto
+    // `TurnTelemetryEvent.client`. The bag merges two sources per key:
+    // caller-supplied `client` metadata (e.g. the sanitized browser/OS/
+    // version headers read by `handleSendMessage`) wins, and the
+    // transport-reported OS (validated through `parseClientOs`) fills in
+    // `os` when the caller didn't supply one — so header-less paths (CLI,
+    // channel ingress) keep their OS attribution.
     const clientOs = parseClientOs(ctx.clientOs);
+    const callerClient =
+      metadataWithoutSlackInbound.client != null &&
+      typeof metadataWithoutSlackInbound.client === "object"
+        ? (metadataWithoutSlackInbound.client as Record<string, unknown>)
+        : null;
+    const clientEntries = {
+      ...(clientOs ? { os: clientOs } : {}),
+      ...(callerClient ?? {}),
+    };
     const clientBag =
-      metadataWithoutSlackInbound.client == null && clientOs
-        ? { client: { os: clientOs } }
-        : {};
+      Object.keys(clientEntries).length > 0 ? { client: clientEntries } : {};
 
     const mergedMetadata = {
       ...metadataWithoutSlackInbound,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -169,10 +169,13 @@ export const messageMetadataSchema = z
      * "macos" | "android") from the request body's `clientOs` field, stamped
      * by `persistQueuedMessageBody` — the transport `userMessageInterface` is
      * "web" for the web, iOS, and macOS apps alike, so this is the only
-     * per-platform attribution. Forwarded verbatim onto
-     * `TurnTelemetryEvent.client` for downstream analytics. Kept as a
-     * permissive `record` so adding a new client field doesn't require a
-     * migration -- dbt can unpack later via JSON_VALUE.
+     * per-platform attribution. `browser_family` / `browser_version` /
+     * `interface_version` (and an `os` override) come from the sanitized
+     * `x-vellum-*` client-metadata headers read by `handleSendMessage`
+     * (see `@vellumai/service-contracts/client-metadata`). Forwarded
+     * verbatim onto `TurnTelemetryEvent.client` for downstream analytics.
+     * Kept as a permissive `record` so adding a new client field doesn't
+     * require a migration -- dbt can unpack later via JSON_VALUE.
      */
     client: z.record(z.string(), z.unknown()).optional(),
     subagentNotification: subagentNotificationSchema.optional(),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -3,6 +3,11 @@
  */
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
+import {
+  CLIENT_METADATA_HEADERS,
+  type ClientMetadataField,
+  sanitizeClientMetadataValue,
+} from "@vellumai/service-contracts/client-metadata";
 import { z } from "zod";
 
 import { enrichMessageWithSourcePaths } from "../../agent/attachments.js";
@@ -1289,6 +1294,51 @@ export function persistOnboardingArtifacts(onboarding: {
   });
 }
 
+type ClientMetadataBag = Partial<Record<ClientMetadataField, string>>;
+
+/**
+ * Read the sanitized client-metadata headers (browser family/version, OS
+ * surface, build version) sent by web-bundle clients. Values are persisted
+ * under `metadata.client` on the user message, which `turn-events-store`
+ * projects onto `TurnTelemetryEvent.client` for analytics. Returns
+ * `undefined` when no valid header is present so callers can omit the bag.
+ */
+function readClientMetadataHeaders(
+  headers: Record<string, string> | undefined,
+): ClientMetadataBag | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const bag: ClientMetadataBag = {};
+  for (const [field, headerName] of Object.entries(
+    CLIENT_METADATA_HEADERS,
+  ) as Array<[ClientMetadataField, string]>) {
+    const value = sanitizeClientMetadataValue(headers[headerName]);
+    if (value) {
+      bag[field] = value;
+    }
+  }
+  return Object.keys(bag).length > 0 ? bag : undefined;
+}
+
+/**
+ * Attach the client-metadata bag to a persist-time metadata object under the
+ * `client` key. Passes `metadata` through untouched (including `undefined`)
+ * when there is no client metadata.
+ */
+function withClientMetadata(
+  metadata: Record<string, unknown> | undefined,
+  clientMetadata: ClientMetadataBag | undefined,
+): Record<string, unknown> | undefined {
+  if (!clientMetadata) {
+    return metadata;
+  }
+  return {
+    ...(metadata ?? {}),
+    client: clientMetadata,
+  };
+}
+
 export async function handleSendMessage(
   { body: rawBody, headers }: RouteHandlerArgs,
   deps: {
@@ -1342,6 +1392,7 @@ export async function handleSendMessage(
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
   const principalType = headers?.["x-vellum-principal-type"];
   const originClientId = headers?.["x-vellum-client-id"]?.trim() || undefined;
+  const clientMetadata = readClientMetadataHeaders(headers);
 
   const { conversationKey, content, attachmentIds } = body;
   const inboundConversationId =
@@ -1998,17 +2049,20 @@ export async function handleSendMessage(
       attachments,
       onEvent: broadcastMessage,
       requestId,
-      metadata: {
-        userMessageChannel: sourceChannel,
-        assistantMessageChannel: sourceChannel,
-        userMessageInterface: sourceInterface,
-        assistantMessageInterface: sourceInterface,
-        ...(body.automated === true ? { automated: true } : {}),
-        // Carry the transcript-suppression flag through the queue so a
-        // hidden send that lands mid-turn stays hidden when drained —
-        // the drain path persists this metadata and skips the echo.
-        ...(body.hidden === true ? { hidden: true } : {}),
-      },
+      metadata: withClientMetadata(
+        {
+          userMessageChannel: sourceChannel,
+          assistantMessageChannel: sourceChannel,
+          userMessageInterface: sourceInterface,
+          assistantMessageInterface: sourceInterface,
+          ...(body.automated === true ? { automated: true } : {}),
+          // Carry the transcript-suppression flag through the queue so a
+          // hidden send that lands mid-turn stays hidden when drained —
+          // the drain path persists this metadata and skips the echo.
+          ...(body.hidden === true ? { hidden: true } : {}),
+        },
+        clientMetadata,
+      ),
       isInteractive,
       sourceActorPrincipalId,
       transport,
@@ -2144,7 +2198,7 @@ export async function handleSendMessage(
         content: rawContent,
         attachments,
         requestId: crypto.randomUUID(),
-        metadata: slashMeta,
+        metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
       });
       if (persisted.deduplicated) {
@@ -2243,7 +2297,7 @@ export async function handleSendMessage(
         content: rawContent,
         attachments,
         requestId: crypto.randomUUID(),
-        metadata: slashMeta,
+        metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
       });
     } catch (err) {
@@ -2356,7 +2410,7 @@ export async function handleSendMessage(
         content: rawContent,
         attachments,
         requestId: crypto.randomUUID(),
-        metadata: slashMeta,
+        metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
       });
       if (persisted.deduplicated) {
@@ -2439,13 +2493,15 @@ export async function handleSendMessage(
     content: resolvedContent,
     attachments,
     requestId,
-    metadata:
+    metadata: withClientMetadata(
       body.automated === true || body.hidden === true
         ? {
             ...(body.automated === true ? { automated: true } : {}),
             ...(body.hidden === true ? { hidden: true } : {}),
           }
         : undefined,
+      clientMetadata,
+    ),
     clientMessageId,
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,7 @@
         "@vellumai/design-library": "workspace:*",
         "@vellumai/ipc-contract": "workspace:*",
         "@vellumai/local-mode": "workspace:*",
+        "@vellumai/service-contracts": "workspace:*",
         "capacitor-plugin-safe-area": "5.0.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -66,6 +66,7 @@
     "@vellumai/design-library": "workspace:*",
     "@vellumai/ipc-contract": "workspace:*",
     "@vellumai/local-mode": "workspace:*",
+    "@vellumai/service-contracts": "workspace:*",
     "capacitor-plugin-safe-area": "5.0.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -346,9 +346,11 @@ mock.module("@/runtime/platform-detection", () => ({
   useIsIOSWeb: () => isIOSWeb,
   useIsMacOSWeb: () => isMacOSWeb,
   // `messages`/`research-runner` (pulled in transitively) import
-  // `detectClientOs`; this onboarding test doesn't exercise the OS surface, so
-  // stub the web default to keep the partial module mock complete.
+  // `detectClientOs`, and `client-identity` imports `detectBrowserInfo`;
+  // this onboarding test doesn't exercise the OS/browser surface, so stub
+  // the web defaults to keep the partial module mock complete.
   detectClientOs: () => "web",
+  detectBrowserInfo: () => ({}),
 }));
 
 mock.module("@/hooks/use-ios-app-nudge", () => ({

--- a/clients/web/src/lib/telemetry/client-identity.test.ts
+++ b/clients/web/src/lib/telemetry/client-identity.test.ts
@@ -6,7 +6,16 @@
  * reload, duplicated tab, or bfcache restore).
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// `getClientMetadataHeaders` reaches `detectClientOs`, whose Electron /
+// Capacitor shell probes are irrelevant to header shape — pin both to the
+// plain-browser branch (the platform-detection.test.ts pattern) so the OS
+// header is driven purely by the `navigator` overrides below.
+mock.module("@/runtime/is-electron", () => ({ isElectron: () => false }));
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => false,
+}));
 
 const MODULE_PATH = "@/lib/telemetry/client-identity";
 
@@ -15,6 +24,45 @@ async function freshImport(): Promise<typeof import("./client-identity")> {
   // Each test that wants a fresh id calls this.
   const mod = await import(`${MODULE_PATH}?t=${Math.random()}`);
   return mod as typeof import("./client-identity");
+}
+
+const IOS_SAFARI_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) " +
+  "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+
+/**
+ * Override `navigator` properties for the duration of `callback`, restoring
+ * the original descriptors (or deleting instance-own overrides) afterwards.
+ */
+function withNavigatorValues<T>(
+  values: Record<string, unknown>,
+  callback: () => T,
+): T {
+  const descriptors = Object.fromEntries(
+    Object.keys(values).map((key) => [
+      key,
+      Object.getOwnPropertyDescriptor(Navigator.prototype, key) ??
+        Object.getOwnPropertyDescriptor(navigator, key),
+    ]),
+  );
+
+  try {
+    for (const [key, value] of Object.entries(values)) {
+      Object.defineProperty(navigator, key, {
+        configurable: true,
+        value,
+      });
+    }
+    return callback();
+  } finally {
+    for (const [key, descriptor] of Object.entries(descriptors)) {
+      if (descriptor) {
+        Object.defineProperty(navigator, key, descriptor);
+      } else {
+        delete (navigator as unknown as Record<string, unknown>)[key];
+      }
+    }
+  }
 }
 
 describe("client-identity", () => {
@@ -72,20 +120,96 @@ describe("client-identity", () => {
     expect(localStorage.getItem("vellum_client_id")).toBeNull();
   });
 
-  test("getClientRegistrationHeaders returns both client + interface headers", async () => {
+  test("getClientRegistrationHeaders returns exactly the identity + metadata header set", async () => {
     const mod = await freshImport();
-    const headers = mod.getClientRegistrationHeaders();
+    process.env.VITE_APP_VERSION = "1.2.3";
+    try {
+      const headers = withNavigatorValues(
+        {
+          userAgent: IOS_SAFARI_UA,
+          platform: "iPhone",
+          maxTouchPoints: 5,
+          userAgentData: undefined,
+        },
+        () => mod.getClientRegistrationHeaders(),
+      );
 
+      // Exact key-set assertion: any header beyond this allowlist (e.g. a
+      // future change leaking raw UA or locale data) must fail this test.
+      expect(Object.keys(headers).sort()).toEqual([
+        "X-Vellum-Client-Id",
+        "X-Vellum-Interface-Id",
+        "x-vellum-browser-family",
+        "x-vellum-browser-version",
+        "x-vellum-client-os",
+        "x-vellum-interface-version",
+      ]);
+      expect(headers["X-Vellum-Client-Id"]).toBe(mod.getClientId());
+      // The registration interface is intentionally a constant "web" on every
+      // platform — it must NOT reflect the real OS, since the daemon derives
+      // host-proxy capabilities from this id and the web renderer is never a
+      // host provider (see the comment in `client-identity.ts`). Platform
+      // awareness flows through the message body and the analytics-only
+      // metadata headers instead.
+      expect(headers["X-Vellum-Interface-Id"]).toBe("web");
+      expect(headers["x-vellum-browser-family"]).toBe("safari");
+      expect(headers["x-vellum-browser-version"]).toBe("17");
+      expect(headers["x-vellum-client-os"]).toBe("ios");
+      expect(headers["x-vellum-interface-version"]).toBe("1.2.3");
+      // Never the raw user-agent string, in any header.
+      expect(JSON.stringify(headers)).not.toContain("Mozilla");
+    } finally {
+      delete process.env.VITE_APP_VERSION;
+    }
+  });
+
+  test("metadata headers degrade to the identity set + OS when nothing is detectable", async () => {
+    const mod = await freshImport();
+    delete process.env.VITE_APP_VERSION;
+    const headers = withNavigatorValues(
+      {
+        userAgent: "",
+        platform: "",
+        maxTouchPoints: 0,
+        userAgentData: undefined,
+      },
+      () => mod.getClientRegistrationHeaders(),
+    );
+
+    // No browser match and no build version → those headers are omitted
+    // entirely (never sent empty). The OS surface always resolves — an
+    // unrecognizable browser environment reports the "web" fallback.
     expect(Object.keys(headers).sort()).toEqual([
       "X-Vellum-Client-Id",
       "X-Vellum-Interface-Id",
+      "x-vellum-client-os",
     ]);
-    expect(headers["X-Vellum-Client-Id"]).toBe(mod.getClientId());
-    // The registration interface is intentionally a constant "web" on every
-    // platform — it must NOT reflect the real OS, since the daemon derives
-    // host-proxy capabilities from this id and the web renderer is never a
-    // host provider (see the comment in `client-identity.ts`). Platform
-    // awareness flows through the message body instead.
-    expect(headers["X-Vellum-Interface-Id"]).toBe("web");
+    expect(headers["x-vellum-client-os"]).toBe("web");
+  });
+
+  test("browser detection prefers userAgentData brands over the UA string", async () => {
+    const mod = await freshImport();
+    const headers = withNavigatorValues(
+      {
+        // Chrome-style UA that would also match the UA fallback — the brands
+        // entry must win and GREASE entries must not match.
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+          "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+        userAgentData: {
+          brands: [
+            { brand: "Not_A Brand", version: "99" },
+            { brand: "Google Chrome", version: "126" },
+            { brand: "Chromium", version: "126" },
+          ],
+        },
+      },
+      () => mod.getClientRegistrationHeaders(),
+    );
+
+    expect(headers["x-vellum-browser-family"]).toBe("chrome");
+    expect(headers["x-vellum-browser-version"]).toBe("126");
   });
 });

--- a/clients/web/src/lib/telemetry/client-identity.test.ts
+++ b/clients/web/src/lib/telemetry/client-identity.test.ts
@@ -187,6 +187,32 @@ describe("client-identity", () => {
     expect(headers["x-vellum-client-os"]).toBe("web");
   });
 
+  test("WKWebView-style shell UA degrades to OS-only metadata", async () => {
+    const mod = await freshImport();
+    const headers = withNavigatorValues(
+      {
+        // Embedded WKWebView (Capacitor iOS shell) UA: no `Version/` or
+        // `Safari/` tokens and no `userAgentData`, so browser family/version
+        // don't resolve. The behavior is defined: those headers are omitted
+        // and the OS surface still reports through `detectClientOs()`.
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) " +
+          "AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+        platform: "iPhone",
+        maxTouchPoints: 5,
+        userAgentData: undefined,
+      },
+      () => mod.getClientRegistrationHeaders(),
+    );
+
+    expect(Object.keys(headers).sort()).toEqual([
+      "X-Vellum-Client-Id",
+      "X-Vellum-Interface-Id",
+      "x-vellum-client-os",
+    ]);
+    expect(headers["x-vellum-client-os"]).toBe("ios");
+  });
+
   test("browser detection prefers userAgentData brands over the UA string", async () => {
     const mod = await freshImport();
     const headers = withNavigatorValues(

--- a/clients/web/src/lib/telemetry/client-identity.ts
+++ b/clients/web/src/lib/telemetry/client-identity.ts
@@ -1,3 +1,13 @@
+import {
+  CLIENT_METADATA_HEADERS,
+  sanitizeClientMetadataValue,
+} from "@vellumai/service-contracts/client-metadata";
+
+import {
+  detectBrowserInfo,
+  detectClientOs,
+} from "@/runtime/platform-detection";
+
 let cached: string | null = null;
 
 /**
@@ -17,6 +27,42 @@ export function getClientId(): string {
   if (cached) return cached;
   cached = crypto.randomUUID();
   return cached;
+}
+
+let cachedMetadataHeaders: Record<string, string> | null = null;
+
+/**
+ * Sanitized client-metadata headers persisted by the daemon under
+ * `metadata.client` for turn analytics. All inputs (browser, OS surface,
+ * build version) are constant for the lifetime of the page, so the result
+ * is computed once and cached in module memory.
+ *
+ * These are analytics-only: unlike `X-Vellum-Interface-Id`, none of them
+ * feed subscriber capability resolution.
+ */
+function getClientMetadataHeaders(): Record<string, string> {
+  if (cachedMetadataHeaders) {
+    return cachedMetadataHeaders;
+  }
+  const browser = detectBrowserInfo();
+  const candidates: Array<[string, string | undefined]> = [
+    [CLIENT_METADATA_HEADERS.browser_family, browser.family],
+    [CLIENT_METADATA_HEADERS.browser_version, browser.version],
+    [CLIENT_METADATA_HEADERS.os, detectClientOs()],
+    [
+      CLIENT_METADATA_HEADERS.interface_version,
+      import.meta.env.VITE_APP_VERSION,
+    ],
+  ];
+  const headers: Record<string, string> = {};
+  for (const [name, raw] of candidates) {
+    const value = sanitizeClientMetadataValue(raw);
+    if (value) {
+      headers[name] = value;
+    }
+  }
+  cachedMetadataHeaders = headers;
+  return headers;
 }
 
 /**
@@ -52,5 +98,9 @@ export function getClientRegistrationHeaders(): Record<string, string> {
     // feeds the per-turn `client_os` context and has no bearing on subscriber
     // capabilities.
     "X-Vellum-Interface-Id": "web",
+    // Analytics-only client metadata (browser family/version, OS surface,
+    // build version), persisted under `metadata.client` on user messages.
+    // Values are sanitized and bounded; none affect capability resolution.
+    ...getClientMetadataHeaders(),
   };
 }

--- a/clients/web/src/runtime/platform-detection.ts
+++ b/clients/web/src/runtime/platform-detection.ts
@@ -148,6 +148,88 @@ export function detectClientOs(): ClientOs {
   return "web";
 }
 
+/**
+ * Browser attribution for turn telemetry (`metadata.client.browser_family` /
+ * `.browser_version`). Family is engine-level: Chromium derivatives without
+ * their own brand entry (Opera, Brave, Arc) report as `"chrome"`.
+ */
+export type BrowserInfo = {
+  family?: "chrome" | "edge" | "firefox" | "safari";
+  version?: string;
+};
+
+type UADataBrand = { brand: string; version: string };
+
+/**
+ * Detect the browser from `navigator.userAgentData.brands` (Chromium-only
+ * API). Brand names are full strings like "Microsoft Edge" / "Google Chrome"
+ * / "Chromium"; GREASE entries ("Not_A Brand" and friends) match neither
+ * pattern. The brand version is the (possibly reduced) major version.
+ */
+function browserFromBrands(
+  brands: UADataBrand[] | undefined,
+): BrowserInfo | null {
+  if (!brands || brands.length === 0) {
+    return null;
+  }
+  const families = [
+    { family: "edge", pattern: /microsoft edge/i },
+    { family: "chrome", pattern: /google chrome|chromium/i },
+  ] as const;
+  for (const { family, pattern } of families) {
+    const match = brands.find((brand) => pattern.test(brand.brand));
+    if (match) {
+      const version = match.version.match(/^\d+/)?.[0];
+      return { family, ...(version ? { version } : {}) };
+    }
+  }
+  return null;
+}
+
+/**
+ * Detect the browser from the UA string (Safari and Firefox never expose
+ * `userAgentData`). Order matters: Edge UAs contain "Chrome/", Chrome and
+ * Firefox UAs contain "Safari/", so Safari's `Version/` pattern goes last.
+ * iOS third-party browsers use injected engine tokens (EdgiOS / CriOS /
+ * FxiOS — same token set as `isSafariBrowser`).
+ */
+function browserFromUserAgent(ua: string): BrowserInfo | null {
+  const patterns = [
+    { family: "edge", pattern: /(?:Edg|EdgiOS|EdgA)\/(\d+)/ },
+    { family: "chrome", pattern: /(?:Chrome|CriOS|Chromium)\/(\d+)/ },
+    { family: "firefox", pattern: /(?:Firefox|FxiOS)\/(\d+)/ },
+    { family: "safari", pattern: /Version\/(\d+).*Safari\// },
+  ] as const;
+  for (const { family, pattern } of patterns) {
+    const match = ua.match(pattern);
+    if (match) {
+      return { family, version: match[1] };
+    }
+  }
+  return null;
+}
+
+/**
+ * Detect the current browser's family and major version for telemetry.
+ * Prefers `userAgentData.brands` where available, falls back to UA-string
+ * parsing. Returns `{}` when neither yields a match (or during SSR).
+ */
+export function detectBrowserInfo(): BrowserInfo {
+  if (typeof navigator === "undefined") {
+    return {};
+  }
+  const uaData = (
+    navigator as Navigator & {
+      userAgentData?: { brands?: UADataBrand[] };
+    }
+  ).userAgentData;
+  return (
+    browserFromBrands(uaData?.brands) ??
+    browserFromUserAgent(navigator.userAgent) ??
+    {}
+  );
+}
+
 // ---------------------------------------------------------------------------
 // React hooks — safe thin wrappers for use in component render bodies
 // ---------------------------------------------------------------------------

--- a/gateway/src/__tests__/pair-origin-allowlist.test.ts
+++ b/gateway/src/__tests__/pair-origin-allowlist.test.ts
@@ -19,9 +19,12 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 
 const { handlePair, resetPairRateLimiterForTests } =
   await import("../http/routes/pair.js");
-const { resolveExtensionOrigin } = await import("../http/middleware/cors.js");
+const { resolveExtensionOrigin, corsHeaders } =
+  await import("../http/middleware/cors.js");
 const { KNOWN_EXTENSION_ORIGINS } =
   await import("../chrome-extension-origins.js");
+const { CLIENT_METADATA_HEADERS } =
+  await import("@vellumai/service-contracts/client-metadata");
 
 // Simulate a loopback peer IP as supplied by the gateway server to the handler.
 const LOOPBACK_IP = "127.0.0.1";
@@ -103,6 +106,21 @@ describe("resolveExtensionOrigin", () => {
       headers: { origin: "https://evil.example.com" },
     });
     expect(resolveExtensionOrigin(req)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Webview CORS — client-metadata analytics headers
+// ---------------------------------------------------------------------------
+
+describe("webview CORS headers", () => {
+  test("Access-Control-Allow-Headers includes every client-metadata header", () => {
+    const headers = corsHeaders("https://app.vellum.local");
+    const allowHeaders =
+      headers["Access-Control-Allow-Headers"]?.toLowerCase() ?? "";
+    for (const header of Object.values(CLIENT_METADATA_HEADERS)) {
+      expect(allowHeaders).toContain(header);
+    }
   });
 });
 

--- a/gateway/src/http/middleware/cors.ts
+++ b/gateway/src/http/middleware/cors.ts
@@ -1,3 +1,5 @@
+import { CLIENT_METADATA_HEADERS } from "@vellumai/service-contracts/client-metadata";
+
 import { KNOWN_EXTENSION_ORIGINS } from "../../chrome-extension-origins.js";
 import { getLogger } from "../../logger.js";
 
@@ -20,7 +22,7 @@ const ALLOWED_METHODS = "GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS";
 
 /**
  * Headers the webview bridge sends (auth + content type + org id + client
- * identity for ATL-703 self-echo suppression).
+ * identity for ATL-703 self-echo suppression + analytics metadata).
  *
  * `X-Vellum-Client-Id` / `X-Vellum-Interface-Id` mirror the headers the
  * Chrome extension already sends (see `extensionCorsHeaders` below) and the
@@ -28,9 +30,21 @@ const ALLOWED_METHODS = "GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS";
  * central HeyAPI interceptor (`clients/web/src/lib/api-interceptors.ts`)
  * attaches them to every generated-client request so the daemon route
  * handlers can echo the id back on `sync_changed`.
+ *
+ * The client-metadata analytics headers (`CLIENT_METADATA_HEADERS`) carry the
+ * browser family/version, client OS, and interface version the daemon persists
+ * under `metadata.client`; the shared contract is the single source of truth.
  */
-const ALLOWED_HEADERS =
-  "Authorization, Content-Type, X-Session-Token, Vellum-Organization-Id, X-Trace-Id, X-Vellum-Client-Id, X-Vellum-Interface-Id";
+const ALLOWED_HEADERS = [
+  "Authorization",
+  "Content-Type",
+  "X-Session-Token",
+  "Vellum-Organization-Id",
+  "X-Trace-Id",
+  "X-Vellum-Client-Id",
+  "X-Vellum-Interface-Id",
+  ...Object.values(CLIENT_METADATA_HEADERS),
+].join(", ");
 
 /**
  * Check whether the request `Origin` header matches a known Vellum Chrome

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./channels": "./src/channels.ts",
+    "./client-metadata": "./src/client-metadata.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
     "./ingress": "./src/ingress.ts",
     "./twilio-ingress": "./src/twilio-ingress.ts",

--- a/packages/service-contracts/src/client-metadata.ts
+++ b/packages/service-contracts/src/client-metadata.ts
@@ -1,0 +1,46 @@
+/**
+ * Client-metadata analytics headers.
+ *
+ * The web client attaches these to every daemon request via
+ * `getClientRegistrationHeaders()` (`clients/web/src/lib/telemetry/
+ * client-identity.ts`), the gateway allows them through webview CORS
+ * (`gateway/src/http/middleware/cors.ts`) and forwards them to the daemon
+ * by `x-vellum-*` prefix, and the daemon persists them under
+ * `metadata.client` on user messages (`handleSendMessage`), where
+ * `turn-events-store` projects them onto `TurnTelemetryEvent.client` for
+ * downstream analytics.
+ *
+ * Keys are the persisted `metadata.client` field names; values are the
+ * lowercase HTTP header names (HTTP header matching is case-insensitive).
+ */
+export const CLIENT_METADATA_HEADERS = {
+  browser_family: "x-vellum-browser-family",
+  browser_version: "x-vellum-browser-version",
+  os: "x-vellum-client-os",
+  interface_version: "x-vellum-interface-version",
+} as const;
+
+export type ClientMetadataField = keyof typeof CLIENT_METADATA_HEADERS;
+
+/**
+ * Bound on client-metadata header values: lowercase alphanumerics plus
+ * dot / underscore / dash, at most 64 chars. Enforced identically by the
+ * sender (web client) and the reader (daemon) so malformed or oversized
+ * values are dropped rather than transmitted or persisted.
+ */
+const CLIENT_METADATA_VALUE_RE = /^[a-z0-9._-]{1,64}$/;
+
+/**
+ * Normalize a candidate client-metadata value (trim + lowercase) and
+ * validate it against {@link CLIENT_METADATA_VALUE_RE}. Returns `undefined`
+ * for empty or out-of-bounds values.
+ */
+export function sanitizeClientMetadataValue(
+  value: string | undefined | null,
+): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return CLIENT_METADATA_VALUE_RE.test(normalized) ? normalized : undefined;
+}

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -19,6 +19,7 @@
  */
 
 export * from "./channels.js";
+export * from "./client-metadata.js";
 export * from "./transport.js";
 export * from "./error.js";
 export * from "./handles.js";


### PR DESCRIPTION
## Summary
- web-bundle clients (browser, Electron renderer, Capacitor iOS) attach sanitized `x-vellum-browser-family` / `x-vellum-browser-version` / `x-vellum-client-os` / `x-vellum-interface-version` headers to every daemon request via `getClientRegistrationHeaders()`
- the daemon's `handleSendMessage` persists them under `metadata.client` on user messages — the bag `turn-events-store` already projects onto `TurnTelemetryEvent.client`, which feeds the BigQuery `turn_raw.client` column (currently always NULL)
- header names + the value sanitizer (`[a-z0-9._-]{1,64}`, lowercased) live once in `@vellumai/service-contracts/client-metadata` and are imported by the web client, gateway CORS allowlist, and daemon
- browser detection (`detectBrowserInfo()`) lives in `clients/web/src/runtime/platform-detection.ts` next to the existing helpers: `userAgentData.brands` first, UA-string fallback (Edge → Chrome → Firefox → Safari, iOS engine tokens included); OS reuses the existing `detectClientOs()` — no second OS detector
- `persistQueuedMessageBody` merges the client bag per key: caller-supplied fields win, the transport-reported `clientOs` fills in `os` when absent, so header-less paths (CLI, channel ingress) keep OS attribution

## Notes
- no raw user-agent strings are transmitted; values failing the sanitizer are dropped, never sent or persisted empty
- `X-Vellum-Interface-Id` stays a constant `"web"` — the analytics headers don't feed capability resolution
- no migrations: `metadata.client` is an existing permissive record and the BigQuery column already exists; data populates going forward only
- follow-up (platform repo): add analytics queries/charts consuming `client.browser_family` / `client.os` / `client.interface_version` — nothing reads the column yet

## Tests
- `cd clients/web && bun test src/lib/telemetry/client-identity.test.ts src/runtime/platform-detection.test.ts` (16 pass) + `bun run typecheck`
- `cd assistant && bun test src/__tests__/http-user-message-parity.test.ts` (19 pass) + `src/__tests__/client-os-metadata-persistence.test.ts` (8 pass, incl. new per-key merge case) + `bun run typecheck:fast`
- `cd gateway && bun test src/__tests__/pair-origin-allowlist.test.ts` (13 pass) + `bunx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)