### PR TITLE
feat(memory): distill ready proc-candidate clusters into managed skills

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -447,6 +447,11 @@ describe("ToolExecutor policy context plumbing", () => {
       conversationId: "conversation-1",
       executionContext: "conversation",
       executionTarget: "sandbox",
+      // Origin-scoping signal: buildPolicyContext now copies the turn's trust
+      // class onto the PolicyContext so the checker can scope narrow
+      // non-interactive auto-grants. requestOrigin/sourceChannel are unset for
+      // this interactive turn (omitted — toEqual ignores undefined-valued keys).
+      trustClass: "guardian",
     });
   });
 
@@ -466,6 +471,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(lastCheckArgs!.policyContext).toEqual({
       conversationId: "conversation-1",
       executionContext: "conversation",
+      // Trust class is now threaded onto the PolicyContext (see above).
+      trustClass: "guardian",
     });
   });
 
@@ -495,6 +502,8 @@ describe("ToolExecutor policy context plumbing", () => {
     expect(lastCheckArgs!.policyContext).toEqual({
       conversationId: "conversation-1",
       executionContext: "conversation",
+      // Trust class is now threaded onto the PolicyContext (see above).
+      trustClass: "guardian",
     });
   });
 
@@ -526,6 +535,8 @@ describe("ToolExecutor policy context plumbing", () => {
       conversationId: "conversation-1",
       executionContext: "conversation",
       executionTarget: "host",
+      // Trust class is now threaded onto the PolicyContext (see above).
+      trustClass: "guardian",
     });
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -281,6 +281,14 @@ export async function runAgentLoopImpl(
      * sites. Used when a caller explicitly pins a background run to a profile.
      */
     forceOverrideProfile?: boolean;
+    /**
+     * Origin tag of this turn (the conversation's `TitleOrigin`, e.g.
+     * "memory_consolidation"), threaded from `runBackgroundJob`. Exposed on
+     * the conversation so tool execution can scope narrow non-interactive
+     * permission auto-grants to a specific internal background origin. Unset
+     * for normal user-initiated turns.
+     */
+    requestOrigin?: string;
   },
 ): Promise<void> {
   if (!ctx.abortController) {
@@ -334,6 +342,12 @@ export async function runAgentLoopImpl(
   // Expose the turn's call site on the live conversation so the runtime
   // injection assembly self-resolves it for the turn's plugin contexts.
   ctx.currentCallSite = turnCallSite;
+
+  // Expose the turn's request origin (e.g. "memory_consolidation") on the live
+  // conversation so the tool context — and through it `buildPolicyContext` —
+  // can scope narrow non-interactive permission auto-grants to a specific
+  // internal background origin. Unset for normal user turns.
+  ctx.currentTurnRequestOrigin = options?.requestOrigin;
 
   // Optional per-turn inference-profile override. Plumbed through to every
   // LLM call the loop emits and inherited by any subagents spawned during
@@ -1524,6 +1538,9 @@ export async function runAgentLoopImpl(
     // opportunity wakes calling `agentLoop.run` directly) don't inherit a stale
     // value and instead fall back to live client state in the tool context.
     ctx.currentTurnIsNonInteractive = undefined;
+    // Turn-scoped request origin. Clear so a later turn on a reused
+    // conversation cannot inherit a stale origin-scoped permission grant.
+    ctx.currentTurnRequestOrigin = undefined;
     // Channel command intents (e.g. Telegram /start) are single-turn metadata.
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -199,6 +199,7 @@ export function createToolExecutor(
       taskRunId: ctx.taskRunId,
       trustClass: resolveTrustClass(turnTrust),
       executionChannel: turnTrust.sourceChannel,
+      requestOrigin: ctx.currentTurnRequestOrigin,
       sourceActorPrincipalId: turnTrust.guardianPrincipalId,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -378,6 +378,7 @@ export class Conversation {
   wakePersonaOverride?: SystemPromptPersonaOverride;
   /** @internal */ currentTurnOverrideProfile?: string;
   /** @internal */ currentTurnIsNonInteractive?: boolean;
+  /** @internal */ currentTurnRequestOrigin?: string;
   /** @internal */ authContext?: AuthContext;
   /** @internal */ currentTurnAuthContext?: AuthContext;
   /** @internal */ currentTurnSourceActorPrincipalId?: string;

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -71,6 +71,14 @@ type ProcessMessageOptions = ConversationCreateOptions & {
   sourceChannel?: string;
   /** Originating interface (e.g. "cli", "web"). Defaults to "web". */
   sourceInterface?: string;
+  /**
+   * Origin tag of the turn (the conversation's `TitleOrigin`, e.g.
+   * "memory_consolidation"), threaded from `runBackgroundJob`. Propagated
+   * into the agent loop and tool context so the permission checker can scope
+   * narrow non-interactive auto-grants to a specific internal background
+   * origin. Unset for normal user-initiated turns.
+   */
+  requestOrigin?: string;
 };
 
 function buildEventEmitter(
@@ -536,6 +544,9 @@ export async function processMessage(
       ...(options?.callSite ? { callSite: options.callSite } : {}),
       ...(options?.overrideProfile
         ? { overrideProfile: options.overrideProfile }
+        : {}),
+      ...(options?.requestOrigin
+        ? { requestOrigin: options.requestOrigin }
         : {}),
     });
   } finally {

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -133,4 +133,12 @@ export interface ToolSetupContext extends SurfaceConversationContext {
    * scheduled turn running on a client-attached conversation as interactive.
    */
   currentTurnIsNonInteractive?: boolean;
+  /**
+   * Origin tag of the current turn (the conversation's `TitleOrigin`, e.g.
+   * "memory_consolidation"), set by `runAgentLoop` from its `requestOrigin`
+   * option. Propagated into `ToolContext.requestOrigin` so the permission
+   * checker can scope narrow non-interactive auto-grants to a specific
+   * internal background origin. Absent for normal interactive turns.
+   */
+  currentTurnRequestOrigin?: string;
 }

--- a/assistant/src/memory/v2/prompts/proc-distill.ts
+++ b/assistant/src/memory/v2/prompts/proc-distill.ts
@@ -1,0 +1,85 @@
+/**
+ * Memory v3 — procedure-distillation prompt.
+ *
+ * Built per `ready` proc-candidate cluster by the distillation trigger
+ * (`proc-distill-trigger.ts`) and handed to a guardian background agent run as
+ * the wake hint. The agent reads the cluster's member candidate notes,
+ * synthesizes the ONE canonical procedure they all describe — stripping the
+ * task-specific noise that differs across the ≥ N traces — and registers it as
+ * a managed skill via `scaffold_managed_skill`. The procedure then lives only
+ * in the skill; the trigger deletes the candidate notes on success.
+ *
+ * The run executes under the memory-consolidation origin (guardian trust,
+ * `vellum` channel), so the permission checker auto-approves
+ * `skill_load skill-management` and `scaffold_managed_skill` without an
+ * interactive prompt (the background run has no client to answer one).
+ *
+ * Kept under `prompts/` rather than inlined in the trigger so the prompt body
+ * is reviewable on its own, mirroring the consolidation/sweep prompt
+ * convention.
+ */
+
+/** The member candidate notes a distillation run synthesizes into a skill. */
+export interface ProcDistillNote {
+  /** The note's concept-page slug (its on-disk home). */
+  slug: string;
+  /** The note body — one observed trace of the procedure. */
+  body: string;
+}
+
+export interface ProcDistillPromptInput {
+  /** Stable, immutable skill id the agent must scaffold under. */
+  skillId: string;
+  /** The cluster's `goal:` identity phrase (what the procedure accomplishes). */
+  goal: string;
+  /** The member candidate notes — the ≥ N observed traces to synthesize. */
+  notes: ProcDistillNote[];
+}
+
+/**
+ * Render the distillation wake hint for one ready cluster. The agent is told
+ * the exact `skill_id` to use (derived immutably from the goal upstream) so the
+ * scaffolded skill is the stable link target future facts reference via
+ * `skill:`.
+ */
+export function renderProcDistillPrompt(input: ProcDistillPromptInput): string {
+  const traces = input.notes
+    .map(
+      (note, i) =>
+        `--- Trace ${i + 1} (note ${note.slug}) ---\n${note.body.trim()}`,
+    )
+    .join("\n\n");
+
+  return [
+    "You are distilling a recurring procedure into a reusable skill.",
+    "",
+    `The user has performed this procedure several times. Its goal is:`,
+    `  ${input.goal}`,
+    "",
+    "Below are the captured traces of that procedure — each is one observed",
+    "run, recorded as a candidate note. They share the same goal but differ in",
+    "task-specific detail (different inputs, a retry here, a skipped step",
+    "there). Your job is to synthesize the ONE canonical procedure they all",
+    "describe.",
+    "",
+    traces,
+    "",
+    "Steps:",
+    "1. Read every trace above. Identify the stable, reusable shape of the",
+    "   procedure — the steps that recur across the traces. Strip the",
+    "   task-specific noise (concrete values, one-off detours, retries) so the",
+    "   result generalizes to the next run.",
+    "2. Load the skill-management skill: `skill_load skill-management`.",
+    "3. Call `scaffold_managed_skill` with:",
+    `   - skill_id: "${input.skillId}"  (use exactly this id — it is the stable`,
+    "     link target and must not change)",
+    "   - name: a short human-readable name for the procedure",
+    "   - description: one sentence on when to use this skill",
+    "   - body_markdown: the canonical procedure as clear, step-by-step",
+    "     markdown instructions (it may invoke CLI commands or tools as steps)",
+    "",
+    "Author the skill body as durable instructions for a future run, not as a",
+    "report of what happened in these traces. Do not include the raw traces or",
+    "any one-off values. Scaffold exactly one skill, then stop.",
+  ].join("\n");
+}

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -98,9 +98,12 @@ mock.module("./workspace-policy.js", () => ({
   isPathWithinWorkspaceRoot: () => false,
 }));
 
-// Mock tool registry — no tools by default.
+// Mock tool registry — no tools by default. `getToolOwner` backs
+// `buildPolicyContext` (used by the integration test below); core tools have no
+// owner, so it returns undefined.
 mock.module("../tools/registry.js", () => ({
   getTool: () => undefined,
+  getToolOwner: () => undefined,
 }));
 
 // Mock URL safety helpers.
@@ -135,6 +138,8 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { buildPolicyContext } from "../tools/policy-context.js";
+import type { Tool, ToolContext } from "../tools/types.js";
 import {
   check,
   classifyRisk,
@@ -732,6 +737,87 @@ describe("Permission Checker (gateway IPC)", () => {
           sourceChannel: "vellum",
           executionContext: "background",
         },
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    // ── Integration: production `buildPolicyContext` → `check` path ──────────
+    // The hand-built-PolicyContext tests above prove the grant LOGIC. These
+    // exercise the WIRING: a `ToolContext` (the shape the agent loop actually
+    // builds — see conversation-tool-setup.ts) is run through the real
+    // `buildPolicyContext`, and only then handed to `check`. Without the
+    // origin/trust/channel threading added here, `buildPolicyContext` would
+    // drop those fields and the grant would be dead code (Codex #35987).
+
+    /** A bare core tool — `buildPolicyContext` reads only `tool.name`/owner. */
+    const scaffoldTool = {
+      name: "scaffold_managed_skill",
+    } as unknown as Tool;
+
+    /** The ToolContext a memory-consolidation distillation turn produces. */
+    const consolidationToolContext: ToolContext = {
+      conversationId: "conv-distill",
+      workingDir: "/home/user/project",
+      trustClass: "guardian",
+      executionChannel: "vellum",
+      requestOrigin: "memory_consolidation",
+      isInteractive: false,
+    };
+
+    test("grant fires through the real buildPolicyContext path for the consolidation turn", async () => {
+      // High risk would normally force a prompt; the grant short-circuits it.
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const policyContext = buildPolicyContext(
+        scaffoldTool,
+        consolidationToolContext,
+      );
+      // Prove the threading: buildPolicyContext copied the ToolContext signals.
+      expect(policyContext.requestOrigin).toBe("memory_consolidation");
+      expect(policyContext.trustClass).toBe("guardian");
+      expect(policyContext.sourceChannel).toBe("vellum");
+
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        policyContext,
+      );
+      expect(result.decision).toBe("allow");
+    });
+
+    test("grant does NOT fire for a normal interactive tool call via buildPolicyContext", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      // A normal interactive turn: a guardian on the desktop, no consolidation
+      // origin. buildPolicyContext leaves `requestOrigin` unset, so the grant
+      // must not fire and the high-risk tool prompts.
+      const interactiveContext: ToolContext = {
+        conversationId: "conv-chat",
+        workingDir: "/home/user/project",
+        trustClass: "guardian",
+        executionChannel: "vellum",
+        isInteractive: true,
+      };
+      const policyContext = buildPolicyContext(
+        scaffoldTool,
+        interactiveContext,
+      );
+      expect(policyContext.requestOrigin).toBeUndefined();
+
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        policyContext,
       );
       expect(result.decision).toBe("prompt");
     });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
@@ -230,6 +230,7 @@ function harness(opts: HarnessOpts) {
     // `ready`. Distillation behavior is covered in `proc-distill.test.ts`.
     loadClusterNotes: async () => [],
     distill: async () => ({ ok: false }),
+    skillExists: () => false,
     deleteNote: async () => {},
   };
   return { rows, deps, judgeCalls };
@@ -258,6 +259,7 @@ describe("procDistillTriggerJob — gating", () => {
       listReadyClusters: () => [],
       loadClusterNotes: async () => [],
       distill: async () => ({ ok: false }),
+      skillExists: () => false,
       deleteNote: async () => {},
     });
     expect(outcome.disabled).toBe(true);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
@@ -27,7 +27,13 @@ import type { MemoryJob } from "../../../../memory/jobs-store.js";
 import type { CandidateClusterRef, MatchResult } from "../candidate-match.js";
 import type { ProcCandidate } from "../proc-candidate-store.js";
 
+// Spread the real logger module and override only `getLogger`: the distillation
+// launcher transitively imports the background-job runner, whose import graph
+// reads other logger exports (e.g. `truncateForLog`), so a wholesale replacement
+// of just `getLogger` would strip symbols the chain needs.
+const realLogger = await import("../../../../util/logger.js");
 mock.module("../../../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () => makeMockLogger(),
 }));
 
@@ -38,6 +44,10 @@ mock.module("../../../../util/logger.js", () => ({
 let procToSkillsEnabledSlot = true;
 mock.module("../../../../config/memory-v3-gate.js", () => ({
   isProcToSkillsEnabled: () => procToSkillsEnabledSlot,
+  // The distillation launcher transitively imports the background-job runner,
+  // whose import graph pulls `isMemoryV3Live`, so both gate exports must be
+  // present when this mock replaces the module wholesale.
+  isMemoryV3Live: () => false,
 }));
 
 const { procDistillTriggerJob } = await import("../proc-distill-trigger.js");
@@ -79,6 +89,7 @@ function fakeRegistry() {
     | "getCandidate"
     | "markCandidateStatus"
     | "listClusters"
+    | "listReadyClusters"
   > = {
     upsertCandidate: (input) => {
       const existing = rows.get(input.clusterId);
@@ -121,6 +132,8 @@ function fakeRegistry() {
         clusterId: r.clusterId,
         memberNoteSlugs: r.memberNoteSlugs,
       })),
+    listReadyClusters: (): ProcCandidate[] =>
+      [...rows.values()].filter((r) => r.status === "ready"),
   };
   return { rows, store };
 }
@@ -210,6 +223,14 @@ function harness(opts: HarnessOpts) {
     addMemberNote: store.addMemberNote,
     getCandidate: store.getCandidate,
     markCandidateStatus: store.markCandidateStatus,
+    listReadyClusters: store.listReadyClusters,
+    // These tally-only tests assert on the recurrence phase. The distillation
+    // phase finds no member-note bodies (`loadClusterNotes` returns none), so
+    // it never launches an agent or deletes a note — a `ready` cluster stays
+    // `ready`. Distillation behavior is covered in `proc-distill.test.ts`.
+    loadClusterNotes: async () => [],
+    distill: async () => ({ ok: false }),
+    deleteNote: async () => {},
   };
   return { rows, deps, judgeCalls };
 }
@@ -234,6 +255,10 @@ describe("procDistillTriggerJob — gating", () => {
       addMemberNote: () => {},
       getCandidate: () => null,
       markCandidateStatus: () => {},
+      listReadyClusters: () => [],
+      loadClusterNotes: async () => [],
+      distill: async () => ({ ok: false }),
+      deleteNote: async () => {},
     });
     expect(outcome.disabled).toBe(true);
     expect(matched).toBe(0);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for the DISTILLATION phase of `proc-distill-trigger.ts` (PR 9).
+ *
+ * The tally phase (open / join / judge / mark-ready) is covered by
+ * `proc-distill-trigger.test.ts`. This file isolates the second phase: turning
+ * a `ready` cluster into a managed skill and retiring its candidate notes.
+ * Every collaborator is dependency-injected, so the `distill` launcher (which
+ * in production drives a guardian background agent run via `runBackgroundJob`)
+ * and the note reader/deleter are in-memory fakes — no agent, no Qdrant, no DB.
+ *
+ * Coverage:
+ *   - a `ready` cluster → ONE distill call with a coherent input (the right
+ *     skill id, goal, and member-note bodies), candidate notes deleted, cluster
+ *     marked `distilled`;
+ *   - an `observing` cluster is never distilled (not in the ready queue);
+ *   - a distillation FAILURE leaves the cluster `ready` and does NOT delete the
+ *     notes (safe retry).
+ *
+ * The logger is stubbed so best-effort warn paths stay quiet.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+
+import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
+import type { AssistantConfig } from "../../../../config/types.js";
+import type { MemoryJob } from "../../../../memory/jobs-store.js";
+import type { CandidateClusterRef } from "../candidate-match.js";
+import type { ProcCandidate } from "../proc-candidate-store.js";
+
+// Spread the real logger module and override only `getLogger`: the distillation
+// launcher transitively imports the background-job runner, whose import graph
+// reads other logger exports (e.g. `truncateForLog`), so a wholesale replacement
+// of just `getLogger` would strip symbols the chain needs.
+const realLogger = await import("../../../../util/logger.js");
+mock.module("../../../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => makeMockLogger(),
+}));
+
+let procToSkillsEnabledSlot = true;
+// Replace the whole gate module (mock.module is process-global). The
+// distillation launcher transitively imports the background-job runner, whose
+// import graph pulls `isMemoryV3Live`, so both gate exports must be present.
+mock.module("../../../../config/memory-v3-gate.js", () => ({
+  isProcToSkillsEnabled: () => procToSkillsEnabledSlot,
+  isMemoryV3Live: () => false,
+}));
+
+const { procDistillTriggerJob, skillIdForGoal } =
+  await import("../proc-distill-trigger.js");
+import type {
+  DistillRunInput,
+  DistillRunResult,
+  ProcDistillTriggerDeps,
+} from "../proc-distill-trigger.js";
+
+const JOB = {
+  id: "job-1",
+  type: "memory_proc_distill",
+} as unknown as MemoryJob;
+
+afterEach(() => {
+  procToSkillsEnabledSlot = true;
+});
+
+function config(minRecurrence = 2): AssistantConfig {
+  return {
+    memory: { procToSkills: { minRecurrence } },
+  } as unknown as AssistantConfig;
+}
+
+// In-memory candidate registry seeded directly with clusters in a chosen status
+// so the distillation phase has work without driving the tally phase.
+function fakeRegistry(seed: ProcCandidate[]) {
+  const rows = new Map<string, ProcCandidate>();
+  for (const c of seed) rows.set(c.clusterId, { ...c });
+  return {
+    rows,
+    getCandidate: (id: string) => rows.get(id) ?? null,
+    markCandidateStatus: (id: string, status: ProcCandidate["status"]) => {
+      const row = rows.get(id);
+      if (row) row.status = status;
+    },
+    listReadyClusters: (): ProcCandidate[] =>
+      [...rows.values()].filter((r) => r.status === "ready"),
+    listClusters: (): CandidateClusterRef[] =>
+      [...rows.values()].map((r) => ({
+        clusterId: r.clusterId,
+        memberNoteSlugs: r.memberNoteSlugs,
+      })),
+  };
+}
+
+function cluster(
+  over: Partial<ProcCandidate> & { clusterId: string },
+): ProcCandidate {
+  return {
+    goal: "deploy the web app",
+    memberNoteSlugs: [],
+    count: 2,
+    status: "ready",
+    explicit: false,
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+interface HarnessOpts {
+  seed: ProcCandidate[];
+  noteBodies?: Record<string, string>;
+  distillResult?: DistillRunResult;
+}
+
+function harness(opts: HarnessOpts) {
+  const reg = fakeRegistry(opts.seed);
+  const bodies = opts.noteBodies ?? {};
+  const distillCalls: DistillRunInput[] = [];
+  const deletedSlugs: string[] = [];
+
+  const deps: ProcDistillTriggerDeps = {
+    config: config(),
+    // Tally phase finds nothing — these tests start from pre-seeded clusters.
+    loadCandidateNotes: async () => [],
+    listClusters: reg.listClusters,
+    matchCandidate: async () => ({ kind: "new" }),
+    judge: async () => false,
+    upsertCandidate: () => {},
+    incrementCandidate: () => {},
+    setCandidateExplicit: () => {},
+    addMemberNote: () => {},
+    getCandidate: reg.getCandidate,
+    markCandidateStatus: reg.markCandidateStatus,
+    listReadyClusters: reg.listReadyClusters,
+    loadClusterNotes: async (slugs) =>
+      slugs
+        .filter((s) => s in bodies)
+        .map((s) => ({ slug: s, body: bodies[s] })),
+    distill: async (input) => {
+      distillCalls.push(input);
+      return opts.distillResult ?? { ok: true };
+    },
+    deleteNote: async (slug) => {
+      deletedSlugs.push(slug);
+    },
+  };
+  return { reg, deps, distillCalls, deletedSlugs };
+}
+
+describe("skillIdForGoal", () => {
+  test("derives a stable, valid slug from the goal", () => {
+    expect(skillIdForGoal("Deploy the Web App")).toBe("deploy-the-web-app");
+    // Deterministic for a given goal (immutable link target).
+    expect(skillIdForGoal("Deploy the Web App")).toBe(
+      skillIdForGoal("Deploy the Web App"),
+    );
+  });
+
+  test("strips punctuation and collapses separators", () => {
+    expect(skillIdForGoal("  rotate: the *signing* secrets!  ")).toBe(
+      "rotate-the-signing-secrets",
+    );
+  });
+
+  test("returns null when the goal has no alphanumeric content", () => {
+    expect(skillIdForGoal("!!!")).toBeNull();
+    expect(skillIdForGoal("   ")).toBeNull();
+  });
+});
+
+describe("procDistillTriggerJob — distillation", () => {
+  test("a ready cluster is distilled, its notes deleted, and marked distilled", async () => {
+    const { reg, deps, distillCalls, deletedSlugs } = harness({
+      seed: [
+        cluster({
+          clusterId: "cluster/proc/deploy-1",
+          goal: "deploy the web app",
+          memberNoteSlugs: ["proc/deploy-1", "proc/deploy-2"],
+        }),
+      ],
+      noteBodies: {
+        "proc/deploy-1": "ran build, then pushed to prod via the CLI",
+        "proc/deploy-2": "rebuilt, retried once, pushed to prod via the CLI",
+      },
+    });
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    // Exactly one scaffold launch, with the stable id + both trace bodies.
+    expect(distillCalls).toHaveLength(1);
+    expect(distillCalls[0].skillId).toBe("deploy-the-web-app");
+    expect(distillCalls[0].goal).toBe("deploy the web app");
+    expect(distillCalls[0].notes.map((n) => n.slug)).toEqual([
+      "proc/deploy-1",
+      "proc/deploy-2",
+    ]);
+    expect(distillCalls[0].notes[0].body).toContain("pushed to prod");
+
+    // Notes retired, cluster marked distilled.
+    expect(deletedSlugs).toEqual(["proc/deploy-1", "proc/deploy-2"]);
+    expect(reg.rows.get("cluster/proc/deploy-1")!.status).toBe("distilled");
+    expect(outcome.distilled).toEqual(["cluster/proc/deploy-1"]);
+    expect(outcome.distillFailures).toBe(0);
+  });
+
+  test("an observing cluster is never distilled", async () => {
+    const { reg, deps, distillCalls, deletedSlugs } = harness({
+      seed: [
+        cluster({
+          clusterId: "cluster/proc/draft",
+          status: "observing",
+          memberNoteSlugs: ["proc/draft"],
+        }),
+      ],
+      noteBodies: { "proc/draft": "did the thing once" },
+    });
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    expect(distillCalls).toHaveLength(0);
+    expect(deletedSlugs).toEqual([]);
+    expect(reg.rows.get("cluster/proc/draft")!.status).toBe("observing");
+    expect(outcome.distilled).toEqual([]);
+  });
+
+  test("a distillation failure leaves the cluster ready and keeps its notes", async () => {
+    const { reg, deps, distillCalls, deletedSlugs } = harness({
+      seed: [
+        cluster({
+          clusterId: "cluster/proc/deploy-1",
+          memberNoteSlugs: ["proc/deploy-1", "proc/deploy-2"],
+        }),
+      ],
+      noteBodies: {
+        "proc/deploy-1": "trace one",
+        "proc/deploy-2": "trace two",
+      },
+      distillResult: { ok: false },
+    });
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    // The run was attempted, but nothing was retired and the cluster is still
+    // ready — the next pass can safely retry.
+    expect(distillCalls).toHaveLength(1);
+    expect(deletedSlugs).toEqual([]);
+    expect(reg.rows.get("cluster/proc/deploy-1")!.status).toBe("ready");
+    expect(outcome.distilled).toEqual([]);
+    expect(outcome.distillFailures).toBe(1);
+  });
+
+  test("a ready cluster with no readable notes is left ready (nothing to distill)", async () => {
+    const { reg, deps, distillCalls, deletedSlugs } = harness({
+      seed: [
+        cluster({
+          clusterId: "cluster/proc/gone",
+          memberNoteSlugs: ["proc/gone"],
+        }),
+      ],
+      // No body registered → loadClusterNotes returns [].
+      noteBodies: {},
+    });
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    expect(distillCalls).toHaveLength(0);
+    expect(deletedSlugs).toEqual([]);
+    expect(reg.rows.get("cluster/proc/gone")!.status).toBe("ready");
+    expect(outcome.distillFailures).toBe(1);
+  });
+
+  test("flag off → distillation phase no-ops", async () => {
+    procToSkillsEnabledSlot = false;
+    const { reg, deps, distillCalls } = harness({
+      seed: [
+        cluster({
+          clusterId: "cluster/proc/deploy-1",
+          memberNoteSlugs: ["proc/deploy-1"],
+        }),
+      ],
+      noteBodies: { "proc/deploy-1": "trace" },
+    });
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    expect(outcome.disabled).toBe(true);
+    expect(distillCalls).toHaveLength(0);
+    expect(reg.rows.get("cluster/proc/deploy-1")!.status).toBe("ready");
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
@@ -111,6 +111,13 @@ interface HarnessOpts {
   seed: ProcCandidate[];
   noteBodies?: Record<string, string>;
   distillResult?: DistillRunResult;
+  /**
+   * Skill ids the (fake) catalog reports as existing AFTER the distill run. The
+   * production check is `loadSkillCatalog().some(...)`; here it is a fixed set.
+   * Defaults to "every requested skill id exists" so a plain successful run
+   * verifies — tests exercising the no-skill path pass an explicit `[]`.
+   */
+  existingSkillIds?: string[];
 }
 
 function harness(opts: HarnessOpts) {
@@ -118,6 +125,10 @@ function harness(opts: HarnessOpts) {
   const bodies = opts.noteBodies ?? {};
   const distillCalls: DistillRunInput[] = [];
   const deletedSlugs: string[] = [];
+  // `undefined` → the skill always verifies (default happy path). An explicit
+  // array → only those ids verify (used to simulate a run that scaffolded
+  // nothing, where the target skill is absent afterward).
+  const existingSkillIds = opts.existingSkillIds;
 
   const deps: ProcDistillTriggerDeps = {
     config: config(),
@@ -141,6 +152,10 @@ function harness(opts: HarnessOpts) {
       distillCalls.push(input);
       return opts.distillResult ?? { ok: true };
     },
+    skillExists: (skillId) =>
+      existingSkillIds === undefined
+        ? true
+        : existingSkillIds.includes(skillId),
     deleteNote: async (slug) => {
       deletedSlugs.push(slug);
     },
@@ -170,7 +185,7 @@ describe("skillIdForGoal", () => {
 });
 
 describe("procDistillTriggerJob — distillation", () => {
-  test("a ready cluster is distilled, its notes deleted, and marked distilled", async () => {
+  test("a verified skill creation → notes deleted and cluster marked distilled", async () => {
     const { reg, deps, distillCalls, deletedSlugs } = harness({
       seed: [
         cluster({
@@ -183,6 +198,8 @@ describe("procDistillTriggerJob — distillation", () => {
         "proc/deploy-1": "ran build, then pushed to prod via the CLI",
         "proc/deploy-2": "rebuilt, retried once, pushed to prod via the CLI",
       },
+      // The run actually scaffolded the skill — it now appears in the catalog.
+      existingSkillIds: ["deploy-the-web-app"],
     });
 
     const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
@@ -243,6 +260,65 @@ describe("procDistillTriggerJob — distillation", () => {
 
     // The run was attempted, but nothing was retired and the cluster is still
     // ready — the next pass can safely retry.
+    expect(distillCalls).toHaveLength(1);
+    expect(deletedSlugs).toEqual([]);
+    expect(reg.rows.get("cluster/proc/deploy-1")!.status).toBe("ready");
+    expect(outcome.distilled).toEqual([]);
+    expect(outcome.distillFailures).toBe(1);
+  });
+
+  test("a skipped run (skipReason) is NOT distilled; cluster stays ready, notes intact", async () => {
+    const { reg, deps, distillCalls, deletedSlugs } = harness({
+      seed: [
+        cluster({
+          clusterId: "cluster/proc/deploy-1",
+          goal: "deploy the web app",
+          memberNoteSlugs: ["proc/deploy-1", "proc/deploy-2"],
+        }),
+      ],
+      noteBodies: {
+        "proc/deploy-1": "trace one",
+        "proc/deploy-2": "trace two",
+      },
+      // The pre-first-message gate tripped: the runner returns ok:true but ran
+      // no conversation. Even if the skill somehow "exists", a skip never
+      // distills — the notes must be preserved.
+      distillResult: { ok: true, skipReason: "pre_first_user_message" },
+      existingSkillIds: ["deploy-the-web-app"],
+    });
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    // The run was attempted but skipped — nothing retired, cluster still ready.
+    expect(distillCalls).toHaveLength(1);
+    expect(deletedSlugs).toEqual([]);
+    expect(reg.rows.get("cluster/proc/deploy-1")!.status).toBe("ready");
+    expect(outcome.distilled).toEqual([]);
+    expect(outcome.distillFailures).toBe(1);
+  });
+
+  test("a run that finishes but the skill does not exist → stays ready, notes intact", async () => {
+    const { reg, deps, distillCalls, deletedSlugs } = harness({
+      seed: [
+        cluster({
+          clusterId: "cluster/proc/deploy-1",
+          goal: "deploy the web app",
+          memberNoteSlugs: ["proc/deploy-1", "proc/deploy-2"],
+        }),
+      ],
+      noteBodies: {
+        "proc/deploy-1": "trace one",
+        "proc/deploy-2": "trace two",
+      },
+      // The turn completed (ok:true, no skip) but never scaffolded the skill —
+      // the catalog has nothing for this id afterward.
+      distillResult: { ok: true },
+      existingSkillIds: [],
+    });
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    // Skill was never created → the captured procedure must be preserved.
     expect(distillCalls).toHaveLength(1);
     expect(deletedSlugs).toEqual([]);
     expect(reg.rows.get("cluster/proc/deploy-1")!.status).toBe("ready");

--- a/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
@@ -5,9 +5,20 @@
  * freshly-seen procedure as a `kind: proc-candidate` note (PR 6); this pass
  * decides whether that note is a NEW procedure or another run of one we have
  * already been tracking, tallies recurrence in the candidate registry (PR 3),
- * and marks a cluster `ready` once it has crossed the threshold — at which point
- * a later pass (PR 9) distills it into a real skill. This job NEVER scaffolds a
- * skill and NEVER deletes a note: it only counts and marks `ready`.
+ * and marks a cluster `ready` once it has crossed the threshold — then distills
+ * each `ready` cluster into a real, registered skill.
+ *
+ * The pass has two phases:
+ *   1. TALLY — classify each candidate note against the skill catalog and the
+ *      existing clusters, opening/joining clusters and marking those that cross
+ *      the recurrence threshold (or were seeded explicitly) `ready`.
+ *   2. DISTILL — for each `ready` cluster, launch a guardian background agent
+ *      run that reads the cluster's member notes, synthesizes the canonical
+ *      procedure across the ≥ N traces, and registers it as a managed skill via
+ *      `scaffold_managed_skill`. On success the member notes are deleted (the
+ *      procedure now lives only in the skill) and the cluster is marked
+ *      `distilled` with its new skill id; on failure the cluster stays `ready`
+ *      and its notes are preserved so the next pass can retry safely.
  *
  * Per candidate note (its `goal:` frontmatter is the identity key — see the
  * design doc's "Candidate-identity matching"):
@@ -46,13 +57,20 @@
 import { isProcToSkillsEnabled } from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import type { MemoryJob } from "../../../memory/jobs-store.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../../memory/v2/constants.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
-import { readPage } from "../../../memory/v2/page-store.js";
+import { deletePage, readPage } from "../../../memory/v2/page-store.js";
+import {
+  type ProcDistillNote,
+  renderProcDistillPrompt,
+} from "../../../memory/v2/prompts/proc-distill.js";
 import {
   createTimeout,
   extractText,
   getConfiguredProvider,
 } from "../../../providers/provider-send-message.js";
+import { runBackgroundJob } from "../../../runtime/background-job-runner.js";
+import { validateManagedSkillId } from "../../../skills/managed-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import {
@@ -86,6 +104,26 @@ const PROC_CANDIDATE_KIND = "proc-candidate";
 
 /** Bound on the Tier-2 judge call so a hung provider can never stall the pass. */
 const JUDGE_TIMEOUT_MS = 20_000;
+
+/**
+ * Title origin AND request origin for the distillation background run. The
+ * request origin is the key the permission checker matches to auto-approve
+ * `skill_load skill-management` / `scaffold_managed_skill` non-interactively
+ * (see `isMemoryConsolidationSkillAuthoringGrant` in permissions/checker.ts).
+ */
+const DISTILL_ORIGIN = "memory_consolidation";
+
+/** Short stable label for the distillation run's logs/notifications. */
+const DISTILL_JOB_NAME = "memory.proc_distill";
+
+/** Hard timeout for a single distillation agent run. */
+const DISTILL_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** Guardian trust context the distillation run executes under (matches the grant). */
+const DISTILL_TRUST_CONTEXT = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+} as const;
 
 /**
  * A `kind: proc-candidate` note projected to what the trigger needs: its slug
@@ -150,6 +188,38 @@ export interface ProcDistillTriggerDeps {
   getCandidate: (clusterId: string) => ProcCandidate | null;
   /** Promote a cluster to `ready` for distillation. */
   markCandidateStatus: (clusterId: string, status: ProcCandidateStatus) => void;
+  /** Every cluster currently in `ready` status (the distillation work queue). */
+  listReadyClusters: () => ProcCandidate[];
+  /**
+   * Read the bodies of a cluster's member notes — the observed traces the
+   * distillation agent synthesizes into the canonical procedure. A note that
+   * cannot be read is dropped; the order matches `slugs`.
+   */
+  loadClusterNotes: (slugs: string[]) => Promise<ProcDistillNote[]>;
+  /**
+   * Launch the distillation agent run for one ready cluster and report whether
+   * the skill was scaffolded. Injected so tests never spin up an agent; the
+   * production default drives `runBackgroundJob` under the consolidation origin
+   * so the permission grant fires.
+   */
+  distill: (input: DistillRunInput) => Promise<DistillRunResult>;
+  /** Delete a candidate note once its cluster has been distilled into a skill. */
+  deleteNote: (slug: string) => Promise<void>;
+}
+
+/** Everything the distillation agent run needs for one ready cluster. */
+export interface DistillRunInput {
+  clusterId: string;
+  /** Stable, immutable skill id derived from the cluster goal. */
+  skillId: string;
+  goal: string;
+  notes: ProcDistillNote[];
+}
+
+/** Outcome of one distillation agent run. */
+export interface DistillRunResult {
+  /** True when the agent ran to completion and scaffolded the skill. */
+  ok: boolean;
 }
 
 /** Outcome of one trigger pass, for the log summary and test assertions. */
@@ -168,6 +238,13 @@ export interface ProcDistillOutcome {
   judged: number;
   /** Clusters marked `ready` this pass. */
   markedReady: string[];
+  /** Clusters distilled into a skill this pass (now `distilled`). */
+  distilled: string[];
+  /**
+   * Ready clusters whose distillation run failed (or scaffolded nothing) and
+   * were left `ready` with their notes intact for a later retry.
+   */
+  distillFailures: number;
   /** Per-note failures (matcher/judge/store) that did not abort the pass. */
   failures: number;
 }
@@ -192,6 +269,8 @@ export async function procDistillTriggerJob(
     joined: 0,
     judged: 0,
     markedReady: [],
+    distilled: [],
+    distillFailures: 0,
     failures: 0,
   };
 
@@ -267,6 +346,21 @@ export async function procDistillTriggerJob(
     }
   }
 
+  // Distillation phase: turn every `ready` cluster into a registered skill.
+  // Best-effort per cluster — a failure is recorded and the cluster left
+  // `ready` (notes intact) so the next pass can retry, never aborting the rest.
+  for (const cluster of deps.listReadyClusters()) {
+    try {
+      await distillCluster(cluster, deps, outcome);
+    } catch (err) {
+      outcome.distillFailures += 1;
+      log.warn(
+        { err, clusterId: cluster.clusterId },
+        "proc-distill: failed to distill ready cluster; left ready for retry",
+      );
+    }
+  }
+
   log.info(
     {
       candidates: notes.length,
@@ -276,11 +370,111 @@ export async function procDistillTriggerJob(
       joined: outcome.joined,
       judged: outcome.judged,
       markedReady: outcome.markedReady,
+      distilled: outcome.distilled,
+      distillFailures: outcome.distillFailures,
       failures: outcome.failures,
     },
     "proc-distill trigger pass complete",
   );
   return outcome;
+}
+
+/**
+ * Distill one `ready` cluster into a managed skill.
+ *
+ * Reads the cluster's member candidate notes (the observed traces), launches
+ * the distillation agent run, and — only on a successful scaffold — deletes the
+ * member notes (the procedure now lives only in the skill) and marks the
+ * cluster `distilled`. The order is deliberate: notes are deleted AFTER the
+ * skill is registered, so a failed/empty run leaves both the cluster `ready`
+ * and its notes on disk, making the next pass a safe retry.
+ *
+ * A cluster with no readable member notes is left `ready` untouched — there is
+ * nothing to synthesize, and dropping it would lose the recurrence evidence.
+ */
+async function distillCluster(
+  cluster: ProcCandidate,
+  deps: ProcDistillTriggerDeps,
+  outcome: ProcDistillOutcome,
+): Promise<void> {
+  const skillId = skillIdForGoal(cluster.goal);
+  if (!skillId) {
+    outcome.distillFailures += 1;
+    log.warn(
+      { clusterId: cluster.clusterId, goal: cluster.goal },
+      "proc-distill: cannot derive a valid skill id from cluster goal; skipping",
+    );
+    return;
+  }
+
+  const notes = await deps.loadClusterNotes(cluster.memberNoteSlugs);
+  if (notes.length === 0) {
+    outcome.distillFailures += 1;
+    log.warn(
+      { clusterId: cluster.clusterId },
+      "proc-distill: ready cluster has no readable member notes; left ready",
+    );
+    return;
+  }
+
+  const result = await deps.distill({
+    clusterId: cluster.clusterId,
+    skillId,
+    goal: cluster.goal,
+    notes,
+  });
+
+  if (!result.ok) {
+    outcome.distillFailures += 1;
+    log.warn(
+      { clusterId: cluster.clusterId, skillId },
+      "proc-distill: distillation run did not complete; left ready for retry",
+    );
+    return;
+  }
+
+  // Skill registered — retire the candidate notes, then mark the cluster
+  // `distilled`. Member-note deletion is best-effort: a stray note left on
+  // disk is harmless (its slug is already a cluster member, so the trigger
+  // skips it), whereas re-distilling would re-scaffold the same skill.
+  for (const slug of cluster.memberNoteSlugs) {
+    try {
+      await deps.deleteNote(slug);
+    } catch (err) {
+      log.warn(
+        { err, clusterId: cluster.clusterId, slug },
+        "proc-distill: failed to delete distilled candidate note; continuing",
+      );
+    }
+  }
+
+  deps.markCandidateStatus(cluster.clusterId, "distilled");
+  outcome.distilled.push(cluster.clusterId);
+  log.info(
+    { clusterId: cluster.clusterId, skillId },
+    "proc-distill: distilled ready cluster into a managed skill",
+  );
+}
+
+/**
+ * Derive a stable, immutable skill id from the cluster goal. The id is the
+ * `skill:` link target future facts reference (PR 2), so it must be
+ * deterministic for a given goal and valid per the managed-skill id rules
+ * (`^[a-z0-9][a-z0-9._-]*$`, no path traversal). Returns `null` when the goal
+ * has no usable alphanumeric content to slugify.
+ */
+export function skillIdForGoal(goal: string): string | null {
+  const slug = goal
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+    .replace(/-+$/g, "");
+  if (slug.length === 0) return null;
+  // Defense in depth: the slug shape already satisfies the managed-skill id
+  // rules, but validate so a future change to either side can't silently
+  // produce an id `scaffold_managed_skill` would reject.
+  return validateManagedSkillId(slug) === null ? slug : null;
 }
 
 /**
@@ -371,6 +565,11 @@ function defaultDeps(config: AssistantConfig): ProcDistillTriggerDeps {
     addMemberNote: realAddMemberNote,
     getCandidate: realGetCandidate,
     markCandidateStatus: realMarkCandidateStatus,
+    listReadyClusters: () => realListCandidatesByStatus("ready"),
+    loadClusterNotes: (slugs) =>
+      loadClusterNotesFromWorkspace(workspaceDir, slugs),
+    distill: launchDistillation,
+    deleteNote: (slug) => deletePage(workspaceDir, slug),
   };
 }
 
@@ -418,6 +617,65 @@ function listClustersFromRegistry(): CandidateClusterRef[] {
     }
   }
   return clusters;
+}
+
+/**
+ * Read the bodies of a cluster's member notes as the distillation traces. A
+ * note that is missing or unreadable is dropped (best-effort) — the surviving
+ * traces still describe the procedure, and a vanished note is just one fewer
+ * sample.
+ */
+async function loadClusterNotesFromWorkspace(
+  workspaceDir: string,
+  slugs: string[],
+): Promise<ProcDistillNote[]> {
+  const notes: ProcDistillNote[] = [];
+  for (const slug of slugs) {
+    try {
+      const page = await readPage(workspaceDir, slug);
+      if (page) notes.push({ slug, body: page.body });
+    } catch {
+      // Skip an unreadable note; the rest still distill.
+    }
+  }
+  return notes;
+}
+
+/**
+ * Production distillation launcher: a guardian background agent run that reads
+ * the cluster's traces, synthesizes the canonical procedure, and scaffolds the
+ * managed skill. It runs under the `memory_consolidation` request origin so the
+ * permission checker auto-approves `skill_load skill-management` /
+ * `scaffold_managed_skill` without an interactive prompt (the run has no client
+ * to answer one).
+ *
+ * Reports `ok` from `runBackgroundJob` only — whether the agent actually
+ * scaffolded the skill is the agent's own responsibility; a run that completes
+ * without scaffolding still leaves the cluster `ready` because the next pass
+ * re-reads `ready` clusters. `ok: false` (timeout, provider error, bootstrap
+ * failure, or the pre-first-message gate) keeps the cluster `ready` with notes
+ * intact for a safe retry.
+ */
+async function launchDistillation(
+  input: DistillRunInput,
+): Promise<DistillRunResult> {
+  const result = await runBackgroundJob({
+    jobName: DISTILL_JOB_NAME,
+    source: MEMORY_V2_CONSOLIDATION_SOURCE,
+    prompt: renderProcDistillPrompt({
+      skillId: input.skillId,
+      goal: input.goal,
+      notes: input.notes,
+    }),
+    systemHint: "Procedure distillation",
+    trustContext: DISTILL_TRUST_CONTEXT,
+    callSite: "memoryV2Consolidation",
+    timeoutMs: DISTILL_TIMEOUT_MS,
+    origin: DISTILL_ORIGIN,
+    requestOrigin: DISTILL_ORIGIN,
+    suppressFailureNotifications: true,
+  });
+  return { ok: result.ok };
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
@@ -15,10 +15,13 @@
  *   2. DISTILL — for each `ready` cluster, launch a guardian background agent
  *      run that reads the cluster's member notes, synthesizes the canonical
  *      procedure across the ≥ N traces, and registers it as a managed skill via
- *      `scaffold_managed_skill`. On success the member notes are deleted (the
- *      procedure now lives only in the skill) and the cluster is marked
- *      `distilled` with its new skill id; on failure the cluster stays `ready`
- *      and its notes are preserved so the next pass can retry safely.
+ *      `scaffold_managed_skill`. Success is CONFIRMED by verifying the skill now
+ *      exists — NOT by the run's `ok` flag, which is also `true` for a skipped
+ *      run (the pre-first-message gate) or a turn that finished without
+ *      scaffolding. Only once the skill is verified are the member notes deleted
+ *      (the procedure now lives only in the skill) and the cluster marked
+ *      `distilled`; on any other outcome the cluster stays `ready` and its notes
+ *      are preserved so the next pass can retry safely without data loss.
  *
  * Per candidate note (its `goal:` frontmatter is the identity key — see the
  * design doc's "Candidate-identity matching"):
@@ -55,6 +58,7 @@
  */
 
 import { isProcToSkillsEnabled } from "../../../config/memory-v3-gate.js";
+import { loadSkillCatalog } from "../../../config/skills.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import type { MemoryJob } from "../../../memory/jobs-store.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../../memory/v2/constants.js";
@@ -203,6 +207,14 @@ export interface ProcDistillTriggerDeps {
    * so the permission grant fires.
    */
   distill: (input: DistillRunInput) => Promise<DistillRunResult>;
+  /**
+   * Confirm that a skill with this id now genuinely exists (it appears in the
+   * managed-skill catalog). This is the ONLY proof a distillation run actually
+   * scaffolded its skill — `distill` reporting `ok` does not establish it (a
+   * skipped/no-scaffold/errored run also reports `ok`). Injected so tests never
+   * depend on a real on-disk catalog.
+   */
+  skillExists: (skillId: string) => boolean;
   /** Delete a candidate note once its cluster has been distilled into a skill. */
   deleteNote: (slug: string) => Promise<void>;
 }
@@ -218,8 +230,20 @@ export interface DistillRunInput {
 
 /** Outcome of one distillation agent run. */
 export interface DistillRunResult {
-  /** True when the agent ran to completion and scaffolded the skill. */
+  /**
+   * True when the background run *finished without throwing*. This is NOT a
+   * statement that the skill was scaffolded: the runner also returns `ok: true`
+   * when the pre-first-message gate skipped the run, or when the agent turn
+   * completed but never called `scaffold_managed_skill` (or the tool errored).
+   * The caller MUST confirm the skill actually exists before retiring notes.
+   */
   ok: boolean;
+  /**
+   * Set when the runner declined to execute the run (e.g. the pre-first-message
+   * gate tripped). A skipped run did NOT distill anything: the cluster must be
+   * left `ready` with its notes intact for a later retry.
+   */
+  skipReason?: string;
 }
 
 /** Outcome of one trigger pass, for the log summary and test assertions. */
@@ -383,11 +407,15 @@ export async function procDistillTriggerJob(
  * Distill one `ready` cluster into a managed skill.
  *
  * Reads the cluster's member candidate notes (the observed traces), launches
- * the distillation agent run, and — only on a successful scaffold — deletes the
- * member notes (the procedure now lives only in the skill) and marks the
- * cluster `distilled`. The order is deliberate: notes are deleted AFTER the
- * skill is registered, so a failed/empty run leaves both the cluster `ready`
- * and its notes on disk, making the next pass a safe retry.
+ * the distillation agent run, and — only once the skill is CONFIRMED to exist —
+ * deletes the member notes (the procedure now lives only in the skill) and
+ * marks the cluster `distilled`. Confirmation is by `skillExists`, not by the
+ * run's `ok` flag: a skipped run, or a turn that finished without scaffolding
+ * (or a scaffold-tool error), also reports `ok: true`, and retiring the notes
+ * on that signal would destroy the captured procedure while pointing a phantom
+ * `distilled` cluster at a skill that does not exist. The order is deliberate:
+ * notes are deleted AFTER the skill is verified, so a failed/skipped/empty run
+ * leaves both the cluster `ready` and its notes on disk for a safe retry.
  *
  * A cluster with no readable member notes is left `ready` untouched — there is
  * nothing to synthesize, and dropping it would lose the recurrence evidence.
@@ -433,9 +461,37 @@ async function distillCluster(
     return;
   }
 
-  // Skill registered — retire the candidate notes, then mark the cluster
-  // `distilled`. Member-note deletion is best-effort: a stray note left on
-  // disk is harmless (its slug is already a cluster member, so the trigger
+  // A skipped run (e.g. the pre-first-message gate tripped) reports `ok: true`
+  // but bootstrapped no conversation — nothing was distilled. Leave the cluster
+  // `ready` with its notes intact so a later pass retries once the gate clears.
+  if (result.skipReason) {
+    outcome.distillFailures += 1;
+    log.info(
+      { clusterId: cluster.clusterId, skillId, skipReason: result.skipReason },
+      "proc-distill: distillation run was skipped; left ready for retry",
+    );
+    return;
+  }
+
+  // `ok` only means the run finished without throwing — it does NOT prove the
+  // agent scaffolded the skill (the turn may have completed without ever
+  // calling `scaffold_managed_skill`, or the tool may have errored). Retiring
+  // the notes now would destroy the captured procedure AND leave a phantom
+  // `distilled` cluster pointing at a skill that does not exist. So verify the
+  // skill genuinely exists before touching anything; otherwise leave the
+  // cluster `ready` with its notes intact for a safe retry.
+  if (!deps.skillExists(skillId)) {
+    outcome.distillFailures += 1;
+    log.warn(
+      { clusterId: cluster.clusterId, skillId },
+      "proc-distill: distillation run finished but the skill was not created; left ready for retry",
+    );
+    return;
+  }
+
+  // Skill registered AND verified — retire the candidate notes, then mark the
+  // cluster `distilled`. Member-note deletion is best-effort: a stray note left
+  // on disk is harmless (its slug is already a cluster member, so the trigger
   // skips it), whereas re-distilling would re-scaffold the same skill.
   for (const slug of cluster.memberNoteSlugs) {
     try {
@@ -569,6 +625,7 @@ function defaultDeps(config: AssistantConfig): ProcDistillTriggerDeps {
     loadClusterNotes: (slugs) =>
       loadClusterNotesFromWorkspace(workspaceDir, slugs),
     distill: launchDistillation,
+    skillExists: skillExistsInCatalog,
     deleteNote: (slug) => deletePage(workspaceDir, slug),
   };
 }
@@ -649,12 +706,13 @@ async function loadClusterNotesFromWorkspace(
  * `scaffold_managed_skill` without an interactive prompt (the run has no client
  * to answer one).
  *
- * Reports `ok` from `runBackgroundJob` only — whether the agent actually
- * scaffolded the skill is the agent's own responsibility; a run that completes
- * without scaffolding still leaves the cluster `ready` because the next pass
- * re-reads `ready` clusters. `ok: false` (timeout, provider error, bootstrap
- * failure, or the pre-first-message gate) keeps the cluster `ready` with notes
- * intact for a safe retry.
+ * Reports `ok` and any `skipReason` from `runBackgroundJob`. `ok` only means
+ * the run finished without throwing — it does NOT establish that the agent
+ * scaffolded the skill (the gate may have skipped the run, or the turn may have
+ * completed without calling `scaffold_managed_skill`). The caller verifies the
+ * skill actually exists (`skillExists`) before retiring the cluster's notes;
+ * `ok: false`, a `skipReason`, or a missing skill all keep the cluster `ready`
+ * with its notes intact for a safe retry.
  */
 async function launchDistillation(
   input: DistillRunInput,
@@ -675,7 +733,18 @@ async function launchDistillation(
     requestOrigin: DISTILL_ORIGIN,
     suppressFailureNotifications: true,
   });
-  return { ok: result.ok };
+  return { ok: result.ok, skipReason: result.skipReason };
+}
+
+/**
+ * Production skill-existence check: does a managed skill with this id appear in
+ * the live catalog? `loadSkillCatalog()` includes scaffolded managed skills, so
+ * a successful `scaffold_managed_skill` from the distillation run shows up here.
+ * This is what proves the run actually created the skill before we retire the
+ * cluster's candidate notes.
+ */
+function skillExistsInCatalog(skillId: string): boolean {
+  return loadSkillCatalog().some((skill) => skill.id === skillId);
 }
 
 /**

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -159,7 +159,24 @@ describe("runBackgroundJob", () => {
       trustContext: TRUST_CONTEXT,
       callSite: "heartbeatAgent",
     });
+    // No requestOrigin set on baseOpts → none threaded to processMessage, so no
+    // origin-scoped permission grant can fire for an ordinary background job.
+    expect(
+      (processMessageCalls[0].options as { requestOrigin?: string })
+        .requestOrigin,
+    ).toBeUndefined();
     expect(emitCalls).toHaveLength(0);
+  });
+
+  test("threads requestOrigin into processMessage options when set", async () => {
+    await runBackgroundJob(baseOpts({ requestOrigin: "memory_consolidation" }));
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options).toMatchObject({
+      trustContext: TRUST_CONTEXT,
+      callSite: "heartbeatAgent",
+      requestOrigin: "memory_consolidation",
+    });
   });
 
   test("generic exception: returns ok=false with errorKind=exception and emits activity.failed with dedupeKey", async () => {

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -86,6 +86,16 @@ export interface RunBackgroundJobOptions {
   groupId?: string;
   /** Title origin tag for `bootstrapConversation`. */
   origin: TitleOrigin;
+  /**
+   * Origin tag threaded into the agent turn's tool context (and through it
+   * `buildPolicyContext`), letting the permission checker scope narrow
+   * non-interactive auto-grants to a specific internal background origin
+   * (e.g. memory-consolidation skill authoring). Background jobs cannot
+   * answer interactive approval prompts, so a job that legitimately needs an
+   * otherwise-gated tool opts in by setting this to the origin its grant
+   * keys on. Omitted = no origin-scoped grant can fire for the turn.
+   */
+  requestOrigin?: string;
   /** Conversation type to bootstrap with. Defaults to `"background"`. */
   conversationType?: "background" | "scheduled";
   /**
@@ -276,6 +286,7 @@ export async function runBackgroundJob(
       ...(opts.overrideProfile
         ? { overrideProfile: opts.overrideProfile }
         : {}),
+      ...(opts.requestOrigin ? { requestOrigin: opts.requestOrigin } : {}),
     });
     // Absorb late rejections: if the timeout wins the race, `work` keeps
     // running and may eventually reject — swallow so it doesn't surface as

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -32,17 +32,31 @@ export function buildPolicyContext(
 
   const conversationId = context?.conversationId;
 
+  // Origin/trust/channel signals the checker uses to scope narrow
+  // non-interactive auto-grants (e.g. the memory-consolidation skill-authoring
+  // grant) to a specific internal origin. Background-job turns populate
+  // `requestOrigin`; `trustClass`/`executionChannel` come from the turn's
+  // resolved trust context. Undefined for normal interactive turns, so no
+  // origin-scoped grant can fire for them.
+  const originSignals = {
+    requestOrigin: context?.requestOrigin,
+    trustClass: context?.trustClass,
+    sourceChannel: context?.executionChannel,
+  };
+
   const ownerKind = getToolOwner(tool.name)?.kind;
   if (ownerKind === "skill" || ownerKind === "plugin") {
     return {
       executionTarget: tool.executionTarget,
       executionContext,
       conversationId,
+      ...originSignals,
     };
   }
 
   return {
     executionContext,
     conversationId,
+    ...originSignals,
   };
 }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -319,6 +319,15 @@ export interface ToolContext {
   trustClass: TrustClass;
   /** Channel through which the tool invocation originates (e.g. 'telegram', 'phone'). Used for scoped grant consumption. */
   executionChannel?: string;
+  /**
+   * Origin tag of the turn driving this tool invocation (the conversation's
+   * `TitleOrigin`, e.g. "memory_consolidation"). Set for background-job turns
+   * that pass `requestOrigin` to `runBackgroundJob`. `buildPolicyContext`
+   * copies it onto the `PolicyContext` so the permission checker can scope
+   * narrow non-interactive auto-grants (e.g. consolidation skill authoring) to
+   * a specific internal origin. Unset for normal interactive turns.
+   */
+  requestOrigin?: string;
   /** Voice/call session ID, if the invocation originates from a call. Used for scoped grant consumption. */
   callSessionId?: string;
   /** True when the tool invocation was triggered by a user clicking a surface action button (not a regular message). */


### PR DESCRIPTION
## Summary
- Distill ready clusters into managed skills via scaffold_managed_skill; delete candidate notes; mark distilled
- Thread requestOrigin/trust/channel through ToolContext -> buildPolicyContext so PR4's consolidation skill-authoring grant fires (Codex #35987); add a PermissionChecker integration test

Part of plan: procedural-memory-as-skills.md (PR 9 of 9)