### PR TITLE
refactor(channels): hoist canonical CHANNEL_IDS into service-contracts

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -1,26 +1,16 @@
-export const CHANNEL_IDS = [
-  "telegram",
-  "phone",
-  "vellum",
-  "whatsapp",
-  "slack",
-  "email",
-  "platform",
-  "a2a",
-] as const;
+import {
+  CHANNEL_IDS,
+  type ChannelId,
+  isChannelId,
+} from "@vellumai/service-contracts/channels";
 
-export type ChannelId = (typeof CHANNEL_IDS)[number];
-
-export function isChannelId(value: unknown): value is ChannelId {
-  return (
-    typeof value === "string" &&
-    (CHANNEL_IDS as readonly string[]).includes(value)
-  );
-}
+// The assistant understands the full canonical channel set, so it adopts the
+// shared vocabulary wholesale. `parseChannelId` stays local — it is only used
+// daemon-side and is a thin convenience over the shared guard.
+export { CHANNEL_IDS, type ChannelId, isChannelId };
 
 export function parseChannelId(value: unknown): ChannelId | null {
-  if (isChannelId(value)) return value;
-  return null;
+  return isChannelId(value) ? value : null;
 }
 
 export interface TurnChannelContext {

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -1,3 +1,13 @@
+import type { ChannelId as CanonicalChannelId } from "@vellumai/service-contracts/channels";
+
+/**
+ * Channels the gateway can ingress — a strict subset of the canonical
+ * `ChannelId` set. The gateway never sees `platform` (internal control plane),
+ * and the admission-policy routes rely on that omission: a request for a
+ * `platform` policy fails the `isChannelId` gate and returns 403. The
+ * `satisfies` clause asserts every entry is a real canonical channel, so the
+ * gateway can never list one the assistant doesn't recognize.
+ */
 export const CHANNEL_IDS = [
   "telegram",
   "phone",
@@ -6,7 +16,7 @@ export const CHANNEL_IDS = [
   "slack",
   "email",
   "a2a",
-] as const;
+] as const satisfies readonly CanonicalChannelId[];
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];
 
@@ -15,10 +25,6 @@ export function isChannelId(value: unknown): value is ChannelId {
     typeof value === "string" &&
     (CHANNEL_IDS as readonly string[]).includes(value)
   );
-}
-
-export function parseChannelId(value: unknown): ChannelId | null {
-  return isChannelId(value) ? value : null;
 }
 
 export const INTERFACE_IDS = [

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./channels": "./src/channels.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
     "./ingress": "./src/ingress.ts",
     "./twilio-ingress": "./src/twilio-ingress.ts",

--- a/packages/service-contracts/src/__tests__/channels.test.ts
+++ b/packages/service-contracts/src/__tests__/channels.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { CHANNEL_IDS, isChannelId } from "../channels.js";
+
+describe("isChannelId", () => {
+  test("accepts every canonical channel id", () => {
+    for (const id of CHANNEL_IDS) {
+      expect(isChannelId(id)).toBe(true);
+    }
+  });
+
+  test("includes the internal channels no external surface ingresses", () => {
+    // `platform` (control plane) and `vellum` (native app) are part of the
+    // canonical vocabulary even though the gateway never ingresses them. The
+    // gateway's narrower list is a compile-time-asserted subset of this set,
+    // so these must remain canonical for that assertion to mean anything.
+    expect(isChannelId("platform")).toBe(true);
+    expect(isChannelId("vellum")).toBe(true);
+  });
+
+  test("rejects unknown strings and non-string values", () => {
+    expect(isChannelId("discord")).toBe(false);
+    expect(isChannelId("")).toBe(false);
+    expect(isChannelId(undefined)).toBe(false);
+    expect(isChannelId(null)).toBe(false);
+    expect(isChannelId(42)).toBe(false);
+  });
+});

--- a/packages/service-contracts/src/channels.ts
+++ b/packages/service-contracts/src/channels.ts
@@ -1,0 +1,41 @@
+/**
+ * Canonical channel-id vocabulary shared between the assistant daemon and the
+ * gateway.
+ *
+ * A "channel" is an external messaging surface an actor can reach the
+ * assistant through (Slack, Telegram, WhatsApp, phone, …) plus a couple of
+ * internal ids (`vellum` for native app conversations, `platform` for the
+ * internal control plane). This is the single source of truth for that set:
+ * the assistant adopts it wholesale as its `ChannelId`, and the gateway
+ * asserts its own (narrower) inbound list is a subset of it so the two sides
+ * cannot silently drift.
+ *
+ * Both packages depend on `@vellumai/service-contracts`, so hoisting the set
+ * here (rather than maintaining a copy on each side) means adding or renaming
+ * a channel happens in exactly one place.
+ *
+ * Note that a consumer may legitimately handle only a *subset* of these — the
+ * gateway, for example, never ingresses `platform`. Use a local list guarded
+ * by `satisfies readonly ChannelId[]` for those cases rather than redefining
+ * the union.
+ */
+
+export const CHANNEL_IDS = [
+  "telegram",
+  "phone",
+  "vellum",
+  "whatsapp",
+  "slack",
+  "email",
+  "platform",
+  "a2a",
+] as const;
+
+export type ChannelId = (typeof CHANNEL_IDS)[number];
+
+export function isChannelId(value: unknown): value is ChannelId {
+  return (
+    typeof value === "string" &&
+    (CHANNEL_IDS as readonly string[]).includes(value)
+  );
+}

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -18,6 +18,7 @@
  * module so that both sides can depend on it without circular references.
  */
 
+export * from "./channels.js";
 export * from "./transport.js";
 export * from "./error.js";
 export * from "./handles.js";


### PR DESCRIPTION
## What

[LUM-2576](https://linear.app/vellum/issue/LUM-2576)

The assistant and gateway each maintained their **own** `CHANNEL_IDS` array. They were free to drift apart silently — nothing connected the two definitions, so adding/removing a channel on one side and forgetting the other would compile cleanly and only surface as a runtime bug.

This moves the canonical channel-id vocabulary into a new `@vellumai/service-contracts/channels` module (mirroring how `trust-rules` is already shared between the two services) and makes that the single source of truth.

## How

- **`@vellumai/service-contracts/channels`** (new) — exports the canonical `CHANNEL_IDS`, `ChannelId`, and `isChannelId`. Pure, zero-import (validated by the existing `package-boundary.test.ts`).
- **Assistant** (`assistant/src/channels/types.ts`) — adopts the canonical set wholesale: re-exports `CHANNEL_IDS` / `ChannelId` / `isChannelId`, keeping the daemon-only `parseChannelId` convenience over the shared guard. No behavior change; the ~10 consumers keep importing from `channels/types.ts`.
- **Gateway** (`gateway/src/channels/types.ts`) — keeps its **narrower** inbound list and its own `isChannelId`, because the admission-policy routes depend on `platform` being *absent* (an unknown `platform` policy request must 403, and the seed loop must skip it). It now imports the canonical type only to assert the subset relationship:
  ```ts
  export const CHANNEL_IDS = [ ... ] as const satisfies readonly CanonicalChannelId[];
  ```
  This makes drift a **compile error**: the gateway can never list a channel the assistant doesn't recognize.
- Removes the gateway's `parseChannelId` (dead — zero call sites).

## Why subset-assert rather than one shared list

The gateway genuinely handles fewer channels than the assistant (it never ingresses `platform`), and several gateway code paths rely on that narrowness. Forcing both onto one identical list would break admission-policy behavior. The `satisfies` guard gives us the drift safety we want while preserving the meaningful gateway/assistant distinction. The reverse direction (canonical gains a channel the gateway doesn't yet handle) is intentionally allowed — the gateway is permitted to lag as a subset.

## Verification

- `tsc --noEmit` clean: service-contracts, gateway, assistant.
- New `channels.test.ts` pins `isChannelId` + the `platform`/`vellum` canonical membership that the subset relationship hinges on.
- Gateway `channel-admission-policy-routes.test.ts` (14) and assistant `local-principal-trust` / `conversation-serializer` consumer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_