### PR TITLE
[codex] Bound onboarding avatar handoff retries

### DIFF
--- a/clients/web/src/components/onboarding-avatar-applier.test.tsx
+++ b/clients/web/src/components/onboarding-avatar-applier.test.tsx
@@ -24,9 +24,11 @@ mock.module("@/assistant/avatar-api", () => ({
   saveCharacterTraits: saveCharacterTraitsMock,
 }));
 
-const { OnboardingAvatarApplier } = await import(
-  "@/components/onboarding-avatar-applier"
-);
+const {
+  OnboardingAvatarApplier,
+  getAvatarApplyRetryDelayMs,
+  shouldDropAvatarHandoff,
+} = await import("@/components/onboarding-avatar-applier");
 
 describe("OnboardingAvatarApplier", () => {
   beforeEach(() => {
@@ -65,5 +67,17 @@ describe("OnboardingAvatarApplier", () => {
     expect(useOnboardingFocusStore.getState().pendingAvatarTraits).toEqual(
       TRAITS,
     );
+  });
+
+  test("backs off retry delays after failed saves", () => {
+    expect(getAvatarApplyRetryDelayMs(1)).toBe(1_500);
+    expect(getAvatarApplyRetryDelayMs(2)).toBe(3_000);
+    expect(getAvatarApplyRetryDelayMs(3)).toBe(6_000);
+    expect(getAvatarApplyRetryDelayMs(5)).toBe(15_000);
+  });
+
+  test("drops the staged handoff after the retry budget is exhausted", () => {
+    expect(shouldDropAvatarHandoff(5)).toBe(false);
+    expect(shouldDropAvatarHandoff(6)).toBe(true);
   });
 });

--- a/clients/web/src/components/onboarding-avatar-applier.tsx
+++ b/clients/web/src/components/onboarding-avatar-applier.tsx
@@ -6,9 +6,9 @@
  * The chosen avatar traits aren't part of the pre-chat handoff context, so they
  * can't be set during hatch. This invisible component (mounted in `ChatLayout`)
  * watches for the staged `pendingAvatarTraits` and the active assistant id, then
- * persists the traits via `saveCharacterTraits`. Transient save failures keep
- * the staged value queued for a retry; the value clears only after a successful
- * save.
+ * persists the traits via `saveCharacterTraits`. Transient save failures retry
+ * with bounded backoff; the staged value clears after a successful save or after
+ * the retry budget is exhausted.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -16,8 +16,22 @@ import { useEffect, useRef, useState } from "react";
 import { saveCharacterTraits } from "@/assistant/avatar-api";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { CharacterTraits } from "@/types/avatar";
 
-const AVATAR_APPLY_RETRY_MS = 1_500;
+const AVATAR_APPLY_INITIAL_RETRY_MS = 1_500;
+const AVATAR_APPLY_MAX_RETRY_MS = 15_000;
+const AVATAR_APPLY_MAX_ATTEMPTS = 6;
+
+export function getAvatarApplyRetryDelayMs(failedAttempts: number): number {
+  return Math.min(
+    AVATAR_APPLY_INITIAL_RETRY_MS * 2 ** Math.max(0, failedAttempts - 1),
+    AVATAR_APPLY_MAX_RETRY_MS,
+  );
+}
+
+export function shouldDropAvatarHandoff(failedAttempts: number): boolean {
+  return failedAttempts >= AVATAR_APPLY_MAX_ATTEMPTS;
+}
 
 export function OnboardingAvatarApplier() {
   const pendingAvatarTraits =
@@ -26,10 +40,26 @@ export function OnboardingAvatarApplier() {
     useOnboardingFocusStore.use.setPendingAvatarTraits();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const savingRef = useRef(false);
+  const failedAttemptsRef = useRef(0);
+  const currentHandoffRef = useRef<{
+    assistantId: string;
+    traits: CharacterTraits;
+  } | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
 
   useEffect(() => {
     if (!pendingAvatarTraits || !assistantId || savingRef.current) return;
+    const currentHandoff = currentHandoffRef.current;
+    if (
+      currentHandoff?.assistantId !== assistantId ||
+      currentHandoff.traits !== pendingAvatarTraits
+    ) {
+      currentHandoffRef.current = {
+        assistantId,
+        traits: pendingAvatarTraits,
+      };
+      failedAttemptsRef.current = 0;
+    }
     savingRef.current = true;
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -37,13 +67,24 @@ export function OnboardingAvatarApplier() {
     void saveCharacterTraits(assistantId, traits)
       .then((saved) => {
         if (!saved) throw new Error("Avatar traits were not saved");
-        if (!cancelled) setPendingAvatarTraits(null);
+        if (!cancelled) {
+          currentHandoffRef.current = null;
+          failedAttemptsRef.current = 0;
+          setPendingAvatarTraits(null);
+        }
       })
       .catch(() => {
         if (cancelled) return;
+        const failedAttempts = failedAttemptsRef.current + 1;
+        failedAttemptsRef.current = failedAttempts;
+        if (shouldDropAvatarHandoff(failedAttempts)) {
+          currentHandoffRef.current = null;
+          setPendingAvatarTraits(null);
+          return;
+        }
         retryTimer = setTimeout(() => {
           setRetryNonce((nonce) => nonce + 1);
-        }, AVATAR_APPLY_RETRY_MS);
+        }, getAvatarApplyRetryDelayMs(failedAttempts));
       })
       .finally(() => {
         if (!cancelled) savingRef.current = false;


### PR DESCRIPTION
## Summary

Follow-up to PR #36002 addressing the P2 review comment about unbounded avatar handoff retries.

- retries failed onboarding avatar saves with exponential backoff
- caps the retry budget at six failed save attempts
- clears the staged avatar handoff after the budget is exhausted so a permanent failure cannot keep hitting the avatar save endpoint indefinitely
- adds focused coverage for the retry delay and drop policy

## Validation

- `cd clients/web && bun test src/components/onboarding-avatar-applier.test.tsx`
- `cd clients/web && bun run lint src/components/onboarding-avatar-applier.tsx src/components/onboarding-avatar-applier.test.tsx`
- `cd clients/web && bunx tsc --noEmit`
- commit hook reran web lint, OpenAPI generation, and typecheck