### PR TITLE
Notify requester and release interaction on guardian request expiry

### DIFF
--- a/assistant/src/__tests__/guardian-expiry-notifier.test.ts
+++ b/assistant/src/__tests__/guardian-expiry-notifier.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for guardian request expiry side effects:
+ *
+ * 1. notifyExpiredGuardianRequest — per-kind behavior (requester notice for
+ *    access_request / tool_grant_request, interaction release for tool_approval,
+ *    no-op for pending_question), Slack DM routing, non-deliverable channels,
+ *    and best-effort (non-throwing) delivery.
+ * 2. Sweep integration — an expired request is transitioned to `expired` and the
+ *    requester is notified through the wired-in notifier.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence logging.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+// Capture requester channel deliveries; optionally fail to exercise the
+// best-effort path.
+const deliveredReplies: Array<{
+  url: string;
+  payload: { chatId: string; text: string; assistantId?: string };
+}> = [];
+let deliveryError: Error | null = null;
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async (
+    url: string,
+    payload: { chatId: string; text: string; assistantId?: string },
+  ) => {
+    if (deliveryError) throw deliveryError;
+    deliveredReplies.push({ url, payload });
+  },
+}));
+
+// Capture hub broadcasts (interaction_resolved) emitted by pendingInteractions.
+const broadcasts: Array<Record<string, unknown>> = [];
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: Record<string, unknown>) => {
+    broadcasts.push(msg);
+  },
+}));
+
+// The sweep withdraws cards via this module; we only assert it is invoked, and
+// mocking it keeps the sweep import light (no surface/slack transitive deps).
+let withdrawCalls = 0;
+mock.module("../approvals/guardian-card-withdrawal.js", () => ({
+  withdrawGuardianRequestCards: async () => {
+    withdrawCalls++;
+  },
+}));
+
+import { notifyExpiredGuardianRequest } from "../approvals/guardian-expiry-notifier.js";
+import type { CanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import {
+  createCanonicalGuardianRequest,
+  getCanonicalGuardianRequest,
+} from "../memory/canonical-guardian-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { sweepExpiredCanonicalGuardianRequests } from "../runtime/routes/canonical-guardian-expiry-sweep.js";
+
+await initializeDb();
+
+/** Build a fully-populated canonical request, overriding the interesting bits. */
+function makeRequest(
+  overrides: Partial<CanonicalGuardianRequest> & { kind: string },
+): CanonicalGuardianRequest {
+  return {
+    id: "req-1",
+    sourceType: "channel",
+    sourceChannel: "telegram",
+    conversationId: "conv-1",
+    requesterExternalUserId: "req-user",
+    requesterChatId: "req-chat",
+    guardianExternalUserId: "guardian-user",
+    guardianPrincipalId: "guardian-principal",
+    callSessionId: null,
+    pendingQuestionId: null,
+    questionText: null,
+    requestCode: "ABC123",
+    toolName: null,
+    inputDigest: null,
+    commandPreview: null,
+    riskLevel: null,
+    activityText: null,
+    executionTarget: null,
+    status: "expired",
+    answerText: null,
+    decidedByExternalUserId: null,
+    decidedByPrincipalId: null,
+    followupState: null,
+    expiresAt: 1000,
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  deliveredReplies.length = 0;
+  broadcasts.length = 0;
+  deliveryError = null;
+  withdrawCalls = 0;
+  pendingInteractions.clear();
+});
+
+describe("notifyExpiredGuardianRequest", () => {
+  test("access_request: notifies the requester on their channel", async () => {
+    await notifyExpiredGuardianRequest(
+      makeRequest({
+        kind: "access_request",
+        sourceChannel: "telegram",
+        requesterChatId: "tg-chat",
+        requesterExternalUserId: "tg-user",
+      }),
+    );
+
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].url).toBe("/deliver/telegram");
+    expect(deliveredReplies[0].payload.chatId).toBe("tg-chat");
+    expect(deliveredReplies[0].payload.text).toContain(
+      "access request expired",
+    );
+  });
+
+  test("access_request on Slack: routes to the requester DM, not the channel", async () => {
+    await notifyExpiredGuardianRequest(
+      makeRequest({
+        kind: "access_request",
+        sourceChannel: "slack",
+        requesterChatId: "C0SHARED",
+        requesterExternalUserId: "U123",
+      }),
+    );
+
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].url).toBe("/deliver/slack");
+    // DM via the user id, never the shared channel id.
+    expect(deliveredReplies[0].payload.chatId).toBe("U123");
+  });
+
+  test("tool_grant_request: notice names the tool", async () => {
+    await notifyExpiredGuardianRequest(
+      makeRequest({
+        kind: "tool_grant_request",
+        sourceChannel: "telegram",
+        requesterChatId: "tg-chat",
+        toolName: "bash",
+      }),
+    );
+
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].payload.text).toContain('"bash"');
+    expect(deliveredReplies[0].payload.text).toContain("expired");
+  });
+
+  test("tool_approval: releases the pending interaction, sends no channel notice", async () => {
+    pendingInteractions.register("req-ta", {
+      conversationId: "conv-1",
+      kind: "confirmation",
+    });
+
+    await notifyExpiredGuardianRequest(
+      makeRequest({ id: "req-ta", kind: "tool_approval" }),
+    );
+
+    expect(pendingInteractions.get("req-ta")).toBeUndefined();
+    const resolvedEvent = broadcasts.find(
+      (b) => b.type === "interaction_resolved",
+    );
+    expect(resolvedEvent).toMatchObject({
+      requestId: "req-ta",
+      state: "cancelled",
+    });
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test("tool_approval: no registered interaction is a safe no-op", async () => {
+    await notifyExpiredGuardianRequest(
+      makeRequest({ id: "req-none", kind: "tool_approval" }),
+    );
+
+    expect(deliveredReplies).toHaveLength(0);
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  test("pending_question: no notice (voice owns its lifecycle)", async () => {
+    await notifyExpiredGuardianRequest(
+      makeRequest({ kind: "pending_question", sourceChannel: "phone" }),
+    );
+
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test("non-deliverable channel: no notice", async () => {
+    await notifyExpiredGuardianRequest(
+      makeRequest({ kind: "access_request", sourceChannel: "vellum" }),
+    );
+
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test("missing requester chat: no notice", async () => {
+    await notifyExpiredGuardianRequest(
+      makeRequest({
+        kind: "access_request",
+        sourceChannel: "telegram",
+        requesterChatId: null,
+        requesterExternalUserId: null,
+      }),
+    );
+
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test("delivery failure is swallowed (best-effort)", async () => {
+    deliveryError = new Error("gateway down");
+
+    await expect(
+      notifyExpiredGuardianRequest(
+        makeRequest({
+          kind: "access_request",
+          sourceChannel: "telegram",
+          requesterChatId: "tg-chat",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("sweep integration", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM canonical_guardian_requests");
+    db.run("DELETE FROM canonical_guardian_deliveries");
+  });
+
+  test("expired access_request is transitioned and the requester is notified", async () => {
+    const request = createCanonicalGuardianRequest({
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      requesterChatId: "tg-chat",
+      requesterExternalUserId: "tg-user",
+      guardianPrincipalId: "guardian-principal",
+      expiresAt: Date.now() - 1000, // already past
+    });
+
+    const expiredCount = await sweepExpiredCanonicalGuardianRequests();
+
+    expect(expiredCount).toBe(1);
+    expect(getCanonicalGuardianRequest(request.id)?.status).toBe("expired");
+    expect(withdrawCalls).toBe(1);
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].payload.text).toContain(
+      "access request expired",
+    );
+  });
+
+  test("not-yet-expired requests are left pending and unnotified", async () => {
+    const request = createCanonicalGuardianRequest({
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      requesterChatId: "tg-chat",
+      guardianPrincipalId: "guardian-principal",
+      expiresAt: Date.now() + 60_000, // still in the future
+    });
+
+    const expiredCount = await sweepExpiredCanonicalGuardianRequests();
+
+    expect(expiredCount).toBe(0);
+    expect(getCanonicalGuardianRequest(request.id)?.status).toBe("pending");
+    expect(deliveredReplies).toHaveLength(0);
+  });
+});

--- a/assistant/src/approvals/guardian-channel-delivery.ts
+++ b/assistant/src/approvals/guardian-channel-delivery.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared addressing helpers for guardian requester-facing channel notices.
+ *
+ * Requester notices (approval, denial, expiry) are delivered straight to the
+ * requester's chat via `deliverChannelReply` — independent of the
+ * guardian-facing notification pipeline. Centralizing the addressing rules here
+ * keeps the decision resolvers and the timer-driven expiry sweep from drifting
+ * apart on how a requester is reached.
+ */
+
+/**
+ * Resolve the callback-less delivery route for a channel (e.g. `/deliver/slack`).
+ *
+ * Used when there is no inbound reply callback URL to post back to — the
+ * guardian decided off-channel (desktop), or the expiry sweep fired on a timer
+ * with no originating request in hand. Returns null for channels that have no
+ * deliverable route (e.g. email, the in-app vellum surface).
+ */
+export function resolveDeliverCallbackUrlForChannel(
+  channel: string,
+): string | null {
+  switch (channel) {
+    case "telegram":
+    case "whatsapp":
+    case "slack":
+      return `/deliver/${channel}`;
+    default:
+      return null;
+  }
+}

--- a/assistant/src/approvals/guardian-expiry-notifier.ts
+++ b/assistant/src/approvals/guardian-expiry-notifier.ts
@@ -1,0 +1,148 @@
+/**
+ * Expiry side effects for canonical guardian requests.
+ *
+ * When the canonical expiry sweep transitions a pending request to `expired`,
+ * the request's cards are withdrawn — but nobody is told and any in-memory
+ * interaction is left dangling. This module fills that gap:
+ *
+ *  - the requester is told their request expired (for the persistent,
+ *    requester-facing kinds: `access_request`, `tool_grant_request`), and
+ *  - the in-memory pending interaction is released (for the interaction-bound
+ *    `tool_approval` kind).
+ *
+ * Delivery goes straight to the requester via `deliverChannelReply` on the
+ * callback-less `/deliver/<channel>` route — NOT the notification pipeline,
+ * which is guardian-facing (`emitNotificationSignal` resolves the *guardian's*
+ * delivery channels). The guardian is intentionally left passive here: the
+ * withdrawn card already reflects the expired state, so a fresh ping would be
+ * noise.
+ *
+ * Best-effort by contract: the request is already resolved (CAS committed)
+ * before this runs, so a failed notice or interaction release must never
+ * surface as a sweep failure. Nothing here throws.
+ */
+
+import type { CanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { deliverChannelReply } from "../runtime/gateway-client.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { getLogger } from "../util/logger.js";
+import { resolveDeliverCallbackUrlForChannel } from "./guardian-channel-delivery.js";
+
+const log = getLogger("guardian-expiry-notifier");
+
+/**
+ * Run the expiry side effects for a single canonical guardian request that the
+ * sweep just transitioned to `expired`. Dispatches by kind; never throws.
+ */
+export async function notifyExpiredGuardianRequest(
+  request: CanonicalGuardianRequest,
+): Promise<void> {
+  try {
+    switch (request.kind) {
+      case "tool_approval":
+        releaseExpiredInteraction(request);
+        return;
+      case "access_request":
+        await notifyRequesterOfExpiry(
+          request,
+          "Your access request expired before it was reviewed. " +
+            "Send a new message if you still need access.",
+        );
+        return;
+      case "tool_grant_request":
+        await notifyRequesterOfExpiry(
+          request,
+          `Your request to use "${request.toolName ?? "a tool"}" expired ` +
+            "before it was reviewed. Ask again if you still need it.",
+        );
+        return;
+      case "pending_question":
+        // Voice call sessions own their own lifecycle and timeout. By the time
+        // the canonical TTL lapses the call is long over and there is no
+        // durable requester channel to notify, so there is nothing to do.
+        return;
+      default:
+        return;
+    }
+  } catch (err) {
+    log.warn(
+      { err, requestId: request.id, kind: request.kind },
+      "Expiry side effects failed for canonical guardian request (non-fatal)",
+    );
+  }
+}
+
+/**
+ * Release the in-memory pending interaction for an expired `tool_approval`.
+ *
+ * `tool_approval` is the one interaction-bound kind the periodic sweep can
+ * reach (it carries a 30-minute `expiresAt`). In practice the canonical request
+ * id does not key a *blocking* prompter interaction: ingress escalations — the
+ * sole producer of this kind — register no interaction at all, and
+ * PermissionPrompter confirmations are keyed by their own request id with their
+ * own (far shorter) timeout. So this is a safe cleanup: it no-ops when nothing
+ * is registered under the request id, and otherwise drops a waiter-less async
+ * entry and emits `interaction_resolved` so clients clear the attention
+ * indicator. `cancelled` is the documented runtime-termination/timeout outcome.
+ */
+function releaseExpiredInteraction(request: CanonicalGuardianRequest): void {
+  const released = pendingInteractions.resolve(request.id, "cancelled");
+  if (released) {
+    log.info(
+      { requestId: request.id, kind: request.kind },
+      "Released pending interaction for expired guardian request",
+    );
+  }
+}
+
+/**
+ * Deliver an expiry notice straight to the requester's chat.
+ *
+ * The sweep is timer-driven and holds no inbound reply callback URL, so this
+ * mirrors the resolvers' off-channel (desktop) delivery path: post to the
+ * callback-less `/deliver/<channel>` route. On Slack the notice is routed to
+ * the requester's DM via their user id rather than the channel id, so it is
+ * never posted into a shared channel. No-ops on channels without a deliverable
+ * route (e.g. email, the in-app vellum surface) or when the requester chat is
+ * unknown. Best-effort: a delivery failure is logged, never thrown.
+ */
+async function notifyRequesterOfExpiry(
+  request: CanonicalGuardianRequest,
+  text: string,
+): Promise<void> {
+  const channel = request.sourceChannel ?? "";
+  const deliverUrl = resolveDeliverCallbackUrlForChannel(channel);
+  const requesterChatId =
+    request.requesterChatId ?? request.requesterExternalUserId ?? "";
+  const requesterExternalUserId = request.requesterExternalUserId ?? "";
+
+  if (!deliverUrl || !requesterChatId) {
+    return;
+  }
+
+  // On Slack, target the requester's DM (their `U…` user id) instead of the
+  // channel id so the expiry notice stays private. Other channels deliver to
+  // the requester chat directly.
+  const targetChatId =
+    channel === "slack" && requesterExternalUserId
+      ? requesterExternalUserId
+      : requesterChatId;
+
+  try {
+    await deliverChannelReply(deliverUrl, {
+      chatId: targetChatId,
+      text,
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    });
+    log.info(
+      { requestId: request.id, kind: request.kind, channel },
+      "Notified requester that guardian request expired",
+    );
+  } catch (err) {
+    log.warn(
+      { err, requestId: request.id, channel },
+      "Failed to notify requester of guardian request expiry (non-fatal)",
+    );
+  }
+}

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -36,6 +36,7 @@ import { deliverChannelReply } from "../runtime/gateway-client.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { TC_GRANT_WAIT_MAX_MS } from "../tools/tool-approval-handler.js";
 import { getLogger } from "../util/logger.js";
+import { resolveDeliverCallbackUrlForChannel } from "./guardian-channel-delivery.js";
 
 const log = getLogger("guardian-request-resolvers");
 
@@ -241,17 +242,6 @@ export type ResolverResult =
       };
     }
   | { ok: false; reason: string };
-
-function resolveDeliverCallbackUrlForChannel(channel: string): string | null {
-  switch (channel) {
-    case "telegram":
-    case "whatsapp":
-    case "slack":
-      return `/deliver/${channel}`;
-    default:
-      return null;
-  }
-}
 
 /** Interface that kind-specific resolvers implement. */
 export interface GuardianRequestResolver {

--- a/assistant/src/runtime/routes/canonical-guardian-expiry-sweep.ts
+++ b/assistant/src/runtime/routes/canonical-guardian-expiry-sweep.ts
@@ -8,13 +8,16 @@
  * requester.
  *
  * This sweep operates on the unified canonical domain
- * (`canonical_guardian_requests`) and does not auto-deny pending interactions
- * or deliver channel notices — the canonical request status transition is the
- * single source of truth, and consumers (resolvers, clients polling prompts)
- * observe the expired status directly.
+ * (`canonical_guardian_requests`). On expiry it transitions the request status
+ * (the single source of truth), withdraws the approval cards on every surface,
+ * notifies the requester that their request expired, and releases any in-memory
+ * pending interaction. Requester notices are delivered straight to the
+ * requester's channel — not the guardian-facing notification pipeline — and the
+ * guardian stays passive, since the withdrawn card already reflects expiry.
  */
 
 import { withdrawGuardianRequestCards } from "../../approvals/guardian-card-withdrawal.js";
+import { notifyExpiredGuardianRequest } from "../../approvals/guardian-expiry-notifier.js";
 import {
   listCanonicalGuardianRequests,
   resolveCanonicalGuardianRequest,
@@ -39,7 +42,7 @@ let sweepInProgress = false;
  * concurrent decision that wins the race is never overwritten by the
  * sweep.  Returns the count of requests transitioned to expired.
  */
-async function sweepExpiredCanonicalGuardianRequests(): Promise<number> {
+export async function sweepExpiredCanonicalGuardianRequests(): Promise<number> {
   const pending = listCanonicalGuardianRequests({ status: "pending" });
   const now = Date.now();
   let expiredCount = 0;
@@ -76,6 +79,11 @@ async function sweepExpiredCanonicalGuardianRequests(): Promise<number> {
         request: resolved,
         status: "expired",
       });
+
+      // Notify the requester their request expired and release any in-memory
+      // pending interaction. Best-effort and non-throwing, like the card
+      // withdrawal above.
+      await notifyExpiredGuardianRequest(resolved);
     }
   }
 


### PR DESCRIPTION
## What & why

`LUM-2578`. When a guardian-gated request (access request, tool grant, tool approval) times out, the canonical expiry sweep (`canonical-guardian-expiry-sweep.ts`) flipped it `pending → expired` and withdrew its approval cards — but **notified no one** and left any in-memory pending interaction dangling. Someone who asked for access or a tool grant was left waiting on a request that had already died. Pre-existing since the Feb 2026 canonical cutover; not a regression.

## Change

Adds a best-effort, kind-aware side-effect step to the sweep (new `approvals/guardian-expiry-notifier.ts`):

| Kind | On expiry |
|---|---|
| `access_request` | Notify the requester — "your access request expired…" |
| `tool_grant_request` | Notify the requester — "your request to use *tool* expired…" |
| `tool_approval` | Release the in-memory pending interaction (`cancelled`) |
| `pending_question` | No-op — the voice call owns its own lifecycle |

### Notes for review
- **Delivery path:** requester notices go out **directly** via `deliverChannelReply` on the callback-less `/deliver/<channel>` route — *not* `emitNotificationSignal`, which resolves the **guardian's** delivery channels (using it here would notify the wrong party). The sweep is timer-driven and holds no inbound reply callback, so it mirrors the resolvers' off-channel/desktop delivery path. On Slack the notice routes to the requester's DM (user id), never a shared channel. The guardian stays passive — the withdrawn card already reflects expiry.
- **`tool_approval` interaction release is safe:** the sole producer of `tool_approval` canonical requests (ingress escalation) registers no `pendingInteractions` entry, and `PermissionPrompter` confirmations are keyed by their own request id with their own timeout (far shorter than the 30-min TTL). So `pendingInteractions.resolve(id, "cancelled")` no-ops in the common case and otherwise cleanly drops a waiter-less async entry — no blocking waiter is orphaned.
- **Refactor:** extracted `resolveDeliverCallbackUrlForChannel` into a shared `approvals/guardian-channel-delivery.ts` so the resolvers and the new notifier can't drift apart.

## Tests
New `guardian-expiry-notifier.test.ts` — 11 tests: per-kind behavior, Slack DM routing, non-deliverable channels, missing requester chat, best-effort (swallowed) delivery failure, and a DB-backed sweep integration (expired → transitioned + notified; not-yet-expired → untouched). Typecheck, lint, and existing resolver tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtJTFw6vPz9mr2qoFFdjg1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtJTFw6vPz9mr2qoFFdjg1)_