### PR TITLE
feat(web): add useActiveSubagentIds selector hook

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-active-subagent-ids.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-subagent-ids.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for `useActiveSubagentIds` — the atomic selector that exposes the
+ * currently-active (running | pending | awaiting_input) subagent ids in
+ * stable `orderedIds` order.
+ *
+ * Drives the real `useSubagentStore` (seeded via `spawnSubagent` /
+ * `changeStatus`) so the selector + `useShallow` reference stability are
+ * exercised exactly as a consumer would observe them.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import type { SubagentStatus } from "@vellumai/assistant-api";
+
+afterEach(() => {
+  cleanup();
+  useSubagentStore.getState().reset();
+});
+
+/** Spawn a subagent (defaults to `pending`) and move it to `status`. */
+function seed(subagentId: string, status: SubagentStatus) {
+  const store = useSubagentStore.getState();
+  store.spawnSubagent({
+    subagentId,
+    label: subagentId,
+    objective: "test",
+    timestamp: Date.now(),
+  });
+  store.changeStatus({ subagentId, status });
+}
+
+describe("useActiveSubagentIds", () => {
+  test("returns only running/pending ids in spawn order", () => {
+    // GIVEN three subagents spawned in order with mixed statuses
+    act(() => {
+      seed("a", "running");
+      seed("b", "completed");
+      seed("c", "pending");
+    });
+
+    // WHEN the hook renders
+    const { result } = renderHook(() => useActiveSubagentIds());
+
+    // THEN only the active ids surface, in `orderedIds` (spawn) order
+    expect(result.current).toEqual(["a", "c"]);
+  });
+
+  test("excludes completed, failed, and aborted subagents", () => {
+    act(() => {
+      seed("running", "running");
+      seed("awaiting", "awaiting_input");
+      seed("completed", "completed");
+      seed("failed", "failed");
+      seed("aborted", "aborted");
+    });
+
+    const { result } = renderHook(() => useActiveSubagentIds());
+
+    expect(result.current).toEqual(["running", "awaiting"]);
+  });
+
+  test("keeps a stable array reference across no-op active-set updates", () => {
+    // GIVEN one active and one completed subagent
+    act(() => {
+      seed("active", "running");
+      seed("done", "completed");
+    });
+
+    const { result } = renderHook(() => useActiveSubagentIds());
+    const first = result.current;
+    expect(first).toEqual(["active"]);
+
+    // WHEN a store update lands that does NOT change the active set
+    // (re-applying `completed` to the already-completed subagent bumps
+    // `byId` but leaves the filtered ids identical)
+    act(() => {
+      useSubagentStore.getState().changeStatus({
+        subagentId: "done",
+        status: "completed",
+      });
+    });
+
+    // THEN `useShallow` suppresses the churn — same reference, no re-render
+    expect(result.current).toBe(first);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-active-subagent-ids.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-subagent-ids.ts
@@ -1,0 +1,21 @@
+import { useShallow } from "zustand/react/shallow";
+
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { isActiveStatus } from "@/utils/subagent-status";
+
+/**
+ * Active (running | pending | awaiting_input) subagent ids in stable
+ * `orderedIds` order. `useShallow` keeps the returned array reference
+ * stable across unrelated store ticks (e.g. token-usage updates) so
+ * consumers only re-render when the active set actually changes.
+ */
+export function useActiveSubagentIds(): string[] {
+  return useSubagentStore(
+    useShallow((s) =>
+      s.orderedIds.filter((id) => {
+        const status = s.byId[id]?.status;
+        return status !== undefined && isActiveStatus(status);
+      }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Add `useActiveSubagentIds` — active (running/pending/awaiting_input) subagent ids in stable order via a `useShallow` selector.
- Unit tests cover filtering, ordering, exclusion of terminal statuses, and reference stability.

Part of plan: active-subagents-overlay.md (PR 1 of 3)