### PR TITLE
feat(web): add ActiveSubagentsOverlay floating component

### DIFF
--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for `ActiveSubagentsOverlay`.
+ *
+ * Seeds the Zustand subagent store with `running` entries for each id (the
+ * reused `SubagentInlineProgressCard` reads the store), then asserts the
+ * empty/collapsed/expanded states, the "+N" overflow, the per-row stop/open
+ * callbacks, and Escape / outside-click dismissal.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  useSubagentStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function seed(id: string) {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: id,
+    label: "Research Agent",
+    objective: "Find the answer",
+    timestamp: NOW,
+  });
+  useSubagentStore.getState().changeStatus({ subagentId: id, status: "running" });
+}
+
+function seedMany(count: number): string[] {
+  const ids = Array.from({ length: count }, (_, i) => `sa-${i}`);
+  ids.forEach(seed);
+  return ids;
+}
+
+describe("ActiveSubagentsOverlay — empty", () => {
+  test("renders nothing when subagentIds is empty", () => {
+    const { queryByTestId } = render(
+      <ActiveSubagentsOverlay subagentIds={[]} />,
+    );
+    expect(queryByTestId("active-subagents-overlay")).toBeNull();
+  });
+});
+
+describe("ActiveSubagentsOverlay — collapsed", () => {
+  test("shows the pill, hides the panel, and renders +N overflow for >6 ids", () => {
+    const ids = seedMany(8);
+    const { getByTestId, queryByText } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    expect(getByTestId("active-subagents-pill")).toBeTruthy();
+    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+    // 8 ids, 6 visible avatars → "+2" overflow.
+    expect(queryByText("+2")).toBeTruthy();
+    expect(queryByText("8 Active Subagents")).toBeNull();
+  });
+});
+
+describe("ActiveSubagentsOverlay — expanded", () => {
+  test("clicking the pill reveals the panel with the title and one row per id", () => {
+    const ids = seedMany(3);
+    const { getByTestId, getByText, getAllByTestId } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+
+    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    expect(getByText("3 Active Subagents")).toBeTruthy();
+    expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
+  });
+
+  test("per-row stop invokes onStopSubagent and per-row open invokes onSubagentClick", () => {
+    const ids = seedMany(2);
+    const stopped: string[] = [];
+    const opened: string[] = [];
+    const { getByTestId, getAllByTestId, getAllByRole } = render(
+      <ActiveSubagentsOverlay
+        subagentIds={ids}
+        onSubagentClick={(id) => opened.push(id)}
+        onStopSubagent={(id) => stopped.push(id)}
+      />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+
+    fireEvent.click(getAllByTestId("subagent-inline-card-stop")[0]);
+    expect(stopped).toEqual(["sa-0"]);
+
+    fireEvent.click(getAllByRole("button", { name: /open subagent/i })[1]);
+    expect(opened).toEqual(["sa-1"]);
+  });
+});
+
+describe("ActiveSubagentsOverlay — dismissal", () => {
+  test("Escape collapses the open panel", () => {
+    const ids = seedMany(2);
+    const { getByTestId, queryByText } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(queryByText("2 Active Subagents")).toBeNull();
+  });
+
+  test("pointerdown outside the container collapses the open panel", () => {
+    const ids = seedMany(2);
+    const { getByTestId, queryByText } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+
+    fireEvent.pointerDown(document.body);
+    expect(queryByText("2 Active Subagents")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -1,0 +1,92 @@
+// Floating "Active Subagents" overlay: a collapsed avatar pill that expands
+// into a scrollable panel of SubagentInlineProgressCard rows. Purely
+// presentational and props-driven (PR 3 wires it from chat-route-content).
+// Renders nothing when there are no active subagents.
+
+import { useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ActiveSubagentsPill } from "@/domains/chat/components/active-subagents-overlay/active-subagents-pill";
+import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
+
+export interface ActiveSubagentsOverlayProps {
+  subagentIds: string[];
+  onSubagentClick?: (subagentId: string) => void;
+  onStopSubagent?: (subagentId: string) => void;
+}
+
+export function ActiveSubagentsOverlay({
+  subagentIds,
+  onSubagentClick,
+  onStopSubagent,
+}: ActiveSubagentsOverlayProps) {
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Defensive: collapse if the active set drains while open.
+  useEffect(() => {
+    if (subagentIds.length === 0) setExpanded(false);
+  }, [subagentIds.length]);
+
+  // While open, dismiss on outside pointerdown or Escape.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expanded]);
+
+  if (subagentIds.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="active-subagents-overlay"
+      className="pointer-events-auto flex flex-col items-center gap-2"
+    >
+      <ActiveSubagentsPill
+        subagentIds={subagentIds}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
+
+      {expanded && (
+        <div className="flex w-[min(589px,calc(100vw-2rem))] max-w-[589px] flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
+          <Typography
+            variant="title-small"
+            className="text-[var(--content-emphasised)]"
+          >
+            {subagentIds.length} Active Subagents
+          </Typography>
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+            {subagentIds.map((id) => (
+              <SubagentInlineProgressCard
+                key={id}
+                subagentId={id}
+                onSubagentClick={onSubagentClick}
+                onStopSubagent={onStopSubagent}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
@@ -1,0 +1,66 @@
+// Collapsed trigger for the active-subagents overlay: an overlapping stack of
+// up to MAX_VISIBLE_SUBAGENT_AVATARS subagent avatars, a "+N" overflow chip,
+// and a chevron that reflects the expanded state. ChatPill-style chrome.
+
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+import { MAX_VISIBLE_SUBAGENT_AVATARS } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
+
+export interface ActiveSubagentsPillProps {
+  subagentIds: string[];
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function ActiveSubagentsPill({
+  subagentIds,
+  expanded,
+  onToggle,
+}: ActiveSubagentsPillProps) {
+  const visibleIds = subagentIds.slice(0, MAX_VISIBLE_SUBAGENT_AVATARS);
+  const overflowCount = subagentIds.length - MAX_VISIBLE_SUBAGENT_AVATARS;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-label="Active subagents"
+      data-testid="active-subagents-pill"
+      className="pointer-events-auto inline-flex cursor-pointer items-center gap-2 rounded-full bg-[var(--surface-lift)] px-3 py-1.5 shadow-md"
+    >
+      <span className="flex items-center">
+        {visibleIds.map((id, index) => (
+          <SubagentAvatarChip
+            key={id}
+            subagentId={id}
+            size={16}
+            className={
+              index === 0
+                ? undefined
+                : "-ml-1 rounded-full ring-2 ring-[var(--surface-lift)]"
+            }
+          />
+        ))}
+      </span>
+
+      {overflowCount > 0 && (
+        <Typography
+          variant="body-small-default"
+          className="text-[var(--content-emphasised)]"
+        >
+          +{overflowCount}
+        </Typography>
+      )}
+
+      {expanded ? (
+        <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+      ) : (
+        <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ActiveSubagentsOverlay` — a collapsed avatar pill that expands into a scrollable '{N} Active Subagents' panel reusing `SubagentInlineProgressCard` rows.
- Collapses on Escape / outside-click; per-row stop + open wired through props.

Part of plan: active-subagents-overlay.md (PR 2 of 3)