### PR TITLE
refactor(memory): dedupe candidate-matcher fusion + skill-slug construction

### DIFF
--- a/assistant/src/memory/embed.ts
+++ b/assistant/src/memory/embed.ts
@@ -13,8 +13,8 @@ import { type EmbeddingInput, embedWithBackend } from "./embedding-backend.js";
 
 const log = getLogger("memory-embed");
 
-const EMBED_MAX_RETRIES = 3;
-const EMBED_BASE_DELAY_MS = 500;
+export const EMBED_MAX_RETRIES = 3;
+export const EMBED_BASE_DELAY_MS = 500;
 
 /**
  * Wrap embedWithBackend with retry + exponential backoff for transient failures
@@ -32,8 +32,7 @@ export async function embedWithRetry(
     } catch (err) {
       lastError = err;
       if (opts?.signal?.aborted || isAbortError(err)) throw err;
-      const isTransient =
-        isRetryableNetworkError(err) || isHttpStatusError(err);
+      const isTransient = isTransientEmbeddingError(err);
       if (!isTransient || attempt === EMBED_MAX_RETRIES) throw err;
       const delay = computeRetryDelay(attempt, EMBED_BASE_DELAY_MS);
       log.warn(
@@ -47,9 +46,24 @@ export async function embedWithRetry(
   throw lastError;
 }
 
-function isAbortError(err: unknown): boolean {
+/**
+ * A caller-initiated abort, never a transient failure — must propagate
+ * immediately rather than being retried.
+ */
+export function isAbortError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return err.name === "AbortError" || err.name === "APIUserAbortError";
+}
+
+/**
+ * Whether an embedding failure is transient and worth retrying: a retryable
+ * network error (ECONNRESET, timeout, …) or a 429 / 5xx from the provider.
+ * Shared so other embedding paths (e.g. the v3 candidate matcher, which embeds
+ * via `simBatch`) can apply the same bounded-retry policy as
+ * {@link embedWithRetry} instead of degrading on the first blip.
+ */
+export function isTransientEmbeddingError(err: unknown): boolean {
+  return isRetryableNetworkError(err) || isHttpStatusError(err);
 }
 
 function getErrorStatusCode(err: Error): unknown {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
@@ -29,8 +29,39 @@ import { describe, expect, mock, test } from "bun:test";
 import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
 import type { CandidateClusterRef, ScoredSlug } from "../candidate-match.js";
 
+// Spread the real logger module so we override ONLY `getLogger`. The matcher's
+// import graph transitively reaches CLI modules that import `getCliLogger` from
+// this same module (candidate-match → config/skills → … → cli/program), so a
+// mock that dropped `getCliLogger` would crash module evaluation with
+// "export 'getCliLogger' not found in '../util/logger.js'".
+const realLogger = await import("../../../../util/logger.js");
 mock.module("../../../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () => makeMockLogger(),
+}));
+
+// `simBatch` is the matcher's DEFAULT scorer (used only when the caller does not
+// inject `scoreSlugs`). The retry tests below drive this default path, so the
+// real `simBatch` is replaced by a programmable stub whose behavior each test
+// sets via `simBatchImpl`. The tier-logic tests inject their own `scoreSlugs`
+// and never touch this stub.
+let simBatchImpl: (
+  text: string,
+  slugs: readonly string[],
+) => Promise<Map<string, number>> = async () => new Map();
+const realSim = await import("../../../../memory/v2/sim.js");
+mock.module("../../../../memory/v2/sim.js", () => ({
+  ...realSim,
+  simBatch: (text: string, slugs: readonly string[]) =>
+    simBatchImpl(text, slugs),
+}));
+
+// Make the retry backoff instant so the persistent-failure test does not wait
+// out the real exponential delays.
+const realRetry = await import("../../../../util/retry.js");
+mock.module("../../../../util/retry.js", () => ({
+  ...realRetry,
+  abortableSleep: async () => {},
 }));
 
 const {
@@ -285,5 +316,91 @@ describe("matchCandidate — thresholds are ordered for precision bias", () => {
     expect(CLUSTER_MATCH_THRESHOLD).toBeLessThanOrEqual(
       EXISTING_SKILL_THRESHOLD,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default-scorer retry. These tests do NOT inject `scoreSlugs`, so the matcher
+// uses its real `scoreSlugsWithSimBatch` path, which calls the (stubbed)
+// `simBatch`. `simBatch` embeds via `embedWithBackend` ONCE with no retry, so a
+// transient provider blip would throw and degrade the matcher to a no-hit —
+// silently missing an existing skill or forking a duplicate cluster. The
+// matcher wraps `simBatch` in a bounded retry mirroring `embedWithRetry`'s
+// policy and degrades to no-hit ONLY after the budget is exhausted.
+// ---------------------------------------------------------------------------
+
+// A 429 / 5xx-shaped transient error (recognized by `isTransientEmbeddingError`
+// via its `status` field) versus a non-transient one (no status, non-matching
+// message) that must NOT be retried.
+const transientError = () =>
+  Object.assign(new Error("rate limited"), { status: 429 });
+const persistentError = () => new Error("qdrant collection not found");
+
+// A config stub — the stubbed `simBatch` ignores it, but `matchCandidate` reads
+// `opts.config ?? getConfig()`, and passing one keeps the test off the real
+// config loader.
+const fakeConfig = {} as never;
+
+describe("matchCandidate — default scorer retries transient embedding failures", () => {
+  test("a transient embedding error that succeeds on retry yields the correct hit, not []", async () => {
+    let calls = 0;
+    simBatchImpl = async (_text, slugs) => {
+      calls++;
+      if (calls === 1) throw transientError();
+      // Second attempt succeeds: the skill's capability page scores high.
+      return new Map(
+        slugs
+          .filter((s) => s === "skills/deploy-web")
+          .map((s) => [s, 0.95] as const),
+      );
+    };
+
+    const result = await matchCandidate("ship the web app to prod", {
+      config: fakeConfig,
+      loadCatalog: catalog("deploy-web"),
+      listCandidateClusters: clusters(),
+    });
+
+    // Without retry the first throw would degrade to `new`; with retry we get
+    // the existing-skill hit on the second attempt.
+    expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
+    expect(calls).toBe(2);
+  });
+
+  test("a persistent transient error still degrades to no-hit after the retry budget", async () => {
+    let calls = 0;
+    simBatchImpl = async () => {
+      calls++;
+      throw transientError();
+    };
+
+    const result = await matchCandidate("ship the web app to prod", {
+      config: fakeConfig,
+      loadCatalog: catalog("deploy-web"),
+      listCandidateClusters: clusters(),
+    });
+
+    // Retries exhausted → scorer returns [] → matcher treats the goal as new.
+    expect(result).toEqual({ kind: "new" });
+    // 1 initial attempt + EMBED_MAX_RETRIES (3) retries = 4 calls.
+    expect(calls).toBe(4);
+  });
+
+  test("a non-transient error is NOT retried — degrades to no-hit immediately", async () => {
+    let calls = 0;
+    simBatchImpl = async () => {
+      calls++;
+      throw persistentError();
+    };
+
+    const result = await matchCandidate("ship the web app to prod", {
+      config: fakeConfig,
+      loadCatalog: catalog("deploy-web"),
+      listCandidateClusters: clusters(),
+    });
+
+    expect(result).toEqual({ kind: "new" });
+    // No retry on a non-transient failure: exactly one attempt.
+    expect(calls).toBe(1);
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
@@ -31,9 +31,16 @@
 import { getConfig } from "../../../config/loader.js";
 import { loadSkillCatalog } from "../../../config/skills.js";
 import type { AssistantConfig } from "../../../config/types.js";
+import {
+  EMBED_BASE_DELAY_MS,
+  EMBED_MAX_RETRIES,
+  isAbortError,
+  isTransientEmbeddingError,
+} from "../../../memory/embed.js";
 import { simBatch } from "../../../memory/v2/sim.js";
 import { skillSlugFor } from "../../../memory/v2/skill-store.js";
 import { getLogger } from "../../../util/logger.js";
+import { abortableSleep, computeRetryDelay } from "../../../util/retry.js";
 
 const log = getLogger("memory-v3-candidate-match");
 
@@ -213,9 +220,18 @@ async function bestHit(
  * scorer. `simBatch` embeds the goal (dense + BM25 sparse), runs the
  * slug-restricted hybrid query, applies the adaptive dense/sparse reweighting,
  * and fuses the body/summary halves — so candidate-match scores land on the
- * same scale as v2 recall scores against the configured thresholds. Returns
- * `[]` on any embedding/Qdrant failure (logged at warn) so a matcher outage
- * degrades to "treat as new" rather than throwing.
+ * same scale as v2 recall scores against the configured thresholds.
+ *
+ * `simBatch` embeds via `embedWithBackend` ONCE (not `embedWithRetry`), so a
+ * brief provider blip (429 / 5xx / transient network error) would throw and
+ * make this scorer return `[]` — a no-hit. For the matcher that silently means
+ * "treat as new", so a momentary outage could miss an existing skill or fork a
+ * duplicate cluster (a permanent bad catalog entry). To prevent that we wrap
+ * the `simBatch` call in a bounded retry mirroring {@link embedWithRetry}'s
+ * policy (same max-retries / base-delay / exponential backoff, same transient
+ * predicate, same abort handling). Only AFTER retries are exhausted — or on a
+ * non-transient error (a real Qdrant/config bug, where retrying is pointless) —
+ * do we degrade to `[]`, logged at warn.
  */
 async function scoreSlugsWithSimBatch(
   config: AssistantConfig,
@@ -223,13 +239,46 @@ async function scoreSlugsWithSimBatch(
   restrictToSlugs: readonly string[],
 ): Promise<ScoredSlug[]> {
   try {
-    const scores = await simBatch(goal, restrictToSlugs, config);
+    const scores = await simBatchWithRetry(config, goal, restrictToSlugs);
     return [...scores].map(([slug, score]) => ({ slug, score }));
   } catch (err) {
     log.warn(
       { err },
-      "candidate-match scorer failed; degrading to no hits (treat as new)",
+      "candidate-match scorer failed after retries; degrading to no hits (treat as new)",
     );
     return [];
   }
+}
+
+/**
+ * Run {@link simBatch} with the same bounded retry policy as `embedWithRetry`
+ * (`simBatch` itself embeds via `embedWithBackend` with no retry). Retries only
+ * transient embedding failures (429 / 5xx / retryable network error); a
+ * non-transient error or an exhausted retry budget rethrows so the caller can
+ * degrade to no-hit. Aborts propagate immediately and are never retried.
+ */
+async function simBatchWithRetry(
+  config: AssistantConfig,
+  goal: string,
+  restrictToSlugs: readonly string[],
+): Promise<Map<string, number>> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= EMBED_MAX_RETRIES; attempt++) {
+    try {
+      return await simBatch(goal, restrictToSlugs, config);
+    } catch (err) {
+      lastError = err;
+      if (isAbortError(err)) throw err;
+      if (!isTransientEmbeddingError(err) || attempt === EMBED_MAX_RETRIES) {
+        throw err;
+      }
+      const delay = computeRetryDelay(attempt, EMBED_BASE_DELAY_MS);
+      log.warn(
+        { err, attempt: attempt + 1, delayMs: Math.round(delay) },
+        "transient candidate-match embedding failure, retrying",
+      );
+      await abortableSleep(delay);
+    }
+  }
+  throw lastError;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
@@ -31,15 +31,9 @@
 import { getConfig } from "../../../config/loader.js";
 import { loadSkillCatalog } from "../../../config/skills.js";
 import type { AssistantConfig } from "../../../config/types.js";
-import { embedWithRetry } from "../../../memory/embed.js";
-import { hybridQueryConceptPages } from "../../../memory/v2/qdrant.js";
-import { fuseHalf } from "../../../memory/v2/sim.js";
-import { generateBm25QueryEmbedding } from "../../../memory/v2/sparse-bm25.js";
+import { simBatch } from "../../../memory/v2/sim.js";
+import { skillSlugFor } from "../../../memory/v2/skill-store.js";
 import { getLogger } from "../../../util/logger.js";
-import {
-  listCandidatesByStatus,
-  type ProcCandidateStatus,
-} from "./proc-candidate-store.js";
 
 const log = getLogger("memory-v3-candidate-match");
 
@@ -73,18 +67,6 @@ export const CLUSTER_MATCH_THRESHOLD = 0.78;
  */
 export const GRAY_BAND_THRESHOLD = 0.7;
 
-/**
- * Per-channel ANN fetch limit. The candidate/skill pools are small (tens to low
- * thousands of pages), and we only ever read the single best hit, so a modest
- * limit is plenty of headroom while keeping each Qdrant round-trip cheap.
- */
-const ANN_LIMIT = 32;
-
-/** Prefix under which a skill `<id>` is embedded as a capability page. */
-function skillSlug(id: string): string {
-  return `skills/${id}`;
-}
-
 /** A scored ANN hit: a corpus slug and its fused dense+sparse similarity. */
 export interface ScoredSlug {
   slug: string;
@@ -92,10 +74,12 @@ export interface ScoredSlug {
 }
 
 /**
- * The injectable scoring seam. Given the embedded goal and a slug restriction,
+ * The injectable scoring seam. Given the goal text and a slug restriction,
  * return each restricted slug's fused dense+sparse similarity to the goal.
- * Defaults to a real Qdrant-backed query (`scoreSlugsWithQdrant`); tests pass a
- * fake so the tier logic runs without a live collection.
+ * Defaults to {@link simBatch} (the v2 slug-restricted hybrid scorer, including
+ * its adaptive dense/sparse reweighting, so candidate-match scores stay on the
+ * same scale as v2 recall); tests pass a fake so the tier logic runs without a
+ * live collection.
  */
 export type ScoreSlugsFn = (
   goal: string,
@@ -115,19 +99,20 @@ export interface CandidateClusterRef {
 }
 
 export interface MatchCandidateOptions {
-  /** Config used for embedding + fusion weights. Defaults to `getConfig()`. */
-  config?: AssistantConfig;
-  /** ANN scorer (Tier 0 + Tier 1). Defaults to the Qdrant-backed scorer. */
-  scoreSlugs?: ScoreSlugsFn;
-  /** Live skill catalog (Tier 0 targets). Defaults to `loadSkillCatalog()`. */
-  loadCatalog?: () => { id: string }[];
   /**
    * Existing candidate clusters (Tier 1 targets), each carrying its `clusterId`
    * and its embedded member-note slugs. The matcher ANN-restricts to the union
-   * of member-note slugs but maps any hit back to its owning `clusterId`.
-   * Defaults to every registered cluster across the tracked statuses.
+   * of member-note slugs but maps any hit back to its owning `clusterId`. The
+   * caller owns enumeration of the candidate pool (the trigger re-reads it per
+   * note so a cluster opened earlier in the pass is visible to later notes).
    */
-  listCandidateClusters?: () => CandidateClusterRef[];
+  listCandidateClusters: () => CandidateClusterRef[];
+  /** Config used for embedding + fusion weights. Defaults to `getConfig()`. */
+  config?: AssistantConfig;
+  /** ANN scorer (Tier 0 + Tier 1). Defaults to the {@link simBatch} scorer. */
+  scoreSlugs?: ScoreSlugsFn;
+  /** Live skill catalog (Tier 0 targets). Defaults to `loadSkillCatalog()`. */
+  loadCatalog?: () => { id: string }[];
 }
 
 /** The matcher's verdict — which tier (if any) claimed the goal. */
@@ -155,21 +140,20 @@ export type MatchResult =
  */
 export async function matchCandidate(
   goal: string,
-  opts: MatchCandidateOptions = {},
+  opts: MatchCandidateOptions,
 ): Promise<MatchResult> {
   const config = opts.config ?? getConfig();
   const scoreSlugs =
-    opts.scoreSlugs ?? ((g, slugs) => scoreSlugsWithQdrant(config, g, slugs));
+    opts.scoreSlugs ?? ((g, slugs) => scoreSlugsWithSimBatch(config, g, slugs));
   const loadCatalog = opts.loadCatalog ?? (() => loadSkillCatalog());
-  const listCandidateClusters =
-    opts.listCandidateClusters ?? defaultCandidateClusters;
+  const { listCandidateClusters } = opts;
 
   // ── Tier 0 — existing skill. ───────────────────────────────────────────────
   // Map each skill id to its capability-page slug, score them, and resolve the
   // best back to its id.
   const slugToSkillId = new Map<string, string>();
   for (const skill of loadCatalog()) {
-    slugToSkillId.set(skillSlug(skill.id), skill.id);
+    slugToSkillId.set(skillSlugFor(skill.id), skill.id);
   }
   const skillBest = await bestHit(scoreSlugs, goal, [...slugToSkillId.keys()]);
   if (skillBest && skillBest.score >= EXISTING_SKILL_THRESHOLD) {
@@ -225,97 +209,22 @@ async function bestHit(
 }
 
 /**
- * Default Tier-1 target set: every registered candidate cluster across the
- * tracked statuses, each carrying its `clusterId` and embedded member-note
- * slugs. Read-only — `listCandidatesByStatus` only SELECTs.
+ * Default scorer: delegate to {@link simBatch}, the v2 slug-restricted hybrid
+ * scorer. `simBatch` embeds the goal (dense + BM25 sparse), runs the
+ * slug-restricted hybrid query, applies the adaptive dense/sparse reweighting,
+ * and fuses the body/summary halves — so candidate-match scores land on the
+ * same scale as v2 recall scores against the configured thresholds. Returns
+ * `[]` on any embedding/Qdrant failure (logged at warn) so a matcher outage
+ * degrades to "treat as new" rather than throwing.
  */
-const CANDIDATE_STATUSES: ProcCandidateStatus[] = [
-  "observing",
-  "ready",
-  "distilled",
-];
-
-function defaultCandidateClusters(): CandidateClusterRef[] {
-  const clusters: CandidateClusterRef[] = [];
-  for (const status of CANDIDATE_STATUSES) {
-    for (const candidate of listCandidatesByStatus(status)) {
-      clusters.push({
-        clusterId: candidate.clusterId,
-        memberNoteSlugs: candidate.memberNoteSlugs,
-      });
-    }
-  }
-  return clusters;
-}
-
-/**
- * Default scorer: embed `goal` (dense via `embedWithRetry`, sparse via
- * `generateBm25QueryEmbedding` — the same pair `sources/memory-v2.ts` builds),
- * run a slug-restricted hybrid query, and fuse each hit's dense+sparse channels
- * into one similarity via `fuseHalf` with the configured `dense_weight` /
- * `sparse_weight`. Body and summary halves are fused independently and the max
- * is taken per slug, exactly as the recall source does. Returns `[]` on any
- * embedding/Qdrant failure (logged at warn) so a matcher outage degrades to
- * "treat as new" rather than throwing.
- */
-async function scoreSlugsWithQdrant(
+async function scoreSlugsWithSimBatch(
   config: AssistantConfig,
   goal: string,
   restrictToSlugs: readonly string[],
 ): Promise<ScoredSlug[]> {
-  const trimmed = goal.trim();
-  if (trimmed.length === 0 || restrictToSlugs.length === 0) return [];
-
   try {
-    const denseResult = await embedWithRetry(config, [trimmed]);
-    const denseVector = denseResult.vectors[0] ?? [];
-    const sparseVector = generateBm25QueryEmbedding(trimmed);
-
-    const hits = await hybridQueryConceptPages(
-      denseVector,
-      sparseVector,
-      ANN_LIMIT,
-      restrictToSlugs,
-    );
-    if (hits.length === 0) return [];
-
-    const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
-      config.memory.v2;
-
-    // Normalize each sparse channel against its own per-batch max, mirroring
-    // sim.ts / the v2 recall source so scores are comparable to the thresholds.
-    let maxBodySparse = 0;
-    let maxSummarySparse = 0;
-    for (const hit of hits) {
-      if (hit.sparseScore !== undefined && hit.sparseScore > maxBodySparse) {
-        maxBodySparse = hit.sparseScore;
-      }
-      if (
-        hit.summarySparseScore !== undefined &&
-        hit.summarySparseScore > maxSummarySparse
-      ) {
-        maxSummarySparse = hit.summarySparseScore;
-      }
-    }
-
-    return hits.map((hit) => {
-      const bodyScore = fuseHalf(
-        hit.denseScore,
-        hit.sparseScore,
-        maxBodySparse,
-        denseWeight,
-        sparseWeight,
-      );
-      const summaryScore = fuseHalf(
-        hit.summaryDenseScore,
-        hit.summarySparseScore,
-        maxSummarySparse,
-        denseWeight,
-        sparseWeight,
-      );
-      const score = Math.max(bodyScore ?? 0, summaryScore ?? bodyScore ?? 0);
-      return { slug: hit.slug, score };
-    });
+    const scores = await simBatch(goal, restrictToSlugs, config);
+    return [...scores].map(([slug, score]) => ({ slug, score }));
   } catch (err) {
     log.warn(
       { err },

--- a/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
@@ -1,4 +1,9 @@
+import { CLI_COMMAND_SLUG_PREFIX } from "../../../memory/v2/cli-command-store.js";
 import type { PageIndexEntry } from "../../../memory/v2/page-index.js";
+import {
+  SKILL_SLUG_PREFIX,
+  skillSlugFor,
+} from "../../../memory/v2/skill-store.js";
 import { parseFrontmatterFields } from "../../../skills/frontmatter.js";
 import type { Slug } from "./types.js";
 
@@ -47,7 +52,10 @@ const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
  * many facts would otherwise be flagged a hub and filtered out of expansion, so
  * it is exempt from the hub filter — a skill should still co-surface with its
  * facts no matter how many link to it. */
-const CAPABILITY_TARGET_PREFIXES = ["skills/", "cli-commands/"] as const;
+const CAPABILITY_TARGET_PREFIXES = [
+  SKILL_SLUG_PREFIX,
+  CLI_COMMAND_SLUG_PREFIX,
+] as const;
 
 /** Whether `slug` names a capability page exempt from the hub filter. */
 function isCapabilityTarget(slug: Slug): boolean {
@@ -199,7 +207,11 @@ export async function buildEdgeGraph(
     // the corpus, so a skill with no capability page is a safe no-op.
     const skill = parsed?.fields.skill;
     if (typeof skill === "string" && skill.trim() !== "") {
-      addEdge(source, `skills/${skill}`, "procedural knowledge for this skill");
+      addEdge(
+        source,
+        skillSlugFor(skill),
+        "procedural knowledge for this skill",
+      );
     }
 
     // (b) inline `[[wikilink]]` targets from the body. `parsed.body` strips


### PR DESCRIPTION
## Summary
Self-review slop remediation: replace candidate-match's triplicated (and diverged) fusion with sim.ts simBatch; delete dead defaultCandidateClusters (listCandidateClusters now required); use canonical skillSlugFor/SKILL_SLUG_PREFIX in candidate-match + edge.

Part of plan: procedural-memory-as-skills.md (self-review remediation)