### PR TITLE
fix(research-onboarding): keep dark-surface steps' text light for every avatar

### DIFF
--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -23,13 +23,24 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
-import { useOnboardingTone, type OnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import {
+  toneForBg,
+  useOnboardingTone,
+  type OnboardingTone,
+} from "@/domains/onboarding/onboarding-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import {
   pluginDisplayName,
   type ResearchFact,
   type ResearchSuggestion,
 } from "@/utils/research-facts";
+
+// Once the calendar step blends the background to black, every step from there
+// on sits on a constant dark surface — so their text/UI must be a constant
+// light tone, NOT one derived from the chosen avatar color (a light avatar like
+// yellow would otherwise render dark text, invisible on black). The avatar color
+// is still used where it's intentional (e.g. the plugin pills).
+const DARK_TONE = toneForBg("#17191C");
 
 function useViewportSize() {
   const [size, setSize] = useState(() => ({
@@ -235,7 +246,7 @@ export function LookingYouUpStep({
    */
   ready: boolean;
 }) {
-  const tone = useOnboardingTone();
+  const tone = DARK_TONE;
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
@@ -299,7 +310,7 @@ export function ResearchResultsStep({
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
-  const tone = useOnboardingTone();
+  const tone = DARK_TONE;
   const reduce = useReducedMotion();
   // Locally track removed claims by their text so a user can prune what's wrong
   // without mutating the streamed list (which may still be growing).
@@ -453,12 +464,16 @@ type Anchor = { x: number; y: number };
 function PluginSetupNote({
   pluginLabels,
   tone,
+  pillTone,
   reduce,
   slotRef,
   revealed,
 }: {
   pluginLabels: string[];
+  /** Surface tone for the line's text (constant light on the dark surface). */
   tone: OnboardingTone;
+  /** Avatar tone for the pills (their fill + contrast text). */
+  pillTone: OnboardingTone;
   reduce: boolean | null;
   slotRef: React.RefObject<HTMLDivElement | null>;
   /** True once the avatar has landed — the text only appears then. */
@@ -479,7 +494,7 @@ function PluginSetupNote({
         animate={{ opacity: revealed ? 1 : 0, x: revealed ? 0 : -6 }}
         transition={reduce ? { duration: 0 } : { duration: 0.35 }}
       >
-        Already set up the {joinPills(pluginLabels, tone)} plugin{plural ? "s" : ""}{" "}
+        Already set up the {joinPills(pluginLabels, pillTone)} plugin{plural ? "s" : ""}{" "}
         to help with your work
       </motion.p>
     </div>
@@ -568,7 +583,9 @@ export function SuggestionsStep({
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
-  const tone = useOnboardingTone();
+  // Constant dark surface for the UI; the avatar tone is only for the pills.
+  const tone = DARK_TONE;
+  const avatarTone = useOnboardingTone();
   const reduce = useReducedMotion();
   // Show real suggestions as they arrive; only fall back once the turn settles
   // with nothing, so we never flash generic prompts over an in-flight result.
@@ -701,6 +718,7 @@ export function SuggestionsStep({
           <PluginSetupNote
             pluginLabels={pluginLabels}
             tone={tone}
+            pillTone={avatarTone}
             reduce={reduce}
             slotRef={noteSlotRef}
             revealed={landed}


### PR DESCRIPTION
## Problem
On the looking-up, results, and suggestions steps the text could render **dark on a black background** for a light chosen avatar (e.g. the yellow variant) — effectively invisible.

These steps always sit on the constant black surface the calendar step blends to (they're `postCalendar` → `darkBg`), but they derived their text/UI color from the chosen avatar via `useOnboardingTone()`. A light avatar resolves to a dark foreground, which then sits on black.

| Before (yellow variant) | |
|---|---|
| "Connecting the dots…" → dark text on black, invisible | Results "Continue" → dark button on black |

## Fix
Give those three steps a **constant dark tone** (`toneForBg("#17191C")`) so their text/UI stays light for every avatar variant — matching the meeting step, which already hardcodes white. This also fixes the results step's "Continue" button (was a dark button on black for light avatars).

The avatar color is still used where it's intentional: the suggestions **plugin pills** keep the avatar tone for their fill + contrast text, via a new `pillTone` prop.

The earlier avatar-tinted steps (pitch / credits / calendar-connect) are untouched — those correctly use dark text on the avatar color.

## Testing
- `bunx tsc --noEmit`, `eslint`, and `bun run build` all pass.
- Verified against the yellow (light) variant and a dark variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)