### PR TITLE
feat(web): mount ActiveSubagentsOverlay in chat transcript

### DIFF
--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -59,7 +59,7 @@ export function ActiveSubagentsOverlay({
     <div
       ref={containerRef}
       data-testid="active-subagents-overlay"
-      className="pointer-events-auto flex flex-col items-center gap-2"
+      className="pointer-events-auto flex w-full max-w-[589px] flex-col items-center gap-2"
     >
       <ActiveSubagentsPill
         subagentIds={subagentIds}
@@ -68,7 +68,7 @@ export function ActiveSubagentsOverlay({
       />
 
       {expanded && (
-        <div className="flex w-[min(589px,calc(100vw-2rem))] max-w-[589px] flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
+        <div className="flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -252,6 +252,61 @@ describe("ChatBody — startersSlot rendering", () => {
 
 });
 
+describe("ChatBody — active subagents overlay slot", () => {
+  const activeSubagentsSlot = (
+    <div data-testid="active-subagents-slot">ACTIVE_SUBAGENTS</div>
+  );
+
+  test("renders the slot top-center when scrolled up and slot is provided", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("ACTIVE_SUBAGENTS");
+  });
+
+  test("does NOT render the slot when pinned (showScrollToLatest false)", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: false,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_SUBAGENTS");
+  });
+
+  test("does NOT render the slot on the empty state", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...withEmptyState({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_SUBAGENTS");
+  });
+
+  test("Go-to-Newest bottom overlay still renders alongside the slot (no regression)", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("SCROLL_TO_LATEST");
+    expect(html).toContain("ACTIVE_SUBAGENTS");
+  });
+});
+
 describe("ChatBody — read-only cancellation", () => {
   test("renders the read-only banner without a stop control while idle", () => {
     const html = renderToStaticMarkup(

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -144,6 +144,13 @@ export interface ChatBodyProps {
    * starter data model.
    */
   startersSlot?: ReactNode;
+
+  /**
+   * Top-center floating overlay; shown only when scrolled up. Visibility on
+   * scroll is gated here on `showScrollToLatest`; the caller passes the slot
+   * only when there is ≥1 active subagent.
+   */
+  activeSubagentsSlot?: ReactNode;
 }
 
 /**
@@ -199,6 +206,7 @@ export function ChatBody({
   channelFooterSlot,
   readonlyBannerSlot,
   startersSlot,
+  activeSubagentsSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
 
@@ -234,6 +242,12 @@ export function ChatBody({
       onDrop={dragHandlers.onDrop}
     >
       <ChatScrollArea {...scrollAreaProps} />
+
+      {!isEmptyState && showScrollToLatest && activeSubagentsSlot && (
+        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center pt-2">
+          {activeSubagentsSlot}
+        </div>
+      )}
 
       {/* Composer stack — stays at the same tree position across the
           empty→active transition so React preserves its state (focus,

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -244,7 +244,7 @@ export function ChatBody({
       <ChatScrollArea {...scrollAreaProps} />
 
       {!isEmptyState && showScrollToLatest && activeSubagentsSlot && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center pt-2">
+        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center px-3 pt-2">
           {activeSubagentsSlot}
         </div>
       )}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -19,6 +19,7 @@
 
 import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
+import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
@@ -35,6 +36,7 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone";
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
+import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
@@ -258,6 +260,8 @@ export function ChatMainPanel({
     haptic.light();
     if (assistantId) void useViewerStore.getState().loadDocument(assistantId, surfaceId);
   }, [assistantId]);
+
+  const activeSubagentIds = useActiveSubagentIds();
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);
@@ -810,6 +814,15 @@ export function ChatMainPanel({
     transcriptProps: chatTranscriptProps,
   };
 
+  const activeSubagentsSlot =
+    activeSubagentIds.length > 0 ? (
+      <ActiveSubagentsOverlay
+        subagentIds={activeSubagentIds}
+        onSubagentClick={onSubagentClick}
+        onStopSubagent={onStopSubagent}
+      />
+    ) : undefined;
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -845,6 +858,7 @@ export function ChatMainPanel({
         queuedDrawerSlot={isSidePanel ? undefined : mainQueuedDrawerSlot}
         readonlyBannerSlot={channelReadonlyBannerSlot}
         startersSlot={startersSlot}
+        activeSubagentsSlot={activeSubagentsSlot}
       />
       <MicPermissionPrimer
         open={showPrimer}


### PR DESCRIPTION
## Summary
- Mount the Active Subagents overlay top-center in the chat transcript via a new `activeSubagentsSlot` on `ChatBody`, gated on `showScrollToLatest` (mirrors the Go-to-Newest trigger).
- Wire it from `chat-route-content` using `useActiveSubagentIds` + the existing open/stop handlers; slot passed only when ≥1 subagent is active.

Part of plan: active-subagents-overlay.md (PR 3 of 3)