### PR TITLE
fix(memory): coherent flag+v3-live gating; flag-gate the skill-authoring grant

### DIFF
--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -53,10 +53,15 @@ mock.module("../plugins/defaults/memory-retrieval/injector-chain.js", () => ({
 }));
 
 // `applyRuntimeInjections` reads the v3-live gate (`config.memory.v3.live`)
-// via `isMemoryV3Live`; drive it directly through this slot per-test.
+// via `isMemoryV3Live`; drive it directly through this slot per-test. The
+// import graph also pulls `isProcToSkillsActive`/`isProcToSkillsEnabled` (the
+// permission policy-context precomputes the proc-to-skills gate), so the
+// wholesale mock must expose them — keyed off the same v3-live slot, flag off.
 let memoryV3LiveSlot = false;
 mock.module("../config/memory-v3-gate.js", () => ({
   isMemoryV3Live: () => memoryV3LiveSlot,
+  isProcToSkillsEnabled: () => false,
+  isProcToSkillsActive: () => false,
 }));
 
 const { applyRuntimeInjections } =

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -452,6 +452,11 @@ describe("ToolExecutor policy context plumbing", () => {
       // non-interactive auto-grants. requestOrigin/sourceChannel are unset for
       // this interactive turn (omitted — toEqual ignores undefined-valued keys).
       trustClass: "guardian",
+      // buildPolicyContext also precomputes the proc-to-skills gate (flag on AND
+      // v3 live) so the leaf permission checker can read it without touching
+      // config. This test does not mock memory-v3-gate.js, so the real gate runs
+      // against the default config and resolves inactive → false.
+      procToSkillsActive: false,
     });
   });
 
@@ -473,6 +478,8 @@ describe("ToolExecutor policy context plumbing", () => {
       executionContext: "conversation",
       // Trust class is now threaded onto the PolicyContext (see above).
       trustClass: "guardian",
+      // Real (unmocked) proc-to-skills gate resolves inactive (see above).
+      procToSkillsActive: false,
     });
   });
 
@@ -504,6 +511,8 @@ describe("ToolExecutor policy context plumbing", () => {
       executionContext: "conversation",
       // Trust class is now threaded onto the PolicyContext (see above).
       trustClass: "guardian",
+      // Real (unmocked) proc-to-skills gate resolves inactive (see above).
+      procToSkillsActive: false,
     });
   });
 
@@ -537,6 +546,8 @@ describe("ToolExecutor policy context plumbing", () => {
       executionTarget: "host",
       // Trust class is now threaded onto the PolicyContext (see above).
       trustClass: "guardian",
+      // Real (unmocked) proc-to-skills gate resolves inactive (see above).
+      procToSkillsActive: false,
     });
   });
 });

--- a/assistant/src/config/__tests__/proc-to-skills.test.ts
+++ b/assistant/src/config/__tests__/proc-to-skills.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
-import { isProcToSkillsEnabled } from "../memory-v3-gate.js";
+import {
+  isProcToSkillsActive,
+  isProcToSkillsEnabled,
+} from "../memory-v3-gate.js";
 import type { AssistantConfig } from "../schema.js";
 import { MemoryConfigSchema } from "../schemas/memory.js";
 
@@ -48,5 +51,24 @@ describe("isProcToSkillsEnabled", () => {
   test("returns true when the flag is enabled", () => {
     setOverridesForTesting({ [PROC_TO_SKILLS_FLAG]: true });
     expect(isProcToSkillsEnabled(config)).toBe(true);
+  });
+});
+
+describe("isProcToSkillsActive (flag AND v3-live)", () => {
+  const v3Live = { memory: { v3: { live: true } } } as AssistantConfig;
+  const v3NotLive = { memory: { v3: { live: false } } } as AssistantConfig;
+
+  test("false when the flag is off, even with v3 live", () => {
+    expect(isProcToSkillsActive(v3Live)).toBe(false);
+  });
+
+  test("false when the flag is on but v3 is not live", () => {
+    setOverridesForTesting({ [PROC_TO_SKILLS_FLAG]: true });
+    expect(isProcToSkillsActive(v3NotLive)).toBe(false);
+  });
+
+  test("true only when the flag is on AND v3 is live", () => {
+    setOverridesForTesting({ [PROC_TO_SKILLS_FLAG]: true });
+    expect(isProcToSkillsActive(v3Live)).toBe(true);
   });
 });

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -20,3 +20,17 @@ export function isMemoryV3Live(config: AssistantConfig): boolean {
 export function isProcToSkillsEnabled(config: AssistantConfig): boolean {
   return isAssistantFeatureFlagEnabled("procedural-memory-as-skills", config);
 }
+
+/**
+ * Whether procedural-memory-as-skills is ACTIVE: the flag is on AND memory-v3 is
+ * the live injected source. The feature requires v3-live because the only place
+ * the consolidation pass captures candidate notes is the
+ * `{{PROC_TO_SKILLS_SECTION}}` of the v3 prompt template — the v2 template has no
+ * such placeholder, so with the flag on but v3 not live the pass writes no
+ * candidate notes. Gating the whole feature (prompt section, distill follow-up
+ * enqueue, distill job, and the skill-authoring permission grant) on this
+ * combined predicate keeps it coherently inert unless both are on.
+ */
+export function isProcToSkillsActive(config: AssistantConfig): boolean {
+  return isProcToSkillsEnabled(config) && isMemoryV3Live(config);
+}

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -121,14 +121,20 @@ mock.module("../../../config/assistant-feature-flags.js", () => ({
 // `isMemoryV3Live`. Mirror the flag mock so the shadow-vs-live tests keep
 // driving live through `flagStates["memory-v3-live"]` (and `v3FlagOn` toggles
 // it alongside shadow for the existing on/off tests).
+const procToSkillsLive = () => flagStates["memory-v3-live"] ?? v3FlagOn;
+const procToSkillsFlagOn = () =>
+  flagStates["procedural-memory-as-skills"] ?? false;
 mock.module("../../../config/memory-v3-gate.js", () => ({
-  isMemoryV3Live: () => flagStates["memory-v3-live"] ?? v3FlagOn,
+  isMemoryV3Live: () => procToSkillsLive(),
   // Proc-to-skills routing is gated by the `procedural-memory-as-skills`
   // assistant flag (default off). Drive it through `flagStates` so suites that
   // need the proc-to-skills consolidation section ON can flip it the same way
   // they flip the other gates, while existing cases keep the default-off shape.
-  isProcToSkillsEnabled: () =>
-    flagStates["procedural-memory-as-skills"] ?? false,
+  isProcToSkillsEnabled: () => procToSkillsFlagOn(),
+  // Active = flag on AND v3 live. The consolidation prompt section, the distill
+  // follow-up enqueue, and the skill-authoring grant all gate on this combined
+  // predicate, so drive it from the same flag slots.
+  isProcToSkillsActive: () => procToSkillsFlagOn() && procToSkillsLive(),
 }));
 
 // ── Workspace pin ───────────────────────────────────────────────────
@@ -574,6 +580,49 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     await memoryV2ConsolidateJob(makeJob(), CONFIG);
     expect(runnerLastArgs?.prompt as string).toContain(
       "## 10. Review `memory/core-pages.md`",
+    );
+  });
+
+  test("includes the proc-to-skills routing section and enqueues memory_proc_distill only when the flag is on AND v3 is live", async () => {
+    const PROC_MARKER = "## 11. Route procedures and procedural knowledge";
+
+    // Flag on but v3 NOT live → feature inactive: the v2 template renders (no
+    // proc-to-skills placeholder), and the distill follow-up must NOT enqueue.
+    flagStates = {
+      "procedural-memory-as-skills": true,
+      "memory-v3-live": false,
+    };
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    expect(runnerLastArgs?.prompt as string).not.toContain(PROC_MARKER);
+    expect(enqueuedJobs.map((j) => j.type)).not.toContain(
+      "memory_proc_distill",
+    );
+
+    // Flag on AND v3 live → feature active: the v3 template renders the section
+    // and the distill follow-up enqueues.
+    enqueuedJobs.length = 0;
+    flagStates = {
+      "procedural-memory-as-skills": true,
+      "memory-v3-live": true,
+    };
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    expect(runnerLastArgs?.prompt as string).toContain(PROC_MARKER);
+    expect(enqueuedJobs.map((j) => j.type)).toContain("memory_proc_distill");
+  });
+
+  test("v3 live but proc-to-skills flag off → no routing section, no distill follow-up", async () => {
+    // v3-live alone selects the v3 template but must NOT pull in the
+    // proc-to-skills section or its follow-up — that needs the feature flag too.
+    flagStates = {
+      "procedural-memory-as-skills": false,
+      "memory-v3-live": true,
+    };
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    expect(runnerLastArgs?.prompt as string).not.toContain(
+      "## 11. Route procedures and procedural knowledge",
+    );
+    expect(enqueuedJobs.map((j) => j.type)).not.toContain(
+      "memory_proc_distill",
     );
   });
 

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -67,7 +67,7 @@ import { dirname, join } from "node:path";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
   isMemoryV3Live,
-  isProcToSkillsEnabled,
+  isProcToSkillsActive,
 } from "../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { runBackgroundJob } from "../../runtime/background-job-runner.js";
@@ -134,9 +134,12 @@ const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = ["memory_v2_reembed"];
 const V3_FOLLOW_UP_JOB_TYPE: MemoryJobType = "memory_v3_maintain";
 
 /**
- * Follow-up enqueued only when procedural-memory-as-skills is on. The trigger
+ * Follow-up enqueued only when procedural-memory-as-skills is active (the flag
+ * is on AND memory-v3 is live — see {@link isProcToSkillsActive}). The trigger
  * tallies the `kind: proc-candidate` notes this consolidation pass just wrote,
- * clustering them by goal toward the recurrence threshold.
+ * clustering them by goal toward the recurrence threshold. The candidate notes
+ * only exist under v3-live (the v2 prompt has no proc-to-skills section), so
+ * enqueueing this follow-up without v3-live would tally nothing.
  */
 const PROC_DISTILL_FOLLOW_UP_JOB_TYPE: MemoryJobType = "memory_proc_distill";
 
@@ -287,7 +290,7 @@ export async function memoryV2ConsolidateJob(
       cutoff,
       {
         includeCorePagesSection: memoryV3Active,
-        includeProcToSkillsSection: isProcToSkillsEnabled(config),
+        includeProcToSkillsSection: isProcToSkillsActive(config),
         articleShape: memoryV3Live ? "v3" : "v2",
       },
     );
@@ -327,7 +330,7 @@ export async function memoryV2ConsolidateJob(
     if (memoryV3Active) {
       jobTypes.push(V3_FOLLOW_UP_JOB_TYPE);
     }
-    if (isProcToSkillsEnabled(config)) {
+    if (isProcToSkillsActive(config)) {
       jobTypes.push(PROC_DISTILL_FOLLOW_UP_JOB_TYPE);
     }
     for (const jobType of jobTypes) {

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -36,6 +36,16 @@ mock.module("../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: () => false,
 }));
 
+// `buildPolicyContext` (used by the integration tests below) precomputes the
+// proc-to-skills gate via `isProcToSkillsActive`. Drive it through this slot so
+// a test can put the production threading path in the active / inactive state.
+let mockProcToSkillsActive = true;
+mock.module("../config/memory-v3-gate.js", () => ({
+  isProcToSkillsActive: () => mockProcToSkillsActive,
+  isProcToSkillsEnabled: () => mockProcToSkillsActive,
+  isMemoryV3Live: () => mockProcToSkillsActive,
+}));
+
 // Mock skill resolution — return null by default (no skill found).
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => [],
@@ -158,6 +168,7 @@ describe("Permission Checker (gateway IPC)", () => {
     mockIpcClassifyRiskResult = undefined;
     mockCachedThreshold = "low";
     mockRefreshedThreshold = null;
+    mockProcToSkillsActive = true;
   });
 
   // ── classifyRisk ──────────────────────────────────────────────────────────
@@ -617,13 +628,15 @@ describe("Permission Checker (gateway IPC)", () => {
     // trustClass "guardian", origin "memory_consolidation") cannot answer
     // interactive prompts, so `scaffold_managed_skill` and
     // `skill_load skill-management` resolve to allow without prompting. The
-    // grant is scoped to that origin + those two tools only.
+    // grant is scoped to that origin + those two tools, and ONLY fires when the
+    // feature is active (`procToSkillsActive: true`).
 
     const consolidationContext = {
       requestOrigin: "memory_consolidation",
       trustClass: "guardian",
       sourceChannel: "vellum",
       executionContext: "background" as const,
+      procToSkillsActive: true,
     };
 
     test("allows scaffold_managed_skill for the consolidation origin without prompting", async () => {
@@ -741,6 +754,25 @@ describe("Permission Checker (gateway IPC)", () => {
       expect(result.decision).toBe("prompt");
     });
 
+    test("does not grant scaffold when proc-to-skills is inactive (flag off / v3 not live)", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      // The exact consolidation origin/trust/channel, but the feature is
+      // inactive — `procToSkillsActive` is not true — so the grant must NOT
+      // fire and the high-risk tool prompts.
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        { ...consolidationContext, procToSkillsActive: false },
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
     // ── Integration: production `buildPolicyContext` → `check` path ──────────
     // The hand-built-PolicyContext tests above prove the grant LOGIC. These
     // exercise the WIRING: a `ToolContext` (the shape the agent loop actually
@@ -776,10 +808,12 @@ describe("Permission Checker (gateway IPC)", () => {
         scaffoldTool,
         consolidationToolContext,
       );
-      // Prove the threading: buildPolicyContext copied the ToolContext signals.
+      // Prove the threading: buildPolicyContext copied the ToolContext signals
+      // and stamped the active proc-to-skills gate.
       expect(policyContext.requestOrigin).toBe("memory_consolidation");
       expect(policyContext.trustClass).toBe("guardian");
       expect(policyContext.sourceChannel).toBe("vellum");
+      expect(policyContext.procToSkillsActive).toBe(true);
 
       const result = await check(
         "scaffold_managed_skill",
@@ -812,6 +846,33 @@ describe("Permission Checker (gateway IPC)", () => {
         interactiveContext,
       );
       expect(policyContext.requestOrigin).toBeUndefined();
+
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        policyContext,
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("grant does NOT fire when proc-to-skills is inactive, even for the consolidation turn", async () => {
+      // Same consolidation ToolContext, but the feature is inactive (flag off
+      // or v3 not live). buildPolicyContext stamps `procToSkillsActive: false`,
+      // so the grant is dead and the high-risk scaffold prompts.
+      mockProcToSkillsActive = false;
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const policyContext = buildPolicyContext(
+        scaffoldTool,
+        consolidationToolContext,
+      );
+      expect(policyContext.procToSkillsActive).toBe(false);
+      expect(policyContext.requestOrigin).toBe("memory_consolidation");
 
       const result = await check(
         "scaffold_managed_skill",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -676,16 +676,16 @@ export async function classifyRisk(
 // loading the `skill-management` skill (`skill_load skill-management`, which
 // exposes that tool) require an interactive approval. The memory-consolidation
 // background job runs without any connected client, so it can never answer that
-// prompt. When a turn is the consolidation background source — guardian trust,
-// `vellum` source channel, `memory_consolidation` origin (set in
-// consolidation-job.ts) — these two tools resolve to ALLOW non-interactively.
+// prompt. The grant resolves these two tools to ALLOW non-interactively, and
+// ONLY when all of these hold:
+//   - procedural-memory-as-skills is active (`policyContext.procToSkillsActive`,
+//     precomputed by buildPolicyContext: the flag is on AND memory-v3 is live),
+//   - the turn is the consolidation background source — guardian trust, `vellum`
+//     source channel, `memory_consolidation` origin (set in proc-distill-trigger.ts).
 //
 // The grant is intentionally narrow: it matches exactly these two tools AND the
-// consolidation origin, so no interactive session or other origin is affected.
-// It is inert until a later PR actually drives `scaffold_managed_skill` from
-// consolidation; no current caller sets `requestOrigin` to this origin. Once the
-// `isProcToSkillsEnabled` flag helper lands (sibling PR), this grant can also be
-// gated on that flag.
+// consolidation origin under the active flag, so no interactive session, other
+// origin, or feature-off install is affected.
 const MEMORY_CONSOLIDATION_ORIGIN = "memory_consolidation";
 const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
 
@@ -695,7 +695,8 @@ function isMemoryConsolidationSkillAuthoringGrant(
   policyContext?: PolicyContext,
 ): boolean {
   if (
-    policyContext?.requestOrigin !== MEMORY_CONSOLIDATION_ORIGIN ||
+    policyContext?.procToSkillsActive !== true ||
+    policyContext.requestOrigin !== MEMORY_CONSOLIDATION_ORIGIN ||
     policyContext.trustClass !== "guardian" ||
     policyContext.sourceChannel !== "vellum"
   ) {

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -87,4 +87,12 @@ export interface PolicyContext {
   trustClass?: string;
   /** Source channel the turn arrived on (e.g. "vellum" for internal jobs). */
   sourceChannel?: string;
+  /**
+   * Whether procedural-memory-as-skills is active for this assistant (the
+   * `procedural-memory-as-skills` flag is on AND memory-v3 is live). Precomputed
+   * in {@link buildPolicyContext} so the checker can gate the memory-consolidation
+   * skill-authoring auto-grant on the feature without reading config itself.
+   * Undefined/false when the feature is inactive — the grant then never fires.
+   */
+  procToSkillsActive?: boolean;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
@@ -95,6 +95,7 @@ function fakeRegistry() {
     | "getCandidate"
     | "markCandidateStatus"
     | "listClusters"
+    | "listAssignedClusters"
     | "listReadyClusters"
   > = {
     upsertCandidate: (input) => {
@@ -133,11 +134,30 @@ function fakeRegistry() {
       const row = rows.get(clusterId);
       if (row) row.status = status;
     },
+    // Tier-1 match targets: `observing` + `ready` only — mirrors production's
+    // MATCH_TARGET_STATUSES, so a `distilled` cluster is NOT a match target.
     listClusters: (): CandidateClusterRef[] =>
-      [...rows.values()].map((r) => ({
-        clusterId: r.clusterId,
-        memberNoteSlugs: r.memberNoteSlugs,
-      })),
+      [...rows.values()]
+        .filter((r) => r.status === "observing" || r.status === "ready")
+        .map((r) => ({
+          clusterId: r.clusterId,
+          memberNoteSlugs: r.memberNoteSlugs,
+        })),
+    // Idempotency skip-set source: `observing` + `ready` + `distilled` — mirrors
+    // production's ASSIGNED_STATUSES, so a leftover note on a `distilled` cluster
+    // still counts as assigned and is skipped, never re-tallied.
+    listAssignedClusters: (): CandidateClusterRef[] =>
+      [...rows.values()]
+        .filter(
+          (r) =>
+            r.status === "observing" ||
+            r.status === "ready" ||
+            r.status === "distilled",
+        )
+        .map((r) => ({
+          clusterId: r.clusterId,
+          memberNoteSlugs: r.memberNoteSlugs,
+        })),
     listReadyClusters: (): ProcCandidate[] =>
       [...rows.values()].filter((r) => r.status === "ready"),
   };
@@ -184,7 +204,13 @@ interface HarnessOpts {
   skills?: Set<string>;
   gray?: Map<string, string>;
   judge?: ProcDistillTriggerDeps["judge"];
-  seed?: Array<{ clusterId: string; goal: string; members: string[] }>;
+  seed?: Array<{
+    clusterId: string;
+    goal: string;
+    members: string[];
+    /** Defaults to `observing`; set to seed e.g. an already-`distilled` cluster. */
+    status?: ProcCandidate["status"];
+  }>;
 }
 
 function harness(opts: HarnessOpts) {
@@ -200,6 +226,11 @@ function harness(opts: HarnessOpts) {
       count: seed.members.length,
       explicit: false,
     });
+    // `upsertCandidate` always opens at `observing`; honor an explicit seed
+    // status (e.g. `distilled`) by transitioning the freshly-seeded row.
+    if (seed.status && seed.status !== "observing") {
+      store.markCandidateStatus(seed.clusterId, seed.status);
+    }
     clustersByGoal.set(seed.goal, seed.clusterId);
   }
   for (const n of opts.notes) {
@@ -215,6 +246,7 @@ function harness(opts: HarnessOpts) {
     config: config(opts.minRecurrence),
     loadCandidateNotes: async () => opts.notes,
     listClusters: store.listClusters,
+    listAssignedClusters: store.listAssignedClusters,
     matchCandidate: (goal, listClusters) =>
       matcher(goal, listClusters, clustersByGoal),
     judge:
@@ -256,6 +288,7 @@ describe("procDistillTriggerJob — gating", () => {
       config: config(),
       loadCandidateNotes: async () => [note("proc/a", "do a")],
       listClusters: () => [],
+      listAssignedClusters: () => [],
       matchCandidate: async () => {
         matched += 1;
         return { kind: "new" };
@@ -529,6 +562,41 @@ describe("procDistillTriggerJob — idempotency", () => {
       "proc/deploy-1",
       "proc/deploy-2",
     ]);
+  });
+
+  test("a leftover note on a distilled cluster is skipped, not re-tallied", async () => {
+    // Distillation's `deleteNote` is best-effort: the cluster is marked
+    // `distilled` even when a member-note delete fails, so that note can remain
+    // on disk. Its slug must stay in the idempotency skip set (which spans
+    // observing + ready + DISTILLED) so the next pass skips it rather than
+    // re-tallying it as a brand-new cluster. The matcher returns `new` for this
+    // goal (no existing-skill ANN hit), so a re-tally WOULD open a fresh cluster
+    // — exactly the regression this guards against.
+    const { rows, deps } = harness({
+      notes: [note("proc/deploy-leftover", "deploy the web app")],
+      seed: [
+        {
+          clusterId: "cluster/proc/deploy-leftover",
+          goal: "deploy the web app",
+          members: ["proc/deploy-leftover", "proc/deploy-2"],
+          status: "distilled",
+        },
+      ],
+      minRecurrence: 2,
+    });
+    // Sanity: the cluster is retired and the leftover note is a known member.
+    expect(rows.get("cluster/proc/deploy-leftover")!.status).toBe("distilled");
+
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+
+    // The leftover note is skipped — no new cluster, no re-count.
+    expect(outcome.skippedAssigned).toBe(1);
+    expect(outcome.opened).toBe(0);
+    expect(outcome.joined).toBe(0);
+    expect(outcome.existingSkill).toBe(0);
+    // Still exactly one cluster (the distilled one); no fresh cluster opened.
+    expect(rows.size).toBe(1);
+    expect(rows.get("cluster/proc/deploy-leftover")!.status).toBe("distilled");
   });
 
   test("two same-goal notes in ONE pass open exactly one cluster (count 2)", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill-trigger.test.ts
@@ -37,17 +37,22 @@ mock.module("../../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-// The gate is driven through this slot rather than the feature-flag override
+// The gate is driven through these slots rather than the feature-flag override
 // cache: `mock.module` is process-global, and a sibling file in a directory run
 // (e.g. `consolidation-job.test.ts`) replaces `memory-v3-gate.js` wholesale —
-// owning the mock here keeps this file's gate under this file's control.
-let procToSkillsEnabledSlot = true;
+// owning the mock here keeps this file's gate under this file's control. The job
+// gates on `isProcToSkillsActive` (flag on AND v3 live), so the two slots model
+// each input independently — both default on so the recurrence suites run with
+// the feature active.
+let procToSkillsFlagSlot = true;
+let memoryV3LiveSlot = true;
 mock.module("../../../../config/memory-v3-gate.js", () => ({
-  isProcToSkillsEnabled: () => procToSkillsEnabledSlot,
-  // The distillation launcher transitively imports the background-job runner,
-  // whose import graph pulls `isMemoryV3Live`, so both gate exports must be
-  // present when this mock replaces the module wholesale.
-  isMemoryV3Live: () => false,
+  isProcToSkillsEnabled: () => procToSkillsFlagSlot,
+  isMemoryV3Live: () => memoryV3LiveSlot,
+  // Active = flag on AND v3 live. The distillation launcher transitively imports
+  // the background-job runner, whose import graph pulls these gate exports, so
+  // all three must be present when this mock replaces the module wholesale.
+  isProcToSkillsActive: () => procToSkillsFlagSlot && memoryV3LiveSlot,
 }));
 
 const { procDistillTriggerJob } = await import("../proc-distill-trigger.js");
@@ -61,9 +66,10 @@ const JOB = {
   type: "memory_proc_distill",
 } as unknown as MemoryJob;
 
-// The gating test flips the slot off; reset it so later tests stay enabled.
+// The gating tests flip the slots off; reset them so later tests stay active.
 afterEach(() => {
-  procToSkillsEnabledSlot = true;
+  procToSkillsFlagSlot = true;
+  memoryV3LiveSlot = true;
 });
 
 function config(minRecurrence = 2): AssistantConfig {
@@ -237,11 +243,16 @@ function harness(opts: HarnessOpts) {
 }
 
 describe("procDistillTriggerJob — gating", () => {
-  test("flag off → disabled no-op (matcher never called)", async () => {
-    procToSkillsEnabledSlot = false;
+  // Deps that count whether the matcher ran — an inactive pass must short-circuit
+  // before touching any candidate note.
+  function gatingDeps(): {
+    deps: ProcDistillTriggerDeps;
+    matched: () => number;
+    rows: Map<string, ProcCandidate>;
+  } {
     let matched = 0;
     const { rows } = fakeRegistry();
-    const outcome = await procDistillTriggerJob(JOB, config(), {
+    const deps: ProcDistillTriggerDeps = {
       config: config(),
       loadCandidateNotes: async () => [note("proc/a", "do a")],
       listClusters: () => [],
@@ -261,9 +272,29 @@ describe("procDistillTriggerJob — gating", () => {
       distill: async () => ({ ok: false }),
       skillExists: () => false,
       deleteNote: async () => {},
-    });
+    };
+    return { deps, matched: () => matched, rows };
+  }
+
+  test("flag off → disabled no-op (matcher never called)", async () => {
+    procToSkillsFlagSlot = false;
+    memoryV3LiveSlot = true;
+    const { deps, matched, rows } = gatingDeps();
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
     expect(outcome.disabled).toBe(true);
-    expect(matched).toBe(0);
+    expect(matched()).toBe(0);
+    expect(rows.size).toBe(0);
+  });
+
+  test("flag on but v3 not live → disabled no-op (matcher never called)", async () => {
+    // The candidate notes this pass tallies only exist under v3-live, so the
+    // job must short-circuit even with the flag on when v3 is not live.
+    procToSkillsFlagSlot = true;
+    memoryV3LiveSlot = false;
+    const { deps, matched, rows } = gatingDeps();
+    const outcome = await procDistillTriggerJob(JOB, deps.config, deps);
+    expect(outcome.disabled).toBe(true);
+    expect(matched()).toBe(0);
     expect(rows.size).toBe(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
@@ -88,10 +88,27 @@ function fakeRegistry(seed: ProcCandidate[]) {
     listReadyClusters: (): ProcCandidate[] =>
       [...rows.values()].filter((r) => r.status === "ready"),
     listClusters: (): CandidateClusterRef[] =>
-      [...rows.values()].map((r) => ({
-        clusterId: r.clusterId,
-        memberNoteSlugs: r.memberNoteSlugs,
-      })),
+      [...rows.values()]
+        .filter((r) => r.status === "observing" || r.status === "ready")
+        .map((r) => ({
+          clusterId: r.clusterId,
+          memberNoteSlugs: r.memberNoteSlugs,
+        })),
+    // Idempotency skip-set source (observing + ready + distilled). Unused here —
+    // these distillation tests don't run the tally phase — but required by the
+    // deps shape, so mirror the full-membership projection.
+    listAssignedClusters: (): CandidateClusterRef[] =>
+      [...rows.values()]
+        .filter(
+          (r) =>
+            r.status === "observing" ||
+            r.status === "ready" ||
+            r.status === "distilled",
+        )
+        .map((r) => ({
+          clusterId: r.clusterId,
+          memberNoteSlugs: r.memberNoteSlugs,
+        })),
   };
 }
 
@@ -138,6 +155,7 @@ function harness(opts: HarnessOpts) {
     // Tally phase finds nothing — these tests start from pre-seeded clusters.
     loadCandidateNotes: async () => [],
     listClusters: reg.listClusters,
+    listAssignedClusters: reg.listAssignedClusters,
     matchCandidate: async () => ({ kind: "new" }),
     judge: async () => false,
     upsertCandidate: () => {},

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/proc-distill.test.ts
@@ -38,13 +38,16 @@ mock.module("../../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-let procToSkillsEnabledSlot = true;
+// The job gates on `isProcToSkillsActive` (flag on AND v3 live); this slot
+// drives the active predicate so the disabled-path test can flip it off.
+let procToSkillsActiveSlot = true;
 // Replace the whole gate module (mock.module is process-global). The
 // distillation launcher transitively imports the background-job runner, whose
-// import graph pulls `isMemoryV3Live`, so both gate exports must be present.
+// import graph pulls these gate exports, so all three must be present.
 mock.module("../../../../config/memory-v3-gate.js", () => ({
-  isProcToSkillsEnabled: () => procToSkillsEnabledSlot,
-  isMemoryV3Live: () => false,
+  isProcToSkillsActive: () => procToSkillsActiveSlot,
+  isProcToSkillsEnabled: () => procToSkillsActiveSlot,
+  isMemoryV3Live: () => true,
 }));
 
 const { procDistillTriggerJob, skillIdForGoal } =
@@ -61,7 +64,7 @@ const JOB = {
 } as unknown as MemoryJob;
 
 afterEach(() => {
-  procToSkillsEnabledSlot = true;
+  procToSkillsActiveSlot = true;
 });
 
 function config(minRecurrence = 2): AssistantConfig {
@@ -346,8 +349,8 @@ describe("procDistillTriggerJob — distillation", () => {
     expect(outcome.distillFailures).toBe(1);
   });
 
-  test("flag off → distillation phase no-ops", async () => {
-    procToSkillsEnabledSlot = false;
+  test("inactive (flag off / v3 not live) → distillation phase no-ops", async () => {
+    procToSkillsActiveSlot = false;
     const { reg, deps, distillCalls } = harness({
       seed: [
         cluster({

--- a/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
@@ -1,7 +1,8 @@
 /**
  * Memory v3 — `memory_proc_distill` job handler (recurrence/distillation trigger).
  *
- * A flag-gated, best-effort follow-up to consolidation. Consolidation captures a
+ * A gated, best-effort follow-up to consolidation (active only when the
+ * procedural-memory-as-skills flag is on AND memory-v3 is live). Consolidation captures a
  * freshly-seen procedure as a `kind: proc-candidate` note (PR 6); this pass
  * decides whether that note is a NEW procedure or another run of one we have
  * already been tracking, tallies recurrence in the candidate registry (PR 3),
@@ -57,9 +58,10 @@
  * Qdrant, an LLM provider, or a SQLite database.
  */
 
-import { isProcToSkillsEnabled } from "../../../config/memory-v3-gate.js";
+import { isProcToSkillsActive } from "../../../config/memory-v3-gate.js";
 import { loadSkillCatalog } from "../../../config/skills.js";
 import type { AssistantConfig } from "../../../config/types.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../../daemon/trust-context.js";
 import type { MemoryJob } from "../../../memory/jobs-store.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../../memory/v2/constants.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
@@ -96,12 +98,14 @@ import {
 
 const log = getLogger("memory-v3-proc-distill");
 
-/** The lifecycle statuses a note can already be a member of (idempotency set). */
-const TRACKED_STATUSES: ProcCandidateStatus[] = [
-  "observing",
-  "ready",
-  "distilled",
-];
+/**
+ * The lifecycle statuses whose clusters feed BOTH the Tier-1 match target set
+ * and the idempotency skip set. `distilled` clusters are omitted: their member
+ * notes are deleted at distillation, so they carry no live members to skip, and
+ * a re-seen procedure that already has a skill is caught by Tier 0 (the skill
+ * catalog) — carrying them here would be dead weight.
+ */
+const TRACKED_STATUSES: ProcCandidateStatus[] = ["observing", "ready"];
 
 /** Frontmatter marker identifying a procedure candidate note (PR 6). */
 const PROC_CANDIDATE_KIND = "proc-candidate";
@@ -122,12 +126,6 @@ const DISTILL_JOB_NAME = "memory.proc_distill";
 
 /** Hard timeout for a single distillation agent run. */
 const DISTILL_TIMEOUT_MS = 10 * 60 * 1000;
-
-/** Guardian trust context the distillation run executes under (matches the grant). */
-const DISTILL_TRUST_CONTEXT = {
-  sourceChannel: "vellum",
-  trustClass: "guardian",
-} as const;
 
 /**
  * A `kind: proc-candidate` note projected to what the trigger needs: its slug
@@ -248,7 +246,7 @@ export interface DistillRunResult {
 
 /** Outcome of one trigger pass, for the log summary and test assertions. */
 export interface ProcDistillOutcome {
-  /** True when the feature flag was off — the pass no-ops. */
+  /** True when the feature was inactive (flag off or v3 not live) — the pass no-ops. */
   disabled: boolean;
   /** Candidate notes that were already cluster members and so were skipped. */
   skippedAssigned: number;
@@ -276,9 +274,11 @@ export interface ProcDistillOutcome {
 /**
  * Run one recurrence/distillation-trigger pass.
  *
- * No-ops (returns a disabled outcome) unless the `procedural-memory-as-skills`
- * flag is on. Best-effort: a failure tallying one note is logged and recorded
- * but never aborts the rest of the pass.
+ * No-ops (returns a disabled outcome) unless procedural-memory-as-skills is
+ * active — the flag is on AND memory-v3 is live (see {@link isProcToSkillsActive}).
+ * The candidate notes this pass tallies are only written under v3-live, so the
+ * pass has nothing to do when v3 is not live. Best-effort: a failure tallying
+ * one note is logged and recorded but never aborts the rest of the pass.
  */
 export async function procDistillTriggerJob(
   _job: MemoryJob,
@@ -298,7 +298,7 @@ export async function procDistillTriggerJob(
     failures: 0,
   };
 
-  if (!isProcToSkillsEnabled(config)) {
+  if (!isProcToSkillsActive(config)) {
     outcome.disabled = true;
     return outcome;
   }
@@ -726,7 +726,7 @@ async function launchDistillation(
       notes: input.notes,
     }),
     systemHint: "Procedure distillation",
-    trustContext: DISTILL_TRUST_CONTEXT,
+    trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
     callSite: "memoryV2Consolidation",
     timeoutMs: DISTILL_TIMEOUT_MS,
     origin: DISTILL_ORIGIN,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/proc-distill-trigger.ts
@@ -99,13 +99,29 @@ import {
 const log = getLogger("memory-v3-proc-distill");
 
 /**
- * The lifecycle statuses whose clusters feed BOTH the Tier-1 match target set
- * and the idempotency skip set. `distilled` clusters are omitted: their member
- * notes are deleted at distillation, so they carry no live members to skip, and
- * a re-seen procedure that already has a skill is caught by Tier 0 (the skill
- * catalog) — carrying them here would be dead weight.
+ * The lifecycle statuses whose clusters are live Tier-1 *match targets* — a new
+ * note's goal can be classified into one of these. `distilled` is excluded: a
+ * distilled cluster's procedure is done (its skill exists), so a re-seen
+ * procedure is caught by Tier 0 (the skill catalog), not by re-matching into the
+ * retired cluster.
  */
-const TRACKED_STATUSES: ProcCandidateStatus[] = ["observing", "ready"];
+const MATCH_TARGET_STATUSES: ProcCandidateStatus[] = ["observing", "ready"];
+
+/**
+ * The lifecycle statuses whose member notes count as already *assigned* for the
+ * idempotency skip set. This MUST include `distilled`: distillation's
+ * `deleteNote` is best-effort and the cluster is marked `distilled` even if a
+ * note delete fails, so a candidate note can legitimately remain on disk after
+ * its cluster was retired. Keeping `distilled` here ensures that leftover note's
+ * slug stays in the skip set, so the next pass skips it instead of re-tallying
+ * it as a fresh cluster (which would happen when Tier 0's skill ANN is below
+ * threshold or unavailable).
+ */
+const ASSIGNED_STATUSES: ProcCandidateStatus[] = [
+  "observing",
+  "ready",
+  "distilled",
+];
 
 /** Frontmatter marker identifying a procedure candidate note (PR 6). */
 const PROC_CANDIDATE_KIND = "proc-candidate";
@@ -156,11 +172,22 @@ export interface ProcDistillTriggerDeps {
   /** The `kind: proc-candidate` notes currently on disk. */
   loadCandidateNotes: () => Promise<CandidateNote[]>;
   /**
-   * Every registered candidate cluster across the tracked statuses, each with
-   * its `clusterId` and member-note slugs. Feeds BOTH the idempotency skip set
-   * (union of members) and the matcher's Tier-1 target set.
+   * The matcher's Tier-1 *match-target* clusters: `observing` + `ready` only
+   * (see {@link MATCH_TARGET_STATUSES}). A new note's goal can be classified into
+   * one of these. Distilled clusters are intentionally excluded — re-seen
+   * procedures that already have a skill are caught by Tier 0, not by matching
+   * into a retired cluster.
    */
   listClusters: () => CandidateClusterRef[];
+  /**
+   * The idempotency *skip-set* source: every registered cluster whose members
+   * count as already assigned, across `observing` + `ready` + `distilled` (see
+   * {@link ASSIGNED_STATUSES}). The union of these members is the set of slugs a
+   * pass skips. Distinct from {@link listClusters} so a leftover note from a
+   * best-effort-failed delete on a `distilled` cluster is still skipped (not
+   * re-tallied) even though that cluster is no longer a Tier-1 match target.
+   */
+  listAssignedClusters: () => CandidateClusterRef[];
   /** Classify a goal against skills (Tier 0) and clusters (Tier 1). */
   matchCandidate: (
     goal: string,
@@ -305,8 +332,13 @@ export async function procDistillTriggerJob(
 
   const notes = await deps.loadCandidateNotes();
 
-  // Idempotency: a note already recorded as a member (in ANY status) has been
-  // tallied; skip it so re-running over the same notes never double-counts.
+  // Idempotency: a note already recorded as a member (in ANY assigned status —
+  // observing, ready, OR distilled) has been tallied; skip it so re-running over
+  // the same notes never double-counts. This reads `listAssignedClusters`, NOT
+  // the Tier-1 `listClusters` set: a `distilled` cluster is excluded as a match
+  // target but its members must still be skipped, because distillation's
+  // `deleteNote` is best-effort — a leftover note from a failed delete would
+  // otherwise be re-tallied as a brand-new cluster on the next pass.
   //
   // Recurrence is counted in DISTINCT candidate notes: one note = one observed
   // trace. The consolidation prompt enforces this by writing an append-only NEW
@@ -315,7 +347,7 @@ export async function procDistillTriggerJob(
   // count. That contract is what makes skipping already-assigned slugs correct
   // — a re-seen slug is a re-run of the SAME trace, not a new observation.
   const assigned = new Set<string>();
-  for (const cluster of deps.listClusters()) {
+  for (const cluster of deps.listAssignedClusters()) {
     for (const slug of cluster.memberNoteSlugs) {
       assigned.add(slug);
     }
@@ -611,7 +643,8 @@ function defaultDeps(config: AssistantConfig): ProcDistillTriggerDeps {
   return {
     config,
     loadCandidateNotes: () => loadCandidateNotesFromWorkspace(workspaceDir),
-    listClusters: listClustersFromRegistry,
+    listClusters: listMatchTargetClustersFromRegistry,
+    listAssignedClusters: listAssignedClustersFromRegistry,
     matchCandidate: (goal, listClusters) =>
       realMatchCandidate(goal, { config, listCandidateClusters: listClusters }),
     judge: (goalA, goalB) => defaultJudge(goalA, goalB),
@@ -662,10 +695,12 @@ async function loadCandidateNotesFromWorkspace(
   return notes;
 }
 
-/** Default Tier-1 target / idempotency source: every registered cluster. */
-function listClustersFromRegistry(): CandidateClusterRef[] {
+/** Project the clusters in `statuses` to their `{ clusterId, memberNoteSlugs }`. */
+function listClustersFromRegistry(
+  statuses: ProcCandidateStatus[],
+): CandidateClusterRef[] {
   const clusters: CandidateClusterRef[] = [];
-  for (const status of TRACKED_STATUSES) {
+  for (const status of statuses) {
     for (const candidate of realListCandidatesByStatus(status)) {
       clusters.push({
         clusterId: candidate.clusterId,
@@ -674,6 +709,20 @@ function listClustersFromRegistry(): CandidateClusterRef[] {
     }
   }
   return clusters;
+}
+
+/** Default Tier-1 match targets: `observing` + `ready` clusters only. */
+function listMatchTargetClustersFromRegistry(): CandidateClusterRef[] {
+  return listClustersFromRegistry(MATCH_TARGET_STATUSES);
+}
+
+/**
+ * Default idempotency skip-set source: `observing` + `ready` + `distilled`. The
+ * `distilled` rows carry any notes a best-effort delete left behind, keeping
+ * those slugs in the skip set so the next pass never re-tallies them.
+ */
+function listAssignedClustersFromRegistry(): CandidateClusterRef[] {
+  return listClustersFromRegistry(ASSIGNED_STATUSES);
 }
 
 /**

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -1,3 +1,5 @@
+import { getConfig } from "../config/loader.js";
+import { isProcToSkillsActive } from "../config/memory-v3-gate.js";
 import type { ExecutionContext } from "../permissions/approval-policy.js";
 import type { PolicyContext } from "../permissions/types.js";
 import { getToolOwner } from "./registry.js";
@@ -42,6 +44,11 @@ export function buildPolicyContext(
     requestOrigin: context?.requestOrigin,
     trustClass: context?.trustClass,
     sourceChannel: context?.executionChannel,
+    // Precompute the proc-to-skills gate (flag on AND v3 live) here so the
+    // permission checker — a leaf module that must not read config — can deny
+    // the memory-consolidation skill-authoring grant whenever the feature is
+    // inactive, just by reading this boolean.
+    procToSkillsActive: isProcToSkillsActive(getConfig()),
   };
 
   const ownerKind = getToolOwner(tool.name)?.kind;

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -383,7 +383,7 @@
       "scope": "assistant",
       "key": "procedural-memory-as-skills",
       "label": "Procedural Memory as Skills",
-      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Off by default.",
+      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Requires memory-v3-live to take effect (the candidate-note routing lives only in the v3 consolidation prompt); with v3 not live the feature is inert. Off by default.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -383,7 +383,7 @@
       "scope": "assistant",
       "key": "procedural-memory-as-skills",
       "label": "Procedural Memory as Skills",
-      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Off by default.",
+      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Requires memory-v3-live to take effect (the candidate-note routing lives only in the v3 consolidation prompt); with v3 not live the feature is inert. Off by default.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
Self-review remediation: introduce isProcToSkillsActive (flag AND v3-live) and apply it to the consolidation prompt section, the distill follow-up enqueue, the distill job, and the skill-authoring permission grant — so the feature is fully inert unless both are on. Fix the stale grant comment; drop distilled clusters from Tier-1; dedupe the trust context; document the v3-live requirement on the flag.

Self-review gaps fixed: permission grant not flag-gated; consolidation routing inert/split-brain unless v3-live.
Part of plan: procedural-memory-as-skills.md (self-review remediation)