### PR TITLE
refactor(contacts): remove role/status WHERE/ORDER BY predicates and ACL response fields

### DIFF
--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -66,7 +66,7 @@ describe("upsertContact user_file selection", () => {
     resetContactTables();
   });
 
-  test("reuses an existing sibling's userFile when principalId matches", () => {
+  test("assigns a fresh slug per contact; principalId is gateway-owned and no longer groups siblings locally", () => {
     const primary = upsertContact({
       displayName: "Chris",
       role: "guardian",
@@ -77,20 +77,14 @@ describe("upsertContact user_file selection", () => {
         },
       ],
     });
-    // principalId is gateway-owned and no longer written by upsertContact; stamp
-    // it directly so the (still-present) sibling lookup resolves it.
-    getSqlite().run("UPDATE contacts SET principal_id = ? WHERE id = ?", [
-      "principal-abc",
-      primary.id,
-    ]);
     expect(primary.userFile).toBe("chris.md");
 
-    // Second contact for the same principal on Slack — must inherit the
-    // first contact's userFile, NOT auto-increment to chris-2.md.
+    // A second contact with the same display name no longer inherits the
+    // first's userFile via a local principal lookup — it gets a fresh
+    // (collision-incremented) slug. Sibling grouping is owned by the gateway.
     const slack = upsertContact({
       displayName: "chris",
       role: "guardian",
-      principalId: "principal-abc",
       channels: [
         {
           type: "slack",
@@ -99,15 +93,14 @@ describe("upsertContact user_file selection", () => {
         },
       ],
     });
-    expect(slack.userFile).toBe("chris.md");
+    expect(slack.userFile).toBe("chris-2.md");
     expect(slack.id).not.toBe(primary.id);
   });
 
-  test("falls back to generateUserFileSlug when principalId has no existing sibling", () => {
+  test("generates a slug from the display name for a brand-new contact", () => {
     const contact = upsertContact({
       displayName: "Alice",
       role: "contact",
-      principalId: "principal-alone",
       channels: [
         {
           type: "slack",
@@ -146,7 +139,7 @@ describe("upsertContact user_file selection", () => {
     expect(second.userFile).toBe("bob-2.md");
   });
 
-  test("ignores a sibling whose userFile is null and generates a new slug", () => {
+  test("a null-userFile contact does not block a fresh slug for a new contact", () => {
     insertContact({
       id: "seed-null",
       displayName: "legacy",
@@ -159,7 +152,6 @@ describe("upsertContact user_file selection", () => {
     const contact = upsertContact({
       displayName: "Legacy",
       role: "guardian",
-      principalId: "principal-null",
       channels: [
         {
           type: "phone",

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -63,19 +63,18 @@ const realContactStore = await import("../contacts/contact-store.js");
 // contactType is filtered in SQL (before the limit) rather than relayed.
 const listContactsArgs: Array<{
   limit?: number;
-  role?: string;
   contactType?: string;
 }> = [];
 mock.module("../contacts/contact-store.js", () => ({
   ...realContactStore,
-  listContacts: (limit?: number, role?: string, contactType?: string) => {
+  listContacts: (limit?: number, contactType?: string) => {
     localCalls.push("listContacts");
-    listContactsArgs.push({ limit, role, contactType });
+    listContactsArgs.push({ limit, contactType });
     return [
       {
         id: "local-1",
         displayName: "Local Contact",
-        role: role ?? "contact",
+        role: "contact",
         contactType: contactType ?? "human",
         interactionCount: 0,
         channels: [],
@@ -248,20 +247,18 @@ describe("handleListContacts relay", () => {
     // contactType + limit are pushed into the SQL-filtered daemon read (the
     // daemon-native listContacts filters contactType BEFORE applying limit).
     expect(listContactsArgs).toEqual([
-      { limit: 50, role: undefined, contactType: "assistant" },
+      { limit: 50, contactType: "assistant" },
     ]);
     expect(result.contacts[0].id).toBe("local-1");
     expect(result.contacts[0].contactType).toBe("assistant");
     expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
   });
 
-  test("contactType + role both flow into the daemon-native read", async () => {
+  test("contactType filters daemon-native; role is gateway-owned and no longer a local predicate", async () => {
     await handleListContacts({ contactType: "human", role: "guardian" });
 
     expect(ipcCalls).toEqual([]);
-    expect(listContactsArgs).toEqual([
-      { limit: 50, role: "guardian", contactType: "human" },
-    ]);
+    expect(listContactsArgs).toEqual([{ limit: 50, contactType: "human" }]);
   });
 });
 

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNotNull, like, sql } from "drizzle-orm";
+import { and, asc, desc, eq, like, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { ChannelId } from "../channels/types.js";
@@ -225,7 +225,6 @@ export function upsertContact(params: {
   notes?: string | null;
   role?: ContactRole;
   contactType?: ContactType;
-  principalId?: string | null;
   userFile?: string | null;
   channels?: SyncChannelData[];
   /** When true, conflicting channels on other contacts are reassigned to this
@@ -313,27 +312,13 @@ export function upsertContact(params: {
 
   // Create new contact
   contactId = contactId ?? uuid();
-  // Sibling contacts sharing a principal_id must share a user_file so every
-  // channel for one principal resolves to the same persona + journal slug.
-  let resolvedUserFile: string | null;
-  if (params.userFile !== undefined) {
-    resolvedUserFile = params.userFile;
-  } else if (params.principalId) {
-    const sibling = db
-      .select({ userFile: contacts.userFile })
-      .from(contacts)
-      .where(
-        and(
-          eq(contacts.principalId, params.principalId),
-          isNotNull(contacts.userFile),
-        ),
-      )
-      .get();
-    resolvedUserFile =
-      sibling?.userFile ?? generateUserFileSlug(params.displayName);
-  } else {
-    resolvedUserFile = generateUserFileSlug(params.displayName);
-  }
+  // principalId is gateway-owned and no longer a local key; sibling persona
+  // sharing is resolved upstream, so a new contact takes its explicit userFile
+  // or a freshly slugified one.
+  const resolvedUserFile =
+    params.userFile !== undefined
+      ? params.userFile
+      : generateUserFileSlug(params.displayName);
   db.insert(contacts)
     .values({
       id: contactId,
@@ -451,7 +436,6 @@ export function searchContacts(params: {
   query?: string;
   channelAddress?: string;
   channelType?: string;
-  role?: ContactRole;
   contactType?: ContactType;
   limit?: number;
 }): ContactWithChannels[] {
@@ -491,7 +475,6 @@ export function searchContacts(params: {
       const contact = getContactInternal(id);
       if (
         contact &&
-        (!params.role || contact.role === params.role) &&
         (!params.contactType || contact.contactType === params.contactType) &&
         (!sanitizedQuery ||
           (contact.displayName &&
@@ -521,7 +504,6 @@ export function searchContacts(params: {
       const contact = getContactInternal(id);
       if (
         contact &&
-        (!params.role || contact.role === params.role) &&
         (!params.contactType || contact.contactType === params.contactType)
       ) {
         results.push(contact);
@@ -534,13 +516,10 @@ export function searchContacts(params: {
   const conditions = [];
   if (params.query) {
     const sanitized = escapeLike(params.query);
-    if (!sanitized && !params.role && !params.contactType) return [];
+    if (!sanitized && !params.contactType) return [];
     if (sanitized) {
       conditions.push(like(contacts.displayName, `%${sanitized}%`));
     }
-  }
-  if (params.role) {
-    conditions.push(eq(contacts.role, params.role));
   }
   if (params.contactType) {
     conditions.push(eq(contacts.contactType, params.contactType));
@@ -590,20 +569,16 @@ export function searchContacts(params: {
 
 export function listContacts(
   limit = 50,
-  role?: ContactRole,
   contactType?: ContactType,
   opts?: { uncapped?: boolean },
 ): ContactWithChannels[] {
   const db = getDb();
   const effectiveLimit = opts?.uncapped ? limit : Math.min(limit, 200);
-  const conditions = [];
-  if (role) conditions.push(eq(contacts.role, role));
-  if (contactType) conditions.push(eq(contacts.contactType, contactType));
   const rows = db
     .select()
     .from(contacts)
-    .where(conditions.length === 1 ? conditions[0] : and(...conditions))
-    .orderBy(sql`${contacts.role} = 'guardian' DESC`, desc(contacts.updatedAt))
+    .where(contactType ? eq(contacts.contactType, contactType) : undefined)
+    .orderBy(desc(contacts.updatedAt))
     .limit(effectiveLimit)
     .all();
   return rows.map((r) => withChannels(parseContact(r)));
@@ -715,7 +690,8 @@ export function findContactByAddress(
 /**
  * Find a contact by channel external chat ID. Fallback for callers that only
  * have a chat ID (no user-level address) — matches by (type, externalChatId).
- * No unique constraint exists on externalChatId, so ORDER BY is needed.
+ * No unique constraint exists on externalChatId, so ORDER BY is needed for a
+ * deterministic pick; channel ranking (status) is owned by the gateway now.
  */
 function findContactByChannelExternalChatId(
   channelType: string,
@@ -731,14 +707,7 @@ function findContactByChannelExternalChatId(
         eq(contactChannels.externalChatId, externalChatId),
       ),
     )
-    .orderBy(
-      sql`CASE ${contactChannels.status}
-        WHEN 'active' THEN 0
-        WHEN 'unverified' THEN 1
-        ELSE 2
-      END`,
-      desc(contactChannels.updatedAt),
-    )
+    .orderBy(desc(contactChannels.updatedAt), desc(contactChannels.createdAt))
     .get();
   if (!channel) return null;
   return getContactInternal(channel.contactId);

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -188,7 +188,6 @@ export async function handleListContacts(queryParams: Record<string, string>) {
       query,
       channelAddress,
       channelType,
-      role,
       contactType,
       limit,
     });
@@ -206,7 +205,7 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     log.debug(
       "handleListContacts: contactType-filtered read served daemon-native (gateway-native contactType filtering is design-blocked, pending ACL classification)",
     );
-    const contacts = listContacts(limit, role, contactType);
+    const contacts = listContacts(limit, contactType);
     return {
       ok: true,
       contacts: contacts.map(prepareContactResponse),


### PR DESCRIPTION
## Summary
- Remove ORDER BY status / role filter / principalId lookup predicates from contact-store queries
- contact-routes no longer serializes ACL fields from local columns

Part of plan: combo11-phase-b2-drop-acl-columns.md (PR 7 of 11)