### PR TITLE
feat(web): make the macOS app nudge banner time-based (24h after first seen)

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-app-nudges.ts
+++ b/clients/web/src/domains/chat/hooks/use-app-nudges.ts
@@ -152,14 +152,17 @@ export function useAppNudges(
     nudgeMinTurns,
   ]);
 
-  const bannerEligible = assistantTurnsSeen >= nudgeMinTurns;
-
   // -------------------------------------------------------------------------
   // Platform nudge (iOS xor macOS)
   // -------------------------------------------------------------------------
   const iosNudge = useIOSNudgeState();
   const macNudge = useMacOsNudgeState();
   const nudge = isOnIOS ? iosNudge : macNudge;
+
+  // macOS is time-based (shows ~24h after first seen); iOS stays turn-based.
+  const bannerEligible = isOnIOS
+    ? assistantTurnsSeen >= IOS_APP_BANNER_MIN_TURNS
+    : macNudge.ageEligible;
 
   const showBanner = isOnNudgePlatform && bannerEligible && nudge.bannerShouldShow;
 

--- a/clients/web/src/hooks/use-macos-app-nudge.ts
+++ b/clients/web/src/hooks/use-macos-app-nudge.ts
@@ -2,8 +2,8 @@
  * macOS app-download nudge module.
  *
  * Manages whether the user has downloaded the macOS app, banner
- * dismissal state, and assistant turn counting for the minimum-turn
- * threshold before the nudge banner surfaces.
+ * dismissal state, and a first-seen timestamp that gates the nudge
+ * banner behind a minimum age (it surfaces ~24h after first observation).
  */
 
 import { useCallback, useEffect, useState } from "react";
@@ -30,6 +30,12 @@ export const KEY_MAC_APP_ASSISTANT_TURNS_SEEN =
   "app.macOsNudge.assistantTurnsSeen";
 
 export const MAC_APP_BANNER_MIN_TURNS = 5;
+
+/** localStorage key: epoch ms of the first time the macOS nudge observed the user. 0 = not yet. */
+export const KEY_MAC_APP_FIRST_SEEN_AT = "app.macOsNudge.firstSeenAt";
+
+/** Minimum age (ms since first seen) before the banner is eligible. 24 hours. */
+export const MAC_APP_BANNER_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
 /**
  * macOS app download URL. Replace with the canonical CDN or marketing
@@ -67,22 +73,56 @@ export function incrementMacOsAssistantTurnsSeen(delta = 1): void {
   setLocalNumber(KEY_MAC_APP_ASSISTANT_TURNS_SEEN, nextValue);
 }
 
+export function readMacOsFirstSeenAt(): number {
+  return getLocalNumber(KEY_MAC_APP_FIRST_SEEN_AT, 0);
+}
+
+/** Stamp the first-seen timestamp once. Idempotent: later calls are no-ops. */
+export function ensureMacOsFirstSeenAt(): void {
+  if (readMacOsFirstSeenAt() === 0) {
+    setLocalNumber(KEY_MAC_APP_FIRST_SEEN_AT, Date.now());
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
 export function useMacOsNudgeState(): {
   bannerShouldShow: boolean;
+  ageEligible: boolean;
   handleDownload: () => void;
   handleBannerDismiss: () => void;
 } {
   const [downloaded, setDownloaded] = useState(false);
   const [bannerDismissed, setBannerDismissed] = useState(false);
+  const [firstSeenAt, setFirstSeenAt] = useState(0);
+  const [ageEligible, setAgeEligible] = useState(false);
 
   useEffect(() => {
     setDownloaded(readMacOsAppDownloaded());
     setBannerDismissed(readMacOsAppBannerDismissed());
+    ensureMacOsFirstSeenAt();
+    const seenAt = readMacOsFirstSeenAt();
+    setFirstSeenAt(seenAt);
+    setAgeEligible(
+      seenAt !== 0 && Date.now() - seenAt >= MAC_APP_BANNER_MIN_AGE_MS,
+    );
   }, []);
+
+  // Flip eligibility mid-session once the age threshold elapses. For a 24h
+  // gate this rarely fires in-session; the mount effect above recomputes it
+  // on the user's next visit, which is the real trigger.
+  useEffect(() => {
+    if (firstSeenAt === 0 || ageEligible) return;
+    const remaining = MAC_APP_BANNER_MIN_AGE_MS - (Date.now() - firstSeenAt);
+    if (remaining <= 0) {
+      setAgeEligible(true);
+      return;
+    }
+    const timer = setTimeout(() => setAgeEligible(true), remaining);
+    return () => clearTimeout(timer);
+  }, [firstSeenAt, ageEligible]);
 
   const handleDownload = useCallback(() => {
     openMacOsDownload();
@@ -96,7 +136,10 @@ export function useMacOsNudgeState(): {
   }, []);
 
   return {
+    // Unchanged — drives the iOS/macOS → GitHub → Discord cascade.
     bannerShouldShow: !downloaded && !bannerDismissed,
+    // New — drives whether the macOS banner has waited long enough to render.
+    ageEligible,
     handleDownload,
     handleBannerDismiss,
   };

--- a/clients/web/src/hooks/use-macos-app-nudge.ts
+++ b/clients/web/src/hooks/use-macos-app-nudge.ts
@@ -136,9 +136,10 @@ export function useMacOsNudgeState(): {
   }, []);
 
   return {
-    // Unchanged — drives the iOS/macOS → GitHub → Discord cascade.
+    // Drives the iOS/macOS → GitHub → Discord cascade: true until the user
+    // downloads or dismisses.
     bannerShouldShow: !downloaded && !bannerDismissed,
-    // New — drives whether the macOS banner has waited long enough to render.
+    // True once the banner has waited the minimum age (24h) to render.
     ageEligible,
     handleDownload,
     handleBannerDismiss,


### PR DESCRIPTION
## What

Changes the **"Get the macOS app"** in-chat banner from a **turn-based** gate (5 completed assistant turns) to a **time-based** one: it now surfaces **~24h after the user's first web session**.

Anchor = first web-app entry, threshold = 24h elapsed. Reuses the exact `firstSeenAt` + age-timer pattern the GitHub nudge already uses.

## How

- **`use-macos-app-nudge.ts`**
  - New `app.macOsNudge.firstSeenAt` localStorage key, stamped once on first mount via idempotent `ensureMacOsFirstSeenAt()`.
  - New `MAC_APP_BANNER_MIN_AGE_MS = 24h`.
  - Hook now computes `ageEligible` (with a `setTimeout` to flip mid-session, mirroring the GitHub nudge) and returns it **separately** from `bannerShouldShow`.
- **`use-app-nudges.ts`**
  - macOS branch of `bannerEligible` now uses `macNudge.ageEligible`; **iOS stays turn-based**.

## What is intentionally preserved

`bannerShouldShow` is **unchanged** (`!downloaded && !bannerDismissed`), so the age gate lives at the same junction the turn gate occupied. That keeps all previous "don't-show" logic intact:

- ✅ Platform suppression — never shown in the **macOS desktop app (Electron)**, the **iOS app (Capacitor)**, iOS Safari, or non-Apple browsers (`isOnNudgePlatform` gate untouched).
- ✅ Already-downloaded / already-dismissed suppression.
- ✅ The **iOS → macOS → GitHub → Discord** mutual-exclusivity cascade (it keys off `bannerShouldShow`, which didn't change, so the macOS nudge still "reserves the slot" until the user downloads/dismisses).
- ✅ iOS behavior fully unchanged.

The only behavioral change: the macOS banner's render trigger is now **24h elapsed** instead of **5 turns**.

## Notes / follow-ups

- A brand-new macOS user now sees **no nudge for the first 24h** (same philosophy as the old "nothing until turn 5", just longer). If we'd rather let the GitHub nudge fill that window, that's a one-line change (fold `ageEligible` into `bannerShouldShow`) — deliberately **not** done here to preserve current behavior.
- The macOS assistant-turn counter (`incrementMacOsAssistantTurnsSeen`) is now **vestigial** for macOS but left in place to keep the diff focused; safe to remove in a follow-up.
- `app.macOsNudge.firstSeenAt` is under the `app.*` prefix, so it is **preserved across logout** by `session-cleanup.ts` (verified by the existing `session-cleanup.test.ts`) — the 24h clock correctly survives a logout/login.
- Pre-existing: `MACOS_DOWNLOAD_URL` is still the `https://vellum.ai/download` placeholder (unrelated to this PR).

## Verification

- `bunx tsc --noEmit` — clean on both changed files.
- `bun run lint` (eslint) — clean on both changed files.
- `bun test src/lib/auth/session-cleanup.test.ts` — passes (confirms the new key survives logout).
- The `onboarding-lifecycle-sync.test.tsx` failure is **pre-existing on `main`** (a `@vellumai/design-library` subpath resolution issue under plain `bun test`), not caused by this change.

### Manual QA
1. On macOS Chrome/Safari (web), clear `app.macOsNudge.*` → no banner on first visit.
2. Set `localStorage["app.macOsNudge.firstSeenAt"]` to `Date.now() - 86400000` → banner appears.
3. Click Download or dismiss → banner gone and stays gone (`downloaded`/`bannerDismissed`).
4. In the Electron macOS app and the iOS app → banner never appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)