### PR TITLE
refactor(web): reuse ChatPill chrome for active-subagents overlay

### DIFF
--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -51,14 +51,11 @@ describe("ActiveSubagentsOverlay — empty", () => {
 describe("ActiveSubagentsOverlay — collapsed", () => {
   test("shows the pill, hides the panel, and renders +N overflow for >6 ids", () => {
     const ids = seedMany(8);
-    const { getByTestId, queryByText } = render(
-      <ActiveSubagentsOverlay subagentIds={ids} />,
-    );
+    const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
-    expect(getByTestId("active-subagents-pill")).toBeTruthy();
-    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
-      "false",
-    );
+    const pill = screen.getByRole("button", { name: /active subagents/i });
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
     // 8 ids, 6 visible avatars → "+2" overflow.
     expect(queryByText("+2")).toBeTruthy();
     expect(queryByText("8 Active Subagents")).toBeNull();
@@ -68,15 +65,14 @@ describe("ActiveSubagentsOverlay — collapsed", () => {
 describe("ActiveSubagentsOverlay — expanded", () => {
   test("clicking the pill reveals the panel with the title and one row per id", () => {
     const ids = seedMany(3);
-    const { getByTestId, getByText, getAllByTestId } = render(
+    const { getByText, getAllByTestId } = render(
       <ActiveSubagentsOverlay subagentIds={ids} />,
     );
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    const pill = screen.getByRole("button", { name: /active subagents/i });
+    fireEvent.click(pill);
 
-    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
-      "true",
-    );
+    expect(pill.getAttribute("aria-expanded")).toBe("true");
     expect(getByText("3 Active Subagents")).toBeTruthy();
     expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
   });
@@ -85,7 +81,7 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     const ids = seedMany(2);
     const stopped: string[] = [];
     const opened: string[] = [];
-    const { getByTestId, getAllByTestId, getAllByRole } = render(
+    const { getAllByTestId, getAllByRole } = render(
       <ActiveSubagentsOverlay
         subagentIds={ids}
         onSubagentClick={(id) => opened.push(id)}
@@ -93,7 +89,7 @@ describe("ActiveSubagentsOverlay — expanded", () => {
       />,
     );
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
 
     fireEvent.click(getAllByTestId("subagent-inline-card-stop")[0]);
     expect(stopped).toEqual(["sa-0"]);
@@ -106,11 +102,9 @@ describe("ActiveSubagentsOverlay — expanded", () => {
 describe("ActiveSubagentsOverlay — dismissal", () => {
   test("Escape collapses the open panel", () => {
     const ids = seedMany(2);
-    const { getByTestId, queryByText } = render(
-      <ActiveSubagentsOverlay subagentIds={ids} />,
-    );
+    const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.keyDown(document, { key: "Escape" });
@@ -119,11 +113,9 @@ describe("ActiveSubagentsOverlay — dismissal", () => {
 
   test("pointerdown outside the container collapses the open panel", () => {
     const ids = seedMany(2);
-    const { getByTestId, queryByText } = render(
-      <ActiveSubagentsOverlay subagentIds={ids} />,
-    );
+    const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.pointerDown(document.body);

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -1,8 +1,3 @@
-// Floating "Active Subagents" overlay: a collapsed avatar pill that expands
-// into a scrollable panel of SubagentInlineProgressCard rows. Purely
-// presentational and props-driven (PR 3 wires it from chat-route-content).
-// Renders nothing when there are no active subagents.
-
 import { useEffect, useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
@@ -59,6 +54,7 @@ export function ActiveSubagentsOverlay({
     <div
       ref={containerRef}
       data-testid="active-subagents-overlay"
+      // Panel max width per Figma node 6063:149685 (narrower than the chat column).
       className="pointer-events-auto flex w-full max-w-[589px] flex-col items-center gap-2"
     >
       <ActiveSubagentsPill

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
@@ -1,12 +1,9 @@
-// Collapsed trigger for the active-subagents overlay: an overlapping stack of
-// up to MAX_VISIBLE_SUBAGENT_AVATARS subagent avatars, a "+N" overflow chip,
-// and a chevron that reflects the expanded state. ChatPill-style chrome.
-
 import { ChevronDown, ChevronUp } from "lucide-react";
 
 import { Typography } from "@vellumai/design-library";
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+import { ChatPill } from "@/domains/chat/components/chat-pill";
 import { MAX_VISIBLE_SUBAGENT_AVATARS } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
 
 export interface ActiveSubagentsPillProps {
@@ -24,43 +21,43 @@ export function ActiveSubagentsPill({
   const overflowCount = subagentIds.length - MAX_VISIBLE_SUBAGENT_AVATARS;
 
   return (
-    <button
-      type="button"
+    <ChatPill
       onClick={onToggle}
-      aria-expanded={expanded}
-      aria-label="Active subagents"
-      data-testid="active-subagents-pill"
-      className="pointer-events-auto inline-flex cursor-pointer items-center gap-2 rounded-full bg-[var(--surface-lift)] px-3 py-1.5 shadow-md"
+      ariaLabel="Active subagents"
+      ariaExpanded={expanded}
+      size="compact"
     >
-      <span className="flex items-center">
-        {visibleIds.map((id, index) => (
-          <SubagentAvatarChip
-            key={id}
-            subagentId={id}
-            size={16}
-            className={
-              index === 0
-                ? undefined
-                : "-ml-1 rounded-full ring-2 ring-[var(--surface-lift)]"
-            }
-          />
-        ))}
+      <span className="inline-flex items-center gap-2">
+        <span className="flex items-center">
+          {visibleIds.map((id, index) => (
+            <SubagentAvatarChip
+              key={id}
+              subagentId={id}
+              size={16}
+              className={
+                index === 0
+                  ? undefined
+                  : "-ml-1 rounded-full ring-2 ring-[var(--surface-lift)]"
+              }
+            />
+          ))}
+        </span>
+
+        {overflowCount > 0 && (
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-emphasised)]"
+          >
+            +{overflowCount}
+          </Typography>
+        )}
+
+        {expanded ? (
+          <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+        ) : (
+          <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
+        )}
       </span>
-
-      {overflowCount > 0 && (
-        <Typography
-          variant="body-small-default"
-          className="text-[var(--content-emphasised)]"
-        >
-          +{overflowCount}
-        </Typography>
-      )}
-
-      {expanded ? (
-        <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
-      ) : (
-        <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
-      )}
-    </button>
+    </ChatPill>
   );
 }

--- a/clients/web/src/domains/chat/components/chat-pill.tsx
+++ b/clients/web/src/domains/chat/components/chat-pill.tsx
@@ -36,6 +36,8 @@ interface ChatPillProps {
   onClick?: () => void;
   /** Accessible label. Required when `onClick` is set. */
   ariaLabel?: string;
+  /** aria-expanded for the interactive case. Ignored when `onClick` is unset. */
+  ariaExpanded?: boolean;
   /** Role for the non-interactive case (e.g. "status"). Ignored when
    *  `onClick` is set. */
   role?: string;
@@ -66,6 +68,7 @@ export function ChatPill({
   size = "compact",
   onClick,
   ariaLabel,
+  ariaExpanded,
   role,
   ariaLive,
   className,
@@ -83,6 +86,7 @@ export function ChatPill({
         type="button"
         onClick={onClick}
         aria-label={ariaLabel}
+        aria-expanded={ariaExpanded}
         className={clsx(merged, "cursor-pointer")}
       >
         {children}


### PR DESCRIPTION
## Summary
Self-review remediation for the active-subagents overlay:
- Reuse `ChatPill` (add optional `ariaExpanded` pass-through) instead of hand-rolling identical chrome.
- Remove narration/plan-referencing comments; document the 589px panel width with its Figma node.

Part of plan: active-subagents-overlay.md (self-review fix)