### PR TITLE
fix(web): collapsed active-subagents overlay no longer blocks transcript clicks

### DIFF
--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -60,6 +60,14 @@ describe("ActiveSubagentsOverlay — collapsed", () => {
     expect(queryByText("+2")).toBeTruthy();
     expect(queryByText("8 Active Subagents")).toBeNull();
   });
+
+  test("root is pointer-events-none so the gutter doesn't block the transcript", () => {
+    const ids = seedMany(2);
+    render(<ActiveSubagentsOverlay subagentIds={ids} />);
+    expect(
+      screen.getByTestId("active-subagents-overlay").className,
+    ).toContain("pointer-events-none");
+  });
 });
 
 describe("ActiveSubagentsOverlay — expanded", () => {

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -55,7 +55,8 @@ export function ActiveSubagentsOverlay({
       ref={containerRef}
       data-testid="active-subagents-overlay"
       // Panel max width per Figma node 6063:149685 (narrower than the chat column).
-      className="pointer-events-auto flex w-full max-w-[589px] flex-col items-center gap-2"
+      // pointer-events-none so the blank gutter around the centered pill doesn't block the transcript; pill (ChatPill) + panel re-enable pointer events.
+      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
     >
       <ActiveSubagentsPill
         subagentIds={subagentIds}
@@ -64,7 +65,7 @@ export function ActiveSubagentsOverlay({
       />
 
       {expanded && (
-        <div className="flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
+        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"


### PR DESCRIPTION
## Summary
The overlay wrapper was pointer-events-auto + w-full (up to 589px), so the blank band around the collapsed pill swallowed transcript clicks/drags when scrolled up. Make the wrapper pointer-events-none and re-enable pointer events only on the pill (ChatPill) and the expanded panel — mirroring the Go-to-Newest bottom overlay.

Addresses Codex P2 on #36028. Part of plan: active-subagents-overlay.md (self-review fix)