### PR TITLE
feat(web): Active Subagents floating overlay

### DIFF
--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -85,6 +85,19 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
   });
 
+  test("clicking a collapsed avatar expands the panel", () => {
+    const ids = seedMany(3);
+    render(<ActiveSubagentsOverlay subagentIds={ids} />);
+
+    const pill = screen.getByRole("button", { name: /active subagents/i });
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(screen.getAllByLabelText(/^Subagent /)[0]);
+
+    expect(pill.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("3 Active Subagents")).toBeTruthy();
+  });
+
   test("uses the singular noun when exactly one subagent is active", () => {
     const ids = seedMany(1);
     render(<ActiveSubagentsOverlay subagentIds={ids} />);

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for `ActiveSubagentsOverlay`.
+ *
+ * Seeds the Zustand subagent store with `running` entries for each id (the
+ * reused `SubagentInlineProgressCard` reads the store), then asserts the
+ * empty/collapsed/expanded states, the "+N" overflow, the per-row stop/open
+ * callbacks, and Escape / outside-click dismissal.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  useSubagentStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function seed(id: string) {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: id,
+    label: "Research Agent",
+    objective: "Find the answer",
+    timestamp: NOW,
+  });
+  useSubagentStore.getState().changeStatus({ subagentId: id, status: "running" });
+}
+
+function seedMany(count: number): string[] {
+  const ids = Array.from({ length: count }, (_, i) => `sa-${i}`);
+  ids.forEach(seed);
+  return ids;
+}
+
+describe("ActiveSubagentsOverlay — empty", () => {
+  test("renders nothing when subagentIds is empty", () => {
+    const { queryByTestId } = render(
+      <ActiveSubagentsOverlay subagentIds={[]} />,
+    );
+    expect(queryByTestId("active-subagents-overlay")).toBeNull();
+  });
+});
+
+describe("ActiveSubagentsOverlay — collapsed", () => {
+  test("shows the pill, hides the panel, and renders +N overflow for >6 ids", () => {
+    const ids = seedMany(8);
+    const { getByTestId, queryByText } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    expect(getByTestId("active-subagents-pill")).toBeTruthy();
+    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+    // 8 ids, 6 visible avatars → "+2" overflow.
+    expect(queryByText("+2")).toBeTruthy();
+    expect(queryByText("8 Active Subagents")).toBeNull();
+  });
+});
+
+describe("ActiveSubagentsOverlay — expanded", () => {
+  test("clicking the pill reveals the panel with the title and one row per id", () => {
+    const ids = seedMany(3);
+    const { getByTestId, getByText, getAllByTestId } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+
+    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    expect(getByText("3 Active Subagents")).toBeTruthy();
+    expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
+  });
+
+  test("per-row stop invokes onStopSubagent and per-row open invokes onSubagentClick", () => {
+    const ids = seedMany(2);
+    const stopped: string[] = [];
+    const opened: string[] = [];
+    const { getByTestId, getAllByTestId, getAllByRole } = render(
+      <ActiveSubagentsOverlay
+        subagentIds={ids}
+        onSubagentClick={(id) => opened.push(id)}
+        onStopSubagent={(id) => stopped.push(id)}
+      />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+
+    fireEvent.click(getAllByTestId("subagent-inline-card-stop")[0]);
+    expect(stopped).toEqual(["sa-0"]);
+
+    fireEvent.click(getAllByRole("button", { name: /open subagent/i })[1]);
+    expect(opened).toEqual(["sa-1"]);
+  });
+});
+
+describe("ActiveSubagentsOverlay — dismissal", () => {
+  test("Escape collapses the open panel", () => {
+    const ids = seedMany(2);
+    const { getByTestId, queryByText } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(queryByText("2 Active Subagents")).toBeNull();
+  });
+
+  test("pointerdown outside the container collapses the open panel", () => {
+    const ids = seedMany(2);
+    const { getByTestId, queryByText } = render(
+      <ActiveSubagentsOverlay subagentIds={ids} />,
+    );
+
+    fireEvent.click(getByTestId("active-subagents-pill"));
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+
+    fireEvent.pointerDown(document.body);
+    expect(queryByText("2 Active Subagents")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -51,14 +51,11 @@ describe("ActiveSubagentsOverlay — empty", () => {
 describe("ActiveSubagentsOverlay — collapsed", () => {
   test("shows the pill, hides the panel, and renders +N overflow for >6 ids", () => {
     const ids = seedMany(8);
-    const { getByTestId, queryByText } = render(
-      <ActiveSubagentsOverlay subagentIds={ids} />,
-    );
+    const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
-    expect(getByTestId("active-subagents-pill")).toBeTruthy();
-    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
-      "false",
-    );
+    const pill = screen.getByRole("button", { name: /active subagents/i });
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
     // 8 ids, 6 visible avatars → "+2" overflow.
     expect(queryByText("+2")).toBeTruthy();
     expect(queryByText("8 Active Subagents")).toBeNull();
@@ -68,15 +65,14 @@ describe("ActiveSubagentsOverlay — collapsed", () => {
 describe("ActiveSubagentsOverlay — expanded", () => {
   test("clicking the pill reveals the panel with the title and one row per id", () => {
     const ids = seedMany(3);
-    const { getByTestId, getByText, getAllByTestId } = render(
+    const { getByText, getAllByTestId } = render(
       <ActiveSubagentsOverlay subagentIds={ids} />,
     );
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    const pill = screen.getByRole("button", { name: /active subagents/i });
+    fireEvent.click(pill);
 
-    expect(getByTestId("active-subagents-pill").getAttribute("aria-expanded")).toBe(
-      "true",
-    );
+    expect(pill.getAttribute("aria-expanded")).toBe("true");
     expect(getByText("3 Active Subagents")).toBeTruthy();
     expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
   });
@@ -85,7 +81,7 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     const ids = seedMany(2);
     const stopped: string[] = [];
     const opened: string[] = [];
-    const { getByTestId, getAllByTestId, getAllByRole } = render(
+    const { getAllByTestId, getAllByRole } = render(
       <ActiveSubagentsOverlay
         subagentIds={ids}
         onSubagentClick={(id) => opened.push(id)}
@@ -93,7 +89,7 @@ describe("ActiveSubagentsOverlay — expanded", () => {
       />,
     );
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
 
     fireEvent.click(getAllByTestId("subagent-inline-card-stop")[0]);
     expect(stopped).toEqual(["sa-0"]);
@@ -106,11 +102,9 @@ describe("ActiveSubagentsOverlay — expanded", () => {
 describe("ActiveSubagentsOverlay — dismissal", () => {
   test("Escape collapses the open panel", () => {
     const ids = seedMany(2);
-    const { getByTestId, queryByText } = render(
-      <ActiveSubagentsOverlay subagentIds={ids} />,
-    );
+    const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.keyDown(document, { key: "Escape" });
@@ -119,11 +113,9 @@ describe("ActiveSubagentsOverlay — dismissal", () => {
 
   test("pointerdown outside the container collapses the open panel", () => {
     const ids = seedMany(2);
-    const { getByTestId, queryByText } = render(
-      <ActiveSubagentsOverlay subagentIds={ids} />,
-    );
+    const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
-    fireEvent.click(getByTestId("active-subagents-pill"));
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.pointerDown(document.body);

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -60,6 +60,14 @@ describe("ActiveSubagentsOverlay — collapsed", () => {
     expect(queryByText("+2")).toBeTruthy();
     expect(queryByText("8 Active Subagents")).toBeNull();
   });
+
+  test("root is pointer-events-none so the gutter doesn't block the transcript", () => {
+    const ids = seedMany(2);
+    render(<ActiveSubagentsOverlay subagentIds={ids} />);
+    expect(
+      screen.getByTestId("active-subagents-overlay").className,
+    ).toContain("pointer-events-none");
+  });
 });
 
 describe("ActiveSubagentsOverlay — expanded", () => {

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -85,6 +85,16 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
   });
 
+  test("uses the singular noun when exactly one subagent is active", () => {
+    const ids = seedMany(1);
+    render(<ActiveSubagentsOverlay subagentIds={ids} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
+
+    expect(screen.getByText("1 Active Subagent")).toBeTruthy();
+    expect(screen.queryByText("1 Active Subagents")).toBeNull();
+  });
+
   test("per-row stop invokes onStopSubagent and per-row open invokes onSubagentClick", () => {
     const ids = seedMany(2);
     const stopped: string[] = [];

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -54,8 +54,7 @@ export function ActiveSubagentsOverlay({
     <div
       ref={containerRef}
       data-testid="active-subagents-overlay"
-      // Panel max width per Figma node 6063:149685 (narrower than the chat column).
-      // pointer-events-none so the blank gutter around the centered pill doesn't block the transcript; pill (ChatPill) + panel re-enable pointer events.
+      // none here so gutter clicks reach the transcript; pill + panel re-enable. 589px per Figma 6063:149685.
       className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
     >
       <ActiveSubagentsPill
@@ -72,9 +71,7 @@ export function ActiveSubagentsOverlay({
           >
             {subagentIds.length} Active Subagents
           </Typography>
-          {/* -mx-2 cancels each row's own p-2 so row content aligns with the
-              title at the panel's 12px edge, while the hover highlight keeps a
-              small gutter. */}
+          {/* -mx-2 aligns row content with the title (rows add their own p-2). */}
           <div className="-mx-2 flex max-h-[320px] flex-col gap-2 overflow-y-auto">
             {subagentIds.map((id) => (
               <SubagentInlineProgressCard

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -69,7 +69,8 @@ export function ActiveSubagentsOverlay({
             variant="title-small"
             className="text-[var(--content-emphasised)]"
           >
-            {subagentIds.length} Active Subagents
+            {subagentIds.length} Active Subagent
+            {subagentIds.length === 1 ? "" : "s"}
           </Typography>
           <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
             {subagentIds.map((id) => (

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -65,14 +65,17 @@ export function ActiveSubagentsOverlay({
       />
 
       {expanded && (
-        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
+        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"
           >
             {subagentIds.length} Active Subagents
           </Typography>
-          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+          {/* -mx-2 cancels each row's own p-2 so row content aligns with the
+              title at the panel's 12px edge, while the hover highlight keeps a
+              small gutter. */}
+          <div className="-mx-2 flex max-h-[320px] flex-col gap-2 overflow-y-auto">
             {subagentIds.map((id) => (
               <SubagentInlineProgressCard
                 key={id}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -59,7 +59,7 @@ export function ActiveSubagentsOverlay({
     <div
       ref={containerRef}
       data-testid="active-subagents-overlay"
-      className="pointer-events-auto flex flex-col items-center gap-2"
+      className="pointer-events-auto flex w-full max-w-[589px] flex-col items-center gap-2"
     >
       <ActiveSubagentsPill
         subagentIds={subagentIds}
@@ -68,7 +68,7 @@ export function ActiveSubagentsOverlay({
       />
 
       {expanded && (
-        <div className="flex w-[min(589px,calc(100vw-2rem))] max-w-[589px] flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
+        <div className="flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -55,7 +55,8 @@ export function ActiveSubagentsOverlay({
       ref={containerRef}
       data-testid="active-subagents-overlay"
       // Panel max width per Figma node 6063:149685 (narrower than the chat column).
-      className="pointer-events-auto flex w-full max-w-[589px] flex-col items-center gap-2"
+      // pointer-events-none so the blank gutter around the centered pill doesn't block the transcript; pill (ChatPill) + panel re-enable pointer events.
+      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
     >
       <ActiveSubagentsPill
         subagentIds={subagentIds}
@@ -64,7 +65,7 @@ export function ActiveSubagentsOverlay({
       />
 
       {expanded && (
-        <div className="flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
+        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -1,8 +1,3 @@
-// Floating "Active Subagents" overlay: a collapsed avatar pill that expands
-// into a scrollable panel of SubagentInlineProgressCard rows. Purely
-// presentational and props-driven (PR 3 wires it from chat-route-content).
-// Renders nothing when there are no active subagents.
-
 import { useEffect, useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
@@ -59,6 +54,7 @@ export function ActiveSubagentsOverlay({
     <div
       ref={containerRef}
       data-testid="active-subagents-overlay"
+      // Panel max width per Figma node 6063:149685 (narrower than the chat column).
       className="pointer-events-auto flex w-full max-w-[589px] flex-col items-center gap-2"
     >
       <ActiveSubagentsPill

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -71,8 +71,7 @@ export function ActiveSubagentsOverlay({
           >
             {subagentIds.length} Active Subagents
           </Typography>
-          {/* -mx-2 aligns row content with the title (rows add their own p-2). */}
-          <div className="-mx-2 flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
             {subagentIds.map((id) => (
               <SubagentInlineProgressCard
                 key={id}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -1,0 +1,92 @@
+// Floating "Active Subagents" overlay: a collapsed avatar pill that expands
+// into a scrollable panel of SubagentInlineProgressCard rows. Purely
+// presentational and props-driven (PR 3 wires it from chat-route-content).
+// Renders nothing when there are no active subagents.
+
+import { useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ActiveSubagentsPill } from "@/domains/chat/components/active-subagents-overlay/active-subagents-pill";
+import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
+
+export interface ActiveSubagentsOverlayProps {
+  subagentIds: string[];
+  onSubagentClick?: (subagentId: string) => void;
+  onStopSubagent?: (subagentId: string) => void;
+}
+
+export function ActiveSubagentsOverlay({
+  subagentIds,
+  onSubagentClick,
+  onStopSubagent,
+}: ActiveSubagentsOverlayProps) {
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Defensive: collapse if the active set drains while open.
+  useEffect(() => {
+    if (subagentIds.length === 0) setExpanded(false);
+  }, [subagentIds.length]);
+
+  // While open, dismiss on outside pointerdown or Escape.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expanded]);
+
+  if (subagentIds.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="active-subagents-overlay"
+      className="pointer-events-auto flex flex-col items-center gap-2"
+    >
+      <ActiveSubagentsPill
+        subagentIds={subagentIds}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
+
+      {expanded && (
+        <div className="flex w-[min(589px,calc(100vw-2rem))] max-w-[589px] flex-col gap-4 rounded-xl bg-[var(--surface-lift)] p-4 shadow-lg">
+          <Typography
+            variant="title-small"
+            className="text-[var(--content-emphasised)]"
+          >
+            {subagentIds.length} Active Subagents
+          </Typography>
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+            {subagentIds.map((id) => (
+              <SubagentInlineProgressCard
+                key={id}
+                subagentId={id}
+                onSubagentClick={onSubagentClick}
+                onStopSubagent={onStopSubagent}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
@@ -1,12 +1,9 @@
-// Collapsed trigger for the active-subagents overlay: an overlapping stack of
-// up to MAX_VISIBLE_SUBAGENT_AVATARS subagent avatars, a "+N" overflow chip,
-// and a chevron that reflects the expanded state. ChatPill-style chrome.
-
 import { ChevronDown, ChevronUp } from "lucide-react";
 
 import { Typography } from "@vellumai/design-library";
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+import { ChatPill } from "@/domains/chat/components/chat-pill";
 import { MAX_VISIBLE_SUBAGENT_AVATARS } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
 
 export interface ActiveSubagentsPillProps {
@@ -24,43 +21,43 @@ export function ActiveSubagentsPill({
   const overflowCount = subagentIds.length - MAX_VISIBLE_SUBAGENT_AVATARS;
 
   return (
-    <button
-      type="button"
+    <ChatPill
       onClick={onToggle}
-      aria-expanded={expanded}
-      aria-label="Active subagents"
-      data-testid="active-subagents-pill"
-      className="pointer-events-auto inline-flex cursor-pointer items-center gap-2 rounded-full bg-[var(--surface-lift)] px-3 py-1.5 shadow-md"
+      ariaLabel="Active subagents"
+      ariaExpanded={expanded}
+      size="compact"
     >
-      <span className="flex items-center">
-        {visibleIds.map((id, index) => (
-          <SubagentAvatarChip
-            key={id}
-            subagentId={id}
-            size={16}
-            className={
-              index === 0
-                ? undefined
-                : "-ml-1 rounded-full ring-2 ring-[var(--surface-lift)]"
-            }
-          />
-        ))}
+      <span className="inline-flex items-center gap-2">
+        <span className="flex items-center">
+          {visibleIds.map((id, index) => (
+            <SubagentAvatarChip
+              key={id}
+              subagentId={id}
+              size={16}
+              className={
+                index === 0
+                  ? undefined
+                  : "-ml-1 rounded-full ring-2 ring-[var(--surface-lift)]"
+              }
+            />
+          ))}
+        </span>
+
+        {overflowCount > 0 && (
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-emphasised)]"
+          >
+            +{overflowCount}
+          </Typography>
+        )}
+
+        {expanded ? (
+          <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+        ) : (
+          <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
+        )}
       </span>
-
-      {overflowCount > 0 && (
-        <Typography
-          variant="body-small-default"
-          className="text-[var(--content-emphasised)]"
-        >
-          +{overflowCount}
-        </Typography>
-      )}
-
-      {expanded ? (
-        <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
-      ) : (
-        <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
-      )}
-    </button>
+    </ChatPill>
   );
 }

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
@@ -27,7 +27,8 @@ export function ActiveSubagentsPill({
       ariaExpanded={expanded}
       size="compact"
     >
-      <span className="inline-flex items-center gap-2">
+      {/* pointer-events-none so the ChatPill button owns clicks + cursor — clicking any avatar toggles. */}
+      <span className="pointer-events-none inline-flex items-center gap-2">
         <span className="flex items-center">
           {visibleIds.map((id, index) => (
             <SubagentAvatarChip

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-pill.tsx
@@ -1,0 +1,66 @@
+// Collapsed trigger for the active-subagents overlay: an overlapping stack of
+// up to MAX_VISIBLE_SUBAGENT_AVATARS subagent avatars, a "+N" overflow chip,
+// and a chevron that reflects the expanded state. ChatPill-style chrome.
+
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+import { MAX_VISIBLE_SUBAGENT_AVATARS } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
+
+export interface ActiveSubagentsPillProps {
+  subagentIds: string[];
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function ActiveSubagentsPill({
+  subagentIds,
+  expanded,
+  onToggle,
+}: ActiveSubagentsPillProps) {
+  const visibleIds = subagentIds.slice(0, MAX_VISIBLE_SUBAGENT_AVATARS);
+  const overflowCount = subagentIds.length - MAX_VISIBLE_SUBAGENT_AVATARS;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-label="Active subagents"
+      data-testid="active-subagents-pill"
+      className="pointer-events-auto inline-flex cursor-pointer items-center gap-2 rounded-full bg-[var(--surface-lift)] px-3 py-1.5 shadow-md"
+    >
+      <span className="flex items-center">
+        {visibleIds.map((id, index) => (
+          <SubagentAvatarChip
+            key={id}
+            subagentId={id}
+            size={16}
+            className={
+              index === 0
+                ? undefined
+                : "-ml-1 rounded-full ring-2 ring-[var(--surface-lift)]"
+            }
+          />
+        ))}
+      </span>
+
+      {overflowCount > 0 && (
+        <Typography
+          variant="body-small-default"
+          className="text-[var(--content-emphasised)]"
+        >
+          +{overflowCount}
+        </Typography>
+      )}
+
+      {expanded ? (
+        <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+      ) : (
+        <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
+      )}
+    </button>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -252,6 +252,61 @@ describe("ChatBody — startersSlot rendering", () => {
 
 });
 
+describe("ChatBody — active subagents overlay slot", () => {
+  const activeSubagentsSlot = (
+    <div data-testid="active-subagents-slot">ACTIVE_SUBAGENTS</div>
+  );
+
+  test("renders the slot top-center when scrolled up and slot is provided", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("ACTIVE_SUBAGENTS");
+  });
+
+  test("does NOT render the slot when pinned (showScrollToLatest false)", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: false,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_SUBAGENTS");
+  });
+
+  test("does NOT render the slot on the empty state", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...withEmptyState({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_SUBAGENTS");
+  });
+
+  test("Go-to-Newest bottom overlay still renders alongside the slot (no regression)", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("SCROLL_TO_LATEST");
+    expect(html).toContain("ACTIVE_SUBAGENTS");
+  });
+});
+
 describe("ChatBody — read-only cancellation", () => {
   test("renders the read-only banner without a stop control while idle", () => {
     const html = renderToStaticMarkup(

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -144,6 +144,13 @@ export interface ChatBodyProps {
    * starter data model.
    */
   startersSlot?: ReactNode;
+
+  /**
+   * Top-center floating overlay; shown only when scrolled up. Visibility on
+   * scroll is gated here on `showScrollToLatest`; the caller passes the slot
+   * only when there is ≥1 active subagent.
+   */
+  activeSubagentsSlot?: ReactNode;
 }
 
 /**
@@ -199,6 +206,7 @@ export function ChatBody({
   channelFooterSlot,
   readonlyBannerSlot,
   startersSlot,
+  activeSubagentsSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
 
@@ -234,6 +242,12 @@ export function ChatBody({
       onDrop={dragHandlers.onDrop}
     >
       <ChatScrollArea {...scrollAreaProps} />
+
+      {!isEmptyState && showScrollToLatest && activeSubagentsSlot && (
+        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center px-3 pt-2">
+          {activeSubagentsSlot}
+        </div>
+      )}
 
       {/* Composer stack — stays at the same tree position across the
           empty→active transition so React preserves its state (focus,

--- a/clients/web/src/domains/chat/components/chat-pill.tsx
+++ b/clients/web/src/domains/chat/components/chat-pill.tsx
@@ -36,6 +36,8 @@ interface ChatPillProps {
   onClick?: () => void;
   /** Accessible label. Required when `onClick` is set. */
   ariaLabel?: string;
+  /** aria-expanded for the interactive case. Ignored when `onClick` is unset. */
+  ariaExpanded?: boolean;
   /** Role for the non-interactive case (e.g. "status"). Ignored when
    *  `onClick` is set. */
   role?: string;
@@ -66,6 +68,7 @@ export function ChatPill({
   size = "compact",
   onClick,
   ariaLabel,
+  ariaExpanded,
   role,
   ariaLive,
   className,
@@ -83,6 +86,7 @@ export function ChatPill({
         type="button"
         onClick={onClick}
         aria-label={ariaLabel}
+        aria-expanded={ariaExpanded}
         className={clsx(merged, "cursor-pointer")}
       >
         {children}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -19,6 +19,7 @@
 
 import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
+import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
@@ -35,6 +36,7 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone";
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
+import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
@@ -258,6 +260,8 @@ export function ChatMainPanel({
     haptic.light();
     if (assistantId) void useViewerStore.getState().loadDocument(assistantId, surfaceId);
   }, [assistantId]);
+
+  const activeSubagentIds = useActiveSubagentIds();
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);
@@ -810,6 +814,15 @@ export function ChatMainPanel({
     transcriptProps: chatTranscriptProps,
   };
 
+  const activeSubagentsSlot =
+    activeSubagentIds.length > 0 ? (
+      <ActiveSubagentsOverlay
+        subagentIds={activeSubagentIds}
+        onSubagentClick={onSubagentClick}
+        onStopSubagent={onStopSubagent}
+      />
+    ) : undefined;
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -845,6 +858,7 @@ export function ChatMainPanel({
         queuedDrawerSlot={isSidePanel ? undefined : mainQueuedDrawerSlot}
         readonlyBannerSlot={channelReadonlyBannerSlot}
         startersSlot={startersSlot}
+        activeSubagentsSlot={activeSubagentsSlot}
       />
       <MicPermissionPrimer
         open={showPrimer}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -297,7 +297,8 @@ export function SubagentDetailPanel({
         <Typography
           variant="title-medium"
           title={headerTitle}
-          className="min-w-0 shrink truncate text-[var(--content-default)]"
+          // leading-snug: title-medium is line-height:1, so truncate clips the descenders.
+          className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
         >
           {headerTitle}
         </Typography>

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.test.tsx
@@ -79,4 +79,15 @@ describe("SubagentAvatarRow", () => {
     fireEvent.click(getByTestId("subagent-avatar-row-details"));
     expect(expanded).toBe(1);
   });
+
+  test("clicking an avatar badge invokes onExpand", () => {
+    const ids = spawnIds(2);
+    let expanded = 0;
+    const { getAllByTestId } = render(
+      <SubagentAvatarRow subagentIds={ids} onExpand={() => (expanded += 1)} />,
+    );
+
+    fireEvent.click(getAllByTestId("subagent-avatar-badge")[0]);
+    expect(expanded).toBe(1);
+  });
 });

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
@@ -22,8 +22,15 @@ export function SubagentAvatarRow({
   const overflowCount = subagentIds.length - MAX_VISIBLE_SUBAGENT_AVATARS;
 
   return (
-    <div className="flex items-center gap-3">
-      <div className="flex items-center gap-1">
+    <button
+      type="button"
+      onClick={onExpand}
+      aria-label="Show subagent details"
+      data-testid="subagent-avatar-row-details"
+      className="flex cursor-pointer items-center gap-3"
+    >
+      {/* pointer-events-none so clicking an avatar triggers the button, not the avatar. */}
+      <div className="pointer-events-none flex items-center gap-1">
         {subagentIds
           .slice(0, MAX_VISIBLE_SUBAGENT_AVATARS)
           .map((id) => (
@@ -45,13 +52,7 @@ export function SubagentAvatarRow({
         )}
       </div>
 
-      <button
-        type="button"
-        onClick={onExpand}
-        aria-label="Show subagent details"
-        data-testid="subagent-avatar-row-details"
-        className="flex cursor-pointer items-center gap-1"
-      >
+      <span className="flex items-center gap-1">
         <Typography
           variant="body-medium-default"
           className="text-[var(--content-tertiary)]"
@@ -59,7 +60,7 @@ export function SubagentAvatarRow({
           Details
         </Typography>
         <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
-      </button>
-    </div>
+      </span>
+    </button>
   );
 }

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card.tsx
@@ -110,7 +110,9 @@ export function SubagentInlineProgressCard({
         aria-label={canOpen ? "Open subagent" : undefined}
         onClick={canOpen ? handleOpenClick : undefined}
         onKeyDown={canOpen ? handleOpenKeyDown : undefined}
-        className="flex min-w-0 flex-1 items-center gap-1 text-left"
+        className={`flex min-w-0 flex-1 items-center gap-1 text-left${
+          canOpen ? " cursor-pointer" : ""
+        }`}
       >
         {statusIndicator}
         <span className="mx-1 flex shrink-0 items-center">

--- a/clients/web/src/domains/chat/hooks/use-active-subagent-ids.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-subagent-ids.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for `useActiveSubagentIds` — the atomic selector that exposes the
+ * currently-active (running | pending | awaiting_input) subagent ids in
+ * stable `orderedIds` order.
+ *
+ * Drives the real `useSubagentStore` (seeded via `spawnSubagent` /
+ * `changeStatus`) so the selector + `useShallow` reference stability are
+ * exercised exactly as a consumer would observe them.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import type { SubagentStatus } from "@vellumai/assistant-api";
+
+afterEach(() => {
+  cleanup();
+  useSubagentStore.getState().reset();
+});
+
+/** Spawn a subagent (defaults to `pending`) and move it to `status`. */
+function seed(subagentId: string, status: SubagentStatus) {
+  const store = useSubagentStore.getState();
+  store.spawnSubagent({
+    subagentId,
+    label: subagentId,
+    objective: "test",
+    timestamp: Date.now(),
+  });
+  store.changeStatus({ subagentId, status });
+}
+
+describe("useActiveSubagentIds", () => {
+  test("returns only running/pending ids in spawn order", () => {
+    // GIVEN three subagents spawned in order with mixed statuses
+    act(() => {
+      seed("a", "running");
+      seed("b", "completed");
+      seed("c", "pending");
+    });
+
+    // WHEN the hook renders
+    const { result } = renderHook(() => useActiveSubagentIds());
+
+    // THEN only the active ids surface, in `orderedIds` (spawn) order
+    expect(result.current).toEqual(["a", "c"]);
+  });
+
+  test("excludes completed, failed, and aborted subagents", () => {
+    act(() => {
+      seed("running", "running");
+      seed("awaiting", "awaiting_input");
+      seed("completed", "completed");
+      seed("failed", "failed");
+      seed("aborted", "aborted");
+    });
+
+    const { result } = renderHook(() => useActiveSubagentIds());
+
+    expect(result.current).toEqual(["running", "awaiting"]);
+  });
+
+  test("keeps a stable array reference across no-op active-set updates", () => {
+    // GIVEN one active and one completed subagent
+    act(() => {
+      seed("active", "running");
+      seed("done", "completed");
+    });
+
+    const { result } = renderHook(() => useActiveSubagentIds());
+    const first = result.current;
+    expect(first).toEqual(["active"]);
+
+    // WHEN a store update lands that does NOT change the active set
+    // (re-applying `completed` to the already-completed subagent bumps
+    // `byId` but leaves the filtered ids identical)
+    act(() => {
+      useSubagentStore.getState().changeStatus({
+        subagentId: "done",
+        status: "completed",
+      });
+    });
+
+    // THEN `useShallow` suppresses the churn — same reference, no re-render
+    expect(result.current).toBe(first);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-active-subagent-ids.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-subagent-ids.ts
@@ -1,0 +1,21 @@
+import { useShallow } from "zustand/react/shallow";
+
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { isActiveStatus } from "@/utils/subagent-status";
+
+/**
+ * Active (running | pending | awaiting_input) subagent ids in stable
+ * `orderedIds` order. `useShallow` keeps the returned array reference
+ * stable across unrelated store ticks (e.g. token-usage updates) so
+ * consumers only re-render when the active set actually changes.
+ */
+export function useActiveSubagentIds(): string[] {
+  return useSubagentStore(
+    useShallow((s) =>
+      s.orderedIds.filter((id) => {
+        const status = s.byId[id]?.status;
+        return status !== undefined && isActiveStatus(status);
+      }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
Adds a floating, scroll-triggered **Active Subagents** overlay to the web chat transcript. When the user has scrolled up (same trigger as the "Go to Newest" button — `showScrollToLatest`) **and** ≥1 subagent is active, a top-center pill shows the active subagents' avatars; clicking it expands a scrollable **"{N} Active Subagents"** panel. Each row reuses `SubagentInlineProgressCard` (stop button → `abortSubagent`, row click → open detail). Collapses on Escape / outside-click. Hidden when pinned to bottom, on the empty state, or with no active subagents.

Figma: collapsed `6063:149133` (pill `6063:149179`), expanded `6063:149639` (panel `6063:149685`).

## PRs merged into this feature branch
- #36023 — feat(web): add `useActiveSubagentIds` selector hook
- #36025 — feat(web): add `ActiveSubagentsOverlay` component (pill + expandable panel)
- #36028 — feat(web): mount overlay in chat transcript (`ChatBody` slot + route wiring)

### Self-review fix PRs
- #36034 — refactor: reuse `ChatPill` chrome (+ optional `ariaExpanded`); tidy comments; cite Figma node for panel width
- #36035 — fix: collapsed overlay no longer blocks transcript clicks (`pointer-events-none` gutter)

## Self-review result
PASS across all passes (external feedback, plan faithfulness, repo integration, slop/reuse) after 2 remediation rounds:
1. Reuse the shared `ChatPill` instead of hand-rolling its chrome (design-system drift).
2. Fix a real pointer-events regression (Codex P2): the collapsed overlay's full-width wrapper was swallowing clicks meant for the transcript.

Also addressed Codex P2 on #36028 (constrain the expanded panel to the chat-pane width, not the viewport — fixes clipping in narrow split panes).

Part of plan: active-subagents-overlay.md