### PR TITLE
fix(research-onboarding): push pitch-step text up so it clears the bottom eyes

### DIFF
--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -141,6 +141,13 @@ export function PitchStep({
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
 
+  // Push the text/Continue block up so it doesn't crowd the eyes peeking from
+  // the bottom — more so on short viewports, where the three lines + button and
+  // the eyes are otherwise tight. The eye-wipe "above" target tracks this.
+  const shortScreen = h > 0 && h <= 800;
+  const contentTopFrac = shortScreen ? 0.12 : 0.22;
+  const topClass = shortScreen ? "top-[12%]" : "top-[22%]";
+
   // The assistant's eyes rise to wipe the first lines in, then settle at rest.
   const eyeCy = useMotionValue(0);
   const eyeScale = useMotionValue(1);
@@ -233,7 +240,7 @@ export function PitchStep({
     setCarousel2(false);
 
     const smallScale = 0.55; // up above the words
-    const aboveCy = Math.max(eyesH * 0.5, h * 0.3 - 36); // clear above the title
+    const aboveCy = Math.max(eyesH * 0.5, h * contentTopFrac - 36); // clear above the title
 
     const controls: ReturnType<typeof animate>[] = [];
     const timeouts: ReturnType<typeof setTimeout>[] = [];
@@ -310,6 +317,7 @@ export function PitchStep({
     reduce,
     art,
     h,
+    contentTopFrac,
     eyesH,
     restCy,
     eyeCy,
@@ -407,7 +415,7 @@ export function PitchStep({
         </motion.div>
       )}
 
-      <div className={`${ONBOARDING_STEP_CONTENT} max-w-3xl`}>
+      <div className={`${ONBOARDING_STEP_CONTENT.replace("top-[30%]", topClass)} max-w-3xl`}>
         <div
           className="flex w-full flex-col gap-3 text-[clamp(2.25rem,5.5vw,4.5rem)] leading-[1.15]"
           style={{ fontFamily: "var(--font-serif)" }}


### PR DESCRIPTION
## Problem
On the pitch step ("different"), the three lines + Continue button used the shared `top-[30%]` layout and drifted toward the eyes peeking from the bottom — tight especially on short viewports.

## Fix
Push the content block up with a **height-aware top** (22% normally, 12% on viewports ≤ 800px tall), scoped to the pitch step only — the shared `ONBOARDING_STEP_CONTENT` class is untouched, so other steps are unaffected. The eye-wipe "above" target is driven from the same height check, so the eyes still rise to clear the text on both screen sizes (no choreography desync).

## Testing
- `bunx tsc --noEmit`, `eslint`, and `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)