### PR TITLE
[codex] Bootstrap local assistant platform identity

### DIFF
--- a/clients/web/src/domains/chat/api/managed-oauth.ts
+++ b/clients/web/src/domains/chat/api/managed-oauth.ts
@@ -12,7 +12,7 @@ import {
   oauthCompletionStorageKey,
   type OAuthCompletePayload,
 } from "@/lib/auth/oauth-popup";
-import { resolveManagedOAuthPlatformAssistantId } from "@/lib/local-managed-oauth-identity";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { isNativePlatform } from "@/runtime/native-auth";
 import {
@@ -335,7 +335,7 @@ export async function connectManagedOAuthProvider({
       }
 
       try {
-        platformAssistantId = await resolveManagedOAuthPlatformAssistantId(assistantId);
+        platformAssistantId = await resolveLocalAssistantPlatformIdentity(assistantId);
         baselineSignatures = getProviderConnectionSignatures(
           await listOAuthConnections(platformAssistantId).catch(() => []),
           providerKey,

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -210,6 +210,7 @@ mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => false,
   isLocalAssistant: () => false,
   isPlatformAssistant: () => false,
+  isPlatformDisabled: () => false,
   hasAssistants: () => false,
   getPlatformAssistants: () => [],
   getPlatformRuntimeUrl: () => "https://platform.vellum.ai",

--- a/clients/web/src/domains/onboarding/screens/google-connect-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/google-connect-screen.tsx
@@ -16,7 +16,7 @@ import {
     oauthCompletionStorageKey,
     type OAuthCompletePayload,
 } from "@/lib/auth/oauth-popup";
-import { resolveManagedOAuthPlatformAssistantId } from "@/lib/local-managed-oauth-identity";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -234,7 +234,7 @@ export function GoogleConnectScreen({
       void (async () => {
         let platformAssistantId: string;
         try {
-          platformAssistantId = await resolveManagedOAuthPlatformAssistantId(assistantId);
+          platformAssistantId = await resolveLocalAssistantPlatformIdentity(assistantId);
         } catch {
           clearPendingRequest();
           return;
@@ -355,7 +355,7 @@ export function GoogleConnectScreen({
     void (async () => {
       let platformAssistantId: string;
       try {
-        platformAssistantId = await resolveManagedOAuthPlatformAssistantId(assistantId);
+        platformAssistantId = await resolveLocalAssistantPlatformIdentity(assistantId);
       } catch {
         closePopupWindow();
         clearPendingRequest();

--- a/clients/web/src/domains/settings/mcp/mcp-page.test.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-page.test.tsx
@@ -66,6 +66,7 @@ mock.module("./mcp-api", () => ({
   pollMcpAuthStatus: mock(async () => ({ status: "pending" })),
   reloadMcpServers: mock(async () => {}),
   removeMcpServer: mock(async () => {}),
+  revokeMcpOAuth: mock(async () => {}),
   updateMcpServer: mock(async () => {}),
 }));
 

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -13,7 +13,7 @@ import { useNavigate } from "react-router";
 
 import { getAssistantHealthz, hatchAssistant } from "@/assistant/api";
 import { retireAssistant } from "@/assistant/retire-service";
-import { resolveManagedOAuthPlatformAssistantId } from "@/lib/local-managed-oauth-identity";
+import { bootstrapLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { getAppVersionInfo } from "@/runtime/app-info";
 import {
   assistantsList,
@@ -182,11 +182,12 @@ export function useTeleport(): TeleportController {
           // and inject those credentials (the web equivalent of the CLI's
           // post-import injection) so managed/platform integrations keep working.
           // Best-effort: a failure here shouldn't block the switch.
-          void resolveManagedOAuthPlatformAssistantId(target.id).catch((error) =>
-            captureError(error, {
-              context: "teleport-inject-platform-identity",
-            }),
-          );
+          bootstrapLocalAssistantPlatformIdentity(target.id, {
+            onError: (error) =>
+              captureError(error, {
+                context: "teleport-inject-platform-identity",
+              }),
+          });
         }
       } catch (error) {
         // The switch failed — keep the target around and surface the error

--- a/clients/web/src/hooks/use-managed-oauth-platform-assistant-id.ts
+++ b/clients/web/src/hooks/use-managed-oauth-platform-assistant-id.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { resolveManagedOAuthPlatformAssistantId } from "@/lib/local-managed-oauth-identity";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 
 type ManagedOAuthPlatformAssistantIdState = {
   platformAssistantId: string | null;
@@ -27,7 +27,7 @@ export function useManagedOAuthPlatformAssistantId(
     let active = true;
     setState({ platformAssistantId: null, isLoading: true, error: null });
 
-    void resolveManagedOAuthPlatformAssistantId(assistantId)
+    void resolveLocalAssistantPlatformIdentity(assistantId)
       .then((resolvedPlatformAssistantId) => {
         if (!active) return;
         setState({

--- a/clients/web/src/hooks/use-oauth-connect.ts
+++ b/clients/web/src/hooks/use-oauth-connect.ts
@@ -14,7 +14,7 @@ import {
   parseOAuthCompletePayload,
   type OAuthCompletePayload,
 } from "@/lib/auth/oauth-popup";
-import { resolveManagedOAuthPlatformAssistantId } from "@/lib/local-managed-oauth-identity";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import type { OAuthCompleteDeepLinkPayload } from "@/runtime/native-deep-link";
@@ -282,7 +282,7 @@ export function useOAuthConnect({
     const start = async (popup: Window | null) => {
       let platformAssistantId: string;
       try {
-        platformAssistantId = await resolveManagedOAuthPlatformAssistantId(assistantId);
+        platformAssistantId = await resolveLocalAssistantPlatformIdentity(assistantId);
       } catch (error) {
         closePopupWindow();
         clearPendingRequest();

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -18,6 +18,7 @@ let activeAssistant = {
   resources: { gatewayPort: 20101 },
 };
 let isLocalModeValue = true;
+let isPlatformDisabledValue = false;
 let isRemoteGatewayModeValue = false;
 let selfHostedIngressUrl: string | null = GATEWAY_URL;
 let selfHostedActorToken: string | null = "actor-token";
@@ -46,8 +47,10 @@ mock.module("@/lib/local-mode", () => ({
   getActiveAssistant: () => activeAssistant,
   getLocalGatewayUrl: () => "/assistant/__gateway/20101",
   getPlatformRuntimeUrl: () => "http://localhost:8000",
+  getSelectedAssistant: () => activeAssistant,
   isLocalAssistant: (assistant: { cloud?: string }) => assistant?.cloud === "local",
   isLocalMode: () => isLocalModeValue,
+  isPlatformDisabled: () => isPlatformDisabledValue,
   isRemoteGatewayMode: () => isRemoteGatewayModeValue,
   primeLocalGatewayConnectionWithRepair:
     primeLocalGatewayConnectionWithRepairMock,
@@ -80,9 +83,10 @@ mock.module("@/stores/organization-store", () => ({
 }));
 
 const {
-  resetLocalManagedOAuthIdentityCacheForTesting,
-  resolveManagedOAuthPlatformAssistantId,
-} = await import("@/lib/local-managed-oauth-identity");
+  bootstrapLocalAssistantPlatformIdentity,
+  resetLocalPlatformIdentityCacheForTesting,
+  resolveLocalAssistantPlatformIdentity,
+} = await import("@/lib/local-platform-identity");
 
 const originalFetch = globalThis.fetch;
 
@@ -104,6 +108,10 @@ function requestNames(): string[] {
     .filter((value): value is string => Boolean(value));
 }
 
+async function flushAsyncWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   activeAssistant = {
     assistantId: RUNTIME_ASSISTANT_ID,
@@ -112,6 +120,7 @@ beforeEach(() => {
     resources: { gatewayPort: 20101 },
   };
   isLocalModeValue = true;
+  isPlatformDisabledValue = false;
   isRemoteGatewayModeValue = false;
   selfHostedIngressUrl = GATEWAY_URL;
   selfHostedActorToken = "actor-token";
@@ -131,7 +140,7 @@ beforeEach(() => {
   buildVellumMutatingHeadersMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   fetchOrganizationsMock.mockClear();
-  resetLocalManagedOAuthIdentityCacheForTesting();
+  resetLocalPlatformIdentityCacheForTesting();
 
   globalThis.fetch = mock(
     async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -174,13 +183,13 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
-  resetLocalManagedOAuthIdentityCacheForTesting();
+  resetLocalPlatformIdentityCacheForTesting();
 });
 
-describe("resolveManagedOAuthPlatformAssistantId", () => {
+describe("resolveLocalAssistantPlatformIdentity", () => {
   test("returns the stored platform id without registration when the API key is present", async () => {
     const platformAssistantId =
-      await resolveManagedOAuthPlatformAssistantId(RUNTIME_ASSISTANT_ID);
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
     expect(requestNames()).toEqual(["status"]);
@@ -198,7 +207,7 @@ describe("resolveManagedOAuthPlatformAssistantId", () => {
     };
 
     const platformAssistantId =
-      await resolveManagedOAuthPlatformAssistantId(RUNTIME_ASSISTANT_ID);
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
     expect(requestNames()).toEqual([
@@ -224,5 +233,70 @@ describe("resolveManagedOAuthPlatformAssistantId", () => {
       name: "vellum:platform_assistant_id",
       value: PLATFORM_ASSISTANT_ID,
     });
+  });
+
+  test("repairs gateway access by default for blocking platform identity resolution", async () => {
+    selfHostedIngressUrl = null;
+    selfHostedActorToken = null;
+    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(async () => {
+      selfHostedIngressUrl = GATEWAY_URL;
+      selfHostedActorToken = "actor-token";
+    });
+
+    const platformAssistantId =
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+
+    expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
+    expect(primeLocalGatewayConnectionWithRepairMock).toHaveBeenCalledTimes(1);
+    expect(requestNames()).toEqual(["status"]);
+  });
+
+  test("skips raw platform calls when platform features are disabled", async () => {
+    isPlatformDisabledValue = true;
+
+    const platformAssistantId =
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+
+    expect(platformAssistantId).toBe(RUNTIME_ASSISTANT_ID);
+    expect(requestNames()).toEqual([]);
+  });
+});
+
+describe("bootstrapLocalAssistantPlatformIdentity", () => {
+  test("uses the same identity resolution flow for best-effort bootstrap", async () => {
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+    await flushAsyncWork();
+
+    expect(requestNames()).toEqual(["status"]);
+  });
+
+  test("does not repair gateway access during best-effort bootstrap", async () => {
+    selfHostedIngressUrl = null;
+    selfHostedActorToken = null;
+    const onError = mock((_error: unknown) => {});
+
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID, { onError });
+    await flushAsyncWork();
+
+    expect(primeLocalGatewayConnectionWithRepairMock).not.toHaveBeenCalled();
+    expect(requestNames()).toEqual([]);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  test("uses the selected local assistant when no id is supplied", async () => {
+    bootstrapLocalAssistantPlatformIdentity();
+    await flushAsyncWork();
+
+    expect(requestNames()).toEqual(["status"]);
+  });
+
+  test("does nothing when platform features are disabled", async () => {
+    isPlatformDisabledValue = true;
+
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+    await flushAsyncWork();
+
+    expect(primeLocalGatewayConnectionWithRepairMock).not.toHaveBeenCalled();
+    expect(requestNames()).toEqual([]);
   });
 });

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -3,8 +3,10 @@ import {
   getActiveAssistant,
   getLocalGatewayUrl,
   getPlatformRuntimeUrl,
+  getSelectedAssistant,
   isLocalAssistant,
   isLocalMode,
+  isPlatformDisabled,
   isRemoteGatewayMode,
   primeLocalGatewayConnectionWithRepair,
   type LockfileAssistant,
@@ -57,16 +59,31 @@ type ReprovisionApiKeyResponse = {
   };
 };
 
+type BootstrapLocalAssistantPlatformIdentityOptions = {
+  allowGatewayRepair?: boolean;
+  onError?: (error: unknown) => void;
+};
+
+type ResolveLocalAssistantPlatformIdentityOptions = {
+  allowGatewayRepair?: boolean;
+};
+
 const platformAssistantIdCache = new Map<string, Promise<string>>();
 
-export function resetLocalManagedOAuthIdentityCacheForTesting(): void {
+export function resetLocalPlatformIdentityCacheForTesting(): void {
   platformAssistantIdCache.clear();
 }
 
-export async function resolveManagedOAuthPlatformAssistantId(
+export async function resolveLocalAssistantPlatformIdentity(
   assistantId: string,
+  options: ResolveLocalAssistantPlatformIdentityOptions = {},
 ): Promise<string> {
-  if (!isLocalMode() || isRemoteGatewayMode() || isUuid(assistantId)) {
+  if (
+    !isLocalMode() ||
+    isRemoteGatewayMode() ||
+    isPlatformDisabled() ||
+    isUuid(assistantId)
+  ) {
     return assistantId;
   }
 
@@ -78,7 +95,9 @@ export async function resolveManagedOAuthPlatformAssistantId(
   const cached = platformAssistantIdCache.get(assistant.assistantId);
   if (cached) return cached;
 
-  const promise = ensureLocalAssistantPlatformIdentity(assistant);
+  const promise = ensureLocalAssistantPlatformIdentity(assistant, {
+    allowGatewayRepair: options.allowGatewayRepair ?? true,
+  });
   platformAssistantIdCache.set(assistant.assistantId, promise);
   try {
     return await promise;
@@ -88,18 +107,46 @@ export async function resolveManagedOAuthPlatformAssistantId(
   }
 }
 
+export function bootstrapLocalAssistantPlatformIdentity(
+  assistantId?: string,
+  options: BootstrapLocalAssistantPlatformIdentityOptions = {},
+): void {
+  if (!isLocalMode() || isRemoteGatewayMode() || isPlatformDisabled()) return;
+
+  let targetAssistantId = assistantId;
+  if (!targetAssistantId) {
+    const assistant = getSelectedAssistant();
+    if (!assistant || !isLocalAssistant(assistant)) return;
+    targetAssistantId = assistant.assistantId;
+  }
+
+  void resolveLocalAssistantPlatformIdentity(targetAssistantId, {
+    allowGatewayRepair: options.allowGatewayRepair ?? false,
+  }).catch(
+    options.onError ??
+      ((error: unknown) => {
+        console.warn("local assistant platform bootstrap failed", error);
+      }),
+  );
+}
+
 function resolveLocalAssistant(assistantId: string): LockfileAssistant | null {
   const active = getActiveAssistant();
   if (active?.assistantId === assistantId && isLocalAssistant(active)) {
     return active;
+  }
+  const selected = getSelectedAssistant();
+  if (selected?.assistantId === assistantId && isLocalAssistant(selected)) {
+    return selected;
   }
   return null;
 }
 
 async function ensureLocalAssistantPlatformIdentity(
   assistant: LockfileAssistant,
+  options: { allowGatewayRepair: boolean },
 ): Promise<string> {
-  const gateway = await ensureGatewayAccess(assistant);
+  const gateway = await ensureGatewayAccess(assistant, options);
   const status = await fetchPlatformStatus(gateway, assistant.assistantId);
   const statusPlatformAssistantId =
     status?.assistantId && isUuid(status.assistantId)
@@ -114,7 +161,7 @@ async function ensureLocalAssistantPlatformIdentity(
     assistant,
   );
   if (!organizationId) {
-    throw new Error("Sign in to Vellum and select an organization to connect managed OAuth providers.");
+    throw new Error("Sign in to Vellum and select an organization to register this local assistant.");
   }
 
   const registration = await ensureRegistration(assistant, organizationId);
@@ -149,11 +196,12 @@ async function ensureLocalAssistantPlatformIdentity(
 
 async function ensureGatewayAccess(
   assistant: LockfileAssistant,
+  options: { allowGatewayRepair: boolean },
 ): Promise<{ gatewayUrl: string; actorToken: string }> {
   let gatewayUrl = getSelfHostedIngressUrl();
   let actorToken = getSelfHostedActorToken();
 
-  if (!gatewayUrl || !actorToken) {
+  if (options.allowGatewayRepair && (!gatewayUrl || !actorToken)) {
     await primeLocalGatewayConnectionWithRepair(assistant);
     gatewayUrl = getSelfHostedIngressUrl();
     actorToken = getSelfHostedActorToken();
@@ -167,7 +215,7 @@ async function ensureGatewayAccess(
   }
 
   if (!gatewayUrl || !actorToken) {
-    throw new Error("Unable to reach the local assistant for managed OAuth setup.");
+    throw new Error("Unable to reach the local assistant for platform identity setup.");
   }
 
   return { gatewayUrl, actorToken };
@@ -248,7 +296,7 @@ async function platformPost<T>(
 ): Promise<T> {
   const deviceId = getDeviceId();
   if (!deviceId) {
-    throw new Error("Unable to identify this device for managed OAuth setup.");
+    throw new Error("Unable to identify this device for local assistant platform registration.");
   }
 
   const headers = new Headers({
@@ -267,7 +315,7 @@ async function platformPost<T>(
   const sessionToken = getElectronSessionToken();
   if (isElectron()) {
     if (!sessionToken) {
-      throw new Error("Sign in to Vellum to connect managed OAuth providers.");
+      throw new Error("Sign in to Vellum to register this local assistant.");
     }
     headers.set(
       ELECTRON_RENDERER_ORIGIN_HEADER,

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -23,6 +23,7 @@ let mockIsGatewayAuth = false;
 let mockIsLocalMode = false;
 let mockIsRemoteGatewayMode = false;
 let mockPlatformAssistants: unknown[] = [];
+let mockSelectedAssistant: { assistantId: string; cloud: string } | undefined;
 let mockPrimeError: Error | null = null;
 let mockGatewayToken: string | null = null;
 const setSelectedAssistantMock = mock(async (_id: string | null) => {});
@@ -116,6 +117,9 @@ const listAssistantsMock = mock(async () => mockListAssistantsResult);
 const syncPlatformAssistantsToLockfileMock = mock(
   async (_list: unknown, _orgId?: string) => {},
 );
+const bootstrapLocalAssistantPlatformIdentityMock = mock(
+  (_assistantId?: string) => {},
+);
 
 mock.module("@/lib/auth/allauth-client", () => ({
   getSession: async () => {
@@ -170,10 +174,16 @@ mock.module("@/lib/local-mode", () => ({
   isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
   getPlatformAssistants: () => mockPlatformAssistants,
   getLocalAssistants: () => [],
+  getSelectedAssistant: () => mockSelectedAssistant,
   primeLocalGatewayConnection: primeLocalGatewayConnectionMock,
   primeLocalGatewayConnectionWithRepair:
     primeLocalGatewayConnectionWithRepairMock,
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
+}));
+
+mock.module("@/lib/local-platform-identity", () => ({
+  bootstrapLocalAssistantPlatformIdentity:
+    bootstrapLocalAssistantPlatformIdentityMock,
 }));
 
 mock.module("@/runtime/native-auth", () => ({
@@ -324,6 +334,7 @@ beforeEach(() => {
   mockIsLocalMode = false;
   mockIsRemoteGatewayMode = false;
   mockPlatformAssistants = [];
+  mockSelectedAssistant = undefined;
   mockIsNativePlatform = false;
   mockIsBiometricEnabled = false;
   mockBiometricToken = null;
@@ -360,6 +371,7 @@ beforeEach(() => {
   mockListAssistantsResult = [];
   listAssistantsMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
+  bootstrapLocalAssistantPlatformIdentityMock.mockClear();
   resetAuthStore();
 });
 
@@ -491,6 +503,19 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().platformSession).toBe("present");
     // A live probe confirmed it — not a believed offline restore.
     expect(useAuthStore.getState().platformSessionRestoredOffline).toBe(false);
+  });
+
+  test("successful local platform probe bootstraps the selected local assistant identity", async () => {
+    mockIsLocalMode = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = "access-token";
+    mockSelectedAssistant = { assistantId: "local-a", cloud: "local" };
+    sessionUser = { id: "user-1", email: "user@example.com" };
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(bootstrapLocalAssistantPlatformIdentityMock).toHaveBeenCalledWith();
   });
 
   test("initSession uses server consent when server has a consent record", async () => {
@@ -1018,6 +1043,21 @@ describe("connectLocalAssistant", () => {
     await useAuthStore.getState().connectLocalAssistant("local-a");
 
     expect(lifecycleCheckAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("bootstraps a newly connected local assistant when already signed into the platform", async () => {
+    mockIsLocalMode = true;
+    mockPlatformAssistants = [];
+    useAuthStore.setState({
+      platformSession: "present",
+      platformSessionRestoredOffline: false,
+    });
+
+    await useAuthStore.getState().connectLocalAssistant("local-a");
+
+    expect(bootstrapLocalAssistantPlatformIdentityMock).toHaveBeenCalledWith(
+      "local-a",
+    );
   });
 
   test("rethrows the prime failure without selecting or marking the session logged in", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -51,6 +51,7 @@ import {
   primeLocalGatewayConnectionWithRepair,
   syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
+import { bootstrapLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
@@ -470,6 +471,7 @@ function probePlatformSession(
           platformSessionRestoredOffline: false,
           ...userUpdate,
         });
+        bootstrapLocalAssistantPlatformIdentity();
       } else if (options.clearOnFailure) {
         set({ platformSession: "absent" });
       }
@@ -738,6 +740,14 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     await setSelectedAssistant(assistantId);
     set(authenticatedLocalUser());
     await lifecycleService.checkAssistant();
+    if (
+      isConfirmedPlatformSession(
+        get().platformSession,
+        get().platformSessionRestoredOffline,
+      )
+    ) {
+      bootstrapLocalAssistantPlatformIdentity(assistantId);
+    }
     probePlatformSessionIfReachable(set);
   },
 


### PR DESCRIPTION
## Summary
- re-home local assistant platform identity setup in `local-platform-identity`, away from the OAuth-specific module name
- centralize best-effort bootstrap via `bootstrapLocalAssistantPlatformIdentity`
- trigger bootstrap after a live platform session appears for the selected local assistant
- trigger bootstrap when a signed-in user connects or hatches a local assistant
- route teleport platform-to-local post-import identity injection through the same helper
- keep OAuth surfaces as consumers of `resolveLocalAssistantPlatformIdentity` when they need the platform assistant UUID

## Root Cause
Local assistant platform registration was only guaranteed when a managed OAuth path needed a platform assistant id. Normal login/connect/hatch lifecycle paths could leave a local assistant unregistered until a later feature happened to invoke the identity resolver. The identity resolver/bootstrap itself is platform registration infrastructure, not OAuth-specific behavior.

## Codex Feedback Addressed
- Best-effort auth/session bootstrap no longer repairs gateway access, so it cannot wake a stopped local assistant from an auth probe.
- Platform-disabled local mode now exits before raw platform registration/reprovision calls.

## Notes
Lifecycle/bootstrap call sites now use one centralized fire-and-forget path. OAuth call sites still resolve a platform assistant UUID, but through the platform identity module rather than an OAuth-owned module.