### PR TITLE
[codex] Configure OS Beta as low-effort Balanced profile

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1703,8 +1703,8 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 // ---------------------------------------------------------------------------
 // Tests: OS Beta flag-gated managed profile. The template is defined but
 // intentionally NOT part of MANAGED_PROFILE_TEMPLATES, so seedInferenceProfiles
-// must never create it. A later PR reconciles it in/out based on the `os-beta`
-// feature flag.
+// must never create it. The flag-gated reconcile creates or removes it based on
+// the `os-beta` feature flag.
 // ---------------------------------------------------------------------------
 
 describe("OS Beta managed profile template", () => {
@@ -1751,20 +1751,21 @@ describe("OS Beta managed profile template", () => {
     expect(MANAGED_PROFILE_NAMES.has("os-beta")).toBe(true);
   });
 
-  test("materializeProfile honors the explicit OS Beta model", () => {
+  test("materializeProfile resolves OS Beta to the Balanced model with low effort", () => {
     const entry = materializeProfile(
       OS_BETA_PROFILE_TEMPLATE,
-      "fireworks",
-      "fireworks-managed",
+      "together",
+      "together-managed",
     );
 
-    expect(entry.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(entry.provider_connection).toBe("fireworks-managed");
-    expect(entry.provider).toBe("fireworks");
+    expect(entry.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(entry.provider_connection).toBe("together-managed");
+    expect(entry.provider).toBe("together");
     expect(entry.label).toBe("OS Beta");
     expect(entry.source).toBe("managed");
     expect(entry.maxTokens).toBe(32000);
-    expect(entry.effort).toBe("high");
+    expect(entry.effort).toBe("low");
     expect(entry.thinking?.enabled).toBe(true);
+    expect(entry.topP).toBe(0.95);
   });
 });

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -109,10 +109,13 @@ describe("reconcileFlagGatedProfiles", () => {
 
     const raw = readConfig();
     const osBeta = raw.llm.profiles["os-beta"]!;
-    expect(osBeta.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(osBeta.provider_connection).toBe("fireworks-managed");
+    expect(osBeta.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(osBeta.provider_connection).toBe("together-managed");
+    expect(osBeta.provider).toBe("together");
     expect(osBeta.source).toBe("managed");
     expect(osBeta.label).toBe("OS Beta");
+    expect(osBeta.effort).toBe("low");
+    expect(osBeta.topP).toBe(0.95);
 
     const order = raw.llm.profileOrder;
     expect(order.indexOf("os-beta")).toBe(order.indexOf("balanced") + 1);
@@ -128,6 +131,7 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(osBeta.status).toBe("disabled");
     expect(osBeta.label).toBe("OS Beta (Managed)");
     expect(osBeta.source).toBe("managed");
+    expect(osBeta.effort).toBe("low");
   });
 
   test("flag on is idempotent across repeated runs", () => {
@@ -150,6 +154,7 @@ describe("reconcileFlagGatedProfiles", () => {
     raw.llm.profiles["os-beta"]!.label = "My OS Beta";
     raw.llm.profiles["os-beta"]!.status = "disabled";
     raw.llm.profiles["os-beta"]!.advisorEnabled = true;
+    raw.llm.profiles["os-beta"]!.topP = 0.8;
     writeConfig(raw);
     invalidateConfigCache();
 
@@ -159,7 +164,10 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(after.label).toBe("My OS Beta");
     expect(after.status).toBe("disabled");
     expect(after.advisorEnabled).toBe(true);
-    expect(after.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(after.topP).toBe(0.8);
+    expect(after.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(after.provider_connection).toBe("together-managed");
+    expect(after.effort).toBe("low");
   });
 
   test("flag off removes a managed os-beta and applies fallbacks", () => {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -164,19 +164,20 @@ export const OS_BETA_FEATURE_FLAG_KEY = "os-beta";
  * Flag-gated managed profile. NOT in MANAGED_PROFILE_TEMPLATES, so the
  * unconditional boot seed never creates it. Reconciled in/out by
  * the flag-gated profile reconcile based on the `os-beta` feature flag.
- * Balanced-parity defaults; GLM 5.2 pinned explicitly via `model`.
+ * Balanced defaults, with lower reasoning effort while the profile is in beta.
  */
 export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
-  model: "accounts/fireworks/models/glm-5p2",
-  provider: "fireworks",
-  connectionName: "fireworks-managed",
+  intent: "balanced",
+  provider: "together",
+  connectionName: "together-managed",
   source: "managed",
   label: "OS Beta",
-  description: "Open-source frontier model (GLM 5.2), in beta",
+  description: "Good balance of quality, cost, and speed, in beta",
   maxTokens: 32000,
-  effort: "high",
+  effort: "low",
   thinking: { enabled: true, streamThinking: true },
   contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  topP: 0.95,
 };
 
 // Membership here marks a name as managed. The route layer applies managed

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -23,12 +23,12 @@ const log = getLogger("sync-gated-profiles");
  * Reconcile flag-gated managed profiles against the current feature-flag state.
  *
  * `seedInferenceProfiles()` runs synchronously at boot before feature flags are
- * available, so the OS Beta profile (GLM 5.2 / fireworks-managed) is materialized
- * here once flags have loaded. When the `os-beta` flag is on, the managed profile
- * is created (ordered right after `balanced`); when it is off, a previously
- * managed entry is removed with `profileOrder` / `activeProfile` / `advisorProfile`
- * fallbacks. The reconcile is idempotent and never touches a user-owned profile of
- * the same name.
+ * available, so the OS Beta profile (MiniMax M3 / together-managed) is
+ * materialized here once flags have loaded. When the `os-beta` flag is on, the
+ * managed profile is created (ordered right after `balanced`); when it is off, a
+ * previously managed entry is removed with `profileOrder` / `activeProfile` /
+ * `advisorProfile` fallbacks. The reconcile is idempotent and never touches a
+ * user-owned profile of the same name.
  *
  * Returns whether the on-disk config changed.
  */
@@ -105,23 +105,22 @@ function enableProfile(
     OS_BETA_PROFILE_TEMPLATE.connectionName,
   ) as Record<string, unknown>;
 
-  // BYOK installs seed managed profiles disabled: the platform-auth
-  // `fireworks-managed` connection backing this profile isn't usable until the
-  // user enables it, so a fresh OS Beta entry starts disabled to avoid offering
-  // an unusable route. A user's own status override (preserved below) wins on
-  // later reconciles.
+  // BYOK installs seed managed profiles disabled: the managed inference
+  // connection backing this profile isn't usable until the user enables it, so a
+  // fresh OS Beta entry starts disabled to avoid offering an unusable route. A
+  // user's own status override (preserved below) wins on later reconciles.
   if (isByokMode && !previous) {
     next.status = "disabled";
   }
 
   if (previous) {
-    // The only fields a user may override on a managed profile. Carry `label`
-    // by key-presence so an explicit null (user cleared it) survives too.
+    // Preserve user-owned overrides across reconciles.
     if ("label" in previous) next.label = previous.label;
     if ("status" in previous) next.status = previous.status;
     if ("advisorEnabled" in previous) {
       next.advisorEnabled = previous.advisorEnabled;
     }
+    if ("topP" in previous) next.topP = previous.topP;
   }
 
   let changed = false;

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -415,7 +415,7 @@
       "scope": "assistant",
       "key": "os-beta",
       "label": "OS Beta",
-      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "description": "Enable the OS Beta model profile (MiniMax M3 / Together) in the assistant's model profile selection.",
       "defaultEnabled": false
     }
   ]

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -415,7 +415,7 @@
       "scope": "assistant",
       "key": "os-beta",
       "label": "OS Beta",
-      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "description": "Enable the OS Beta model profile (MiniMax M3 / Together) in the assistant's model profile selection.",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Configure the flag-gated OS Beta profile to use the Balanced model route: MiniMax M3 on Together via `together-managed`.
- Keep OS Beta aligned with Balanced defaults for max tokens, thinking, context window, and `topP`, while setting `effort` to `low`.
- Update OS Beta feature-flag registry copy to describe MiniMax M3 / Together instead of GLM / Fireworks.

## Validation
- `bun test src/config/__tests__/sync-gated-profiles.test.ts src/__tests__/config-loader-backfill.test.ts --grep "OS Beta|flag on materializes|flag on in BYOK"`
- `bun test src/config/__tests__/feature-flag-registry-guard.test.ts src/config/__tests__/feature-flag-registry-bundled.test.ts`
- `bunx tsc --noEmit`
- pre-commit and pre-push assistant formatting/lint/typecheck hooks