### PR TITLE
fix(web): preserve legacy MCP flag assignments

### DIFF
--- a/clients/web/src/hooks/use-assistant-feature-flag-sync.test.ts
+++ b/clients/web/src/hooks/use-assistant-feature-flag-sync.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { mapAssistantFeatureFlagEntriesForStore } from "@/hooks/use-assistant-feature-flag-sync";
+import type { AssistantFeatureFlagsGetResponse } from "@/generated/gateway/types.gen";
+
+type FeatureFlagEntry = AssistantFeatureFlagsGetResponse["flags"][number];
+
+function flag(key: string, enabled: boolean | string): FeatureFlagEntry {
+  return { key, enabled } as FeatureFlagEntry;
+}
+
+describe("mapAssistantFeatureFlagEntriesForStore", () => {
+  test("maps the legacy MCP settings key to the add-server gate", () => {
+    const { boolFlags } = mapAssistantFeatureFlagEntriesForStore([
+      flag("mcp-settings", true),
+    ]);
+
+    expect(boolFlags).toEqual({ mcpAddServer: true });
+    expect(boolFlags).not.toHaveProperty("mcpSettings");
+  });
+
+  test("prefers canonical MCP add-server payloads over legacy MCP settings payloads", () => {
+    const { boolFlags } = mapAssistantFeatureFlagEntriesForStore([
+      flag("mcp-settings", true),
+      flag("mcp-add-server", false),
+    ]);
+
+    expect(boolFlags).toEqual({ mcpAddServer: false });
+    expect(boolFlags).not.toHaveProperty("mcpSettings");
+  });
+});

--- a/clients/web/src/hooks/use-assistant-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-assistant-feature-flag-sync.ts
@@ -5,6 +5,7 @@ import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-st
 import {
   ASSISTANT_FLAG_DEFAULTS,
   ASSISTANT_STRING_FLAG_DEFAULTS,
+  canonicalFlagKey,
   flagKeyToStoreKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
 import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
@@ -16,16 +17,26 @@ const VALID_STRING_KEYS = new Set(Object.keys(ASSISTANT_STRING_FLAG_DEFAULTS));
 
 type FeatureFlagEntry = AssistantFeatureFlagsGetResponse["flags"][number];
 
-function mapFlags(
+export function mapAssistantFeatureFlagEntriesForStore(
   entries: FeatureFlagEntry[],
 ): { boolFlags: Record<string, boolean>; stringFlags: Record<string, string> } {
   const boolFlags: Record<string, boolean> = {};
   const stringFlags: Record<string, string> = {};
+  const entryKeys = new Set(entries.map((entry) => entry.key));
+
   for (const entry of entries) {
-    const storeKey = flagKeyToStoreKey(entry.key);
+    const canonicalKey = canonicalFlagKey(entry.key);
+    if (canonicalKey !== entry.key && entryKeys.has(canonicalKey)) {
+      continue;
+    }
+
+    const storeKey = flagKeyToStoreKey(canonicalKey);
     if (typeof entry.enabled === "boolean" && VALID_BOOL_KEYS.has(storeKey)) {
       boolFlags[storeKey] = entry.enabled;
-    } else if (typeof entry.enabled === "string" && VALID_STRING_KEYS.has(storeKey)) {
+    } else if (
+      typeof entry.enabled === "string" &&
+      VALID_STRING_KEYS.has(storeKey)
+    ) {
       stringFlags[storeKey] = entry.enabled;
     }
   }
@@ -63,7 +74,8 @@ export function useAssistantFeatureFlagSync(assistantId: string | null) {
   useEffect(() => {
     if (data?.flags) {
       const store = useAssistantFeatureFlagStore.getState();
-      const { boolFlags, stringFlags } = mapFlags(data.flags);
+      const { boolFlags, stringFlags } =
+        mapAssistantFeatureFlagEntriesForStore(data.flags);
       store.setFlags(boolFlags);
       if (Object.keys(stringFlags).length > 0) {
         store.setStringFlags(stringFlags);
@@ -75,5 +87,4 @@ export function useAssistantFeatureFlagSync(assistantId: string | null) {
     }
   }, [data]);
 }
-
 

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -4,6 +4,7 @@ import {
   ASSISTANT_FLAG_DEFAULTS,
   CLIENT_FLAG_DEFAULTS,
   CLIENT_STRING_FLAG_DEFAULTS,
+  flagKeyToStoreKey,
   getEnvFlagOverridesForScope,
   readEnvFlagOverrides,
   resetEnvOverridesCache,
@@ -53,6 +54,11 @@ describe("feature flag catalog", () => {
   test("exposes the MCP add-server gate without a page-level MCP gate", () => {
     expect("mcpSettings" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
     expect(ASSISTANT_FLAG_DEFAULTS.mcpAddServer).toBe(false);
+  });
+
+  test("maps the legacy MCP settings key to the add-server store key", () => {
+    expect(flagKeyToStoreKey("mcp-settings")).toBe("mcpAddServer");
+    expect(flagKeyToStoreKey("mcp-add-server")).toBe("mcpAddServer");
   });
 });
 
@@ -119,6 +125,33 @@ describe("getEnvFlagOverridesForScope", () => {
 
     expect(clientResult.bool).toEqual({ selfIntroGreeting: true });
     expect(assistantResult.bool).toEqual({ selfIntroGreeting: true });
+  });
+
+  test("maps legacy MCP settings overrides to the add-server gate", () => {
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        "mcp-settings": true,
+      },
+    };
+    resetEnvOverridesCache();
+
+    const result = getEnvFlagOverridesForScope("assistant");
+    expect(result.bool).toEqual({ mcpAddServer: true });
+    expect(result.bool).not.toHaveProperty("mcpSettings");
+  });
+
+  test("prefers canonical MCP add-server overrides over legacy MCP settings overrides", () => {
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        "mcp-settings": true,
+        "mcp-add-server": false,
+      },
+    };
+    resetEnvOverridesCache();
+
+    const result = getEnvFlagOverridesForScope("assistant");
+    expect(result.bool).toEqual({ mcpAddServer: false });
+    expect(result.bool).not.toHaveProperty("mcpSettings");
   });
 });
 

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -23,6 +23,9 @@ export interface FlagDefinition {
 const flags = registry.flags as FlagDefinition[];
 
 const STORE_KEY_OVERRIDES: Record<string, string> = {};
+const LEGACY_FLAG_KEY_ALIASES: Record<string, string> = {
+  "mcp-settings": "mcp-add-server",
+};
 
 function kebabToStoreKey(kebabKey: string): string {
   const override = STORE_KEY_OVERRIDES[kebabKey];
@@ -59,6 +62,10 @@ function buildStringScopeDefaults(scope: SingleScope): Record<string, string> {
   return defaults;
 }
 
+export function canonicalFlagKey(flagKey: string): string {
+  return LEGACY_FLAG_KEY_ALIASES[flagKey] ?? flagKey;
+}
+
 export const CLIENT_FLAG_DEFAULTS = buildScopeDefaults("client");
 export const ASSISTANT_FLAG_DEFAULTS = buildScopeDefaults("assistant");
 export const CLIENT_STRING_FLAG_DEFAULTS = buildStringScopeDefaults("client");
@@ -78,7 +85,7 @@ for (const flag of flags) {
 }
 
 export function flagKeyToStoreKey(flagKey: string): string {
-  return kebabToStoreKey(flagKey);
+  return kebabToStoreKey(canonicalFlagKey(flagKey));
 }
 
 export function storeKeyToFlagKey(storeKey: string): string | undefined {
@@ -157,10 +164,18 @@ export function getEnvFlagOverridesForScope(
   const str: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(overrides)) {
-    const def = FLAG_KEY_TO_DEF.get(key);
+    const canonicalKey = canonicalFlagKey(key);
+    if (
+      canonicalKey !== key &&
+      Object.prototype.hasOwnProperty.call(overrides, canonicalKey)
+    ) {
+      continue;
+    }
+
+    const def = FLAG_KEY_TO_DEF.get(canonicalKey);
     if (!def || !scopeIncludes(def.scope, scope)) continue;
 
-    const storeKey = flagKeyToStoreKey(key);
+    const storeKey = flagKeyToStoreKey(canonicalKey);
     if (typeof value === "boolean") {
       bool[storeKey] = value;
     } else {

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -40,6 +40,14 @@ const TEST_REGISTRY = {
       defaultEnabled: false,
     },
     {
+      id: "mcp-add-server",
+      scope: "assistant",
+      key: "mcp-add-server",
+      label: "MCP Add Server",
+      description: "Allow adding MCP servers",
+      defaultEnabled: false,
+    },
+    {
       id: "user-hosted-enabled",
       scope: "client",
       key: "user-hosted-enabled",
@@ -394,6 +402,55 @@ describe("GET /v1/feature-flags handler", () => {
       (f: { key: string }) => f.key === "a2a-channel",
     );
     expect(a2aFlag2.enabled).toBe(true);
+  });
+
+  test("maps legacy remote MCP settings assignments to MCP add-server", async () => {
+    writeRemoteFeatureFlags({ "mcp-settings": true });
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const mcpFlag = body.flags.find(
+      (f: { key: string }) => f.key === "mcp-add-server",
+    );
+    expect(mcpFlag).toBeDefined();
+    expect(mcpFlag.enabled).toBe(true);
+    expect(
+      body.flags.some((f: { key: string }) => f.key === "mcp-settings"),
+    ).toBe(false);
+  });
+
+  test("maps legacy remote MCP settings assignments loaded from disk", async () => {
+    writeFileSync(
+      remoteFeatureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: { "mcp-settings": true },
+      }),
+    );
+    clearRemoteFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const mcpFlag = body.flags.find(
+      (f: { key: string }) => f.key === "mcp-add-server",
+    );
+    expect(mcpFlag).toBeDefined();
+    expect(mcpFlag.enabled).toBe(true);
+    expect(
+      body.flags.some((f: { key: string }) => f.key === "mcp-settings"),
+    ).toBe(false);
   });
 
   test("registry default used when neither local nor remote is set", async () => {

--- a/gateway/src/feature-flag-remote-store.ts
+++ b/gateway/src/feature-flag-remote-store.ts
@@ -49,6 +49,31 @@ export function getRemoteFeatureFlagStorePath(): string {
 
 let cachedRemoteValues: Record<string, boolean | string> | null = null;
 
+const REMOTE_FLAG_KEY_ALIASES: Record<string, string> = {
+  "mcp-settings": "mcp-add-server",
+};
+
+function normalizeRemoteFeatureFlags(
+  values: Record<string, boolean | string>,
+): Record<string, boolean | string> {
+  const normalized: Record<string, boolean | string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (REMOTE_FLAG_KEY_ALIASES[key]) continue;
+    normalized[key] = value;
+  }
+
+  for (const [key, value] of Object.entries(values)) {
+    const canonicalKey = REMOTE_FLAG_KEY_ALIASES[key];
+    if (!canonicalKey) continue;
+    if (Object.prototype.hasOwnProperty.call(normalized, canonicalKey)) {
+      continue;
+    }
+    normalized[canonicalKey] = value;
+  }
+
+  return normalized;
+}
+
 export function readRemoteFeatureFlags(): Record<string, boolean | string> {
   if (cachedRemoteValues != null) return cachedRemoteValues;
 
@@ -80,7 +105,7 @@ export function readRemoteFeatureFlags(): Record<string, boolean | string> {
       for (const [k, v] of Object.entries(data.values)) {
         if (typeof v === "boolean" || typeof v === "string") filtered[k] = v;
       }
-      cachedRemoteValues = filtered;
+      cachedRemoteValues = normalizeRemoteFeatureFlags(filtered);
     } else {
       cachedRemoteValues = {};
     }
@@ -99,23 +124,24 @@ export function readRemoteFeatureFlags(): Record<string, boolean | string> {
 export function writeRemoteFeatureFlags(
   values: Record<string, boolean | string>,
 ): boolean {
+  const normalizedValues = normalizeRemoteFeatureFlags(values);
   const path = getRemoteFeatureFlagStorePath();
   const dir = dirname(path);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
 
-  const data: FeatureFlagFileData = { version: 1, values };
+  const data: FeatureFlagFileData = { version: 1, values: normalizedValues };
   const tmpPath = path + ".tmp." + process.pid;
   writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
   renameSync(tmpPath, path);
   chmodSync(path, 0o600);
 
-  const changed = !shallowEqual(cachedRemoteValues, values);
-  cachedRemoteValues = values;
+  const changed = !shallowEqual(cachedRemoteValues, normalizedValues);
+  cachedRemoteValues = normalizedValues;
 
   const msg = "Wrote remote feature flags";
-  const meta = { count: Object.keys(values).length };
+  const meta = { count: Object.keys(normalizedValues).length };
   if (changed) {
     log.info(meta, msg);
   } else {


### PR DESCRIPTION
## Summary
- treat legacy `mcp-settings` flag keys as read aliases for canonical `mcp-add-server`
- prefer canonical `mcp-add-server` values when both keys are present
- add regression coverage for env/window overrides and assistant feature-flag sync payloads

Follow-up to #35790 / review discussion: https://github.com/vellum-ai/vellum-assistant/pull/35790#discussion_r3462244441

## Testing
- `cd clients/web && bun test src/lib/feature-flags/feature-flag-catalog.test.ts src/hooks/use-assistant-feature-flag-sync.test.ts src/domains/settings/mcp/mcp-page.test.tsx src/domains/settings/pages/integrations-page.test.tsx src/domains/settings/settings-layout.test.tsx src/routes.test.ts`
- `cd clients/web && bunx tsc --noEmit`
- `cd clients/web && bun run lint src/lib/feature-flags/feature-flag-catalog.ts src/lib/feature-flags/feature-flag-catalog.test.ts src/hooks/use-assistant-feature-flag-sync.ts src/hooks/use-assistant-feature-flag-sync.test.ts`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->