### PR TITLE
[codex] Add reusable schedule model profile picker

### DIFF
--- a/clients/web/src/domains/settings/components/model-profile-select.test.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@vellumai/design-library/components/dropdown", () => ({
+  Dropdown: () => null,
+}));
+
+const { dropdownValueToProfileOption, profileOptionToDropdownValue } =
+  await import("./model-profile-select");
+
+describe("ModelProfileSelect", () => {
+  test("maps null to a non-empty dropdown value", () => {
+    expect(profileOptionToDropdownValue(null)).toBe("__default_profile__");
+    expect(profileOptionToDropdownValue("fast")).toBe("fast");
+  });
+
+  test("maps the Default dropdown value back to null", () => {
+    expect(dropdownValueToProfileOption("__default_profile__")).toBeNull();
+    expect(dropdownValueToProfileOption("fast")).toBe("fast");
+  });
+});

--- a/clients/web/src/domains/settings/components/model-profile-select.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.tsx
@@ -1,0 +1,47 @@
+import { Dropdown } from "@vellumai/design-library/components/dropdown";
+
+import { useProfileOptions } from "@/domains/settings/hooks/use-profile-options";
+
+const DEFAULT_PROFILE_OPTION_VALUE = "__default_profile__";
+
+export function profileOptionToDropdownValue(value: string | null): string {
+  return value ?? DEFAULT_PROFILE_OPTION_VALUE;
+}
+
+export function dropdownValueToProfileOption(value: string): string | null {
+  return value === DEFAULT_PROFILE_OPTION_VALUE ? null : value;
+}
+
+export interface ModelProfileSelectProps {
+  assistantId: string;
+  value: string | null;
+  onChange: (profileKey: string | null) => void;
+  disabled?: boolean;
+  isSaving?: boolean;
+  className?: string;
+}
+
+export function ModelProfileSelect({
+  assistantId,
+  value,
+  onChange,
+  disabled = false,
+  isSaving = false,
+  className,
+}: ModelProfileSelectProps) {
+  const options = useProfileOptions(assistantId, value).map((option) => ({
+    value: profileOptionToDropdownValue(option.value),
+    label: option.label,
+  }));
+
+  return (
+    <Dropdown
+      value={profileOptionToDropdownValue(value)}
+      onChange={(selected) => onChange(dropdownValueToProfileOption(selected))}
+      options={options}
+      disabled={disabled || isSaving}
+      className={className}
+      aria-label="Model profile"
+    />
+  );
+}

--- a/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildProfileOptions } from "@/domains/settings/hooks/use-profile-options";
+
+import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+
+type LlmConfig = NonNullable<ConfigGetResponse["llm"]>;
+
+const llm: LlmConfig = {
+  profileOrder: ["smart", "fast", "legacy"],
+  profiles: {
+    fast: { label: "Fast" },
+    smart: { label: "Smart" },
+    legacy: { label: "Legacy", status: "disabled" },
+    extra: {},
+  },
+} as LlmConfig;
+
+describe("buildProfileOptions", () => {
+  test("orders by profileOrder, omits disabled profiles, and prepends Default", () => {
+    expect(buildProfileOptions(llm)).toEqual([
+      { value: null, label: "Default" },
+      { value: "smart", label: "Smart" },
+      { value: "fast", label: "Fast" },
+      { value: "extra", label: "extra" },
+    ]);
+  });
+
+  test("keeps the selected disabled profile visible", () => {
+    expect(buildProfileOptions(llm, "legacy")).toEqual([
+      { value: null, label: "Default" },
+      { value: "smart", label: "Smart" },
+      { value: "fast", label: "Fast" },
+      { value: "legacy", label: "Legacy (Disabled)" },
+      { value: "extra", label: "extra" },
+    ]);
+  });
+
+  test("returns just the Default option when config is missing", () => {
+    expect(buildProfileOptions(undefined)).toEqual([
+      { value: null, label: "Default" },
+    ]);
+  });
+});

--- a/clients/web/src/domains/settings/hooks/use-profile-options.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.ts
@@ -1,0 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import {
+  profilePickerLabel,
+  visibleProfilesForPicker,
+} from "@/assistant/profile-pickers";
+import { buildOrderedProfiles } from "@/domains/settings/ai/utils";
+import { configGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+
+import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+
+type LlmConfig = ConfigGetResponse["llm"];
+
+export interface ProfileOption {
+  readonly value: string | null;
+  readonly label: string;
+}
+
+export function buildProfileOptions(
+  llm: LlmConfig | undefined,
+  selectedProfile?: string | null,
+): ProfileOption[] {
+  const profiles = llm?.profiles ?? {};
+  const profileOrder = llm?.profileOrder ?? [];
+  const visibleProfiles = visibleProfilesForPicker(
+    buildOrderedProfiles(profiles, profileOrder),
+    [selectedProfile],
+  );
+
+  return [
+    { value: null, label: "Default" },
+    ...visibleProfiles.map((profile) => ({
+      value: profile.name,
+      label: profilePickerLabel(profile),
+    })),
+  ];
+}
+
+export function useProfileOptions(
+  assistantId: string,
+  selectedProfile?: string | null,
+): ProfileOption[] {
+  const { data: daemonConfig } = useQuery({
+    ...configGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: Boolean(assistantId),
+    staleTime: 60_000,
+  });
+
+  return useMemo(
+    () => buildProfileOptions(daemonConfig?.llm, selectedProfile),
+    [daemonConfig?.llm, selectedProfile],
+  );
+}


### PR DESCRIPTION
## Summary
- Add `useProfileOptions` plus a pure `buildProfileOptions` helper for ordered inference-profile dropdown options
- Add `ModelProfileSelect`, a controlled dropdown wrapper that maps `null` to the Default option and back
- Preserve a selected disabled profile in the option list so existing schedules can still display/recover from that state

## Context
This replaces the useful slice from #35098 after the schedules UI moved out of the old Settings schedules page and the web app moved from `apps/web` to `clients/web`. #35098 has been closed in favor of this fresh branch against current `main`.

## Validation
- `cd clients/web && bun test src/domains/settings/hooks/use-profile-options.test.ts src/domains/settings/components/model-profile-select.test.tsx`
- `cd clients/web && bun run lint src/domains/settings/hooks/use-profile-options.ts src/domains/settings/hooks/use-profile-options.test.ts src/domains/settings/components/model-profile-select.tsx src/domains/settings/components/model-profile-select.test.tsx`
- `cd clients/web && bunx tsc --noEmit`