### PR TITLE
Fix MCP auth header leaks in settings config APIs

### DIFF
--- a/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
+++ b/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { makeMockLogger } from "./helpers/mock-logger.js";
 
 mock.module("../util/logger.js", () => ({
+  LOG_FILE_PATTERN: /^assistant-(\d{4}-\d{2}-\d{2})\.log$/,
+  getCliLogger: () => makeMockLogger(),
   getLogger: () => makeMockLogger(),
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+  truncateForLog: (value: string, maxLen = 500) => value.slice(0, maxLen),
 }));
 
 let rawConfig: Record<string, unknown> = {};
@@ -53,18 +58,38 @@ function setNestedValue(
 }
 
 mock.module("../config/loader.js", () => ({
+  API_KEY_PROVIDERS: [],
+  applyNestedDefaults: (config: unknown) => config,
   loadRawConfig: () => structuredClone(savedRawConfig ?? rawConfig),
   saveRawConfig: (raw: Record<string, unknown>) => {
     savedRawConfig = structuredClone(raw);
   },
   deepMergeOverwrite: deepMerge,
   fillContextDefaultsForMissingKeys: () => {},
+  loadConfig: () => structuredClone(savedRawConfig ?? rawConfig),
   getConfig: () => structuredClone(savedRawConfig ?? rawConfig),
+  getConfigReadOnly: () => structuredClone(savedRawConfig ?? rawConfig),
   getDeploymentContextDefaults: () => ({}),
+  getNestedValue: (obj: Record<string, unknown>, path: string) =>
+    path.split(".").reduce<unknown>((current, key) => {
+      if (
+        current === null ||
+        typeof current !== "object" ||
+        Array.isArray(current)
+      ) {
+        return undefined;
+      }
+      return (current as Record<string, unknown>)[key];
+    }, obj),
   invalidateConfigCache: () => {},
+  mergeDefaultWorkspaceConfig: () => ({
+    merged: false,
+    config: structuredClone(savedRawConfig ?? rawConfig),
+  }),
   setNestedValue,
   withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
   withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
+  _writeQuarantineNotice: () => {},
 }));
 
 mock.module("../daemon/config-watcher.js", () => ({
@@ -76,19 +101,47 @@ mock.module("../daemon/config-watcher.js", () => ({
 }));
 
 mock.module("../providers/registry.js", () => ({
+  clearConnectionProviderCache: () => {},
+  getProvider: () => {
+    throw new Error("provider registry mock not implemented");
+  },
+  getProviderRoutingSource: () => null,
   initializeProviders: async () => {},
+  isNativeWebSearchCapableProvider: () => false,
+  listProviders: () => [],
+  resolveProviderFromConnection: async () => null,
 }));
 
 mock.module("../memory/embedding-backend.js", () => ({
+  EmbeddingBackendUnavailableError: class EmbeddingBackendUnavailableError extends Error {},
+  SPARSE_EMBEDDING_VERSION: 4,
   clearEmbeddingBackendCache: () => {},
+  embedWithBackend: async () => ({
+    provider: "local",
+    model: "test",
+    vectors: [],
+  }),
+  generateSparseEmbedding: () => ({ indices: [], values: [] }),
+  getMemoryBackendStatus: async () => ({
+    enabled: false,
+    provider: null,
+    model: null,
+  }),
+  resetLocalEmbeddingFailureState: () => {},
+  selectEmbeddingBackend: async () => null,
+  selectedBackendSupportsMultimodal: async () => false,
 }));
 
 mock.module("../security/secret-allowlist.js", () => ({
+  isAllowlisted: () => false,
+  loadAllowlist: () => {},
+  resetAllowlist: () => {},
   validateAllowlistFile: () => null,
 }));
 
-import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
-import { BadRequestError } from "../runtime/routes/errors.js";
+const { ROUTES } =
+  await import("../runtime/routes/conversation-query-routes.js");
+const { BadRequestError } = await import("../runtime/routes/errors.js");
 
 function findRoute(operationId: string) {
   const route = ROUTES.find((r) => r.operationId === operationId);

--- a/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
+++ b/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+let rawConfig: Record<string, unknown> = {};
+let savedRawConfig: Record<string, unknown> | null = null;
+
+function deepMerge(
+  target: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): void {
+  for (const [key, value] of Object.entries(patch)) {
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      target[key] !== null &&
+      typeof target[key] === "object" &&
+      !Array.isArray(target[key])
+    ) {
+      deepMerge(
+        target[key] as Record<string, unknown>,
+        value as Record<string, unknown>,
+      );
+    } else {
+      target[key] = value;
+    }
+  }
+}
+
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const keys = path.split(".");
+  let current = obj;
+  for (const key of keys.slice(0, -1)) {
+    if (
+      current[key] === null ||
+      typeof current[key] !== "object" ||
+      Array.isArray(current[key])
+    ) {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]!] = value;
+}
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => structuredClone(rawConfig),
+  saveRawConfig: (raw: Record<string, unknown>) => {
+    savedRawConfig = structuredClone(raw);
+  },
+  deepMergeOverwrite: deepMerge,
+  fillContextDefaultsForMissingKeys: () => {},
+  getConfig: () => structuredClone(savedRawConfig ?? rawConfig),
+  getDeploymentContextDefaults: () => ({}),
+  invalidateConfigCache: () => {},
+  setNestedValue,
+  withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
+  withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
+}));
+
+mock.module("../daemon/config-watcher.js", () => ({
+  getConfigWatcher: () => ({
+    suppressConfigReload: false,
+    timers: { schedule: () => {} },
+    updateFingerprint: () => {},
+  }),
+}));
+
+mock.module("../providers/registry.js", () => ({
+  initializeProviders: async () => {},
+}));
+
+mock.module("../memory/embedding-backend.js", () => ({
+  clearEmbeddingBackendCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  validateAllowlistFile: () => null,
+}));
+
+import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+
+function findRoute(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route not found: ${operationId}`);
+  return route;
+}
+
+const configGetRoute = findRoute("config_get");
+const configPatchRoute = findRoute("config_patch");
+const configSetRoute = findRoute("config_set");
+
+describe("MCP config secret boundary", () => {
+  beforeEach(() => {
+    rawConfig = {};
+    savedRawConfig = null;
+  });
+
+  test("config_get omits legacy MCP transport headers from settings-read responses", () => {
+    rawConfig = {
+      mcp: {
+        servers: {
+          remote: {
+            transport: {
+              type: "streamable-http",
+              url: "https://mcp.example.com",
+              headers: {
+                Authorization: "Bearer mcp-secret",
+                "X-API-Key": "mcp-api-secret",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = configGetRoute.handler({}) as Record<string, unknown>;
+
+    expect(JSON.stringify(result)).not.toContain("mcp-secret");
+    expect(JSON.stringify(result)).not.toContain("mcp-api-secret");
+    const mcp = result.mcp as {
+      servers: { remote: { transport: Record<string, unknown> } };
+    };
+    expect(mcp.servers.remote.transport).toEqual({
+      type: "streamable-http",
+      url: "https://mcp.example.com",
+    });
+  });
+
+  test("config_patch rejects MCP transport headers so generic writes cannot reintroduce plaintext credentials", async () => {
+    await expect(
+      configPatchRoute.handler({
+        body: {
+          mcp: {
+            servers: {
+              remote: {
+                transport: {
+                  type: "streamable-http",
+                  url: "https://mcp.example.com",
+                  headers: { Authorization: "Bearer mcp-secret" },
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(BadRequestError);
+    expect(savedRawConfig).toBeNull();
+  });
+
+  test("config_set rejects direct MCP transport header paths", async () => {
+    rawConfig = {
+      mcp: {
+        servers: {
+          remote: {
+            transport: {
+              type: "streamable-http",
+              url: "https://mcp.example.com",
+            },
+          },
+        },
+      },
+    };
+
+    await expect(
+      configSetRoute.handler({
+        body: {
+          path: "mcp.servers.remote.transport.headers.Authorization",
+          value: "Bearer mcp-secret",
+        },
+      }),
+    ).rejects.toThrow(BadRequestError);
+    expect(savedRawConfig).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
+++ b/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
@@ -137,6 +137,33 @@ describe("MCP config secret boundary", () => {
     });
   });
 
+  test("config_get omits headers inside malformed MCP server trees", () => {
+    rawConfig = {
+      mcp: {
+        servers: [
+          {
+            transport: {
+              headers: { Authorization: "Bearer malformed-secret" },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = configGetRoute.handler({}) as Record<string, unknown>;
+
+    expect(JSON.stringify(result)).not.toContain("malformed-secret");
+    expect(result).toEqual({
+      mcp: {
+        servers: [
+          {
+            transport: {},
+          },
+        ],
+      },
+    });
+  });
+
   test("config_patch rejects MCP transport headers so generic writes cannot reintroduce plaintext credentials", async () => {
     await expect(
       configPatchRoute.handler({
@@ -152,6 +179,24 @@ describe("MCP config secret boundary", () => {
               },
             },
           },
+        },
+      }),
+    ).rejects.toThrow(BadRequestError);
+    expect(savedRawConfig).toBeNull();
+  });
+
+  test("config_set rejects malformed MCP server trees containing headers", async () => {
+    await expect(
+      configSetRoute.handler({
+        body: {
+          path: "mcp.servers",
+          value: [
+            {
+              transport: {
+                headers: { Authorization: "Bearer malformed-secret" },
+              },
+            },
+          ],
         },
       }),
     ).rejects.toThrow(BadRequestError);

--- a/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
+++ b/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
@@ -183,6 +183,28 @@ describe("MCP config secret boundary", () => {
     expect(result).toEqual(rawConfig);
   });
 
+  test("config_get preserves non-credential headers env vars", () => {
+    rawConfig = {
+      mcp: {
+        servers: {
+          local: {
+            transport: {
+              type: "stdio",
+              command: "npx",
+              env: {
+                headers: "not-a-transport-header",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = configGetRoute.handler({}) as Record<string, unknown>;
+
+    expect(result).toEqual(rawConfig);
+  });
+
   test("config_patch rejects MCP transport headers so generic writes cannot reintroduce plaintext credentials", async () => {
     await expect(
       configPatchRoute.handler({
@@ -227,6 +249,42 @@ describe("MCP config secret boundary", () => {
             transport: {
               type: "streamable-http",
               url: "https://mcp.example.com",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test("config_patch allows non-credential headers env vars", async () => {
+    const result = await configPatchRoute.handler({
+      body: {
+        mcp: {
+          servers: {
+            local: {
+              transport: {
+                type: "stdio",
+                command: "npx",
+                env: {
+                  headers: "not-a-transport-header",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      mcp: {
+        servers: {
+          local: {
+            transport: {
+              type: "stdio",
+              command: "npx",
+              env: {
+                headers: "not-a-transport-header",
+              },
             },
           },
         },

--- a/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
+++ b/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
@@ -53,7 +53,7 @@ function setNestedValue(
 }
 
 mock.module("../config/loader.js", () => ({
-  loadRawConfig: () => structuredClone(rawConfig),
+  loadRawConfig: () => structuredClone(savedRawConfig ?? rawConfig),
   saveRawConfig: (raw: Record<string, unknown>) => {
     savedRawConfig = structuredClone(raw);
   },
@@ -164,6 +164,25 @@ describe("MCP config secret boundary", () => {
     });
   });
 
+  test("config_get preserves an MCP server named headers", () => {
+    rawConfig = {
+      mcp: {
+        servers: {
+          headers: {
+            transport: {
+              type: "streamable-http",
+              url: "https://mcp.example.com",
+            },
+          },
+        },
+      },
+    };
+
+    const result = configGetRoute.handler({}) as Record<string, unknown>;
+
+    expect(result).toEqual(rawConfig);
+  });
+
   test("config_patch rejects MCP transport headers so generic writes cannot reintroduce plaintext credentials", async () => {
     await expect(
       configPatchRoute.handler({
@@ -183,6 +202,36 @@ describe("MCP config secret boundary", () => {
       }),
     ).rejects.toThrow(BadRequestError);
     expect(savedRawConfig).toBeNull();
+  });
+
+  test("config_patch allows an MCP server named headers when its value has no header credentials", async () => {
+    const result = await configPatchRoute.handler({
+      body: {
+        mcp: {
+          servers: {
+            headers: {
+              transport: {
+                type: "streamable-http",
+                url: "https://mcp.example.com",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      mcp: {
+        servers: {
+          headers: {
+            transport: {
+              type: "streamable-http",
+              url: "https://mcp.example.com",
+            },
+          },
+        },
+      },
+    });
   });
 
   test("config_set rejects malformed MCP server trees containing headers", async () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -486,6 +486,41 @@ function readPlainObject(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
+function sanitizeMcpTransportHeadersForSettingsRead(config: unknown): void {
+  const root = readPlainObject(config);
+  if (!root) return;
+  const mcp = readPlainObject(root.mcp);
+  const servers = readPlainObject(mcp?.servers);
+  if (!servers) return;
+
+  for (const server of Object.values(servers)) {
+    const serverConfig = readPlainObject(server);
+    const transport = readPlainObject(serverConfig?.transport);
+    if (!transport) continue;
+    delete transport.headers;
+  }
+}
+
+function patchContainsMcpTransportHeaders(patch: unknown): boolean {
+  const root = readPlainObject(patch);
+  const mcp = readPlainObject(root?.mcp);
+  const servers = readPlainObject(mcp?.servers);
+  if (!servers) return false;
+
+  return Object.values(servers).some((server) => {
+    const serverConfig = readPlainObject(server);
+    const transport = readPlainObject(serverConfig?.transport);
+    return transport ? Object.hasOwn(transport, "headers") : false;
+  });
+}
+
+function rejectMcpTransportHeaderWrite(patch: unknown): void {
+  if (!patchContainsMcpTransportHeaders(patch)) return;
+  throw new BadRequestError(
+    "MCP authentication headers must be managed through MCP server add/update APIs, not generic config writes.",
+  );
+}
+
 const WireProfileEntry = ProfileEntry.extend({
   supportsVision: z.boolean().optional(),
 })
@@ -688,6 +723,7 @@ const ConfigPatchRequestSchema = z
 function handleGetConfig() {
   try {
     const config = applyContextDefaultsToRawConfig(loadRawConfig());
+    sanitizeMcpTransportHeadersForSettingsRead(config);
     enrichProfilesWithVisionFlag(config);
     return config;
   } catch (err) {
@@ -840,6 +876,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
     throw new BadRequestError("Body must be a non-empty JSON object");
   }
   rejectManagedProfileDeletion(body as Record<string, unknown>);
+  rejectMcpTransportHeaderWrite(body);
 
   const raw = loadRawConfig();
   const patch = body as Record<string, unknown>;
@@ -848,6 +885,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
   await commitConfigWrite(raw, "patch");
 
   const merged = applyContextDefaultsToRawConfig(loadRawConfig());
+  sanitizeMcpTransportHeadersForSettingsRead(merged);
   enrichProfilesWithVisionFlag(merged);
   return merged;
 }
@@ -892,6 +930,7 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
   const patchShape: Record<string, unknown> = {};
   setNestedValue(patchShape, path, value);
   rejectManagedProfileDeletion(patchShape);
+  rejectMcpTransportHeaderWrite(patchShape);
 
   const raw = loadRawConfig();
   setNestedValue(raw, path, value);

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -486,32 +486,34 @@ function readPlainObject(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
-function stripHeadersRecursively(value: unknown): void {
+function stripTransportHeadersRecursively(value: unknown): void {
   if (Array.isArray(value)) {
     for (const item of value) {
-      stripHeadersRecursively(item);
+      stripTransportHeadersRecursively(item);
     }
     return;
   }
 
   const object = readPlainObject(value);
   if (!object) return;
-  delete object.headers;
+  const transport = readPlainObject(object.transport);
+  if (transport) delete transport.headers;
   for (const child of Object.values(object)) {
-    stripHeadersRecursively(child);
+    stripTransportHeadersRecursively(child);
   }
 }
 
-function containsHeadersRecursively(value: unknown): boolean {
+function containsTransportHeadersRecursively(value: unknown): boolean {
   if (Array.isArray(value)) {
-    return value.some((item) => containsHeadersRecursively(item));
+    return value.some((item) => containsTransportHeadersRecursively(item));
   }
 
   const object = readPlainObject(value);
   if (!object) return false;
-  if (Object.hasOwn(object, "headers")) return true;
+  const transport = readPlainObject(object.transport);
+  if (transport && Object.hasOwn(transport, "headers")) return true;
   return Object.values(object).some((child) =>
-    containsHeadersRecursively(child),
+    containsTransportHeadersRecursively(child),
   );
 }
 
@@ -521,13 +523,13 @@ function sanitizeMcpTransportHeadersForSettingsRead(config: unknown): void {
   const mcp = readPlainObject(root.mcp);
   if (!mcp || !Object.hasOwn(mcp, "servers")) return;
   if (Array.isArray(mcp.servers)) {
-    stripHeadersRecursively(mcp.servers);
+    stripTransportHeadersRecursively(mcp.servers);
     return;
   }
   const servers = readPlainObject(mcp.servers);
   if (!servers) return;
   for (const server of Object.values(servers)) {
-    stripHeadersRecursively(server);
+    stripTransportHeadersRecursively(server);
   }
 }
 
@@ -536,12 +538,12 @@ function patchContainsMcpTransportHeaders(patch: unknown): boolean {
   const mcp = readPlainObject(root?.mcp);
   if (!mcp || !Object.hasOwn(mcp, "servers")) return false;
   if (Array.isArray(mcp.servers)) {
-    return containsHeadersRecursively(mcp.servers);
+    return containsTransportHeadersRecursively(mcp.servers);
   }
   const servers = readPlainObject(mcp.servers);
   if (!servers) return false;
   return Object.values(servers).some((server) =>
-    containsHeadersRecursively(server),
+    containsTransportHeadersRecursively(server),
   );
 }
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -520,14 +520,29 @@ function sanitizeMcpTransportHeadersForSettingsRead(config: unknown): void {
   if (!root) return;
   const mcp = readPlainObject(root.mcp);
   if (!mcp || !Object.hasOwn(mcp, "servers")) return;
-  stripHeadersRecursively(mcp.servers);
+  if (Array.isArray(mcp.servers)) {
+    stripHeadersRecursively(mcp.servers);
+    return;
+  }
+  const servers = readPlainObject(mcp.servers);
+  if (!servers) return;
+  for (const server of Object.values(servers)) {
+    stripHeadersRecursively(server);
+  }
 }
 
 function patchContainsMcpTransportHeaders(patch: unknown): boolean {
   const root = readPlainObject(patch);
   const mcp = readPlainObject(root?.mcp);
   if (!mcp || !Object.hasOwn(mcp, "servers")) return false;
-  return containsHeadersRecursively(mcp.servers);
+  if (Array.isArray(mcp.servers)) {
+    return containsHeadersRecursively(mcp.servers);
+  }
+  const servers = readPlainObject(mcp.servers);
+  if (!servers) return false;
+  return Object.values(servers).some((server) =>
+    containsHeadersRecursively(server),
+  );
 }
 
 function rejectMcpTransportHeaderWrite(patch: unknown): void {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -486,32 +486,48 @@ function readPlainObject(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
+function stripHeadersRecursively(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      stripHeadersRecursively(item);
+    }
+    return;
+  }
+
+  const object = readPlainObject(value);
+  if (!object) return;
+  delete object.headers;
+  for (const child of Object.values(object)) {
+    stripHeadersRecursively(child);
+  }
+}
+
+function containsHeadersRecursively(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((item) => containsHeadersRecursively(item));
+  }
+
+  const object = readPlainObject(value);
+  if (!object) return false;
+  if (Object.hasOwn(object, "headers")) return true;
+  return Object.values(object).some((child) =>
+    containsHeadersRecursively(child),
+  );
+}
+
 function sanitizeMcpTransportHeadersForSettingsRead(config: unknown): void {
   const root = readPlainObject(config);
   if (!root) return;
   const mcp = readPlainObject(root.mcp);
-  const servers = readPlainObject(mcp?.servers);
-  if (!servers) return;
-
-  for (const server of Object.values(servers)) {
-    const serverConfig = readPlainObject(server);
-    const transport = readPlainObject(serverConfig?.transport);
-    if (!transport) continue;
-    delete transport.headers;
-  }
+  if (!mcp || !Object.hasOwn(mcp, "servers")) return;
+  stripHeadersRecursively(mcp.servers);
 }
 
 function patchContainsMcpTransportHeaders(patch: unknown): boolean {
   const root = readPlainObject(patch);
   const mcp = readPlainObject(root?.mcp);
-  const servers = readPlainObject(mcp?.servers);
-  if (!servers) return false;
-
-  return Object.values(servers).some((server) => {
-    const serverConfig = readPlainObject(server);
-    const transport = readPlainObject(serverConfig?.transport);
-    return transport ? Object.hasOwn(transport, "headers") : false;
-  });
+  if (!mcp || !Object.hasOwn(mcp, "servers")) return false;
+  return containsHeadersRecursively(mcp.servers);
 }
 
 function rejectMcpTransportHeaderWrite(patch: unknown): void {


### PR DESCRIPTION
## Summary
- Strip legacy MCP transport headers from `GET /v1/config` and `PATCH /v1/config` responses.
- Reject generic config writes that attempt to persist MCP transport headers.
- Add regression coverage for the settings-read credential boundary.

## Original prompt
Implement the recommended fix for ATL-902 so MCP static auth headers cannot be exposed through read-only settings APIs.

Fixes ATL-902.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->