### PR TITLE
Add server-side system task usage summaries

### DIFF
--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -17,6 +17,9 @@ mock.module("../config/loader.js", () => ({
       cronExpression: null,
       timezone: null,
     },
+    llm: {
+      pricingOverrides: {},
+    },
   }),
   getConfigReadOnly: () => ({
     llm: {
@@ -82,6 +85,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { recordUsageEvent } from "../memory/llm-usage-store.js";
 import { rawRun } from "../memory/raw-query.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../memory/v2/constants.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
@@ -178,6 +182,30 @@ function setScheduleRunWindow({
     finishedAt == null ? null : finishedAt - startedAt,
     startedAt,
     runId,
+  );
+}
+
+function setConversationCreatedAt(conversationId: string, createdAt: number) {
+  rawRun(
+    "UPDATE conversations SET created_at = ?, updated_at = ? WHERE id = ?",
+    createdAt,
+    createdAt,
+    conversationId,
+  );
+}
+
+function insertMessage(
+  conversationId: string,
+  role: "user" | "assistant",
+  createdAt: number,
+) {
+  rawRun(
+    "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)",
+    `msg-${conversationId}-${role}-${createdAt}`,
+    conversationId,
+    role,
+    "x",
+    createdAt,
   );
 }
 
@@ -1126,6 +1154,111 @@ describe("GET /schedules/usage-summary", () => {
       eventCount: 3,
     });
     expect(result.summaries[0].totalEstimatedCostUsd).toBeCloseTo(0.06);
+  });
+
+  test("includes heartbeat task usage without counting skipped scheduler ticks", () => {
+    const conversation = createConversation({
+      title: "Heartbeat summary conversation",
+      source: "heartbeat",
+    });
+    const completedRun = insertPendingHeartbeatRun(1000);
+    rawRun(
+      "UPDATE heartbeat_runs SET status = 'ok', scheduled_for = ?, started_at = ?, finished_at = ?, duration_ms = ?, conversation_id = ?, created_at = ? WHERE id = ?",
+      1000,
+      1000,
+      2000,
+      1000,
+      conversation.id,
+      1000,
+      completedRun,
+    );
+    const skippedRun = insertPendingHeartbeatRun(1500);
+    rawRun(
+      "UPDATE heartbeat_runs SET status = 'skipped', skip_reason = 'outside_active_hours', scheduled_for = ?, started_at = NULL, finished_at = NULL, duration_ms = NULL, created_at = ? WHERE id = ?",
+      1500,
+      1500,
+      skippedRun,
+    );
+
+    recordUsageCostAt(conversation.id, "heartbeat-summary-before", 999, 0.4);
+    recordUsageCostAt(conversation.id, "heartbeat-summary-start", 1000, 0.01);
+    recordUsageCostAt(conversation.id, "heartbeat-summary-inside", 1500, 0.02);
+    recordUsageCostAt(conversation.id, "heartbeat-summary-finish", 2000, 0.03);
+    recordUsageCostAt(conversation.id, "heartbeat-summary-after", 2001, 0.5);
+
+    const result = getUsageSummary({ from: "1000", to: "2000" });
+    const byScheduleId = new Map(
+      result.summaries.map((summary) => [summary.scheduleId, summary]),
+    );
+
+    expect(byScheduleId.get("system-heartbeat")).toMatchObject({
+      scheduleId: "system-heartbeat",
+      runCount: 1,
+      eventCount: 3,
+    });
+    expect(
+      byScheduleId.get("system-heartbeat")?.totalEstimatedCostUsd,
+    ).toBeCloseTo(0.06);
+  });
+
+  test("includes completed consolidation task usage without counting in-flight conversations", () => {
+    const completedConversation = createConversation({
+      title: "Completed consolidation",
+      source: MEMORY_V2_CONSOLIDATION_SOURCE,
+    });
+    const runningConversation = createConversation({
+      title: "Running consolidation",
+      source: MEMORY_V2_CONSOLIDATION_SOURCE,
+    });
+    setConversationCreatedAt(completedConversation.id, 1000);
+    setConversationCreatedAt(runningConversation.id, 1500);
+    insertMessage(completedConversation.id, "assistant", 2000);
+    insertMessage(runningConversation.id, "user", 1600);
+
+    recordUsageCostAt(
+      completedConversation.id,
+      "consolidation-summary-before",
+      999,
+      0.4,
+    );
+    recordUsageCostAt(
+      completedConversation.id,
+      "consolidation-summary-start",
+      1000,
+      0.01,
+    );
+    recordUsageCostAt(
+      completedConversation.id,
+      "consolidation-summary-inside",
+      1500,
+      0.02,
+    );
+    recordUsageCostAt(
+      completedConversation.id,
+      "consolidation-summary-finish",
+      2000,
+      0.03,
+    );
+    recordUsageCostAt(
+      completedConversation.id,
+      "consolidation-summary-after",
+      2001,
+      0.5,
+    );
+
+    const result = getUsageSummary({ from: "1000", to: "2000" });
+    const byScheduleId = new Map(
+      result.summaries.map((summary) => [summary.scheduleId, summary]),
+    );
+
+    expect(byScheduleId.get("system-consolidation")).toMatchObject({
+      scheduleId: "system-consolidation",
+      runCount: 1,
+      eventCount: 3,
+    });
+    expect(
+      byScheduleId.get("system-consolidation")?.totalEstimatedCostUsd,
+    ).toBeCloseTo(0.06);
   });
 
   test("validates required numeric range parameters", () => {

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -38,6 +38,7 @@ import {
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
+import { getSystemTaskUsageSummaries } from "../../schedule/system-task-usage-store.js";
 import { areCoreToolsInitialized } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { normalizeCapabilityManifest } from "../../workflows/capabilities.js";
@@ -580,7 +581,12 @@ function handleListScheduleRuns(
 
 function handleScheduleUsageSummary(queryParams: Record<string, string>) {
   const range = parseEpochMillisRange(queryParams);
-  return { summaries: getScheduleUsageSummaries(range) };
+  return {
+    summaries: [
+      ...getScheduleUsageSummaries(range),
+      ...getSystemTaskUsageSummaries(range),
+    ],
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/schedule/system-task-usage-store.ts
+++ b/assistant/src/schedule/system-task-usage-store.ts
@@ -1,0 +1,163 @@
+import { MEMORY_RETROSPECTIVE_SOURCES } from "../memory/memory-retrospective-constants.js";
+import { rawAll } from "../memory/raw-query.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../memory/v2/constants.js";
+import type { ScheduleUsageSummary } from "./schedule-usage-store.js";
+
+const SYSTEM_TASK_IDS = {
+  heartbeat: "system-heartbeat",
+  consolidation: "system-consolidation",
+  retrospective: "system-memory-retrospective",
+} as const;
+
+interface UsageSummaryRow {
+  schedule_id: string;
+  run_count: number;
+  total_estimated_cost_usd: number | null;
+  event_count: number | null;
+}
+
+interface UsageRange {
+  from: number;
+  to: number;
+}
+
+export function getSystemTaskUsageSummaries(
+  range: UsageRange,
+): ScheduleUsageSummary[] {
+  const summaries = [
+    getHeartbeatUsageSummary(range),
+    getConversationTaskUsageSummary(
+      SYSTEM_TASK_IDS.consolidation,
+      [MEMORY_V2_CONSOLIDATION_SOURCE],
+      range,
+    ),
+    getConversationTaskUsageSummary(
+      SYSTEM_TASK_IDS.retrospective,
+      [...MEMORY_RETROSPECTIVE_SOURCES],
+      range,
+    ),
+  ];
+  return summaries.filter((summary) => !isEmptySummary(summary));
+}
+
+function getHeartbeatUsageSummary({
+  from,
+  to,
+}: UsageRange): ScheduleUsageSummary {
+  const now = Date.now();
+  const rows = rawAll<UsageSummaryRow>(
+    /*sql*/ `
+    WITH countable_runs AS (
+      SELECT
+        conversation_id,
+        COALESCE(started_at, scheduled_for) AS started_at,
+        COALESCE(finished_at, ?) AS finished_at
+      FROM heartbeat_runs
+      WHERE status IN ('ok', 'error', 'timeout')
+        AND scheduled_for >= ?
+        AND scheduled_for <= ?
+    ),
+    usage_totals AS (
+      SELECT
+        COALESCE(SUM(e.estimated_cost_usd), 0) AS total_estimated_cost_usd,
+        COALESCE(SUM(COALESCE(e.llm_call_count, 1)), 0) AS event_count
+      FROM llm_usage_events e
+      JOIN countable_runs r ON r.conversation_id = e.conversation_id
+      WHERE e.created_at >= CASE WHEN r.started_at > ? THEN r.started_at ELSE ? END
+        AND e.created_at <= CASE WHEN r.finished_at < ? THEN r.finished_at ELSE ? END
+    )
+    SELECT
+      ? AS schedule_id,
+      (SELECT COUNT(*) FROM countable_runs) AS run_count,
+      usage_totals.total_estimated_cost_usd,
+      usage_totals.event_count
+    FROM usage_totals
+    `,
+    now,
+    from,
+    to,
+    from,
+    from,
+    to,
+    to,
+    SYSTEM_TASK_IDS.heartbeat,
+  );
+  return rowToSummary(rows[0], SYSTEM_TASK_IDS.heartbeat);
+}
+
+function getConversationTaskUsageSummary(
+  scheduleId: string,
+  sources: readonly string[],
+  { from, to }: UsageRange,
+): ScheduleUsageSummary {
+  if (sources.length === 0) return rowToSummary(undefined, scheduleId);
+
+  const sourcePlaceholders = sources.map(() => "?").join(", ");
+  const rows = rawAll<UsageSummaryRow>(
+    /*sql*/ `
+    WITH candidate_conversations AS (
+      SELECT id, created_at
+      FROM conversations
+      WHERE source IN (${sourcePlaceholders})
+        AND created_at >= ?
+        AND created_at <= ?
+    ),
+    completed_runs AS (
+      SELECT
+        c.id AS conversation_id,
+        c.created_at AS started_at,
+        MAX(m.created_at) AS finished_at
+      FROM candidate_conversations c
+      JOIN messages m
+        ON m.conversation_id = c.id
+       AND m.role = 'assistant'
+       AND m.created_at >= c.created_at
+      GROUP BY c.id, c.created_at
+    ),
+    usage_totals AS (
+      SELECT
+        COALESCE(SUM(e.estimated_cost_usd), 0) AS total_estimated_cost_usd,
+        COALESCE(SUM(COALESCE(e.llm_call_count, 1)), 0) AS event_count
+      FROM llm_usage_events e
+      JOIN completed_runs r ON r.conversation_id = e.conversation_id
+      WHERE e.created_at >= CASE WHEN r.started_at > ? THEN r.started_at ELSE ? END
+        AND e.created_at <= CASE WHEN r.finished_at < ? THEN r.finished_at ELSE ? END
+    )
+    SELECT
+      ? AS schedule_id,
+      (SELECT COUNT(*) FROM completed_runs) AS run_count,
+      usage_totals.total_estimated_cost_usd,
+      usage_totals.event_count
+    FROM usage_totals
+    `,
+    ...sources,
+    from,
+    to,
+    from,
+    from,
+    to,
+    to,
+    scheduleId,
+  );
+  return rowToSummary(rows[0], scheduleId);
+}
+
+function rowToSummary(
+  row: UsageSummaryRow | undefined,
+  scheduleId: string,
+): ScheduleUsageSummary {
+  return {
+    scheduleId,
+    runCount: row?.run_count ?? 0,
+    totalEstimatedCostUsd: row?.total_estimated_cost_usd ?? 0,
+    eventCount: row?.event_count ?? 0,
+  };
+}
+
+function isEmptySummary(summary: ScheduleUsageSummary): boolean {
+  return (
+    summary.runCount === 0 &&
+    summary.totalEstimatedCostUsd === 0 &&
+    summary.eventCount === 0
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -429,6 +429,8 @@ export function useStreamEventHandler(
         // handler ignores them.
         case "trace_event":
           break;
+        case "conversation_notice":
+          break;
         case "unknown":
           break;
         default: {

--- a/clients/web/src/domains/settings/hooks/use-system-tasks.ts
+++ b/clients/web/src/domains/settings/hooks/use-system-tasks.ts
@@ -4,37 +4,28 @@ import { useMemo } from "react";
 import {
   consolidationConfigGetOptions,
   consolidationRunsGetInfiniteQueryKey,
-  consolidationRunsGetOptions,
   heartbeatConfigGetOptions,
   heartbeatConfigGetSetQueryData,
   heartbeatRunsGetInfiniteQueryKey,
-  heartbeatRunsGetOptions,
   retrospectiveConfigGetOptions,
   retrospectiveRunsGetInfiniteQueryKey,
-  retrospectiveRunsGetOptions,
   useConsolidationRunnowPostMutation,
   useHeartbeatConfigPutMutation,
   useHeartbeatRunnowPostMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-  selectConsolidationRuns,
-  selectHeartbeatRuns,
-  selectRetrospectiveRuns,
-} from "@/domains/settings/utils/system-task-run-transforms";
-import {
+  scheduleUsageSummaryQueryOptions,
   type ScheduleRowUsage,
-  SYSTEM_TASK_STATS_RUN_LIMIT,
   SYSTEM_TASK_URL_IDS,
-  summarizeRunsForUsage,
+  zeroScheduleUsageSummary,
 } from "@/domains/settings/utils/schedule-formatters";
-import {
-  type ScheduleUsageWindow,
-  resolveScheduleUsageWindow,
-} from "@/domains/settings/utils/schedule-usage-window";
 import { captureError } from "@/lib/sentry/capture-error";
 import { toast } from "@vellumai/design-library/components/toast";
 
-import type { ScheduleRun, SystemTaskKind } from "@/domains/settings/types/schedules";
+import type {
+  ScheduleUsageSummary,
+  SystemTaskKind,
+} from "@/domains/settings/types/schedules";
 
 const STALE_TIME = 10_000;
 
@@ -42,12 +33,14 @@ function deriveUsage(
   isLoading: boolean,
   isError: boolean,
   urlId: string,
-  runs: ScheduleRun[] | undefined,
-  range: ScheduleUsageWindow,
+  usageSummaryById: Map<string, ScheduleUsageSummary>,
 ): ScheduleRowUsage {
   if (isLoading) return { status: "loading" };
   if (isError) return { status: "error" };
-  return { status: "ready", summary: summarizeRunsForUsage(urlId, runs, range) };
+  return {
+    status: "ready",
+    summary: usageSummaryById.get(urlId) ?? zeroScheduleUsageSummary(urlId),
+  };
 }
 
 /**
@@ -97,72 +90,61 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
   });
 
   // ---------------------------------------------------------------------------
-  // Stats queries (recent runs for usage summary in the list view)
+  // Usage summary
   // ---------------------------------------------------------------------------
 
-  const statsOpts = {
-    path: { assistant_id: assistantId ?? "" },
-    query: { limit: SYSTEM_TASK_STATS_RUN_LIMIT },
-  };
-
   const {
-    data: heartbeatRunsForStats,
-    isLoading: isHeartbeatStatsLoading,
-    isError: isHeartbeatStatsError,
-    refetch: refetchHeartbeatStats,
-  } = useQuery({
-    ...heartbeatRunsGetOptions(statsOpts),
-    select: selectHeartbeatRuns,
-    enabled: Boolean(assistantId) && heartbeatConfig != null,
-    staleTime: STALE_TIME,
-  });
-
-  const {
-    data: consolidationRunsForStats,
-    isLoading: isConsolidationStatsLoading,
-    isError: isConsolidationStatsError,
-    refetch: refetchConsolidationStats,
-  } = useQuery({
-    ...consolidationRunsGetOptions(statsOpts),
-    select: selectConsolidationRuns,
-    enabled: Boolean(assistantId) && consolidationConfig?.available === true,
-    staleTime: STALE_TIME,
-  });
-
-  const {
-    data: retrospectiveRunsForStats,
-    isLoading: isRetrospectiveStatsLoading,
-    isError: isRetrospectiveStatsError,
-    refetch: refetchRetrospectiveStats,
-  } = useQuery({
-    ...retrospectiveRunsGetOptions(statsOpts),
-    select: selectRetrospectiveRuns,
-    enabled: Boolean(assistantId) && retrospectiveConfig?.available === true,
-    staleTime: STALE_TIME,
-  });
+    data: usageSummaries,
+    isLoading: isUsageSummaryLoading,
+    isError: isUsageSummaryError,
+    refetch: refetchUsageSummary,
+  } = useQuery(
+    scheduleUsageSummaryQueryOptions(assistantId, tz, Boolean(assistantId)),
+  );
 
   // ---------------------------------------------------------------------------
   // Derived usage stats
   // ---------------------------------------------------------------------------
 
-  const systemStatsRange = useMemo(
-    () => resolveScheduleUsageWindow(tz),
-    [tz],
+  const usageSummaryById = useMemo(
+    () =>
+      new Map(
+        (usageSummaries ?? []).map((summary) => [summary.scheduleId, summary]),
+      ),
+    [usageSummaries],
   );
 
   const heartbeatUsage: ScheduleRowUsage = useMemo(
-    () => deriveUsage(isHeartbeatStatsLoading, isHeartbeatStatsError, SYSTEM_TASK_URL_IDS.heartbeat, heartbeatRunsForStats, systemStatsRange),
-    [heartbeatRunsForStats, isHeartbeatStatsError, isHeartbeatStatsLoading, systemStatsRange],
+    () =>
+      deriveUsage(
+        isUsageSummaryLoading,
+        isUsageSummaryError,
+        SYSTEM_TASK_URL_IDS.heartbeat,
+        usageSummaryById,
+      ),
+    [isUsageSummaryError, isUsageSummaryLoading, usageSummaryById],
   );
 
   const consolidationUsage: ScheduleRowUsage = useMemo(
-    () => deriveUsage(isConsolidationStatsLoading, isConsolidationStatsError, SYSTEM_TASK_URL_IDS.consolidation, consolidationRunsForStats, systemStatsRange),
-    [consolidationRunsForStats, isConsolidationStatsError, isConsolidationStatsLoading, systemStatsRange],
+    () =>
+      deriveUsage(
+        isUsageSummaryLoading,
+        isUsageSummaryError,
+        SYSTEM_TASK_URL_IDS.consolidation,
+        usageSummaryById,
+      ),
+    [isUsageSummaryError, isUsageSummaryLoading, usageSummaryById],
   );
 
   const retrospectiveUsage: ScheduleRowUsage = useMemo(
-    () => deriveUsage(isRetrospectiveStatsLoading, isRetrospectiveStatsError, SYSTEM_TASK_URL_IDS.retrospective, retrospectiveRunsForStats, systemStatsRange),
-    [retrospectiveRunsForStats, isRetrospectiveStatsError, isRetrospectiveStatsLoading, systemStatsRange],
+    () =>
+      deriveUsage(
+        isUsageSummaryLoading,
+        isUsageSummaryError,
+        SYSTEM_TASK_URL_IDS.retrospective,
+        usageSummaryById,
+      ),
+    [isUsageSummaryError, isUsageSummaryLoading, usageSummaryById],
   );
 
   // ---------------------------------------------------------------------------
@@ -174,22 +156,21 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     const keysForKind = {
       heartbeat: {
         config: heartbeatConfigGetOptions(pathOpts).queryKey,
-        runs: heartbeatRunsGetOptions(statsOpts).queryKey,
         infinite: heartbeatRunsGetInfiniteQueryKey(pathOpts),
       },
       consolidation: {
         config: consolidationConfigGetOptions(pathOpts).queryKey,
-        runs: consolidationRunsGetOptions(statsOpts).queryKey,
         infinite: consolidationRunsGetInfiniteQueryKey(pathOpts),
       },
       retrospective: {
         config: retrospectiveConfigGetOptions(pathOpts).queryKey,
-        runs: retrospectiveRunsGetOptions(statsOpts).queryKey,
         infinite: retrospectiveRunsGetInfiniteQueryKey(pathOpts),
       },
     }[kind];
+    void queryClient.invalidateQueries({
+      queryKey: scheduleUsageSummaryQueryOptions(assistantId, tz).queryKey,
+    });
     void queryClient.invalidateQueries({ queryKey: keysForKind.config });
-    void queryClient.invalidateQueries({ queryKey: keysForKind.runs });
     void queryClient.invalidateQueries({ queryKey: keysForKind.infinite });
   };
 
@@ -264,9 +245,7 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     void refetchHeartbeat();
     void refetchConsolidation();
     void refetchRetrospective();
-    void refetchHeartbeatStats();
-    void refetchConsolidationStats();
-    void refetchRetrospectiveStats();
+    void refetchUsageSummary();
   };
 
   return {

--- a/clients/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/clients/web/src/domains/settings/utils/schedule-formatters.ts
@@ -13,7 +13,6 @@ import type { TagTone } from "@vellumai/design-library/components/tag";
 import { fetchScheduleUsageSummary } from "@/domains/settings/api/schedules";
 import { resolveScheduleUsageWindow } from "@/domains/settings/utils/schedule-usage-window";
 
-
 // ---------------------------------------------------------------------------
 // Timestamp / duration / cost formatting
 // ---------------------------------------------------------------------------
@@ -130,8 +129,6 @@ export const SYSTEM_TASK_URL_IDS = {
   consolidation: "system-consolidation",
   retrospective: "system-memory-retrospective",
 } as const satisfies Record<SystemTaskKind, string>;
-
-export const SYSTEM_TASK_STATS_RUN_LIMIT = 100;
 
 export function systemTaskKindFromUrlId(
   scheduleId: string | undefined,
@@ -314,29 +311,6 @@ export function zeroScheduleUsageSummary(
     scheduleId,
     runCount: 0,
     totalEstimatedCostUsd: 0,
-    eventCount: 0,
-  };
-}
-
-export function summarizeRunsForUsage(
-  scheduleId: string,
-  runs: ScheduleRun[] | undefined,
-  range: { from: number; to: number },
-): ScheduleUsageSummary {
-  const runsInRange = (runs ?? []).filter((run) => {
-    const startedAt = run.startedAt ?? run.createdAt;
-    return startedAt >= range.from && startedAt <= range.to;
-  });
-
-  return {
-    scheduleId,
-    runCount: runsInRange.length,
-    totalEstimatedCostUsd: runsInRange.reduce((total, run) => {
-      const cost = run.estimatedCostUsd;
-      return typeof cost === "number" && Number.isFinite(cost)
-        ? total + cost
-        : total;
-    }, 0),
     eventCount: 0,
   };
 }


### PR DESCRIPTION
## Summary
- Extend `schedules/usage-summary` to append system-task pseudo-summaries for heartbeat, consolidation, and memory retrospective usage.
- Replace the settings system-task usage badges with the shared usage-summary query instead of capped run-history queries.
- Treat heartbeat no-op scheduler ticks as non-runs for the summary, while keeping detailed run history paginated for the drawer.
- Add the missing `conversation_notice` stream handler case so web typecheck stays exhaustive.

## Cost display decision
The list-row cost display now comes from the backend summary endpoint. Heartbeat counts terminal attempts (`ok`, `error`, `timeout`) and excludes skipped scheduler ticks; consolidation/retrospective count completed background conversations with assistant output. Costs are attributed through the relevant run/conversation window and clipped by the requested usage range.

## Tests
- `cd assistant && bun test src/__tests__/schedule-routes.test.ts --grep "schedules/usage-summary"`
- `cd assistant && bunx prettier --check src/__tests__/schedule-routes.test.ts src/runtime/routes/schedule-routes.ts src/schedule/system-task-usage-store.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun run lint src/__tests__/schedule-routes.test.ts src/runtime/routes/schedule-routes.ts src/schedule/system-task-usage-store.ts`
- `cd clients/web && bun test src/domains/settings/components/schedule-components.test.ts src/domains/settings/utils/schedule-formatters.test.ts`
- `cd clients/web && bun run typecheck`
- `cd clients/web && bun run lint src/domains/settings/hooks/use-system-tasks.ts src/domains/settings/utils/schedule-formatters.ts src/domains/chat/hooks/use-stream-event-handler.ts`