### PR TITLE
fix(contacts): integration-review remediations (voice cold-cache P1, CLI fields, migration retry)

### DIFF
--- a/assistant/src/__tests__/voice-guardian-cold-cache-warm.test.ts
+++ b/assistant/src/__tests__/voice-guardian-cold-cache-warm.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Cold-cache guardian voice/phone regression.
+ *
+ * The sync trust resolver (`resolveActorTrust`) reads the IO-free guardian-
+ * delivery cache snapshot (`peekCachedGuardianDelivery`) keyed per channel
+ * filter. On a cold process only `vellum` is warmed at daemon startup, so for
+ * `phone` the snapshot is empty until some read warms that exact channel key.
+ * The voice setup path therefore awaits
+ * `getGuardianDelivery({ channelTypes: ["phone"] })` BEFORE the sync resolve so
+ * an inbound guardian call classifies as `guardian` rather than misclassifying
+ * during a gateway verdict blip.
+ *
+ * This test drives the REAL guardian-delivery reader cache (mocking only the
+ * gateway `ipcCall`) so the cold→warm transition is exercised end to end.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const GUARDIAN_PHONE = "+15550100";
+
+// Gateway IPC stub: returns the phone guardian delivery. The real reader caches
+// the result under the `phone` key, so a subsequent sync `peek` finds it.
+let ipcCalls: Array<{ route: string; input: unknown }> = [];
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCall: async (route: string, input: unknown) => {
+    ipcCalls.push({ route, input });
+    return {
+      guardians: [
+        {
+          channelType: "phone",
+          contactId: "guardian-contact",
+          principalId: "P_GUARDIAN_COLD",
+          address: GUARDIAN_PHONE,
+          externalChatId: null,
+          status: "active",
+        },
+      ],
+    };
+  },
+}));
+
+// Member lookup is irrelevant to guardian classification (address match on the
+// cached delivery decides it); return null so the member path is a no-op.
+mock.module("../contacts/contact-store.js", () => ({
+  findContactByAddress: () => null,
+  getLocalMemberAcl: () => null,
+}));
+
+import {
+  __resetGuardianDeliveryCacheForTest,
+  getGuardianDelivery,
+  peekCachedGuardianDelivery,
+} from "../contacts/guardian-delivery-reader.js";
+import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
+
+describe("voice path warms the phone guardian cache before sync trust", () => {
+  beforeEach(() => {
+    __resetGuardianDeliveryCacheForTest();
+    ipcCalls = [];
+  });
+
+  test("cold phone cache: guardian call misclassifies until upstream warm", async () => {
+    // Precondition: cold cache for phone — the sync peek would miss.
+    expect(
+      peekCachedGuardianDelivery({ channelTypes: ["phone"] }),
+    ).toBeUndefined();
+
+    // Sync resolve on a cold cache: no guardian snapshot → classified unknown.
+    const cold = resolveActorTrust({
+      assistantId: "asst-1",
+      sourceChannel: "phone",
+      conversationExternalId: GUARDIAN_PHONE,
+      actorExternalId: GUARDIAN_PHONE,
+    });
+    expect(cold.trustClass).toBe("unknown");
+
+    // The voice setup path warms the phone-specific key via the async reader.
+    await getGuardianDelivery({ channelTypes: ["phone"] });
+    expect(
+      ipcCalls.some(
+        (c) =>
+          c.route === "resolve_guardian_delivery" &&
+          JSON.stringify(c.input) ===
+            JSON.stringify({ channelTypes: ["phone"] }),
+      ),
+    ).toBe(true);
+
+    // The sync resolve, reading the now-warm snapshot, classifies the caller as
+    // the guardian — not misclassified as `unknown`.
+    const warm = resolveActorTrust({
+      assistantId: "asst-1",
+      sourceChannel: "phone",
+      conversationExternalId: GUARDIAN_PHONE,
+      actorExternalId: GUARDIAN_PHONE,
+    });
+    expect(warm.trustClass).toBe("guardian");
+  });
+
+  test("startup vellum-only warm leaves the phone key cold", async () => {
+    // Daemon startup warms only `vellum`; that must not populate the `phone` key.
+    await getGuardianDelivery({ channelTypes: ["vellum"] });
+    expect(
+      peekCachedGuardianDelivery({ channelTypes: ["phone"] }),
+    ).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/voice-guardian-cold-cache-warm.test.ts
+++ b/assistant/src/__tests__/voice-guardian-cold-cache-warm.test.ts
@@ -6,9 +6,11 @@
  * filter. On a cold process only `vellum` is warmed at daemon startup, so for
  * `phone` the snapshot is empty until some read warms that exact channel key.
  * The voice setup path therefore awaits
- * `getGuardianDelivery({ channelTypes: ["phone"] })` BEFORE the sync resolve so
- * an inbound guardian call classifies as `guardian` rather than misclassifying
- * during a gateway verdict blip.
+ * `getGuardianDeliveryFresh({ channelTypes: ["phone"] })` BEFORE the sync
+ * resolve so an inbound guardian call classifies as `guardian` rather than
+ * misclassifying during a gateway verdict blip. It reads FRESH because gateway-
+ * side binding writes don't invalidate the daemon cache: a stale empty snapshot
+ * from an earlier setup would otherwise survive the TTL.
  *
  * This test drives the REAL guardian-delivery reader cache (mocking only the
  * gateway `ipcCall`) so the cold→warm transition is exercised end to end.
@@ -18,22 +20,27 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const GUARDIAN_PHONE = "+15550100";
 
 // Gateway IPC stub: returns the phone guardian delivery. The real reader caches
-// the result under the `phone` key, so a subsequent sync `peek` finds it.
+// the result under the `phone` key, so a subsequent sync `peek` finds it. When
+// `guardianBound` is false the gateway reports no guardian — simulating the
+// pre-binding state whose empty result the cache would otherwise pin.
+let guardianBound = true;
 let ipcCalls: Array<{ route: string; input: unknown }> = [];
 mock.module("../ipc/gateway-client.js", () => ({
   ipcCall: async (route: string, input: unknown) => {
     ipcCalls.push({ route, input });
     return {
-      guardians: [
-        {
-          channelType: "phone",
-          contactId: "guardian-contact",
-          principalId: "P_GUARDIAN_COLD",
-          address: GUARDIAN_PHONE,
-          externalChatId: null,
-          status: "active",
-        },
-      ],
+      guardians: guardianBound
+        ? [
+            {
+              channelType: "phone",
+              contactId: "guardian-contact",
+              principalId: "P_GUARDIAN_COLD",
+              address: GUARDIAN_PHONE,
+              externalChatId: null,
+              status: "active",
+            },
+          ]
+        : [],
     };
   },
 }));
@@ -48,6 +55,7 @@ mock.module("../contacts/contact-store.js", () => ({
 import {
   __resetGuardianDeliveryCacheForTest,
   getGuardianDelivery,
+  getGuardianDeliveryFresh,
   peekCachedGuardianDelivery,
 } from "../contacts/guardian-delivery-reader.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
@@ -56,6 +64,7 @@ describe("voice path warms the phone guardian cache before sync trust", () => {
   beforeEach(() => {
     __resetGuardianDeliveryCacheForTest();
     ipcCalls = [];
+    guardianBound = true;
   });
 
   test("cold phone cache: guardian call misclassifies until upstream warm", async () => {
@@ -73,8 +82,8 @@ describe("voice path warms the phone guardian cache before sync trust", () => {
     });
     expect(cold.trustClass).toBe("unknown");
 
-    // The voice setup path warms the phone-specific key via the async reader.
-    await getGuardianDelivery({ channelTypes: ["phone"] });
+    // The voice setup path warms the phone-specific key via the fresh reader.
+    await getGuardianDeliveryFresh({ channelTypes: ["phone"] });
     expect(
       ipcCalls.some(
         (c) =>
@@ -86,6 +95,30 @@ describe("voice path warms the phone guardian cache before sync trust", () => {
 
     // The sync resolve, reading the now-warm snapshot, classifies the caller as
     // the guardian — not misclassified as `unknown`.
+    const warm = resolveActorTrust({
+      assistantId: "asst-1",
+      sourceChannel: "phone",
+      conversationExternalId: GUARDIAN_PHONE,
+      actorExternalId: GUARDIAN_PHONE,
+    });
+    expect(warm.trustClass).toBe("guardian");
+  });
+
+  test("fresh warm bypasses a stale empty phone snapshot after a gateway-side binding", async () => {
+    // An earlier setup cached an empty phone snapshot (no guardian yet). Gateway-
+    // side binding writes don't invalidate the daemon cache, so the entry stays
+    // warm-but-stale until the TTL.
+    guardianBound = false;
+    await getGuardianDelivery({ channelTypes: ["phone"] });
+    expect(peekCachedGuardianDelivery({ channelTypes: ["phone"] })).toEqual([]);
+
+    // Guardian binding now exists gateway-side. A non-force read would still
+    // return the pinned empty snapshot; the fresh read bypasses it.
+    guardianBound = true;
+    expect(await getGuardianDelivery({ channelTypes: ["phone"] })).toEqual([]);
+    await getGuardianDeliveryFresh({ channelTypes: ["phone"] });
+
+    // The sync resolve now reads the refreshed snapshot and classifies guardian.
     const warm = resolveActorTrust({
       assistantId: "asst-1",
       sourceChannel: "phone",

--- a/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
@@ -207,6 +207,12 @@ describe("workspace migration 031-drop-user-md", () => {
     );
   });
 
+  test("is retryable so a failed (null gateway read) checkpoint re-runs", () => {
+    // A clean return would checkpoint `completed` and skip forever; throwing on
+    // a null read needs this flag so the runner retries the failed checkpoint.
+    expect(dropUserMdMigration.retryFailedCheckpoint).toBe(true);
+  });
+
   test("fresh install (no guardian, no USER.md) is a no-op", async () => {
     // No guardian stubbed in, no USER.md on disk.
     await dropUserMdMigration.run(workspaceDir);
@@ -216,15 +222,20 @@ describe("workspace migration 031-drop-user-md", () => {
     expect(updatedUserFiles).toEqual([]);
   });
 
-  test("gateway read FAILS (null) — leaves customized USER.md intact and defers", async () => {
-    // Gateway IPC timeout / unreachable / malformed → reader returns null.
+  test("gateway read FAILS (null) — throws to defer, leaving customized USER.md intact", async () => {
+    // Gateway IPC timeout / unreachable / malformed → reader returns null. The
+    // migration throws so the checkpoint records `failed` (not `completed`) and
+    // `retryFailedCheckpoint` re-runs it next startup — a clean return would
+    // strand the cleanup forever.
     mockGuardianDeliveries = null;
 
     const userMdPath = join(workspaceDir, "USER.md");
     const content = customizedContent();
     writeFileSync(userMdPath, content, "utf-8");
 
-    await dropUserMdMigration.run(workspaceDir);
+    await expect(dropUserMdMigration.run(workspaceDir)).rejects.toThrow(
+      /gateway guardian read failed/i,
+    );
 
     // USER.md is preserved (NOT deleted) — the only copy survives the miss.
     expect(existsSync(userMdPath)).toBe(true);

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -13,6 +13,7 @@ import type { ServerWebSocket } from "bun";
 
 import {
   getGuardianDelivery,
+  getGuardianDeliveryFresh,
   voiceGuardianDisplayName,
 } from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
@@ -605,12 +606,14 @@ export class RelayConnection {
     // delivery cache before routeSetup's SYNC resolveActorTrust fallback. That
     // fallback reads the IO-free cache snapshot keyed per channel-filter; daemon
     // startup warms only `vellum`, so a cold-process phone call would otherwise
-    // misclassify a guardian during a gateway verdict blip. Both are independent
-    // IPC reads on different cache keys, so run them concurrently off the sync
-    // resolver's hot path.
+    // misclassify a guardian during a gateway verdict blip. Read fresh: gateway-
+    // side binding writes don't invalidate the daemon cache, so a stale empty
+    // snapshot from an earlier setup would survive the TTL otherwise. Both are
+    // independent IPC reads on different cache keys, so run them concurrently
+    // off the sync resolver's hot path.
     await Promise.all([
       this.primeGuardianDisplayName(),
-      getGuardianDelivery({ channelTypes: ["phone"] }),
+      getGuardianDeliveryFresh({ channelTypes: ["phone"] }),
     ]);
 
     // Resolve the phone channel's inbound admission floor. The reader fails
@@ -952,8 +955,10 @@ export class RelayConnection {
 
     // Warm the phone-channel guardian-delivery cache before the SYNC
     // resolveActorTrust fallback, which reads the IO-free per-channel snapshot
-    // that daemon startup leaves cold for `phone`.
-    await getGuardianDelivery({ channelTypes: ["phone"] });
+    // that daemon startup leaves cold for `phone`. Read fresh: gateway-side
+    // binding writes don't invalidate the daemon cache, so a stale empty
+    // snapshot would otherwise survive the TTL and misclassify the guardian.
+    await getGuardianDeliveryFresh({ channelTypes: ["phone"] });
 
     return toTrustContext(
       resolveActorTrust({

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -601,7 +601,17 @@ export class RelayConnection {
     const session = getCallSession(this.callSessionId);
     this.recordSetupBookkeeping(session, msg);
 
-    await this.primeGuardianDisplayName();
+    // Prime the guardian displayName and warm the phone-channel guardian-
+    // delivery cache before routeSetup's SYNC resolveActorTrust fallback. That
+    // fallback reads the IO-free cache snapshot keyed per channel-filter; daemon
+    // startup warms only `vellum`, so a cold-process phone call would otherwise
+    // misclassify a guardian during a gateway verdict blip. Both are independent
+    // IPC reads on different cache keys, so run them concurrently off the sync
+    // resolver's hot path.
+    await Promise.all([
+      this.primeGuardianDisplayName(),
+      getGuardianDelivery({ channelTypes: ["phone"] }),
+    ]);
 
     // Resolve the phone channel's inbound admission floor. The reader fails
     // open to `null` by contract, so a transport hiccup admits the caller.
@@ -939,6 +949,11 @@ export class RelayConnection {
         conversationExternalId: fromNumber,
       });
     }
+
+    // Warm the phone-channel guardian-delivery cache before the SYNC
+    // resolveActorTrust fallback, which reads the IO-free per-channel snapshot
+    // that daemon startup leaves cold for `phone`.
+    await getGuardianDelivery({ channelTypes: ["phone"] });
 
     return toTrustContext(
       resolveActorTrust({

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -8,13 +8,16 @@ import { shouldOutputJson, writeOutput } from "../output.js";
 // IPC response shapes
 // ---------------------------------------------------------------------------
 
+// ACL fields (role, status, policy) are gateway-owned and not hydrated by the
+// daemon-native filtered reads (`--query`/`--channel-address`/`--channel-type`),
+// so they are optional here. The unfiltered default read carries them.
 interface ContactChannel {
   id: string;
   contactId: string;
   type: string;
   address: string;
-  status: string;
-  policy: string;
+  status?: string;
+  policy?: string;
   isPrimary?: boolean;
   revokedReason?: string | null;
   blockedReason?: string | null;
@@ -23,7 +26,7 @@ interface ContactChannel {
 interface ContactWithChannels {
   id: string;
   displayName: string;
-  role: string;
+  role?: string;
   contactType: string;
   notes?: string;
   principalId?: string;
@@ -56,7 +59,7 @@ function formatContactTable(contacts: ContactWithChannels[]): string {
   const rows = contacts.map((c) => [
     c.id,
     c.displayName,
-    `${c.role}/${c.contactType}`,
+    `${c.role ?? "—"}/${c.contactType}`,
     String(c.channels.length),
   ]);
 
@@ -81,8 +84,8 @@ function formatChannelTable(channels: ContactChannel[]): string {
   const rows = channels.map((ch) => {
     const flags = [
       ch.isPrimary ? "primary" : null,
-      ch.status !== "active" ? ch.status : null,
-      ch.policy !== "allow" ? ch.policy : null,
+      ch.status && ch.status !== "active" ? ch.status : null,
+      ch.policy && ch.policy !== "allow" ? ch.policy : null,
     ]
       .filter(Boolean)
       .join(", ");
@@ -124,7 +127,7 @@ function formatContactDetail(
   const lines: string[] = [];
   lines.push(`ID:           ${c.id}`);
   lines.push(`Display Name: ${c.displayName}`);
-  lines.push(`Role:         ${c.role}`);
+  if (c.role) lines.push(`Role:         ${c.role}`);
   lines.push(`Type:         ${c.contactType}`);
   if (c.notes) lines.push(`Notes:        ${c.notes}`);
   if (c.principalId) lines.push(`Principal:    ${c.principalId}`);

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -9,10 +9,6 @@ import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
 import { getGuardianDelivery } from "../../../contacts/guardian-delivery-reader.js";
 import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
-import type {
-  ContactChannel,
-  ContactWithChannels,
-} from "../../../contacts/types.js";
 import { deleteInbound, recordInbound } from "../../../memory/delivery-crud.js";
 import { markProcessed } from "../../../memory/delivery-status.js";
 import {
@@ -95,12 +91,6 @@ export interface AclEnforcementParams {
    */
   effectiveAdmissionPolicy?: AdmissionPolicy;
 }
-
-/** Resolved contact + channel pair from ACL enforcement. */
-export type ResolvedMember = {
-  contact: ContactWithChannels;
-  channel: ContactChannel;
-};
 
 export interface AclResult {
   resolvedMember: VerdictMember | null;

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -18,7 +18,7 @@
 import type { SourceMetadata } from "@vellumai/gateway-client";
 
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
-import { getGuardianDelivery } from "../../../contacts/guardian-delivery-reader.js";
+import { getGuardianDeliveryFresh } from "../../../contacts/guardian-delivery-reader.js";
 import { getDiskPressureStatus } from "../../../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../../../daemon/disk-pressure-policy.js";
 import { addMessage } from "../../../memory/conversation-crud.js";
@@ -130,9 +130,11 @@ export async function handleSlackReactionIntercept(
   // Warm the channel-specific guardian-delivery cache before the SYNC trust
   // resolve below. The sync resolver reads the IO-free cache snapshot; on a
   // cold process only `vellum` is warmed at startup, so a Slack guardian
-  // reaction would otherwise misclassify as `unknown` and drop. This await runs
-  // in the already-async intercept, off the sync resolver's hot path.
-  await getGuardianDelivery({ channelTypes: [sourceChannel] });
+  // reaction would otherwise misclassify as `unknown` and drop. Read fresh:
+  // gateway-side binding writes don't invalidate the daemon cache, so a stale
+  // empty snapshot would otherwise survive the TTL. This await runs in the
+  // already-async intercept, off the sync resolver's hot path.
+  await getGuardianDeliveryFresh({ channelTypes: [sourceChannel] });
 
   // Classify the reactor. No timezone enrichment — reactions never drive an
   // agent turn, so only the trust class / guardian principal matter.

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -145,6 +145,9 @@ export const dropUserMdMigration: WorkspaceMigration = {
   id: "031-drop-user-md",
   description:
     "Delete legacy workspace-root USER.md after migrating content to users/<slug>.md",
+  // A null gateway read throws (below) so the checkpoint records `failed`; this
+  // flag lets the runner retry the cleanup on the next startup.
+  retryFailedCheckpoint: true,
 
   async run(workspaceDir: string): Promise<void> {
     const userMdPath = join(workspaceDir, "USER.md");
@@ -154,22 +157,28 @@ export const dropUserMdMigration: WorkspaceMigration = {
     // guardian has the most recently verified active channel. Guardian
     // identity comes from the gateway delivery; local INFO (id/displayName/
     // userFile) is joined from the local contact by the guardian's address.
+    // `null` means the gateway read FAILED (timeout / unreachable / malformed).
+    // Treat that as DATA-PRESERVING: leave USER.md in place and throw so the
+    // checkpoint records `failed`. A clean return would record `completed` and
+    // skip this migration forever, permanently stranding the USER.md cleanup +
+    // guardian-persona seed on a transient gateway miss; `retryFailedCheckpoint`
+    // re-runs it on the next startup. Deleting on a failed read could destroy
+    // the only copy of a customized root USER.md. `[]` means the gateway
+    // DEFINITIVELY reported no guardian, which proceeds normally. Read outside
+    // the try below so the throw isn't swallowed by the DB-error guard.
+    const guardians = await getGuardianDelivery();
+    if (guardians === null) {
+      log.warn(
+        {},
+        "Gateway guardian read failed; deferring USER.md cleanup for retry",
+      );
+      throw new Error(
+        "Gateway guardian read failed; deferring USER.md cleanup for retry",
+      );
+    }
+
     let guardian: { id: string; displayName: string; userFile: string | null };
     try {
-      const guardians = await getGuardianDelivery();
-      // `null` means the gateway read FAILED (timeout / unreachable /
-      // malformed). Treat that as DATA-PRESERVING: leave USER.md in place and
-      // defer. The migration is idempotent and re-runs on the next startup, so
-      // deferring is safe; deleting on a failed read could destroy the only
-      // copy of a customized root USER.md. `[]` means the gateway DEFINITIVELY
-      // reported no guardian, which proceeds normally.
-      if (guardians === null) {
-        log.warn(
-          {},
-          "Gateway guardian read failed; deferring USER.md cleanup",
-        );
-        return;
-      }
       const delivery =
         guardianForChannel(guardians, "vellum") ?? anyGuardian(guardians);
       const localContact = delivery


### PR DESCRIPTION
## Summary
- Voice path pre-warms the channel-specific guardian cache before the sync trust resolve (P1 cold-cache fix)
- CLI contacts formatter tolerates absent ACL fields on filtered/native reads
- Migration 031 throws + retries on a null gateway read instead of deferring forever
- Remove dead ResolvedMember export

Addresses Phase B2 integration self-review findings.
Part of plan: combo11-phase-b2-drop-acl-columns.md (remediation)