### PR TITLE
[codex] Fix web tool-result image rendering

### DIFF
--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -521,6 +521,41 @@ describe("TranscriptMessageBody", () => {
     ).toBeNull();
   });
 
+  test("renders images returned by an assistant tool result", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-img",
+      name: "media_generate_image",
+      input: { prompt: "diagram" },
+      result: "Generated 2 images",
+      imageData: "img-a",
+      imageDataList: ["img-a", "img-b"],
+      completedAt: 1,
+    };
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-generated-images",
+          role: "assistant",
+          contentBlocks: [toolUseBlock(toolCall)],
+          toolCalls: [toolCall],
+          timestamp: 1_000,
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const images = container.querySelectorAll(
+      "[data-testid='tool-result-image']",
+    );
+    expect(images.length).toBe(2);
+    expect(images[0]!.getAttribute("src")).toBe(
+      "data:image/png;base64,img-a",
+    );
+    expect(images[1]!.getAttribute("src")).toBe(
+      "data:image/png;base64,img-b",
+    );
+  });
+
   test("a tool + thinking run still renders the boxed activity card", () => {
     // A run with more than one card item (tool + thinking) is NOT a lone tool,
     // so it stays the boxed card rather than collapsing to the inline chip.

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -556,6 +556,35 @@ describe("TranscriptMessageBody", () => {
     );
   });
 
+  test("infers non-png MIME types for assistant tool-result images", () => {
+    const jpegData = "/9j/4AAQSkZJRgABAQAAAQABAAD";
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-jpeg",
+      name: "media_generate_image",
+      input: { prompt: "photo" },
+      result: "Generated 1 image",
+      imageDataList: [jpegData],
+      completedAt: 1,
+    };
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-generated-jpeg",
+          role: "assistant",
+          contentBlocks: [toolUseBlock(toolCall)],
+          toolCalls: [toolCall],
+          timestamp: 1_000,
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const image = container.querySelector("[data-testid='tool-result-image']");
+    expect(image?.getAttribute("src")).toBe(
+      `data:image/jpeg;base64,${jpegData}`,
+    );
+  });
+
   test("a tool + thinking run still renders the boxed activity card", () => {
     // A run with more than one card item (tool + thinking) is NOT a lone tool,
     // so it stays the boxed card rather than collapsing to the inline chip.

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -48,6 +48,24 @@ import {
   workflowRunIdForCall,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
 
+function inferImageMimeType(imageData: string): string {
+  const normalized = imageData.replace(/\s/g, "");
+  if (normalized.startsWith("iVBORw0KGgo")) return "image/png";
+  if (normalized.startsWith("/9j/")) return "image/jpeg";
+  if (normalized.startsWith("UklGR")) return "image/webp";
+  if (normalized.startsWith("R0lGOD")) return "image/gif";
+  if (normalized.startsWith("Qk")) return "image/bmp";
+  return "image/png";
+}
+
+function toolResultImageSrc(imageData: string): string {
+  const trimmed = imageData.trim();
+  if (/^data:image\/[a-z0-9.+-]+;base64,/i.test(trimmed)) {
+    return trimmed;
+  }
+  return `data:${inferImageMimeType(trimmed)};base64,${trimmed}`;
+}
+
 /**
  * Renders a `DisplayMessage`'s body by walking its unified `contentBlocks`
  * projection — grouped by `groupContentBlocks`. Each block embeds its own
@@ -279,7 +297,7 @@ export function TranscriptMessageBody({
           <img
             key={`tool-result-image-${index}`}
             data-testid="tool-result-image"
-            src={`data:image/png;base64,${imageData}`}
+            src={toolResultImageSrc(imageData)}
             alt={`Generated image ${index + 1}`}
             className="max-h-72 max-w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] object-contain sm:max-w-[28rem]"
           />

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -266,6 +266,28 @@ export function TranscriptMessageBody({
     );
   };
 
+  const renderToolResultImages = (toolCalls: ChatMessageToolCall[]) => {
+    if (hasAttachments) return null;
+    const images = toolCalls.flatMap((tc) => {
+      if (tc.imageDataList?.length) return tc.imageDataList;
+      return tc.imageData ? [tc.imageData] : [];
+    });
+    if (images.length === 0) return null;
+    return (
+      <div className="flex w-full flex-wrap gap-2">
+        {images.map((imageData, index) => (
+          <img
+            key={`tool-result-image-${index}`}
+            data-testid="tool-result-image"
+            src={`data:image/png;base64,${imageData}`}
+            alt={`Generated image ${index + 1}`}
+            className="max-h-72 max-w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] object-contain sm:max-w-[28rem]"
+          />
+        ))}
+      </div>
+    );
+  };
+
   const renderSurfaceNode = (
     surface: ConversationMessageSurface,
     key: string,
@@ -333,6 +355,7 @@ export function TranscriptMessageBody({
       return (
         <Fragment key={key}>
           <SingleActivity variant="tool" toolCall={loneTool} />
+          {renderToolResultImages(groupToolCalls)}
           {renderInlineSubagentCards(groupToolCalls)}
           {renderInlineWorkflowCards(groupToolCalls)}
         </Fragment>
@@ -376,6 +399,7 @@ export function TranscriptMessageBody({
               onDismissUnknownNudge={onDismissUnknownNudge}
             />
           </div>
+          {renderToolResultImages(groupToolCalls)}
           {renderInlineSubagentCards(groupToolCalls)}
           {renderInlineWorkflowCards(groupToolCalls)}
         </Fragment>
@@ -397,6 +421,7 @@ export function TranscriptMessageBody({
             groupIndex={groupIndex}
           />
         )}
+        {renderToolResultImages(groupToolCalls)}
         {renderInlineSubagentCards(groupToolCalls)}
         {renderInlineWorkflowCards(groupToolCalls)}
       </Fragment>

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
@@ -5,6 +5,8 @@ import {
   handleToolResult,
   handleToolUseStart,
 } from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 
 describe("handleToolUseStart", () => {
   it("cancels reconciliation and creates tool call with generated id", () => {
@@ -155,6 +157,46 @@ describe("handleToolResult", () => {
       "tc-1",
       metadata,
     );
+  });
+
+  it("forwards image data from the tool_result event into transcript state", () => {
+    const ctx = makeCtx();
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-img",
+      name: "media_generate_image",
+      input: { prompt: "diagram" },
+    };
+    const initial: DisplayMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        toolCalls: [toolCall],
+        contentBlocks: [{ type: "tool_use", toolCall }],
+        timestamp: 1_000,
+      },
+    ];
+
+    handleToolResult(
+      {
+        type: "tool_result",
+        toolName: "media_generate_image",
+        result: "Generated 2 images",
+        toolUseId: "tc-img",
+        imageData: "img-a",
+        imageDataList: ["img-a", "img-b"],
+      },
+      ctx,
+    );
+
+    const updater = (ctx.setMessages as unknown as ReturnType<typeof Object>)
+      .mock.calls[0][0] as (prev: DisplayMessage[]) => DisplayMessage[];
+    const next = updater(initial);
+
+    expect(next[0]!.toolCalls![0]!.imageData).toBe("img-a");
+    expect(next[0]!.toolCalls![0]!.imageDataList).toEqual([
+      "img-a",
+      "img-b",
+    ]);
   });
 
   it("does NOT route activityMetadata when toolUseId is missing", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
@@ -80,6 +80,8 @@ export function handleToolResult(
       riskAllowlistOptions: event.riskAllowlistOptions,
       riskScopeOptions: event.riskScopeOptions,
       riskDirectoryScopeOptions: event.riskDirectoryScopeOptions,
+      imageData: event.imageData,
+      imageDataList: event.imageDataList,
       activityMetadata: event.activityMetadata,
       completedAt:
         "completedAt" in event &&

--- a/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -945,6 +945,36 @@ describe("finalizeOnIdle", () => {
 // ---------------------------------------------------------------------------
 
 describe("applyToolResult — cross-message matching", () => {
+  it("preserves image data from tool result events on the matching tool call", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-img",
+      name: "media_generate_image",
+      input: { prompt: "diagram" },
+    };
+    const msg = makeAssistantMsg({
+      toolCalls: [toolCall],
+      contentOrder: [{ type: "toolCall", id: "tc-img" }],
+      contentBlocks: [{ type: "tool_use", toolCall }],
+    });
+
+    const result = applyToolResult([msg], {
+      toolUseId: "tc-img",
+      result: "Generated 2 images",
+      imageData: "img-a",
+      imageDataList: ["img-a", "img-b"],
+    });
+
+    const updatedToolCall = result[0]!.toolCalls![0]!;
+    expect(updatedToolCall.imageData).toBe("img-a");
+    expect(updatedToolCall.imageDataList).toEqual(["img-a", "img-b"]);
+
+    const toolUseBlock = result[0]!.contentBlocks!.find(
+      (block) => block.type === "tool_use",
+    );
+    expect(toolUseBlock?.toolCall.imageData).toBe("img-a");
+    expect(toolUseBlock?.toolCall.imageDataList).toEqual(["img-a", "img-b"]);
+  });
+
   it("finds the tool call on an earlier message when toolUseId is provided", () => {
     // Simulate: tool_use_start on msg1, then a new bubble was created (msg2),
     // then tool_result arrives with toolUseId pointing to msg1's tool call.

--- a/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
@@ -153,6 +153,8 @@ export function applyToolResult(
     riskAllowlistOptions?: AllowlistOption[];
     riskScopeOptions?: RiskScopeOption[];
     riskDirectoryScopeOptions?: DirectoryScopeOption[];
+    imageData?: string;
+    imageDataList?: string[];
     /**
      * Structured activity metadata from the tool_result event. Persisted on
      * the tool call so web-search steps can keep rendering after the active
@@ -199,6 +201,14 @@ export function applyToolResult(
   const existingTc = msg.toolCalls![tcIdx];
   if (!existingTc) return prev;
 
+  const imageDataList =
+    opts.imageDataList !== undefined
+      ? opts.imageDataList
+      : opts.imageData !== undefined
+        ? [opts.imageData]
+        : undefined;
+  const imageData =
+    opts.imageData !== undefined ? opts.imageData : imageDataList?.[0];
   const updatedToolCalls = [...msg.toolCalls!];
   const updatedTc = {
     ...existingTc,
@@ -213,6 +223,8 @@ export function applyToolResult(
     riskAllowlistOptions: opts.riskAllowlistOptions,
     riskScopeOptions: opts.riskScopeOptions,
     riskDirectoryScopeOptions: opts.riskDirectoryScopeOptions,
+    ...(imageData !== undefined ? { imageData } : {}),
+    ...(imageDataList !== undefined ? { imageDataList } : {}),
     ...(opts.activityMetadata !== undefined
       ? { activityMetadata: opts.activityMetadata }
       : {}),


### PR DESCRIPTION
## Summary
- Preserve `imageData` / `imageDataList` from `tool_result` events through the web stream handler and updater.
- Render tool-result images inline in the transcript while the turn is live; the existing attachment strip remains the settled display path once attachments are present.
- Add regression coverage for stream state and transcript rendering.

## Root Cause
The backend and media generation skill already returned inline image blocks, but the React web stream path dropped the emitted `imageDataList` fields and the transcript had no renderer for tool-result images. The old Swift/shared client had this path, but the React web/Electron transcript did not carry it over.

## Impact
Fixes generated images not appearing in the browser web app and all clients that wrap the React web transcript, including Electron macOS and Capacitor clients.

## Validation
- `cd clients/web && bun test src/domains/chat/utils/stream-updaters/stream-updaters.test.ts src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts src/domains/chat/transcript/transcript-message-body.test.tsx`
- `cd clients/web && bunx tsc --noEmit`
- `git diff --check`

## Notes
- Required fresh `bun install` in `clients/web`, `packages/design-library`, and `packages/local-mode` in this worktree before local verification because dependencies were not installed.