### PR TITLE
Refine channel admission copy + add floor confirmations and option tooltips

### DIFF
--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -27,7 +27,42 @@ type ChannelKey = AssistantChannelState["key"];
 const TRUST_FLOOR_OPTIONS = ADMISSION_POLICY_VALUES.map((value) => ({
   value,
   label: POLICY_LABELS[value],
+  tooltip: POLICY_DESCRIPTIONS[value],
 }));
+
+/**
+ * Floors that loosen or hard-deny who can reach the assistant and warrant an
+ * explicit confirmation before persisting. Floors not listed here apply
+ * immediately. Web-only UI concern — the cross-surface contract lives in
+ * `@/lib/channel-admission-policy/types`.
+ */
+const POLICY_CONFIRMATIONS: Partial<
+  Record<
+    AdmissionPolicy,
+    { title: string; message: string; confirmLabel: string; destructive?: boolean }
+  >
+> = {
+  no_one: {
+    title: "Block all inbound messages?",
+    message:
+      "Setting this channel to “No one” hard-denies every inbound message — including messages from you. You can reverse this at any time.",
+    confirmLabel: "Block all",
+    destructive: true,
+  },
+  any_contact: {
+    title: "Allow any contact to reach your assistant?",
+    message:
+      "“Any contact” admits every matched contact in this channel — including pending, unverified ones — not just your verified contacts. Best for channels consisting of only people you already trust.",
+    confirmLabel: "Allow any contact",
+  },
+  strangers: {
+    title: "Allow strangers to reach your assistant?",
+    message:
+      "Are you sure you want to allow strangers to contact your assistant through this channel? Doing so could cost you money and open you up to security and privacy vulnerabilities. Enable with extreme caution.",
+    confirmLabel: "Allow strangers",
+    destructive: true,
+  },
+};
 
 interface AssistantChannelsDetailProps {
   assistantName: string;
@@ -100,17 +135,23 @@ export function AssistantChannelsDetail({
   const displayName = assistantName.trim() || "your assistant";
   const [pendingDisconnect, setPendingDisconnect] = useState<ChannelKey | null>(null);
   const [expandedChannels, setExpandedChannels] = useState<Set<ChannelKey>>(new Set());
-  // Kill-switch confirmation: non-null while the "no_one" floor dialog is shown.
-  const [killSwitchPending, setKillSwitchPending] = useState<ChannelKey | null>(null);
+  // Floor confirmation: non-null while a floor in POLICY_CONFIRMATIONS awaits
+  // the user's go-ahead before persisting.
+  const [pendingPolicy, setPendingPolicy] = useState<{
+    channelKey: ChannelKey;
+    policy: AdmissionPolicy;
+  } | null>(null);
 
   const disconnectMeta = pendingDisconnect ? CHANNEL_META[pendingDisconnect] : null;
-  const killSwitchMeta = killSwitchPending ? CHANNEL_META[killSwitchPending] : null;
+  const pendingConfirmation = pendingPolicy
+    ? POLICY_CONFIRMATIONS[pendingPolicy.policy]
+    : null;
 
-  // Intercept "no_one" to show a destructive confirmation before persisting;
-  // every other floor applies immediately. Mirrors the old ChannelPolicyCard.
+  // Floors that loosen or hard-deny access prompt a confirmation before
+  // persisting; every other floor applies immediately.
   const handlePolicyChange = (channelKey: ChannelKey, next: AdmissionPolicy) => {
-    if (next === "no_one") {
-      setKillSwitchPending(channelKey);
+    if (POLICY_CONFIRMATIONS[next]) {
+      setPendingPolicy({ channelKey, policy: next });
       return;
     }
     onChannelPolicyChange?.(channelKey, next);
@@ -196,24 +237,20 @@ export function AssistantChannelsDetail({
         onCancel={() => setPendingDisconnect(null)}
       />
 
-      {/* Kill-switch confirmation — "no_one" hard-denies all inbound traffic. */}
+      {/* Floor confirmation — loosening or hard-denying access needs a nod. */}
       <ConfirmDialog
-        open={killSwitchPending !== null}
-        title="Block all inbound messages?"
-        message={
-          killSwitchMeta
-            ? `Setting ${killSwitchMeta.label} to "No one" will hard-deny every inbound message on this channel. You can reverse this at any time.`
-            : ""
-        }
-        confirmLabel="Block all"
-        destructive
+        open={pendingPolicy !== null}
+        title={pendingConfirmation?.title ?? ""}
+        message={pendingConfirmation?.message ?? ""}
+        confirmLabel={pendingConfirmation?.confirmLabel ?? "Confirm"}
+        destructive={pendingConfirmation?.destructive ?? false}
         onConfirm={() => {
-          if (killSwitchPending) {
-            onChannelPolicyChange?.(killSwitchPending, "no_one");
+          if (pendingPolicy) {
+            onChannelPolicyChange?.(pendingPolicy.channelKey, pendingPolicy.policy);
           }
-          setKillSwitchPending(null);
+          setPendingPolicy(null);
         }}
-        onCancel={() => setKillSwitchPending(null)}
+        onCancel={() => setPendingPolicy(null)}
       />
     </div>
   );

--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -45,16 +45,16 @@ export interface ChannelPolicyView {
 }
 
 export const POLICY_LABELS: Record<AdmissionPolicy, string> = {
-  no_one: "No one (kill switch)",
-  guardian_only: "Guardian only",
-  trusted_contacts: "Trusted contacts",
+  no_one: "No one",
+  guardian_only: "Only you",
+  trusted_contacts: "Verified contacts",
   any_contact: "Any contact",
   strangers: "Strangers",
 };
 
 export const POLICY_DESCRIPTIONS: Record<AdmissionPolicy, string> = {
   no_one: "Hard-deny every inbound message on this channel.",
-  guardian_only: "Only messages from the guardian are admitted.",
+  guardian_only: "Only messages sent by you are admitted.",
   trusted_contacts:
     "Admit verified contacts and the guardian; deny everyone else.",
   any_contact:

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -17,6 +17,7 @@ import { createPortal } from "react-dom";
 
 import { cn } from "../utils/cn";
 import { usePortalContainer } from "../utils/portal-container";
+import { Tooltip } from "./tooltip";
 
 export interface DropdownMenuPosition {
   readonly left: number;
@@ -31,6 +32,12 @@ export interface DropdownOption<T extends string> {
   readonly label: string;
   readonly icon?: ReactNode;
   readonly suffix?: ReactNode;
+  /**
+   * Optional hover/focus tooltip describing the option. When present, the
+   * option row is wrapped in a styled `Tooltip` (anchored to its right) so the
+   * meaning is discoverable without selecting. Only shows while the menu is open.
+   */
+  readonly tooltip?: ReactNode;
   /**
    * When true, the option renders dimmed and cannot be selected (by click,
    * keyboard, or hover-highlight). The option still occupies a row so the
@@ -311,7 +318,7 @@ export function Dropdown<T extends string>({
         const isSelected = option.value === value;
         const isDisabled = Boolean(option.disabled);
         const isHighlighted = !isDisabled && index === highlightedIndex;
-        return (
+        const optionRow = (
           <li
             key={option.value}
             id={`${triggerId}-option-${index}`}
@@ -367,6 +374,13 @@ export function Dropdown<T extends string>({
               />
             )}
           </li>
+        );
+        return option.tooltip ? (
+          <Tooltip key={option.value} content={option.tooltip} side="right">
+            {optionRow}
+          </Tooltip>
+        ) : (
+          optionRow
         );
       })}
     </ul>


### PR DESCRIPTION
## Summary

Copy and UX refinements to the **Who Can Reach** (channel admission floor) control in Contacts → Channels.

### Copy
- Removed **"(kill switch)"** from the **No one** label.
- Renamed **Guardian only → "Only you"**; its description now reads *"Only messages sent by you are admitted."*
- Renamed **Trusted contacts → "Verified contacts"** — display label only; the cross-surface `trusted_contacts` policy value (gateway/Swift contract) is unchanged.

### Confirmation modals
Generalized the single hard-coded kill-switch dialog into a data-driven `POLICY_CONFIRMATIONS` map. Floors that loosen or hard-deny access now prompt before persisting:
- **No one** — warns it hard-denies every inbound message, including your own (destructive).
- **Any contact** — warns it admits pending/unverified contacts; *"Best for channels consisting of only people you already trust."*
- **Strangers** — strong caution about cost and security/privacy exposure (destructive).

Floors that don't loosen access (Only you, Verified contacts) still apply immediately.

### Per-option tooltips
Added an optional `tooltip` field to `DropdownOption` in the design library. When present, the option row is wrapped in a styled `Tooltip` (anchored right). The Who Can Reach dropdown wires each option to its `POLICY_DESCRIPTIONS` entry, so each option's meaning is discoverable on hover without selecting it. This is a reusable addition — any dropdown can opt in.

## Testing
- `tsc --noEmit` clean (web client)
- eslint clean (changed files)
- `bun test dropdown.test.tsx` — 6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)