### PR TITLE
feat(web): make MCP empty state actionable

### DIFF
--- a/clients/web/src/domains/settings/mcp/mcp-page.test.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-page.test.tsx
@@ -1,10 +1,22 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
 
 let assistantFlags: Record<string, boolean> = {};
+
+const navigateToNewConversation = mock((..._args: unknown[]) => {});
+mock.module("@/utils/conversation-navigation", () => ({
+  navigateToNewConversation,
+}));
 
 mock.module("@/assistant/use-active-assistant-id", () => ({
   useActiveAssistantId: () => "assistant-123",
@@ -76,12 +88,17 @@ function Wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {
   cleanup();
   assistantFlags = {};
+  navigateToNewConversation.mockClear();
 });
 
 describe("McpPage", () => {
@@ -104,5 +121,34 @@ describe("McpPage", () => {
     expect(
       await screen.findByRole("button", { name: "Add Server" }),
     ).not.toBeNull();
+  });
+
+  test("empty state starts a setup conversation when the mcpAddServer flag is off", async () => {
+    assistantFlags = { mcpAddServer: false };
+
+    render(<McpPage />, { wrapper: Wrapper });
+
+    const cta = await screen.findByRole("button", {
+      name: /Chat with your assistant to set up an MCP server/,
+    });
+    fireEvent.click(cta);
+
+    expect(navigateToNewConversation).toHaveBeenCalledTimes(1);
+    expect(navigateToNewConversation.mock.calls[0]?.[1]).toMatchObject({
+      prompt: expect.stringContaining("MCP server"),
+    });
+  });
+
+  test("empty state opens the add server modal when the mcpAddServer flag is on", async () => {
+    assistantFlags = { mcpAddServer: true };
+
+    render(<McpPage />, { wrapper: Wrapper });
+
+    const cta = await screen.findByRole("button", {
+      name: /Add an MCP server to extend your assistant with external tools/,
+    });
+    fireEvent.click(cta);
+
+    expect(navigateToNewConversation).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/settings/mcp/mcp-page.test.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-page.test.tsx
@@ -12,6 +12,7 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 
 let assistantFlags: Record<string, boolean> = {};
+let flagsHydrated = true;
 
 const navigateToNewConversation = mock((..._args: unknown[]) => {});
 mock.module("@/utils/conversation-navigation", () => ({
@@ -26,6 +27,7 @@ mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
     mcpAddServer: () => assistantFlags.mcpAddServer ?? false,
+    hasHydrated: () => flagsHydrated,
   };
   return { useAssistantFeatureFlagStore: store };
 });
@@ -98,6 +100,7 @@ function Wrapper({ children }: { children: ReactNode }) {
 afterEach(() => {
   cleanup();
   assistantFlags = {};
+  flagsHydrated = true;
   navigateToNewConversation.mockClear();
 });
 
@@ -147,6 +150,21 @@ describe("McpPage", () => {
     const cta = await screen.findByRole("button", {
       name: /Add an MCP server to extend your assistant with external tools/,
     });
+    fireEvent.click(cta);
+
+    expect(navigateToNewConversation).not.toHaveBeenCalled();
+  });
+
+  test("empty state CTA stays inert until feature flags hydrate", async () => {
+    assistantFlags = { mcpAddServer: false };
+    flagsHydrated = false;
+
+    render(<McpPage />, { wrapper: Wrapper });
+
+    const cta = await screen.findByRole("button", {
+      name: /Chat with your assistant to set up an MCP server/,
+    });
+    expect((cta as HTMLButtonElement).disabled).toBe(true);
     fireEvent.click(cta);
 
     expect(navigateToNewConversation).not.toHaveBeenCalled();

--- a/clients/web/src/domains/settings/mcp/mcp-page.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-page.tsx
@@ -41,6 +41,7 @@ function McpPageInner() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const mcpAddServerEnabled = useAssistantFeatureFlagStore.use.mcpAddServer();
+  const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
 
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [configureServerId, setConfigureServerId] = useState<string | null>(null);
@@ -353,7 +354,8 @@ function McpPageInner() {
         <button
           type="button"
           onClick={handleEmptyStateAction}
-          className="flex w-full flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--border-element)] px-4 py-12 text-center transition-colors hover:border-[var(--border-active)] hover:bg-[var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+          disabled={!flagsHydrated}
+          className="flex w-full flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--border-element)] px-4 py-12 text-center transition-colors hover:border-[var(--border-active)] hover:bg-[var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:pointer-events-none"
         >
           <Cable className="h-6 w-6 text-[var(--content-disabled)]" />
           <p className="text-body-medium-default text-[var(--content-default)]">No MCP Servers</p>

--- a/clients/web/src/domains/settings/mcp/mcp-page.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-page.tsx
@@ -1,9 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Cable, Loader2, Plus, RefreshCw } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { navigateToNewConversation } from "@/utils/conversation-navigation";
 import { McpAddServerModal } from "./mcp-add-server-modal";
 import {
   addMcpServer,
@@ -27,9 +29,17 @@ import { toast } from "@vellumai/design-library/components/toast";
 const MCP_SERVERS_KEY = "mcp-servers";
 const MCP_TOOLS_KEY = "mcp-tools-summary";
 
+/**
+ * First message auto-sent when a user without the add-server flag clicks the
+ * empty-state call to action — kicks off an assistant-guided MCP setup.
+ */
+const MCP_SETUP_PROMPT =
+  "Help me set up an MCP server to extend you with external tools.";
+
 function McpPageInner() {
   const assistantId = useActiveAssistantId();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const mcpAddServerEnabled = useAssistantFeatureFlagStore.use.mcpAddServer();
 
   const [addModalOpen, setAddModalOpen] = useState(false);
@@ -281,6 +291,14 @@ function McpPageInner() {
     }
   }, [assistantId, invalidateAll]);
 
+  const handleEmptyStateAction = useCallback(() => {
+    if (mcpAddServerEnabled) {
+      setAddModalOpen(true);
+    } else {
+      navigateToNewConversation(navigate, { prompt: MCP_SETUP_PROMPT });
+    }
+  }, [mcpAddServerEnabled, navigate]);
+
   const servers = serversData?.servers ?? [];
 
   return (
@@ -332,13 +350,19 @@ function McpPageInner() {
           Failed to load MCP servers. Check that an assistant is running.
         </p>
       ) : servers.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--border-element)] px-4 py-12 text-center">
+        <button
+          type="button"
+          onClick={handleEmptyStateAction}
+          className="flex w-full flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--border-element)] px-4 py-12 text-center transition-colors hover:border-[var(--border-active)] hover:bg-[var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        >
           <Cable className="h-6 w-6 text-[var(--content-disabled)]" />
           <p className="text-body-medium-default text-[var(--content-default)]">No MCP Servers</p>
           <p className="text-body-small-default text-[var(--content-tertiary)]">
-            Add an MCP server to extend your assistant with external tools.
+            {mcpAddServerEnabled
+              ? "Add an MCP server to extend your assistant with external tools."
+              : "Chat with your assistant to set up an MCP server."}
           </p>
-        </div>
+        </button>
       ) : (
         <div className="space-y-2">
           {servers.map((server) => (


### PR DESCRIPTION
## Summary

- The "No MCP Servers" empty state is now a clickable button instead of static text, giving the page a clear next action.
- When the `mcp-add-server` feature flag is **on**, clicking opens the existing Add Server modal flow.
- When the flag is **off**, the copy reads "Chat with your assistant to set up an MCP server" and clicking starts a new conversation with a setup prompt already sent (reuses `navigateToNewConversation({ prompt })` → `?prompt=` auto-send).

## Original prompt

The MCP settings empty state ("No MCP Servers" / "Add an MCP server to extend your assistant with external tools.") wasn't actionable. The ask: make the empty state clickable. If the add-server feature flag is off, show "Chat with your assistant to setup an MCP server" and route the user into a new conversation with the kickoff message already sent; if the flag is on, clicking should open the add MCP server modal flow instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->