### PR TITLE
Add onboarding attribution UTM params to check-in CTA link

### DIFF
--- a/assistant/src/onboarding/checkin-event.test.ts
+++ b/assistant/src/onboarding/checkin-event.test.ts
@@ -54,6 +54,8 @@ describe("buildCheckinDescription", () => {
     expect(html).toContain(
       "https://www.vellum.ai/assistant/conversations/uuid-123?prompt=What%20would%20you%20recommend",
     );
+    // Carries onboarding attribution for the calendar-event CTA.
+    expect(html).toContain("&utm_source=onboarding&utm_medium=calendar_event");
     // Only sanitization-safe tags; the CTA is a bold link, not a styled button.
     expect(html).toContain("<a href=");
     expect(html).toContain("<strong>");

--- a/assistant/src/onboarding/checkin-event.ts
+++ b/assistant/src/onboarding/checkin-event.ts
@@ -66,7 +66,7 @@ export function buildCheckinTitle({
  * (`uuid`) pre-seeded with the first-week prompt.
  */
 export function buildCheckinDescription(uuid: string): string {
-  const href = `https://www.vellum.ai/assistant/conversations/${uuid}?prompt=${CTA_ENCODED_PROMPT}`;
+  const href = `https://www.vellum.ai/assistant/conversations/${uuid}?prompt=${CTA_ENCODED_PROMPT}&utm_source=onboarding&utm_medium=calendar_event`;
   return [
     "<p>👋 <strong>Hi, it was great to meet you properly.</strong></p>",
     "<p>You just set me up, and I've already started learning <strong>what you're working on</strong>. This 15 minutes is the natural place to put that to work. I'll walk you through one thing I'd like to do for you this week.</p>",


### PR DESCRIPTION
## What

Appends `utm_source=onboarding&utm_medium=calendar_event` to the CTA deep link embedded in the Day 2 check-in calendar event description (`buildCheckinDescription` in `assistant/src/onboarding/checkin-event.ts`).

## Why

Makes click-throughs from the onboarding calendar invite attributable in analytics.

## Notes

- The UTM params ride alongside the existing `?prompt=` query param on the conversation deep link.
- Added a test assertion locking in the params; all 21 `checkin-event` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)