### PR TITLE
refactor(migrations): 031 self-contained guardian read; drop historical comments

### DIFF
--- a/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
@@ -155,12 +155,24 @@ describe("workspace migration 031-drop-user-md", () => {
     expect(existsSync(join(workspaceDir(), "users"))).toBe(false);
   });
 
-  test("no guardian with stale USER.md — deletes it", () => {
-    writeFileSync(userMdPath(), customizedContent(), "utf-8");
+  test("no guardian with unmodified-template USER.md — deletes it", () => {
+    writeFileSync(userMdPath(), templateContent(), "utf-8");
 
     dropUserMdMigration.run(workspaceDir());
 
     expect(existsSync(userMdPath())).toBe(false);
+  });
+
+  test("no guardian with customized USER.md — preserves it (mirror may be stale)", () => {
+    const content = customizedContent();
+    writeFileSync(userMdPath(), content, "utf-8");
+
+    dropUserMdMigration.run(workspaceDir());
+
+    // The local guardian mirror can be stale, so a customized profile must
+    // not be destroyed when no guardian row resolves.
+    expect(existsSync(userMdPath())).toBe(true);
+    expect(readFileSync(userMdPath(), "utf-8")).toBe(content);
   });
 
   test("pre-017 customized USER.md with guardian missing userFile backfills slug and migrates content", () => {

--- a/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
@@ -1,152 +1,104 @@
 /**
  * Tests for workspace migration `031-drop-user-md`.
  *
- * Validates the five behavioral contracts spelled out in the plan:
- *   1. Fresh install (no guardian) — no-op.
- *   2. Pre-017 customized USER.md, guardian has no userFile — backfill slug,
- *      copy content into users/<slug>.md, delete USER.md.
- *   3. Post-017 state (users/<slug>.md already populated, USER.md still on disk
- *      as template) — migration does NOT overwrite users/<slug>.md, deletes USER.md.
- *   4. Idempotent re-run — running twice has no additional effect.
- *   5. Guardian with missing users/ directory — migration creates the directory.
+ * The migration resolves the guardian contact via a frozen raw-SQL read of
+ * the local `contacts`/`contact_channels` tables, backfills a `user_file`
+ * slug when missing, migrates any customized `USER.md` into
+ * `users/<slug>.md`, and deletes the legacy root `USER.md`.
  *
- * The migration resolves the guardian identity from the gateway delivery
- * reader, joins the local contact via `findContactByAddress`, and calls
- * `getDb()` to persist backfilled slugs. These tests stub the reader, contact
- * store, and DB layer so no real DB is exercised.
+ * These tests seed the guardian directly in the local DB so the migration
+ * is exercised end-to-end against real SQLite — no gateway or mocks.
  */
 
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-// ── Mock state ────────────────────────────────────────────────────
+import { getSqlite } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
 
-interface MockContact {
+await initializeDb();
+
+import { dropUserMdMigration } from "../workspace/migrations/031-drop-user-md.js";
+
+// ── DB seeding helpers ────────────────────────────────────────────
+
+function resetContactTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+/**
+ * Insert a guardian contact plus an active channel so the migration's
+ * raw-SQL guardian read resolves it.
+ */
+function seedGuardian(input: {
   id: string;
   displayName: string;
   userFile: string | null;
-}
-
-interface GuardianDeliveryStub {
-  channelType: string;
-  address: string;
-  status: string;
-}
-
-// Gateway guardian deliveries (first entry is the "any guardian" fallback).
-// `null` models a FAILED gateway read (timeout / unreachable / malformed),
-// distinct from `[]` which models a definitive "no guardian" result.
-let mockGuardianDeliveries: GuardianDeliveryStub[] | null = [];
-// Local contact joined by the guardian delivery's (channelType, address).
-let mockLocalContact: MockContact | null = null;
-let mockSlugOverride: ((displayName: string) => string) | null = null;
-
-// Records drizzle `.update(contacts).set({userFile: ...}).where(...).run()` calls.
-let updatedUserFiles: Array<{ contactId: string; userFile: string }> = [];
-
-/**
- * Seed a guardian: a gateway delivery for `deliveryChannel` and the local
- * contact joined by that delivery's address.
- */
-function seedGuardian(input: {
-  deliveryChannel: string;
-  address: string;
-  contact: MockContact;
+  channelType?: string;
+  address?: string;
+  verifiedAt?: number;
 }): void {
-  mockGuardianDeliveries = [
-    {
-      channelType: input.deliveryChannel,
-      address: input.address,
-      status: "active",
-    },
-  ];
-  mockLocalContact = input.contact;
+  const now = Date.now();
+  const sqlite = getSqlite();
+  sqlite.run(
+    `INSERT INTO contacts (id, display_name, created_at, updated_at, role, user_file, contact_type)
+     VALUES (?, ?, ?, ?, 'guardian', ?, 'human')`,
+    [input.id, input.displayName, now, now, input.userFile],
+  );
+  sqlite.run(
+    `INSERT INTO contact_channels (id, contact_id, type, address, status, verified_at, created_at)
+     VALUES (?, ?, ?, ?, 'active', ?, ?)`,
+    [
+      `${input.id}-ch`,
+      input.id,
+      input.channelType ?? "vellum",
+      input.address ?? "vellum:self",
+      input.verifiedAt ?? now,
+      now,
+    ],
+  );
 }
 
-// ── Mock modules (must precede migration import) ──────────────────
-
-mock.module("../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: async () => mockGuardianDeliveries,
-  guardianForChannel: (list: GuardianDeliveryStub[], channelType: string) =>
-    list.find((g) => g.channelType === channelType && g.status === "active"),
-  anyGuardian: (list: GuardianDeliveryStub[]) => list[0],
-}));
-
-mock.module("../contacts/contact-store.js", () => ({
-  findContactByAddress: () => mockLocalContact,
-  generateUserFileSlug: (displayName: string) => {
-    if (mockSlugOverride) return mockSlugOverride(displayName);
-    const base =
-      displayName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-+|-+$/g, "") || "user";
-    return `${base}.md`;
-  },
-}));
-
-// Minimal drizzle-compatible stub for the single `update` call in the
-// migration. The migration builds:
-//   db.update(contacts).set({ userFile: slug }).where(eq(contacts.id, guardian.id)).run();
-// The stub captures the payload into `updatedUserFiles` and also mutates
-// the active mock guardian in place so downstream reads observe the new slug.
-mock.module("../memory/db-connection.js", () => ({
-  getDb: () => ({
-    update: () => ({
-      set: (values: { userFile: string }) => ({
-        where: () => ({
-          run: () => {
-            if (mockLocalContact) {
-              mockLocalContact.userFile = values.userFile;
-              updatedUserFiles.push({
-                contactId: mockLocalContact.id,
-                userFile: values.userFile,
-              });
-            }
-          },
-        }),
-      }),
-    }),
-  }),
-}));
-
-// drizzle-orm's `eq()` is invoked by the migration; stub it out so we
-// don't need the real module loaded for unit tests.
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, value: unknown) => ({ col: _col, value }),
-}));
-
-// Stub the schema import so drizzle operand construction doesn't touch
-// the real sqlite schema (which pulls in the DB).
-mock.module("../memory/schema/contacts.js", () => ({
-  contacts: { id: "id", userFile: "userFile" },
-}));
-
-// Import AFTER mocks so the migration binds to the stubs above.
-import { dropUserMdMigration } from "../workspace/migrations/031-drop-user-md.js";
+function guardianUserFile(id: string): string | null {
+  const row = getSqlite()
+    .query<{ user_file: string | null }, [string]>(
+      `SELECT user_file FROM contacts WHERE id = ?`,
+    )
+    .get(id);
+  return row?.user_file ?? null;
+}
 
 // ── Test workspace scaffold ───────────────────────────────────────
 
-let testRoot: string;
-let workspaceDir: string;
+function workspaceDir(): string {
+  const dir = process.env.VELLUM_WORKSPACE_DIR;
+  if (!dir) {
+    throw new Error(
+      "VELLUM_WORKSPACE_DIR should be set by the test preload — aborting",
+    );
+  }
+  return dir;
+}
+
+function userMdPath(): string {
+  return join(workspaceDir(), "USER.md");
+}
+
+function cleanupWorkspaceFiles(): void {
+  const dir = workspaceDir();
+  for (const p of [join(dir, "USER.md"), join(dir, "users")]) {
+    rmSync(p, { recursive: true, force: true });
+  }
+}
 
 function templateContent(): string {
   return `_ Lines starting with _ are comments - they won't appear in the system prompt
@@ -177,24 +129,9 @@ function customizedContent(): string {
 `;
 }
 
-beforeAll(() => {
-  testRoot = mkdtempSync(join(tmpdir(), "drop-user-md-test-"));
-});
-
-afterAll(() => {
-  rmSync(testRoot, { recursive: true, force: true });
-});
-
 beforeEach(() => {
-  workspaceDir = mkdtempSync(join(testRoot, "ws-"));
-  mockGuardianDeliveries = [];
-  mockLocalContact = null;
-  mockSlugOverride = null;
-  updatedUserFiles = [];
-});
-
-afterEach(() => {
-  rmSync(workspaceDir, { recursive: true, force: true });
+  resetContactTables();
+  cleanupWorkspaceFiles();
 });
 
 // ── Tests ─────────────────────────────────────────────────────────
@@ -207,214 +144,171 @@ describe("workspace migration 031-drop-user-md", () => {
     );
   });
 
-  test("is retryable so a failed (null gateway read) checkpoint re-runs", () => {
-    // A clean return would checkpoint `completed` and skip forever; throwing on
-    // a null read needs this flag so the runner retries the failed checkpoint.
-    expect(dropUserMdMigration.retryFailedCheckpoint).toBe(true);
+  test("does not declare retryFailedCheckpoint (no gateway coupling)", () => {
+    expect(dropUserMdMigration.retryFailedCheckpoint).toBeUndefined();
   });
 
-  test("fresh install (no guardian, no USER.md) is a no-op", async () => {
-    // No guardian stubbed in, no USER.md on disk.
-    await dropUserMdMigration.run(workspaceDir);
+  test("fresh install (no guardian, no USER.md) is a no-op", () => {
+    dropUserMdMigration.run(workspaceDir());
 
-    expect(existsSync(join(workspaceDir, "USER.md"))).toBe(false);
-    expect(existsSync(join(workspaceDir, "users"))).toBe(false);
-    expect(updatedUserFiles).toEqual([]);
+    expect(existsSync(userMdPath())).toBe(false);
+    expect(existsSync(join(workspaceDir(), "users"))).toBe(false);
   });
 
-  test("gateway read FAILS (null) — throws to defer, leaving customized USER.md intact", async () => {
-    // Gateway IPC timeout / unreachable / malformed → reader returns null. The
-    // migration throws so the checkpoint records `failed` (not `completed`) and
-    // `retryFailedCheckpoint` re-runs it next startup — a clean return would
-    // strand the cleanup forever.
-    mockGuardianDeliveries = null;
+  test("no guardian with stale USER.md — deletes it", () => {
+    writeFileSync(userMdPath(), customizedContent(), "utf-8");
 
-    const userMdPath = join(workspaceDir, "USER.md");
+    dropUserMdMigration.run(workspaceDir());
+
+    expect(existsSync(userMdPath())).toBe(false);
+  });
+
+  test("pre-017 customized USER.md with guardian missing userFile backfills slug and migrates content", () => {
+    seedGuardian({ id: "guardian-1", displayName: "Chris", userFile: null });
+
     const content = customizedContent();
-    writeFileSync(userMdPath, content, "utf-8");
+    writeFileSync(userMdPath(), content, "utf-8");
 
-    await expect(dropUserMdMigration.run(workspaceDir)).rejects.toThrow(
-      /gateway guardian read failed/i,
-    );
+    dropUserMdMigration.run(workspaceDir());
 
-    // USER.md is preserved (NOT deleted) — the only copy survives the miss.
-    expect(existsSync(userMdPath)).toBe(true);
-    expect(readFileSync(userMdPath, "utf-8")).toBe(content);
-    // No users/ dir created, no backfill — fully deferred to the next run.
-    expect(existsSync(join(workspaceDir, "users"))).toBe(false);
-    expect(updatedUserFiles).toEqual([]);
-  });
-
-  test("gateway DEFINITIVELY reports no guardian ([]) with stale USER.md — deletes it", async () => {
-    // Empty list = gateway succeeded and there is genuinely no guardian.
-    mockGuardianDeliveries = [];
-
-    const userMdPath = join(workspaceDir, "USER.md");
-    writeFileSync(userMdPath, customizedContent(), "utf-8");
-
-    await dropUserMdMigration.run(workspaceDir);
-
-    // Pre-onboarding / no-guardian stale cleanup removes the lingering file.
-    expect(existsSync(userMdPath)).toBe(false);
-    expect(updatedUserFiles).toEqual([]);
-  });
-
-  test("pre-017 customized USER.md with guardian missing userFile backfills slug and migrates content", async () => {
-    // Guardian exists on the 'vellum' channel but has no userFile.
-    seedGuardian({
-      deliveryChannel: "vellum",
-      address: "vellum:self",
-      contact: { id: "guardian-1", displayName: "Chris", userFile: null },
-    });
-
-    const userMdPath = join(workspaceDir, "USER.md");
-    const content = customizedContent();
-    writeFileSync(userMdPath, content, "utf-8");
-
-    await dropUserMdMigration.run(workspaceDir);
-
-    // Backfill happened: drizzle update was called with the generated slug.
-    expect(updatedUserFiles).toHaveLength(1);
-    expect(updatedUserFiles[0].contactId).toBe("guardian-1");
-    expect(updatedUserFiles[0].userFile).toBe("chris.md");
+    // Backfill happened: the contact's user_file is now the generated slug.
+    expect(guardianUserFile("guardian-1")).toBe("chris.md");
 
     // Content was migrated into users/chris.md.
-    const destPath = join(workspaceDir, "users", "chris.md");
+    const destPath = join(workspaceDir(), "users", "chris.md");
     expect(existsSync(destPath)).toBe(true);
     expect(readFileSync(destPath, "utf-8")).toBe(content);
 
     // Legacy USER.md was deleted.
-    expect(existsSync(userMdPath)).toBe(false);
+    expect(existsSync(userMdPath())).toBe(false);
   });
 
-  test("post-017 users/<slug>.md already populated, USER.md still on disk as template — does not overwrite dest, deletes USER.md", async () => {
-    // Guardian already has a userFile from a prior 017 run.
+  test("post-017 users/<slug>.md already populated, USER.md still on disk as template — does not overwrite dest, deletes USER.md", () => {
     seedGuardian({
-      deliveryChannel: "vellum",
-      address: "vellum:self",
-      contact: { id: "guardian-2", displayName: "Chris", userFile: "chris.md" },
+      id: "guardian-2",
+      displayName: "Chris",
+      userFile: "chris.md",
     });
 
-    // Pre-populated persona file (post-017 state).
-    const usersDir = join(workspaceDir, "users");
+    const usersDir = join(workspaceDir(), "users");
     mkdirSync(usersDir, { recursive: true });
     const destPath = join(usersDir, "chris.md");
     const existingPersona = "# Chris's Profile\n\n- Loves kayaking\n";
     writeFileSync(destPath, existingPersona, "utf-8");
 
-    // Leftover template-shape USER.md at workspace root.
-    const userMdPath = join(workspaceDir, "USER.md");
-    writeFileSync(userMdPath, templateContent(), "utf-8");
+    writeFileSync(userMdPath(), templateContent(), "utf-8");
 
-    await dropUserMdMigration.run(workspaceDir);
+    dropUserMdMigration.run(workspaceDir());
 
     // users/chris.md is untouched.
     expect(readFileSync(destPath, "utf-8")).toBe(existingPersona);
-
     // USER.md is gone.
-    expect(existsSync(userMdPath)).toBe(false);
-
+    expect(existsSync(userMdPath())).toBe(false);
     // No slug backfill necessary.
-    expect(updatedUserFiles).toEqual([]);
+    expect(guardianUserFile("guardian-2")).toBe("chris.md");
   });
 
-  test("idempotent: second run is a no-op after the first run deleted USER.md", async () => {
+  test("idempotent: second run is a no-op after the first run deleted USER.md", () => {
     seedGuardian({
-      deliveryChannel: "vellum",
-      address: "vellum:self",
-      contact: { id: "guardian-3", displayName: "Alice", userFile: "alice.md" },
+      id: "guardian-3",
+      displayName: "Alice",
+      userFile: "alice.md",
     });
 
-    const userMdPath = join(workspaceDir, "USER.md");
-    writeFileSync(userMdPath, customizedContent(), "utf-8");
+    writeFileSync(userMdPath(), customizedContent(), "utf-8");
 
-    // First run: migrates content and deletes USER.md.
-    await dropUserMdMigration.run(workspaceDir);
-    expect(existsSync(userMdPath)).toBe(false);
-    const destPath = join(workspaceDir, "users", "alice.md");
+    dropUserMdMigration.run(workspaceDir());
+    expect(existsSync(userMdPath())).toBe(false);
+    const destPath = join(workspaceDir(), "users", "alice.md");
     expect(existsSync(destPath)).toBe(true);
     const afterFirst = readFileSync(destPath, "utf-8");
 
-    // Second run: no USER.md remains, users/alice.md already has content,
-    // so the destination is not rewritten and USER.md is still absent.
-    await dropUserMdMigration.run(workspaceDir);
-    expect(existsSync(userMdPath)).toBe(false);
+    dropUserMdMigration.run(workspaceDir());
+    expect(existsSync(userMdPath())).toBe(false);
     expect(existsSync(destPath)).toBe(true);
     expect(readFileSync(destPath, "utf-8")).toBe(afterFirst);
   });
 
-  test("guardian exists but users/ directory is missing — migration creates the directory", async () => {
-    seedGuardian({
-      deliveryChannel: "vellum",
-      address: "vellum:self",
-      contact: { id: "guardian-4", displayName: "Bob", userFile: "bob.md" },
-    });
+  test("guardian exists but users/ directory is missing — migration creates the directory", () => {
+    seedGuardian({ id: "guardian-4", displayName: "Bob", userFile: "bob.md" });
 
-    // USER.md present but no users/ dir yet.
-    const userMdPath = join(workspaceDir, "USER.md");
-    writeFileSync(userMdPath, customizedContent(), "utf-8");
-    expect(existsSync(join(workspaceDir, "users"))).toBe(false);
+    writeFileSync(userMdPath(), customizedContent(), "utf-8");
+    expect(existsSync(join(workspaceDir(), "users"))).toBe(false);
 
-    await dropUserMdMigration.run(workspaceDir);
+    dropUserMdMigration.run(workspaceDir());
 
-    expect(existsSync(join(workspaceDir, "users"))).toBe(true);
-    const destPath = join(workspaceDir, "users", "bob.md");
+    expect(existsSync(join(workspaceDir(), "users"))).toBe(true);
+    const destPath = join(workspaceDir(), "users", "bob.md");
     expect(existsSync(destPath)).toBe(true);
     expect(readFileSync(destPath, "utf-8")).toBe(customizedContent());
-    expect(existsSync(userMdPath)).toBe(false);
+    expect(existsSync(userMdPath())).toBe(false);
   });
 
-  // ─── Bonus coverage for edge cases ───────────────────────────────
-
-  test("falls back to any guardian when no vellum-channel guardian exists", async () => {
-    // No vellum delivery — the first (telegram) delivery is the any-guardian
-    // fallback, and its local contact carries the userFile.
+  test("falls back to any guardian when no vellum-channel guardian exists", () => {
     seedGuardian({
-      deliveryChannel: "telegram",
+      id: "guardian-5",
+      displayName: "Carol",
+      userFile: "carol.md",
+      channelType: "telegram",
       address: "carol-tg",
-      contact: { id: "guardian-5", displayName: "Carol", userFile: "carol.md" },
     });
 
-    const userMdPath = join(workspaceDir, "USER.md");
-    writeFileSync(userMdPath, customizedContent(), "utf-8");
+    writeFileSync(userMdPath(), customizedContent(), "utf-8");
 
-    await dropUserMdMigration.run(workspaceDir);
+    dropUserMdMigration.run(workspaceDir());
 
-    const destPath = join(workspaceDir, "users", "carol.md");
+    const destPath = join(workspaceDir(), "users", "carol.md");
     expect(existsSync(destPath)).toBe(true);
     expect(readFileSync(destPath, "utf-8")).toBe(customizedContent());
-    expect(existsSync(userMdPath)).toBe(false);
+    expect(existsSync(userMdPath())).toBe(false);
   });
 
-  test("template-shaped USER.md with no destination file — seeds scaffold and deletes USER.md", async () => {
+  test("prefers vellum-channel guardian over a more-recently-verified other guardian", () => {
+    // Older vellum guardian vs newer telegram guardian: vellum wins.
     seedGuardian({
-      deliveryChannel: "vellum",
+      id: "guardian-vellum",
+      displayName: "Vee",
+      userFile: "vee.md",
+      channelType: "vellum",
       address: "vellum:self",
-      contact: { id: "guardian-6", displayName: "Dana", userFile: "dana.md" },
+      verifiedAt: 1_000,
+    });
+    seedGuardian({
+      id: "guardian-tg",
+      displayName: "Tom",
+      userFile: "tom.md",
+      channelType: "telegram",
+      address: "tom-tg",
+      verifiedAt: 2_000,
     });
 
-    const userMdPath = join(workspaceDir, "USER.md");
-    writeFileSync(userMdPath, templateContent(), "utf-8");
+    writeFileSync(userMdPath(), customizedContent(), "utf-8");
 
-    await dropUserMdMigration.run(workspaceDir);
+    dropUserMdMigration.run(workspaceDir());
 
-    // USER.md is gone.
-    expect(existsSync(userMdPath)).toBe(false);
+    expect(existsSync(join(workspaceDir(), "users", "vee.md"))).toBe(true);
+    expect(existsSync(join(workspaceDir(), "users", "tom.md"))).toBe(false);
+  });
 
-    // The destination was scaffolded with the guardian persona template
-    // (parity with ensureGuardianPersonaFile for new installs).
-    const destPath = join(workspaceDir, "users", "dana.md");
+  test("template-shaped USER.md with no destination file — seeds scaffold and deletes USER.md", () => {
+    seedGuardian({ id: "guardian-6", displayName: "Dana", userFile: "dana.md" });
+
+    writeFileSync(userMdPath(), templateContent(), "utf-8");
+
+    dropUserMdMigration.run(workspaceDir());
+
+    expect(existsSync(userMdPath())).toBe(false);
+
+    const destPath = join(workspaceDir(), "users", "dana.md");
     expect(existsSync(destPath)).toBe(true);
     const content = readFileSync(destPath, "utf-8");
     expect(content).toContain("# User Profile");
     expect(content).toContain("Preferred name/reference:");
-    // Not the legacy template header.
     expect(content).not.toContain("# USER.md");
   });
 
   test("down() is a no-op (deletion is irreversible)", () => {
-    // Should not throw.
-    dropUserMdMigration.down(workspaceDir);
-    expect(existsSync(join(workspaceDir, "USER.md"))).toBe(false);
+    dropUserMdMigration.down(workspaceDir());
+    expect(existsSync(userMdPath())).toBe(false);
   });
 });

--- a/assistant/src/calls/relay-access-wait.ts
+++ b/assistant/src/calls/relay-access-wait.ts
@@ -255,8 +255,6 @@ export function emitAccessRequestCallbackHandoff(
         address: fromNumber,
         externalChatId: fromNumber,
       });
-      // DRAIN-MISS (PR 6 member ACL): status/policy still read from the local
-      // ACL columns until the member-ACL drain to the gateway lands.
       if (contactResult) {
         const acl = getLocalMemberAcl(contactResult.channel.id);
         if (acl?.status === "active" && acl.policy === "allow") {

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -306,9 +306,6 @@ export function upsertContact(params: {
 
   // Create new contact
   contactId = contactId ?? uuid();
-  // principalId is gateway-owned and no longer a local key; sibling persona
-  // sharing is resolved upstream, so a new contact takes its explicit userFile
-  // or a freshly slugified one.
   const resolvedUserFile =
     params.userFile !== undefined
       ? params.userFile
@@ -756,15 +753,7 @@ export interface LocalMemberAcl {
   role: ContactRole;
 }
 
-/**
- * Read a channel's local ACL columns (status/policy/role) by row id.
- *
- * DRAIN-MISS (PR 6 member ACL): the member status/policy/role is still read
- * locally here — only the GUARDIAN read was drained to the gateway. The voice
- * trust resolver is sync, so it cannot await the gateway ACL read; this keeps
- * the pre-existing local-fallback behavior off the dropped interface fields
- * until the member-ACL drain lands. Returns null when the channel is missing.
- */
+/** Read a channel's local ACL columns (status/policy/role) by row id; null if missing. */
 export function getLocalMemberAcl(channelId: string): LocalMemberAcl | null {
   const row = getDb()
     .select({

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -8,9 +8,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, join } from "node:path";
+import { Database } from "bun:sqlite";
 
-import { generateUserFileSlug } from "../../contacts/contact-store.js";
-import { getSqlite } from "../../memory/db-connection.js";
 import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -18,11 +17,11 @@ const log = getLogger("workspace-migration-031-drop-user-md");
 
 // ── Inlined helpers ───────────────────────────────────────────────
 //
-// Per AGENTS.md, migrations should minimize cross-module imports so
-// they remain stable as code around them evolves. The helpers below
-// are duplicated inline (rather than imported from
-// `util/strip-comment-lines.js` and `prompts/system-prompt.js`) so
-// this migration does not regress if those modules change later.
+// AGENTS.md requires each migration to be self-contained: it may import
+// only `./types.js`, `./utils.js`, the logger, and runtime built-ins.
+// The helpers below (including the guardian DB read and the userFile
+// slug) are inlined so this migration does not regress if the modules
+// they originate from change later.
 
 /**
  * Strip lines starting with `_` (comment convention for prompt .md files)
@@ -117,11 +116,58 @@ function isValidSlug(slug: string): boolean {
 }
 
 /**
+ * Strip LIKE metacharacters so the prefix match runs literally. SQLite has
+ * no default LIKE escape character, so strip rather than escape. Inlined
+ * from `contacts/contact-store.ts`.
+ */
+function escapeLike(value: string): string {
+  return value.replace(/%/g, "").replace(/_/g, "");
+}
+
+/** Pure slug transform applied to a display name. */
+function computeUserFileBaseSlug(displayName: string): string {
+  return (
+    displayName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 100) || "user"
+  );
+}
+
+/**
+ * Generate a collision-free `users/<slug>.md` filename for a display name,
+ * inlined verbatim from `contacts/contact-store.ts` to keep this migration
+ * self-contained. Produces "alice.md", "alice-2.md", etc.
+ */
+function generateUserFileSlug(db: Database, displayName: string): string {
+  const slug = computeUserFileBaseSlug(displayName);
+
+  const rows = db
+    .query<{ user_file: string | null }, [string]>(
+      `SELECT user_file FROM contacts WHERE user_file LIKE ?`,
+    )
+    .all(`${escapeLike(slug)}%`);
+
+  const taken = new Set(rows.map((r) => r.user_file?.toLowerCase()));
+
+  const base = `${slug}.md`;
+  if (!taken.has(base)) return base;
+
+  for (let i = 2; ; i++) {
+    const candidate = `${slug}-${i}.md`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/**
  * Delete the legacy `USER.md` at the workspace root after migrating
  * any customized content into `users/<slug>.md`.
  *
- * Handles four relevant states:
- *   1. Fresh install, no guardian → no-op (nothing to migrate yet).
+ * Handles these relevant states:
+ *   1. No local guardian → preserve a customized `USER.md` (the local
+ *      mirror can be stale, so a customized profile may still belong to a
+ *      real guardian); delete only the unmodified template/empty file.
  *   2. Pre-017 customized `USER.md`, guardian has no `userFile` →
  *      backfill the slug, copy `USER.md` → `users/<slug>.md`, delete `USER.md`.
  *   3. Post-017 state where `users/<slug>.md` already has content →
@@ -143,163 +189,203 @@ export const dropUserMdMigration: WorkspaceMigration = {
   run(workspaceDir: string): void {
     const userMdPath = join(workspaceDir, "USER.md");
 
-    // Resolve the guardian contact from the local DB. Prefer the
-    // vellum-channel binding (the canonical native guardian); fall back to
-    // whichever guardian has the most recently verified active channel.
-    let guardianRow: GuardianRow | null;
+    const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+    if (!existsSync(dbPath)) return; // DB not created yet — defer cleanup.
+
+    let db: Database;
     try {
-      guardianRow =
-        getSqlite()
-          .query<GuardianRow, []>(
-            `SELECT c.id AS id, c.display_name AS display_name, c.user_file AS user_file
-               FROM contacts c JOIN contact_channels cc ON cc.contact_id = c.id
-              WHERE c.role = 'guardian' AND cc.status = 'active'
-              ORDER BY (cc.type = 'vellum') DESC, cc.verified_at DESC
-              LIMIT 1`,
-          )
-          .get() ?? null;
+      db = new Database(dbPath);
     } catch (err) {
-      // DB not ready or query failed — leave USER.md alone. The next
-      // startup after DB init will try again.
-      log.warn(
-        { err },
-        "Failed to resolve guardian contact; deferring USER.md cleanup",
-      );
+      log.warn({ err }, "Cannot open assistant DB; deferring USER.md cleanup");
       return;
     }
 
-    if (!guardianRow) {
-      // Fresh install or pre-onboarding. If a stale USER.md somehow remains
-      // on disk (e.g. leftover from an older build), best-effort remove it so
-      // future first runs are clean.
-      if (existsSync(userMdPath)) {
+    try {
+      // Resolve the guardian contact from the local DB. Prefer the
+      // vellum-channel binding (the canonical native guardian); fall back to
+      // whichever guardian has the most recently verified active channel.
+      let guardianRow: GuardianRow | null;
+      try {
+        guardianRow =
+          db
+            .query<GuardianRow, []>(
+              `SELECT c.id AS id, c.display_name AS display_name, c.user_file AS user_file
+                 FROM contacts c JOIN contact_channels cc ON cc.contact_id = c.id
+                WHERE c.role = 'guardian' AND cc.status = 'active'
+                ORDER BY (cc.type = 'vellum') DESC, cc.verified_at DESC
+                LIMIT 1`,
+            )
+            .get() ?? null;
+      } catch (err) {
+        // DB not ready or query failed — leave USER.md alone. The next
+        // startup after DB init tries again.
+        log.warn(
+          { err },
+          "Failed to resolve guardian contact; deferring USER.md cleanup",
+        );
+        return;
+      }
+
+      if (!guardianRow) {
+        // No local guardian. The mirror can be stale (the gateway mirrors
+        // best-effort), so a customized USER.md may still belong to a real
+        // guardian — preserve it. Only delete the unmodified template/empty
+        // stale file.
+        if (existsSync(userMdPath)) {
+          let isStaleTemplate = false;
+          try {
+            isStaleTemplate =
+              !statSync(userMdPath).isFile() ||
+              isLegacyTemplateContent(readFileSync(userMdPath, "utf-8"));
+          } catch (err) {
+            log.warn(
+              { err, path: userMdPath },
+              "Cannot read USER.md with no guardian; leaving in place",
+            );
+            return;
+          }
+
+          if (!isStaleTemplate) {
+            log.info(
+              { path: userMdPath },
+              "Preserving customized USER.md with no local guardian",
+            );
+            return;
+          }
+
+          try {
+            unlinkSync(userMdPath);
+            log.info(
+              { path: userMdPath },
+              "Deleting stale template USER.md with no guardian",
+            );
+          } catch (err) {
+            log.warn(
+              { err, path: userMdPath },
+              "Failed to delete stale USER.md; leaving in place",
+            );
+          }
+        }
+        return;
+      }
+
+      const guardian = {
+        id: guardianRow.id,
+        displayName: guardianRow.display_name,
+        userFile: guardianRow.user_file ?? null,
+      };
+
+      // Backfill a userFile slug on the guardian contact if one isn't set.
+      if (!guardian.userFile) {
         try {
-          unlinkSync(userMdPath);
+          const slug = generateUserFileSlug(db, guardian.displayName);
+          db.run("UPDATE contacts SET user_file = ? WHERE id = ?", [
+            slug,
+            guardian.id,
+          ]);
+          guardian.userFile = slug;
           log.info(
-            { path: userMdPath },
-            "Deleted stale pre-onboarding USER.md with no guardian",
+            { contactId: guardian.id, slug },
+            "Backfilled missing guardian.userFile",
           );
         } catch (err) {
           log.warn(
+            { err, contactId: guardian.id },
+            "Failed to backfill guardian.userFile; deferring USER.md cleanup",
+          );
+          return;
+        }
+      }
+
+      const userFile = guardian.userFile;
+      if (!userFile || !isValidSlug(userFile)) {
+        log.warn(
+          { userFile },
+          "Guardian userFile is missing or not a safe basename; deferring USER.md cleanup",
+        );
+        return;
+      }
+
+      const usersDir = join(workspaceDir, "users");
+      mkdirSync(usersDir, { recursive: true });
+
+      const destPath = join(usersDir, userFile);
+
+      // Read USER.md if it exists and classify its content.
+      let userMdRaw: string | null = null;
+      let userMdIsCustomized = false;
+      if (existsSync(userMdPath)) {
+        try {
+          // Guard against USER.md being a directory (hostile state).
+          if (statSync(userMdPath).isFile()) {
+            userMdRaw = readFileSync(userMdPath, "utf-8");
+            userMdIsCustomized = !isLegacyTemplateContent(userMdRaw);
+          }
+        } catch (err) {
+          log.warn(
             { err, path: userMdPath },
-            "Failed to delete pre-onboarding USER.md; leaving in place",
+            "Failed to read USER.md; treating as unreadable",
           );
         }
       }
-      return;
-    }
 
-    const guardian = {
-      id: guardianRow.id,
-      displayName: guardianRow.display_name,
-      userFile: guardianRow.user_file ?? null,
-    };
-
-    // Backfill a userFile slug on the guardian contact if one isn't set.
-    if (!guardian.userFile) {
-      try {
-        const slug = generateUserFileSlug(guardian.displayName);
-        getSqlite().run("UPDATE contacts SET user_file = ? WHERE id = ?", [
-          slug,
-          guardian.id,
-        ]);
-        guardian.userFile = slug;
-        log.info(
-          { contactId: guardian.id, slug },
-          "Backfilled missing guardian.userFile",
-        );
-      } catch (err) {
-        log.warn(
-          { err, contactId: guardian.id },
-          "Failed to backfill guardian.userFile; deferring USER.md cleanup",
-        );
-        return;
-      }
-    }
-
-    const userFile = guardian.userFile;
-    if (!userFile || !isValidSlug(userFile)) {
-      log.warn(
-        { userFile },
-        "Guardian userFile is missing or not a safe basename; deferring USER.md cleanup",
-      );
-      return;
-    }
-
-    const usersDir = join(workspaceDir, "users");
-    mkdirSync(usersDir, { recursive: true });
-
-    const destPath = join(usersDir, userFile);
-
-    // Read USER.md if it exists and classify its content.
-    let userMdRaw: string | null = null;
-    let userMdIsCustomized = false;
-    if (existsSync(userMdPath)) {
-      try {
-        // Guard against USER.md being a directory (hostile state).
-        if (statSync(userMdPath).isFile()) {
-          userMdRaw = readFileSync(userMdPath, "utf-8");
-          userMdIsCustomized = !isLegacyTemplateContent(userMdRaw);
+      // Copy customized USER.md content into users/<slug>.md when the
+      // destination is missing or effectively empty. Post-017 installs
+      // that already populated users/<slug>.md are left untouched.
+      if (
+        userMdIsCustomized &&
+        userMdRaw !== null &&
+        destFileIsMissingOrEmpty(destPath)
+      ) {
+        try {
+          copyFileSync(userMdPath, destPath);
+          log.info(
+            { src: userMdPath, dest: destPath },
+            "Copied customized USER.md content into users/<slug>.md",
+          );
+        } catch (err) {
+          log.warn(
+            { err, src: userMdPath, dest: destPath },
+            "Failed to copy USER.md; deferring USER.md cleanup",
+          );
+          return;
         }
-      } catch (err) {
-        log.warn(
-          { err, path: userMdPath },
-          "Failed to read USER.md; treating as unreadable",
-        );
       }
-    }
 
-    // Copy customized USER.md content into users/<slug>.md when the
-    // destination is missing or effectively empty. Post-017 installs
-    // that already populated users/<slug>.md are left untouched.
-    if (
-      userMdIsCustomized &&
-      userMdRaw !== null &&
-      destFileIsMissingOrEmpty(destPath)
-    ) {
-      try {
-        copyFileSync(userMdPath, destPath);
-        log.info(
-          { src: userMdPath, dest: destPath },
-          "Copied customized USER.md content into users/<slug>.md",
-        );
-      } catch (err) {
-        log.warn(
-          { err, src: userMdPath, dest: destPath },
-          "Failed to copy USER.md; deferring USER.md cleanup",
-        );
-        return;
+      // Seed the guardian persona scaffold when the destination file
+      // still doesn't exist (e.g. no USER.md and no post-017 content).
+      // This keeps parity with `ensureGuardianPersonaFile` for new
+      // installs so downstream readers always find a file.
+      if (!existsSync(destPath)) {
+        try {
+          writeFileSync(destPath, GUARDIAN_PERSONA_TEMPLATE, "utf-8");
+          log.info(
+            { dest: destPath },
+            "Seeded guardian persona scaffold at users/<slug>.md",
+          );
+        } catch (err) {
+          log.warn(
+            { err, dest: destPath },
+            "Failed to seed guardian persona scaffold; continuing with USER.md deletion",
+          );
+        }
       }
-    }
 
-    // Seed the guardian persona scaffold when the destination file
-    // still doesn't exist (e.g. no USER.md and no post-017 content).
-    // This keeps parity with `ensureGuardianPersonaFile` for new
-    // installs so downstream readers always find a file.
-    if (!existsSync(destPath)) {
-      try {
-        writeFileSync(destPath, GUARDIAN_PERSONA_TEMPLATE, "utf-8");
-        log.info(
-          { dest: destPath },
-          "Seeded guardian persona scaffold at users/<slug>.md",
-        );
-      } catch (err) {
-        log.warn(
-          { err, dest: destPath },
-          "Failed to seed guardian persona scaffold; continuing with USER.md deletion",
-        );
+      // Finally, delete the legacy USER.md if it still exists — template or
+      // customized, it has no remaining consumer.
+      if (existsSync(userMdPath)) {
+        try {
+          unlinkSync(userMdPath);
+          log.info({ path: userMdPath }, "Deleted legacy workspace USER.md");
+        } catch (err) {
+          log.warn(
+            { err, path: userMdPath },
+            "Failed to delete legacy USER.md",
+          );
+        }
       }
-    }
-
-    // Finally, delete the legacy USER.md if it still exists — template or
-    // customized, it has no remaining consumer.
-    if (existsSync(userMdPath)) {
-      try {
-        unlinkSync(userMdPath);
-        log.info({ path: userMdPath }, "Deleted legacy workspace USER.md");
-      } catch (err) {
-        log.warn({ err, path: userMdPath }, "Failed to delete legacy USER.md");
-      }
+    } finally {
+      db.close();
     }
   },
 

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -9,19 +9,8 @@ import {
 } from "node:fs";
 import { basename, join } from "node:path";
 
-import { eq } from "drizzle-orm";
-
-import {
-  findContactByAddress,
-  generateUserFileSlug,
-} from "../../contacts/contact-store.js";
-import {
-  anyGuardian,
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../contacts/guardian-delivery-reader.js";
-import { getDb } from "../../memory/db-connection.js";
-import { contacts } from "../../memory/schema/contacts.js";
+import { generateUserFileSlug } from "../../contacts/contact-store.js";
+import { getSqlite } from "../../memory/db-connection.js";
 import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -132,8 +121,7 @@ function isValidSlug(slug: string): boolean {
  * any customized content into `users/<slug>.md`.
  *
  * Handles four relevant states:
- *   1. Fresh install, no guardian → no-op (nothing to migrate yet;
- *      `USER.md` is no longer seeded post PR 11).
+ *   1. Fresh install, no guardian → no-op (nothing to migrate yet).
  *   2. Pre-017 customized `USER.md`, guardian has no `userFile` →
  *      backfill the slug, copy `USER.md` → `users/<slug>.md`, delete `USER.md`.
  *   3. Post-017 state where `users/<slug>.md` already has content →
@@ -141,74 +129,35 @@ function isValidSlug(slug: string): boolean {
  *   4. Missing `users/<slug>.md` after guardian is resolved → seed a bare
  *      `GUARDIAN_PERSONA_TEMPLATE` scaffold so downstream readers have a file.
  */
+interface GuardianRow {
+  id: string;
+  display_name: string;
+  user_file: string | null;
+}
+
 export const dropUserMdMigration: WorkspaceMigration = {
   id: "031-drop-user-md",
   description:
     "Delete legacy workspace-root USER.md after migrating content to users/<slug>.md",
-  // A null gateway read throws (below) so the checkpoint records `failed`; this
-  // flag lets the runner retry the cleanup on the next startup.
-  retryFailedCheckpoint: true,
 
-  async run(workspaceDir: string): Promise<void> {
+  run(workspaceDir: string): void {
     const userMdPath = join(workspaceDir, "USER.md");
 
-    // Resolve the guardian contact. Prefer the vellum-channel binding
-    // (the canonical local/native guardian); fall back to whichever
-    // guardian has the most recently verified active channel. Guardian
-    // identity comes from the gateway delivery; local INFO (id/displayName/
-    // userFile) is joined from the local contact by the guardian's address.
-    // `null` means the gateway read FAILED (timeout / unreachable / malformed).
-    // Treat that as DATA-PRESERVING: leave USER.md in place and throw so the
-    // checkpoint records `failed`. A clean return would record `completed` and
-    // skip this migration forever, permanently stranding the USER.md cleanup +
-    // guardian-persona seed on a transient gateway miss; `retryFailedCheckpoint`
-    // re-runs it on the next startup. Deleting on a failed read could destroy
-    // the only copy of a customized root USER.md. `[]` means the gateway
-    // DEFINITIVELY reported no guardian, which proceeds normally. Read outside
-    // the try below so the throw isn't swallowed by the DB-error guard.
-    const guardians = await getGuardianDelivery();
-    if (guardians === null) {
-      log.warn(
-        {},
-        "Gateway guardian read failed; deferring USER.md cleanup for retry",
-      );
-      throw new Error(
-        "Gateway guardian read failed; deferring USER.md cleanup for retry",
-      );
-    }
-
-    let guardian: { id: string; displayName: string; userFile: string | null };
+    // Resolve the guardian contact from the local DB. Prefer the
+    // vellum-channel binding (the canonical native guardian); fall back to
+    // whichever guardian has the most recently verified active channel.
+    let guardianRow: GuardianRow | null;
     try {
-      const delivery =
-        guardianForChannel(guardians, "vellum") ?? anyGuardian(guardians);
-      const localContact = delivery
-        ? findContactByAddress(delivery.channelType, delivery.address)
-        : null;
-      if (!localContact) {
-        // Fresh install or pre-onboarding. If a stale USER.md somehow
-        // remains on disk (e.g. leftover from an older build), best-
-        // effort remove it so future first runs are clean.
-        if (existsSync(userMdPath)) {
-          try {
-            unlinkSync(userMdPath);
-            log.info(
-              { path: userMdPath },
-              "Deleted stale pre-onboarding USER.md with no guardian",
-            );
-          } catch (err) {
-            log.warn(
-              { err, path: userMdPath },
-              "Failed to delete pre-onboarding USER.md; leaving in place",
-            );
-          }
-        }
-        return;
-      }
-      guardian = {
-        id: localContact.id,
-        displayName: localContact.displayName,
-        userFile: localContact.userFile ?? null,
-      };
+      guardianRow =
+        getSqlite()
+          .query<GuardianRow, []>(
+            `SELECT c.id AS id, c.display_name AS display_name, c.user_file AS user_file
+               FROM contacts c JOIN contact_channels cc ON cc.contact_id = c.id
+              WHERE c.role = 'guardian' AND cc.status = 'active'
+              ORDER BY (cc.type = 'vellum') DESC, cc.verified_at DESC
+              LIMIT 1`,
+          )
+          .get() ?? null;
     } catch (err) {
       // DB not ready or query failed — leave USER.md alone. The next
       // startup after DB init will try again.
@@ -219,15 +168,41 @@ export const dropUserMdMigration: WorkspaceMigration = {
       return;
     }
 
+    if (!guardianRow) {
+      // Fresh install or pre-onboarding. If a stale USER.md somehow remains
+      // on disk (e.g. leftover from an older build), best-effort remove it so
+      // future first runs are clean.
+      if (existsSync(userMdPath)) {
+        try {
+          unlinkSync(userMdPath);
+          log.info(
+            { path: userMdPath },
+            "Deleted stale pre-onboarding USER.md with no guardian",
+          );
+        } catch (err) {
+          log.warn(
+            { err, path: userMdPath },
+            "Failed to delete pre-onboarding USER.md; leaving in place",
+          );
+        }
+      }
+      return;
+    }
+
+    const guardian = {
+      id: guardianRow.id,
+      displayName: guardianRow.display_name,
+      userFile: guardianRow.user_file ?? null,
+    };
+
     // Backfill a userFile slug on the guardian contact if one isn't set.
     if (!guardian.userFile) {
       try {
         const slug = generateUserFileSlug(guardian.displayName);
-        const db = getDb();
-        db.update(contacts)
-          .set({ userFile: slug })
-          .where(eq(contacts.id, guardian.id))
-          .run();
+        getSqlite().run("UPDATE contacts SET user_file = ? WHERE id = ?", [
+          slug,
+          guardian.id,
+        ]);
         guardian.userFile = slug;
         log.info(
           { contactId: guardian.id, slug },

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -316,9 +316,8 @@ export const dropUserMdMigration: WorkspaceMigration = {
       }
     }
 
-    // Finally, delete the legacy USER.md if it still exists. Template
-    // or customized, it has no remaining consumer now that PR 11
-    // dropped the seed/fallback read path.
+    // Finally, delete the legacy USER.md if it still exists — template or
+    // customized, it has no remaining consumer.
     if (existsSync(userMdPath)) {
       try {
         unlinkSync(userMdPath);


### PR DESCRIPTION
## Summary
- 031-drop-user-md resolves the guardian via a frozen raw-SQL local read instead of the live gateway IPC (restores migration self-containment; removes the gateway-availability coupling + the data-loss/defer/retry complexity it required)
- run() is sync again; retryFailedCheckpoint removed
- Drop historical DRAIN-MISS / PR-N comments across the B2 diff

Follow-up to the Combo 11 Phase B2 feature branch.