### PR TITLE
fix(web): slow the research-onboarding loading carousel rotation

### DIFF
--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -213,6 +213,9 @@ const LOOKING_MESSAGES = [
   "Almost there…",
 ];
 
+/** How long each rotating message lingers before advancing to the next. */
+const LOOKING_MESSAGE_INTERVAL_MS = 2800;
+
 export function LookingYouUpStep({
   onDone,
   onBack,
@@ -232,10 +235,13 @@ export function LookingYouUpStep({
   useEffect(() => {
     onAdvance?.(index);
     if (index >= LOOKING_MESSAGES.length - 1) {
-      const done = setTimeout(onDone, 1500);
+      const done = setTimeout(onDone, LOOKING_MESSAGE_INTERVAL_MS);
       return () => clearTimeout(done);
     }
-    const next = setTimeout(() => setIndex((i) => i + 1), 1500);
+    const next = setTimeout(
+      () => setIndex((i) => i + 1),
+      LOOKING_MESSAGE_INTERVAL_MS,
+    );
     return () => clearTimeout(next);
   }, [index, onDone, onAdvance]);
 


### PR DESCRIPTION
## What

Slows the rotating "looking you up" placeholder messages shown during the research-onboarding flow while research claims resolve.

Each message now lingers **2800ms** instead of **1500ms**, giving users time to read each line. The timing is extracted into a named `LOOKING_MESSAGE_INTERVAL_MS` constant (previously a hardcoded `1500`), applied to both the inter-message advance and the final hold before the step completes.

## Why

The messages cycled too fast to comfortably read.

## Notes

- File: `clients/web/src/domains/onboarding/screens/research-result-steps.tsx`
- The unrelated `POLL_INTERVAL_MS` (1500ms) in `research-runner.ts` — which polls for actual research claims — was intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)