### PR TITLE
fix(web): slow the research-onboarding loading carousel rotation

### DIFF
--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -226,6 +226,9 @@ const LOOKING_MESSAGES = [
   "Almost there…",
 ];
 
+/** How long each rotating message lingers before advancing to the next. */
+const LOOKING_MESSAGE_INTERVAL_MS = 2800;
+
 export function LookingYouUpStep({
   onDone,
   onBack,
@@ -255,12 +258,12 @@ export function LookingYouUpStep({
     // Finish on the last message once research is ready; otherwise keep cycling
     // (looping back to the start) until it lands.
     if (ready && isLast) {
-      const done = setTimeout(onDone, 1500);
+      const done = setTimeout(onDone, LOOKING_MESSAGE_INTERVAL_MS);
       return () => clearTimeout(done);
     }
     const next = setTimeout(
       () => setIndex((i) => (i + 1) % LOOKING_MESSAGES.length),
-      1500,
+      LOOKING_MESSAGE_INTERVAL_MS,
     );
     return () => clearTimeout(next);
   }, [index, ready, onDone, onAdvance]);


### PR DESCRIPTION
## What

Slows the rotating "looking you up" placeholder messages shown during the research-onboarding flow while research claims resolve.

Each message now lingers **2800ms** instead of **1500ms**, giving users time to read each line. The timing is extracted into a named `LOOKING_MESSAGE_INTERVAL_MS` constant (previously a hardcoded `1500`), applied to both the message cycle and the final hold before advancing once research is ready.

## Why

The messages cycled too fast to comfortably read.

## Notes

- File: `clients/web/src/domains/onboarding/screens/research-result-steps.tsx`
- The unrelated `POLL_INTERVAL_MS` (1500ms) in `research-runner.ts` — which polls for actual research claims — was intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)