### PR TITLE
Fix channel admission UI nits + enable trust-floors flag by default

### DIFF
--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -43,22 +43,22 @@ const POLICY_CONFIRMATIONS: Partial<
   >
 > = {
   no_one: {
-    title: "Block all inbound messages?",
+    title: "Block all messages?",
     message:
-      "Setting this channel to “No one” hard-denies every inbound message — including messages from you. You can reverse this at any time.",
+      "Setting this channel to “No one” hard-denies every inbound message — including messages from you.\n\nYou can reverse this at any time.",
     confirmLabel: "Block all",
     destructive: true,
   },
   any_contact: {
-    title: "Allow any contact to reach your assistant?",
+    title: "Allow any contact?",
     message:
-      "“Any contact” admits every matched contact in this channel — including pending, unverified ones — not just your verified contacts. Best for channels consisting of only people you already trust.",
+      "“Any contact” admits every matched contact in this channel — including pending, unverified ones — not just your verified contacts.\n\nBest for channels consisting of only people you already trust.",
     confirmLabel: "Allow any contact",
   },
   strangers: {
-    title: "Allow strangers to reach your assistant?",
+    title: "Allow strangers?",
     message:
-      "Are you sure you want to allow strangers to contact your assistant through this channel? Doing so could cost you money and open you up to security and privacy vulnerabilities. Enable with extreme caution.",
+      "Are you sure you want to allow strangers to contact your assistant through this channel?\n\nDoing so could cost you money and open you up to security and privacy vulnerabilities.\n\nEnable with extreme caution.",
     confirmLabel: "Allow strangers",
     destructive: true,
   },

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -399,8 +399,8 @@
       "scope": "assistant",
       "key": "channel-trust-floors",
       "label": "Channel Trust Floors",
-      "description": "Expose the Channel Trust Floors settings card (per-channel inbound admission policy) on the Privacy settings page. When off, the card is hidden and channels fall back to their default admission floors. Off by default while the feature is in development.",
-      "defaultEnabled": false
+      "description": "Expose the per-channel “Who Can Reach” admission control (inbound trust floor) inline on each connected channel in Contacts → Channels. When off, the control is hidden and channels fall back to their default admission floor.",
+      "defaultEnabled": true
     },
     {
       "id": "mcp-add-server",

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -358,7 +358,10 @@ export function Dropdown<T extends string>({
             <span className="flex min-w-0 flex-1 items-center gap-2">
               <span
                 className="min-w-0 flex-1 truncate"
-                title={option.label || undefined}
+                // Skip the native title when a styled tooltip is present — it
+                // would surface a second, redundant browser tooltip repeating
+                // the label. Truncation recovery still applies otherwise.
+                title={option.tooltip ? undefined : option.label || undefined}
               >
                 {option.label}
               </span>


### PR DESCRIPTION
Follow-up fixes after #36051 merged, plus enabling the feature.

## Fixes
1. **Double tooltip on the "Who Can Reach" dropdown** — each option showed two overlapping tooltips: the native browser `title` (repeating the label) and our styled `Tooltip` (the description). The dropdown now skips the native `title` when a styled `tooltip` is present. Truncation-recovery `title` still applies to options without tooltips.
2. **Confirmation modal titles truncated** — `Modal.Title` is single-line/truncating, so the long titles were clipped ("Allow strangers to reach your…"). Shortened to **"Block all messages?"**, **"Allow any contact?"**, **"Allow strangers?"**.
3. **Confirmation body copy now has paragraph breaks** — `Modal.Description` renders `whitespace-pre-line`, so the messages now use blank lines between sentences for readability.

## Feature enablement
- Flipped the **`channel-trust-floors`** feature flag to **`defaultEnabled: true`**.
- Updated its registry description (it was stale — referenced a "Privacy settings card"; the control now lives inline on each connected channel in **Contacts → Channels**).

## Testing
- `dropdown.test.tsx` — 6 pass
- `assistant-feature-flag-store.test.ts` — 4 pass
- eslint clean on changed files; registry JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)