### PR TITLE
feat(web): ChatBody hosts subagent + workflow overlay pills side by side

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -309,6 +309,81 @@ describe("ChatBody — active subagents overlay slot", () => {
   });
 });
 
+describe("ChatBody — active workflows overlay slot", () => {
+  const activeSubagentsSlot = (
+    <div data-testid="active-subagents-slot">ACTIVE_SUBAGENTS</div>
+  );
+  const activeWorkflowsSlot = (
+    <div data-testid="active-workflows-slot">ACTIVE_WORKFLOWS</div>
+  );
+
+  test("renders the slot top-center when scrolled up and slot is provided", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("does NOT render the slot when pinned (showScrollToLatest false)", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: false,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("does NOT render the slot on the empty state", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...withEmptyState({
+          showScrollToLatest: true,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("renders BOTH slots simultaneously when both are provided", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("ACTIVE_SUBAGENTS");
+    expect(html).toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("renders the subagent pill to the LEFT of the workflow pill", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    // DOM order: subagents must precede workflows in the centered row.
+    expect(html.indexOf("ACTIVE_SUBAGENTS")).toBeLessThan(
+      html.indexOf("ACTIVE_WORKFLOWS"),
+    );
+  });
+});
+
 describe("ChatBody — read-only cancellation", () => {
   test("renders the read-only banner without a stop control while idle", () => {
     const html = renderToStaticMarkup(

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -155,6 +155,9 @@ export interface ChatBodyProps {
    * only when there is ≥1 active subagent.
    */
   activeSubagentsSlot?: ReactNode;
+
+  /** Floating overlay for active workflow runs; gated like activeSubagentsSlot. */
+  activeWorkflowsSlot?: ReactNode;
 }
 
 /**
@@ -211,6 +214,7 @@ export function ChatBody({
   readonlyBannerSlot,
   startersSlot,
   activeSubagentsSlot,
+  activeWorkflowsSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
 
@@ -247,11 +251,15 @@ export function ChatBody({
     >
       <ChatScrollArea {...scrollAreaProps} />
 
-      {!isEmptyState && showScrollToLatest && activeSubagentsSlot && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center px-3 pt-2">
-          {activeSubagentsSlot}
-        </div>
-      )}
+      {!isEmptyState &&
+        showScrollToLatest &&
+        (activeSubagentsSlot || activeWorkflowsSlot) && (
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
+            {/* subagents on the left, workflows on the right (do not reorder) */}
+            {activeSubagentsSlot}
+            {activeWorkflowsSlot}
+          </div>
+        )}
 
       {/* Composer stack — stays at the same tree position across the
           empty→active transition so React preserves its state (focus,


### PR DESCRIPTION
## Summary
- ChatBody gains an activeWorkflowsSlot prop and renders both overlay pills in one centered top-row, subagents left / workflows right, under the existing scroll + non-empty gating.

Part of plan: active-workflows-overlay-pill.md (PR 3 of 5)