### PR TITLE
feat(web): ActiveWorkflowsOverlay floating pill + expandable dropdown

### DIFF
--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for `ActiveWorkflowsOverlay`.
+ *
+ * `WorkflowInlineProgressCard` renders `null` until its store entry exists
+ * (spawn race), so it is mocked to a testid stub here to keep the overlay test
+ * focused on the overlay's own empty/collapsed/expanded states and the
+ * Escape / outside-click dismissal — not workflow-store hydration.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+mock.module(
+  "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card",
+  () => ({
+    WorkflowInlineProgressCard: ({ runId }: { runId: string }) => (
+      <div data-testid="wf-card" data-run-id={runId} />
+    ),
+  }),
+);
+
+import { ActiveWorkflowsOverlay } from "@/domains/chat/components/active-workflows-overlay/active-workflows-overlay";
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+function makeIds(count: number): string[] {
+  return Array.from({ length: count }, (_, i) => `wf-${i}`);
+}
+
+describe("ActiveWorkflowsOverlay — empty", () => {
+  test("renders nothing when workflowRunIds is empty", () => {
+    const { queryByTestId } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={[]} />,
+    );
+    expect(queryByTestId("active-workflows-overlay")).toBeNull();
+  });
+});
+
+describe("ActiveWorkflowsOverlay — collapsed", () => {
+  test("shows the pill with the count and hides the panel", () => {
+    const ids = makeIds(3);
+    const { queryByText, queryAllByTestId } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    const pill = screen.getByRole("button", { name: /active workflows/i });
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
+    // Count is rendered in the pill.
+    expect(queryByText("3")).toBeTruthy();
+    // Panel is collapsed: no title, no cards.
+    expect(queryByText("3 Active Workflows")).toBeNull();
+    expect(queryAllByTestId("wf-card").length).toBe(0);
+  });
+
+  test("root is pointer-events-none so the gutter doesn't block the transcript", () => {
+    const ids = makeIds(2);
+    render(<ActiveWorkflowsOverlay workflowRunIds={ids} />);
+    expect(
+      screen.getByTestId("active-workflows-overlay").className,
+    ).toContain("pointer-events-none");
+  });
+});
+
+describe("ActiveWorkflowsOverlay — expanded", () => {
+  test("clicking the pill reveals the panel with the title and one card per id", () => {
+    const ids = makeIds(3);
+    const { getByText, getAllByTestId } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    const pill = screen.getByRole("button", { name: /active workflows/i });
+    fireEvent.click(pill);
+
+    expect(pill.getAttribute("aria-expanded")).toBe("true");
+    expect(getByText("3 Active Workflows")).toBeTruthy();
+    expect(getAllByTestId("wf-card").length).toBe(3);
+  });
+
+  test("uses the singular noun when exactly one workflow is active", () => {
+    const ids = makeIds(1);
+    render(<ActiveWorkflowsOverlay workflowRunIds={ids} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflow/i }));
+
+    expect(screen.getByText("1 Active Workflow")).toBeTruthy();
+    expect(screen.queryByText("1 Active Workflows")).toBeNull();
+  });
+});
+
+describe("ActiveWorkflowsOverlay — dismissal", () => {
+  test("Escape collapses the open panel", () => {
+    const ids = makeIds(2);
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(queryByText("2 Active Workflows")).toBeNull();
+  });
+
+  test("pointerdown outside the container collapses the open panel", () => {
+    const ids = makeIds(2);
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
+
+    fireEvent.pointerDown(document.body);
+    expect(queryByText("2 Active Workflows")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ActiveWorkflowsPill } from "@/domains/chat/components/active-workflows-overlay/active-workflows-pill";
+import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
+
+export interface ActiveWorkflowsOverlayProps {
+  workflowRunIds: string[];
+  onWorkflowClick?: (runId: string) => void;
+  onStopWorkflow?: (runId: string) => void;
+}
+
+export function ActiveWorkflowsOverlay({
+  workflowRunIds,
+  onWorkflowClick,
+  onStopWorkflow,
+}: ActiveWorkflowsOverlayProps) {
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Defensive: collapse if the active set drains while open.
+  useEffect(() => {
+    if (workflowRunIds.length === 0) setExpanded(false);
+  }, [workflowRunIds.length]);
+
+  // While open, dismiss on outside pointerdown or Escape.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expanded]);
+
+  if (workflowRunIds.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="active-workflows-overlay"
+      // none here so gutter clicks reach the transcript; pill + panel re-enable. 589px per Figma 6063:149685.
+      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
+    >
+      <ActiveWorkflowsPill
+        count={workflowRunIds.length}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
+
+      {expanded && (
+        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+          <Typography
+            variant="title-small"
+            className="text-[var(--content-emphasised)]"
+          >
+            {workflowRunIds.length} Active Workflow
+            {workflowRunIds.length === 1 ? "" : "s"}
+          </Typography>
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+            {workflowRunIds.map((runId) => (
+              <WorkflowInlineProgressCard
+                key={runId}
+                runId={runId}
+                onWorkflowClick={onWorkflowClick}
+                onStopWorkflow={onStopWorkflow}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-pill.tsx
@@ -1,0 +1,45 @@
+import { ChevronDown, ChevronUp, Workflow } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ChatPill } from "@/domains/chat/components/chat-pill";
+
+export interface ActiveWorkflowsPillProps {
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function ActiveWorkflowsPill({
+  count,
+  expanded,
+  onToggle,
+}: ActiveWorkflowsPillProps) {
+  return (
+    <ChatPill
+      onClick={onToggle}
+      ariaLabel={`${count} active workflow${count === 1 ? "" : "s"}`}
+      ariaExpanded={expanded}
+      size="compact"
+    >
+      {/* pointer-events-none so the ChatPill button owns clicks + cursor — clicking anywhere toggles. */}
+      <span className="pointer-events-none inline-flex items-center gap-1.5">
+        <Workflow
+          className="h-4 w-4 shrink-0 text-[var(--content-secondary)]"
+          aria-hidden
+        />
+        <Typography
+          variant="body-small-default"
+          className="text-[var(--content-emphasised)]"
+        >
+          {count}
+        </Typography>
+        {expanded ? (
+          <ChevronUp className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" aria-hidden />
+        ) : (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" aria-hidden />
+        )}
+      </span>
+    </ChatPill>
+  );
+}


### PR DESCRIPTION
## Summary
- New ActiveWorkflowsOverlay + ActiveWorkflowsPill (Workflow glyph + count + chevron, no avatars).
- Expanded dropdown reuses WorkflowInlineProgressCard rows; Escape/outside-click dismissal mirrors the subagent overlay.

Part of plan: active-workflows-overlay-pill.md (PR 2 of 5)