### PR TITLE
feat(web): wire active-workflows overlay into the chat main panel

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -20,6 +20,7 @@
 import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
+import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
@@ -37,6 +38,7 @@ import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attach
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
+import { ActiveWorkflowsOverlay } from "@/domains/chat/components/active-workflows-overlay/active-workflows-overlay";
 import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
@@ -263,6 +265,7 @@ export function ChatMainPanel({
   }, [assistantId]);
 
   const activeSubagentIds = useActiveSubagentIds();
+  const activeWorkflowRunIds = useActiveWorkflowRunIds();
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);
@@ -841,6 +844,15 @@ export function ChatMainPanel({
       />
     ) : undefined;
 
+  const activeWorkflowsSlot =
+    activeWorkflowRunIds.length > 0 ? (
+      <ActiveWorkflowsOverlay
+        workflowRunIds={activeWorkflowRunIds}
+        onWorkflowClick={onWorkflowClick}
+        onStopWorkflow={onStopWorkflow}
+      />
+    ) : undefined;
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -877,6 +889,7 @@ export function ChatMainPanel({
         readonlyBannerSlot={channelReadonlyBannerSlot}
         startersSlot={startersSlot}
         activeSubagentsSlot={activeSubagentsSlot}
+        activeWorkflowsSlot={activeWorkflowsSlot}
       />
       <MicPermissionPrimer
         open={showPrimer}


### PR DESCRIPTION
## Summary
- ChatMainPanel now derives active workflow run ids and passes an ActiveWorkflowsOverlay slot to ChatBody, reusing the existing onWorkflowClick/onStopWorkflow handlers. Completes the both-pills feature.

Part of plan: active-workflows-overlay-pill.md (PR 4 of 5)