### PR TITLE
fix(web): let subagent + workflow pills sit adjacent (absolute dropdowns)

### DIFF
--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -81,8 +81,15 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     fireEvent.click(pill);
 
     expect(pill.getAttribute("aria-expanded")).toBe("true");
-    expect(getByText("3 Active Subagents")).toBeTruthy();
+    const title = getByText("3 Active Subagents");
+    expect(title).toBeTruthy();
     expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
+
+    // Panel is an absolutely-positioned dropdown so its width can't stretch the
+    // row when a sibling overlay pill is present (regression guard).
+    const panel = title.parentElement;
+    expect(panel?.className).toContain("absolute");
+    expect(panel?.className).toContain("pointer-events-auto");
   });
 
   test("clicking a collapsed avatar expands the panel", () => {

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -54,8 +54,9 @@ export function ActiveSubagentsOverlay({
     <div
       ref={containerRef}
       data-testid="active-subagents-overlay"
-      // none here so gutter clicks reach the transcript; pill + panel re-enable. 589px per Figma 6063:149685.
-      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
+      // Content-width + relative so the pill can sit adjacent to a sibling overlay
+      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
+      className="pointer-events-none relative flex w-auto flex-col items-center"
     >
       <ActiveSubagentsPill
         subagentIds={subagentIds}
@@ -64,7 +65,9 @@ export function ActiveSubagentsOverlay({
       />
 
       {expanded && (
-        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+        // Absolute dropdown anchored under the pill so its 589px width no longer
+        // dictates the row's width (Figma 6063:149685).
+        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -79,8 +79,15 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
     fireEvent.click(pill);
 
     expect(pill.getAttribute("aria-expanded")).toBe("true");
-    expect(getByText("3 Active Workflows")).toBeTruthy();
+    const title = getByText("3 Active Workflows");
+    expect(title).toBeTruthy();
     expect(getAllByTestId("wf-card").length).toBe(3);
+
+    // Panel is an absolutely-positioned dropdown so its width can't stretch the
+    // row when a sibling overlay pill is present (regression guard).
+    const panel = title.parentElement;
+    expect(panel?.className).toContain("absolute");
+    expect(panel?.className).toContain("pointer-events-auto");
   });
 
   test("uses the singular noun when exactly one workflow is active", () => {

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -54,8 +54,9 @@ export function ActiveWorkflowsOverlay({
     <div
       ref={containerRef}
       data-testid="active-workflows-overlay"
-      // none here so gutter clicks reach the transcript; pill + panel re-enable. 589px per Figma 6063:149685.
-      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
+      // Content-width + relative so the pill can sit adjacent to a sibling overlay
+      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
+      className="pointer-events-none relative flex w-auto flex-col items-center"
     >
       <ActiveWorkflowsPill
         count={workflowRunIds.length}
@@ -64,7 +65,9 @@ export function ActiveWorkflowsOverlay({
       />
 
       {expanded && (
-        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+        // Absolute dropdown anchored under the pill so its 589px width no longer
+        // dictates the row's width (Figma 6063:149685).
+        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"


### PR DESCRIPTION
## Summary
- Decouple each overlay's dropdown width from its pill: collapsed root is now content-width and the expanded panel is an absolutely-positioned dropdown, so the subagent and workflow pills sit adjacent/centered instead of being pushed apart. Applied to both overlays for consistency.

Part of plan: active-workflows-overlay-pill.md (PR 5 of 5)