### PR TITLE
refactor(web): extract shared ActiveOverlayShell from the active-* overlays

### DIFF
--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -1,0 +1,85 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+export interface ActiveOverlayShellProps {
+  /** `data-testid` for the root container (e.g. `"active-workflows-overlay"`). */
+  testId: string;
+  /** Pre-formatted, already-singularized title, e.g. `"3 Active Workflows"`. */
+  title: string;
+  /** Renders the pill; receives the current expand state + a toggle handler. */
+  renderPill: (args: { expanded: boolean; onToggle: () => void }) => ReactNode;
+  /** The mapped inline-card rows shown inside the expanded dropdown. */
+  children: ReactNode;
+}
+
+/**
+ * Shared chrome for the floating "active X" overlays (subagents, workflows).
+ *
+ * Owns the expand/collapse state, the dismissal effects (collapse-on-empty is
+ * left to callers via their `length === 0` guard; Escape + outside-pointerdown
+ * live here), the relative root container, and the absolute dropdown panel with
+ * its title. Callers supply the pill (via `renderPill`) and the inline-card rows
+ * (via `children`), which are the only things that differ between overlays.
+ */
+export function ActiveOverlayShell({
+  testId,
+  title,
+  renderPill,
+  children,
+}: ActiveOverlayShellProps) {
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // While open, dismiss on outside pointerdown or Escape.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expanded]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid={testId}
+      // Content-width + relative so the pill can sit adjacent to a sibling overlay
+      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
+      className="pointer-events-none relative flex w-auto flex-col items-center"
+    >
+      {renderPill({ expanded, onToggle: () => setExpanded((v) => !v) })}
+
+      {expanded && (
+        // Absolute dropdown anchored under the pill so its 589px width no longer
+        // dictates the row's width (Figma 6063:149685).
+        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+          <Typography
+            variant="title-small"
+            className="text-[var(--content-emphasised)]"
+          >
+            {title}
+          </Typography>
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+            {children}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useRef, useState } from "react";
-
-import { Typography } from "@vellumai/design-library";
-
+import { ActiveOverlayShell } from "@/domains/chat/components/active-overlay-shell";
 import { ActiveSubagentsPill } from "@/domains/chat/components/active-subagents-overlay/active-subagents-pill";
 import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
 
@@ -16,77 +13,30 @@ export function ActiveSubagentsOverlay({
   onSubagentClick,
   onStopSubagent,
 }: ActiveSubagentsOverlayProps) {
-  const [expanded, setExpanded] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  // Defensive: collapse if the active set drains while open.
-  useEffect(() => {
-    if (subagentIds.length === 0) setExpanded(false);
-  }, [subagentIds.length]);
-
-  // While open, dismiss on outside pointerdown or Escape.
-  useEffect(() => {
-    if (!expanded) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setExpanded(false);
-      }
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setExpanded(false);
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [expanded]);
-
   if (subagentIds.length === 0) return null;
 
   return (
-    <div
-      ref={containerRef}
-      data-testid="active-subagents-overlay"
-      // Content-width + relative so the pill can sit adjacent to a sibling overlay
-      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
-      className="pointer-events-none relative flex w-auto flex-col items-center"
-    >
-      <ActiveSubagentsPill
-        subagentIds={subagentIds}
-        expanded={expanded}
-        onToggle={() => setExpanded((v) => !v)}
-      />
-
-      {expanded && (
-        // Absolute dropdown anchored under the pill so its 589px width no longer
-        // dictates the row's width (Figma 6063:149685).
-        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
-          <Typography
-            variant="title-small"
-            className="text-[var(--content-emphasised)]"
-          >
-            {subagentIds.length} Active Subagent
-            {subagentIds.length === 1 ? "" : "s"}
-          </Typography>
-          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-            {subagentIds.map((id) => (
-              <SubagentInlineProgressCard
-                key={id}
-                subagentId={id}
-                onSubagentClick={onSubagentClick}
-                onStopSubagent={onStopSubagent}
-              />
-            ))}
-          </div>
-        </div>
+    <ActiveOverlayShell
+      testId="active-subagents-overlay"
+      title={`${subagentIds.length} Active Subagent${
+        subagentIds.length === 1 ? "" : "s"
+      }`}
+      renderPill={({ expanded, onToggle }) => (
+        <ActiveSubagentsPill
+          subagentIds={subagentIds}
+          expanded={expanded}
+          onToggle={onToggle}
+        />
       )}
-    </div>
+    >
+      {subagentIds.map((id) => (
+        <SubagentInlineProgressCard
+          key={id}
+          subagentId={id}
+          onSubagentClick={onSubagentClick}
+          onStopSubagent={onStopSubagent}
+        />
+      ))}
+    </ActiveOverlayShell>
   );
 }

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useRef, useState } from "react";
-
-import { Typography } from "@vellumai/design-library";
-
+import { ActiveOverlayShell } from "@/domains/chat/components/active-overlay-shell";
 import { ActiveWorkflowsPill } from "@/domains/chat/components/active-workflows-overlay/active-workflows-pill";
 import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
 
@@ -16,77 +13,30 @@ export function ActiveWorkflowsOverlay({
   onWorkflowClick,
   onStopWorkflow,
 }: ActiveWorkflowsOverlayProps) {
-  const [expanded, setExpanded] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  // Defensive: collapse if the active set drains while open.
-  useEffect(() => {
-    if (workflowRunIds.length === 0) setExpanded(false);
-  }, [workflowRunIds.length]);
-
-  // While open, dismiss on outside pointerdown or Escape.
-  useEffect(() => {
-    if (!expanded) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setExpanded(false);
-      }
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setExpanded(false);
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [expanded]);
-
   if (workflowRunIds.length === 0) return null;
 
   return (
-    <div
-      ref={containerRef}
-      data-testid="active-workflows-overlay"
-      // Content-width + relative so the pill can sit adjacent to a sibling overlay
-      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
-      className="pointer-events-none relative flex w-auto flex-col items-center"
-    >
-      <ActiveWorkflowsPill
-        count={workflowRunIds.length}
-        expanded={expanded}
-        onToggle={() => setExpanded((v) => !v)}
-      />
-
-      {expanded && (
-        // Absolute dropdown anchored under the pill so its 589px width no longer
-        // dictates the row's width (Figma 6063:149685).
-        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
-          <Typography
-            variant="title-small"
-            className="text-[var(--content-emphasised)]"
-          >
-            {workflowRunIds.length} Active Workflow
-            {workflowRunIds.length === 1 ? "" : "s"}
-          </Typography>
-          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-            {workflowRunIds.map((runId) => (
-              <WorkflowInlineProgressCard
-                key={runId}
-                runId={runId}
-                onWorkflowClick={onWorkflowClick}
-                onStopWorkflow={onStopWorkflow}
-              />
-            ))}
-          </div>
-        </div>
+    <ActiveOverlayShell
+      testId="active-workflows-overlay"
+      title={`${workflowRunIds.length} Active Workflow${
+        workflowRunIds.length === 1 ? "" : "s"
+      }`}
+      renderPill={({ expanded, onToggle }) => (
+        <ActiveWorkflowsPill
+          count={workflowRunIds.length}
+          expanded={expanded}
+          onToggle={onToggle}
+        />
       )}
-    </div>
+    >
+      {workflowRunIds.map((runId) => (
+        <WorkflowInlineProgressCard
+          key={runId}
+          runId={runId}
+          onWorkflowClick={onWorkflowClick}
+          onStopWorkflow={onStopWorkflow}
+        />
+      ))}
+    </ActiveOverlayShell>
   );
 }


### PR DESCRIPTION
## Summary
Fixes a slop/reuse gap from plan self-review: ActiveWorkflowsOverlay and ActiveSubagentsOverlay were byte-identical except for the pill + inline-card type. Extracts a shared ActiveOverlayShell (expand/dismiss state, container, absolute dropdown, title); both overlays become thin wrappers. Pills stay separate. Behavior-preserving.

**Gap:** ActiveWorkflowsOverlay is a pure rename of ActiveSubagentsOverlay (PR 5 had to edit both in lockstep).

Part of plan: active-workflows-overlay-pill.md (self-review remediation)