### PR TITLE
feat(web): active workflows floating overlay pill

### DIFF
--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -44,7 +44,14 @@ export function ActiveOverlayShell({
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setExpanded(false);
+      if (event.key === "Escape") {
+        // Claim Escape so it dismisses only this dropdown, not also an
+        // underlying side panel: `ChatContentLayout`'s window keydown handler
+        // bails on `event.defaultPrevented`. The listener is attached only
+        // while expanded, so reaching here always means we own this Escape.
+        event.preventDefault();
+        setExpanded(false);
+      }
     };
 
     document.addEventListener("pointerdown", handlePointerDown);

--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -1,0 +1,85 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+export interface ActiveOverlayShellProps {
+  /** `data-testid` for the root container (e.g. `"active-workflows-overlay"`). */
+  testId: string;
+  /** Pre-formatted, already-singularized title, e.g. `"3 Active Workflows"`. */
+  title: string;
+  /** Renders the pill; receives the current expand state + a toggle handler. */
+  renderPill: (args: { expanded: boolean; onToggle: () => void }) => ReactNode;
+  /** The mapped inline-card rows shown inside the expanded dropdown. */
+  children: ReactNode;
+}
+
+/**
+ * Shared chrome for the floating "active X" overlays (subagents, workflows).
+ *
+ * Owns the expand/collapse state, the dismissal effects (collapse-on-empty is
+ * left to callers via their `length === 0` guard; Escape + outside-pointerdown
+ * live here), the relative root container, and the absolute dropdown panel with
+ * its title. Callers supply the pill (via `renderPill`) and the inline-card rows
+ * (via `children`), which are the only things that differ between overlays.
+ */
+export function ActiveOverlayShell({
+  testId,
+  title,
+  renderPill,
+  children,
+}: ActiveOverlayShellProps) {
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // While open, dismiss on outside pointerdown or Escape.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expanded]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid={testId}
+      // Content-width + relative so the pill can sit adjacent to a sibling overlay
+      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
+      className="pointer-events-none relative flex w-auto flex-col items-center"
+    >
+      {renderPill({ expanded, onToggle: () => setExpanded((v) => !v) })}
+
+      {expanded && (
+        // Absolute dropdown anchored under the pill so its 589px width no longer
+        // dictates the row's width (Figma 6063:149685).
+        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+          <Typography
+            variant="title-small"
+            className="text-[var(--content-emphasised)]"
+          >
+            {title}
+          </Typography>
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+            {children}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -81,8 +81,15 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     fireEvent.click(pill);
 
     expect(pill.getAttribute("aria-expanded")).toBe("true");
-    expect(getByText("3 Active Subagents")).toBeTruthy();
+    const title = getByText("3 Active Subagents");
+    expect(title).toBeTruthy();
     expect(getAllByTestId("subagent-inline-progress-card").length).toBe(3);
+
+    // Panel is an absolutely-positioned dropdown so its width can't stretch the
+    // row when a sibling overlay pill is present (regression guard).
+    const panel = title.parentElement;
+    expect(panel?.className).toContain("absolute");
+    expect(panel?.className).toContain("pointer-events-auto");
   });
 
   test("clicking a collapsed avatar expands the panel", () => {

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -54,8 +54,9 @@ export function ActiveSubagentsOverlay({
     <div
       ref={containerRef}
       data-testid="active-subagents-overlay"
-      // none here so gutter clicks reach the transcript; pill + panel re-enable. 589px per Figma 6063:149685.
-      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
+      // Content-width + relative so the pill can sit adjacent to a sibling overlay
+      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
+      className="pointer-events-none relative flex w-auto flex-col items-center"
     >
       <ActiveSubagentsPill
         subagentIds={subagentIds}
@@ -64,7 +65,9 @@ export function ActiveSubagentsOverlay({
       />
 
       {expanded && (
-        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+        // Absolute dropdown anchored under the pill so its 589px width no longer
+        // dictates the row's width (Figma 6063:149685).
+        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useRef, useState } from "react";
-
-import { Typography } from "@vellumai/design-library";
-
+import { ActiveOverlayShell } from "@/domains/chat/components/active-overlay-shell";
 import { ActiveSubagentsPill } from "@/domains/chat/components/active-subagents-overlay/active-subagents-pill";
 import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
 
@@ -16,77 +13,30 @@ export function ActiveSubagentsOverlay({
   onSubagentClick,
   onStopSubagent,
 }: ActiveSubagentsOverlayProps) {
-  const [expanded, setExpanded] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  // Defensive: collapse if the active set drains while open.
-  useEffect(() => {
-    if (subagentIds.length === 0) setExpanded(false);
-  }, [subagentIds.length]);
-
-  // While open, dismiss on outside pointerdown or Escape.
-  useEffect(() => {
-    if (!expanded) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setExpanded(false);
-      }
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setExpanded(false);
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [expanded]);
-
   if (subagentIds.length === 0) return null;
 
   return (
-    <div
-      ref={containerRef}
-      data-testid="active-subagents-overlay"
-      // Content-width + relative so the pill can sit adjacent to a sibling overlay
-      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
-      className="pointer-events-none relative flex w-auto flex-col items-center"
-    >
-      <ActiveSubagentsPill
-        subagentIds={subagentIds}
-        expanded={expanded}
-        onToggle={() => setExpanded((v) => !v)}
-      />
-
-      {expanded && (
-        // Absolute dropdown anchored under the pill so its 589px width no longer
-        // dictates the row's width (Figma 6063:149685).
-        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
-          <Typography
-            variant="title-small"
-            className="text-[var(--content-emphasised)]"
-          >
-            {subagentIds.length} Active Subagent
-            {subagentIds.length === 1 ? "" : "s"}
-          </Typography>
-          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-            {subagentIds.map((id) => (
-              <SubagentInlineProgressCard
-                key={id}
-                subagentId={id}
-                onSubagentClick={onSubagentClick}
-                onStopSubagent={onStopSubagent}
-              />
-            ))}
-          </div>
-        </div>
+    <ActiveOverlayShell
+      testId="active-subagents-overlay"
+      title={`${subagentIds.length} Active Subagent${
+        subagentIds.length === 1 ? "" : "s"
+      }`}
+      renderPill={({ expanded, onToggle }) => (
+        <ActiveSubagentsPill
+          subagentIds={subagentIds}
+          expanded={expanded}
+          onToggle={onToggle}
+        />
       )}
-    </div>
+    >
+      {subagentIds.map((id) => (
+        <SubagentInlineProgressCard
+          key={id}
+          subagentId={id}
+          onSubagentClick={onSubagentClick}
+          onStopSubagent={onStopSubagent}
+        />
+      ))}
+    </ActiveOverlayShell>
   );
 }

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -79,8 +79,15 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
     fireEvent.click(pill);
 
     expect(pill.getAttribute("aria-expanded")).toBe("true");
-    expect(getByText("3 Active Workflows")).toBeTruthy();
+    const title = getByText("3 Active Workflows");
+    expect(title).toBeTruthy();
     expect(getAllByTestId("wf-card").length).toBe(3);
+
+    // Panel is an absolutely-positioned dropdown so its width can't stretch the
+    // row when a sibling overlay pill is present (regression guard).
+    const panel = title.parentElement;
+    expect(panel?.className).toContain("absolute");
+    expect(panel?.className).toContain("pointer-events-auto");
   });
 
   test("uses the singular noun when exactly one workflow is active", () => {

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for `ActiveWorkflowsOverlay`.
+ *
+ * `WorkflowInlineProgressCard` renders `null` until its store entry exists
+ * (spawn race), so it is mocked to a testid stub here to keep the overlay test
+ * focused on the overlay's own empty/collapsed/expanded states and the
+ * Escape / outside-click dismissal — not workflow-store hydration.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+mock.module(
+  "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card",
+  () => ({
+    WorkflowInlineProgressCard: ({ runId }: { runId: string }) => (
+      <div data-testid="wf-card" data-run-id={runId} />
+    ),
+  }),
+);
+
+import { ActiveWorkflowsOverlay } from "@/domains/chat/components/active-workflows-overlay/active-workflows-overlay";
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+function makeIds(count: number): string[] {
+  return Array.from({ length: count }, (_, i) => `wf-${i}`);
+}
+
+describe("ActiveWorkflowsOverlay — empty", () => {
+  test("renders nothing when workflowRunIds is empty", () => {
+    const { queryByTestId } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={[]} />,
+    );
+    expect(queryByTestId("active-workflows-overlay")).toBeNull();
+  });
+});
+
+describe("ActiveWorkflowsOverlay — collapsed", () => {
+  test("shows the pill with the count and hides the panel", () => {
+    const ids = makeIds(3);
+    const { queryByText, queryAllByTestId } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    const pill = screen.getByRole("button", { name: /active workflows/i });
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
+    // Count is rendered in the pill.
+    expect(queryByText("3")).toBeTruthy();
+    // Panel is collapsed: no title, no cards.
+    expect(queryByText("3 Active Workflows")).toBeNull();
+    expect(queryAllByTestId("wf-card").length).toBe(0);
+  });
+
+  test("root is pointer-events-none so the gutter doesn't block the transcript", () => {
+    const ids = makeIds(2);
+    render(<ActiveWorkflowsOverlay workflowRunIds={ids} />);
+    expect(
+      screen.getByTestId("active-workflows-overlay").className,
+    ).toContain("pointer-events-none");
+  });
+});
+
+describe("ActiveWorkflowsOverlay — expanded", () => {
+  test("clicking the pill reveals the panel with the title and one card per id", () => {
+    const ids = makeIds(3);
+    const { getByText, getAllByTestId } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    const pill = screen.getByRole("button", { name: /active workflows/i });
+    fireEvent.click(pill);
+
+    expect(pill.getAttribute("aria-expanded")).toBe("true");
+    expect(getByText("3 Active Workflows")).toBeTruthy();
+    expect(getAllByTestId("wf-card").length).toBe(3);
+  });
+
+  test("uses the singular noun when exactly one workflow is active", () => {
+    const ids = makeIds(1);
+    render(<ActiveWorkflowsOverlay workflowRunIds={ids} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflow/i }));
+
+    expect(screen.getByText("1 Active Workflow")).toBeTruthy();
+    expect(screen.queryByText("1 Active Workflows")).toBeNull();
+  });
+});
+
+describe("ActiveWorkflowsOverlay — dismissal", () => {
+  test("Escape collapses the open panel", () => {
+    const ids = makeIds(2);
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(queryByText("2 Active Workflows")).toBeNull();
+  });
+
+  test("pointerdown outside the container collapses the open panel", () => {
+    const ids = makeIds(2);
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay workflowRunIds={ids} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
+
+    fireEvent.pointerDown(document.body);
+    expect(queryByText("2 Active Workflows")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -111,8 +111,13 @@ describe("ActiveWorkflowsOverlay — dismissal", () => {
     fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
     expect(queryByText("2 Active Workflows")).toBeTruthy();
 
-    fireEvent.keyDown(document, { key: "Escape" });
+    // Escape collapses the dropdown AND claims the event (preventDefault), so a
+    // single Escape doesn't also close an underlying side panel —
+    // ChatContentLayout's window keydown handler bails on defaultPrevented.
+    // fireEvent returns false when the event was canceled.
+    const notCanceled = fireEvent.keyDown(document, { key: "Escape" });
     expect(queryByText("2 Active Workflows")).toBeNull();
+    expect(notCanceled).toBe(false);
   });
 
   test("pointerdown outside the container collapses the open panel", () => {

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -54,8 +54,9 @@ export function ActiveWorkflowsOverlay({
     <div
       ref={containerRef}
       data-testid="active-workflows-overlay"
-      // none here so gutter clicks reach the transcript; pill + panel re-enable. 589px per Figma 6063:149685.
-      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
+      // Content-width + relative so the pill can sit adjacent to a sibling overlay
+      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
+      className="pointer-events-none relative flex w-auto flex-col items-center"
     >
       <ActiveWorkflowsPill
         count={workflowRunIds.length}
@@ -64,7 +65,9 @@ export function ActiveWorkflowsOverlay({
       />
 
       {expanded && (
-        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+        // Absolute dropdown anchored under the pill so its 589px width no longer
+        // dictates the row's width (Figma 6063:149685).
+        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
           <Typography
             variant="title-small"
             className="text-[var(--content-emphasised)]"

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ActiveWorkflowsPill } from "@/domains/chat/components/active-workflows-overlay/active-workflows-pill";
+import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
+
+export interface ActiveWorkflowsOverlayProps {
+  workflowRunIds: string[];
+  onWorkflowClick?: (runId: string) => void;
+  onStopWorkflow?: (runId: string) => void;
+}
+
+export function ActiveWorkflowsOverlay({
+  workflowRunIds,
+  onWorkflowClick,
+  onStopWorkflow,
+}: ActiveWorkflowsOverlayProps) {
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Defensive: collapse if the active set drains while open.
+  useEffect(() => {
+    if (workflowRunIds.length === 0) setExpanded(false);
+  }, [workflowRunIds.length]);
+
+  // While open, dismiss on outside pointerdown or Escape.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expanded]);
+
+  if (workflowRunIds.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="active-workflows-overlay"
+      // none here so gutter clicks reach the transcript; pill + panel re-enable. 589px per Figma 6063:149685.
+      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
+    >
+      <ActiveWorkflowsPill
+        count={workflowRunIds.length}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
+
+      {expanded && (
+        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+          <Typography
+            variant="title-small"
+            className="text-[var(--content-emphasised)]"
+          >
+            {workflowRunIds.length} Active Workflow
+            {workflowRunIds.length === 1 ? "" : "s"}
+          </Typography>
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+            {workflowRunIds.map((runId) => (
+              <WorkflowInlineProgressCard
+                key={runId}
+                runId={runId}
+                onWorkflowClick={onWorkflowClick}
+                onStopWorkflow={onStopWorkflow}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useRef, useState } from "react";
-
-import { Typography } from "@vellumai/design-library";
-
+import { ActiveOverlayShell } from "@/domains/chat/components/active-overlay-shell";
 import { ActiveWorkflowsPill } from "@/domains/chat/components/active-workflows-overlay/active-workflows-pill";
 import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
 
@@ -16,77 +13,30 @@ export function ActiveWorkflowsOverlay({
   onWorkflowClick,
   onStopWorkflow,
 }: ActiveWorkflowsOverlayProps) {
-  const [expanded, setExpanded] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  // Defensive: collapse if the active set drains while open.
-  useEffect(() => {
-    if (workflowRunIds.length === 0) setExpanded(false);
-  }, [workflowRunIds.length]);
-
-  // While open, dismiss on outside pointerdown or Escape.
-  useEffect(() => {
-    if (!expanded) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setExpanded(false);
-      }
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setExpanded(false);
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [expanded]);
-
   if (workflowRunIds.length === 0) return null;
 
   return (
-    <div
-      ref={containerRef}
-      data-testid="active-workflows-overlay"
-      // Content-width + relative so the pill can sit adjacent to a sibling overlay
-      // pill; none here so gutter clicks reach the transcript, pill + panel re-enable.
-      className="pointer-events-none relative flex w-auto flex-col items-center"
-    >
-      <ActiveWorkflowsPill
-        count={workflowRunIds.length}
-        expanded={expanded}
-        onToggle={() => setExpanded((v) => !v)}
-      />
-
-      {expanded && (
-        // Absolute dropdown anchored under the pill so its 589px width no longer
-        // dictates the row's width (Figma 6063:149685).
-        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
-          <Typography
-            variant="title-small"
-            className="text-[var(--content-emphasised)]"
-          >
-            {workflowRunIds.length} Active Workflow
-            {workflowRunIds.length === 1 ? "" : "s"}
-          </Typography>
-          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-            {workflowRunIds.map((runId) => (
-              <WorkflowInlineProgressCard
-                key={runId}
-                runId={runId}
-                onWorkflowClick={onWorkflowClick}
-                onStopWorkflow={onStopWorkflow}
-              />
-            ))}
-          </div>
-        </div>
+    <ActiveOverlayShell
+      testId="active-workflows-overlay"
+      title={`${workflowRunIds.length} Active Workflow${
+        workflowRunIds.length === 1 ? "" : "s"
+      }`}
+      renderPill={({ expanded, onToggle }) => (
+        <ActiveWorkflowsPill
+          count={workflowRunIds.length}
+          expanded={expanded}
+          onToggle={onToggle}
+        />
       )}
-    </div>
+    >
+      {workflowRunIds.map((runId) => (
+        <WorkflowInlineProgressCard
+          key={runId}
+          runId={runId}
+          onWorkflowClick={onWorkflowClick}
+          onStopWorkflow={onStopWorkflow}
+        />
+      ))}
+    </ActiveOverlayShell>
   );
 }

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-pill.tsx
@@ -1,0 +1,45 @@
+import { ChevronDown, ChevronUp, Workflow } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ChatPill } from "@/domains/chat/components/chat-pill";
+
+export interface ActiveWorkflowsPillProps {
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function ActiveWorkflowsPill({
+  count,
+  expanded,
+  onToggle,
+}: ActiveWorkflowsPillProps) {
+  return (
+    <ChatPill
+      onClick={onToggle}
+      ariaLabel={`${count} active workflow${count === 1 ? "" : "s"}`}
+      ariaExpanded={expanded}
+      size="compact"
+    >
+      {/* pointer-events-none so the ChatPill button owns clicks + cursor — clicking anywhere toggles. */}
+      <span className="pointer-events-none inline-flex items-center gap-1.5">
+        <Workflow
+          className="h-4 w-4 shrink-0 text-[var(--content-secondary)]"
+          aria-hidden
+        />
+        <Typography
+          variant="body-small-default"
+          className="text-[var(--content-emphasised)]"
+        >
+          {count}
+        </Typography>
+        {expanded ? (
+          <ChevronUp className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" aria-hidden />
+        ) : (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" aria-hidden />
+        )}
+      </span>
+    </ChatPill>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -309,6 +309,81 @@ describe("ChatBody — active subagents overlay slot", () => {
   });
 });
 
+describe("ChatBody — active workflows overlay slot", () => {
+  const activeSubagentsSlot = (
+    <div data-testid="active-subagents-slot">ACTIVE_SUBAGENTS</div>
+  );
+  const activeWorkflowsSlot = (
+    <div data-testid="active-workflows-slot">ACTIVE_WORKFLOWS</div>
+  );
+
+  test("renders the slot top-center when scrolled up and slot is provided", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("does NOT render the slot when pinned (showScrollToLatest false)", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: false,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("does NOT render the slot on the empty state", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...withEmptyState({
+          showScrollToLatest: true,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).not.toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("renders BOTH slots simultaneously when both are provided", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    expect(html).toContain("ACTIVE_SUBAGENTS");
+    expect(html).toContain("ACTIVE_WORKFLOWS");
+  });
+
+  test("renders the subagent pill to the LEFT of the workflow pill", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          activeSubagentsSlot,
+          activeWorkflowsSlot,
+        })}
+      />,
+    );
+    // DOM order: subagents must precede workflows in the centered row.
+    expect(html.indexOf("ACTIVE_SUBAGENTS")).toBeLessThan(
+      html.indexOf("ACTIVE_WORKFLOWS"),
+    );
+  });
+});
+
 describe("ChatBody — read-only cancellation", () => {
   test("renders the read-only banner without a stop control while idle", () => {
     const html = renderToStaticMarkup(

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -155,6 +155,9 @@ export interface ChatBodyProps {
    * only when there is ≥1 active subagent.
    */
   activeSubagentsSlot?: ReactNode;
+
+  /** Floating overlay for active workflow runs; gated like activeSubagentsSlot. */
+  activeWorkflowsSlot?: ReactNode;
 }
 
 /**
@@ -211,6 +214,7 @@ export function ChatBody({
   readonlyBannerSlot,
   startersSlot,
   activeSubagentsSlot,
+  activeWorkflowsSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
 
@@ -247,11 +251,15 @@ export function ChatBody({
     >
       <ChatScrollArea {...scrollAreaProps} />
 
-      {!isEmptyState && showScrollToLatest && activeSubagentsSlot && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center px-3 pt-2">
-          {activeSubagentsSlot}
-        </div>
-      )}
+      {!isEmptyState &&
+        showScrollToLatest &&
+        (activeSubagentsSlot || activeWorkflowsSlot) && (
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
+            {/* subagents on the left, workflows on the right (do not reorder) */}
+            {activeSubagentsSlot}
+            {activeWorkflowsSlot}
+          </div>
+        )}
 
       {/* Composer stack — stays at the same tree position across the
           empty→active transition so React preserves its state (focus,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -20,6 +20,7 @@
 import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
+import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
@@ -37,6 +38,7 @@ import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attach
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
+import { ActiveWorkflowsOverlay } from "@/domains/chat/components/active-workflows-overlay/active-workflows-overlay";
 import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
@@ -263,6 +265,7 @@ export function ChatMainPanel({
   }, [assistantId]);
 
   const activeSubagentIds = useActiveSubagentIds();
+  const activeWorkflowRunIds = useActiveWorkflowRunIds();
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);
@@ -841,6 +844,15 @@ export function ChatMainPanel({
       />
     ) : undefined;
 
+  const activeWorkflowsSlot =
+    activeWorkflowRunIds.length > 0 ? (
+      <ActiveWorkflowsOverlay
+        workflowRunIds={activeWorkflowRunIds}
+        onWorkflowClick={onWorkflowClick}
+        onStopWorkflow={onStopWorkflow}
+      />
+    ) : undefined;
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -877,6 +889,7 @@ export function ChatMainPanel({
         readonlyBannerSlot={channelReadonlyBannerSlot}
         startersSlot={startersSlot}
         activeSubagentsSlot={activeSubagentsSlot}
+        activeWorkflowsSlot={activeWorkflowsSlot}
       />
       <MicPermissionPrimer
         open={showPrimer}

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
@@ -2,8 +2,9 @@
  * Tests for `WorkflowInlineProgressCard`.
  *
  * Drives the Zustand workflow store with fixture runs/leaves and asserts
- * the rendered shell's presence, step-count pill, the spawn-race `null`
- * fallback, the stop affordance gating, and the header-click callback.
+ * the rendered card's presence, the agent count, the step-count→stop order,
+ * the spawn-race `null` fallback, the stop affordance gating, and the
+ * header-click callback.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -41,7 +42,7 @@ describe("WorkflowInlineProgressCard — spawn race", () => {
 });
 
 describe("WorkflowInlineProgressCard — fixture run", () => {
-  test("renders the shell and the agent-count pill once an entry exists", () => {
+  test("renders the card and the agent count once an entry exists", () => {
     startRun("wf-1");
     addLeaf("wf-1", 0, "Agent A");
     addLeaf("wf-1", 1, "Agent B");
@@ -50,8 +51,26 @@ describe("WorkflowInlineProgressCard — fixture run", () => {
       <WorkflowInlineProgressCard runId="wf-1" />,
     );
 
-    expect(getByTestId("workflow-inline-card-shell")).toBeTruthy();
+    expect(getByTestId("workflow-inline-progress-card")).toBeTruthy();
     expect(getByText("2 agents")).toBeTruthy();
+  });
+
+  test("orders the step count before the stop button (matching the subagent card)", () => {
+    startRun("wf-order");
+    addLeaf("wf-order", 0, "Agent A");
+    addLeaf("wf-order", 1, "Agent B");
+
+    const { getByTestId } = render(
+      <WorkflowInlineProgressCard runId="wf-order" onStopWorkflow={() => {}} />,
+    );
+
+    const stepCount = getByTestId("workflow-inline-card-step-count");
+    const stop = getByTestId("workflow-inline-card-stop");
+    // The stop button follows the step count in DOM order (step count first).
+    expect(
+      stepCount.compareDocumentPosition(stop) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
@@ -1,43 +1,36 @@
-/**
- * Inline workflow progress card rendered per-`run_workflow` run in the
- * assistant transcript. Built on `ToolProgressCardShell` with a workflow
- * glyph slotted into the leading-icon slot — workflows have no avatar.
- *
- * Subscribes to the workflow store via `useWorkflowCardData(runId)`.
- * Returns `null` when the entry isn't in the store yet — handles the
- * spawn race where the assistant message containing the inline card
- * mounts a hair before the `workflow_started` SSE event lands. A later
- * PR wires this into the transcript; this PR ships the component
- * standalone.
- *
- * Interaction model mirrors the subagent inline card:
- *   - Clicking anywhere on the header row opens the workflow's detail
- *     panel via `onWorkflowClick`. There is no inline expand — the panel
- *     is the only detail view.
- *   - Stop is exposed via `onStopWorkflow`; the shell renders a small
- *     stop chip in the right rail while the run is in-flight.
- */
+// Inline per-`run_workflow` progress row, rendered in the transcript and in the
+// active-workflows overlay dropdown. Mirrors the subagent inline card
+// (`SubagentInlineProgressCard`, Figma 6063:148642) exactly so the two read as
+// one language: status indicator → workflow glyph → Name | detail carousel →
+// "X agents" → stop, on the transparent chat background with a full-row
+// --surface-active hover (no boxed surface). The leading cluster is the open
+// affordance (role="button"); the stop button stays a separate sibling so it
+// isn't nested inside an interactive element.
+//
+// Subscribes to the workflow store via `useWorkflowCardData(runId)`. Returns
+// `null` when the entry isn't in the store yet — the spawn race where the
+// assistant message mounts a hair before the `workflow_started` SSE event lands.
+//
+// Interaction model:
+//   - Clicking the leading cluster opens the workflow detail panel via
+//     `onWorkflowClick`. There is no inline expand — the panel is the only
+//     detail view.
+//   - Stop is exposed via `onStopWorkflow` while the run is in-flight.
 
-import { Square, Workflow } from "lucide-react";
-import { useCallback, type MouseEvent } from "react";
+import { AlertCircle, CheckCircle2, Square, Workflow } from "lucide-react";
+import { useCallback, type KeyboardEvent, type MouseEvent } from "react";
 
-import { Button } from "@vellumai/design-library";
+import { Button, Typography } from "@vellumai/design-library";
 
-import { PhaseGroupedStepList } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
-import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
 import { useWorkflowCardData } from "@/domains/chat/hooks/use-workflow-card-data";
 
 export interface WorkflowInlineProgressCardProps {
   runId: string;
-  /**
-   * Invoked when the user activates the header row. Routes to the
-   * workflow detail panel.
-   */
+  /** Open the workflow detail panel (row activation, not the stop button). */
   onWorkflowClick?: (runId: string) => void;
-  /**
-   * Invoked when the user activates the stop button while the run is
-   * in-flight. Omitted callers hide the button entirely.
-   */
+  /** Stop an in-flight workflow; omit to hide the stop button. */
   onStopWorkflow?: (runId: string) => void;
 }
 
@@ -47,13 +40,25 @@ export function WorkflowInlineProgressCard({
   onStopWorkflow,
 }: WorkflowInlineProgressCardProps) {
   const data = useWorkflowCardData(runId);
-  // The shell's `loading` state is the live window where stopping the
-  // workflow is a meaningful action (see `deriveCardState`).
+  // "loading" = the live window where stopping the run is meaningful
+  // (see `deriveCardState`).
   const isRunning = data?.state === "loading";
 
-  const handleHeaderClick = useCallback(() => {
+  const handleOpenClick = useCallback(() => {
     onWorkflowClick?.(runId);
   }, [onWorkflowClick, runId]);
+
+  const handleOpenKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Ignore keydowns bubbled from children (e.g. the stop button).
+      if (e.target !== e.currentTarget) return;
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onWorkflowClick?.(runId);
+      }
+    },
+    [onWorkflowClick, runId],
+  );
 
   const handleStop = useCallback(
     (e: MouseEvent) => {
@@ -63,47 +68,96 @@ export function WorkflowInlineProgressCard({
     [onStopWorkflow, runId],
   );
 
-  // Spawn-race: assistant message references a run before the
-  // `workflow_started` event lands. Render `null` rather than a blank
-  // shell so the transcript doesn't flicker an empty card.
+  // Spawn-race: card mounts before the `workflow_started` event lands.
   if (!data) return null;
 
-  const leadingIcon = <Workflow size={20} aria-hidden />;
+  // Title = workflow name; detail prefers the live step info, else the title
+  // (so it never reads blank or just echoes the name).
+  const headerTitle = data.currentStepTitle;
+  const headerInfo =
+    data.currentStepInfo && data.currentStepInfo !== data.currentStepTitle
+      ? data.currentStepInfo
+      : data.currentStepTitle;
 
-  const actionSlot =
-    onStopWorkflow && isRunning ? (
-      <Button
-        variant="dangerGhost"
-        size="compact"
-        iconOnly={<Square fill="currentColor" />}
-        aria-label="Stop workflow"
-        data-testid="workflow-inline-card-stop"
-        onClick={handleStop}
-      />
-    ) : undefined;
+  // Local copy of the shared StatusIndicator chrome (matches the subagent row).
+  const statusIndicator = isRunning ? (
+    <ThreeDotIndicator
+      className="shrink-0"
+      data-testid="workflow-inline-card-status-indicator"
+    />
+  ) : data.state === "complete" ? (
+    <CheckCircle2
+      data-testid="workflow-inline-card-status-indicator"
+      aria-hidden="true"
+      className="h-[14px] w-[14px] shrink-0 text-[var(--system-positive-strong)]"
+    />
+  ) : (
+    <AlertCircle
+      data-testid="workflow-inline-card-status-indicator"
+      aria-hidden="true"
+      className="h-[14px] w-[14px] shrink-0 text-[var(--system-negative-strong)]"
+    />
+  );
+
+  // Hidden for 0/1-agent rows where the carousel detail already says it.
+  const stepCount = data.stepCount;
+  const showStepCount =
+    !!stepCount &&
+    !stepCount.startsWith("0 ") &&
+    !stepCount.startsWith("1 ");
+
+  // Without a click handler the leading cluster is inert (not a button).
+  const canOpen = !!onWorkflowClick;
 
   return (
-    <div className="w-full" data-testid="workflow-inline-progress-card">
-      <ToolProgressCardShell
-        data-testid="workflow-inline-card-shell"
-        statusIndicatorTestId="workflow-inline-card-status-indicator"
-        state={data.state}
-        leadingIcon={leadingIcon}
-        currentStepTitle={data.currentStepTitle}
-        currentStepInfo={data.currentStepInfo}
-        stepCount={data.stepCount}
-        // No inline timeline to reveal — the detail panel is the only
-        // detail view, so the expanded body stays disabled.
-        disableExpand
-        headerActionSlot={actionSlot}
-        onHeaderClick={onWorkflowClick ? handleHeaderClick : undefined}
-        headerAriaLabel={onWorkflowClick ? "Open workflow" : undefined}
+    <div
+      data-testid="workflow-inline-progress-card"
+      className="group flex w-full items-center justify-between gap-2 rounded-md p-2 text-left hover:bg-[var(--surface-active)]"
+    >
+      <span
+        role={canOpen ? "button" : undefined}
+        tabIndex={canOpen ? 0 : undefined}
+        aria-label={canOpen ? "Open workflow" : undefined}
+        onClick={canOpen ? handleOpenClick : undefined}
+        onKeyDown={canOpen ? handleOpenKeyDown : undefined}
+        className={`flex min-w-0 flex-1 items-center gap-1 text-left${
+          canOpen ? " cursor-pointer" : ""
+        }`}
       >
-        {/* Children unused — `disableExpand` suppresses the body region. */}
-        <div className="hidden">
-          <PhaseGroupedStepList steps={data.steps} />
-        </div>
-      </ToolProgressCardShell>
+        {statusIndicator}
+        <span className="mx-1 flex shrink-0 items-center">
+          <Workflow
+            className="h-4 w-4 text-[var(--content-secondary)]"
+            aria-hidden
+          />
+        </span>
+        <HeaderStepCarousel
+          currentStepTitle={headerTitle}
+          currentStepInfo={headerInfo}
+          bypassDwell={data.state !== "loading"}
+        />
+      </span>
+      <span className="flex shrink-0 items-center gap-2">
+        {showStepCount ? (
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+            data-testid="workflow-inline-card-step-count"
+          >
+            {stepCount}
+          </Typography>
+        ) : null}
+        {onStopWorkflow && isRunning ? (
+          <Button
+            variant="dangerGhost"
+            size="compact"
+            iconOnly={<Square fill="currentColor" />}
+            aria-label="Stop workflow"
+            data-testid="workflow-inline-card-stop"
+            onClick={handleStop}
+          />
+        ) : null}
+      </span>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/hooks/use-active-workflow-run-ids.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-workflow-run-ids.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for `useActiveWorkflowRunIds` — the atomic selector that exposes the
+ * currently-running workflow run ids in stable `orderedIds` (spawn) order.
+ *
+ * Drives the real `useWorkflowStore` (seeded via `startRun` / `completeRun`)
+ * so the selector + `useShallow` reference stability are exercised exactly as
+ * a consumer would observe them.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import type { WorkflowRunStatus } from "@vellumai/assistant-api";
+
+afterEach(() => {
+  cleanup();
+  useWorkflowStore.getState().reset();
+});
+
+/** Start a run (defaults to `running`) and, for terminal statuses, complete it. */
+function seed(runId: string, status: WorkflowRunStatus) {
+  const store = useWorkflowStore.getState();
+  store.startRun({ runId, label: runId, timestamp: Date.now() });
+  if (status !== "running") {
+    store.completeRun({
+      runId,
+      status,
+      agentsSpawned: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+  }
+}
+
+describe("useActiveWorkflowRunIds", () => {
+  test("returns only running ids in spawn order", () => {
+    // GIVEN three runs started in order with mixed statuses
+    act(() => {
+      seed("a", "running");
+      seed("b", "completed");
+      seed("c", "running");
+    });
+
+    // WHEN the hook renders
+    const { result } = renderHook(() => useActiveWorkflowRunIds());
+
+    // THEN only the running ids surface, in `orderedIds` (spawn) order
+    expect(result.current).toEqual(["a", "c"]);
+  });
+
+  test("excludes all terminal statuses", () => {
+    act(() => {
+      seed("running", "running");
+      seed("completed", "completed");
+      seed("failed", "failed");
+      seed("aborted", "aborted");
+      seed("cap_exceeded", "cap_exceeded");
+      seed("interrupted", "interrupted");
+    });
+
+    const { result } = renderHook(() => useActiveWorkflowRunIds());
+
+    expect(result.current).toEqual(["running"]);
+  });
+
+  test("keeps a stable array reference across no-op active-set updates", () => {
+    // GIVEN one running and one completed run
+    act(() => {
+      seed("active", "running");
+      seed("done", "completed");
+    });
+
+    const { result } = renderHook(() => useActiveWorkflowRunIds());
+    const first = result.current;
+    expect(first).toEqual(["active"]);
+
+    // WHEN a store update lands that does NOT change the active set
+    // (re-applying `completed` to the already-completed run bumps `byId`
+    // but leaves the filtered ids identical)
+    act(() => {
+      useWorkflowStore.getState().completeRun({
+        runId: "done",
+        status: "completed",
+        agentsSpawned: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+      });
+    });
+
+    // THEN `useShallow` suppresses the churn — same reference, no re-render
+    expect(result.current).toBe(first);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-active-workflow-run-ids.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-workflow-run-ids.ts
@@ -1,0 +1,20 @@
+import { useShallow } from "zustand/react/shallow";
+
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { isActiveStatus } from "@/utils/workflow-status";
+
+/**
+ * Active workflow run ids (status === "running"), in stable spawn order.
+ * `useShallow` keeps the array reference stable across unrelated store ticks
+ * (token usage, leaf updates) so the overlay doesn't re-render needlessly.
+ */
+export function useActiveWorkflowRunIds(): string[] {
+  return useWorkflowStore(
+    useShallow((s) =>
+      s.orderedIds.filter((id) => {
+        const status = s.byId[id]?.status;
+        return status !== undefined && isActiveStatus(status);
+      }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Adds a floating **pill for active workflow runs** to the main chat, mirroring the existing **Active Subagents** pill. When you scroll up past the latest message, the pill appears top-center showing a `Workflow` glyph + the count of running workflows; clicking it expands a dropdown of live `WorkflowInlineProgressCard` rows (each opens the workflow detail panel / can be stopped).

Both pills can appear **at the same time**, side by side — **subagents on the left, workflows on the right** — each with its own independent dropdown.

Implements the plan `active-workflows-overlay-pill.md` (mirrors PR #36037's subagent overlay). Figma: node `6063-149498`.

## Self-review result

**PASS.** Three fresh-eyes self-review passes ran over the full change:
- **Plan faithfulness** — PASS (also ran the suite: 43 tests pass / 0 fail, `tsc` clean)
- **Repo integration** — PASS (no caller breakage; every store/prop API verified)
- **Slop & reuse** — 1 gap: the two overlays were byte-identical duplicates → **fixed** by extracting a shared `ActiveOverlayShell` (#36064), pills left separate. Re-review: PASS.

## PRs merged into this feature branch

- #36059 — `useActiveWorkflowRunIds` hook (running-only, `useShallow`-stable)
- #36060 — `ChatBody` hosts both overlay pills side by side (subagents left / workflows right)
- #36061 — `ActiveWorkflowsOverlay` + `ActiveWorkflowsPill` (Workflow glyph + count + chevron, no avatar stack; dropdown reuses `WorkflowInlineProgressCard`)
- #36062 — wire the overlay into `ChatMainPanel` (reuses existing `onWorkflowClick`/`onStopWorkflow`)
- #36063 — adjacent-pill layout (decouple dropdown width from pill via absolute dropdowns)

### Fix PRs (self-review remediation)
- #36064 — extract shared `ActiveOverlayShell` from the two overlays (−100 lines; behavior-preserving)

## Notes
- `mainView` is a single enum, so only one *detail panel* shows at a time — the **pills** are independent, the panels remain mutually exclusive (unchanged).
- No daemon/backend changes; client-only.

Part of plan: active-workflows-overlay-pill.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
