### PR TITLE
feat(web): add acp-run-detail view state to viewer store

### DIFF
--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -227,6 +227,64 @@ describe("closeSubagentDetail", () => {
 });
 
 // ---------------------------------------------------------------------------
+// ACP run detail
+// ---------------------------------------------------------------------------
+
+describe("openAcpRunDetail", () => {
+  it("saves current view and switches to acp-run-detail", () => {
+    getState().openAcpRunDetail("acp-1");
+    const state = getState();
+    expect(state.mainView).toBe("acp-run-detail");
+    expect(state.activeAcpRunId).toBe("acp-1");
+    expect(state.viewBeforeAcpRunDetail).toBe("chat");
+  });
+
+  it("preserves existing viewBeforeAcpRunDetail when already in acp-run-detail", () => {
+    useViewerStore.setState({
+      mainView: "acp-run-detail",
+      viewBeforeAcpRunDetail: "app",
+      activeAcpRunId: "acp-1",
+    });
+    getState().openAcpRunDetail("acp-2");
+    const state = getState();
+    expect(state.viewBeforeAcpRunDetail).toBe("app");
+    expect(state.activeAcpRunId).toBe("acp-2");
+  });
+
+  it("saves non-chat view correctly", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openAcpRunDetail("acp-1");
+    expect(getState().viewBeforeAcpRunDetail).toBe("app");
+  });
+});
+
+describe("closeAcpRunDetail", () => {
+  it("restores viewBeforeAcpRunDetail and clears activeAcpRunId", () => {
+    useViewerStore.setState({
+      mainView: "acp-run-detail",
+      viewBeforeAcpRunDetail: "chat",
+      activeAcpRunId: "acp-1",
+    });
+    getState().closeAcpRunDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeAcpRunId).toBeNull();
+  });
+
+  it("restores a non-chat view", () => {
+    useViewerStore.setState({
+      mainView: "acp-run-detail",
+      viewBeforeAcpRunDetail: "app",
+      activeAcpRunId: "acp-1",
+    });
+    getState().closeAcpRunDetail();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeAcpRunId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Workflow detail
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -11,10 +11,11 @@
  * - `isAppMinimized` — mobile-only: app viewer minimized
  * - `intelligenceTab` — sub-tab inside the intelligence panel
  * - `assetsRefreshKey` — counter bumped to force asset re-fetches
- * - `viewBeforeDocument` / `viewBeforeSubagentDetail` / `viewBeforeToolDetail` / `viewBeforeWorkflowDetail` — previous view for restoration
+ * - `viewBeforeDocument` / `viewBeforeSubagentDetail` / `viewBeforeToolDetail` / `viewBeforeWorkflowDetail` / `viewBeforeAcpRunDetail` — previous view for restoration
  * - `activeSubagentId` — subagent detail panel
  * - `activeToolDetail` — tool-call detail drawer payload
  * - `activeWorkflowRunId` — workflow detail panel
+ * - `activeAcpRunId` — ACP run detail panel
  *
  * App share/deploy lifecycle lives in `domains/chat/deploy-store.ts`.
  *
@@ -31,7 +32,12 @@ import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 import { createSelectors } from "@/utils/create-selectors";
 
 /** Views that overlay the main content and track a "back" destination. */
-type OverlayView = "document" | "subagent-detail" | "tool-detail" | "workflow-detail";
+type OverlayView =
+  | "document"
+  | "subagent-detail"
+  | "tool-detail"
+  | "workflow-detail"
+  | "acp-run-detail";
 
 /**
  * Resolve the "view before" value for overlay navigation.
@@ -91,14 +97,16 @@ function resolveViewBefore(
     | "viewBeforeDocument"
     | "viewBeforeSubagentDetail"
     | "viewBeforeToolDetail"
-    | "viewBeforeWorkflowDetail",
+    | "viewBeforeWorkflowDetail"
+    | "viewBeforeAcpRunDetail",
 ): Exclude<MainView, OverlayView> {
   const mv = state.mainView;
   if (
     mv === "document" ||
     mv === "subagent-detail" ||
     mv === "tool-detail" ||
-    mv === "workflow-detail"
+    mv === "workflow-detail" ||
+    mv === "acp-run-detail"
   ) {
     return state[field];
   }
@@ -116,7 +124,8 @@ export type MainView =
   | "document"
   | "subagent-detail"
   | "tool-detail"
-  | "workflow-detail";
+  | "workflow-detail"
+  | "acp-run-detail";
 
 export type IntelligenceTab = "identity" | "skills" | "workspace" | "contacts";
 
@@ -231,13 +240,15 @@ export interface ViewerState {
   isAppMinimized: boolean;
   intelligenceTab: IntelligenceTab;
   assetsRefreshKey: number;
-  viewBeforeDocument: Exclude<MainView, "document" | "subagent-detail" | "tool-detail" | "workflow-detail">;
+  viewBeforeDocument: Exclude<MainView, OverlayView>;
   activeSubagentId: string | null;
-  viewBeforeSubagentDetail: Exclude<MainView, "document" | "subagent-detail" | "tool-detail" | "workflow-detail">;
+  viewBeforeSubagentDetail: Exclude<MainView, OverlayView>;
   activeToolDetail: ToolDetailPayload | null;
-  viewBeforeToolDetail: Exclude<MainView, "document" | "subagent-detail" | "tool-detail" | "workflow-detail">;
+  viewBeforeToolDetail: Exclude<MainView, OverlayView>;
   activeWorkflowRunId: string | null;
-  viewBeforeWorkflowDetail: Exclude<MainView, "document" | "subagent-detail" | "tool-detail" | "workflow-detail">;
+  viewBeforeWorkflowDetail: Exclude<MainView, OverlayView>;
+  activeAcpRunId: string | null;
+  viewBeforeAcpRunDetail: Exclude<MainView, OverlayView>;
   /**
    * Monotonic counter bumped when a viewer (e.g. the mobile tool-detail
    * overlay, which lives in a separate portal subtree) asks to open the trust
@@ -270,6 +281,10 @@ export interface ViewerActions {
   // --- Workflow detail ---
   openWorkflowDetail: (runId: string) => void;
   closeWorkflowDetail: () => void;
+
+  // --- ACP run detail ---
+  openAcpRunDetail: (acpSessionId: string) => void;
+  closeAcpRunDetail: () => void;
 
   // --- Tool detail ---
   openToolDetail: (payload: ToolDetailPayload) => void;
@@ -320,6 +335,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeToolDetail: "chat",
   activeWorkflowRunId: null,
   viewBeforeWorkflowDetail: "chat",
+  activeAcpRunId: null,
+  viewBeforeAcpRunDetail: "chat",
   ruleEditorRequestSeq: 0,
 };
 
@@ -459,6 +476,23 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     set({
       mainView: get().viewBeforeWorkflowDetail,
       activeWorkflowRunId: null,
+    });
+  },
+
+  // --- ACP run detail ---
+
+  openAcpRunDetail: (acpSessionId) => {
+    set({
+      mainView: "acp-run-detail",
+      activeAcpRunId: acpSessionId,
+      viewBeforeAcpRunDetail: resolveViewBefore(get(), "viewBeforeAcpRunDetail"),
+    });
+  },
+
+  closeAcpRunDetail: () => {
+    set({
+      mainView: get().viewBeforeAcpRunDetail,
+      activeAcpRunId: null,
     });
   },
 


### PR DESCRIPTION
## Summary
- Add acp-run-detail MainView/OverlayView plus activeAcpRunId + viewBeforeAcpRunDetail state
- Add openAcpRunDetail/closeAcpRunDetail actions mirroring the subagent-detail pattern
- Inert until layout wiring (PR 10); deploy-safe

Part of plan: acp-runs-ui.md (PR 7 of 13)