### PR TITLE
feat(api): add ACP session event schemas to assistant-api contract

### DIFF
--- a/assistant/src/api/events/acp-session-completed.ts
+++ b/assistant/src/api/events/acp-session-completed.ts
@@ -1,0 +1,34 @@
+/**
+ * `acp_session_completed` SSE event.
+ *
+ * Server → client notification that an ACP session has finished its
+ * turn. `stopReason` mirrors the ACP `StopReason` set.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AcpStopReasonSchema = z.enum([
+  "end_turn",
+  "max_tokens",
+  "max_turn_requests",
+  "refusal",
+  "cancelled",
+]);
+
+export type AcpStopReason = z.infer<typeof AcpStopReasonSchema>;
+
+export const AcpSessionCompletedEventSchema = z
+  .object({
+    type: z.literal("acp_session_completed"),
+    acpSessionId: z.string(),
+    stopReason: AcpStopReasonSchema,
+  })
+  .strict();
+
+export type AcpSessionCompletedEvent = z.infer<
+  typeof AcpSessionCompletedEventSchema
+>;

--- a/assistant/src/api/events/acp-session-error.ts
+++ b/assistant/src/api/events/acp-session-error.ts
@@ -1,0 +1,22 @@
+/**
+ * `acp_session_error` SSE event.
+ *
+ * Server → client notification that an ACP session has errored.
+ * Carries the session identity and a human-readable `error` message.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AcpSessionErrorEventSchema = z
+  .object({
+    type: z.literal("acp_session_error"),
+    acpSessionId: z.string(),
+    error: z.string(),
+  })
+  .strict();
+
+export type AcpSessionErrorEvent = z.infer<typeof AcpSessionErrorEventSchema>;

--- a/assistant/src/api/events/acp-session-spawned.ts
+++ b/assistant/src/api/events/acp-session-spawned.ts
@@ -1,0 +1,33 @@
+/**
+ * `acp_session_spawned` SSE event.
+ *
+ * Server → client notification that a new ACP (Agent Client Protocol)
+ * session has been spawned by the parent conversation. Carries the
+ * session identity (`acpSessionId`), the `agent` driving it, scoping
+ * (`parentConversationId`), and optional spawn-context: `parentToolUseId`
+ * anchors the inline card to the `acp_spawn` tool-use block, and `task`
+ * carries the objective text.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AcpSessionSpawnedEventSchema = z
+  .object({
+    type: z.literal("acp_session_spawned"),
+    acpSessionId: z.string(),
+    agent: z.string(),
+    parentConversationId: z.string(),
+    /** Tool-use id of the `acp_spawn` call that spawned this session. */
+    parentToolUseId: z.string().optional(),
+    /** Objective text for the spawned session. */
+    task: z.string().optional(),
+  })
+  .strict();
+
+export type AcpSessionSpawnedEvent = z.infer<
+  typeof AcpSessionSpawnedEventSchema
+>;

--- a/assistant/src/api/events/acp-session-update.ts
+++ b/assistant/src/api/events/acp-session-update.ts
@@ -1,0 +1,45 @@
+/**
+ * `acp_session_update` SSE event.
+ *
+ * Server → client incremental update from a running ACP session.
+ * `updateType` discriminates the payload (message/thought/user chunks,
+ * tool-call lifecycle, plan). Content and tool-call fields are optional
+ * since they apply only to the relevant `updateType`s. `messageId` and
+ * `seq` let clients correlate and order chunks within a session.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AcpSessionUpdateTypeSchema = z.enum([
+  "agent_message_chunk",
+  "agent_thought_chunk",
+  "user_message_chunk",
+  "tool_call",
+  "tool_call_update",
+  "plan",
+]);
+
+export type AcpSessionUpdateType = z.infer<typeof AcpSessionUpdateTypeSchema>;
+
+export const AcpSessionUpdateEventSchema = z
+  .object({
+    type: z.literal("acp_session_update"),
+    acpSessionId: z.string(),
+    updateType: AcpSessionUpdateTypeSchema,
+    content: z.string().optional(),
+    toolCallId: z.string().optional(),
+    toolTitle: z.string().optional(),
+    toolKind: z.string().optional(),
+    toolStatus: z.string().optional(),
+    /** Stable id for the message this chunk belongs to. */
+    messageId: z.string().optional(),
+    /** Monotonic ordering hint within the session. */
+    seq: z.number().optional(),
+  })
+  .strict();
+
+export type AcpSessionUpdateEvent = z.infer<typeof AcpSessionUpdateEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+import { AcpSessionCompletedEventSchema } from "./events/acp-session-completed.js";
+import { AcpSessionErrorEventSchema } from "./events/acp-session-error.js";
+import { AcpSessionSpawnedEventSchema } from "./events/acp-session-spawned.js";
+import { AcpSessionUpdateEventSchema } from "./events/acp-session-update.js";
 import { AssistantActivityStateEventSchema } from "./events/assistant-activity-state.js";
 import { AssistantTextDeltaEventSchema } from "./events/assistant-text-delta.js";
 import { AssistantThinkingDeltaEventSchema } from "./events/assistant-thinking-delta.js";
@@ -67,6 +71,26 @@ export {
   SSE_REPLAY_RING_COUNT_LIMIT,
 } from "./constants/sse-replay.js";
 export { DEFAULT_TOOL_EXECUTION_TIMEOUT_SEC } from "./constants/tool-execution.js";
+export {
+  type AcpSessionCompletedEvent,
+  AcpSessionCompletedEventSchema,
+  type AcpStopReason,
+  AcpStopReasonSchema,
+} from "./events/acp-session-completed.js";
+export {
+  type AcpSessionErrorEvent,
+  AcpSessionErrorEventSchema,
+} from "./events/acp-session-error.js";
+export {
+  type AcpSessionSpawnedEvent,
+  AcpSessionSpawnedEventSchema,
+} from "./events/acp-session-spawned.js";
+export {
+  type AcpSessionUpdateEvent,
+  AcpSessionUpdateEventSchema,
+  type AcpSessionUpdateType,
+  AcpSessionUpdateTypeSchema,
+} from "./events/acp-session-update.js";
 export {
   type AssistantActivityAnchor,
   AssistantActivityAnchorSchema,
@@ -504,6 +528,10 @@ export {
  * migration recipe.
  */
 export const AssistantEventSchema = z.discriminatedUnion("type", [
+  AcpSessionCompletedEventSchema,
+  AcpSessionErrorEventSchema,
+  AcpSessionSpawnedEventSchema,
+  AcpSessionUpdateEventSchema,
   AssistantActivityStateEventSchema,
   AssistantTextDeltaEventSchema,
   AssistantThinkingDeltaEventSchema,


### PR DESCRIPTION
## Summary
- Add acp_session_{spawned,update,completed,error} Zod event schemas to the public assistant-api contract
- Register them in the AssistantEventSchema discriminated union
- New enrichment fields (parentToolUseId, task, messageId, seq) all optional for version skew

Part of plan: acp-runs-ui.md (PR 1 of 13)