### PR TITLE
feat(web): add acp-run Zustand store and status helpers

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -55,7 +55,7 @@ describe("initial state", () => {
 // ---------------------------------------------------------------------------
 
 describe("spawnRun", () => {
-  it("adds an entry with initializing status and zeroed usage", () => {
+  it("adds an entry with running status and zeroed usage", () => {
     spawn({ task: "research the thing" });
 
     const entry = getState().byId["acp-1"]!;
@@ -63,7 +63,8 @@ describe("spawnRun", () => {
     expect(entry.agent).toBe("claude");
     expect(entry.parentConversationId).toBe("conv-1");
     expect(entry.task).toBe("research the thing");
-    expect(entry.status).toBe("initializing");
+    // Daemon emits `acp_session_spawned` only after the session is running.
+    expect(entry.status).toBe("running");
     expect(entry.startedAt).toBe(NOW);
     expect(entry.inputTokens).toBe(0);
     expect(entry.outputTokens).toBe(0);
@@ -383,6 +384,83 @@ describe("seedFromHistory", () => {
     ]);
 
     expect(getState().byId["acp-1"]!.events).toHaveLength(2);
+  });
+
+  it("merges terminal status/usage onto a live entry while keeping the longer buffer", () => {
+    spawn({ acpSessionId: "acp-1" });
+    const store = getState();
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 1, content: "a" }) });
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 2, updateType: "tool_call" }) });
+    expect(getState().byId["acp-1"]!.status).toBe("running");
+
+    // Equal-length terminal history snapshot must still fold in metadata.
+    getState().seedFromHistory([
+      historyEntry({
+        acpSessionId: "acp-1",
+        status: "completed",
+        completedAt: NOW + 5000,
+        stopReason: "end_turn",
+        inputTokens: 1200,
+        outputTokens: 340,
+        totalCost: 0.012,
+        events: [event({ seq: 1, content: "stale" }), event({ seq: 2 })],
+      }),
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    // Longer live buffer is kept (live content, not history's "stale").
+    expect(entry.events).toHaveLength(2);
+    expect(entry.events[0]!.content).toBe("a");
+    // Terminal metadata is merged.
+    expect(entry.status).toBe("completed");
+    expect(entry.completedAt).toBe(NOW + 5000);
+    expect(entry.stopReason).toBe("end_turn");
+    expect(entry.inputTokens).toBe(1200);
+    expect(entry.outputTokens).toBe(340);
+    expect(entry.totalCost).toBe(0.012);
+  });
+
+  it("does not regress a live terminal entry with empty/non-terminal history metadata", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().setTerminal({
+      acpSessionId: "acp-1",
+      status: "completed",
+      stopReason: "end_turn",
+      completedAt: NOW + 1000,
+    });
+    getState().updateUsage({
+      acpSessionId: "acp-1",
+      inputTokens: 900,
+      outputTokens: 100,
+      totalCost: 0.005,
+    });
+
+    getState().seedFromHistory([
+      historyEntry({
+        acpSessionId: "acp-1",
+        status: "running",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalCost: 0,
+        events: [],
+      }),
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.completedAt).toBe(NOW + 1000);
+    expect(entry.inputTokens).toBe(900);
+    expect(entry.outputTokens).toBe(100);
+    expect(entry.totalCost).toBe(0.005);
+  });
+
+  it("backfills a missing task from history", () => {
+    spawn({ acpSessionId: "acp-1", task: undefined });
+    getState().seedFromHistory([
+      historyEntry({ acpSessionId: "acp-1", task: "recovered task" }),
+    ]);
+
+    expect(getState().byId["acp-1"]!.task).toBe("recovered task");
   });
 });
 

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -1,0 +1,405 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+  useAcpRunStore,
+  type AcpRunEntry,
+  type AcpRunRawEvent,
+} from "@/domains/chat/acp-run-store";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getState() {
+  return useAcpRunStore.getState();
+}
+
+const NOW = 1700000000000;
+
+function spawn(overrides: Partial<Parameters<ReturnType<typeof getState>["spawnRun"]>[0]> = {}) {
+  getState().spawnRun({
+    acpSessionId: "acp-1",
+    agent: "claude",
+    parentConversationId: "conv-1",
+    startedAt: NOW,
+    ...overrides,
+  });
+}
+
+function event(overrides: Partial<AcpRunRawEvent> = {}): AcpRunRawEvent {
+  return {
+    seq: 1,
+    updateType: "agent_message_chunk",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe("initial state", () => {
+  it("starts empty", () => {
+    expect(getState().byId).toEqual({});
+    expect(getState().orderedIds).toEqual([]);
+    expect(getState().byToolUseId.size).toBe(0);
+    expect(getState().highWaterMark.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spawnRun
+// ---------------------------------------------------------------------------
+
+describe("spawnRun", () => {
+  it("adds an entry with initializing status and zeroed usage", () => {
+    spawn({ task: "research the thing" });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(getState().orderedIds).toEqual(["acp-1"]);
+    expect(entry.agent).toBe("claude");
+    expect(entry.parentConversationId).toBe("conv-1");
+    expect(entry.task).toBe("research the thing");
+    expect(entry.status).toBe("initializing");
+    expect(entry.startedAt).toBe(NOW);
+    expect(entry.inputTokens).toBe(0);
+    expect(entry.outputTokens).toBe(0);
+    expect(entry.totalCost).toBe(0);
+    expect(entry.events).toEqual([]);
+  });
+
+  it("is idempotent — a replayed spawn with the same id is ignored", () => {
+    spawn();
+    spawn({ agent: "replayed", startedAt: NOW + 5000 });
+
+    expect(getState().orderedIds).toEqual(["acp-1"]);
+    expect(getState().byId["acp-1"]!.agent).toBe("claude");
+    expect(getState().byId["acp-1"]!.startedAt).toBe(NOW);
+  });
+
+  it("indexes byToolUseId when parentToolUseId is present", () => {
+    spawn({ parentToolUseId: "tool-use-1" });
+
+    expect(getState().byToolUseId.get("tool-use-1")).toBe("acp-1");
+    expect(getState().byId["acp-1"]!.parentToolUseId).toBe("tool-use-1");
+  });
+
+  it("keeps byToolUseId reference-equal when parentToolUseId is omitted", () => {
+    const before = getState().byToolUseId;
+    spawn();
+
+    expect(getState().byToolUseId).toBe(before);
+    expect(getState().byToolUseId.size).toBe(0);
+  });
+
+  it("preserves ordering across multiple spawns", () => {
+    spawn({ acpSessionId: "acp-a" });
+    spawn({ acpSessionId: "acp-b" });
+    spawn({ acpSessionId: "acp-c" });
+
+    expect(getState().orderedIds).toEqual(["acp-a", "acp-b", "acp-c"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// receiveEvent
+// ---------------------------------------------------------------------------
+
+describe("receiveEvent", () => {
+  it("appends an event for a known session", () => {
+    spawn();
+    getState().receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, content: "hello" }),
+    });
+
+    expect(getState().byId["acp-1"]!.events).toHaveLength(1);
+    expect(getState().byId["acp-1"]!.events[0]!.content).toBe("hello");
+  });
+
+  it("ignores events for an unknown session", () => {
+    getState().receiveEvent({
+      acpSessionId: "acp-missing",
+      event: event(),
+    });
+
+    expect(getState().byId).toEqual({});
+    expect(getState().highWaterMark.size).toBe(0);
+  });
+
+  it("coalesces consecutive same-messageId message chunks into one event", () => {
+    spawn();
+    const store = getState();
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, content: "Hello", messageId: "m-1" }),
+    });
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 2, content: " world", messageId: "m-1" }),
+    });
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 3, content: "!", messageId: "m-1" }),
+    });
+
+    const events = getState().byId["acp-1"]!.events;
+    expect(events).toHaveLength(1);
+    expect(events[0]!.content).toBe("Hello world!");
+    // The coalesced event's seq tracks the latest chunk.
+    expect(events[0]!.seq).toBe(3);
+  });
+
+  it("coalesces consecutive same-messageId thought chunks", () => {
+    spawn();
+    const store = getState();
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, updateType: "agent_thought_chunk", content: "think", messageId: "t-1" }),
+    });
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 2, updateType: "agent_thought_chunk", content: "ing", messageId: "t-1" }),
+    });
+
+    const events = getState().byId["acp-1"]!.events;
+    expect(events).toHaveLength(1);
+    expect(events[0]!.content).toBe("thinking");
+  });
+
+  it("does not coalesce chunks with different messageIds", () => {
+    spawn();
+    const store = getState();
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, content: "first", messageId: "m-1" }),
+    });
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 2, content: "second", messageId: "m-2" }),
+    });
+
+    const events = getState().byId["acp-1"]!.events;
+    expect(events).toHaveLength(2);
+    expect(events[0]!.content).toBe("first");
+    expect(events[1]!.content).toBe("second");
+  });
+
+  it("does not coalesce across a non-chunk event of a different type", () => {
+    spawn();
+    const store = getState();
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, content: "msg", messageId: "m-1" }),
+    });
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 2, updateType: "tool_call", toolCallId: "tc-1", toolTitle: "Read" }),
+    });
+
+    const events = getState().byId["acp-1"]!.events;
+    expect(events).toHaveLength(2);
+    expect(events[1]!.updateType).toBe("tool_call");
+  });
+
+  it("does not coalesce chunks that both lack a messageId", () => {
+    spawn();
+    const store = getState();
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, content: "a" }),
+    });
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 2, content: "b" }),
+    });
+
+    expect(getState().byId["acp-1"]!.events).toHaveLength(2);
+  });
+
+  it("tracks the high-water mark monotonically", () => {
+    spawn();
+    const store = getState();
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 5 }) });
+    expect(getState().highWaterMark.get("acp-1")).toBe(5);
+
+    // A higher seq raises the mark.
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 9 }) });
+    expect(getState().highWaterMark.get("acp-1")).toBe(9);
+
+    // A lower (replayed) seq leaves it untouched.
+    const before = getState().highWaterMark;
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 3 }) });
+    expect(getState().highWaterMark.get("acp-1")).toBe(9);
+    expect(getState().highWaterMark).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setTerminal
+// ---------------------------------------------------------------------------
+
+describe("setTerminal", () => {
+  it("applies status, stopReason, error, and completedAt", () => {
+    spawn();
+    getState().setTerminal({
+      acpSessionId: "acp-1",
+      status: "completed",
+      stopReason: "end_turn",
+      completedAt: NOW + 1000,
+    });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.stopReason).toBe("end_turn");
+    expect(entry.completedAt).toBe(NOW + 1000);
+  });
+
+  it("records the error on a failed run", () => {
+    spawn();
+    getState().setTerminal({
+      acpSessionId: "acp-1",
+      status: "failed",
+      error: "agent crashed",
+      completedAt: NOW + 2000,
+    });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("failed");
+    expect(entry.error).toBe("agent crashed");
+  });
+
+  it("ignores an unknown session", () => {
+    getState().setTerminal({
+      acpSessionId: "acp-missing",
+      status: "cancelled",
+      completedAt: NOW,
+    });
+
+    expect(getState().byId).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateUsage
+// ---------------------------------------------------------------------------
+
+describe("updateUsage", () => {
+  it("replaces the usage totals", () => {
+    spawn();
+    getState().updateUsage({
+      acpSessionId: "acp-1",
+      inputTokens: 1500,
+      outputTokens: 500,
+      totalCost: 0.003,
+    });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.inputTokens).toBe(1500);
+    expect(entry.outputTokens).toBe(500);
+    expect(entry.totalCost).toBe(0.003);
+  });
+
+  it("ignores an unknown session", () => {
+    const before = { ...getState().byId };
+    getState().updateUsage({
+      acpSessionId: "acp-missing",
+      inputTokens: 1,
+      outputTokens: 1,
+      totalCost: 1,
+    });
+
+    expect(getState().byId).toEqual(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedFromHistory
+// ---------------------------------------------------------------------------
+
+function historyEntry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
+  return {
+    acpSessionId: "acp-1",
+    agent: "claude",
+    parentConversationId: "conv-1",
+    status: "completed",
+    startedAt: NOW,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalCost: 0,
+    events: [],
+    ...overrides,
+  };
+}
+
+describe("seedFromHistory", () => {
+  it("adds new entries, ordered ids, byToolUseId, and highWaterMark", () => {
+    getState().seedFromHistory([
+      historyEntry({
+        acpSessionId: "acp-h1",
+        parentToolUseId: "tool-h1",
+        events: [event({ seq: 4 }), event({ seq: 7 })],
+      }),
+    ]);
+
+    expect(getState().orderedIds).toEqual(["acp-h1"]);
+    expect(getState().byId["acp-h1"]!.status).toBe("completed");
+    expect(getState().byToolUseId.get("tool-h1")).toBe("acp-h1");
+    expect(getState().highWaterMark.get("acp-h1")).toBe(7);
+  });
+
+  it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {
+    const entry = historyEntry({ acpSessionId: "acp-h1" });
+    getState().seedFromHistory([entry]);
+    getState().seedFromHistory([entry]);
+
+    expect(getState().orderedIds).toEqual(["acp-h1"]);
+  });
+
+  it("does not clobber a live entry's longer event buffer with a shorter snapshot", () => {
+    spawn({ acpSessionId: "acp-1" });
+    const store = getState();
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 1, content: "a" }) });
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 2, updateType: "tool_call" }) });
+
+    getState().seedFromHistory([
+      historyEntry({ acpSessionId: "acp-1", events: [event({ seq: 1, content: "stale" })] }),
+    ]);
+
+    // The live (longer) buffer wins.
+    expect(getState().byId["acp-1"]!.events).toHaveLength(2);
+    expect(getState().byId["acp-1"]!.events[0]!.content).toBe("a");
+  });
+
+  it("prefers the newer/longer historical entry over a shorter existing one", () => {
+    getState().seedFromHistory([
+      historyEntry({ acpSessionId: "acp-1", events: [event({ seq: 1 })] }),
+    ]);
+    getState().seedFromHistory([
+      historyEntry({ acpSessionId: "acp-1", events: [event({ seq: 1 }), event({ seq: 2 })] }),
+    ]);
+
+    expect(getState().byId["acp-1"]!.events).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reset
+// ---------------------------------------------------------------------------
+
+describe("reset", () => {
+  it("clears all state back to initial", () => {
+    spawn({ parentToolUseId: "tool-1" });
+    getState().receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 3 }) });
+
+    getState().reset();
+
+    expect(getState().byId).toEqual({});
+    expect(getState().orderedIds).toEqual([]);
+    expect(getState().byToolUseId.size).toBe(0);
+    expect(getState().highWaterMark.size).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -1,0 +1,333 @@
+/**
+ * Zustand store for ACP run lifecycle state.
+ *
+ * Maintains a map of AcpRunEntry records keyed by acpSessionId, with an
+ * ordered list of IDs for stable rendering. Event buffers are append-only;
+ * consecutive message/thought chunks of the same `messageId` are coalesced
+ * into the last event so high-frequency streaming stays O(1) for projections.
+ *
+ * @see https://zustand.docs.pmnd.rs/guides/flux-inspired-practice
+ * @see https://zustand.docs.pmnd.rs/guides/updating-state
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+import type { AcpRunStatus } from "@/utils/acp-run-status";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export interface AcpRunRawEvent {
+  seq: number;
+  updateType:
+    | "agent_message_chunk"
+    | "agent_thought_chunk"
+    | "user_message_chunk"
+    | "tool_call"
+    | "tool_call_update"
+    | "plan";
+  content?: string;
+  toolCallId?: string;
+  toolTitle?: string;
+  toolKind?: string;
+  toolStatus?: string;
+  messageId?: string;
+}
+
+export interface AcpRunEntry {
+  acpSessionId: string;
+  agent: string;
+  parentConversationId: string;
+  task?: string;
+  status: AcpRunStatus;
+  stopReason?: string;
+  error?: string;
+  startedAt: number;
+  completedAt?: number;
+  /**
+   * Tool-use block ID of the spawning tool call in the parent conversation.
+   * Lets the transcript anchor the inline card to its exact spawn tool call.
+   * Indexed in `byToolUseId`. Optional — older daemons omit it.
+   */
+  parentToolUseId?: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalCost: number;
+  events: AcpRunRawEvent[];
+}
+
+export interface AcpRunState {
+  byId: Record<string, AcpRunEntry>;
+  orderedIds: string[];
+  /**
+   * Index of spawning tool-use block id → acpSessionId. Populated when a run
+   * is spawned with `parentToolUseId`, letting the transcript anchor the
+   * inline card to its exact spawn tool call.
+   */
+  byToolUseId: Map<string, string>;
+  /**
+   * Highest `seq` seen per session. Lets consumers dedup replayed events on
+   * reconnection by ignoring anything at or below the mark.
+   */
+  highWaterMark: Map<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export interface AcpRunActions {
+  spawnRun: (params: {
+    acpSessionId: string;
+    agent: string;
+    parentConversationId: string;
+    parentToolUseId?: string;
+    task?: string;
+    startedAt: number;
+  }) => void;
+
+  receiveEvent: (params: {
+    acpSessionId: string;
+    event: AcpRunRawEvent;
+  }) => void;
+
+  setTerminal: (params: {
+    acpSessionId: string;
+    status: AcpRunStatus;
+    stopReason?: string;
+    error?: string;
+    completedAt: number;
+  }) => void;
+
+  updateUsage: (params: {
+    acpSessionId: string;
+    inputTokens: number;
+    outputTokens: number;
+    totalCost: number;
+  }) => void;
+
+  /**
+   * Idempotent merge of history entries keyed by acpSessionId. Never clobbers
+   * a live entry's longer event buffer with a shorter historical one — the
+   * entry with more events wins. Sets `highWaterMark` to the max seq seen and
+   * indexes `byToolUseId`.
+   */
+  seedFromHistory: (entries: AcpRunEntry[]) => void;
+
+  reset: () => void;
+}
+
+export type AcpRunStore = AcpRunState & AcpRunActions;
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: AcpRunState = {
+  byId: {},
+  orderedIds: [],
+  byToolUseId: new Map<string, string>(),
+  highWaterMark: new Map<string, number>(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const COALESCE_TYPES = new Set<AcpRunRawEvent["updateType"]>([
+  "agent_message_chunk",
+  "agent_thought_chunk",
+]);
+
+/**
+ * Append an event to a run's buffer, coalescing consecutive
+ * message/thought chunks of the same `messageId` into the last event's
+ * `content` by building a new last element (never mutating in place).
+ */
+function appendEvent(
+  events: AcpRunRawEvent[],
+  event: AcpRunRawEvent,
+): AcpRunRawEvent[] {
+  const last = events[events.length - 1];
+  if (
+    last &&
+    COALESCE_TYPES.has(event.updateType) &&
+    last.updateType === event.updateType &&
+    last.messageId !== undefined &&
+    last.messageId === event.messageId
+  ) {
+    const next = events.slice(0, -1);
+    next.push({
+      ...last,
+      seq: event.seq,
+      content: (last.content ?? "") + (event.content ?? ""),
+    });
+    return next;
+  }
+  return [...events, event];
+}
+
+/** Raise a session's high-water mark to the given seq if higher. */
+function bumpHighWaterMark(
+  highWaterMark: Map<string, number>,
+  acpSessionId: string,
+  seq: number,
+): Map<string, number> {
+  const prev = highWaterMark.get(acpSessionId);
+  if (prev !== undefined && prev >= seq) return highWaterMark;
+  return new Map(highWaterMark).set(acpSessionId, seq);
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
+  ...INITIAL_STATE,
+
+  spawnRun: (params) => {
+    const { byId, orderedIds, byToolUseId } = get();
+    if (byId[params.acpSessionId]) return;
+
+    const entry: AcpRunEntry = {
+      acpSessionId: params.acpSessionId,
+      agent: params.agent,
+      parentConversationId: params.parentConversationId,
+      task: params.task,
+      status: "initializing",
+      startedAt: params.startedAt,
+      parentToolUseId: params.parentToolUseId,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalCost: 0,
+      events: [],
+    };
+
+    // Only clone the tool-use index when this spawn carries a
+    // `parentToolUseId`; otherwise keep the reference stable.
+    const nextByToolUseId = params.parentToolUseId
+      ? new Map(byToolUseId).set(params.parentToolUseId, params.acpSessionId)
+      : byToolUseId;
+
+    set({
+      byId: { ...byId, [params.acpSessionId]: entry },
+      orderedIds: [...orderedIds, params.acpSessionId],
+      byToolUseId: nextByToolUseId,
+    });
+  },
+
+  receiveEvent: (params) => {
+    const { byId, highWaterMark } = get();
+    const existing = byId[params.acpSessionId];
+    if (!existing) return;
+
+    set({
+      byId: {
+        ...byId,
+        [params.acpSessionId]: {
+          ...existing,
+          events: appendEvent(existing.events, params.event),
+        },
+      },
+      highWaterMark: bumpHighWaterMark(
+        highWaterMark,
+        params.acpSessionId,
+        params.event.seq,
+      ),
+    });
+  },
+
+  setTerminal: (params) => {
+    const { byId } = get();
+    const existing = byId[params.acpSessionId];
+    if (!existing) return;
+
+    set({
+      byId: {
+        ...byId,
+        [params.acpSessionId]: {
+          ...existing,
+          status: params.status,
+          stopReason: params.stopReason ?? existing.stopReason,
+          error: params.error ?? existing.error,
+          completedAt: params.completedAt,
+        },
+      },
+    });
+  },
+
+  updateUsage: (params) => {
+    const { byId } = get();
+    const existing = byId[params.acpSessionId];
+    if (!existing) return;
+
+    set({
+      byId: {
+        ...byId,
+        [params.acpSessionId]: {
+          ...existing,
+          inputTokens: params.inputTokens,
+          outputTokens: params.outputTokens,
+          totalCost: params.totalCost,
+        },
+      },
+    });
+  },
+
+  seedFromHistory: (entries) => {
+    const { byId, orderedIds, byToolUseId, highWaterMark } = get();
+
+    const nextById = { ...byId };
+    const nextOrderedIds = [...orderedIds];
+    let nextByToolUseId = byToolUseId;
+    let nextHighWaterMark = highWaterMark;
+
+    for (const entry of entries) {
+      const existing = nextById[entry.acpSessionId];
+      // Prefer the entry with more events so a live buffer is never clobbered
+      // by a shorter historical snapshot.
+      nextById[entry.acpSessionId] =
+        existing && existing.events.length >= entry.events.length
+          ? existing
+          : entry;
+
+      if (!nextOrderedIds.includes(entry.acpSessionId)) {
+        nextOrderedIds.push(entry.acpSessionId);
+      }
+
+      if (entry.parentToolUseId) {
+        nextByToolUseId = new Map(nextByToolUseId).set(
+          entry.parentToolUseId,
+          entry.acpSessionId,
+        );
+      }
+
+      for (const event of entry.events) {
+        nextHighWaterMark = bumpHighWaterMark(
+          nextHighWaterMark,
+          entry.acpSessionId,
+          event.seq,
+        );
+      }
+    }
+
+    set({
+      byId: nextById,
+      orderedIds: nextOrderedIds,
+      byToolUseId: nextByToolUseId,
+      highWaterMark: nextHighWaterMark,
+    });
+  },
+
+  reset: () =>
+    set({
+      byId: {},
+      orderedIds: [],
+      byToolUseId: new Map<string, string>(),
+      highWaterMark: new Map<string, number>(),
+    }),
+}));
+
+export const useAcpRunStore = createSelectors(useAcpRunStoreBase);

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -13,7 +13,7 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
-import type { AcpRunStatus } from "@/utils/acp-run-status";
+import { isActiveAcpStatus, type AcpRunStatus } from "@/utils/acp-run-status";
 
 // ---------------------------------------------------------------------------
 // State
@@ -109,10 +109,11 @@ export interface AcpRunActions {
   }) => void;
 
   /**
-   * Idempotent merge of history entries keyed by acpSessionId. Never clobbers
-   * a live entry's longer event buffer with a shorter historical one — the
-   * entry with more events wins. Sets `highWaterMark` to the max seq seen and
-   * indexes `byToolUseId`.
+   * Idempotent merge of history entries keyed by acpSessionId. Keeps the
+   * longer `events` buffer (live vs incoming) so a live stream is never
+   * clobbered, while always merging terminal/status/usage metadata from the
+   * history entry. Sets `highWaterMark` to the max seq over the kept buffer
+   * and indexes `byToolUseId`.
    */
   seedFromHistory: (entries: AcpRunEntry[]) => void;
 
@@ -169,6 +170,41 @@ function appendEvent(
   return [...events, event];
 }
 
+/**
+ * Merge a history entry into an existing live entry. Keeps the longer `events`
+ * buffer but always folds in the history entry's terminal/status/usage
+ * metadata. A terminal history status wins over a live non-terminal one; a live
+ * terminal status is not regressed by a non-terminal history status.
+ */
+function mergeHistoryEntry(
+  existing: AcpRunEntry,
+  incoming: AcpRunEntry,
+): AcpRunEntry {
+  const events =
+    existing.events.length >= incoming.events.length
+      ? existing.events
+      : incoming.events;
+
+  const status =
+    isActiveAcpStatus(existing.status) || !isActiveAcpStatus(incoming.status)
+      ? incoming.status
+      : existing.status;
+
+  return {
+    ...existing,
+    events,
+    status,
+    stopReason: incoming.stopReason ?? existing.stopReason,
+    error: incoming.error ?? existing.error,
+    completedAt: incoming.completedAt ?? existing.completedAt,
+    inputTokens: incoming.inputTokens || existing.inputTokens,
+    outputTokens: incoming.outputTokens || existing.outputTokens,
+    totalCost: incoming.totalCost || existing.totalCost,
+    task: existing.task ?? incoming.task,
+    parentToolUseId: existing.parentToolUseId ?? incoming.parentToolUseId,
+  };
+}
+
 /** Raise a session's high-water mark to the given seq if higher. */
 function bumpHighWaterMark(
   highWaterMark: Map<string, number>,
@@ -196,7 +232,9 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
       agent: params.agent,
       parentConversationId: params.parentConversationId,
       task: params.task,
-      status: "initializing",
+      // Daemon emits `acp_session_spawned` only after the session is already
+      // running, so a spawned run starts as "running", not "initializing".
+      status: "running",
       startedAt: params.startedAt,
       parentToolUseId: params.parentToolUseId,
       inputTokens: 0,
@@ -286,12 +324,10 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
 
     for (const entry of entries) {
       const existing = nextById[entry.acpSessionId];
-      // Prefer the entry with more events so a live buffer is never clobbered
-      // by a shorter historical snapshot.
-      nextById[entry.acpSessionId] =
-        existing && existing.events.length >= entry.events.length
-          ? existing
-          : entry;
+      // Keep the longer event buffer but always merge terminal/status/usage
+      // metadata from history so a live entry can't stay stale.
+      const merged = existing ? mergeHistoryEntry(existing, entry) : entry;
+      nextById[entry.acpSessionId] = merged;
 
       if (!nextOrderedIds.includes(entry.acpSessionId)) {
         nextOrderedIds.push(entry.acpSessionId);
@@ -304,7 +340,7 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         );
       }
 
-      for (const event of entry.events) {
+      for (const event of merged.events) {
         nextHighWaterMark = bumpHighWaterMark(
           nextHighWaterMark,
           entry.acpSessionId,

--- a/clients/web/src/utils/acp-run-status.ts
+++ b/clients/web/src/utils/acp-run-status.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure status-display helpers for ACP run entries.
+ *
+ * Shared by the acp-run inline card, detail panel, and status badge.
+ */
+
+export type AcpRunStatus =
+  | "initializing"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/** Whether the run is in an active (non-terminal) state. */
+export function isActiveAcpStatus(status: AcpRunStatus): boolean {
+  return status === "initializing" || status === "running";
+}
+
+/** Map an AcpRunStatus to a semantic color token. */
+export function acpRunStatusColor(status: AcpRunStatus): string {
+  switch (status) {
+    case "completed":
+      return "var(--system-positive-strong)";
+    case "failed":
+    case "cancelled":
+      return "var(--system-negative-strong)";
+    default:
+      return "var(--primary-base)";
+  }
+}
+
+/** Human-readable label for the status badge. */
+export function acpRunStatusLabel(status: AcpRunStatus): string {
+  switch (status) {
+    case "initializing":
+      return "Initializing";
+    case "running":
+      return "Running";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "Unknown";
+  }
+}


### PR DESCRIPTION
## Summary
- Add acp-run-store (Zustand, atomic selectors) keyed by acpSessionId with append-only event buffers + same-messageId coalescing + highWaterMark dedup tracking
- Add acp-run-status helpers (status type, isActiveAcpStatus, label/color via design tokens)

Part of plan: acp-runs-ui.md (PR 4 of 13)