### PR TITLE
feat(acp): forward messageId, seq, tool title/kind, and spawning tool-use id

### DIFF
--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -152,6 +152,51 @@ describe("VellumAcpClientHandler seq + enriched fields", () => {
     expect(sent.map((m) => (m as { seq: number }).seq)).toEqual([1, 2, 3]);
   });
 
+  test("seedSeq continues seq past the persisted max after resume", async () => {
+    const { handler, sent } = makeHandler();
+
+    // Simulate resume: a fresh handler re-seeded from a persisted log whose
+    // updates carried seq up to 5.
+    handler.seedSeq(5);
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "live after resume" },
+      },
+    });
+
+    // The first live update must continue at 6 (N + 1), not reset to 1, so
+    // the web client's highWaterMark de-dupe doesn't drop it.
+    expect((sent[0] as { seq: number }).seq).toBe(6);
+  });
+
+  test("seedSeq ignores smaller or non-finite values", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "a" },
+      },
+    });
+    // Already at seq 1; a smaller/NaN seed must not regress the counter.
+    handler.seedSeq(0);
+    handler.seedSeq(Number.NaN);
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "b" },
+      },
+    });
+
+    expect(sent.map((m) => (m as { seq: number }).seq)).toEqual([1, 2]);
+  });
+
   test("forwards ContentChunk messageId on message chunks", async () => {
     const { handler, sent } = makeHandler();
 

--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -41,8 +41,10 @@ describe("VellumAcpClientHandler.sessionUpdate", () => {
     expect(sent[0]).toEqual({
       type: "acp_session_update",
       acpSessionId: ACP_SESSION_ID,
+      seq: 1,
       updateType: "agent_thought_chunk",
       content: "internal reasoning here",
+      messageId: undefined,
     });
   });
 
@@ -96,9 +98,103 @@ describe("VellumAcpClientHandler replay suppression", () => {
     expect(sent[0]).toEqual({
       type: "acp_session_update",
       acpSessionId: ACP_SESSION_ID,
+      seq: 1,
       updateType: "agent_message_chunk",
       content: "live response",
+      messageId: undefined,
     });
     expect(handler.responseText).toBe("live response");
+  });
+
+  test("seq is not consumed by updates dropped during suppression", async () => {
+    const { handler, sent } = makeHandler();
+
+    handler.beginReplaySuppression();
+    await handler.sessionUpdate(messageChunk("replayed one"));
+    await handler.sessionUpdate(messageChunk("replayed two"));
+    handler.endReplaySuppression();
+
+    // The first forwarded event must start at seq 1: suppressed replays
+    // never advanced the counter.
+    await handler.sessionUpdate(messageChunk("live one"));
+    await handler.sessionUpdate(messageChunk("live two"));
+
+    expect(sent.map((m) => (m as { seq: number }).seq)).toEqual([1, 2]);
+  });
+});
+
+describe("VellumAcpClientHandler seq + enriched fields", () => {
+  test("seq increments monotonically per forwarded event", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "a" },
+      },
+    });
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "b" },
+      },
+    });
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "plan",
+        entries: [],
+      },
+    });
+
+    expect(sent.map((m) => (m as { seq: number }).seq)).toEqual([1, 2, 3]);
+  });
+
+  test("forwards ContentChunk messageId on message chunks", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "hello" },
+        messageId: "msg-42",
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      updateType: "agent_message_chunk",
+      content: "hello",
+      messageId: "msg-42",
+      seq: 1,
+    });
+  });
+
+  test("tool_call_update carries toolTitle and toolKind", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-1",
+        title: "Edit main.ts",
+        kind: "edit",
+        status: "in_progress",
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      updateType: "tool_call_update",
+      toolCallId: "tc-1",
+      toolTitle: "Edit main.ts",
+      toolKind: "edit",
+      toolStatus: "in_progress",
+      seq: 1,
+    });
   });
 });

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -323,6 +323,34 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ]);
   });
 
+  test("live updates after resume continue seq past the persisted max", async () => {
+    fakeCaps.resume = true;
+    // Persisted log whose updates carry seq up to 4.
+    const persisted: AcpSessionUpdate[] = [
+      { ...PERSISTED_EVENT, seq: 2 },
+      { ...PERSISTED_EVENT, seq: 4 },
+    ];
+    insertHistoryRow({
+      id: "resume-seq-1",
+      eventLogJson: JSON.stringify(persisted),
+    });
+
+    const manager = new AcpSessionManager(4);
+    const sent: ServerMessage[] = [];
+    await manager.resumeFromHistory("resume-seq-1", (msg) => sent.push(msg));
+
+    const fake = fakeInstances[0]!;
+    await fake.emitChunk("live-after-resume");
+
+    // The first live update continues at 5 (max persisted seq + 1), not 1, so
+    // the web client's highWaterMark de-dupe doesn't drop it.
+    const liveUpdates = sent.filter(
+      (m): m is AcpSessionUpdate => m.type === "acp_session_update",
+    );
+    expect(liveUpdates).toHaveLength(1);
+    expect(liveUpdates[0]!.seq).toBe(5);
+  });
+
   test("prefers session/resume when advertised and never calls loadSession", async () => {
     fakeCaps.loadSession = true;
     fakeCaps.resume = true;

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -31,6 +31,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AcpSessionUpdate } from "../daemon/message-types/acp.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("acp:client-handler");
@@ -52,6 +53,8 @@ export class VellumAcpClientHandler implements Client {
   private terminals = new Map<string, TerminalState>();
   private accumulatedText = "";
   private suppressForwarding = false;
+  /** Monotonic ordering counter; advanced only on forwarded updates. */
+  private lastSeq = 0;
   /** Tracks pending ACP permission requestIds for cleanup on session close. */
   readonly pendingRequestIds = new Set<string>();
 
@@ -65,6 +68,18 @@ export class VellumAcpClientHandler implements Client {
     private readonly sendToVellum: (msg: ServerMessage) => void,
     private readonly parentConversationId: string,
   ) {}
+
+  /** Forwards an update to Vellum, stamping a contiguous per-session `seq`. */
+  private forwardUpdate(
+    update: Omit<AcpSessionUpdate, "type" | "acpSessionId" | "seq">,
+  ): void {
+    this.sendToVellum({
+      type: "acp_session_update",
+      acpSessionId: this.acpSessionId,
+      seq: ++this.lastSeq,
+      ...update,
+    });
+  }
 
   /**
    * Begins suppressing session updates from being forwarded to Vellum.
@@ -107,41 +122,36 @@ export class VellumAcpClientHandler implements Client {
       case "agent_message_chunk": {
         const text = extractText(update.content);
         this.accumulatedText += text;
-        this.sendToVellum({
-          type: "acp_session_update",
-          acpSessionId: this.acpSessionId,
+        this.forwardUpdate({
           updateType: "agent_message_chunk",
           content: text,
+          messageId: update.messageId ?? undefined,
         });
         break;
       }
 
       case "agent_thought_chunk": {
         const text = extractText(update.content);
-        this.sendToVellum({
-          type: "acp_session_update",
-          acpSessionId: this.acpSessionId,
+        this.forwardUpdate({
           updateType: "agent_thought_chunk",
           content: text,
+          messageId: update.messageId ?? undefined,
         });
         break;
       }
 
       case "user_message_chunk": {
         const text = extractText(update.content);
-        this.sendToVellum({
-          type: "acp_session_update",
-          acpSessionId: this.acpSessionId,
+        this.forwardUpdate({
           updateType: "user_message_chunk",
           content: text,
+          messageId: update.messageId ?? undefined,
         });
         break;
       }
 
       case "tool_call": {
-        this.sendToVellum({
-          type: "acp_session_update",
-          acpSessionId: this.acpSessionId,
+        this.forwardUpdate({
           updateType: "tool_call",
           toolCallId: update.toolCallId,
           toolTitle: update.title,
@@ -152,11 +162,11 @@ export class VellumAcpClientHandler implements Client {
       }
 
       case "tool_call_update": {
-        this.sendToVellum({
-          type: "acp_session_update",
-          acpSessionId: this.acpSessionId,
+        this.forwardUpdate({
           updateType: "tool_call_update",
           toolCallId: update.toolCallId,
+          toolTitle: update.title ?? undefined,
+          toolKind: update.kind ?? undefined,
           toolStatus: update.status ?? undefined,
           content: update.content ? JSON.stringify(update.content) : undefined,
         });
@@ -164,9 +174,7 @@ export class VellumAcpClientHandler implements Client {
       }
 
       case "plan": {
-        this.sendToVellum({
-          type: "acp_session_update",
-          acpSessionId: this.acpSessionId,
+        this.forwardUpdate({
           updateType: "plan",
           content: JSON.stringify(update.entries),
         });

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -63,6 +63,17 @@ export class VellumAcpClientHandler implements Client {
     return this.accumulatedText;
   }
 
+  /**
+   * Advances the seq counter to at least `maxSeq` so updates forwarded by a
+   * handler created for a resumed session continue strictly increasing past
+   * any seq already persisted. Ignores non-finite or smaller values.
+   */
+  seedSeq(maxSeq: number): void {
+    if (Number.isFinite(maxSeq) && maxSeq > this.lastSeq) {
+      this.lastSeq = maxSeq;
+    }
+  }
+
   constructor(
     private readonly acpSessionId: string,
     private readonly sendToVellum: (msg: ServerMessage) => void,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -480,12 +480,18 @@ export class AcpSessionManager {
 
     // Re-seed the ring buffer from the persisted event log, routed through
     // appendToBuffer so the count/byte caps still apply. The terminal
-    // upsert then persists the merged (old + new) log.
+    // upsert then persists the merged (old + new) log. Track the highest
+    // persisted seq and advance the fresh handler's counter to it so live
+    // updates after resume continue strictly increasing instead of resetting
+    // to 1 (which the web client would drop as seq <= highWaterMark).
+    let maxSeq = 0;
     try {
       const persisted = JSON.parse(row.eventLogJson) as unknown;
       if (Array.isArray(persisted)) {
         for (const update of persisted) {
           this.appendToBuffer(acpSessionId, update as AcpSessionUpdate);
+          const seq = (update as AcpSessionUpdate)?.seq;
+          if (typeof seq === "number" && seq > maxSeq) maxSeq = seq;
         }
       }
     } catch (err) {
@@ -494,6 +500,8 @@ export class AcpSessionManager {
         "Failed to re-seed ACP event buffer from persisted history",
       );
     }
+    // Seed before the child process spawns so no live update can fire first.
+    entry.clientHandler.seedSeq(maxSeq);
 
     try {
       log.info(

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -72,6 +72,10 @@ interface SessionEntry {
   currentPrompt: Promise<unknown> | null;
   parentConversationId: string;
   cwd: string;
+  /** Tool-use id of the `acp_spawn` call that spawned this session, if any. */
+  parentToolUseId?: string;
+  /** Objective text the session was spawned with, if known. */
+  task?: string;
   /** Resolved adapter command basename (e.g. "claude-agent-acp"). Used to
    *  gate resume hints to the only adapter (claude-agent-acp) whose CLI
    *  accepts `--resume`. */
@@ -191,6 +195,7 @@ export class AcpSessionManager {
     cwd: string,
     parentConversationId: string,
     sendToVellum: (msg: ServerMessage) => void,
+    parentToolUseId?: string,
   ): Promise<{ acpSessionId: string; protocolSessionId: string }> {
     this.assertCapacity();
 
@@ -214,6 +219,8 @@ export class AcpSessionManager {
       cwd,
       startedAt: Date.now(),
       sendToVellum,
+      parentToolUseId,
+      task,
     });
     const { process: agentProcess, state } = entry;
 
@@ -268,6 +275,8 @@ export class AcpSessionManager {
     cwd: string;
     startedAt: number;
     sendToVellum: (msg: ServerMessage) => void;
+    parentToolUseId?: string;
+    task?: string;
   }): SessionEntry {
     const { acpSessionId } = opts;
 
@@ -313,6 +322,8 @@ export class AcpSessionManager {
       currentPrompt: null,
       parentConversationId: opts.parentConversationId,
       cwd: opts.cwd,
+      parentToolUseId: opts.parentToolUseId,
+      task: opts.task,
       command: basename(opts.agentConfig.command),
     };
 
@@ -332,6 +343,8 @@ export class AcpSessionManager {
       acpSessionId,
       agent: entry.state.agentId,
       parentConversationId: entry.parentConversationId,
+      parentToolUseId: entry.parentToolUseId,
+      task: entry.task,
     });
   }
 

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -7,6 +7,10 @@ export interface AcpSessionSpawned {
   acpSessionId: string;
   agent: string;
   parentConversationId: string;
+  /** Tool-use id of the `acp_spawn` call that spawned this session. */
+  parentToolUseId?: string;
+  /** Objective text for the spawned session. */
+  task?: string;
 }
 
 export interface AcpSessionUpdate {
@@ -24,6 +28,10 @@ export interface AcpSessionUpdate {
   toolTitle?: string;
   toolKind?: string;
   toolStatus?: string;
+  /** Stable id for the message this chunk belongs to. */
+  messageId?: string;
+  /** Monotonic ordering hint within the session. */
+  seq?: number;
 }
 
 export interface AcpSessionCompleted {

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -77,8 +77,7 @@ mock.module("../../tools/credentials/metadata-store.js", () => ({
     const existing = metadataStore.get(key);
     metadataStore.set(key, {
       allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
-      usageDescription:
-        policy?.usageDescription ?? existing?.usageDescription,
+      usageDescription: policy?.usageDescription ?? existing?.usageDescription,
     });
     return {
       credentialId: `cred-${key}`,
@@ -130,6 +129,7 @@ const spawnMock = mock(
     _cwd: string,
     _parentConversationId: string,
     _sendToVellum: (msg: unknown) => void,
+    _parentToolUseId?: string,
   ) => ({
     acpSessionId: "acp-session-test",
     protocolSessionId: "proto-session-test",
@@ -148,9 +148,8 @@ mock.module("../../acp/index.js", () => ({
 }));
 
 const { executeAcpSpawn } = await import("./spawn.js");
-const { _resetAdapterInstallCacheForTests } = await import(
-  "../../acp/auto-install.js"
-);
+const { _resetAdapterInstallCacheForTests } =
+  await import("../../acp/auto-install.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -203,6 +202,18 @@ describe("executeAcpSpawn - happy path", () => {
     // The real adapter binary is spawned (no `bun x` wrapper).
     const agentConfigArg = spawnMock.mock.calls[0][1] as { command: string };
     expect(agentConfigArg.command).toBe("claude-agent-acp");
+  });
+
+  test("threads the executing tool-use id into manager.spawn as parentToolUseId", async () => {
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something" },
+      { ...makeContext(), toolUseId: "toolu_abc123" },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    // parentToolUseId is the 7th positional arg to spawn().
+    expect(spawnMock.mock.calls[0][6]).toBe("toolu_abc123");
   });
 
   test("default-profile fallback when user config is empty", async () => {

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -66,6 +66,7 @@ export async function executeAcpSpawn(
       cwd,
       context.conversationId,
       sendToClient,
+      context.toolUseId,
     );
 
     // Claude Code-only resume hint; empty for other adapters. Keyed off the


### PR DESCRIPTION
## Summary
- Forward ACP ContentChunk messageId and a monotonic per-session seq on acp_session_update
- Preserve tool title/kind on tool_call_update
- Thread the spawning acp_spawn tool-use id (and task) into acp_session_spawned

Part of plan: acp-runs-ui.md (PR 2 of 13)