### PR TITLE
feat(acp): include in-memory event buffer in /acp/sessions for active runs

### DIFF
--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -814,6 +814,18 @@ export class AcpSessionManager {
   }
 
   /**
+   * Returns the live ring buffer for an active session as wire-shaped
+   * `AcpSessionUpdate[]` (each carrying `seq`), matching exactly what
+   * `persistTerminal` serializes to `eventLogJson` on terminal transition.
+   * Empty array for unknown/already-torn-down ids.
+   */
+  getBufferedUpdates(acpSessionId: string): AcpSessionUpdate[] {
+    const buffer = this.eventBuffers.get(acpSessionId);
+    if (!buffer) return [];
+    return buffer.map((b) => b.update);
+  }
+
+  /**
    * Appends a wire-shaped update to the ring buffer, evicting oldest events
    * when either the count or aggregate-byte cap is exceeded. Byte
    * accounting tracks the sum of element JSON sizes; the cap is a soft

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -76,6 +76,7 @@ mock.module("../../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     getStatus: () => fakeInMemorySessions,
     getActiveAndPendingIds: () => fakeInMemorySessions.map((s) => s.id),
+    getBufferedUpdates: () => [],
     spawn: spawnMock,
     steerOrResume: steerOrResumeMock,
   }),
@@ -207,8 +208,8 @@ describe("GET /v1/acp/sessions — merged in-memory + history", () => {
       status: "running",
       startedAt: 1000,
     });
-    // No eventLog on in-memory sessions.
-    expect(body.sessions[0].eventLog).toBeUndefined();
+    // In-memory sessions carry eventLog from the live ring buffer (empty here).
+    expect(body.sessions[0].eventLog).toEqual([]);
   });
 
   test("returns only history rows when no in-memory sessions exist", async () => {
@@ -252,8 +253,8 @@ describe("GET /v1/acp/sessions — merged in-memory + history", () => {
   });
 
   test("dedupes by id with in-memory winning on collision", async () => {
-    // Same id in both layers — in-memory entry should win and eventLog
-    // (which only history carries) must be absent on the merged record.
+    // Same id in both layers — in-memory entry should win and its eventLog
+    // comes from the live ring buffer (empty here), not the stale history row.
     fakeInMemorySessions = [
       {
         id: "shared-1",
@@ -282,7 +283,7 @@ describe("GET /v1/acp/sessions — merged in-memory + history", () => {
     expect(body.sessions[0].agentId).toBe("agent-live");
     expect(body.sessions[0].status).toBe("running");
     expect(body.sessions[0].startedAt).toBe(5000);
-    expect(body.sessions[0].eventLog).toBeUndefined();
+    expect(body.sessions[0].eventLog).toEqual([]);
   });
 
   test("merges in-memory and disjoint history rows", async () => {

--- a/assistant/src/runtime/routes/acp-routes-event-log.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-event-log.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the GET /v1/acp/sessions list handler's `eventLog` population:
+ * active in-memory sessions source it from the live ring buffer (each item
+ * carrying `seq`), while terminal DB rows source it from persisted
+ * `eventLogJson`.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AcpSessionState } from "../../acp/index.js";
+import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
+
+const inMemoryStates = new Map<string, AcpSessionState>();
+const bufferedUpdates = new Map<string, AcpSessionUpdate[]>();
+
+mock.module("../../acp/index.js", () => ({
+  getAcpSessionManager: () => ({
+    getStatus: (id?: string) => {
+      if (id === undefined) return Array.from(inMemoryStates.values());
+      const state = inMemoryStates.get(id);
+      if (!state) throw new Error(`ACP session "${id}" not found`);
+      return state;
+    },
+    getBufferedUpdates: (id: string) => bufferedUpdates.get(id) ?? [],
+  }),
+}));
+
+// DB stub returning a fixed set of terminal history rows.
+let historyRows: Array<Record<string, unknown>> = [];
+
+mock.module("../../memory/db-connection.js", () => {
+  const builder: any = {};
+  builder.select = () => builder;
+  builder.from = () => builder;
+  builder.where = () => builder;
+  builder.orderBy = () => builder;
+  builder.limit = () => builder;
+  builder.all = () => historyRows;
+  return {
+    getDb: () => builder,
+    getSqlite: () => ({ __stub: true }),
+    getSqliteFrom: () => ({ __stub: true }),
+    getMemoryDb: () => builder,
+    getMemorySqlite: () => ({ __stub: true }),
+    getLogsDb: () => builder,
+    getLogsSqlite: () => ({ __stub: true }),
+    resetDb: () => {},
+  };
+});
+
+const { ROUTES } = await import("./acp-routes.js");
+
+function getListHandler() {
+  const route = ROUTES.find(
+    (r: { endpoint: string; method: string }) =>
+      r.endpoint === "acp/sessions" && r.method === "GET",
+  );
+  if (!route) throw new Error("GET acp/sessions route not registered");
+  return route.handler;
+}
+
+function makeInMemoryState(
+  id: string,
+  parentConversationId: string,
+): AcpSessionState {
+  return {
+    id,
+    agentId: "claude",
+    acpSessionId: `proto-${id}`,
+    parentConversationId,
+    status: "running",
+    startedAt: 1_700_000_000_000,
+  };
+}
+
+function makeUpdate(seq: number, content: string): AcpSessionUpdate {
+  return {
+    type: "acp_session_update",
+    acpSessionId: "active",
+    updateType: "agent_message_chunk",
+    content,
+    seq,
+  };
+}
+
+beforeEach(() => {
+  inMemoryStates.clear();
+  bufferedUpdates.clear();
+  historyRows = [];
+});
+
+afterAll(() => {
+  inMemoryStates.clear();
+  bufferedUpdates.clear();
+  historyRows = [];
+});
+
+describe("GET /v1/acp/sessions — eventLog", () => {
+  test("active in-memory session returns eventLog from the live ring buffer with seq", async () => {
+    inMemoryStates.set("active", makeInMemoryState("active", "conv-1"));
+    bufferedUpdates.set("active", [
+      makeUpdate(1, "hello"),
+      makeUpdate(2, "world"),
+    ]);
+
+    const handler = getListHandler();
+    const result = (await handler({
+      queryParams: { conversationId: "conv-1" },
+    })) as { sessions: Array<Record<string, unknown>> };
+
+    const session = result.sessions.find((s) => s.id === "active");
+    expect(session).toBeDefined();
+    const eventLog = session?.eventLog as AcpSessionUpdate[];
+    expect(eventLog).toHaveLength(2);
+    expect(eventLog.map((u) => u.seq)).toEqual([1, 2]);
+    expect(eventLog[0]?.content).toBe("hello");
+  });
+
+  test("terminal DB row returns its persisted eventLog", async () => {
+    historyRows = [
+      {
+        id: "terminal",
+        agentId: "claude",
+        acpSessionId: "proto-terminal",
+        parentConversationId: "conv-1",
+        status: "completed",
+        startedAt: 1_699_000_000_000,
+        completedAt: 1_699_000_001_000,
+        error: null,
+        stopReason: "end_turn",
+        eventLogJson: JSON.stringify([makeUpdate(7, "persisted")]),
+      },
+    ];
+
+    const handler = getListHandler();
+    const result = (await handler({
+      queryParams: { conversationId: "conv-1" },
+    })) as { sessions: Array<Record<string, unknown>> };
+
+    const session = result.sessions.find((s) => s.id === "terminal");
+    expect(session).toBeDefined();
+    const eventLog = session?.eventLog as AcpSessionUpdate[];
+    expect(eventLog).toHaveLength(1);
+    expect(eventLog[0]?.seq).toBe(7);
+    expect(eventLog[0]?.content).toBe("persisted");
+  });
+});

--- a/assistant/src/runtime/routes/acp-routes-event-log.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-event-log.test.ts
@@ -25,30 +25,20 @@ mock.module("../../acp/index.js", () => ({
   }),
 }));
 
-// DB stub returning a fixed set of terminal history rows.
-let historyRows: Array<Record<string, unknown>> = [];
-
-mock.module("../../memory/db-connection.js", () => {
-  const builder: any = {};
-  builder.select = () => builder;
-  builder.from = () => builder;
-  builder.where = () => builder;
-  builder.orderBy = () => builder;
-  builder.limit = () => builder;
-  builder.all = () => historyRows;
-  return {
-    getDb: () => builder,
-    getSqlite: () => ({ __stub: true }),
-    getSqliteFrom: () => ({ __stub: true }),
-    getMemoryDb: () => builder,
-    getMemorySqlite: () => ({ __stub: true }),
-    getLogsDb: () => builder,
-    getLogsSqlite: () => ({ __stub: true }),
-    resetDb: () => {},
-  };
-});
+// Terminal history rows go through the real DB (like the sibling acp-routes
+// suite), not a `db-connection` module stub. A process-global `db-connection`
+// mock would omit named exports (`getTelemetrySqlite`, …) and poison `getDb`
+// for adjacent route tests that call `initializeDb()` in the same Bun
+// invocation, so we seed real rows via the shared history helper instead.
+import {
+  clearHistory,
+  insertHistoryRow,
+} from "../../acp/__tests__/helpers/acp-history-db.js";
+import { initializeDb } from "../../memory/db-init.js";
 
 const { ROUTES } = await import("./acp-routes.js");
+
+await initializeDb();
 
 function getListHandler() {
   const route = ROUTES.find(
@@ -86,13 +76,13 @@ function makeUpdate(seq: number, content: string): AcpSessionUpdate {
 beforeEach(() => {
   inMemoryStates.clear();
   bufferedUpdates.clear();
-  historyRows = [];
+  clearHistory();
 });
 
 afterAll(() => {
   inMemoryStates.clear();
   bufferedUpdates.clear();
-  historyRows = [];
+  clearHistory();
 });
 
 describe("GET /v1/acp/sessions — eventLog", () => {
@@ -117,20 +107,18 @@ describe("GET /v1/acp/sessions — eventLog", () => {
   });
 
   test("terminal DB row returns its persisted eventLog", async () => {
-    historyRows = [
-      {
-        id: "terminal",
-        agentId: "claude",
-        acpSessionId: "proto-terminal",
-        parentConversationId: "conv-1",
-        status: "completed",
-        startedAt: 1_699_000_000_000,
-        completedAt: 1_699_000_001_000,
-        error: null,
-        stopReason: "end_turn",
-        eventLogJson: JSON.stringify([makeUpdate(7, "persisted")]),
-      },
-    ];
+    insertHistoryRow({
+      id: "terminal",
+      agentId: "claude",
+      acpSessionId: "proto-terminal",
+      parentConversationId: "conv-1",
+      status: "completed",
+      startedAt: 1_699_000_000_000,
+      completedAt: 1_699_000_001_000,
+      error: null,
+      stopReason: "end_turn",
+      eventLogJson: JSON.stringify([makeUpdate(7, "persisted")]),
+    });
 
     const handler = getListHandler();
     const result = (await handler({

--- a/assistant/src/runtime/routes/acp-routes-list.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-list.test.ts
@@ -23,6 +23,7 @@ mock.module("../../acp/index.js", () => ({
       if (!state) throw new Error(`ACP session "${id}" not found`);
       return state;
     },
+    getBufferedUpdates: () => [],
   }),
 }));
 

--- a/assistant/src/runtime/routes/acp-routes-list.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-list.test.ts
@@ -27,33 +27,30 @@ mock.module("../../acp/index.js", () => ({
   }),
 }));
 
-// Spy on the drizzle limit() call to assert the exact value the handler
-// passes to SQL. The stub mirrors only the chained methods used by
-// listMergedSessions; calls fall through to a final `.all()` returning [].
+// Assert the exact SQL limit the handler passes by spying on the real
+// drizzle builder's `limit()` — we run the real DB (like the sibling
+// acp-routes suite) rather than stubbing `db-connection`. A process-global
+// module stub would omit named exports and poison `getDb` for adjacent route
+// tests that call `initializeDb()` in the same Bun invocation.
+import { getDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import { acpSessionHistory } from "../../memory/schema.js";
+
+await initializeDb();
+
 const capturedLimits: number[] = [];
 
-mock.module("../../memory/db-connection.js", () => {
-  const builder: any = {};
-  builder.select = () => builder;
-  builder.from = () => builder;
-  builder.where = () => builder;
-  builder.orderBy = () => builder;
-  builder.limit = (n: number) => {
-    capturedLimits.push(n);
-    return builder;
-  };
-  builder.all = () => [];
-  return {
-    getDb: () => builder,
-    getSqlite: () => ({ __stub: true }),
-    getSqliteFrom: () => ({ __stub: true }),
-    getMemoryDb: () => builder,
-    getMemorySqlite: () => ({ __stub: true }),
-    getLogsDb: () => builder,
-    getLogsSqlite: () => ({ __stub: true }),
-    resetDb: () => {},
-  };
-});
+// `.limit()` lives on the SQLiteSelect prototype and mutates/returns `this`.
+// Patch it once on the prototype so the spy survives across query chains, and
+// restore in `afterAll` so other suites see the unpatched builder.
+const selectProto = Object.getPrototypeOf(
+  getDb().select().from(acpSessionHistory),
+);
+const originalLimit = selectProto.limit;
+selectProto.limit = function patchedLimit(this: unknown, n: number) {
+  capturedLimits.push(n);
+  return originalLimit.call(this, n);
+};
 
 const { ROUTES } = await import("./acp-routes.js");
 
@@ -83,6 +80,7 @@ function makeInMemoryState(
 afterAll(() => {
   inMemoryStates.clear();
   capturedLimits.length = 0;
+  selectProto.limit = originalLimit;
 });
 
 describe("GET /v1/acp/sessions — SQL pad amount", () => {

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -689,6 +689,7 @@ function listMergedSessions(opts: {
       completedAt: s.completedAt ?? null,
       error: s.error ?? null,
       stopReason: s.stopReason ?? null,
+      eventLog: manager.getBufferedUpdates(s.id),
     });
   }
 


### PR DESCRIPTION
## Summary
- Add session-manager getBufferedUpdates() exposing the live ring buffer as wire AcpSessionUpdate[] (carrying seq)
- Populate eventLog for active in-memory sessions in /acp/sessions; terminal rows keep persisted eventLog

Part of plan: acp-runs-ui.md (PR 3 of 13)