### PR TITLE
feat(web): route acp_session_* SSE events into the acp-run store

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -103,6 +103,66 @@ describe("spawnRun", () => {
 
     expect(getState().orderedIds).toEqual(["acp-a", "acp-b", "acp-c"]);
   });
+
+  it("resumes a terminal run — clears terminal fields, marks running, keeps events", () => {
+    spawn();
+    getState().receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, content: "a" }),
+    });
+    getState().setTerminal({
+      acpSessionId: "acp-1",
+      status: "completed",
+      stopReason: "end_turn",
+      completedAt: NOW + 1000,
+    });
+    expect(getState().byId["acp-1"]!.status).toBe("completed");
+
+    // A respawn for the same id (resume/steer) flips it back to running.
+    spawn({ startedAt: NOW + 5000 });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("running");
+    expect(entry.stopReason).toBeUndefined();
+    expect(entry.error).toBeUndefined();
+    expect(entry.completedAt).toBeUndefined();
+    // Events and startedAt are preserved across the resume.
+    expect(entry.events).toHaveLength(1);
+    expect(entry.events[0]!.content).toBe("a");
+    expect(entry.startedAt).toBe(NOW);
+    // No duplicate ordered id.
+    expect(getState().orderedIds).toEqual(["acp-1"]);
+  });
+
+  it("resume clears a failed run's error", () => {
+    spawn();
+    getState().setTerminal({
+      acpSessionId: "acp-1",
+      status: "failed",
+      error: "agent crashed",
+      completedAt: NOW + 2000,
+    });
+
+    spawn();
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("running");
+    expect(entry.error).toBeUndefined();
+  });
+
+  it("backfills parentToolUseId on resume when it was previously missing", () => {
+    spawn();
+    getState().setTerminal({
+      acpSessionId: "acp-1",
+      status: "completed",
+      completedAt: NOW + 1000,
+    });
+
+    spawn({ parentToolUseId: "tool-use-1" });
+
+    expect(getState().byId["acp-1"]!.parentToolUseId).toBe("tool-use-1");
+    expect(getState().byToolUseId.get("tool-use-1")).toBe("acp-1");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -225,7 +225,35 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
 
   spawnRun: (params) => {
     const { byId, orderedIds, byToolUseId } = get();
-    if (byId[params.acpSessionId]) return;
+    const existing = byId[params.acpSessionId];
+
+    if (existing) {
+      // A respawn for an active run is a no-op. A respawn for a terminal run
+      // is a resume (steer/resume-from-history): clear terminal fields and
+      // mark it running while preserving events, usage, and spawn context.
+      if (isActiveAcpStatus(existing.status)) return;
+
+      const resumed: AcpRunEntry = {
+        ...existing,
+        status: "running",
+        stopReason: undefined,
+        error: undefined,
+        completedAt: undefined,
+        task: existing.task ?? params.task,
+        parentToolUseId: existing.parentToolUseId ?? params.parentToolUseId,
+      };
+
+      const nextByToolUseId =
+        params.parentToolUseId && !existing.parentToolUseId
+          ? new Map(byToolUseId).set(params.parentToolUseId, params.acpSessionId)
+          : byToolUseId;
+
+      set({
+        byId: { ...byId, [params.acpSessionId]: resumed },
+        byToolUseId: nextByToolUseId,
+      });
+      return;
+    }
 
     const entry: AcpRunEntry = {
       acpSessionId: params.acpSessionId,

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -65,6 +65,12 @@ import {
   handleSubagentEvent,
 } from "@/domains/chat/utils/stream-handlers/subagent-handlers";
 import {
+  handleAcpSessionSpawned,
+  handleAcpSessionUpdate,
+  handleAcpSessionCompleted,
+  handleAcpSessionError,
+} from "@/domains/chat/utils/stream-handlers/acp-handlers";
+import {
   handleWorkflowStarted,
   handleWorkflowProgress,
   handleWorkflowLeafStarted,
@@ -386,6 +392,19 @@ export function useStreamEventHandler(
           break;
         case "subagent_event":
           handleSubagentEvent(event, ctx);
+          break;
+
+        case "acp_session_spawned":
+          handleAcpSessionSpawned(event);
+          break;
+        case "acp_session_update":
+          handleAcpSessionUpdate(event);
+          break;
+        case "acp_session_completed":
+          handleAcpSessionCompleted(event);
+          break;
+        case "acp_session_error":
+          handleAcpSessionError(event);
           break;
 
         case "workflow_started":

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -51,6 +51,13 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   "subagent_spawned",
   "subagent_status_changed",
   "subagent_event",
+  // ACP session events route by `acpSessionId` into the global acp-run store
+  // and carry no top-level `conversationId`, so (like subagent events) the
+  // conversation-id gate would otherwise drop them.
+  "acp_session_spawned",
+  "acp_session_update",
+  "acp_session_completed",
+  "acp_session_error",
 ] as const;
 
 const GLOBAL_STREAM_EVENT_TYPES: ReadonlySet<string> = new Set(

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import {
+  handleAcpSessionSpawned,
+  handleAcpSessionUpdate,
+  handleAcpSessionCompleted,
+  handleAcpSessionError,
+} from "@/domains/chat/utils/stream-handlers/acp-handlers";
+
+function getState() {
+  return useAcpRunStore.getState();
+}
+
+function spawn() {
+  handleAcpSessionSpawned({
+    type: "acp_session_spawned",
+    acpSessionId: "acp-1",
+    agent: "claude",
+    parentConversationId: "conv-1",
+    parentToolUseId: "tool-1",
+    task: "research the thing",
+  });
+}
+
+beforeEach(() => {
+  getState().reset();
+});
+
+describe("handleAcpSessionSpawned", () => {
+  it("spawns a running run with spawn context", () => {
+    spawn();
+    const entry = getState().byId["acp-1"];
+    expect(entry).toBeDefined();
+    expect(entry?.status).toBe("running");
+    expect(entry?.agent).toBe("claude");
+    expect(entry?.parentConversationId).toBe("conv-1");
+    expect(entry?.parentToolUseId).toBe("tool-1");
+    expect(entry?.task).toBe("research the thing");
+    expect(getState().orderedIds).toEqual(["acp-1"]);
+    expect(getState().byToolUseId.get("tool-1")).toBe("acp-1");
+  });
+});
+
+describe("handleAcpSessionUpdate", () => {
+  it("appends an event and bumps the high-water mark", () => {
+    spawn();
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "agent_message_chunk",
+      content: "hello",
+      messageId: "m-1",
+      seq: 1,
+    });
+    expect(getState().byId["acp-1"]?.events).toHaveLength(1);
+    expect(getState().byId["acp-1"]?.events[0]?.content).toBe("hello");
+    expect(getState().highWaterMark.get("acp-1")).toBe(1);
+  });
+
+  it("drops a replayed event at or below the high-water mark", () => {
+    spawn();
+    const update = {
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "tool_call",
+      seq: 1,
+    } as const;
+    handleAcpSessionUpdate(update);
+    handleAcpSessionUpdate(update);
+    expect(getState().byId["acp-1"]?.events).toHaveLength(1);
+    expect(getState().highWaterMark.get("acp-1")).toBe(1);
+  });
+});
+
+describe("handleAcpSessionCompleted", () => {
+  it("marks the run completed with stop reason", () => {
+    spawn();
+    handleAcpSessionCompleted({
+      type: "acp_session_completed",
+      acpSessionId: "acp-1",
+      stopReason: "end_turn",
+    });
+    const entry = getState().byId["acp-1"];
+    expect(entry?.status).toBe("completed");
+    expect(entry?.stopReason).toBe("end_turn");
+    expect(entry?.completedAt).toBeGreaterThan(0);
+  });
+});
+
+describe("handleAcpSessionError", () => {
+  it("marks the run failed with the error message", () => {
+    spawn();
+    handleAcpSessionError({
+      type: "acp_session_error",
+      acpSessionId: "acp-1",
+      error: "boom",
+    });
+    const entry = getState().byId["acp-1"];
+    expect(entry?.status).toBe("failed");
+    expect(entry?.error).toBe("boom");
+    expect(entry?.completedAt).toBeGreaterThan(0);
+  });
+});

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -86,6 +86,33 @@ describe("handleAcpSessionCompleted", () => {
     expect(entry?.stopReason).toBe("end_turn");
     expect(entry?.completedAt).toBeGreaterThan(0);
   });
+
+  it("resumes a completed run when respawned for the same id", () => {
+    spawn();
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "agent_message_chunk",
+      content: "hello",
+      messageId: "m-1",
+      seq: 1,
+    });
+    handleAcpSessionCompleted({
+      type: "acp_session_completed",
+      acpSessionId: "acp-1",
+      stopReason: "end_turn",
+    });
+    expect(getState().byId["acp-1"]?.status).toBe("completed");
+
+    // resumeFromHistory re-emits acp_session_spawned for the same id.
+    spawn();
+
+    const entry = getState().byId["acp-1"];
+    expect(entry?.status).toBe("running");
+    expect(entry?.stopReason).toBeUndefined();
+    expect(entry?.completedAt).toBeUndefined();
+    expect(entry?.events).toHaveLength(1);
+  });
 });
 
 describe("handleAcpSessionError", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -1,0 +1,61 @@
+import type {
+  AcpSessionSpawnedEvent,
+  AcpSessionUpdateEvent,
+  AcpSessionCompletedEvent,
+  AcpSessionErrorEvent,
+} from "@vellumai/assistant-api";
+
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+
+export function handleAcpSessionSpawned(event: AcpSessionSpawnedEvent): void {
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId: event.acpSessionId,
+    agent: event.agent,
+    parentConversationId: event.parentConversationId,
+    parentToolUseId: event.parentToolUseId,
+    task: event.task,
+    startedAt: Date.now(),
+  });
+}
+
+export function handleAcpSessionUpdate(event: AcpSessionUpdateEvent): void {
+  const store = useAcpRunStore.getState();
+  // Drop replayed events on reconnection: anything at or below the mark.
+  const hwm = store.highWaterMark.get(event.acpSessionId);
+  const seq = event.seq ?? Date.now();
+  if (seq <= (hwm ?? -1)) return;
+
+  store.receiveEvent({
+    acpSessionId: event.acpSessionId,
+    event: {
+      seq,
+      updateType: event.updateType,
+      content: event.content,
+      toolCallId: event.toolCallId,
+      toolTitle: event.toolTitle,
+      toolKind: event.toolKind,
+      toolStatus: event.toolStatus,
+      messageId: event.messageId,
+    },
+  });
+}
+
+export function handleAcpSessionCompleted(
+  event: AcpSessionCompletedEvent,
+): void {
+  useAcpRunStore.getState().setTerminal({
+    acpSessionId: event.acpSessionId,
+    status: "completed",
+    stopReason: event.stopReason,
+    completedAt: Date.now(),
+  });
+}
+
+export function handleAcpSessionError(event: AcpSessionErrorEvent): void {
+  useAcpRunStore.getState().setTerminal({
+    acpSessionId: event.acpSessionId,
+    status: "failed",
+    error: event.error,
+    completedAt: Date.now(),
+  });
+}


### PR DESCRIPTION
## Summary
- Add acp-handlers dispatching acp_session_{spawned,update,completed,error} into the acp-run store
- Register the four event types as global stream events; seq-based highWaterMark dedup drops replays

Part of plan: acp-runs-ui.md (PR 6 of 13)