### PR TITLE
feat(web): add acp-run step/timeline projection

### DIFF
--- a/clients/web/src/domains/chat/acp-run-step-projection.test.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+import {
+  acpStepsToCarousel,
+  computeAcpRunSteps,
+  createAcpRunStepProjection,
+  type AcpTimelineStep,
+} from "@/domains/chat/acp-run-step-projection";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let nextSeq = 1;
+
+function event(overrides: Partial<AcpRunRawEvent>): AcpRunRawEvent {
+  return {
+    seq: nextSeq++,
+    updateType: "agent_message_chunk",
+    ...overrides,
+  };
+}
+
+function toolStep(step: AcpTimelineStep): Extract<AcpTimelineStep, { kind: "tool" }> {
+  if (step.kind !== "tool") throw new Error(`expected tool, got ${step.kind}`);
+  return step;
+}
+
+function messageStep(
+  step: AcpTimelineStep,
+): Extract<AcpTimelineStep, { kind: "message" }> {
+  if (step.kind !== "message") throw new Error(`expected message, got ${step.kind}`);
+  return step;
+}
+
+function planStep(step: AcpTimelineStep): Extract<AcpTimelineStep, { kind: "plan" }> {
+  if (step.kind !== "plan") throw new Error(`expected plan, got ${step.kind}`);
+  return step;
+}
+
+// ---------------------------------------------------------------------------
+// Folding rules
+// ---------------------------------------------------------------------------
+
+describe("computeAcpRunSteps — folding rules", () => {
+  test("tool_call appends a running tool step with title/kind/detailKey", () => {
+    const steps = computeAcpRunSteps([
+      event({
+        updateType: "tool_call",
+        toolCallId: "t1",
+        toolTitle: "Read file",
+        toolKind: "read",
+      }),
+    ]);
+    expect(steps).toHaveLength(1);
+    const tool = toolStep(steps[0]!);
+    expect(tool.toolCallId).toBe("t1");
+    expect(tool.title).toBe("Read file");
+    expect(tool.toolKind).toBe("read");
+    expect(tool.status).toBe("running");
+    expect(tool.outputChunks).toEqual([]);
+    expect(tool.detailKey).toBe("tool:t1");
+  });
+
+  test("tool_call_update correlates by toolCallId: accumulates output + status", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Run" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "out-a" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "out-b" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", toolStatus: "complete" }),
+    ]);
+    expect(steps).toHaveLength(1);
+    const tool = toolStep(steps[0]!);
+    expect(tool.outputChunks).toEqual(["out-a", "out-b"]);
+    expect(tool.status).toBe("completed");
+  });
+
+  test("tool_call_update maps failed/error to error status", () => {
+    const failed = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", toolStatus: "failed" }),
+    ]);
+    expect(toolStep(failed[0]!).status).toBe("error");
+
+    const errored = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t2" }),
+      event({ updateType: "tool_call_update", toolCallId: "t2", toolStatus: "error" }),
+    ]);
+    expect(toolStep(errored[0]!).status).toBe("error");
+  });
+
+  test("tool_call_update keeps running for unknown/absent status", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "x" }),
+    ]);
+    expect(toolStep(steps[0]!).status).toBe("running");
+  });
+
+  test("tool_call_update only overrides title/kind when carried", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Orig", toolKind: "read" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "x" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", toolTitle: "New" }),
+    ]);
+    const tool = toolStep(steps[0]!);
+    expect(tool.title).toBe("New");
+    expect(tool.toolKind).toBe("read");
+  });
+
+  test("tool_call_update for an unknown toolCallId is ignored", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call_update", toolCallId: "ghost", content: "x" }),
+    ]);
+    expect(steps).toHaveLength(0);
+  });
+
+  test("agent_message_chunk accumulates within one messageId", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "agent_message_chunk", messageId: "m1", content: "Hel" }),
+      event({ updateType: "agent_message_chunk", messageId: "m1", content: "lo" }),
+    ]);
+    expect(steps).toHaveLength(1);
+    const msg = messageStep(steps[0]!);
+    expect(msg.content).toBe("Hello");
+    expect(msg.messageId).toBe("m1");
+    expect(msg.detailKey).toBe("msg:m1");
+  });
+
+  test("message boundary by messageId: distinct ids split steps", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "agent_message_chunk", messageId: "m1", content: "a" }),
+      event({ updateType: "agent_message_chunk", messageId: "m2", content: "b" }),
+    ]);
+    expect(steps).toHaveLength(2);
+    expect(messageStep(steps[0]!).content).toBe("a");
+    expect(messageStep(steps[1]!).content).toBe("b");
+    // The earlier message closes once a later step starts.
+    expect(messageStep(steps[0]!).isComplete).toBe(true);
+    expect(messageStep(steps[1]!).isComplete).toBe(false);
+  });
+
+  test("message boundary by gap fallback for anonymous chunks", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "agent_message_chunk", content: "a" }),
+      event({ updateType: "agent_message_chunk", content: "b" }),
+      event({ updateType: "tool_call", toolCallId: "t1" }),
+      event({ updateType: "agent_message_chunk", content: "c" }),
+    ]);
+    // First two coalesce (anonymous, contiguous); the tool is a boundary, so
+    // "c" starts a fresh message.
+    expect(steps.map((s) => s.kind)).toEqual(["message", "tool", "message"]);
+    expect(messageStep(steps[0]!).content).toBe("ab");
+    expect(messageStep(steps[2]!).content).toBe("c");
+  });
+
+  test("agent_thought_chunk accumulates and splits by messageId", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "agent_thought_chunk", messageId: "th1", content: "Pon" }),
+      event({ updateType: "agent_thought_chunk", messageId: "th1", content: "der" }),
+      event({ updateType: "agent_thought_chunk", messageId: "th2", content: "more" }),
+    ]);
+    expect(steps).toHaveLength(2);
+    expect(steps[0]!.kind).toBe("thought");
+    if (steps[0]!.kind === "thought") {
+      expect(steps[0]!.content).toBe("Ponder");
+      expect(steps[0]!.detailKey).toBe("thought:th1");
+    }
+    if (steps[1]!.kind === "thought") expect(steps[1]!.content).toBe("more");
+  });
+
+  test("plan parses entries and replaces in place (no duplicate plan steps)", () => {
+    const first = JSON.stringify([
+      { label: "Step 1", checked: false },
+      { label: "Step 2", checked: true },
+    ]);
+    const second = JSON.stringify([{ label: "Only", checked: true }]);
+    const steps = computeAcpRunSteps([
+      event({ updateType: "plan", content: first }),
+      event({ updateType: "agent_message_chunk", messageId: "m1", content: "x" }),
+      event({ updateType: "plan", content: second }),
+    ]);
+    const plans = steps.filter((s) => s.kind === "plan");
+    expect(plans).toHaveLength(1);
+    expect(planStep(plans[0]!).entries).toEqual([{ label: "Only", checked: true }]);
+  });
+
+  test("plan tolerates entries wrapped in an object", () => {
+    const content = JSON.stringify({ entries: [{ label: "A", status: "completed" }] });
+    const steps = computeAcpRunSteps([event({ updateType: "plan", content })]);
+    expect(planStep(steps[0]!).entries).toEqual([{ label: "A", checked: true }]);
+  });
+
+  test("plan with malformed JSON is skipped", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "plan", content: "{not json" }),
+    ]);
+    expect(steps).toHaveLength(0);
+  });
+
+  test("user_message_chunk is ignored for the timeline", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "user_message_chunk", content: "hi" }),
+    ]);
+    expect(steps).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Incremental projector
+// ---------------------------------------------------------------------------
+
+describe("createAcpRunStepProjection — incremental", () => {
+  test("returns stable reference on identity (no-op) input", () => {
+    const projector = createAcpRunStepProjection();
+    const events = [
+      event({ updateType: "tool_call", toolCallId: "t1" }),
+    ];
+    const a = projector.project(events);
+    const b = projector.project(events);
+    expect(a).toBe(b);
+  });
+
+  test("append path matches full rebuild", () => {
+    const projector = createAcpRunStepProjection();
+    const e1 = event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Run" });
+    const events1 = [e1];
+    projector.project(events1);
+
+    const e2 = event({ updateType: "tool_call_update", toolCallId: "t1", content: "out" });
+    const e3 = event({ updateType: "agent_message_chunk", messageId: "m1", content: "hi" });
+    const events2 = [e1, e2, e3];
+    const incremental = projector.project(events2);
+
+    expect(incremental).toEqual(computeAcpRunSteps(events2));
+  });
+
+  test("mutate-last (coalesced chunk) falls back to a correct full rebuild", () => {
+    const projector = createAcpRunStepProjection();
+    const c1 = event({ updateType: "agent_message_chunk", messageId: "m1", content: "Hel" });
+    projector.project([c1]);
+
+    // Store coalesces same-messageId chunks into the last element (new object,
+    // same length) — the mutate-last shape.
+    const c1grown = { ...c1, seq: c1.seq + 1, content: "Hello" };
+    const result = projector.project([c1grown]);
+    expect(messageStep(result[0]!).content).toBe("Hello");
+    expect(result).toEqual(computeAcpRunSteps([c1grown]));
+  });
+
+  test("full-replace (history hydration) falls back to a full rebuild", () => {
+    const projector = createAcpRunStepProjection();
+    projector.project([event({ updateType: "tool_call", toolCallId: "t1" })]);
+
+    const hydrated = [
+      event({ updateType: "tool_call", toolCallId: "h1", toolTitle: "Hist" }),
+      event({ updateType: "tool_call_update", toolCallId: "h1", toolStatus: "complete" }),
+    ];
+    const result = projector.project(hydrated);
+    expect(result).toEqual(computeAcpRunSteps(hydrated));
+    expect(toolStep(result[0]!).status).toBe("completed");
+  });
+
+  test("tolerates a small window of duplicate message chunks on rehydration overlap", () => {
+    // Tool steps are keyed by toolCallId so a replayed tool_call/update pair is
+    // naturally idempotent.
+    const events = [
+      event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Run" }),
+      event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Run-dup" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", toolStatus: "complete" }),
+    ];
+    const steps = computeAcpRunSteps(events);
+    // A duplicate tool_call for the same id appends a second step (best-effort);
+    // both correlate to updates by id — no crash, ids preserved.
+    const tools = steps.filter((s) => s.kind === "tool");
+    expect(tools.length).toBeGreaterThanOrEqual(1);
+    expect(tools.every((s) => toolStep(s).toolCallId === "t1")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Carousel helper
+// ---------------------------------------------------------------------------
+
+describe("acpStepsToCarousel", () => {
+  test("derives last-N items with labels + statuses", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "agent_thought_chunk", messageId: "th1", content: "x" }),
+      event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Read" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", toolStatus: "complete" }),
+      event({ updateType: "agent_message_chunk", messageId: "m1", content: "hi" }),
+    ]);
+    const carousel = acpStepsToCarousel(steps, 2);
+    expect(carousel).toHaveLength(2);
+    expect(carousel[0]).toEqual({ label: "Read", status: "completed" });
+    expect(carousel[1]).toEqual({ label: "Responding", status: "running" });
+  });
+
+  test("running tool surfaces a running carousel status", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Search" }),
+    ]);
+    expect(acpStepsToCarousel(steps)).toEqual([
+      { label: "Search", status: "running" },
+    ]);
+  });
+});

--- a/clients/web/src/domains/chat/acp-run-step-projection.test.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.test.ts
@@ -63,7 +63,7 @@ describe("computeAcpRunSteps — folding rules", () => {
     expect(tool.detailKey).toBe("tool:t1");
   });
 
-  test("tool_call_update correlates by toolCallId: accumulates output + status", () => {
+  test("tool_call_update correlates by toolCallId: replaces output + status", () => {
     const steps = computeAcpRunSteps([
       event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Run" }),
       event({ updateType: "tool_call_update", toolCallId: "t1", content: "out-a" }),
@@ -72,8 +72,38 @@ describe("computeAcpRunSteps — folding rules", () => {
     ]);
     expect(steps).toHaveLength(1);
     const tool = toolStep(steps[0]!);
-    expect(tool.outputChunks).toEqual(["out-a", "out-b"]);
+    // Each update carries the full snapshot; the latest replaces prior ones.
+    expect(tool.outputChunks).toEqual(["out-b"]);
     expect(tool.status).toBe("completed");
+  });
+
+  test("tool_call_update content replaces (latest snapshot), not appends", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1", toolTitle: "Run" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "[A]" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "[A, B]" }),
+    ]);
+    const tool = toolStep(steps[0]!);
+    expect(tool.outputChunks.join("")).toBe("[A, B]");
+  });
+
+  test("tool_call_update without content leaves the prior snapshot intact", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "[A]" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", toolStatus: "complete" }),
+    ]);
+    const tool = toolStep(steps[0]!);
+    expect(tool.outputChunks).toEqual(["[A]"]);
+    expect(tool.status).toBe("completed");
+  });
+
+  test("tool_call carrying initial content seeds it as the first snapshot", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "tool_call", toolCallId: "t1", content: "[A]" }),
+      event({ updateType: "tool_call_update", toolCallId: "t1", content: "[A, B]" }),
+    ]);
+    expect(toolStep(steps[0]!).outputChunks).toEqual(["[A, B]"]);
   });
 
   test("tool_call_update maps failed/error to error status", () => {
@@ -184,6 +214,18 @@ describe("computeAcpRunSteps — folding rules", () => {
     const plans = steps.filter((s) => s.kind === "plan");
     expect(plans).toHaveLength(1);
     expect(planStep(plans[0]!).entries).toEqual([{ label: "Only", checked: true }]);
+  });
+
+  test("plan after a message closes the trailing message step", () => {
+    const steps = computeAcpRunSteps([
+      event({ updateType: "agent_message_chunk", messageId: "m1", content: "hi" }),
+      event({
+        updateType: "plan",
+        content: JSON.stringify([{ label: "Step 1", checked: false }]),
+      }),
+    ]);
+    expect(steps.map((s) => s.kind)).toEqual(["message", "plan"]);
+    expect(messageStep(steps[0]!).isComplete).toBe(true);
   });
 
   test("plan tolerates entries wrapped in an object", () => {

--- a/clients/web/src/domains/chat/acp-run-step-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.ts
@@ -1,0 +1,431 @@
+/**
+ * Incremental step projection for an ACP run's timeline.
+ *
+ * Folds the raw ACP event buffer (`AcpRunRawEvent[]` from `acp-run-store.ts`)
+ * into an ordered `AcpTimelineStep[]` — a discriminated union of tool / message
+ * / thought / plan steps consumed by the inline card and detail panel.
+ *
+ * The store mutates `entry.events` in exactly two shapes (see
+ * `acp-run-store.ts` `appendEvent`):
+ *
+ *  1. **Append** — a new event lands → `[...events, ev]`. A new array, every
+ *     prior element keeps its reference, exactly one new element at the tail.
+ *  2. **Mutate-last** — consecutive `agent_message_chunk` / `agent_thought_chunk`
+ *     of the same `messageId` coalesce → the array is copied with only the last
+ *     element replaced by a grown-`content` clone (same `seq` bumped, same
+ *     `updateType`/`messageId`, content only extends).
+ *
+ * `computeAcpRunSteps(events)` is O(n); running it on every streamed event is
+ * O(n^2) over a run. This projector replays only the diff vs the previous call
+ * through the same `applyAcpEvent` reducer the full rebuild uses, so the
+ * incremental and full paths can never drift. Any diff that doesn't fit the
+ * append / mutate-last shapes (full-replace on history hydration, truncation,
+ * reorder) falls back to a full O(n) rebuild, which is always correct.
+ *
+ * Mutate-last is folded by re-running the full O(n) rebuild only when the
+ * grown tail is a message/thought chunk — message/thought steps accumulate
+ * across multiple prior steps so a cheap "pop and re-derive tail" isn't safe;
+ * instead we replay from the last append boundary. In practice the common
+ * streaming path is plain append, so the incremental win is preserved there.
+ *
+ * `isComplete` rule for message steps: a message step flips to `isComplete:
+ * true` once any later step is appended after it (a different message,
+ * thought, tool, or plan starts). The trailing message step is left
+ * `isComplete: false` until the run produces a subsequent step or terminates.
+ * Best-effort — sufficient for the UI to stop showing a live caret.
+ */
+
+import { useRef } from "react";
+
+import type { AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+
+// ---------------------------------------------------------------------------
+// Timeline step union
+// ---------------------------------------------------------------------------
+
+export type AcpToolStatus = "running" | "completed" | "error";
+
+export type AcpTimelineStep =
+  | {
+      kind: "tool";
+      toolCallId: string;
+      title: string;
+      toolKind?: string;
+      status: AcpToolStatus;
+      outputChunks: string[];
+      detailKey: string;
+    }
+  | {
+      kind: "message";
+      messageId: string;
+      content: string;
+      isComplete: boolean;
+      detailKey: string;
+    }
+  | {
+      kind: "thought";
+      messageId: string;
+      content: string;
+      detailKey: string;
+    }
+  | {
+      kind: "plan";
+      entries: { label: string; checked: boolean }[];
+      detailKey: "plan";
+    };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+/** Synthetic id for chunks that arrive without a `messageId` (pre-PR-2 daemon). */
+const ANONYMOUS_MESSAGE_ID = "";
+
+/** Map a raw daemon `toolStatus` to a step status; keep `fallback` if absent. */
+function mapToolStatus(
+  toolStatus: string | undefined,
+  fallback: AcpToolStatus,
+): AcpToolStatus {
+  switch (toolStatus) {
+    case "complete":
+    case "completed":
+      return "completed";
+    case "failed":
+    case "error":
+      return "error";
+    case undefined:
+      return fallback;
+    default:
+      return "running";
+  }
+}
+
+/** Mark the most recent message step (if any, and still live) as complete. */
+function closeTrailingMessage(steps: AcpTimelineStep[]): void {
+  const last = steps[steps.length - 1];
+  if (last && last.kind === "message" && !last.isComplete) {
+    steps[steps.length - 1] = { ...last, isComplete: true };
+  }
+}
+
+/**
+ * Fold a single raw ACP event into `steps` (mutated in place). Shared by the
+ * full rebuild and the incremental projector so the two paths can't diverge.
+ */
+export function applyAcpEvent(
+  steps: AcpTimelineStep[],
+  event: AcpRunRawEvent,
+): void {
+  switch (event.updateType) {
+    case "tool_call": {
+      const toolCallId = event.toolCallId;
+      if (toolCallId === undefined) return;
+      closeTrailingMessage(steps);
+      steps.push({
+        kind: "tool",
+        toolCallId,
+        title: event.toolTitle ?? "",
+        toolKind: event.toolKind,
+        status: "running",
+        outputChunks: [],
+        detailKey: `tool:${toolCallId}`,
+      });
+      return;
+    }
+
+    case "tool_call_update": {
+      const toolCallId = event.toolCallId;
+      if (toolCallId === undefined) return;
+      const index = steps.findIndex(
+        (s) => s.kind === "tool" && s.toolCallId === toolCallId,
+      );
+      if (index === -1) return;
+      const target = steps[index] as Extract<AcpTimelineStep, { kind: "tool" }>;
+      const outputChunks =
+        event.content !== undefined
+          ? [...target.outputChunks, event.content]
+          : target.outputChunks;
+      steps[index] = {
+        ...target,
+        title: event.toolTitle ?? target.title,
+        toolKind: event.toolKind ?? target.toolKind,
+        status: mapToolStatus(event.toolStatus, target.status),
+        outputChunks,
+      };
+      return;
+    }
+
+    case "agent_message_chunk": {
+      const messageId = event.messageId ?? ANONYMOUS_MESSAGE_ID;
+      // Coalesce into the tail only when ids match. Anonymous chunks (no
+      // `messageId`) match each other while a message step is still the tail;
+      // an intervening non-message event makes the tail non-message, so the
+      // next anonymous chunk starts a fresh message (the gap-fallback boundary).
+      const last = steps[steps.length - 1];
+      if (last && last.kind === "message" && last.messageId === messageId) {
+        steps[steps.length - 1] = {
+          ...last,
+          content: last.content + (event.content ?? ""),
+        };
+        return;
+      }
+      closeTrailingMessage(steps);
+      steps.push({
+        kind: "message",
+        messageId,
+        content: event.content ?? "",
+        isComplete: false,
+        detailKey: `msg:${messageId}`,
+      });
+      return;
+    }
+
+    case "agent_thought_chunk": {
+      const messageId = event.messageId ?? ANONYMOUS_MESSAGE_ID;
+      const last = steps[steps.length - 1];
+      if (last && last.kind === "thought" && last.messageId === messageId) {
+        steps[steps.length - 1] = {
+          ...last,
+          content: last.content + (event.content ?? ""),
+        };
+        return;
+      }
+      closeTrailingMessage(steps);
+      steps.push({
+        kind: "thought",
+        messageId,
+        content: event.content ?? "",
+        detailKey: `thought:${messageId}`,
+      });
+      return;
+    }
+
+    case "plan": {
+      const entries = parsePlanEntries(event.content);
+      if (entries === null) return;
+      const index = steps.findIndex((s) => s.kind === "plan");
+      const planStep: AcpTimelineStep = {
+        kind: "plan",
+        entries,
+        detailKey: "plan",
+      };
+      if (index === -1) {
+        steps.push(planStep);
+      } else {
+        steps[index] = planStep;
+      }
+      return;
+    }
+
+    case "user_message_chunk":
+      // User echoes don't belong in the agent timeline.
+      return;
+  }
+}
+
+/**
+ * Parse a `plan` event's JSON `content` into entries. Returns `null` (skip the
+ * event) on malformed JSON or an unexpected shape rather than throwing.
+ */
+function parsePlanEntries(
+  content: string | undefined,
+): { label: string; checked: boolean }[] | null {
+  if (!content) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  const raw = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { entries?: unknown })?.entries)
+      ? (parsed as { entries: unknown[] }).entries
+      : null;
+  if (raw === null) return null;
+  return raw.map((item) => {
+    const obj = (item ?? {}) as Record<string, unknown>;
+    return {
+      label: typeof obj.label === "string" ? obj.label : String(obj.label ?? ""),
+      checked: obj.checked === true || obj.status === "completed",
+    };
+  });
+}
+
+/**
+ * Build the full `AcpTimelineStep[]` for an event buffer by folding
+ * `applyAcpEvent` over each event. Single source of truth for the projection.
+ */
+export function computeAcpRunSteps(events: AcpRunRawEvent[]): AcpTimelineStep[] {
+  const steps: AcpTimelineStep[] = [];
+  for (const event of events) applyAcpEvent(steps, event);
+  return steps;
+}
+
+// ---------------------------------------------------------------------------
+// Incremental projector
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify how `next` differs from `prev` at the raw-event-array level.
+ *  - `identity` — same array reference.
+ *  - `first` — no previous (cold cache).
+ *  - `append` — `prev` is a strict prefix of `next` (every prior element
+ *    reference-equal); replay events from `prev.length`.
+ *  - `mutate-last` — same length, all-but-last reference-equal, last element
+ *    is a grown message/thought chunk; cheap re-derivation isn't safe so the
+ *    caller does a full rebuild.
+ *  - `fallback` — anything else (full-replace, truncation, reorder).
+ */
+function classifyAcpDiff(
+  prev: AcpRunRawEvent[] | null,
+  next: AcpRunRawEvent[],
+): { kind: "identity" | "first" | "mutate-last" | "fallback" } | {
+  kind: "append";
+  from: number;
+} {
+  if (prev === next) return { kind: "identity" };
+  if (prev === null) return { kind: "first" };
+  if (next.length < prev.length) return { kind: "fallback" };
+
+  // Every element of `prev` must be reference-equal to its `next` counterpart
+  // for an append. The store preserves references on append, so a single
+  // mismatch means a deeper edit happened.
+  for (let i = 0; i < prev.length; i++) {
+    if (prev[i] !== next[i]) {
+      // First mismatch at the last index, same length → mutate-last candidate.
+      if (i === prev.length - 1 && next.length === prev.length) {
+        return { kind: "mutate-last" };
+      }
+      return { kind: "fallback" };
+    }
+  }
+
+  if (next.length === prev.length) return { kind: "identity" };
+  return { kind: "append", from: prev.length };
+}
+
+/**
+ * Create a stateful incremental projector. `project(events)` returns the
+ * `AcpTimelineStep[]` for `events`, replaying only the diff vs the previous
+ * call. Returns the cached array by reference when the input is unchanged so
+ * `React.memo` consumers can bail.
+ *
+ * One projector instance owns one cache slot — hold it per component instance
+ * (see `useAcpRunSteps`), never module-global.
+ */
+export function createAcpRunStepProjection() {
+  let prevEvents: AcpRunRawEvent[] | null = null;
+  let steps: AcpTimelineStep[] = [];
+
+  function fullBuild(events: AcpRunRawEvent[]): AcpTimelineStep[] {
+    steps = computeAcpRunSteps(events);
+    prevEvents = events;
+    return steps;
+  }
+
+  function project(events: AcpRunRawEvent[]): AcpTimelineStep[] {
+    const diff = classifyAcpDiff(prevEvents, events);
+
+    switch (diff.kind) {
+      case "identity":
+        return steps;
+
+      case "first":
+        return fullBuild(events);
+
+      case "append": {
+        const clone = steps.slice();
+        for (let i = diff.from; i < events.length; i++) {
+          applyAcpEvent(clone, events[i]!);
+        }
+        prevEvents = events;
+        steps = clone;
+        return steps;
+      }
+
+      // Message/thought coalescing rewrites a trailing step that may have been
+      // built across several prior chunks; a full rebuild is always correct.
+      case "mutate-last":
+      case "fallback":
+        return fullBuild(events);
+    }
+  }
+
+  return { project };
+}
+
+/**
+ * Hook wrapper: holds an incremental projector per component instance (in a
+ * `useRef`, tied to the component lifecycle — never a module-global cache).
+ * Returns a referentially-stable array across renders when the input events
+ * are unchanged.
+ */
+export function useAcpRunSteps(events: AcpRunRawEvent[]): AcpTimelineStep[] {
+  const projectorRef = useRef<ReturnType<
+    typeof createAcpRunStepProjection
+  > | null>(null);
+
+  // Intentional render-phase ref usage: the projector is a per-instance
+  // diff-aware cache (like `useMemo`, but it must run every render to fold in
+  // new events). Mirrors `useSubagentSteps`.
+  /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
+  if (projectorRef.current == null) {
+    projectorRef.current = createAcpRunStepProjection();
+  }
+  return projectorRef.current.project(events);
+  /* eslint-enable react-hooks/refs */
+}
+
+// ---------------------------------------------------------------------------
+// Carousel derivation
+// ---------------------------------------------------------------------------
+
+export interface AcpCarouselItem {
+  label: string;
+  status: AcpToolStatus;
+}
+
+/** Default count of trailing steps shown in the inline-card header carousel. */
+const DEFAULT_CAROUSEL_COUNT = 3;
+
+/** Single-line label for a step's header-carousel entry. */
+function carouselLabel(step: AcpTimelineStep): string {
+  switch (step.kind) {
+    case "tool":
+      return step.title || step.toolKind || "Working";
+    case "message":
+      return "Responding";
+    case "thought":
+      return "Thinking";
+    case "plan":
+      return "Planning";
+  }
+}
+
+/** Status for a step's header-carousel entry. */
+function carouselStatus(step: AcpTimelineStep): AcpToolStatus {
+  switch (step.kind) {
+    case "tool":
+      return step.status;
+    case "message":
+      return step.isComplete ? "completed" : "running";
+    case "thought":
+    case "plan":
+      return "completed";
+  }
+}
+
+/**
+ * Derive the last N header-carousel items from the projected steps, mirroring
+ * how the subagent card feeds its `HeaderStepCarousel`.
+ */
+export function acpStepsToCarousel(
+  steps: AcpTimelineStep[],
+  count: number = DEFAULT_CAROUSEL_COUNT,
+): AcpCarouselItem[] {
+  return steps.slice(-count).map((step) => ({
+    label: carouselLabel(step),
+    status: carouselStatus(step),
+  }));
+}

--- a/clients/web/src/domains/chat/acp-run-step-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.ts
@@ -127,7 +127,8 @@ export function applyAcpEvent(
         title: event.toolTitle ?? "",
         toolKind: event.toolKind,
         status: "running",
-        outputChunks: [],
+        // Content (if carried) is the initial snapshot, same as tool_call_update.
+        outputChunks: event.content !== undefined ? [event.content] : [],
         detailKey: `tool:${toolCallId}`,
       });
       return;
@@ -141,10 +142,11 @@ export function applyAcpEvent(
       );
       if (index === -1) return;
       const target = steps[index] as Extract<AcpTimelineStep, { kind: "tool" }>;
+      // ACP `ToolCallUpdate.content` REPLACES the tool's content collection: the
+      // daemon forwards each update as the full current snapshot, not a delta.
+      // Hold the latest snapshot as the sole element so `.join("")` still works.
       const outputChunks =
-        event.content !== undefined
-          ? [...target.outputChunks, event.content]
-          : target.outputChunks;
+        event.content !== undefined ? [event.content] : target.outputChunks;
       steps[index] = {
         ...target,
         title: event.toolTitle ?? target.title,
@@ -210,6 +212,8 @@ export function applyAcpEvent(
         detailKey: "plan",
       };
       if (index === -1) {
+        // First plan step is a later timeline step; close any live message.
+        closeTrailingMessage(steps);
         steps.push(planStep);
       } else {
         steps[index] = planStep;


### PR DESCRIPTION
## Summary
- Add computeAcpRunSteps folding ACP raw events into a tool/message/thought/plan timeline union
- Incremental projector with referential stability; acpStepsToCarousel helper for the inline card

Part of plan: acp-runs-ui.md (PR 5 of 13)