### PR TITLE
feat(web): add ACP run detail sidepanel with step timeline and nested detail

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -1,0 +1,273 @@
+/**
+ * Tests for `AcpRunDetailPanel` — the ACP run side-drawer.
+ *
+ * Runs under happy-dom (see clients/web/test-setup.ts). `ToolDetailBody` (reused
+ * for the tool nested view) subscribes to the chat-session store, which
+ * transitively pulls in the generated daemon SDK; stub every endpoint so the
+ * module loads, then import the panel dynamically so the mock registers first.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+const sdkStub = async () => ({ data: undefined });
+const realSdkPath = new URL(
+  "../../../../generated/daemon/sdk.gen.ts",
+  import.meta.url,
+).pathname;
+const sdkSource = await Bun.file(realSdkPath).text();
+const exportNames = [...sdkSource.matchAll(/^export const (\w+)/gm)].map(
+  (m) => m[1]!,
+);
+const sdkMock = Object.fromEntries(exportNames.map((n) => [n, sdkStub]));
+mock.module("@/generated/daemon/sdk.gen", () => sdkMock);
+
+const { AcpRunDetailPanel } = await import(
+  "@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel"
+);
+const { useAcpRunStore } = await import("@/domains/chat/acp-run-store");
+import type {
+  AcpRunEntry,
+  AcpRunRawEvent,
+} from "@/domains/chat/acp-run-store";
+
+const noop = () => {};
+
+function makeEntry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
+  return {
+    acpSessionId: "acp-1",
+    agent: "claude",
+    parentConversationId: "conv-1",
+    task: "Research the thing",
+    status: "running",
+    startedAt: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalCost: 0,
+    events: [],
+    ...overrides,
+  };
+}
+
+/** Seed the store so `useLiveAcpToolOutput` resolves the run's events. */
+function seedStore(entry: AcpRunEntry) {
+  useAcpRunStore.setState((s) => ({
+    byId: { ...s.byId, [entry.acpSessionId]: entry },
+    orderedIds: s.orderedIds.includes(entry.acpSessionId)
+      ? s.orderedIds
+      : [...s.orderedIds, entry.acpSessionId],
+  }));
+}
+
+const TOOL_CALL_EVENT: AcpRunRawEvent = {
+  seq: 1,
+  updateType: "tool_call",
+  toolCallId: "tool-1",
+  toolTitle: "Read file",
+  toolKind: "read",
+  toolStatus: "running",
+};
+
+afterEach(() => {
+  cleanup();
+  useAcpRunStore.getState().reset();
+});
+afterAll(() => {
+  mock.restore();
+});
+
+describe("AcpRunDetailPanel — header + metrics + objective", () => {
+  test("renders agent title, status, metrics, and objective", () => {
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({ inputTokens: 1200, outputTokens: 340 })}
+        onClose={noop}
+      />,
+    );
+
+    expect(screen.getByText("claude")).toBeDefined();
+    expect(screen.getByText("Running")).toBeDefined();
+    expect(screen.getByText("Input")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
+    expect(screen.getByText("1.2K")).toBeDefined();
+    expect(screen.getByText("340")).toBeDefined();
+    expect(screen.getByText("Objective")).toBeDefined();
+    expect(screen.getByText("Research the thing")).toBeDefined();
+  });
+
+  test("empty events renders 'No events yet'", () => {
+    render(<AcpRunDetailPanel entry={makeEntry({ events: [] })} onClose={noop} />);
+    expect(screen.getByText("No events yet")).toBeDefined();
+  });
+
+  test("Stop button renders only while running and calls onStop", () => {
+    const stopped: string[] = [];
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({ status: "running" })}
+        onClose={noop}
+        onStop={(id) => stopped.push(id)}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Stop run"));
+    expect(stopped).toEqual(["acp-1"]);
+  });
+
+  test("Stop button is hidden for a terminal run", () => {
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({ status: "completed" })}
+        onClose={noop}
+        onStop={noop}
+      />,
+    );
+    expect(screen.queryByLabelText("Stop run")).toBeNull();
+  });
+
+  test("close button fires onClose", () => {
+    let closed = 0;
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry()}
+        onClose={() => {
+          closed += 1;
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Close run detail"));
+    expect(closed).toBe(1);
+  });
+});
+
+describe("AcpRunDetailPanel — timeline + nested detail", () => {
+  test("clicking a tool pill swaps to the tool detail with joined output, Back returns", () => {
+    const entry = makeEntry({
+      events: [
+        { ...TOOL_CALL_EVENT, toolStatus: "completed" },
+        {
+          seq: 2,
+          updateType: "tool_call_update",
+          toolCallId: "tool-1",
+          toolStatus: "completed",
+          content: "file-listing-output",
+        },
+      ],
+    });
+    seedStore(entry);
+    render(<AcpRunDetailPanel entry={entry} onClose={noop} />);
+
+    // Timeline view first.
+    expect(screen.getByText("Read file")).toBeDefined();
+    expect(screen.queryByLabelText("Back to timeline")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("acp-step-pill"));
+
+    // Nested tool detail: Output section with the joined output, breadcrumb,
+    // and a Back button; no "Technical details" label (nested under header).
+    expect(screen.getByText("Output")).toBeDefined();
+    expect(screen.getByText("file-listing-output")).toBeDefined();
+    expect(screen.queryByText("Technical details")).toBeNull();
+    expect(screen.getByLabelText("Back to timeline")).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText("Back to timeline"));
+    expect(screen.getByText("Timeline")).toBeDefined();
+    expect(screen.queryByLabelText("Back to timeline")).toBeNull();
+  });
+
+  test("a still-running tool shows 'Running…' and streams live as updates arrive", () => {
+    const entry = makeEntry({ events: [TOOL_CALL_EVENT] });
+    seedStore(entry);
+    const { rerender } = render(
+      <AcpRunDetailPanel entry={entry} onClose={noop} />,
+    );
+
+    fireEvent.click(screen.getByTestId("acp-step-pill"));
+    expect(screen.getByText("Running…")).toBeDefined();
+
+    // A `tool_call_update` lands: mutate the store + re-render with the grown
+    // entry. The live hook re-derives the joined output from the store.
+    const updated = makeEntry({
+      events: [
+        TOOL_CALL_EVENT,
+        {
+          seq: 2,
+          updateType: "tool_call_update",
+          toolCallId: "tool-1",
+          toolStatus: "running",
+          content: "partial output so far",
+        },
+      ],
+    });
+    act(() => {
+      seedStore(updated);
+    });
+    rerender(<AcpRunDetailPanel entry={updated} onClose={noop} />);
+
+    expect(screen.getByText("partial output so far")).toBeDefined();
+  });
+
+  test("a message pill renders accumulated markdown", () => {
+    const entry = makeEntry({
+      events: [
+        {
+          seq: 1,
+          updateType: "agent_message_chunk",
+          messageId: "m-1",
+          content: "Hello from the agent",
+        },
+      ],
+    });
+    seedStore(entry);
+    render(<AcpRunDetailPanel entry={entry} onClose={noop} />);
+
+    fireEvent.click(screen.getByTestId("acp-step-pill"));
+    expect(screen.getByText("Hello from the agent")).toBeDefined();
+    // No tool sections for a message body.
+    expect(screen.queryByText("Output")).toBeNull();
+  });
+
+  test("a plan pill renders a checklist", () => {
+    const entry = makeEntry({
+      events: [
+        {
+          seq: 1,
+          updateType: "plan",
+          content: JSON.stringify([
+            { label: "First step", checked: true },
+            { label: "Second step", checked: false },
+          ]),
+        },
+      ],
+    });
+    seedStore(entry);
+    render(<AcpRunDetailPanel entry={entry} onClose={noop} />);
+
+    fireEvent.click(screen.getByTestId("acp-step-pill"));
+    expect(screen.getByText("First step")).toBeDefined();
+    expect(screen.getByText("Second step")).toBeDefined();
+  });
+
+  test("nested state resets when switching to a different run", () => {
+    const entry = makeEntry({ events: [TOOL_CALL_EVENT] });
+    seedStore(entry);
+    const { rerender } = render(
+      <AcpRunDetailPanel entry={entry} onClose={noop} />,
+    );
+
+    fireEvent.click(screen.getByTestId("acp-step-pill"));
+    expect(screen.getByLabelText("Back to timeline")).toBeDefined();
+
+    const other = makeEntry({
+      acpSessionId: "acp-2",
+      agent: "gemini",
+      events: [],
+    });
+    seedStore(other);
+    rerender(<AcpRunDetailPanel entry={other} onClose={noop} />);
+
+    // Reset to the timeline for the new run — no leaked nested detail.
+    expect(screen.queryByLabelText("Back to timeline")).toBeNull();
+    expect(screen.getByText("Timeline")).toBeDefined();
+    expect(screen.getByText("gemini")).toBeDefined();
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -247,6 +247,65 @@ describe("AcpRunDetailPanel — timeline + nested detail", () => {
     expect(screen.getByText("Second step")).toBeDefined();
   });
 
+  test("anonymous message steps don't collide — first pill opens the first message", () => {
+    // Two `agent_message_chunk`s with no `messageId`, separated by a tool_call so
+    // the projector closes the first message and starts a second. Both anonymous
+    // steps share `detailKey` "msg:", so selection must key by index, not key.
+    const entry = makeEntry({
+      events: [
+        {
+          seq: 1,
+          updateType: "agent_message_chunk",
+          content: "First anonymous message",
+        },
+        { ...TOOL_CALL_EVENT, seq: 2, toolStatus: "completed" },
+        {
+          seq: 3,
+          updateType: "agent_message_chunk",
+          content: "Second anonymous message",
+        },
+      ],
+    });
+    seedStore(entry);
+    render(<AcpRunDetailPanel entry={entry} onClose={noop} />);
+
+    const pills = screen.getAllByTestId("acp-step-pill");
+    // [message, tool, message]
+    expect(pills.length).toBe(3);
+
+    fireEvent.click(pills[0]!);
+    expect(screen.getByText("First anonymous message")).toBeDefined();
+    expect(screen.queryByText("Second anonymous message")).toBeNull();
+  });
+
+  test("terminal run's trailing message renders complete, not running", () => {
+    // A completed run whose last event is a message chunk: nothing closes it, so
+    // the step stays `isComplete:false`. The pill must show complete, not running.
+    const events: AcpRunRawEvent[] = [
+      {
+        seq: 1,
+        updateType: "agent_message_chunk",
+        messageId: "m-1",
+        content: "Final answer",
+      },
+    ];
+    const terminal = makeEntry({ status: "completed", events });
+    seedStore(terminal);
+    const { rerender } = render(
+      <AcpRunDetailPanel entry={terminal} onClose={noop} />,
+    );
+
+    expect(screen.queryByTestId("acp-step-running")).toBeNull();
+    expect(screen.getByTestId("acp-step-complete")).toBeDefined();
+
+    // The same trailing message on a still-active run DOES show the indicator.
+    const active = makeEntry({ status: "running", events });
+    seedStore(active);
+    rerender(<AcpRunDetailPanel entry={active} onClose={noop} />);
+
+    expect(screen.getByTestId("acp-step-running")).toBeDefined();
+  });
+
   test("nested state resets when switching to a different run", () => {
     const entry = makeEntry({ events: [TOOL_CALL_EVENT] });
     seedStore(entry);

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -209,9 +209,11 @@ export function AcpRunDetailPanel({
   const isRunning = isActiveAcpStatus(entry.status);
   const steps = useAcpRunSteps(entry.events);
 
-  // Which step's nested detail is shown (its `detailKey`), or `null` for the
-  // timeline. Reset on run switch via the render-phase block below.
-  const [selectedDetailKey, setSelectedDetailKey] = useState<string | null>(
+  // Which step's nested detail is shown (its array index in `steps`), or `null`
+  // for the timeline. Index — not `detailKey` — because anonymous message/thought
+  // steps (no `messageId`) share a `detailKey`, so a key-based lookup would
+  // collide. Reset on run switch via the render-phase block below.
+  const [selectedStepIndex, setSelectedStepIndex] = useState<number | null>(
     null,
   );
 
@@ -225,26 +227,20 @@ export function AcpRunDetailPanel({
   const [prevSessionId, setPrevSessionId] = useState(entry.acpSessionId);
   if (prevSessionId !== entry.acpSessionId) {
     setPrevSessionId(entry.acpSessionId);
-    setSelectedDetailKey(null);
+    setSelectedStepIndex(null);
     setObjectiveExpanded(false);
   }
 
-  // Derived map of clickable steps keyed by their `detailKey`.
-  const stepDetails = useMemo(() => {
-    const map = new Map<string, AcpTimelineStep>();
-    for (const step of steps) map.set(step.detailKey, step);
-    return map;
-  }, [steps]);
-
   const handleStepDetailClick = useCallback(
-    (key: string) => setSelectedDetailKey(key),
+    (index: number) => setSelectedStepIndex(index),
     [],
   );
-  const handleBack = useCallback(() => setSelectedDetailKey(null), []);
+  const handleBack = useCallback(() => setSelectedStepIndex(null), []);
 
-  const activeStep = selectedDetailKey
-    ? stepDetails.get(selectedDetailKey)
-    : undefined;
+  // Resolve by index; fall back to the timeline if the steps array shrank past
+  // the selected index (e.g. history hydration replaced the buffer).
+  const activeStep =
+    selectedStepIndex !== null ? steps[selectedStepIndex] : undefined;
 
   const detailTitle = activeStep ? stepTitle(activeStep) : "";
   const headerTitle = activeStep ? detailTitle : entry.agent;
@@ -427,6 +423,7 @@ export function AcpRunDetailPanel({
               {steps.length > 0 ? (
                 <AcpRunPhaseTimeline
                   steps={steps}
+                  isRunActive={isRunning}
                   onStepDetailClick={handleStepDetailClick}
                 />
               ) : (

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -1,0 +1,446 @@
+/**
+ * Side-drawer detail panel for an ACP run. Mirrors `SubagentDetailPanel`:
+ * header (agent title + status badge + optional Stop + Close), a token-metric
+ * row, a collapsible objective, and a step timeline — plus a single-level nested
+ * detail per step (the same pattern the subagent panel uses).
+ *
+ * Nested detail bodies by step kind:
+ *   - `tool:*`   → reuses `ToolDetailBody`; output streams live from the acp-run
+ *                  store via `useLiveAcpToolOutput` while the tool is running.
+ *   - `msg:*`    → accumulated markdown (live while `isComplete === false`).
+ *   - `thought:*`→ accumulated markdown.
+ *   - `plan`     → a checklist of `{ label, checked }` entries.
+ */
+
+import {
+  ArrowDownToLine,
+  ArrowLeft,
+  ArrowUpFromLine,
+  Brain,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Code,
+  ListChecks,
+  MessageSquare,
+  Square,
+  X,
+} from "lucide-react";
+
+import { useCallback, useMemo, useState } from "react";
+
+import { Button, Typography } from "@vellumai/design-library";
+
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import {
+  AnimatedMetricCard,
+  formatNumber,
+} from "@/domains/chat/components/metric-card";
+import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
+import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
+import { AcpRunPhaseTimeline } from "@/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline";
+import {
+  useAcpRunSteps,
+  type AcpTimelineStep,
+} from "@/domains/chat/acp-run-step-projection";
+import { useAcpRunStore, type AcpRunEntry } from "@/domains/chat/acp-run-store";
+import {
+  acpRunStatusColor,
+  acpRunStatusLabel,
+  isActiveAcpStatus,
+} from "@/utils/acp-run-status";
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+/**
+ * Live joined output for a running ACP tool, re-derived from the store so an
+ * open detail streams as `tool_call_update` events land. Re-projects the run's
+ * events to find the matching tool step and joins its `outputChunks`. Returns
+ * `undefined` when the tool can't be resolved, so the caller falls back to the
+ * open-time snapshot. The ACP sibling of `useLiveToolCall`.
+ */
+export function useLiveAcpToolOutput(
+  acpSessionId: string,
+  toolCallId: string,
+): string | undefined {
+  const events = useAcpRunStore((s) => s.byId[acpSessionId]?.events);
+  return useMemo(() => {
+    if (!events) return undefined;
+    let output: string | undefined;
+    for (const ev of events) {
+      // ACP carries the full output snapshot on each event, not a delta — hold
+      // the latest. `tool_call` may seed it; `tool_call_update`s replace it.
+      const matches =
+        (ev.updateType === "tool_call" ||
+          ev.updateType === "tool_call_update") &&
+        ev.toolCallId === toolCallId;
+      if (matches && ev.content !== undefined) output = ev.content;
+    }
+    return output;
+  }, [events, toolCallId]);
+}
+
+/**
+ * Leading header glyph: the active nested step's kind icon, or `Code` for the
+ * top-level run timeline (its agent header).
+ */
+function HeaderGlyph({
+  step,
+  className,
+}: {
+  step: AcpTimelineStep | undefined;
+  className: string;
+}) {
+  switch (step?.kind) {
+    case "message":
+      return <MessageSquare aria-hidden className={className} />;
+    case "thought":
+      return <Brain aria-hidden className={className} />;
+    case "plan":
+      return <ListChecks aria-hidden className={className} />;
+    default:
+      return <Code aria-hidden className={className} />;
+  }
+}
+
+/** The breadcrumb tail / nested-detail header title for a step. */
+function stepTitle(step: AcpTimelineStep): string {
+  switch (step.kind) {
+    case "tool":
+      return step.title || step.toolKind || "Tool call";
+    case "message":
+      return "Response";
+    case "thought":
+      return "Thinking";
+    case "plan":
+      return "Plan";
+  }
+}
+
+/** Renders a plan step as a static checklist. */
+function PlanDetailBody({
+  step,
+}: {
+  step: Extract<AcpTimelineStep, { kind: "plan" }>;
+}) {
+  return (
+    <ul className="flex flex-col gap-2">
+      {step.entries.map((entry, index) => (
+        <li key={`${index}-${entry.label}`} className="flex items-start gap-2">
+          <span
+            aria-hidden
+            className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border ${
+              entry.checked
+                ? "border-[var(--system-positive-strong)] bg-[var(--system-positive-strong)]"
+                : "border-[var(--border-base)]"
+            }`}
+          >
+            {entry.checked && (
+              <Check className="h-3 w-3 text-[var(--surface-base)]" />
+            )}
+          </span>
+          <Typography
+            variant="body-medium-default"
+            as="span"
+            className={
+              entry.checked
+                ? "text-[var(--content-tertiary)] line-through"
+                : "text-[var(--content-default)]"
+            }
+          >
+            {entry.label}
+          </Typography>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Tool-step nested body. Reuses `ToolDetailBody` by building a `ToolDetailPayload`
+ * from the captured step (its title/kind) with the live joined output as the
+ * result/streamed output. A running tool streams via `useLiveAcpToolOutput`.
+ */
+function AcpToolDetailBody({
+  acpSessionId,
+  step,
+}: {
+  acpSessionId: string;
+  step: Extract<AcpTimelineStep, { kind: "tool" }>;
+}) {
+  const liveOutput = useLiveAcpToolOutput(acpSessionId, step.toolCallId);
+  const output = liveOutput ?? step.outputChunks.join("");
+  const isRunning = step.status === "running";
+
+  const detail: ToolDetailPayload = {
+    toolCallId: step.toolCallId,
+    toolName: step.toolKind ?? step.title,
+    title: step.title,
+    activity: "",
+    input: {},
+    // A settled tool surfaces its output as the final result; a running tool
+    // surfaces the same joined output as the live streamed tail.
+    result: isRunning ? undefined : output || undefined,
+    streamedOutput: output || undefined,
+    status: step.status,
+  };
+
+  return <ToolDetailBody detail={detail} showTechnicalDetailsLabel={false} />;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface AcpRunDetailPanelProps {
+  entry: AcpRunEntry;
+  onClose: () => void;
+  onStop?: (acpSessionId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function AcpRunDetailPanel({
+  entry,
+  onClose,
+  onStop,
+}: AcpRunDetailPanelProps) {
+  const isRunning = isActiveAcpStatus(entry.status);
+  const steps = useAcpRunSteps(entry.events);
+
+  // Which step's nested detail is shown (its `detailKey`), or `null` for the
+  // timeline. Reset on run switch via the render-phase block below.
+  const [selectedDetailKey, setSelectedDetailKey] = useState<string | null>(
+    null,
+  );
+
+  // Objective collapse/expand. The "Show more" affordance is gated on the
+  // clamp's static line count via the projected step text length, not a layout
+  // measurement (happy-dom has no layout) — kept simple: always show the toggle
+  // for a multi-line task.
+  const [objectiveExpanded, setObjectiveExpanded] = useState(false);
+
+  // Reset nested state on run switch — render-phase guard tracking the prev id.
+  const [prevSessionId, setPrevSessionId] = useState(entry.acpSessionId);
+  if (prevSessionId !== entry.acpSessionId) {
+    setPrevSessionId(entry.acpSessionId);
+    setSelectedDetailKey(null);
+    setObjectiveExpanded(false);
+  }
+
+  // Derived map of clickable steps keyed by their `detailKey`.
+  const stepDetails = useMemo(() => {
+    const map = new Map<string, AcpTimelineStep>();
+    for (const step of steps) map.set(step.detailKey, step);
+    return map;
+  }, [steps]);
+
+  const handleStepDetailClick = useCallback(
+    (key: string) => setSelectedDetailKey(key),
+    [],
+  );
+  const handleBack = useCallback(() => setSelectedDetailKey(null), []);
+
+  const activeStep = selectedDetailKey
+    ? stepDetails.get(selectedDetailKey)
+    : undefined;
+
+  const detailTitle = activeStep ? stepTitle(activeStep) : "";
+  const headerTitle = activeStep ? detailTitle : entry.agent;
+
+  // A long task offers the collapse toggle. Heuristic on length so happy-dom
+  // (no layout) can exercise it deterministically.
+  const objectiveOverflows = (entry.task?.length ?? 0) > 140;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
+      {/* Breadcrumb — only while a nested step detail is open. */}
+      {activeStep && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hover)] px-5 py-3">
+          <button
+            type="button"
+            onClick={handleBack}
+            title={entry.agent}
+            className="min-w-0 shrink cursor-pointer truncate text-left text-[var(--content-default)] hover:underline"
+          >
+            <Typography variant="body-small-default" as="span">
+              {entry.agent}
+            </Typography>
+          </button>
+          <ChevronRight
+            className="h-2.5 w-2.5 shrink-0 text-[var(--content-tertiary)]"
+            aria-hidden
+          />
+          <Typography
+            variant="body-small-default"
+            as="span"
+            title={detailTitle}
+            className="min-w-0 shrink truncate text-[var(--content-secondary)]"
+          >
+            {detailTitle}
+          </Typography>
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] px-5 py-4">
+        {activeStep && (
+          <Button
+            variant="outlined"
+            iconOnly={<ArrowLeft />}
+            onClick={handleBack}
+            aria-label="Back to timeline"
+            tooltip="Back"
+            className="shrink-0 rounded-lg"
+          />
+        )}
+        <HeaderGlyph
+          step={activeStep}
+          className="h-5 w-5 shrink-0 text-[var(--content-secondary)]"
+        />
+        <Typography
+          variant="title-medium"
+          title={headerTitle}
+          className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
+        >
+          {headerTitle}
+        </Typography>
+        {!activeStep && (
+          <StatusBadgePill
+            color={acpRunStatusColor(entry.status)}
+            label={acpRunStatusLabel(entry.status)}
+          />
+        )}
+        <span className="flex-1" />
+        {isRunning && onStop && (
+          <button
+            type="button"
+            aria-label="Stop run"
+            onClick={() => onStop(entry.acpSessionId)}
+            className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--system-negative-strong)] bg-transparent px-2.5 py-1.5 text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--system-negative-weak)]"
+          >
+            <Square className="h-3 w-3" fill="currentColor" />
+            <Typography variant="label-small-default">Stop</Typography>
+          </button>
+        )}
+        <Button
+          variant="outlined"
+          iconOnly={<X />}
+          onClick={onClose}
+          aria-label="Close run detail"
+          tooltip="Close"
+          className="shrink-0 rounded-lg"
+        />
+      </div>
+
+      {/* Scrollable body — swaps to a step's nested detail when one is selected. */}
+      <div className="flex-1 overflow-y-auto px-5 py-5">
+        {activeStep ? (
+          activeStep.kind === "tool" ? (
+            <AcpToolDetailBody
+              acpSessionId={entry.acpSessionId}
+              step={activeStep}
+            />
+          ) : activeStep.kind === "plan" ? (
+            <PlanDetailBody step={activeStep} />
+          ) : (
+            <ChatMarkdownMessage content={activeStep.content} hardLineBreaks />
+          )
+        ) : (
+          <>
+            {/* Metrics row */}
+            <div className="mb-5 grid grid-cols-2 gap-3">
+              <AnimatedMetricCard
+                icon={
+                  <ArrowDownToLine
+                    className="h-4 w-4 shrink-0"
+                    style={{ color: "var(--content-secondary)" }}
+                  />
+                }
+                target={entry.inputTokens}
+                format={(n) => formatNumber(Math.round(n))}
+                label="Input"
+              />
+              <AnimatedMetricCard
+                icon={
+                  <ArrowUpFromLine
+                    className="h-4 w-4 shrink-0"
+                    style={{ color: "var(--content-secondary)" }}
+                  />
+                }
+                target={entry.outputTokens}
+                format={(n) => formatNumber(Math.round(n))}
+                label="Output"
+              />
+            </div>
+
+            {/* Objective section */}
+            {entry.task && (
+              <div className="mb-5">
+                <Typography
+                  variant="body-medium-default"
+                  as="h3"
+                  className="mb-2 text-[var(--content-emphasised)]"
+                >
+                  Objective
+                </Typography>
+                <Typography
+                  variant="body-medium-lighter"
+                  as="p"
+                  className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
+                    objectiveExpanded ? "" : "line-clamp-5"
+                  }`}
+                >
+                  {entry.task}
+                </Typography>
+                {objectiveOverflows && (
+                  <button
+                    type="button"
+                    onClick={() => setObjectiveExpanded((prev) => !prev)}
+                    className="mt-1.5 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+                  >
+                    <Typography variant="label-small-default">
+                      {objectiveExpanded ? "Show less" : "Show more"}
+                    </Typography>
+                    <ChevronDown
+                      className={`h-3.5 w-3.5 transition-transform ${
+                        objectiveExpanded ? "rotate-180" : ""
+                      }`}
+                      aria-hidden
+                    />
+                  </button>
+                )}
+                <div className="mt-5 h-px w-full bg-[var(--border-hover)]" />
+              </div>
+            )}
+
+            {/* Timeline section */}
+            <div>
+              <Typography
+                variant="title-medium"
+                as="h3"
+                className="mb-4 text-[var(--content-emphasised)]"
+              >
+                Timeline
+              </Typography>
+              {steps.length > 0 ? (
+                <AcpRunPhaseTimeline
+                  steps={steps}
+                  onStepDetailClick={handleStepDetailClick}
+                />
+              ) : (
+                <Typography
+                  variant="body-small-default"
+                  className="py-4 text-center text-[var(--content-tertiary)]"
+                >
+                  No events yet
+                </Typography>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline.tsx
@@ -3,8 +3,9 @@
  *
  * ACP steps are a flat, ordered `AcpTimelineStep[]` (not phase-grouped like the
  * subagent timeline), so this renders one `AcpRunStepPill` per step. Selection
- * is lifted to the owning panel via `onStepDetailClick(detailKey)`, mirroring how
- * `SubagentPhaseTimeline` lifts its expand/selection state.
+ * is lifted to the owning panel via `onStepDetailClick(index)` — by array index,
+ * since anonymous steps share a `detailKey` — mirroring how `SubagentPhaseTimeline`
+ * lifts its expand/selection state.
  *
  * Pure / presentational: takes only `steps`. The owning panel renders the empty
  * state, so this returns `null` for an empty input.
@@ -20,11 +21,14 @@ function stepKey(step: AcpTimelineStep, index: number): string {
 
 export function AcpRunPhaseTimeline({
   steps,
+  isRunActive,
   onStepDetailClick,
 }: {
   steps: AcpTimelineStep[];
-  /** Opens a step's nested detail. */
-  onStepDetailClick: (detailKey: string) => void;
+  /** Whether the owning run is still active (drives trailing-message liveness). */
+  isRunActive: boolean;
+  /** Opens a step's nested detail, identified by its array index. */
+  onStepDetailClick: (index: number) => void;
 }) {
   if (steps.length === 0) return null;
 
@@ -34,6 +38,8 @@ export function AcpRunPhaseTimeline({
         <AcpRunStepPill
           key={stepKey(step, index)}
           step={step}
+          index={index}
+          isRunActive={isRunActive}
           onClick={onStepDetailClick}
         />
       ))}

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline.tsx
@@ -1,0 +1,42 @@
+/**
+ * Vertical list of clickable step pills for the ACP run detail panel.
+ *
+ * ACP steps are a flat, ordered `AcpTimelineStep[]` (not phase-grouped like the
+ * subagent timeline), so this renders one `AcpRunStepPill` per step. Selection
+ * is lifted to the owning panel via `onStepDetailClick(detailKey)`, mirroring how
+ * `SubagentPhaseTimeline` lifts its expand/selection state.
+ *
+ * Pure / presentational: takes only `steps`. The owning panel renders the empty
+ * state, so this returns `null` for an empty input.
+ */
+
+import type { AcpTimelineStep } from "@/domains/chat/acp-run-step-projection";
+import { AcpRunStepPill } from "@/domains/chat/components/acp-run-detail-panel/acp-run-step-pill";
+
+/** Stable key for a step — its detail key plus its positional index. */
+function stepKey(step: AcpTimelineStep, index: number): string {
+  return `${index}-${step.detailKey}`;
+}
+
+export function AcpRunPhaseTimeline({
+  steps,
+  onStepDetailClick,
+}: {
+  steps: AcpTimelineStep[];
+  /** Opens a step's nested detail. */
+  onStepDetailClick: (detailKey: string) => void;
+}) {
+  if (steps.length === 0) return null;
+
+  return (
+    <div className="flex w-full flex-col gap-1.5">
+      {steps.map((step, index) => (
+        <AcpRunStepPill
+          key={stepKey(step, index)}
+          step={step}
+          onClick={onStepDetailClick}
+        />
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-step-pill.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-step-pill.tsx
@@ -1,0 +1,152 @@
+/**
+ * A single clickable row in the ACP run timeline: a kind icon, a status glyph,
+ * and a truncating label. Mirrors the subagent timeline's pill chrome but maps
+ * the flat `AcpTimelineStep` union directly (ACP steps are not phase-grouped).
+ *
+ * Presentational + primitive: takes a resolved label/icon/status rather than the
+ * step object, so it stays independently testable.
+ */
+
+import {
+  AlertCircle,
+  Brain,
+  CheckCircle2,
+  Code,
+  FileText,
+  ListChecks,
+  MessageSquare,
+} from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+import type {
+  AcpTimelineStep,
+  AcpToolStatus,
+} from "@/domains/chat/acp-run-step-projection";
+
+/** Leading kind glyph for a step row. */
+function KindIcon({ step, className }: { step: AcpTimelineStep; className: string }) {
+  switch (step.kind) {
+    case "tool":
+      // Tool kind hints (e.g. "read"/"edit") map to a document glyph; default to
+      // code brackets, matching the tool-detail header's fallback.
+      return step.toolKind === "read" || step.toolKind === "edit" ? (
+        <FileText aria-hidden className={className} />
+      ) : (
+        <Code aria-hidden className={className} />
+      );
+    case "message":
+      return <MessageSquare aria-hidden className={className} />;
+    case "thought":
+      return <Brain aria-hidden className={className} />;
+    case "plan":
+      return <ListChecks aria-hidden className={className} />;
+  }
+}
+
+/** Single-line label for a step row. */
+function stepLabel(step: AcpTimelineStep): string {
+  switch (step.kind) {
+    case "tool":
+      return step.title || step.toolKind || "Tool call";
+    case "message":
+      return step.content || "Response";
+    case "thought":
+      return step.content || "Thinking";
+    case "plan":
+      return "Plan";
+  }
+}
+
+/** A step's tool status, used to pick the trailing status glyph. */
+function stepStatus(step: AcpTimelineStep): AcpToolStatus {
+  switch (step.kind) {
+    case "tool":
+      return step.status;
+    case "message":
+      return step.isComplete ? "completed" : "running";
+    case "thought":
+    case "plan":
+      return "completed";
+  }
+}
+
+/** Trailing status glyph matching the card states (running / complete / error). */
+function StatusGlyph({ status }: { status: AcpToolStatus }) {
+  if (status === "running") {
+    return <ThreeDotIndicator className="shrink-0" data-testid="acp-step-running" />;
+  }
+  if (status === "error") {
+    return (
+      <AlertCircle
+        aria-hidden
+        data-testid="acp-step-error"
+        className="h-4 w-4 shrink-0 text-[var(--system-negative-strong)]"
+      />
+    );
+  }
+  return (
+    <CheckCircle2
+      aria-hidden
+      data-testid="acp-step-complete"
+      className="h-4 w-4 shrink-0 text-[var(--system-positive-strong)]"
+    />
+  );
+}
+
+export function AcpRunStepPill({
+  step,
+  onClick,
+}: {
+  step: AcpTimelineStep;
+  /** Opens the step's nested detail. When omitted the row is non-interactive. */
+  onClick?: (detailKey: string) => void;
+}) {
+  const status = stepStatus(step);
+  const label = stepLabel(step);
+  const tone = status === "error";
+  const iconColor = tone
+    ? "text-[var(--system-negative-strong)]"
+    : "text-[var(--content-tertiary)]";
+
+  const body = (
+    <>
+      <KindIcon step={step} className={`h-4 w-4 shrink-0 ${iconColor}`} />
+      <Typography
+        variant="body-small-default"
+        className="min-w-0 flex-1 truncate text-left text-inherit leading-normal"
+      >
+        {label}
+      </Typography>
+      <StatusGlyph status={status} />
+    </>
+  );
+
+  const colorClasses = tone
+    ? "bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
+    : "bg-[var(--surface-overlay)] text-[var(--content-default)]";
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        data-testid="acp-step-pill"
+        aria-label={`View step details: ${label}`}
+        onClick={() => onClick(step.detailKey)}
+        className={`flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-2.5 py-2 transition-colors hover:bg-[var(--surface-active)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)] ${colorClasses}`}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      data-testid="acp-step-pill"
+      className={`flex w-full min-w-0 items-center gap-2 rounded-lg px-2.5 py-2 ${colorClasses}`}
+    >
+      {body}
+    </span>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-step-pill.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-step-pill.tsx
@@ -59,13 +59,18 @@ function stepLabel(step: AcpTimelineStep): string {
   }
 }
 
-/** A step's tool status, used to pick the trailing status glyph. */
-function stepStatus(step: AcpTimelineStep): AcpToolStatus {
+/**
+ * A step's status, used to pick the trailing status glyph. A message step shows
+ * `running` only while the run is active; once the run is terminal a still-open
+ * trailing message (nothing closed it) renders as complete. Tool steps keep
+ * their own status regardless of run state.
+ */
+function stepStatus(step: AcpTimelineStep, isRunActive: boolean): AcpToolStatus {
   switch (step.kind) {
     case "tool":
       return step.status;
     case "message":
-      return step.isComplete ? "completed" : "running";
+      return step.isComplete || !isRunActive ? "completed" : "running";
     case "thought":
     case "plan":
       return "completed";
@@ -97,13 +102,19 @@ function StatusGlyph({ status }: { status: AcpToolStatus }) {
 
 export function AcpRunStepPill({
   step,
+  index,
+  isRunActive,
   onClick,
 }: {
   step: AcpTimelineStep;
+  /** This step's position in the run's projected steps — its selection identity. */
+  index: number;
+  /** Whether the owning run is still active; gates the trailing-message indicator. */
+  isRunActive: boolean;
   /** Opens the step's nested detail. When omitted the row is non-interactive. */
-  onClick?: (detailKey: string) => void;
+  onClick?: (index: number) => void;
 }) {
-  const status = stepStatus(step);
+  const status = stepStatus(step, isRunActive);
   const label = stepLabel(step);
   const tone = status === "error";
   const iconColor = tone
@@ -133,7 +144,7 @@ export function AcpRunStepPill({
         type="button"
         data-testid="acp-step-pill"
         aria-label={`View step details: ${label}`}
-        onClick={() => onClick(step.detailKey)}
+        onClick={() => onClick(index)}
         className={`flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-2.5 py-2 transition-colors hover:bg-[var(--surface-active)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)] ${colorClasses}`}
       >
         {body}


### PR DESCRIPTION
## Summary
- Add AcpRunDetailPanel mirroring the subagent panel: header + token/cost metrics + objective + step timeline
- Single-level nested detail per step (tool reuses ToolDetailBody with live output; message/thought markdown; plan checklist)
- New useLiveAcpToolOutput hook streams a running tool's output from the store

Part of plan: acp-runs-ui.md (PR 9 of 13)