### PR TITLE
feat(web): render inline ACP run progress card in the transcript

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
@@ -173,7 +173,15 @@ describe("AcpRunInlineProgressCard — interaction", () => {
     expect(seen).toEqual(["acp-open"]);
   });
 
-  test("stop button only renders while the run is in-flight", () => {
+  test("stop button is absent while running when no onStopAcpRun handler is provided", () => {
+    act(() => spawn("acp-no-stop"));
+    const { queryByTestId } = render(
+      <AcpRunInlineProgressCard acpSessionId="acp-no-stop" />,
+    );
+    expect(queryByTestId("acp-run-inline-card-stop")).toBeNull();
+  });
+
+  test("stop button renders and invokes the handler while in-flight, then hides on terminal", () => {
     act(() => spawn("acp-stop"));
     const seen: string[] = [];
     const { getByTestId, queryByTestId } = render(

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * Tests for `AcpRunInlineProgressCard` and its supporting projection/anchor
+ * helpers.
+ *
+ *  - Card renders running / complete / cancelled / error states from a seeded
+ *    ACP run store, plus the spawn-race `null` fallback and the header-click
+ *    callback.
+ *  - `isAcpSpawnCall` detection — direct `acp_spawn` and the `skill_execute`
+ *    wrapper.
+ *  - `resolveAcpRunIds` / `acpRunIdForCall` resolve via `byToolUseId` and the
+ *    result-parse fallback.
+ *  - Raw-chip suppression: a card-backed call resolves to a backing id; an
+ *    absent or failed run resolves to none, so its chip stays.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { AcpRunInlineProgressCard } from "@/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card";
+import {
+  useAcpRunStore,
+  type AcpRunRawEvent,
+} from "@/domains/chat/acp-run-store";
+import { isAcpSpawnCall } from "@/domains/chat/transcript/message-content";
+import {
+  acpRunIdForCall,
+  resolveAcpRunIds,
+} from "@/domains/chat/transcript/transcript-message-body-shared";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+
+const NOW = 1700000000000;
+const STATUS_TESTID = "acp-run-inline-card-status-indicator";
+
+beforeEach(() => {
+  useAcpRunStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Store seeding helpers
+// ---------------------------------------------------------------------------
+
+function spawn(acpSessionId: string, parentToolUseId?: string) {
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId,
+    agent: "claude",
+    parentConversationId: "conv-1",
+    parentToolUseId,
+    startedAt: NOW,
+  });
+}
+
+function toolEvent(
+  acpSessionId: string,
+  overrides: Partial<AcpRunRawEvent>,
+): void {
+  useAcpRunStore.getState().receiveEvent({
+    acpSessionId,
+    event: { seq: 1, updateType: "tool_call", ...overrides },
+  });
+}
+
+function terminal(
+  acpSessionId: string,
+  status: "completed" | "failed",
+  stopReason?: string,
+  error?: string,
+): void {
+  useAcpRunStore.getState().setTerminal({
+    acpSessionId,
+    status,
+    stopReason,
+    error,
+    completedAt: NOW + 1000,
+  });
+}
+
+function toolCall(overrides: Partial<ChatMessageToolCall>): ChatMessageToolCall {
+  return {
+    id: "tc-1",
+    name: "acp_spawn",
+    input: {},
+    ...overrides,
+  } as ChatMessageToolCall;
+}
+
+// ---------------------------------------------------------------------------
+// Card render
+// ---------------------------------------------------------------------------
+
+describe("AcpRunInlineProgressCard — spawn race", () => {
+  test("renders null when no entry exists in the store yet", () => {
+    const { container } = render(
+      <AcpRunInlineProgressCard acpSessionId="missing" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("AcpRunInlineProgressCard — states", () => {
+  test("running run shows the three-dot loading indicator", () => {
+    act(() => {
+      spawn("acp-run");
+      toolEvent("acp-run", { toolCallId: "t1", toolTitle: "Read file" });
+    });
+
+    const { getByTestId } = render(
+      <AcpRunInlineProgressCard acpSessionId="acp-run" />,
+    );
+
+    const indicator = getByTestId(STATUS_TESTID);
+    // The loading indicator is the ThreeDotIndicator span (no `data-state`).
+    expect(indicator.getAttribute("data-state")).toBeNull();
+  });
+
+  test("completed run renders the complete status icon", () => {
+    act(() => {
+      spawn("acp-done");
+      toolEvent("acp-done", { toolCallId: "t1", toolTitle: "Read file" });
+      terminal("acp-done", "completed");
+    });
+
+    const { getByTestId } = render(
+      <AcpRunInlineProgressCard acpSessionId="acp-done" />,
+    );
+    expect(getByTestId(STATUS_TESTID).getAttribute("data-state")).toBe(
+      "complete",
+    );
+  });
+
+  test("cancelled run (completed + stopReason) renders the warning icon", () => {
+    act(() => {
+      spawn("acp-cancel");
+      terminal("acp-cancel", "completed", "cancelled");
+    });
+
+    const { getByTestId } = render(
+      <AcpRunInlineProgressCard acpSessionId="acp-cancel" />,
+    );
+    expect(getByTestId(STATUS_TESTID).getAttribute("data-state")).toBe(
+      "warning",
+    );
+  });
+
+  test("failed run renders the error icon", () => {
+    act(() => {
+      spawn("acp-fail");
+      terminal("acp-fail", "failed", undefined, "boom");
+    });
+
+    const { getByTestId } = render(
+      <AcpRunInlineProgressCard acpSessionId="acp-fail" />,
+    );
+    expect(getByTestId(STATUS_TESTID).getAttribute("data-state")).toBe("error");
+  });
+});
+
+describe("AcpRunInlineProgressCard — interaction", () => {
+  test("clicking the header row invokes onAcpRunClick", () => {
+    act(() => spawn("acp-open"));
+    const seen: string[] = [];
+    const { getByRole } = render(
+      <AcpRunInlineProgressCard
+        acpSessionId="acp-open"
+        onAcpRunClick={(id) => seen.push(id)}
+      />,
+    );
+    fireEvent.click(getByRole("button", { name: /open run/i }));
+    expect(seen).toEqual(["acp-open"]);
+  });
+
+  test("stop button only renders while the run is in-flight", () => {
+    act(() => spawn("acp-stop"));
+    const seen: string[] = [];
+    const { getByTestId, queryByTestId } = render(
+      <AcpRunInlineProgressCard
+        acpSessionId="acp-stop"
+        onStopAcpRun={(id) => seen.push(id)}
+      />,
+    );
+    fireEvent.click(getByTestId("acp-run-inline-card-stop"));
+    expect(seen).toEqual(["acp-stop"]);
+
+    act(() => terminal("acp-stop", "completed"));
+    expect(queryByTestId("acp-run-inline-card-stop")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAcpSpawnCall
+// ---------------------------------------------------------------------------
+
+describe("isAcpSpawnCall", () => {
+  test("matches a direct acp_spawn call", () => {
+    expect(isAcpSpawnCall(toolCall({ name: "acp_spawn" }))).toBe(true);
+  });
+
+  test("matches a skill_execute wrapper with input.tool === acp_spawn", () => {
+    expect(
+      isAcpSpawnCall(
+        toolCall({ name: "skill_execute", input: { tool: "acp_spawn" } }),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects a skill_execute wrapping a different tool", () => {
+    expect(
+      isAcpSpawnCall(
+        toolCall({ name: "skill_execute", input: { tool: "run_workflow" } }),
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects an unrelated tool", () => {
+    expect(isAcpSpawnCall(toolCall({ name: "bash", input: {} }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anchor resolution
+// ---------------------------------------------------------------------------
+
+describe("acpRunIdForCall / resolveAcpRunIds", () => {
+  test("resolves via byToolUseId anchor", () => {
+    const byToolUseId = new Map([["tc-1", "acp-1"]]);
+    const tc = toolCall({ id: "tc-1", name: "acp_spawn" });
+    expect(acpRunIdForCall(tc, byToolUseId)).toBe("acp-1");
+    expect(resolveAcpRunIds([tc], byToolUseId, new Set())).toEqual(["acp-1"]);
+  });
+
+  test("falls back to parsing acpSessionId from the result JSON", () => {
+    const tc = toolCall({
+      id: "tc-1",
+      name: "acp_spawn",
+      result: JSON.stringify({ acpSessionId: "acp-from-result" }),
+    });
+    expect(acpRunIdForCall(tc, new Map())).toBe("acp-from-result");
+    expect(resolveAcpRunIds([tc], new Map(), new Set())).toEqual([
+      "acp-from-result",
+    ]);
+  });
+
+  test("byToolUseId wins over the result parse", () => {
+    const byToolUseId = new Map([["tc-1", "acp-anchor"]]);
+    const tc = toolCall({
+      id: "tc-1",
+      name: "acp_spawn",
+      result: JSON.stringify({ acpSessionId: "acp-result" }),
+    });
+    expect(acpRunIdForCall(tc, byToolUseId)).toBe("acp-anchor");
+  });
+
+  test("returns null/[] for a failed call with no id", () => {
+    const tc = toolCall({ id: "tc-1", name: "acp_spawn" });
+    expect(acpRunIdForCall(tc, new Map())).toBeNull();
+    expect(resolveAcpRunIds([tc], new Map(), new Set())).toEqual([]);
+  });
+
+  test("claimed set prevents two calls anchoring the same id", () => {
+    const byToolUseId = new Map([
+      ["tc-1", "acp-shared"],
+      ["tc-2", "acp-shared"],
+    ]);
+    const calls = [
+      toolCall({ id: "tc-1", name: "acp_spawn" }),
+      toolCall({ id: "tc-2", name: "acp_spawn" }),
+    ];
+    expect(resolveAcpRunIds(calls, byToolUseId, new Set())).toEqual([
+      "acp-shared",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Raw-chip suppression gate
+// ---------------------------------------------------------------------------
+
+describe("raw-chip suppression", () => {
+  test("a resolved id with a store entry is card-backed", () => {
+    act(() => spawn("acp-backed", "tc-1"));
+    const byToolUseId = useAcpRunStore.getState().byToolUseId;
+    const tc = toolCall({ id: "tc-1", name: "acp_spawn" });
+    const id = acpRunIdForCall(tc, byToolUseId);
+    expect(id).toBe("acp-backed");
+    // Card-backed: a store entry exists for the resolved id.
+    expect(useAcpRunStore.getState().byId[id!]).toBeDefined();
+  });
+
+  test("a resolved id with NO store entry is not card-backed (chip stays)", () => {
+    // Result parse resolves an id, but nothing was spawned into the store.
+    const tc = toolCall({
+      id: "tc-1",
+      name: "acp_spawn",
+      result: JSON.stringify({ acpSessionId: "acp-absent" }),
+    });
+    const id = acpRunIdForCall(tc, useAcpRunStore.getState().byToolUseId);
+    expect(id).toBe("acp-absent");
+    expect(useAcpRunStore.getState().byId[id!]).toBeUndefined();
+  });
+
+  test("a failed call resolving to no id is not card-backed (chip stays)", () => {
+    const tc = toolCall({ id: "tc-1", name: "acp_spawn" });
+    expect(acpRunIdForCall(tc, useAcpRunStore.getState().byToolUseId)).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
@@ -1,0 +1,98 @@
+/**
+ * Inline ACP run progress card rendered per-`acp_spawn` run in the assistant
+ * transcript. Built on `ToolProgressCardShell` with a `Code` glyph slotted into
+ * the leading-icon slot — ACP runs have no avatar.
+ *
+ * Subscribes to the ACP run store via `useAcpRunCardData(acpSessionId)`, which
+ * returns `null` until the run's entry lands — the spawn race where the
+ * assistant message containing the inline card mounts a hair before the
+ * `acp_session_spawned` event. The card renders `null` in that window so the
+ * transcript layout doesn't jiggle.
+ *
+ * Interaction model mirrors the subagent / workflow inline cards:
+ *   - Clicking anywhere on the header row opens the run's detail panel via
+ *     `onAcpRunClick`. There is no inline expand — the panel is the detail view.
+ *   - Stop is exposed via `onStopAcpRun`; the shell renders a small stop chip in
+ *     the right rail while the run is in-flight.
+ */
+
+import { Code, Square } from "lucide-react";
+import { useCallback, type MouseEvent } from "react";
+
+import { Button } from "@vellumai/design-library";
+
+import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import { useAcpRunCardData } from "@/domains/chat/components/acp-run-inline-card/use-acp-run-card-data";
+
+export interface AcpRunInlineProgressCardProps {
+  acpSessionId: string;
+  /** Open the run's detail panel (header-row activation, not the stop button). */
+  onAcpRunClick?: (acpSessionId: string) => void;
+  /** Stop an in-flight run; omit to hide the stop button. */
+  onStopAcpRun?: (acpSessionId: string) => void;
+}
+
+export function AcpRunInlineProgressCard({
+  acpSessionId,
+  onAcpRunClick,
+  onStopAcpRun,
+}: AcpRunInlineProgressCardProps) {
+  const data = useAcpRunCardData(acpSessionId);
+  // The shell's `loading` state is the live window where stopping the run is a
+  // meaningful action (see `deriveCardState`).
+  const isRunning = data?.state === "loading";
+
+  const handleHeaderClick = useCallback(() => {
+    onAcpRunClick?.(acpSessionId);
+  }, [onAcpRunClick, acpSessionId]);
+
+  const handleStop = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onStopAcpRun?.(acpSessionId);
+    },
+    [onStopAcpRun, acpSessionId],
+  );
+
+  // Spawn race: assistant message references a run before its spawn event
+  // lands. Render `null` rather than a blank shell so the transcript doesn't
+  // flicker an empty card.
+  if (!data) return null;
+
+  const leadingIcon = <Code size={20} aria-hidden />;
+
+  const actionSlot =
+    onStopAcpRun && isRunning ? (
+      <Button
+        variant="dangerGhost"
+        size="compact"
+        iconOnly={<Square fill="currentColor" />}
+        aria-label="Stop run"
+        data-testid="acp-run-inline-card-stop"
+        onClick={handleStop}
+      />
+    ) : undefined;
+
+  return (
+    <div className="w-full" data-testid="acp-run-inline-progress-card">
+      <ToolProgressCardShell
+        data-testid="acp-run-inline-card-shell"
+        statusIndicatorTestId="acp-run-inline-card-status-indicator"
+        state={data.state}
+        leadingIcon={leadingIcon}
+        currentStepTitle={data.currentStepTitle}
+        currentStepInfo={data.currentStepInfo}
+        stepCount={data.stepCount}
+        // No inline timeline to reveal — the detail panel is the only detail
+        // view, so the expanded body stays disabled.
+        disableExpand
+        headerActionSlot={actionSlot}
+        onHeaderClick={onAcpRunClick ? handleHeaderClick : undefined}
+        headerAriaLabel={onAcpRunClick ? "Open run" : undefined}
+      >
+        {/* Children unused — `disableExpand` suppresses the body region. */}
+        <span className="hidden" />
+      </ToolProgressCardShell>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
@@ -13,7 +13,9 @@
  *   - Clicking anywhere on the header row opens the run's detail panel via
  *     `onAcpRunClick`. There is no inline expand — the panel is the detail view.
  *   - Stop is exposed via `onStopAcpRun`; the shell renders a small stop chip in
- *     the right rail while the run is in-flight.
+ *     the right rail while the run is in-flight ONLY when a real handler is
+ *     wired. With `onStopAcpRun` omitted, no stop affordance renders — avoiding a
+ *     misleading button that does nothing.
  */
 
 import { Code, Square } from "lucide-react";
@@ -61,8 +63,10 @@ export function AcpRunInlineProgressCard({
 
   const leadingIcon = <Code size={20} aria-hidden />;
 
+  // Render the stop affordance only when a real cancel handler is wired AND the
+  // run is in-flight — never a placeholder that no-ops on click.
   const actionSlot =
-    onStopAcpRun && isRunning ? (
+    onStopAcpRun != null && isRunning ? (
       <Button
         variant="dangerGhost"
         size="compact"

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
@@ -1,0 +1,119 @@
+/**
+ * Builds the props for `AcpRunInlineProgressCard` from a single ACP run's
+ * store entry. Projects the run's raw event buffer into the carousel via
+ * `useAcpRunSteps` + `acpStepsToCarousel`, then maps the run status to the
+ * shared card props consumed by the tool-progress card chrome — the same shape
+ * the workflow and subagent inline cards feed their shells.
+ *
+ * Returns `null` when no entry exists for the given session yet — the
+ * spawn-race window where the assistant message containing the inline card
+ * mounts a hair before the `acp_session_spawned` event lands. The card renders
+ * `null` in that window so the transcript layout doesn't jiggle, mirroring
+ * `useWorkflowCardData`.
+ *
+ * State mapping (see `deriveCardState`): `initializing`/`running` → `loading`;
+ * `completed` with `stopReason === "cancelled"` → `warning` (a user-aborted
+ * run still produced partial work, so it's not a clean finish nor an error);
+ * `completed` → `complete`; `failed`/`cancelled` → `error`.
+ */
+
+import { useMemo } from "react";
+
+import {
+  acpStepsToCarousel,
+  useAcpRunSteps,
+  type AcpTimelineStep,
+} from "@/domains/chat/acp-run-step-projection";
+import { useAcpRunStore, type AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+import type { AcpRunStatus } from "@/utils/acp-run-status";
+import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+
+/**
+ * Stable frozen empty buffer for the spawn-race window (no entry yet). A stable
+ * reference keeps the projector's identity check happy so the hook doesn't
+ * churn while waiting for the spawn event.
+ */
+const EMPTY_EVENTS: AcpRunRawEvent[] = [];
+
+export interface AcpRunCardData {
+  state: ToolProgressCardState;
+  currentStepTitle: string;
+  currentStepInfo: string;
+  /** Pre-formatted tool-step count, e.g. `"2 steps"`. */
+  stepCount: string;
+}
+
+/**
+ * Translate the run status to a shell-compatible visual state. A `completed`
+ * run that was cancelled reads as a `warning` (partial work); a clean
+ * `completed` reads as `complete`; `failed`/`cancelled` read as `error`.
+ */
+function deriveCardState(
+  status: AcpRunStatus,
+  stopReason: string | undefined,
+): ToolProgressCardState {
+  switch (status) {
+    case "initializing":
+    case "running":
+      return "loading";
+    case "completed":
+      return stopReason === "cancelled" ? "warning" : "complete";
+    case "failed":
+    case "cancelled":
+      return "error";
+    default:
+      return "loading";
+  }
+}
+
+/**
+ * Secondary descriptor for the header — the detail of the latest projected
+ * step (tool title, message/thought content). Empty when the latest step
+ * carries nothing useful (its carousel label already says it all).
+ */
+function deriveCurrentStepInfo(steps: AcpTimelineStep[]): string {
+  const latest = steps[steps.length - 1];
+  if (!latest) return "";
+  switch (latest.kind) {
+    case "tool":
+      return latest.title;
+    case "message":
+    case "thought":
+      return latest.content;
+    case "plan":
+      return "";
+  }
+}
+
+/**
+ * React hook: subscribe to the ACP run store entry for `acpSessionId` and
+ * project it into card props. Returns `null` when no entry exists yet (spawn
+ * race) so callers can short-circuit rendering.
+ */
+export function useAcpRunCardData(acpSessionId: string): AcpRunCardData | null {
+  const entry = useAcpRunStore((s) => s.byId[acpSessionId]);
+  // Project incrementally (must run unconditionally — `useAcpRunSteps` holds a
+  // ref). In the spawn-race window there's no entry yet, so feed the stable
+  // empty buffer; the `null` return below preserves the contract.
+  const steps = useAcpRunSteps(entry?.events ?? EMPTY_EVENTS);
+
+  return useMemo(() => {
+    if (!entry) return null;
+
+    const carousel = acpStepsToCarousel(steps);
+    const latest = carousel[carousel.length - 1];
+    // Step count reflects tool steps only — message/thought/plan steps are
+    // chatter, not discrete "steps" the run progressed through.
+    const toolStepCount = steps.reduce(
+      (n, step) => (step.kind === "tool" ? n + 1 : n),
+      0,
+    );
+
+    return {
+      state: deriveCardState(entry.status, entry.stopReason),
+      currentStepTitle: latest?.label ?? "Working",
+      currentStepInfo: deriveCurrentStepInfo(steps),
+      stepCount: `${toolStepCount} step${toolStepCount === 1 ? "" : "s"}`,
+    };
+  }, [entry, steps]);
+}

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -228,6 +228,23 @@ export function isRunWorkflowCall(toolCall: ChatMessageToolCall): boolean {
 }
 
 /**
+ * Detect whether a tool call is an `acp_spawn` invocation. Like
+ * `subagent_spawn`/`run_workflow`, the daemon exposes `acp_spawn` as a
+ * bundled-skill tool, so the LLM emits a `skill_execute` call with
+ * `input.tool === "acp_spawn"` — the `tool_use_start` event the frontend
+ * receives still carries `toolName: "skill_execute"`. Matching on the raw
+ * `toolName` alone would miss every spawn and leave the inline ACP run card
+ * unrendered.
+ */
+export function isAcpSpawnCall(toolCall: ChatMessageToolCall): boolean {
+  if (toolCall.name === "acp_spawn") return true;
+  if (toolCall.name !== "skill_execute") return false;
+  const input = toolCall.input;
+  if (input == null || typeof input !== "object") return false;
+  return (input as Record<string, unknown>).tool === "acp_spawn";
+}
+
+/**
  * Detect a task-progress card surface — `template === "task_progress"` with a
  * non-empty `steps` array. Used by the activity-summary hoist-detection path.
  */

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -1,4 +1,5 @@
 import {
+  isAcpSpawnCall,
   isRunWorkflowCall,
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
@@ -294,6 +295,80 @@ export function computeCardBackedWorkflowRunIds(
     backed.add(rid);
   }
   return backed;
+}
+
+/**
+ * Extract the spawned `acpSessionId` from an `acp_spawn` tool call's result.
+ * The daemon's spawn tool returns `JSON.stringify({ acpSessionId, ... })`.
+ * Returns `null` when the result hasn't landed yet or the payload is malformed
+ * — callers fall back to the `byToolUseId` anchor so `running` runs still
+ * render an inline card.
+ */
+function extractAcpSessionIdFromResult(
+  toolCall: ChatMessageToolCall,
+): string | null {
+  if (!isAcpSpawnCall(toolCall)) return null;
+  if (typeof toolCall.result !== "string" || !toolCall.result) return null;
+  try {
+    const parsed = JSON.parse(toolCall.result) as { acpSessionId?: unknown };
+    return typeof parsed.acpSessionId === "string" ? parsed.acpSessionId : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The `acpSessionId` a single `acp_spawn` tool call resolves to — its
+ * `byToolUseId` anchor (from the `acp_session_spawned` event), else the id
+ * encoded in its result — or `null` when none is available (e.g. the call
+ * FAILED before returning a session id). The transcript suppresses the raw tool
+ * chip ONLY for calls that resolve to a card; a failed call (`null`) keeps
+ * rendering its tool result so the error stays visible.
+ */
+export function acpRunIdForCall(
+  toolCall: ChatMessageToolCall,
+  byToolUseId: Map<string, string>,
+): string | null {
+  if (!isAcpSpawnCall(toolCall)) return null;
+  return byToolUseId.get(toolCall.id) ?? extractAcpSessionIdFromResult(toolCall);
+}
+
+/**
+ * Resolve the spawned `acpSessionId` for each `acp_spawn` tool call in
+ * `toolCalls`. Resolution priority per tool call:
+ *
+ *  1. `byToolUseId.get(tc.id)` — the deterministic, reconcile-proof anchor
+ *     carried on the `acp_session_spawned` event.
+ *  2. The id encoded in `toolCall.result` — present once the spawn tool result
+ *     has landed.
+ *
+ * The caller owns the `claimed` Set so it persists across every invocation
+ * within a single message, stopping two non-consecutive spawn tool-call groups
+ * from both anchoring the same session id.
+ */
+export function resolveAcpRunIds(
+  toolCalls: ChatMessageToolCall[],
+  byToolUseId: Map<string, string>,
+  claimed: Set<string>,
+): string[] {
+  const ids: string[] = [];
+
+  for (const tc of toolCalls) {
+    if (!isAcpSpawnCall(tc)) continue;
+    const byId = byToolUseId.get(tc.id);
+    if (byId && !claimed.has(byId)) {
+      ids.push(byId);
+      claimed.add(byId);
+      continue;
+    }
+    const fromResult = extractAcpSessionIdFromResult(tc);
+    if (fromResult && !claimed.has(fromResult)) {
+      ids.push(fromResult);
+      claimed.add(fromResult);
+    }
+  }
+
+  return ids;
 }
 
 function fallbackRoleLabel(

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -17,6 +17,7 @@ import { toast } from "@vellumai/design-library";
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import { SubagentSpawnGroup } from "@/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group";
 import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
+import { AcpRunInlineProgressCard } from "@/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import { SingleActivity } from "@/domains/chat/components/single-activity/single-activity";
 import { MultiActivityGroup } from "@/domains/chat/components/multi-activity-group/multi-activity-group";
@@ -36,12 +37,16 @@ import { wireSurfaceToDisplay } from "@/domains/chat/utils/map-runtime-message";
 import { isPointerCoarse } from "@/utils/pointer";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ConversationMessageSurface } from "@vellumai/assistant-api";
 import {
   computeCardBackedWorkflowRunIds,
   isInteractiveClickTarget,
   lookupSubagentEntriesForMessage,
+  acpRunIdForCall,
+  resolveAcpRunIds,
   resolveSpawnedSubagentIds,
   resolveWorkflowRunIds,
   SlackMessageAttribution,
@@ -66,6 +71,10 @@ function toolResultImageSrc(imageData: string): string {
   }
   return `data:${inferImageMimeType(trimmed)};base64,${trimmed}`;
 }
+
+// Stop wiring for ACP runs lands in PR 13. Plumb a stable no-op so the inline
+// card's stop affordance still renders while a run is in-flight.
+const NOOP_STOP_ACP_RUN = (_acpSessionId: string): void => {};
 
 /**
  * Renders a `DisplayMessage`'s body by walking its unified `contentBlocks`
@@ -185,12 +194,45 @@ export function TranscriptMessageBody({
     () => new Set(cardBackedKey ? cardBackedKey.split("|") : []),
     [cardBackedKey],
   );
+  const byToolUseIdAcp = useAcpRunStore.use.byToolUseId();
+  // The acpSessionIds in THIS message whose `acp_spawn` chip is suppressed in
+  // favor of an inline card ("card-backed"). Subscribed via a narrowed selector
+  // returning a stable key so the message re-renders only when a card's backing
+  // flips (an entry appears) — never on every leaf event. A failed call (no id)
+  // or a run with no store entry is NOT card-backed: its tool result keeps
+  // rendering instead of vanishing behind a card with nothing to show.
+  const cardBackedAcpKey = useAcpRunStore(
+    useCallback(
+      (s) => {
+        const ids: string[] = [];
+        for (const tc of message.toolCalls ?? []) {
+          const id = acpRunIdForCall(tc, s.byToolUseId);
+          if (id !== null && s.byId[id] !== undefined) ids.push(id);
+        }
+        return ids.join("|");
+      },
+      [message.toolCalls],
+    ),
+  );
+  const cardBackedAcpRunIds = useMemo(
+    () => new Set(cardBackedAcpKey ? cardBackedAcpKey.split("|") : []),
+    [cardBackedAcpKey],
+  );
+
   const claimedSpawnIds = new Set<string>();
   const claimedWorkflowIds = new Set<string>();
+  const claimedAcpIds = new Set<string>();
   const cardBackedWorkflowRunId = (tc: ChatMessageToolCall): string | null => {
     const rid = workflowRunIdForCall(tc, byToolUseIdWf);
     return rid !== null && cardBackedWorkflowRunIds.has(rid) ? rid : null;
   };
+  const cardBackedAcpRunId = (tc: ChatMessageToolCall): string | null => {
+    const id = acpRunIdForCall(tc, byToolUseIdAcp);
+    return id !== null && cardBackedAcpRunIds.has(id) ? id : null;
+  };
+  const handleAcpRunClick = useCallback((acpSessionId: string) => {
+    useViewerStore.getState().openAcpRunDetail(acpSessionId);
+  }, []);
 
   const handleVellumLinkClick = useCallback(
     (href: string, linkText: string) => {
@@ -286,6 +328,29 @@ export function TranscriptMessageBody({
     );
   };
 
+  const renderInlineAcpRunCards = (toolCalls: ChatMessageToolCall[]) => {
+    const acpSessionIds = resolveAcpRunIds(
+      toolCalls,
+      byToolUseIdAcp,
+      claimedAcpIds,
+    );
+    if (acpSessionIds.length === 0) return null;
+    return (
+      <div className="flex w-full flex-col gap-1.5">
+        {acpSessionIds.map((acpSessionId) => (
+          <AcpRunInlineProgressCard
+            key={acpSessionId}
+            acpSessionId={acpSessionId}
+            onAcpRunClick={handleAcpRunClick}
+            // Stop wiring lands in PR 13; plumb the prop with a no-op so the
+            // button still renders while the run is in-flight.
+            onStopAcpRun={NOOP_STOP_ACP_RUN}
+          />
+        ))}
+      </div>
+    );
+  };
+
   const renderToolResultImages = (toolCalls: ChatMessageToolCall[]) => {
     if (hasAttachments) return null;
     const images = toolCalls.flatMap((tc) => {
@@ -358,10 +423,14 @@ export function TranscriptMessageBody({
       }
     }
     const renderableToolCalls = groupToolCalls.filter(
-      // Suppress the raw chip only for a card-backed run_workflow call (see
-      // cardBackedWorkflowRunId). A failed call (no runId) or a 404/pruned run is
-      // not card-backed, so it renders its tool result instead of vanishing.
-      (tc) => !isSubagentSpawnCall(tc) && cardBackedWorkflowRunId(tc) === null,
+      // Suppress the raw chip only for a card-backed run_workflow / acp_spawn
+      // call (see cardBackedWorkflowRunId / cardBackedAcpRunId). A failed call
+      // (no id) or a run with no store entry is not card-backed, so it renders
+      // its tool result instead of vanishing.
+      (tc) =>
+        !isSubagentSpawnCall(tc) &&
+        cardBackedWorkflowRunId(tc) === null &&
+        cardBackedAcpRunId(tc) === null,
     );
     const loneTool =
       cardItems.length === 1 &&
@@ -378,31 +447,36 @@ export function TranscriptMessageBody({
           {renderToolResultImages(groupToolCalls)}
           {renderInlineSubagentCards(groupToolCalls)}
           {renderInlineWorkflowCards(groupToolCalls)}
+          {renderInlineAcpRunCards(groupToolCalls)}
         </Fragment>
       );
     }
     if (renderableToolCalls.length > 0) {
-      // A card-backed run_workflow call is shown by its dedicated inline card, so
-      // drop it from the steps MultiActivityGroup renders too (the group filters
-      // subagent_spawn internally but not run_workflow). A failed or 404/pruned
-      // workflow call is not card-backed and is kept, so its tool result still
-      // renders as a step; subagent spawns are left for the group to filter.
-      const suppressedWorkflowIds = new Set(
+      // A card-backed run_workflow / acp_spawn call is shown by its dedicated
+      // inline card, so drop it from the steps MultiActivityGroup renders too
+      // (the group filters subagent_spawn internally but not the others). A
+      // failed or pruned call is not card-backed and is kept, so its tool result
+      // still renders as a step; subagent spawns are left for the group to filter.
+      const suppressedCardIds = new Set(
         groupToolCalls
-          .filter((tc) => cardBackedWorkflowRunId(tc) !== null)
+          .filter(
+            (tc) =>
+              cardBackedWorkflowRunId(tc) !== null ||
+              cardBackedAcpRunId(tc) !== null,
+          )
           .map((tc) => tc.id),
       );
       const groupCardToolCalls =
-        suppressedWorkflowIds.size === 0
+        suppressedCardIds.size === 0
           ? groupToolCalls
-          : groupToolCalls.filter((tc) => !suppressedWorkflowIds.has(tc.id));
+          : groupToolCalls.filter((tc) => !suppressedCardIds.has(tc.id));
       const groupCardItems =
-        suppressedWorkflowIds.size === 0
+        suppressedCardIds.size === 0
           ? cardItems
           : cardItems.filter(
               (it) =>
                 it.kind !== "toolCall" ||
-                !suppressedWorkflowIds.has(it.toolCall.id),
+                !suppressedCardIds.has(it.toolCall.id),
             );
       return (
         <Fragment key={key}>
@@ -422,6 +496,7 @@ export function TranscriptMessageBody({
           {renderToolResultImages(groupToolCalls)}
           {renderInlineSubagentCards(groupToolCalls)}
           {renderInlineWorkflowCards(groupToolCalls)}
+          {renderInlineAcpRunCards(groupToolCalls)}
         </Fragment>
       );
     }
@@ -444,6 +519,7 @@ export function TranscriptMessageBody({
         {renderToolResultImages(groupToolCalls)}
         {renderInlineSubagentCards(groupToolCalls)}
         {renderInlineWorkflowCards(groupToolCalls)}
+        {renderInlineAcpRunCards(groupToolCalls)}
       </Fragment>
     );
   };

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -72,10 +72,6 @@ function toolResultImageSrc(imageData: string): string {
   return `data:${inferImageMimeType(trimmed)};base64,${trimmed}`;
 }
 
-// Stop wiring for ACP runs lands in PR 13. Plumb a stable no-op so the inline
-// card's stop affordance still renders while a run is in-flight.
-const NOOP_STOP_ACP_RUN = (_acpSessionId: string): void => {};
-
 /**
  * Renders a `DisplayMessage`'s body by walking its unified `contentBlocks`
  * projection — grouped by `groupContentBlocks`. Each block embeds its own
@@ -342,9 +338,9 @@ export function TranscriptMessageBody({
             key={acpSessionId}
             acpSessionId={acpSessionId}
             onAcpRunClick={handleAcpRunClick}
-            // Stop wiring lands in PR 13; plumb the prop with a no-op so the
-            // button still renders while the run is in-flight.
-            onStopAcpRun={NOOP_STOP_ACP_RUN}
+            // Stop wiring lands in PR 13. Until a real cancel handler exists, omit
+            // onStopAcpRun so the card hides the stop button instead of showing a
+            // misleading no-op affordance.
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Add AcpRunInlineProgressCard (Code icon, ThreeDotIndicator) + useAcpRunCardData mapping store state to ToolCallCardData
- Anchor cards to acp_spawn tool calls via byToolUseId (with result-parse fallback); suppress the raw chip when card-backed
- Clicking the card opens the run detail panel (openAcpRunDetail)

Part of plan: acp-runs-ui.md (PR 8 of 13)