### PR TITLE
feat(web): floating overlay pill for active ACP runs

### DIFF
--- a/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Tests for `ActiveAcpRunsOverlay`.
+ *
+ * Seeds the Zustand ACP run store with `running` entries for each id (the
+ * reused `AcpRunInlineProgressCard` reads the store and renders `null` until
+ * the entry lands), then asserts the empty/collapsed/expanded states, the
+ * per-row open callback (`openAcpRunDetail`), and Escape / outside-click
+ * dismissal.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { ActiveAcpRunsOverlay } from "@/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay";
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  useAcpRunStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function seed(id: string) {
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId: id,
+    agent: "claude",
+    parentConversationId: "conv-1",
+    startedAt: NOW,
+  });
+}
+
+function seedMany(count: number): string[] {
+  const ids = Array.from({ length: count }, (_, i) => `acp-${i}`);
+  act(() => ids.forEach(seed));
+  return ids;
+}
+
+describe("ActiveAcpRunsOverlay — empty", () => {
+  test("renders nothing when acpRunIds is empty", () => {
+    const { queryByTestId } = render(<ActiveAcpRunsOverlay acpRunIds={[]} />);
+    expect(queryByTestId("active-acp-runs-overlay")).toBeNull();
+  });
+});
+
+describe("ActiveAcpRunsOverlay — collapsed", () => {
+  test("shows the pill and hides the panel", () => {
+    const ids = seedMany(3);
+    const { queryByText } = render(<ActiveAcpRunsOverlay acpRunIds={ids} />);
+
+    const pill = screen.getByRole("button", { name: /active runs/i });
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
+    expect(queryByText("3 Active Runs")).toBeNull();
+  });
+
+  test("root is pointer-events-none so the gutter doesn't block the transcript", () => {
+    const ids = seedMany(2);
+    render(<ActiveAcpRunsOverlay acpRunIds={ids} />);
+    expect(
+      screen.getByTestId("active-acp-runs-overlay").className,
+    ).toContain("pointer-events-none");
+  });
+});
+
+describe("ActiveAcpRunsOverlay — expanded", () => {
+  test("clicking the pill reveals the panel with the title and one row per id", () => {
+    const ids = seedMany(3);
+    const { getByText, getAllByTestId } = render(
+      <ActiveAcpRunsOverlay acpRunIds={ids} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active runs/i }));
+
+    expect(
+      screen.getByRole("button", { name: /active runs/i }).getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(getByText("3 Active Runs")).toBeTruthy();
+    expect(getAllByTestId("acp-run-inline-progress-card").length).toBe(3);
+  });
+
+  test("uses the singular noun when exactly one run is active", () => {
+    const ids = seedMany(1);
+    render(<ActiveAcpRunsOverlay acpRunIds={ids} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /active runs/i }));
+
+    expect(screen.getByText("1 Active Run")).toBeTruthy();
+    expect(screen.queryByText("1 Active Runs")).toBeNull();
+  });
+
+  test("clicking a row invokes onAcpRunClick", () => {
+    const ids = seedMany(2);
+    const opened: string[] = [];
+    const { getAllByRole } = render(
+      <ActiveAcpRunsOverlay
+        acpRunIds={ids}
+        onAcpRunClick={(id) => opened.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active runs/i }));
+    fireEvent.click(getAllByRole("button", { name: /open run/i })[1]);
+    expect(opened).toEqual(["acp-1"]);
+  });
+});
+
+describe("ActiveAcpRunsOverlay — dismissal", () => {
+  test("Escape collapses the open panel", () => {
+    const ids = seedMany(2);
+    const { queryByText } = render(<ActiveAcpRunsOverlay acpRunIds={ids} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /active runs/i }));
+    expect(queryByText("2 Active Runs")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(queryByText("2 Active Runs")).toBeNull();
+  });
+
+  test("pointerdown outside the container collapses the open panel", () => {
+    const ids = seedMany(2);
+    const { queryByText } = render(<ActiveAcpRunsOverlay acpRunIds={ids} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /active runs/i }));
+    expect(queryByText("2 Active Runs")).toBeTruthy();
+
+    fireEvent.pointerDown(document.body);
+    expect(queryByText("2 Active Runs")).toBeNull();
+  });
+
+  test("collapses when the run set drains to 0", () => {
+    const ids = seedMany(2);
+    const { rerender, queryByText, queryByTestId } = render(
+      <ActiveAcpRunsOverlay acpRunIds={ids} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active runs/i }));
+    expect(queryByText("2 Active Runs")).toBeTruthy();
+
+    rerender(<ActiveAcpRunsOverlay acpRunIds={[]} />);
+    expect(queryByTestId("active-acp-runs-overlay")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ActiveAcpRunsPill } from "@/domains/chat/components/active-acp-runs-overlay/active-acp-runs-pill";
+import { AcpRunInlineProgressCard } from "@/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card";
+
+export interface ActiveAcpRunsOverlayProps {
+  acpRunIds: string[];
+  onAcpRunClick?: (acpSessionId: string) => void;
+  onStopAcpRun?: (acpSessionId: string) => void;
+}
+
+export function ActiveAcpRunsOverlay({
+  acpRunIds,
+  onAcpRunClick,
+  onStopAcpRun,
+}: ActiveAcpRunsOverlayProps) {
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Defensive: collapse if the active set drains while open.
+  useEffect(() => {
+    if (acpRunIds.length === 0) setExpanded(false);
+  }, [acpRunIds.length]);
+
+  // While open, dismiss on outside pointerdown or Escape.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expanded]);
+
+  if (acpRunIds.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="active-acp-runs-overlay"
+      // none here so gutter clicks reach the transcript; pill + panel re-enable.
+      className="pointer-events-none flex w-full max-w-[589px] flex-col items-center gap-2"
+    >
+      <ActiveAcpRunsPill
+        acpRunIds={acpRunIds}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
+
+      {expanded && (
+        <div className="pointer-events-auto flex w-full flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
+          <Typography
+            variant="title-small"
+            className="text-[var(--content-emphasised)]"
+          >
+            {acpRunIds.length} Active Run
+            {acpRunIds.length === 1 ? "" : "s"}
+          </Typography>
+          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+            {acpRunIds.map((id) => (
+              <AcpRunInlineProgressCard
+                key={id}
+                acpSessionId={id}
+                onAcpRunClick={onAcpRunClick}
+                onStopAcpRun={onStopAcpRun}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-pill.tsx
+++ b/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-pill.tsx
@@ -1,0 +1,44 @@
+import { ChevronDown, ChevronUp, Code } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ChatPill } from "@/domains/chat/components/chat-pill";
+
+export interface ActiveAcpRunsPillProps {
+  acpRunIds: string[];
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function ActiveAcpRunsPill({
+  acpRunIds,
+  expanded,
+  onToggle,
+}: ActiveAcpRunsPillProps) {
+  return (
+    <ChatPill
+      onClick={onToggle}
+      ariaLabel="Active runs"
+      ariaExpanded={expanded}
+      size="compact"
+    >
+      {/* pointer-events-none so the ChatPill button owns clicks + cursor. */}
+      <span className="pointer-events-none inline-flex items-center gap-2">
+        <Code className="h-4 w-4 text-[var(--content-emphasised)]" />
+
+        <Typography
+          variant="body-small-default"
+          className="text-[var(--content-emphasised)]"
+        >
+          {acpRunIds.length}
+        </Typography>
+
+        {expanded ? (
+          <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+        ) : (
+          <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
+        )}
+      </span>
+    </ChatPill>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -155,6 +155,12 @@ export interface ChatBodyProps {
    * only when there is ≥1 active subagent.
    */
   activeSubagentsSlot?: ReactNode;
+
+  /**
+   * Top-center floating overlay for active ACP runs; gated identically to
+   * {@link activeSubagentsSlot} and stacked directly below it.
+   */
+  activeAcpRunsSlot?: ReactNode;
 }
 
 /**
@@ -211,6 +217,7 @@ export function ChatBody({
   readonlyBannerSlot,
   startersSlot,
   activeSubagentsSlot,
+  activeAcpRunsSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
 
@@ -247,11 +254,14 @@ export function ChatBody({
     >
       <ChatScrollArea {...scrollAreaProps} />
 
-      {!isEmptyState && showScrollToLatest && activeSubagentsSlot && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center px-3 pt-2">
-          {activeSubagentsSlot}
-        </div>
-      )}
+      {!isEmptyState &&
+        showScrollToLatest &&
+        (activeSubagentsSlot || activeAcpRunsSlot) && (
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex flex-col items-center gap-2 px-3 pt-2">
+            {activeSubagentsSlot}
+            {activeAcpRunsSlot}
+          </div>
+        )}
 
       {/* Composer stack — stays at the same tree position across the
           empty→active transition so React preserves its state (focus,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -848,8 +848,7 @@ export function ChatMainPanel({
       />
     ) : undefined;
 
-  // `onStopAcpRun` is wired in a later PR; omit it so the card's stop button
-  // stays hidden.
+  // No stop handler is passed, so the inline card's stop button stays hidden.
   const activeAcpRunsSlot =
     activeAcpRunIds.length > 0 ? (
       <ActiveAcpRunsOverlay

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -20,6 +20,7 @@
 import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
+import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
@@ -37,6 +38,7 @@ import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attach
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
+import { ActiveAcpRunsOverlay } from "@/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay";
 import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
@@ -263,9 +265,14 @@ export function ChatMainPanel({
   }, [assistantId]);
 
   const activeSubagentIds = useActiveSubagentIds();
+  const activeAcpRunIds = useActiveAcpRunIds();
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);
+  }, []);
+
+  const onAcpRunClick = useCallback((acpSessionId: string) => {
+    useViewerStore.getState().openAcpRunDetail(acpSessionId);
   }, []);
 
   const onStopSubagent = useCallback(
@@ -841,6 +848,16 @@ export function ChatMainPanel({
       />
     ) : undefined;
 
+  // `onStopAcpRun` is wired in a later PR; omit it so the card's stop button
+  // stays hidden.
+  const activeAcpRunsSlot =
+    activeAcpRunIds.length > 0 ? (
+      <ActiveAcpRunsOverlay
+        acpRunIds={activeAcpRunIds}
+        onAcpRunClick={onAcpRunClick}
+      />
+    ) : undefined;
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -877,6 +894,7 @@ export function ChatMainPanel({
         readonlyBannerSlot={channelReadonlyBannerSlot}
         startersSlot={startersSlot}
         activeSubagentsSlot={activeSubagentsSlot}
+        activeAcpRunsSlot={activeAcpRunsSlot}
       />
       <MicPermissionPrimer
         open={showPrimer}

--- a/clients/web/src/domains/chat/hooks/use-active-acp-run-ids.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-acp-run-ids.ts
@@ -1,0 +1,21 @@
+import { useShallow } from "zustand/react/shallow";
+
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { isActiveAcpStatus } from "@/utils/acp-run-status";
+
+/**
+ * Active (initializing | running) ACP run ids in stable `orderedIds` order.
+ * `useShallow` keeps the returned array reference stable across unrelated
+ * store ticks (e.g. token-usage updates) so consumers only re-render when the
+ * active set actually changes.
+ */
+export function useActiveAcpRunIds(): string[] {
+  return useAcpRunStore(
+    useShallow((s) =>
+      s.orderedIds.filter((id) => {
+        const status = s.byId[id]?.status;
+        return status !== undefined && isActiveAcpStatus(status);
+      }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Add active-acp-runs overlay/pill (Code icon) mirroring the active-subagents overlay; expands to a scrollable list of running ACP cards
- use-active-acp-run-ids selector; stacked below the subagents overlay in the top-center slot; clicking a row opens the run detail

Part of plan: acp-runs-ui.md (PR 11 of 13)