### PR TITLE
feat(web): wire ACP run detail panel into chat layout

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -26,6 +26,7 @@ import { useDeployStore } from "@/stores/deploy-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useEditApp } from "@/hooks/use-edit-app";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { routes } from "@/utils/routes";
@@ -37,9 +38,14 @@ const importSubagentDetailPanel = () =>
   import("@/domains/chat/components/subagent-detail-panel");
 const importToolDetailPanel = () =>
   import("@/domains/chat/components/tool-detail-panel");
+const importAcpRunDetailPanel = () =>
+  import("@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel");
 
 const SubagentDetailPanel = lazy(() =>
   importSubagentDetailPanel().then((m) => ({ default: m.SubagentDetailPanel })),
+);
+const AcpRunDetailPanel = lazy(() =>
+  importAcpRunDetailPanel().then((m) => ({ default: m.AcpRunDetailPanel })),
 );
 const WorkflowDetailPanel = lazy(() =>
   import("@/domains/chat/components/workflow-detail-panel").then((m) => ({
@@ -70,6 +76,11 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     activeSubagentId ? s.byId[activeSubagentId] : undefined,
   );
   const workflowById = useWorkflowStore((s) => s.byId);
+  const activeAcpRunId = useViewerStore.use.activeAcpRunId();
+  // Active run's entry only — same narrow selector as the subagent entry above.
+  const activeAcpRunEntry = useAcpRunStore((s) =>
+    activeAcpRunId ? s.byId[activeAcpRunId] : undefined,
+  );
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
@@ -150,6 +161,10 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     void useWorkflowStore.getState().fetchJournalIfNeeded(aid, runId);
   }, []);
 
+  const onCloseAcpRunDetail = useCallback(() => {
+    useViewerStore.getState().closeAcpRunDetail();
+  }, []);
+
   // -------------------------------------------------------------------------
   // Escape closes whichever right-hand side panel is open (tool detail /
   // thought process, subagent detail, document viewer). Surfaces stacked
@@ -182,6 +197,9 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
         case "workflow-detail":
           viewer.closeWorkflowDetail();
           break;
+        case "acp-run-detail":
+          viewer.closeAcpRunDetail();
+          break;
         case "document":
           viewer.closeDocument();
           break;
@@ -203,6 +221,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     const run = () => {
       importSubagentDetailPanel().catch(() => {});
       importToolDetailPanel().catch(() => {});
+      importAcpRunDetailPanel().catch(() => {});
     };
     if (typeof window.requestIdleCallback === "function") {
       const id = window.requestIdleCallback(run);
@@ -332,6 +351,21 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             detail={activeToolDetail}
             onClose={closeToolDetail}
             onRiskBadgeClick={() => useViewerStore.getState().requestRuleEditorForActiveTool()}
+          />
+        </LazyBoundary>
+      );
+    } else if (
+      mainView === "acp-run-detail" &&
+      activeAcpRunId &&
+      activeAcpRunEntry
+    ) {
+      // `onStop` intentionally omitted — PR 13 wires stop/abort; until then the
+      // panel's Stop button stays hidden.
+      rightPanel = (
+        <LazyBoundary>
+          <AcpRunDetailPanel
+            entry={activeAcpRunEntry}
+            onClose={onCloseAcpRunDetail}
           />
         </LazyBoundary>
       );

--- a/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for `MobileAcpRunDetailOverlay` — the mobile full-screen host for the
+ * ACP run detail panel.
+ *
+ * Runs under happy-dom. The lazily-loaded `AcpRunDetailPanel` transitively pulls
+ * in the generated daemon SDK (via `ToolDetailBody`), so stub every endpoint
+ * before importing, then import dynamically so the mock registers first.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+const sdkStub = async () => ({ data: undefined });
+const realSdkPath = new URL(
+  "../../../generated/daemon/sdk.gen.ts",
+  import.meta.url,
+).pathname;
+const sdkSource = await Bun.file(realSdkPath).text();
+const exportNames = [...sdkSource.matchAll(/^export const (\w+)/gm)].map(
+  (m) => m[1]!,
+);
+const sdkMock = Object.fromEntries(exportNames.map((n) => [n, sdkStub]));
+mock.module("@/generated/daemon/sdk.gen", () => sdkMock);
+
+const { MobileAcpRunDetailOverlay } = await import(
+  "@/domains/chat/components/mobile-acp-run-detail-overlay"
+);
+import type { AcpRunEntry } from "@/domains/chat/acp-run-store";
+
+const noop = () => {};
+
+function makeEntry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
+  return {
+    acpSessionId: "acp-1",
+    agent: "claude",
+    parentConversationId: "conv-1",
+    task: "Research the thing",
+    status: "running",
+    startedAt: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalCost: 0,
+    events: [],
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+afterAll(() => mock.restore());
+
+describe("MobileAcpRunDetailOverlay", () => {
+  test("renders nothing when entry is null", () => {
+    const { container } = render(
+      <MobileAcpRunDetailOverlay entry={null} onClose={noop} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the panel when given an entry", async () => {
+    render(<MobileAcpRunDetailOverlay entry={makeEntry()} onClose={noop} />);
+    expect(await screen.findByText("claude")).toBeDefined();
+  });
+
+  test("close button fires onClose", async () => {
+    let closed = 0;
+    render(
+      <MobileAcpRunDetailOverlay
+        entry={makeEntry()}
+        onClose={() => {
+          closed += 1;
+        }}
+      />,
+    );
+    fireEvent.click(await screen.findByLabelText("Close run detail"));
+    expect(closed).toBe(1);
+  });
+
+  test("Stop button stays hidden (onStop intentionally unwired)", async () => {
+    render(<MobileAcpRunDetailOverlay entry={makeEntry()} onClose={noop} />);
+    await screen.findByText("claude");
+    expect(screen.queryByLabelText("Stop run")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.tsx
@@ -1,0 +1,51 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import type { AcpRunEntry } from "@/domains/chat/acp-run-store";
+
+const AcpRunDetailPanel = lazy(() =>
+  import(
+    "@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel"
+  ).then((m) => ({ default: m.AcpRunDetailPanel })),
+);
+
+interface MobileAcpRunDetailOverlayProps {
+  /** When `null`, the overlay renders nothing. */
+  entry: AcpRunEntry | null;
+  /** Closes the overlay. */
+  onClose: () => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the ACP run detail panel.
+ *
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
+ *
+ * Stop/abort is intentionally not wired yet — the panel's Stop button stays
+ * hidden without `onStop`.
+ */
+export function MobileAcpRunDetailOverlay({
+  entry,
+  onClose,
+}: MobileAcpRunDetailOverlayProps) {
+  if (!entry) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+      style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+      }}
+    >
+      <LazyBoundary>
+        <AcpRunDetailPanel entry={entry} onClose={onClose} />
+      </LazyBoundary>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -1,7 +1,8 @@
 /**
  * Portal-based mobile overlay container for app, document, subagent-detail,
- * and tool-detail viewers. Reads from Zustand stores directly so the parent
- * (ActiveChatView) doesn't need to assemble inline handlers.
+ * workflow-detail, acp-run-detail, and tool-detail viewers. Reads from Zustand
+ * stores directly so the parent (ActiveChatView) doesn't need to assemble
+ * inline handlers.
  *
  * Renders nothing on desktop viewports (useMobileOverlayTarget returns null).
  */
@@ -13,11 +14,13 @@ import { useNavigate } from "react-router";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
+import { MobileAcpRunDetailOverlay } from "@/domains/chat/components/mobile-acp-run-detail-overlay";
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
@@ -38,8 +41,10 @@ export function MobileChatOverlays() {
   const activeSubagentId = useViewerStore.use.activeSubagentId();
   const activeToolDetail = useViewerStore.use.activeToolDetail();
   const activeWorkflowRunId = useViewerStore.use.activeWorkflowRunId();
+  const activeAcpRunId = useViewerStore.use.activeAcpRunId();
   const subagentById = useSubagentStore.use.byId();
   const workflowById = useWorkflowStore.use.byId();
+  const acpRunById = useAcpRunStore.use.byId();
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
   const handleCloseApp = useCallback(() => {
@@ -108,6 +113,10 @@ export function MobileChatOverlays() {
     void useWorkflowStore.getState().fetchJournalIfNeeded(aid, runId);
   }, []);
 
+  const handleCloseAcpRunDetail = useCallback(() => {
+    useViewerStore.getState().closeAcpRunDetail();
+  }, []);
+
   const handleCloseToolDetail = useCallback(() => {
     useViewerStore.getState().closeToolDetail();
   }, []);
@@ -159,6 +168,14 @@ export function MobileChatOverlays() {
         onClose={handleCloseWorkflowDetail}
         onStop={handleStopWorkflow}
         onRequestJournal={handleRequestWorkflowJournal}
+      />
+      <MobileAcpRunDetailOverlay
+        entry={
+          mainView === "acp-run-detail" && activeAcpRunId
+            ? acpRunById[activeAcpRunId] ?? null
+            : null
+        }
+        onClose={handleCloseAcpRunDetail}
       />
       <MobileToolDetailOverlay
         detail={mainView === "tool-detail" ? activeToolDetail : null}


### PR DESCRIPTION
## Summary
- Mount AcpRunDetailPanel in the desktop AnimatedRightDrawer (lazy + idle-prefetch) and the mobile overlay router on mainView acp-run-detail
- Add Escape-to-close case restoring the prior view; chat never remounts

Part of plan: acp-runs-ui.md (PR 10 of 13)