### PR TITLE
feat(web): wire steering, stop/abort, and error states for ACP runs

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -22,6 +22,25 @@ const exportNames = [...sdkSource.matchAll(/^export const (\w+)/gm)].map(
 const sdkMock = Object.fromEntries(exportNames.map((n) => [n, sdkStub]));
 mock.module("@/generated/daemon/sdk.gen", () => sdkMock);
 
+// Capture the self-contained stop/steer paths (no override props passed).
+const stopCalls: string[] = [];
+const steerCalls: Array<{ id: string; instruction: string }> = [];
+let nextSteerResponse: {
+  acpSessionId: string;
+  steered: boolean;
+  resumed?: boolean;
+  approvalPending?: boolean;
+} = { acpSessionId: "acp-1", steered: true };
+mock.module("@/domains/chat/utils/acp-run-actions", () => ({
+  stopAcpRun: async (id: string) => {
+    stopCalls.push(id);
+  },
+  steerAcpRun: async (id: string, instruction: string) => {
+    steerCalls.push({ id, instruction });
+    return nextSteerResponse;
+  },
+}));
+
 const { AcpRunDetailPanel } = await import(
   "@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel"
 );
@@ -71,6 +90,9 @@ const TOOL_CALL_EVENT: AcpRunRawEvent = {
 afterEach(() => {
   cleanup();
   useAcpRunStore.getState().reset();
+  stopCalls.length = 0;
+  steerCalls.length = 0;
+  nextSteerResponse = { acpSessionId: "acp-1", steered: true };
 });
 afterAll(() => {
   mock.restore();
@@ -328,5 +350,57 @@ describe("AcpRunDetailPanel — timeline + nested detail", () => {
     expect(screen.queryByLabelText("Back to timeline")).toBeNull();
     expect(screen.getByText("Timeline")).toBeDefined();
     expect(screen.getByText("gemini")).toBeDefined();
+  });
+});
+
+describe("AcpRunDetailPanel — stop / steer / error", () => {
+  test("Stop cancels the run directly when no onStop override is passed", () => {
+    render(
+      <AcpRunDetailPanel entry={makeEntry({ status: "running" })} onClose={noop} />,
+    );
+    fireEvent.click(screen.getByLabelText("Stop run"));
+    expect(stopCalls).toEqual(["acp-1"]);
+  });
+
+  test("steering input shows only while running and submits the instruction", () => {
+    const { rerender } = render(
+      <AcpRunDetailPanel entry={makeEntry({ status: "running" })} onClose={noop} />,
+    );
+    const input = screen.getByLabelText("Steering instruction");
+    fireEvent.change(input, { target: { value: "focus on tests" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(steerCalls).toEqual([{ id: "acp-1", instruction: "focus on tests" }]);
+
+    rerender(
+      <AcpRunDetailPanel entry={makeEntry({ status: "completed" })} onClose={noop} />,
+    );
+    expect(screen.queryByLabelText("Steering instruction")).toBeNull();
+  });
+
+  test("approvalPending steer surfaces the awaiting-approval affordance", async () => {
+    nextSteerResponse = {
+      acpSessionId: "acp-1",
+      steered: false,
+      approvalPending: true,
+    };
+    render(
+      <AcpRunDetailPanel entry={makeEntry({ status: "running" })} onClose={noop} />,
+    );
+    const input = screen.getByLabelText("Steering instruction");
+    fireEvent.change(input, { target: { value: "resume" } });
+    await act(async () => {
+      fireEvent.submit(input.closest("form")!);
+    });
+    expect(screen.getByText(/awaiting approval/i)).toBeDefined();
+  });
+
+  test("failed run renders its error message", () => {
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({ status: "failed", error: "agent crashed" })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByText("agent crashed")).toBeDefined();
   });
 });

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -23,11 +23,18 @@ import {
   Code,
   ListChecks,
   MessageSquare,
+  RotateCw,
+  Send,
   Square,
   X,
 } from "lucide-react";
 
-import { useCallback, useMemo, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type FormEvent,
+} from "react";
 
 import { Button, Typography } from "@vellumai/design-library";
 
@@ -45,10 +52,15 @@ import {
 } from "@/domains/chat/acp-run-step-projection";
 import { useAcpRunStore, type AcpRunEntry } from "@/domains/chat/acp-run-store";
 import {
+  steerAcpRun,
+  stopAcpRun,
+} from "@/domains/chat/utils/acp-run-actions";
+import {
   acpRunStatusColor,
   acpRunStatusLabel,
   isActiveAcpStatus,
 } from "@/utils/acp-run-status";
+import { captureError } from "@/lib/sentry/capture-error";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -223,12 +235,24 @@ export function AcpRunDetailPanel({
   // for a multi-line task.
   const [objectiveExpanded, setObjectiveExpanded] = useState(false);
 
-  // Reset nested state on run switch — render-phase guard tracking the prev id.
+  // Stop disables after a click to avoid a double-cancel; steering tracks the
+  // input value and a transient "awaiting approval" affordance.
+  const [stopping, setStopping] = useState(false);
+  const [steerInput, setSteerInput] = useState("");
+  const [steerPending, setSteerPending] = useState(false);
+  const [approvalPending, setApprovalPending] = useState(false);
+
+  // Reset nested + action state on run switch — render-phase guard tracking the
+  // prev id.
   const [prevSessionId, setPrevSessionId] = useState(entry.acpSessionId);
   if (prevSessionId !== entry.acpSessionId) {
     setPrevSessionId(entry.acpSessionId);
     setSelectedStepIndex(null);
     setObjectiveExpanded(false);
+    setStopping(false);
+    setSteerInput("");
+    setSteerPending(false);
+    setApprovalPending(false);
   }
 
   const handleStepDetailClick = useCallback(
@@ -236,6 +260,38 @@ export function AcpRunDetailPanel({
     [],
   );
   const handleBack = useCallback(() => setSelectedStepIndex(null), []);
+
+  const handleStop = useCallback(() => {
+    setStopping(true);
+    if (onStop) {
+      onStop(entry.acpSessionId);
+      return;
+    }
+    void stopAcpRun(entry.acpSessionId).catch((err) => {
+      setStopping(false);
+      captureError(err, { context: "AcpRunDetailPanel.stop" });
+    });
+  }, [onStop, entry.acpSessionId]);
+
+  const handleSteerSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const instruction = steerInput.trim();
+      if (!instruction || steerPending) return;
+      setSteerPending(true);
+      setApprovalPending(false);
+      void steerAcpRun(entry.acpSessionId, instruction)
+        .then((res) => {
+          setSteerInput("");
+          setApprovalPending(res.approvalPending === true);
+        })
+        .catch((err) => {
+          captureError(err, { context: "AcpRunDetailPanel.steer" });
+        })
+        .finally(() => setSteerPending(false));
+    },
+    [steerInput, steerPending, entry.acpSessionId],
+  );
 
   // Resolve by index; fall back to the timeline if the steps array shrank past
   // the selected index (e.g. history hydration replaced the buffer).
@@ -309,12 +365,13 @@ export function AcpRunDetailPanel({
           />
         )}
         <span className="flex-1" />
-        {isRunning && onStop && (
+        {isRunning && !activeStep && (
           <button
             type="button"
             aria-label="Stop run"
-            onClick={() => onStop(entry.acpSessionId)}
-            className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--system-negative-strong)] bg-transparent px-2.5 py-1.5 text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--system-negative-weak)]"
+            onClick={handleStop}
+            disabled={stopping}
+            className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--system-negative-strong)] bg-transparent px-2.5 py-1.5 text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--system-negative-weak)] disabled:cursor-default disabled:opacity-50"
           >
             <Square className="h-3 w-3" fill="currentColor" />
             <Typography variant="label-small-default">Stop</Typography>
@@ -345,6 +402,19 @@ export function AcpRunDetailPanel({
           )
         ) : (
           <>
+            {/* Error — a failed run surfaces its message under the status badge. */}
+            {entry.status === "failed" && entry.error && (
+              <div className="mb-5 rounded-lg border border-[var(--system-negative-strong)] bg-[var(--system-negative-weak)] px-3 py-2.5">
+                <Typography
+                  variant="body-small-default"
+                  as="p"
+                  className="whitespace-pre-wrap break-words text-[var(--system-negative-strong)]"
+                >
+                  {entry.error}
+                </Typography>
+              </div>
+            )}
+
             {/* Metrics row */}
             <div className="mb-5 grid grid-cols-2 gap-3">
               <AnimatedMetricCard
@@ -438,6 +508,45 @@ export function AcpRunDetailPanel({
           </>
         )}
       </div>
+
+      {/* Steering — send a follow-up instruction while the run is live. */}
+      {entry.status === "running" && !activeStep && (
+        <form
+          onSubmit={handleSteerSubmit}
+          className="shrink-0 border-t border-[var(--border-hover)] px-5 py-3"
+        >
+          {approvalPending && (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="mb-2 flex items-center gap-1.5 text-[var(--content-secondary)]"
+            >
+              <RotateCw className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              Awaiting approval to resume…
+            </Typography>
+          )}
+          <div className="flex items-center gap-2 rounded-md bg-[var(--surface-base)] px-3 py-2">
+            <input
+              type="text"
+              value={steerInput}
+              onChange={(e) => setSteerInput(e.target.value)}
+              placeholder="Steer the run…"
+              disabled={steerPending}
+              aria-label="Steering instruction"
+              className="text-body-medium-default min-w-0 flex-1 bg-transparent text-[color:var(--content-default)] placeholder:text-[color:var(--content-tertiary)] focus:outline-none disabled:opacity-50"
+            />
+            <Button
+              type="submit"
+              variant="primary"
+              size="compact"
+              iconOnly={<Send />}
+              disabled={steerPending || steerInput.trim() === ""}
+              aria-label="Send steering instruction"
+              className="shrink-0"
+            />
+          </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
@@ -13,9 +13,19 @@
  *    absent or failed run resolves to none, so its chip stays.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
+
+// The card cancels the run directly via `stopAcpRun` when no override handler is
+// passed. Mock the action so the self-contained path is observable without
+// hitting the daemon client.
+const stopAcpRunCalls: string[] = [];
+mock.module("@/domains/chat/utils/acp-run-actions", () => ({
+  stopAcpRun: async (id: string) => {
+    stopAcpRunCalls.push(id);
+  },
+}));
 
 import { AcpRunInlineProgressCard } from "@/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card";
 import {
@@ -34,6 +44,7 @@ const STATUS_TESTID = "acp-run-inline-card-status-indicator";
 
 beforeEach(() => {
   useAcpRunStore.getState().reset();
+  stopAcpRunCalls.length = 0;
 });
 
 afterEach(() => {
@@ -173,15 +184,18 @@ describe("AcpRunInlineProgressCard — interaction", () => {
     expect(seen).toEqual(["acp-open"]);
   });
 
-  test("stop button is absent while running when no onStopAcpRun handler is provided", () => {
+  test("stop button cancels the run directly while running with no handler, and disables after click", () => {
     act(() => spawn("acp-no-stop"));
-    const { queryByTestId } = render(
+    const { getByTestId } = render(
       <AcpRunInlineProgressCard acpSessionId="acp-no-stop" />,
     );
-    expect(queryByTestId("acp-run-inline-card-stop")).toBeNull();
+    const button = getByTestId("acp-run-inline-card-stop");
+    fireEvent.click(button);
+    expect(stopAcpRunCalls).toEqual(["acp-no-stop"]);
+    expect(button.hasAttribute("disabled")).toBe(true);
   });
 
-  test("stop button renders and invokes the handler while in-flight, then hides on terminal", () => {
+  test("onStopAcpRun overrides the direct cancel; stop hides on terminal", () => {
     act(() => spawn("acp-stop"));
     const seen: string[] = [];
     const { getByTestId, queryByTestId } = render(
@@ -192,6 +206,7 @@ describe("AcpRunInlineProgressCard — interaction", () => {
     );
     fireEvent.click(getByTestId("acp-run-inline-card-stop"));
     expect(seen).toEqual(["acp-stop"]);
+    expect(stopAcpRunCalls).toEqual([]);
 
     act(() => terminal("acp-stop", "completed"));
     expect(queryByTestId("acp-run-inline-card-stop")).toBeNull();

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
@@ -12,25 +12,26 @@
  * Interaction model mirrors the subagent / workflow inline cards:
  *   - Clicking anywhere on the header row opens the run's detail panel via
  *     `onAcpRunClick`. There is no inline expand — the panel is the detail view.
- *   - Stop is exposed via `onStopAcpRun`; the shell renders a small stop chip in
- *     the right rail while the run is in-flight ONLY when a real handler is
- *     wired. With `onStopAcpRun` omitted, no stop affordance renders — avoiding a
- *     misleading button that does nothing.
+ *   - Stop cancels the run via `stopAcpRun` while it is in-flight. A parent may
+ *     override the action with `onStopAcpRun`; otherwise the card cancels the
+ *     run itself. The button disables after a click to avoid a double-cancel.
  */
 
 import { Code, Square } from "lucide-react";
-import { useCallback, type MouseEvent } from "react";
+import { useCallback, useState, type MouseEvent } from "react";
 
 import { Button } from "@vellumai/design-library";
 
 import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
 import { useAcpRunCardData } from "@/domains/chat/components/acp-run-inline-card/use-acp-run-card-data";
+import { stopAcpRun } from "@/domains/chat/utils/acp-run-actions";
+import { captureError } from "@/lib/sentry/capture-error";
 
 export interface AcpRunInlineProgressCardProps {
   acpSessionId: string;
   /** Open the run's detail panel (header-row activation, not the stop button). */
   onAcpRunClick?: (acpSessionId: string) => void;
-  /** Stop an in-flight run; omit to hide the stop button. */
+  /** Override the stop action; defaults to cancelling the run directly. */
   onStopAcpRun?: (acpSessionId: string) => void;
 }
 
@@ -43,6 +44,7 @@ export function AcpRunInlineProgressCard({
   // The shell's `loading` state is the live window where stopping the run is a
   // meaningful action (see `deriveCardState`).
   const isRunning = data?.state === "loading";
+  const [stopping, setStopping] = useState(false);
 
   const handleHeaderClick = useCallback(() => {
     onAcpRunClick?.(acpSessionId);
@@ -51,7 +53,15 @@ export function AcpRunInlineProgressCard({
   const handleStop = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
-      onStopAcpRun?.(acpSessionId);
+      setStopping(true);
+      if (onStopAcpRun) {
+        onStopAcpRun(acpSessionId);
+        return;
+      }
+      void stopAcpRun(acpSessionId).catch((err) => {
+        setStopping(false);
+        captureError(err, { context: "AcpRunInlineProgressCard.stop" });
+      });
     },
     [onStopAcpRun, acpSessionId],
   );
@@ -63,19 +73,19 @@ export function AcpRunInlineProgressCard({
 
   const leadingIcon = <Code size={20} aria-hidden />;
 
-  // Render the stop affordance only when a real cancel handler is wired AND the
-  // run is in-flight — never a placeholder that no-ops on click.
-  const actionSlot =
-    onStopAcpRun != null && isRunning ? (
-      <Button
-        variant="dangerGhost"
-        size="compact"
-        iconOnly={<Square fill="currentColor" />}
-        aria-label="Stop run"
-        data-testid="acp-run-inline-card-stop"
-        onClick={handleStop}
-      />
-    ) : undefined;
+  // Stop is a real action whenever the run is in-flight (it cancels the run
+  // directly), so render it regardless of whether a parent passed a handler.
+  const actionSlot = isRunning ? (
+    <Button
+      variant="dangerGhost"
+      size="compact"
+      iconOnly={<Square fill="currentColor" />}
+      aria-label="Stop run"
+      data-testid="acp-run-inline-card-stop"
+      disabled={stopping}
+      onClick={handleStop}
+    />
+  ) : undefined;
 
   return (
     <div className="w-full" data-testid="acp-run-inline-progress-card">

--- a/clients/web/src/domains/chat/utils/acp-run-actions.test.ts
+++ b/clients/web/src/domains/chat/utils/acp-run-actions.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the ACP run actions (stop / steer / close).
+ *
+ * The ACP routes are excluded from the generated daemon SDK, so the actions
+ * call `client.post` directly. Mock the daemon client to assert the request
+ * shape (url template + path params + body) and stage responses.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface PostCall {
+  url: string;
+  path?: Record<string, string>;
+  body?: Record<string, unknown>;
+}
+
+const calls: PostCall[] = [];
+let nextData: unknown = undefined;
+let nextOk = true;
+let nextStatus = 200;
+
+mock.module("@/generated/daemon/client.gen", () => ({
+  client: {
+    post: async (options: PostCall) => {
+      calls.push(options);
+      return {
+        data: nextData,
+        response: { ok: nextOk, status: nextStatus },
+      };
+    },
+  },
+}));
+
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
+const { stopAcpRun, steerAcpRun, closeAcpRun } = await import(
+  "@/domains/chat/utils/acp-run-actions"
+);
+
+beforeEach(() => {
+  calls.length = 0;
+  nextData = undefined;
+  nextOk = true;
+  nextStatus = 200;
+  useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+});
+
+afterEach(() => {
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+});
+
+describe("stopAcpRun", () => {
+  test("POSTs the cancel route with the assistant + session ids", async () => {
+    await stopAcpRun("acp-1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      "/v1/assistants/{assistant_id}/acp/{id}/cancel",
+    );
+    expect(calls[0]!.path).toEqual({ assistant_id: "asst-1", id: "acp-1" });
+  });
+
+  test("throws on a non-ok response", async () => {
+    nextOk = false;
+    nextStatus = 404;
+    await expect(stopAcpRun("acp-1")).rejects.toThrow();
+  });
+});
+
+describe("steerAcpRun", () => {
+  test("POSTs the steer route with the instruction and returns the response", async () => {
+    nextData = { acpSessionId: "acp-1", steered: true, resumed: true };
+    const res = await steerAcpRun("acp-1", "focus on tests");
+    expect(calls[0]!.url).toBe("/v1/assistants/{assistant_id}/acp/{id}/steer");
+    expect(calls[0]!.path).toEqual({ assistant_id: "asst-1", id: "acp-1" });
+    expect(calls[0]!.body).toEqual({ instruction: "focus on tests" });
+    expect(res).toEqual({
+      acpSessionId: "acp-1",
+      steered: true,
+      resumed: true,
+    });
+  });
+
+  test("surfaces approvalPending from the response", async () => {
+    nextData = { acpSessionId: "acp-1", steered: false, approvalPending: true };
+    const res = await steerAcpRun("acp-1", "resume");
+    expect(res.approvalPending).toBe(true);
+  });
+});
+
+describe("closeAcpRun", () => {
+  test("POSTs the close route with the assistant + session ids", async () => {
+    await closeAcpRun("acp-1");
+    expect(calls[0]!.url).toBe("/v1/assistants/{assistant_id}/acp/{id}/close");
+    expect(calls[0]!.path).toEqual({ assistant_id: "asst-1", id: "acp-1" });
+  });
+});
+
+describe("no active assistant", () => {
+  test("throws before issuing a request", async () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: null });
+    await expect(stopAcpRun("acp-1")).rejects.toThrow("No active assistant");
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/clients/web/src/domains/chat/utils/acp-run-actions.ts
+++ b/clients/web/src/domains/chat/utils/acp-run-actions.ts
@@ -1,0 +1,70 @@
+/**
+ * Imperative actions for ACP runs: stop (cancel), steer, and close.
+ *
+ * The daemon's `/v1/acp/*` routes are excluded from the generated web SDK
+ * (see `scripts/transform-daemon-spec.ts`), so these call the daemon client
+ * directly. The gateway proxies them via `/v1/assistants/{id}/acp/{id}/...`.
+ */
+
+import { client } from "@/generated/daemon/client.gen";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+/** Response of `POST /v1/acp/:id/steer`. Mirrors the daemon's responseBody. */
+export interface SteerAcpRunResponse {
+  acpSessionId: string;
+  steered: boolean;
+  /** Session was resumed from persisted history before steering. */
+  resumed?: boolean;
+  /** Steer triggered an approval-gated resume that runs asynchronously. */
+  approvalPending?: boolean;
+}
+
+// The generated client types `url` against known daemon paths; ACP routes are
+// excluded from codegen, so cast to a sibling path to satisfy the type.
+type KnownDaemonUrl = "/v1/assistants/{assistant_id}/config";
+
+function activeAssistantId(): string {
+  const id = useResolvedAssistantsStore.getState().activeAssistantId;
+  if (!id) throw new Error("No active assistant");
+  return id;
+}
+
+/** Cancel an active ACP run. The daemon emits a terminal SSE event on success. */
+export async function stopAcpRun(acpSessionId: string): Promise<void> {
+  const { response } = await client.post({
+    url: "/v1/assistants/{assistant_id}/acp/{id}/cancel" as KnownDaemonUrl,
+    path: { assistant_id: activeAssistantId(), id: acpSessionId },
+    body: {} as Record<string, unknown>,
+  });
+  if (!response?.ok) {
+    throw new Error(`Failed to stop ACP run: ${response?.status}`);
+  }
+}
+
+/** Send a steering instruction to a running (or resumable) ACP run. */
+export async function steerAcpRun(
+  acpSessionId: string,
+  instruction: string,
+): Promise<SteerAcpRunResponse> {
+  const { data, response } = await client.post({
+    url: "/v1/assistants/{assistant_id}/acp/{id}/steer" as KnownDaemonUrl,
+    path: { assistant_id: activeAssistantId(), id: acpSessionId },
+    body: { instruction } as Record<string, unknown>,
+  });
+  if (!response?.ok) {
+    throw new Error(`Failed to steer ACP run: ${response?.status}`);
+  }
+  return data as unknown as SteerAcpRunResponse;
+}
+
+/** Close a completed ACP run, releasing its subprocess. */
+export async function closeAcpRun(acpSessionId: string): Promise<void> {
+  const { response } = await client.post({
+    url: "/v1/assistants/{assistant_id}/acp/{id}/close" as KnownDaemonUrl,
+    path: { assistant_id: activeAssistantId(), id: acpSessionId },
+    body: {} as Record<string, unknown>,
+  });
+  if (!response?.ok) {
+    throw new Error(`Failed to close ACP run: ${response?.status}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Add acp-run-actions (stop/steer/close) calling the daemon ACP routes
- Self-contained Stop on the inline card + detail panel (cancel route → cancelled/warning); steering input on running runs with an optimistic marker and approvalPending handling
- Error runs render an error card + panel message

Part of plan: acp-runs-ui.md (PR 13 of 13)