### PR TITLE
feat(web): rehydrate ACP runs from /acp/sessions on load

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -420,7 +420,7 @@ describe("seedFromHistory", () => {
     expect(getState().orderedIds).toEqual(["acp-h1"]);
   });
 
-  it("does not clobber a live entry's longer event buffer with a shorter snapshot", () => {
+  it("does not clobber a live entry's events with a shorter snapshot", () => {
     spawn({ acpSessionId: "acp-1" });
     const store = getState();
     store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 1, content: "a" }) });
@@ -430,12 +430,12 @@ describe("seedFromHistory", () => {
       historyEntry({ acpSessionId: "acp-1", events: [event({ seq: 1, content: "stale" })] }),
     ]);
 
-    // The live (longer) buffer wins.
+    // Seq union keeps both live events; the live seq=1 wins over history's.
     expect(getState().byId["acp-1"]!.events).toHaveLength(2);
     expect(getState().byId["acp-1"]!.events[0]!.content).toBe("a");
   });
 
-  it("prefers the newer/longer historical entry over a shorter existing one", () => {
+  it("unions seqs from a longer historical entry into a shorter existing one", () => {
     getState().seedFromHistory([
       historyEntry({ acpSessionId: "acp-1", events: [event({ seq: 1 })] }),
     ]);
@@ -443,10 +443,57 @@ describe("seedFromHistory", () => {
       historyEntry({ acpSessionId: "acp-1", events: [event({ seq: 1 }), event({ seq: 2 })] }),
     ]);
 
-    expect(getState().byId["acp-1"]!.events).toHaveLength(2);
+    expect(getState().byId["acp-1"]!.events.map((e) => e.seq)).toEqual([1, 2]);
   });
 
-  it("merges terminal status/usage onto a live entry while keeping the longer buffer", () => {
+  it("keeps the newest live event when history is longer but has a lower max seq", () => {
+    spawn({ acpSessionId: "acp-1" });
+    const store = getState();
+    // Live store received only the newest events (high seqs) before the HTTP
+    // snapshot resolved.
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 9, content: "live-9" }) });
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 10, updateType: "tool_call", toolCallId: "live-10" }) });
+    expect(getState().highWaterMark.get("acp-1")).toBe(10);
+
+    // A stale-but-longer history snapshot: more events, but max seq 4 < 10.
+    getState().seedFromHistory([
+      historyEntry({
+        acpSessionId: "acp-1",
+        events: [event({ seq: 1 }), event({ seq: 2 }), event({ seq: 3 }), event({ seq: 4 })],
+      }),
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    const seqs = entry.events.map((e) => e.seq);
+    // The newest live event survives, older history events fill in, all unioned.
+    expect(seqs).toEqual([1, 2, 3, 4, 9, 10]);
+    expect(entry.events.find((e) => e.seq === 9)!.content).toBe("live-9");
+    expect(entry.events.find((e) => e.seq === 10)!.toolCallId).toBe("live-10");
+    // highWaterMark reflects the true newest seq, not the incoming-only max.
+    expect(getState().highWaterMark.get("acp-1")).toBe(10);
+  });
+
+  it("appends events lacking a seq without deduping them", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 5, content: "live" }) });
+
+    const seqless = { updateType: "tool_call", toolCallId: "no-seq" } as AcpRunRawEvent;
+    getState().seedFromHistory([
+      historyEntry({
+        acpSessionId: "acp-1",
+        events: [event({ seq: 1 }), seqless, seqless],
+      }),
+    ]);
+
+    const events = getState().byId["acp-1"]!.events;
+    // seq 1 + seq 5, then both seqless events appended (not collapsed).
+    expect(events.filter((e) => typeof e.seq === "number").map((e) => e.seq)).toEqual([1, 5]);
+    expect(events.filter((e) => e.toolCallId === "no-seq")).toHaveLength(2);
+    // highWaterMark ignores seqless events.
+    expect(getState().highWaterMark.get("acp-1")).toBe(5);
+  });
+
+  it("merges terminal status/usage onto a live entry while unioning events", () => {
     spawn({ acpSessionId: "acp-1" });
     const store = getState();
     store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 1, content: "a" }) });
@@ -468,7 +515,7 @@ describe("seedFromHistory", () => {
     ]);
 
     const entry = getState().byId["acp-1"]!;
-    // Longer live buffer is kept (live content, not history's "stale").
+    // Seq union: live seq=1 wins over history's "stale", seq=2 unioned.
     expect(entry.events).toHaveLength(2);
     expect(entry.events[0]!.content).toBe("a");
     // Terminal metadata is merged.

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -109,11 +109,11 @@ export interface AcpRunActions {
   }) => void;
 
   /**
-   * Idempotent merge of history entries keyed by acpSessionId. Keeps the
-   * longer `events` buffer (live vs incoming) so a live stream is never
-   * clobbered, while always merging terminal/status/usage metadata from the
-   * history entry. Sets `highWaterMark` to the max seq over the kept buffer
-   * and indexes `byToolUseId`.
+   * Idempotent merge of history entries keyed by acpSessionId. Unions live and
+   * incoming `events` by `seq` so a live stream is never clobbered by a
+   * stale-but-longer snapshot, while always merging terminal/status/usage
+   * metadata from the history entry. Sets `highWaterMark` to the max seq over
+   * the merged buffer and indexes `byToolUseId`.
    */
   seedFromHistory: (entries: AcpRunEntry[]) => void;
 
@@ -171,19 +171,45 @@ function appendEvent(
 }
 
 /**
- * Merge a history entry into an existing live entry. Keeps the longer `events`
- * buffer but always folds in the history entry's terminal/status/usage
- * metadata. A terminal history status wins over a live non-terminal one; a live
- * terminal status is not regressed by a non-terminal history status.
+ * Seq-keyed union of live + history events. Buffer length is not recency: a
+ * stale-but-longer history snapshot can have a lower max seq than the few live
+ * events already received, so keeping the longer buffer would drop them. Dedup
+ * by `seq` instead, preferring the existing (live) event on collision — it may
+ * be a coalesced/newer-shaped representation — and sort ascending by seq.
+ * Events lacking `seq` (older/fallback data) are appended without deduping so a
+ * missing seq never collapses distinct events.
+ */
+function mergeEvents(
+  existing: AcpRunRawEvent[],
+  incoming: AcpRunRawEvent[],
+): AcpRunRawEvent[] {
+  const bySeq = new Map<number, AcpRunRawEvent>();
+  const seqless: AcpRunRawEvent[] = [];
+
+  for (const event of [...existing, ...incoming]) {
+    if (typeof event.seq !== "number") {
+      seqless.push(event);
+      continue;
+    }
+    if (!bySeq.has(event.seq)) bySeq.set(event.seq, event);
+  }
+
+  const merged = Array.from(bySeq.values()).sort((a, b) => a.seq - b.seq);
+  return seqless.length ? [...merged, ...seqless] : merged;
+}
+
+/**
+ * Merge a history entry into an existing live entry. Unions both event buffers
+ * by `seq` (never dropping the newest live events) and always folds in the
+ * history entry's terminal/status/usage metadata. A terminal history status
+ * wins over a live non-terminal one; a live terminal status is not regressed by
+ * a non-terminal history status.
  */
 function mergeHistoryEntry(
   existing: AcpRunEntry,
   incoming: AcpRunEntry,
 ): AcpRunEntry {
-  const events =
-    existing.events.length >= incoming.events.length
-      ? existing.events
-      : incoming.events;
+  const events = mergeEvents(existing.events, incoming.events);
 
   const status =
     isActiveAcpStatus(existing.status) || !isActiveAcpStatus(incoming.status)
@@ -352,8 +378,8 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
 
     for (const entry of entries) {
       const existing = nextById[entry.acpSessionId];
-      // Keep the longer event buffer but always merge terminal/status/usage
-      // metadata from history so a live entry can't stay stale.
+      // Union live + history events by seq and always merge terminal/status/
+      // usage metadata from history so a live entry can't stay stale.
       const merged = existing ? mergeHistoryEntry(existing, entry) : entry;
       nextById[entry.acpSessionId] = merged;
 
@@ -369,6 +395,7 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
       }
 
       for (const event of merged.events) {
+        if (typeof event.seq !== "number") continue;
         nextHighWaterMark = bumpHighWaterMark(
           nextHighWaterMark,
           entry.acpSessionId,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -21,6 +21,7 @@ import { type Dispatch, type MutableRefObject, type RefObject, type SetStateActi
 
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
 import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
+import { useAcpRunRehydration } from "@/domains/chat/hooks/use-acp-run-rehydration";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
@@ -266,6 +267,10 @@ export function ChatMainPanel({
 
   const activeSubagentIds = useActiveSubagentIds();
   const activeAcpRunIds = useActiveAcpRunIds();
+
+  // Rehydrate ACP runs from the daemon on conversation load so completed and
+  // in-progress runs reappear after a refresh / reconnect.
+  useAcpRunRehydration(assistantId, activeConversationId);
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
@@ -230,4 +230,56 @@ describe("rehydration — active session + live stream dedup", () => {
     expect(events[1]!.toolCallId).toBe("t-new");
     expect(getState().highWaterMark.get("acp-1")).toBe(6);
   });
+
+  test("a live event that arrived before seeding survives a stale-but-longer snapshot", async () => {
+    // Live spawn + an event with seq above the history snapshot's max arrives
+    // BEFORE the /acp/sessions response resolves.
+    getState().spawnRun({
+      acpSessionId: "acp-1",
+      agent: "claude",
+      parentConversationId: "conv-1",
+      startedAt: 1000,
+    });
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "tool_call",
+      toolCallId: "t-live",
+      seq: 9,
+    });
+    expect(getState().highWaterMark.get("acp-1")).toBe(9);
+
+    // Stale-but-longer history snapshot: more events, but max seq 3 < 9.
+    await seed([
+      {
+        acpSessionId: "acp-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "running",
+        startedAt: 1000,
+        eventLog: [
+          { type: "acp_session_update", updateType: "tool_call", toolCallId: "h-1", seq: 1 },
+          { type: "acp_session_update", updateType: "tool_call", toolCallId: "h-2", seq: 2 },
+          { type: "acp_session_update", updateType: "tool_call", toolCallId: "h-3", seq: 3 },
+        ],
+      },
+    ]);
+
+    const events = getState().byId["acp-1"]!.events;
+    // The live seq=9 event is not dropped; older history events fill in.
+    expect(events.find((e) => e.toolCallId === "t-live")).toBeDefined();
+    expect(events.map((e) => e.seq)).toEqual([1, 2, 3, 9]);
+    // highWaterMark reflects the true newest seq, keeping live dedup correct.
+    expect(getState().highWaterMark.get("acp-1")).toBe(9);
+
+    // A later live event at or below the mark is still deduped.
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "tool_call",
+      toolCallId: "t-dup",
+      seq: 9,
+    });
+    expect(getState().byId["acp-1"]!.events).toHaveLength(4);
+  });
 });

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for `fetchAcpSessions` + store seeding behaviour. We mock the
+ * generated daemon `client` (the fetch calls `client.get` under the hood) so
+ * we can stage `/acp/sessions` responses and assert the rehydrated timeline,
+ * terminal status/usage, and seq high-water-mark dedup.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface FakeRequest {
+  url: string;
+  path?: Record<string, string>;
+  query?: Record<string, unknown>;
+}
+
+interface FakeResponse {
+  status: number;
+  body?: unknown;
+}
+
+const requests: FakeRequest[] = [];
+let nextResponses: FakeResponse[] = [];
+
+mock.module("@/generated/daemon/client.gen", () => ({
+  client: {
+    get: async ({
+      url,
+      path,
+      query,
+    }: {
+      url: string;
+      path?: Record<string, string>;
+      query?: Record<string, unknown>;
+      throwOnError?: boolean;
+    }) => {
+      requests.push({ url, path, query });
+      const next = nextResponses.shift();
+      if (!next) throw new Error(`No staged response for ${url}`);
+      const response = {
+        status: next.status,
+        ok: next.status >= 200 && next.status < 300,
+      };
+      return { data: next.body, response };
+    },
+  },
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+// Subject imported after mocks.
+import { fetchAcpSessions } from "@/domains/chat/hooks/use-acp-run-rehydration";
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { handleAcpSessionUpdate } from "@/domains/chat/utils/stream-handlers/acp-handlers";
+
+function getState() {
+  return useAcpRunStore.getState();
+}
+
+beforeEach(() => {
+  requests.length = 0;
+  nextResponses = [];
+  getState().reset();
+});
+
+afterEach(() => {
+  getState().reset();
+});
+
+async function seed(sessions: unknown[]): Promise<void> {
+  nextResponses = [{ status: 200, body: { sessions } }];
+  const entries = await fetchAcpSessions("asst-1", "conv-1");
+  getState().seedFromHistory(entries);
+}
+
+describe("fetchAcpSessions", () => {
+  test("requests the assistant-scoped acp/sessions route with the conversation id", async () => {
+    nextResponses = [{ status: 200, body: { sessions: [] } }];
+    await fetchAcpSessions("asst-1", "conv-1");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toBe("/v1/assistants/{assistant_id}/acp/sessions");
+    expect(requests[0]!.path).toEqual({ assistant_id: "asst-1" });
+    expect(requests[0]!.query).toEqual({ conversationId: "conv-1" });
+  });
+
+  test("returns an empty list on a non-ok response", async () => {
+    nextResponses = [{ status: 500, body: null }];
+    expect(await fetchAcpSessions("asst-1", "conv-1")).toEqual([]);
+  });
+});
+
+describe("rehydration — terminal session", () => {
+  test("reconstructs the timeline with terminal status and usage", async () => {
+    await seed([
+      {
+        acpSessionId: "acp-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        parentToolUseId: "tool-1",
+        task: "research",
+        status: "completed",
+        stopReason: "end_turn",
+        startedAt: 1000,
+        completedAt: 5000,
+        usage: { inputTokens: 1200, outputTokens: 340, totalCost: 0.012 },
+        eventLog: [
+          {
+            type: "acp_session_update",
+            updateType: "agent_message_chunk",
+            content: "hi",
+            messageId: "m-1",
+            seq: 3,
+          },
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "t-1",
+            toolTitle: "Read",
+            seq: 7,
+          },
+        ],
+      },
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.stopReason).toBe("end_turn");
+    expect(entry.completedAt).toBe(5000);
+    expect(entry.startedAt).toBe(1000);
+    expect(entry.agent).toBe("claude");
+    expect(entry.parentToolUseId).toBe("tool-1");
+    expect(entry.inputTokens).toBe(1200);
+    expect(entry.outputTokens).toBe(340);
+    expect(entry.totalCost).toBe(0.012);
+    expect(entry.events).toHaveLength(2);
+    expect(entry.events[1]!.toolCallId).toBe("t-1");
+    expect(getState().highWaterMark.get("acp-1")).toBe(7);
+    expect(getState().byToolUseId.get("tool-1")).toBe("acp-1");
+  });
+
+  test("falls back to the array index when seq is absent", async () => {
+    await seed([
+      {
+        acpSessionId: "acp-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "completed",
+        startedAt: 1000,
+        eventLog: [
+          { type: "acp_session_update", updateType: "tool_call", toolCallId: "t-0" },
+          { type: "acp_session_update", updateType: "tool_call", toolCallId: "t-1" },
+        ],
+      },
+    ]);
+
+    expect(getState().byId["acp-1"]!.events.map((e) => e.seq)).toEqual([0, 1]);
+    expect(getState().highWaterMark.get("acp-1")).toBe(1);
+  });
+});
+
+describe("rehydration — active session + live stream dedup", () => {
+  test("drops a subsequent live event at or below the seeded high-water mark", async () => {
+    await seed([
+      {
+        acpSessionId: "acp-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "running",
+        startedAt: 1000,
+        eventLog: [
+          {
+            type: "acp_session_update",
+            updateType: "agent_message_chunk",
+            content: "seeded",
+            messageId: "m-1",
+            seq: 5,
+          },
+        ],
+      },
+    ]);
+
+    expect(getState().byId["acp-1"]!.status).toBe("running");
+    expect(getState().byId["acp-1"]!.events).toHaveLength(1);
+    expect(getState().highWaterMark.get("acp-1")).toBe(5);
+
+    // Replayed event at the mark is dropped — no double apply.
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "tool_call",
+      toolCallId: "t-dup",
+      seq: 5,
+    });
+
+    expect(getState().byId["acp-1"]!.events).toHaveLength(1);
+  });
+
+  test("applies a live event with seq above the seeded high-water mark", async () => {
+    await seed([
+      {
+        acpSessionId: "acp-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "running",
+        startedAt: 1000,
+        eventLog: [
+          {
+            type: "acp_session_update",
+            updateType: "agent_message_chunk",
+            content: "seeded",
+            messageId: "m-1",
+            seq: 5,
+          },
+        ],
+      },
+    ]);
+
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "tool_call",
+      toolCallId: "t-new",
+      seq: 6,
+    });
+
+    const events = getState().byId["acp-1"]!.events;
+    expect(events).toHaveLength(2);
+    expect(events[1]!.toolCallId).toBe("t-new");
+    expect(getState().highWaterMark.get("acp-1")).toBe(6);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -1,0 +1,152 @@
+/**
+ * Rehydrate ACP runs from the daemon on conversation load.
+ *
+ * On conversation change, fetch `/acp/sessions` for the active conversation
+ * and `seedFromHistory` the acp-run store: completed and in-progress runs
+ * reappear with their event timelines, terminal status, and usage.
+ *
+ * Seeding sets each run's `highWaterMark` to the max `seq` over its events.
+ * The live SSE handler drops updates whose `seq <= highWaterMark`, so events
+ * already in a seeded buffer are not re-applied when streaming resumes. For an
+ * active run whose ring buffer was trimmed (>200 events), a small replay window
+ * may slip past the mark; the step projection is idempotent on `toolCallId` and
+ * tolerant of repeated message chunks, so the duplicate window is harmless.
+ */
+
+import { useEffect } from "react";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { useAcpRunStore, type AcpRunEntry, type AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+import { type AcpRunStatus } from "@/utils/acp-run-status";
+
+interface AcpSessionEventLogItem {
+  updateType?: AcpRunRawEvent["updateType"];
+  content?: string;
+  toolCallId?: string;
+  toolTitle?: string;
+  toolKind?: string;
+  toolStatus?: string;
+  messageId?: string;
+  seq?: number;
+}
+
+interface AcpSessionUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalCost?: number;
+}
+
+interface AcpSessionRow {
+  acpSessionId: string;
+  agentId?: string;
+  agent?: string;
+  parentConversationId?: string;
+  parentToolUseId?: string;
+  task?: string;
+  status: string;
+  stopReason?: string | null;
+  error?: string | null;
+  startedAt?: number;
+  completedAt?: number | null;
+  usage?: AcpSessionUsage;
+  eventLog?: AcpSessionEventLogItem[];
+}
+
+interface AcpSessionsResponse {
+  sessions?: AcpSessionRow[];
+}
+
+// Status-keyed response map (type alias, not interface) so the HeyAPI client's
+// `data` unwraps to the 200 body — an interface lacks the implicit index
+// signature the unwrap conditional needs.
+type AcpSessionsResponses = {
+  200: AcpSessionsResponse;
+};
+
+const TERMINAL_STATUSES = new Set<AcpRunStatus>(["completed", "failed", "cancelled"]);
+
+/** Map a daemon session status string onto an {@link AcpRunStatus}. */
+function toRunStatus(status: string): AcpRunStatus {
+  if (TERMINAL_STATUSES.has(status as AcpRunStatus)) return status as AcpRunStatus;
+  return status === "initializing" ? "initializing" : "running";
+}
+
+function toRawEvents(eventLog: AcpSessionEventLogItem[]): AcpRunRawEvent[] {
+  const events: AcpRunRawEvent[] = [];
+  for (const [index, item] of eventLog.entries()) {
+    if (!item.updateType) continue;
+    events.push({
+      seq: item.seq ?? index,
+      updateType: item.updateType,
+      content: item.content,
+      toolCallId: item.toolCallId,
+      toolTitle: item.toolTitle,
+      toolKind: item.toolKind,
+      toolStatus: item.toolStatus,
+      messageId: item.messageId,
+    });
+  }
+  return events;
+}
+
+function toRunEntry(row: AcpSessionRow): AcpRunEntry {
+  const status = toRunStatus(row.status);
+  const isTerminal = TERMINAL_STATUSES.has(status);
+  const events = toRawEvents(row.eventLog ?? []);
+
+  return {
+    acpSessionId: row.acpSessionId,
+    agent: row.agent ?? row.agentId ?? "",
+    parentConversationId: row.parentConversationId ?? "",
+    task: row.task,
+    status,
+    stopReason: isTerminal ? row.stopReason ?? undefined : undefined,
+    error: isTerminal ? row.error ?? undefined : undefined,
+    startedAt: row.startedAt ?? Date.now(),
+    completedAt: isTerminal ? row.completedAt ?? undefined : undefined,
+    parentToolUseId: row.parentToolUseId,
+    inputTokens: row.usage?.inputTokens ?? 0,
+    outputTokens: row.usage?.outputTokens ?? 0,
+    totalCost: row.usage?.totalCost ?? 0,
+    events,
+  };
+}
+
+export async function fetchAcpSessions(
+  assistantId: string,
+  conversationId: string,
+): Promise<AcpRunEntry[]> {
+  try {
+    const { data, response } = await daemonClient.get<AcpSessionsResponses>({
+      url: "/v1/assistants/{assistant_id}/acp/sessions",
+      path: { assistant_id: assistantId },
+      query: { conversationId },
+      throwOnError: false,
+    });
+    if (!response?.ok || !data?.sessions) return [];
+    return data.sessions
+      .filter((row): row is AcpSessionRow => !!row?.acpSessionId)
+      .map(toRunEntry);
+  } catch (err) {
+    captureError(err, { context: "fetchAcpSessions" });
+    return [];
+  }
+}
+
+export function useAcpRunRehydration(
+  assistantId: string | null,
+  conversationId: string | null,
+): void {
+  useEffect(() => {
+    if (!assistantId || !conversationId) return;
+    let cancelled = false;
+    void fetchAcpSessions(assistantId, conversationId).then((entries) => {
+      if (cancelled || entries.length === 0) return;
+      useAcpRunStore.getState().seedFromHistory(entries);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [assistantId, conversationId]);
+}


### PR DESCRIPTION
## Summary
- Add use-acp-run-rehydration: on conversation load, fetch /acp/sessions and seedFromHistory the acp-run store (events, status, usage, highWaterMark)
- Live seq highWaterMark dedup avoids double-applying events after seeding; in-progress runs resume streaming

Part of plan: acp-runs-ui.md (PR 12 of 13)