### PR TITLE
fix(web): ACP timeline label/thought/title polish

### DIFF
--- a/clients/web/src/domains/chat/acp-run-step-projection.test.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.test.ts
@@ -228,6 +228,18 @@ describe("computeAcpRunSteps — folding rules", () => {
     expect(messageStep(steps[0]!).isComplete).toBe(true);
   });
 
+  test("plan reads entry labels from `content` (ACP PlanEntry shape)", () => {
+    const content = JSON.stringify([
+      { content: "Do X", status: "completed" },
+      { content: "Do Y", status: "pending" },
+    ]);
+    const steps = computeAcpRunSteps([event({ updateType: "plan", content })]);
+    expect(planStep(steps[0]!).entries).toEqual([
+      { label: "Do X", checked: true },
+      { label: "Do Y", checked: false },
+    ]);
+  });
+
   test("plan tolerates entries wrapped in an object", () => {
     const content = JSON.stringify({ entries: [{ label: "A", status: "completed" }] });
     const steps = computeAcpRunSteps([event({ updateType: "plan", content })]);

--- a/clients/web/src/domains/chat/acp-run-step-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.ts
@@ -249,8 +249,10 @@ function parsePlanEntries(
   if (raw === null) return null;
   return raw.map((item) => {
     const obj = (item ?? {}) as Record<string, unknown>;
+    // ACP `PlanEntry` carries its text in `content`; older shapes used `label`.
+    const text = obj.content ?? obj.label ?? "";
     return {
-      label: typeof obj.label === "string" ? obj.label : String(obj.label ?? ""),
+      label: typeof text === "string" ? text : String(text),
       checked: obj.checked === true || obj.status === "completed",
     };
   });

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -328,6 +328,34 @@ describe("AcpRunDetailPanel — timeline + nested detail", () => {
     expect(screen.getByTestId("acp-step-running")).toBeDefined();
   });
 
+  test("trailing thought renders running while active, complete when terminal", () => {
+    // A thought has no `isComplete` field; its liveness is inferred from being
+    // the tail step, so an active run's trailing thought shows the indicator.
+    const events: AcpRunRawEvent[] = [
+      {
+        seq: 1,
+        updateType: "agent_thought_chunk",
+        messageId: "th-1",
+        content: "Considering options",
+      },
+    ];
+    const active = makeEntry({ status: "running", events });
+    seedStore(active);
+    const { rerender } = render(
+      <AcpRunDetailPanel entry={active} onClose={noop} />,
+    );
+
+    expect(screen.getByTestId("acp-step-running")).toBeDefined();
+    expect(screen.queryByTestId("acp-step-complete")).toBeNull();
+
+    const terminal = makeEntry({ status: "completed", events });
+    seedStore(terminal);
+    rerender(<AcpRunDetailPanel entry={terminal} onClose={noop} />);
+
+    expect(screen.queryByTestId("acp-step-running")).toBeNull();
+    expect(screen.getByTestId("acp-step-complete")).toBeDefined();
+  });
+
   test("nested state resets when switching to a different run", () => {
     const entry = makeEntry({ events: [TOOL_CALL_EVENT] });
     seedStore(entry);

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline.tsx
@@ -40,6 +40,7 @@ export function AcpRunPhaseTimeline({
           step={step}
           index={index}
           isRunActive={isRunActive}
+          isLast={index === steps.length - 1}
           onClick={onStepDetailClick}
         />
       ))}

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-step-pill.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-step-pill.tsx
@@ -60,18 +60,24 @@ function stepLabel(step: AcpTimelineStep): string {
 }
 
 /**
- * A step's status, used to pick the trailing status glyph. A message step shows
- * `running` only while the run is active; once the run is terminal a still-open
- * trailing message (nothing closed it) renders as complete. Tool steps keep
- * their own status regardless of run state.
+ * A step's status, used to pick the trailing status glyph. A trailing
+ * message/thought shows `running` only while the run is active; once the run is
+ * terminal (or a later step closes it) it renders as complete. A thought has no
+ * `isComplete` field, so its liveness is inferred from being the tail step.
+ * Tool steps keep their own status regardless of run state.
  */
-function stepStatus(step: AcpTimelineStep, isRunActive: boolean): AcpToolStatus {
+function stepStatus(
+  step: AcpTimelineStep,
+  isRunActive: boolean,
+  isLast: boolean,
+): AcpToolStatus {
   switch (step.kind) {
     case "tool":
       return step.status;
     case "message":
-      return step.isComplete || !isRunActive ? "completed" : "running";
+      return !step.isComplete && isRunActive ? "running" : "completed";
     case "thought":
+      return isLast && isRunActive ? "running" : "completed";
     case "plan":
       return "completed";
   }
@@ -104,17 +110,20 @@ export function AcpRunStepPill({
   step,
   index,
   isRunActive,
+  isLast = false,
   onClick,
 }: {
   step: AcpTimelineStep;
   /** This step's position in the run's projected steps — its selection identity. */
   index: number;
-  /** Whether the owning run is still active; gates the trailing-message indicator. */
+  /** Whether the owning run is still active; gates the trailing message/thought indicator. */
   isRunActive: boolean;
+  /** Whether this is the tail step; a trailing thought stays live while active. */
+  isLast?: boolean;
   /** Opens the step's nested detail. When omitted the row is non-interactive. */
   onClick?: (index: number) => void;
 }) {
-  const status = stepStatus(step, isRunActive);
+  const status = stepStatus(step, isRunActive, isLast);
   const label = stepLabel(step);
   const tone = status === "error";
   const iconColor = tone

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
@@ -128,6 +128,19 @@ describe("AcpRunInlineProgressCard — states", () => {
     expect(indicator.getAttribute("data-state")).toBeNull();
   });
 
+  test("a tool step's title isn't duplicated as the step info", () => {
+    act(() => {
+      spawn("acp-tool");
+      toolEvent("acp-tool", { toolCallId: "t1", toolTitle: "Read file" });
+    });
+
+    const { getAllByText } = render(
+      <AcpRunInlineProgressCard acpSessionId="acp-tool" />,
+    );
+    // The title drives `currentStepTitle`; the info must not repeat it.
+    expect(getAllByText("Read file")).toHaveLength(1);
+  });
+
   test("completed run renders the complete status icon", () => {
     act(() => {
       spawn("acp-done");

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
@@ -76,7 +76,8 @@ function deriveCurrentStepInfo(steps: AcpTimelineStep[]): string {
   if (!latest) return "";
   switch (latest.kind) {
     case "tool":
-      return latest.title;
+      // The title already drives `currentStepTitle`; repeating it duplicates.
+      return "";
     case "message":
     case "thought":
       return latest.content;


### PR DESCRIPTION
## Summary
- Plan checklist labels read PlanEntry.content (were blank)
- Active trailing thought pill shows running (not a checkmark)
- Inline card header no longer duplicates the tool title

Fixes gaps from plan self-review for acp-runs-ui.md.