### PR TITLE
fix(acp): rehydrate ACP objective + transcript anchor for active runs

### DIFF
--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -312,6 +312,8 @@ export class AcpSessionManager {
       parentConversationId: opts.parentConversationId,
       status: "initializing",
       startedAt: opts.startedAt,
+      task: opts.task,
+      parentToolUseId: opts.parentToolUseId,
     };
 
     const entry: SessionEntry = {

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -28,4 +28,8 @@ export interface AcpSessionState {
   completedAt?: number;
   error?: string;
   stopReason?: StopReason;
+  /** Objective text the session was spawned with, if known. */
+  task?: string;
+  /** Tool-use id of the `acp_spawn` call that spawned this session, if any. */
+  parentToolUseId?: string;
 }

--- a/assistant/src/runtime/routes/acp-routes-event-log.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-event-log.test.ts
@@ -52,6 +52,7 @@ function getListHandler() {
 function makeInMemoryState(
   id: string,
   parentConversationId: string,
+  extra?: Pick<AcpSessionState, "task" | "parentToolUseId">,
 ): AcpSessionState {
   return {
     id,
@@ -60,6 +61,7 @@ function makeInMemoryState(
     parentConversationId,
     status: "running",
     startedAt: 1_700_000_000_000,
+    ...extra,
   };
 }
 
@@ -106,6 +108,26 @@ describe("GET /v1/acp/sessions — eventLog", () => {
     expect(eventLog[0]?.content).toBe("hello");
   });
 
+  test("active in-memory session carries task and parentToolUseId from the SessionEntry", async () => {
+    inMemoryStates.set(
+      "active",
+      makeInMemoryState("active", "conv-1", {
+        task: "Refactor the auth module",
+        parentToolUseId: "tool-use-abc",
+      }),
+    );
+
+    const handler = getListHandler();
+    const result = (await handler({
+      queryParams: { conversationId: "conv-1" },
+    })) as { sessions: Array<Record<string, unknown>> };
+
+    const session = result.sessions.find((s) => s.id === "active");
+    expect(session).toBeDefined();
+    expect(session?.task).toBe("Refactor the auth module");
+    expect(session?.parentToolUseId).toBe("tool-use-abc");
+  });
+
   test("terminal DB row returns its persisted eventLog", async () => {
     insertHistoryRow({
       id: "terminal",
@@ -131,5 +153,8 @@ describe("GET /v1/acp/sessions — eventLog", () => {
     expect(eventLog).toHaveLength(1);
     expect(eventLog[0]?.seq).toBe(7);
     expect(eventLog[0]?.content).toBe("persisted");
+    // No acp_session_history columns for these, so terminal rows omit them.
+    expect(session?.task).toBeUndefined();
+    expect(session?.parentToolUseId).toBeUndefined();
   });
 });

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -50,6 +50,8 @@ const sessionEntrySchema = z.object({
   completedAt: z.number().nullable().optional(),
   error: z.string().nullable().optional(),
   stopReason: z.string().nullable().optional(),
+  task: z.string().optional(),
+  parentToolUseId: z.string().optional(),
   eventLog: z.array(z.unknown()).optional(),
 });
 
@@ -689,6 +691,8 @@ function listMergedSessions(opts: {
       completedAt: s.completedAt ?? null,
       error: s.error ?? null,
       stopReason: s.stopReason ?? null,
+      task: s.task,
+      parentToolUseId: s.parentToolUseId,
       eventLog: manager.getBufferedUpdates(s.id),
     });
   }
@@ -723,6 +727,8 @@ function listMergedSessions(opts: {
         "Failed to parse event_log_json for ACP session history row",
       );
     }
+    // Terminal rows omit task and parentToolUseId — acp_session_history has no
+    // columns for them, so they degrade to undefined here.
     merged.set(row.id, {
       id: row.id,
       agentId: row.agentId,


### PR DESCRIPTION
## Summary
- /acp/sessions active rows now include task + parentToolUseId (already on SessionEntry) so refresh restores the detail-panel Objective and the inline card's byToolUseId anchor
- Terminal DB rows still omit these (no acp_session_history columns); they degrade gracefully via the web result-parse fallback

Fixes a gap from plan self-review for acp-runs-ui.md.