### PR TITLE
fix(web): ACP stop/steer cleanup + steering marker + meter gating

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -117,22 +117,31 @@ describe("AcpRunDetailPanel — header + metrics + objective", () => {
     expect(screen.getByText("Research the thing")).toBeDefined();
   });
 
+  test("hides the metric row when there is no usage data", () => {
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({ inputTokens: 0, outputTokens: 0, totalCost: 0 })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.queryByText("Input")).toBeNull();
+    expect(screen.queryByText("Output")).toBeNull();
+  });
+
   test("empty events renders 'No events yet'", () => {
     render(<AcpRunDetailPanel entry={makeEntry({ events: [] })} onClose={noop} />);
     expect(screen.getByText("No events yet")).toBeDefined();
   });
 
-  test("Stop button renders only while running and calls onStop", () => {
-    const stopped: string[] = [];
+  test("Stop button renders only while running and cancels the run directly", () => {
     render(
       <AcpRunDetailPanel
         entry={makeEntry({ status: "running" })}
         onClose={noop}
-        onStop={(id) => stopped.push(id)}
       />,
     );
     fireEvent.click(screen.getByLabelText("Stop run"));
-    expect(stopped).toEqual(["acp-1"]);
+    expect(stopCalls).toEqual(["acp-1"]);
   });
 
   test("Stop button is hidden for a terminal run", () => {
@@ -140,7 +149,6 @@ describe("AcpRunDetailPanel — header + metrics + objective", () => {
       <AcpRunDetailPanel
         entry={makeEntry({ status: "completed" })}
         onClose={noop}
-        onStop={noop}
       />,
     );
     expect(screen.queryByLabelText("Stop run")).toBeNull();
@@ -354,7 +362,7 @@ describe("AcpRunDetailPanel — timeline + nested detail", () => {
 });
 
 describe("AcpRunDetailPanel — stop / steer / error", () => {
-  test("Stop cancels the run directly when no onStop override is passed", () => {
+  test("Stop cancels the run directly via stopAcpRun", () => {
     render(
       <AcpRunDetailPanel entry={makeEntry({ status: "running" })} onClose={noop} />,
     );
@@ -375,6 +383,27 @@ describe("AcpRunDetailPanel — stop / steer / error", () => {
       <AcpRunDetailPanel entry={makeEntry({ status: "completed" })} onClose={noop} />,
     );
     expect(screen.queryByLabelText("Steering instruction")).toBeNull();
+  });
+
+  test("steering writes an optimistic marker to the timeline on submit", () => {
+    const entry = makeEntry({ status: "running", events: [] });
+    seedStore(entry);
+    const { rerender } = render(
+      <AcpRunDetailPanel entry={entry} onClose={noop} />,
+    );
+
+    const input = screen.getByLabelText("Steering instruction");
+    fireEvent.change(input, { target: { value: "focus on tests" } });
+    act(() => {
+      fireEvent.submit(input.closest("form")!);
+    });
+
+    // The marker lands in the store as a message event; re-render with the
+    // grown entry the way the live store subscription would in production.
+    const grown = useAcpRunStore.getState().byId["acp-1"]!;
+    rerender(<AcpRunDetailPanel entry={grown} onClose={noop} />);
+
+    expect(screen.getByText("↻ Steering: focus on tests")).toBeDefined();
   });
 
   test("approvalPending steer surfaces the awaiting-approval affordance", async () => {

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -206,7 +206,6 @@ function AcpToolDetailBody({
 export interface AcpRunDetailPanelProps {
   entry: AcpRunEntry;
   onClose: () => void;
-  onStop?: (acpSessionId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -216,7 +215,6 @@ export interface AcpRunDetailPanelProps {
 export function AcpRunDetailPanel({
   entry,
   onClose,
-  onStop,
 }: AcpRunDetailPanelProps) {
   const isRunning = isActiveAcpStatus(entry.status);
   const steps = useAcpRunSteps(entry.events);
@@ -263,15 +261,11 @@ export function AcpRunDetailPanel({
 
   const handleStop = useCallback(() => {
     setStopping(true);
-    if (onStop) {
-      onStop(entry.acpSessionId);
-      return;
-    }
     void stopAcpRun(entry.acpSessionId).catch((err) => {
       setStopping(false);
       captureError(err, { context: "AcpRunDetailPanel.stop" });
     });
-  }, [onStop, entry.acpSessionId]);
+  }, [entry.acpSessionId]);
 
   const handleSteerSubmit = useCallback(
     (e: FormEvent) => {
@@ -280,6 +274,22 @@ export function AcpRunDetailPanel({
       if (!instruction || steerPending) return;
       setSteerPending(true);
       setApprovalPending(false);
+
+      // Optimistic timeline marker so the steer is visible immediately, ahead
+      // of the daemon's echoed events. Seq sits above the run's high-water mark
+      // so it sorts last and never collides with a replayed event.
+      const store = useAcpRunStore.getState();
+      const seq = (store.highWaterMark.get(entry.acpSessionId) ?? 0) + 1;
+      store.receiveEvent({
+        acpSessionId: entry.acpSessionId,
+        event: {
+          seq,
+          updateType: "agent_message_chunk",
+          messageId: `steer-${seq}`,
+          content: `↻ Steering: ${instruction}`,
+        },
+      });
+
       void steerAcpRun(entry.acpSessionId, instruction)
         .then((res) => {
           setSteerInput("");
@@ -415,31 +425,36 @@ export function AcpRunDetailPanel({
               </div>
             )}
 
-            {/* Metrics row */}
-            <div className="mb-5 grid grid-cols-2 gap-3">
-              <AnimatedMetricCard
-                icon={
-                  <ArrowDownToLine
-                    className="h-4 w-4 shrink-0"
-                    style={{ color: "var(--content-secondary)" }}
-                  />
-                }
-                target={entry.inputTokens}
-                format={(n) => formatNumber(Math.round(n))}
-                label="Input"
-              />
-              <AnimatedMetricCard
-                icon={
-                  <ArrowUpFromLine
-                    className="h-4 w-4 shrink-0"
-                    style={{ color: "var(--content-secondary)" }}
-                  />
-                }
-                target={entry.outputTokens}
-                format={(n) => formatNumber(Math.round(n))}
-                label="Output"
-              />
-            </div>
+            {/* Metrics row — gated on real usage so a run with no token/cost
+                data doesn't show a misleading all-zero meter. */}
+            {(entry.inputTokens > 0 ||
+              entry.outputTokens > 0 ||
+              entry.totalCost > 0) && (
+              <div className="mb-5 grid grid-cols-2 gap-3">
+                <AnimatedMetricCard
+                  icon={
+                    <ArrowDownToLine
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
+                    />
+                  }
+                  target={entry.inputTokens}
+                  format={(n) => formatNumber(Math.round(n))}
+                  label="Input"
+                />
+                <AnimatedMetricCard
+                  icon={
+                    <ArrowUpFromLine
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
+                    />
+                  }
+                  target={entry.outputTokens}
+                  format={(n) => formatNumber(Math.round(n))}
+                  label="Output"
+                />
+              </div>
+            )}
 
             {/* Objective section */}
             {entry.task && (

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.test.tsx
@@ -195,18 +195,13 @@ describe("AcpRunInlineProgressCard — interaction", () => {
     expect(button.hasAttribute("disabled")).toBe(true);
   });
 
-  test("onStopAcpRun overrides the direct cancel; stop hides on terminal", () => {
+  test("stop cancels the run directly and hides on terminal", () => {
     act(() => spawn("acp-stop"));
-    const seen: string[] = [];
     const { getByTestId, queryByTestId } = render(
-      <AcpRunInlineProgressCard
-        acpSessionId="acp-stop"
-        onStopAcpRun={(id) => seen.push(id)}
-      />,
+      <AcpRunInlineProgressCard acpSessionId="acp-stop" />,
     );
     fireEvent.click(getByTestId("acp-run-inline-card-stop"));
-    expect(seen).toEqual(["acp-stop"]);
-    expect(stopAcpRunCalls).toEqual([]);
+    expect(stopAcpRunCalls).toEqual(["acp-stop"]);
 
     act(() => terminal("acp-stop", "completed"));
     expect(queryByTestId("acp-run-inline-card-stop")).toBeNull();

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
@@ -12,9 +12,8 @@
  * Interaction model mirrors the subagent / workflow inline cards:
  *   - Clicking anywhere on the header row opens the run's detail panel via
  *     `onAcpRunClick`. There is no inline expand — the panel is the detail view.
- *   - Stop cancels the run via `stopAcpRun` while it is in-flight. A parent may
- *     override the action with `onStopAcpRun`; otherwise the card cancels the
- *     run itself. The button disables after a click to avoid a double-cancel.
+ *   - Stop cancels the run via `stopAcpRun` while it is in-flight. The button
+ *     disables after a click to avoid a double-cancel.
  */
 
 import { Code, Square } from "lucide-react";
@@ -31,14 +30,11 @@ export interface AcpRunInlineProgressCardProps {
   acpSessionId: string;
   /** Open the run's detail panel (header-row activation, not the stop button). */
   onAcpRunClick?: (acpSessionId: string) => void;
-  /** Override the stop action; defaults to cancelling the run directly. */
-  onStopAcpRun?: (acpSessionId: string) => void;
 }
 
 export function AcpRunInlineProgressCard({
   acpSessionId,
   onAcpRunClick,
-  onStopAcpRun,
 }: AcpRunInlineProgressCardProps) {
   const data = useAcpRunCardData(acpSessionId);
   // The shell's `loading` state is the live window where stopping the run is a
@@ -54,16 +50,12 @@ export function AcpRunInlineProgressCard({
     (e: MouseEvent) => {
       e.stopPropagation();
       setStopping(true);
-      if (onStopAcpRun) {
-        onStopAcpRun(acpSessionId);
-        return;
-      }
       void stopAcpRun(acpSessionId).catch((err) => {
         setStopping(false);
         captureError(err, { context: "AcpRunInlineProgressCard.stop" });
       });
     },
-    [onStopAcpRun, acpSessionId],
+    [acpSessionId],
   );
 
   // Spawn race: assistant message references a run before its spawn event
@@ -73,8 +65,7 @@ export function AcpRunInlineProgressCard({
 
   const leadingIcon = <Code size={20} aria-hidden />;
 
-  // Stop is a real action whenever the run is in-flight (it cancels the run
-  // directly), so render it regardless of whether a parent passed a handler.
+  // Stop cancels the run directly whenever it is in-flight.
   const actionSlot = isRunning ? (
     <Button
       variant="dangerGhost"

--- a/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay.tsx
@@ -8,13 +8,11 @@ import { AcpRunInlineProgressCard } from "@/domains/chat/components/acp-run-inli
 export interface ActiveAcpRunsOverlayProps {
   acpRunIds: string[];
   onAcpRunClick?: (acpSessionId: string) => void;
-  onStopAcpRun?: (acpSessionId: string) => void;
 }
 
 export function ActiveAcpRunsOverlay({
   acpRunIds,
   onAcpRunClick,
-  onStopAcpRun,
 }: ActiveAcpRunsOverlayProps) {
   const [expanded, setExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -78,7 +76,6 @@ export function ActiveAcpRunsOverlay({
                 key={id}
                 acpSessionId={id}
                 onAcpRunClick={onAcpRunClick}
-                onStopAcpRun={onStopAcpRun}
               />
             ))}
           </div>

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -359,8 +359,6 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       activeAcpRunId &&
       activeAcpRunEntry
     ) {
-      // `onStop` intentionally omitted — PR 13 wires stop/abort; until then the
-      // panel's Stop button stays hidden.
       rightPanel = (
         <LazyBoundary>
           <AcpRunDetailPanel

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -853,7 +853,6 @@ export function ChatMainPanel({
       />
     ) : undefined;
 
-  // No stop handler is passed, so the inline card's stop button stays hidden.
   const activeAcpRunsSlot =
     activeAcpRunIds.length > 0 ? (
       <ActiveAcpRunsOverlay

--- a/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.test.tsx
@@ -75,8 +75,24 @@ describe("MobileAcpRunDetailOverlay", () => {
     expect(closed).toBe(1);
   });
 
-  test("Stop button stays hidden (onStop intentionally unwired)", async () => {
-    render(<MobileAcpRunDetailOverlay entry={makeEntry()} onClose={noop} />);
+  test("active run shows the self-wired Stop button", async () => {
+    render(
+      <MobileAcpRunDetailOverlay
+        entry={makeEntry({ status: "running" })}
+        onClose={noop}
+      />,
+    );
+    await screen.findByText("claude");
+    expect(screen.getByLabelText("Stop run")).toBeDefined();
+  });
+
+  test("terminal run hides the Stop button", async () => {
+    render(
+      <MobileAcpRunDetailOverlay
+        entry={makeEntry({ status: "completed" })}
+        onClose={noop}
+      />,
+    );
     await screen.findByText("claude");
     expect(screen.queryByLabelText("Stop run")).toBeNull();
   });

--- a/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.tsx
@@ -21,9 +21,6 @@ interface MobileAcpRunDetailOverlayProps {
  *
  * **Mounting constraint**: must render inside `RootLayout`'s
  * `#viewport-overlays` portal, outside the main content wrapper.
- *
- * Stop/abort is intentionally not wired yet — the panel's Stop button stays
- * hidden without `onStop`.
  */
 export function MobileAcpRunDetailOverlay({
   entry,

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -338,9 +338,6 @@ export function TranscriptMessageBody({
             key={acpSessionId}
             acpSessionId={acpSessionId}
             onAcpRunClick={handleAcpRunClick}
-            // Stop wiring lands in PR 13. Until a real cancel handler exists, omit
-            // onStopAcpRun so the card hides the stop button instead of showing a
-            // misleading no-op affordance.
           />
         ))}
       </div>

--- a/clients/web/src/domains/chat/utils/acp-run-actions.test.ts
+++ b/clients/web/src/domains/chat/utils/acp-run-actions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the ACP run actions (stop / steer / close).
+ * Tests for the ACP run actions (stop / steer).
  *
  * The ACP routes are excluded from the generated daemon SDK, so the actions
  * call `client.post` directly. Mock the daemon client to assert the request
@@ -34,7 +34,7 @@ mock.module("@/generated/daemon/client.gen", () => ({
 const { useResolvedAssistantsStore } = await import(
   "@/stores/resolved-assistants-store"
 );
-const { stopAcpRun, steerAcpRun, closeAcpRun } = await import(
+const { stopAcpRun, steerAcpRun } = await import(
   "@/domains/chat/utils/acp-run-actions"
 );
 
@@ -85,14 +85,6 @@ describe("steerAcpRun", () => {
     nextData = { acpSessionId: "acp-1", steered: false, approvalPending: true };
     const res = await steerAcpRun("acp-1", "resume");
     expect(res.approvalPending).toBe(true);
-  });
-});
-
-describe("closeAcpRun", () => {
-  test("POSTs the close route with the assistant + session ids", async () => {
-    await closeAcpRun("acp-1");
-    expect(calls[0]!.url).toBe("/v1/assistants/{assistant_id}/acp/{id}/close");
-    expect(calls[0]!.path).toEqual({ assistant_id: "asst-1", id: "acp-1" });
   });
 });
 

--- a/clients/web/src/domains/chat/utils/acp-run-actions.ts
+++ b/clients/web/src/domains/chat/utils/acp-run-actions.ts
@@ -1,5 +1,5 @@
 /**
- * Imperative actions for ACP runs: stop (cancel), steer, and close.
+ * Imperative actions for ACP runs: stop (cancel) and steer.
  *
  * The daemon's `/v1/acp/*` routes are excluded from the generated web SDK
  * (see `scripts/transform-daemon-spec.ts`), so these call the daemon client
@@ -55,16 +55,4 @@ export async function steerAcpRun(
     throw new Error(`Failed to steer ACP run: ${response?.status}`);
   }
   return data as unknown as SteerAcpRunResponse;
-}
-
-/** Close a completed ACP run, releasing its subprocess. */
-export async function closeAcpRun(acpSessionId: string): Promise<void> {
-  const { response } = await client.post({
-    url: "/v1/assistants/{assistant_id}/acp/{id}/close" as KnownDaemonUrl,
-    path: { assistant_id: activeAssistantId(), id: acpSessionId },
-    body: {} as Record<string, unknown>,
-  });
-  if (!response?.ok) {
-    throw new Error(`Failed to close ACP run: ${response?.status}`);
-  }
 }


### PR DESCRIPTION
## Summary
- Remove dead onStop/onStopAcpRun override props + false/PR-referencing comments; fix the failing mobile-overlay stop test (stop is self-wired)
- Add optimistic '↻ Steering' timeline marker on steer submit
- Remove dead closeAcpRun export
- Render the token/cost meter only when usage data exists (no misleading zeros)

Fixes gaps from plan self-review for acp-runs-ui.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)