### PR TITLE
fix(web): ACP steering marker seq-collision fix

### DIFF
--- a/clients/web/src/domains/chat/acp-run-step-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.ts
@@ -78,7 +78,7 @@ export type AcpTimelineStep =
 // Reducer
 // ---------------------------------------------------------------------------
 
-/** Synthetic id for chunks that arrive without a `messageId` (pre-PR-2 daemon). */
+/** Synthetic id for chunks from older daemons that don't emit a messageId. */
 const ANONYMOUS_MESSAGE_ID = "";
 
 /** Map a raw daemon `toolStatus` to a step status; keep `fallback` if absent. */

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -4,6 +4,7 @@ import {
   type AcpRunEntry,
   type AcpRunRawEvent,
 } from "@/domains/chat/acp-run-store";
+import { computeAcpRunSteps } from "@/domains/chat/acp-run-step-projection";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -296,6 +297,79 @@ describe("receiveEvent", () => {
     store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 3 }) });
     expect(getState().highWaterMark.get("acp-1")).toBe(9);
     expect(getState().highWaterMark).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendLocalMarker
+// ---------------------------------------------------------------------------
+
+describe("appendLocalMarker", () => {
+  it("appends a marker without advancing the high-water mark", () => {
+    spawn();
+    const store = getState();
+    // Catch the client up to seq N — the normal steer-time case.
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 5, content: "a" }) });
+    expect(getState().highWaterMark.get("acp-1")).toBe(5);
+
+    store.appendLocalMarker({ acpSessionId: "acp-1", content: "↻ Steering: go" });
+
+    const events = getState().byId["acp-1"]!.events;
+    const marker = events[events.length - 1]!;
+    expect(marker.content).toBe("↻ Steering: go");
+    expect(marker.updateType).toBe("agent_message_chunk");
+    // Fractional seq sorts after seq 5 but is never a real daemon integer seq.
+    expect(marker.seq).toBe(5.5);
+    // Crucially, the dedup high-water mark is UNCHANGED.
+    expect(getState().highWaterMark.get("acp-1")).toBe(5);
+
+    // The projection renders the marker as a trailing message step.
+    const steps = computeAcpRunSteps(events);
+    const lastStep = steps[steps.length - 1]!;
+    expect(lastStep.kind).toBe("message");
+    expect(lastStep.kind === "message" && lastStep.content).toBe("↻ Steering: go");
+  });
+
+  it("does not coalesce into an adjacent real message — uses a unique messageId", () => {
+    spawn();
+    const store = getState();
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: 1, content: "real", messageId: "m-1" }),
+    });
+
+    store.appendLocalMarker({ acpSessionId: "acp-1", content: "↻ Steering: go" });
+
+    const events = getState().byId["acp-1"]!.events;
+    expect(events).toHaveLength(2);
+    expect(events[1]!.messageId).not.toBe("m-1");
+  });
+
+  it("keeps the next real daemon event after a marker — it is not dropped by the dedup gate", () => {
+    spawn();
+    const store = getState();
+    // Client is caught up at seq N when the steer fires.
+    store.receiveEvent({ acpSessionId: "acp-1", event: event({ seq: 5, content: "a" }) });
+    store.appendLocalMarker({ acpSessionId: "acp-1", content: "↻ Steering: go" });
+
+    // Simulate the SSE dedup gate (acp-handlers): drop seq <= hwm, else apply.
+    const hwm = getState().highWaterMark.get("acp-1") ?? -1;
+    const nextSeq = 6; // daemon's contiguous ++lastSeq
+    expect(nextSeq).toBeGreaterThan(hwm);
+    store.receiveEvent({
+      acpSessionId: "acp-1",
+      event: event({ seq: nextSeq, content: "post-steer", messageId: "m-post" }),
+    });
+
+    // The daemon's first real post-steer event survives.
+    const events = getState().byId["acp-1"]!.events;
+    expect(events.some((e) => e.content === "post-steer")).toBe(true);
+    expect(getState().highWaterMark.get("acp-1")).toBe(6);
+  });
+
+  it("ignores an unknown session", () => {
+    getState().appendLocalMarker({ acpSessionId: "acp-missing", content: "x" });
+    expect(getState().byId).toEqual({});
   });
 });
 

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -93,6 +93,19 @@ export interface AcpRunActions {
     event: AcpRunRawEvent;
   }) => void;
 
+  /**
+   * Append a local-only timeline marker (e.g. an optimistic steering note)
+   * without touching `highWaterMark`. Uses a fractional seq that sorts after
+   * existing events but never equals a daemon integer seq, and a unique
+   * synthetic `messageId` so it can't coalesce into an adjacent real message.
+   * Leaving the dedup mark untouched keeps the next real daemon event (which
+   * the daemon stamps with a contiguous integer seq) from being dropped.
+   */
+  appendLocalMarker: (params: {
+    acpSessionId: string;
+    content: string;
+  }) => void;
+
   setTerminal: (params: {
     acpSessionId: string;
     status: AcpRunStatus;
@@ -328,6 +341,37 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         params.acpSessionId,
         params.event.seq,
       ),
+    });
+  },
+
+  appendLocalMarker: (params) => {
+    const { byId } = get();
+    const existing = byId[params.acpSessionId];
+    if (!existing) return;
+
+    // Fractional seq sorts after existing events but never collides with a
+    // daemon integer seq; the events-length-derived messageId is unique so it
+    // can't coalesce into an adjacent real message. highWaterMark is left
+    // untouched so the next real daemon event survives the dedup gate.
+    const maxSeq = existing.events.reduce(
+      (max, ev) => (typeof ev.seq === "number" && ev.seq > max ? ev.seq : max),
+      0,
+    );
+    const marker: AcpRunRawEvent = {
+      seq: maxSeq + 0.5,
+      updateType: "agent_message_chunk",
+      messageId: `local-marker-${existing.events.length}`,
+      content: params.content,
+    };
+
+    set({
+      byId: {
+        ...byId,
+        [params.acpSessionId]: {
+          ...existing,
+          events: [...existing.events, marker],
+        },
+      },
     });
   },
 

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -276,18 +276,11 @@ export function AcpRunDetailPanel({
       setApprovalPending(false);
 
       // Optimistic timeline marker so the steer is visible immediately, ahead
-      // of the daemon's echoed events. Seq sits above the run's high-water mark
-      // so it sorts last and never collides with a replayed event.
-      const store = useAcpRunStore.getState();
-      const seq = (store.highWaterMark.get(entry.acpSessionId) ?? 0) + 1;
-      store.receiveEvent({
+      // of the daemon's echoed events. Appended without advancing the dedup
+      // high-water mark so the daemon's first real post-steer event survives.
+      useAcpRunStore.getState().appendLocalMarker({
         acpSessionId: entry.acpSessionId,
-        event: {
-          seq,
-          updateType: "agent_message_chunk",
-          messageId: `steer-${seq}`,
-          content: `↻ Steering: ${instruction}`,
-        },
+        content: `↻ Steering: ${instruction}`,
       });
 
       void steerAcpRun(entry.acpSessionId, instruction)


### PR DESCRIPTION
## Summary
- appendLocalMarker appends the steering marker without bumping highWaterMark, so the daemon's first real post-steer event is no longer dropped by the seq dedup gate
- Reword a PR-referencing projection comment to describe the daemon-version condition

Fixes a gap from plan self-review (round 2) for acp-runs-ui.md.