### PR TITLE
refactor(db-init): consistent migration startup logs

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -243,7 +243,7 @@ export async function initializeDb(): Promise<void> {
       skipped: skipped.length,
       total: migrationSteps.length,
     },
-    `DB migration steps complete (${applied.length} applied, ${skipped.length} skipped via checkpoint)`,
+    "DB migration steps complete",
   );
 
   if (failed.length > 0) {

--- a/assistant/src/memory/migrations/run-migrations.ts
+++ b/assistant/src/memory/migrations/run-migrations.ts
@@ -243,10 +243,13 @@ export async function runMigrationSteps(
   const skipped: string[] = [];
   const ran: string[] = [];
 
-  for (const step of steps) {
+  const totalSteps = steps.length;
+  for (const [index, step] of steps.entries()) {
     const obj = normalizeStep(step);
     const name = obj.name;
     const checkpointable = name !== "";
+    // 1-based position of this step in the ordered migration sequence.
+    const stepNumber = index + 1;
 
     if (checkpointable && applied.has(name)) {
       skipped.push(name);
@@ -258,12 +261,18 @@ export async function runMigrationSteps(
       if (checkpointable) {
         markStarted.run(`${STEP_CHECKPOINT_PREFIX}${name}`, Date.now());
       }
-      log.info({ migration: name }, `Starting migration: ${name}`);
+      log.info(
+        { migration: name, step: stepNumber, totalSteps },
+        "Migration started",
+      );
       const result = obj.run(database);
       if (result instanceof Promise) {
         await result;
       }
-      log.info({ migration: name }, `Migration succeeded: ${name}`);
+      log.info(
+        { migration: name, step: stepNumber, totalSteps },
+        "Migration succeeded",
+      );
       if (checkpointable) {
         markApplied.run(`${STEP_CHECKPOINT_PREFIX}${name}`, Date.now());
         ran.push(name);
@@ -273,7 +282,10 @@ export async function runMigrationSteps(
       // recoverCrashedMigrations will detect it on the next boot, log
       // a warning, and clear it so the step re-runs.
       failed.push(name);
-      log.error({ err, migration: name }, `Migration failed: ${name}`);
+      log.error(
+        { err, migration: name, step: stepNumber, totalSteps },
+        "Migration failed",
+      );
     }
   }
 

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -9,7 +9,10 @@ import {
   STEP_CHECKPOINT_PREFIX,
 } from "./run-migrations.js";
 
-const log = getLogger("memory-db");
+// Share the DB-init logger namespace so the whole startup DB-migration
+// sequence (run steps -> summary -> post-run validation) reports under a
+// single `[db-init]` tag instead of being split across modules.
+const log = getLogger("db-init");
 
 export interface MigrationValidationResult {
   /** Keys of migrations whose checkpoint has value 'started' — started but never completed. */


### PR DESCRIPTION
## Why

The DB-init startup logs were inconsistent and harder to scan than they should be. This cleans up the per-step migration log messages and unifies the namespace the startup DB-migration flow reports under, so the whole sequence reads as one coherent set of logs.

Driven by review of an actual startup log snippet:

```
[db-init] Starting migration: migrateToolCreatedItems
[db-init] Migration succeeded: migrateToolCreatedItems
[db-init] DB migration steps complete (3 applied, 238 skipped via checkpoint)
[memory-db] Database contains 1 migration checkpoint(s) from a newer version. Data may be incompatible.
```

## What changed

**Per-step migration logs** (`memory/migrations/run-migrations.ts`)
- `Starting migration` → `Migration started`, so it's parallel to the existing `Migration succeeded` / `Migration failed`.
- Dropped the migration name from the message text — it's already in the structured `migration` field, so `Migration started: migrateToolCreatedItems` is now just `Migration started` with `{ migration, step, totalSteps }`.
- Added the step number (`step`, 1-based) and `totalSteps` to the started / succeeded / failed logs.

**Summary log** (`memory/db-init.ts`)
- `DB migration steps complete (3 applied, 238 skipped via checkpoint)` → `DB migration steps complete`. The `applied` / `skipped` / `total` counts are already in the log data.

**Log namespace** (`memory/migrations/validate-migration-state.ts`)
- The single startup DB migration runner (`runMigrationSteps`, called once from `initializeDb`) was narrating itself under two module tags: the run + summary under `[db-init]`, but the post-run validation warning under `[memory-db]`. Pointed the validation logger at `[db-init]` so the whole sequence — run steps → summary → validation — shares one tag.

No behavior changes; logging only. Typecheck passes and no tests asserted the old strings/namespace.

## Notes for reviewers

While investigating, I confirmed there is exactly **one** startup DB migration runner (`runMigrationSteps`, one call site). The separate `[workspace-migrations] Running workspace migrations` line in startup logs is a distinct filesystem-migration system (its own `.workspace-migrations.json` checkpoint store), not a duplicate DB runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8uFtdqK6oXX41ysZwJptw)_