### PR TITLE
Remove Plugin prefix from lifecycle hook context types

### DIFF
--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -2,7 +2,7 @@
  * Tests for plugin bootstrap (PR 14).
  *
  * Covers:
- * - A noop `init()` fires with a valid `PluginInitContext` that exposes every
+ * - A noop `init()` fires with a valid `InitContext` that exposes every
  *   documented field.
  * - Version-mismatch registration fails with an error that names the plugin
  *   (the registry enforces this at `registerPlugin` time, so bootstrap never
@@ -29,7 +29,7 @@ import {
   registerPlugin,
   resetPluginRegistryForTests,
 } from "../plugins/registry.js";
-import { type Plugin, type PluginInitContext } from "../plugins/types.js";
+import { type InitContext, type Plugin } from "../plugins/types.js";
 import { APP_VERSION } from "../version.js";
 import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
@@ -51,7 +51,7 @@ function buildPlugin(
   name: string,
   extras: Partial<Omit<Plugin, "manifest" | "hooks">> & {
     hooks?: Plugin["hooks"];
-    init?: (ctx: PluginInitContext) => Promise<void>;
+    init?: (ctx: InitContext) => Promise<void>;
     onShutdown?: () => Promise<void>;
   } = {},
   options: {
@@ -98,8 +98,8 @@ describe("plugin bootstrap", () => {
     await rm(TEST_WORKSPACE_DIR, { recursive: true, force: true });
   });
 
-  test("noop plugin: init fires with a fully-populated PluginInitContext", async () => {
-    let received: PluginInitContext | undefined;
+  test("noop plugin: init fires with a fully-populated InitContext", async () => {
+    let received: InitContext | undefined;
     const plugin: Plugin = buildPlugin("alpha", {
       async init(ctx) {
         received = ctx;

--- a/assistant/src/__tests__/plugin-route-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-route-contribution.test.ts
@@ -38,7 +38,7 @@ import {
   registerPlugin,
   resetPluginRegistryForTests,
 } from "../plugins/registry.js";
-import type { Plugin, PluginInitContext } from "../plugins/types.js";
+import type { InitContext, Plugin } from "../plugins/types.js";
 import {
   matchSkillRoute,
   resetSkillRoutesForTests,
@@ -64,7 +64,7 @@ function buildPlugin(
   name: string,
   extras: Partial<Omit<Plugin, "manifest" | "hooks">> & {
     hooks?: Plugin["hooks"];
-    init?: (ctx: PluginInitContext) => Promise<void>;
+    init?: (ctx: InitContext) => Promise<void>;
     onShutdown?: () => Promise<void>;
   } = {},
 ): Plugin {

--- a/assistant/src/__tests__/plugin-tool-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-tool-contribution.test.ts
@@ -33,7 +33,7 @@ import {
   registerPlugin,
   resetPluginRegistryForTests,
 } from "../plugins/registry.js";
-import type { Plugin, PluginInitContext } from "../plugins/types.js";
+import type { InitContext, Plugin } from "../plugins/types.js";
 import {
   __clearRegistryForTesting,
   __resetRegistryForTesting,
@@ -82,7 +82,7 @@ function buildPlugin(
   name: string,
   extras: Partial<Omit<Plugin, "manifest" | "hooks">> & {
     hooks?: Plugin["hooks"];
-    init?: (ctx: PluginInitContext) => Promise<void>;
+    init?: (ctx: InitContext) => Promise<void>;
     onShutdown?: () => Promise<void>;
   } = {},
 ): Plugin {

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -13,9 +13,9 @@ import { describe, expect, test } from "bun:test";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { RiskLevel } from "../permissions/types.js";
 import {
+  type InitContext,
   type Plugin,
   PluginExecutionError,
-  type PluginInitContext,
   type PluginManifest,
   type TurnContext,
 } from "../plugins/types.js";
@@ -57,7 +57,7 @@ describe("plugin core types", () => {
     const plugin = {
       manifest,
       hooks: {
-        async init(ctx: PluginInitContext) {
+        async init(ctx: InitContext) {
           // Touch every field so refactors that rename any of them break here.
           void ctx.config;
           void ctx.logger;

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -24,7 +24,7 @@
  *    (Zod schemas with `.parse()` are supported; anything else is passed
  *    through untouched).
  * 5. Creates `<workspaceDir>/plugins-data/<plugin>/` on demand for per-plugin
- *    writable state and exposes it via {@link PluginInitContext.pluginStorageDir}.
+ *    writable state and exposes it via {@link InitContext.pluginStorageDir}.
  * 6. For each surviving plugin, registers its contributed tools and routes
  *    into their global registries via {@link registerPluginTools} and
  *    {@link registerSkillRoute}. Contributions land BEFORE `init()` so
@@ -64,7 +64,7 @@ import { getRegisteredPlugins, unregisterPlugin } from "../plugins/registry.js";
 import {
   type Plugin,
   PluginExecutionError,
-  type PluginShutdownContext,
+  type ShutdownContext,
 } from "../plugins/types.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
 import {
@@ -222,8 +222,8 @@ export async function bootstrapPlugins(): Promise<void> {
   // Shutdown context is identical for every plugin in this boot — construct
   // once and reuse across the per-plugin teardown and the normal shutdown
   // hook below. Only `assistantVersion` is exposed today; future additions
-  // live on {@link PluginShutdownContext}.
-  const shutdownContext: PluginShutdownContext = {
+  // live on {@link ShutdownContext}.
+  const shutdownContext: ShutdownContext = {
     assistantVersion: APP_VERSION,
   };
 
@@ -407,7 +407,7 @@ async function initializePlugin(
 async function teardownPlugin(
   active: ActivePlugin,
   reason: string,
-  shutdownContext: PluginShutdownContext,
+  shutdownContext: ShutdownContext,
 ): Promise<void> {
   const { plugin, routeHandles } = active;
   const name = plugin.manifest.name;

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -25,9 +25,9 @@ import { join } from "node:path";
 import { getConfig } from "../config/loader.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type {
+  InitContext,
   PluginHookFn,
-  PluginInitContext,
-  PluginShutdownContext,
+  ShutdownContext,
 } from "../plugin-api/types.js";
 import { listSurfaceDir } from "../plugins/external-plugin-loader.js";
 import { getMtime, importWithTimeout } from "../plugins/surface-import.js";
@@ -233,7 +233,7 @@ export async function runInitHook(ownerName: string): Promise<void> {
   if (initHookEntry === undefined) return;
 
   try {
-    const initContext: PluginInitContext = {
+    const initContext: InitContext = {
       config: getConfig().plugins?.[ownerName],
       logger: log.child({ plugin: ownerName }),
       pluginStorageDir: ensureHookStorageDir(ownerName),
@@ -256,7 +256,7 @@ export async function runInitHook(ownerName: string): Promise<void> {
  */
 export async function runShutdownHook(
   ownerName: string,
-  context: PluginShutdownContext,
+  context: ShutdownContext,
   reason: string,
 ): Promise<void> {
   const shutdownHookEntry = hookCache.get(hookKey(ownerName, HOOKS.SHUTDOWN));

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -37,8 +37,8 @@
  *   (optionally overriding the profile) and run inference through the
  *   workspace's configured profiles and credentials — no plugin-supplied API key
  *
- * - {@link PluginInitContext} — passed to `init` hook at bootstrap
- * - {@link PluginShutdownContext} — passed to `shutdown` hook at teardown
+ * - {@link InitContext} — passed to `init` hook at bootstrap
+ * - {@link ShutdownContext} — passed to `shutdown` hook at teardown
  * - {@link UserPromptSubmitContext} — passed to `user-prompt-submit` hook,
  *   fired immediately before the agent loop receives a user's prompt
  * - {@link PostCompactContext} — passed to `post-compact` hook, fired after
@@ -98,16 +98,16 @@ export type {
 export type { LLMCallSite } from "../config/schemas/llm.js";
 export type {
   AgentLoopExitReason,
+  InitContext,
   ModelProfileInfo,
   PluginHookFn,
-  PluginInitContext,
   PluginLogger,
-  PluginShutdownContext,
   PostCompactContext,
   PostModelCallContext,
   PostModelCallDecision,
   PostToolUseContext,
   PreModelCallContext,
+  ShutdownContext,
   StopContext,
   ToolContext,
   ToolDefinition,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -57,8 +57,8 @@ export interface PluginLogger {
  * empty model that with `| null`, not `| undefined`.
  *
  * Each known hook key has a documented context shape:
- *   - `init` — {@link PluginInitContext}
- *   - `shutdown` — {@link PluginShutdownContext}
+ *   - `init` — {@link InitContext}
+ *   - `shutdown` — {@link ShutdownContext}
  *   - `user-prompt-submit` — {@link UserPromptSubmitContext}
  *   - `pre-model-call` — {@link PreModelCallContext}
  *   - `post-tool-use` — {@link PostToolUseContext}
@@ -76,7 +76,7 @@ export type PluginHookFn<TCtx = unknown> = (
  * config, a pino-compatible logger scoped to the plugin, a per-plugin
  * writable data directory, and the assistant's version metadata.
  */
-export interface PluginInitContext {
+export interface InitContext {
   /** Parsed config for this plugin (may be `unknown` until the manifest validates). */
   config: unknown;
   /** Pino-compatible child logger bound to `{ plugin: <name> }`. */
@@ -125,7 +125,7 @@ export interface ModelProfileInfo {
 
 /**
  * Context passed to the `shutdown` hook during daemon teardown. Kept
- * intentionally narrower than {@link PluginInitContext} — most teardown
+ * intentionally narrower than {@link InitContext} — most teardown
  * paths only need to know which assistant version they're shutting
  * down against (e.g. for version-conditional cleanup of state files
  * written by a previous boot).
@@ -135,7 +135,7 @@ export interface ModelProfileInfo {
  * stash a version stamp at init can compare against the same name on
  * tear-down without keeping their own copy.
  */
-export interface PluginShutdownContext {
+export interface ShutdownContext {
   /** Assistant semver for compatibility checks inside the plugin. */
   assistantVersion: string;
 }

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -35,10 +35,7 @@ import {
   runShutdownHook,
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
-import type {
-  PluginHookFn,
-  PluginShutdownContext,
-} from "../plugin-api/types.js";
+import type { PluginHookFn, ShutdownContext } from "../plugin-api/types.js";
 import {
   registerPluginTools,
   unregisterPluginTools,
@@ -439,7 +436,7 @@ const activatedPlugins: Array<{ name: string }> = [];
  */
 const activatedNames = new Set<string>();
 
-const shutdownContext: PluginShutdownContext = {
+const shutdownContext: ShutdownContext = {
   assistantVersion: APP_VERSION,
 };
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -67,9 +67,9 @@ export interface PluginManifest {
 // existing internal call sites keep working. Plugin authors import these from
 // `@vellumai/plugin-api`.
 export type {
+  InitContext,
   PluginHookFn,
-  PluginInitContext,
-  PluginShutdownContext,
+  ShutdownContext,
 } from "../plugin-api/types.js";
 
 // ─── Memory-graph result ─────────────────────────────────────────────────────
@@ -347,7 +347,7 @@ export type PluginRouteRegistration = SkillRoute;
  */
 // The map stores hooks for arbitrary keys with arbitrary context shapes.
 // `any` (rather than `unknown`) is required so concrete plugin signatures
-// like `(ctx: PluginInitContext) => Promise<void>` and `() => Promise<void>`
+// like `(ctx: InitContext) => Promise<void>` and `() => Promise<void>`
 // both assign in/out of slot entries under strict-function-types contravariance.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PluginHooks = Record<string, PluginHookFn<any>>;

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -152,9 +152,9 @@ plugin.
 
 ```ts
 // hooks/init.ts
-import type { PluginInitContext } from "@vellumai/plugin-api";
+import type { InitContext } from "@vellumai/plugin-api";
 
-export default async function init(ctx: PluginInitContext): Promise<void> {
+export default async function init(ctx: InitContext): Promise<void> {
   // ctx.config            — your validated config (typed `unknown` for now)
   // ctx.logger            — pino child, bound to { plugin: <name> }
   // ctx.pluginStorageDir  — writable dir at <workspace>/plugins-data/<name>/
@@ -176,10 +176,10 @@ explicit unload, etc.).
 
 ```ts
 // hooks/shutdown.ts
-import type { PluginShutdownContext } from "@vellumai/plugin-api";
+import type { ShutdownContext } from "@vellumai/plugin-api";
 
 export default async function shutdown(
-  ctx: PluginShutdownContext,
+  ctx: ShutdownContext,
 ): Promise<void> {
   // ctx.assistantVersion  — host semver string
 }
@@ -286,7 +286,7 @@ whenever you need the current set — at `init` to build a map once, or per call
 
 ```ts
 // hooks/init.ts — build and validate the router's category → profile map
-import { getModelProfiles, type PluginInitContext } from "@vellumai/plugin-api";
+import { getModelProfiles, type InitContext } from "@vellumai/plugin-api";
 
 const CATEGORY_PROFILE: Record<string, string> = {
   chat: "cost-optimized",
@@ -294,7 +294,7 @@ const CATEGORY_PROFILE: Record<string, string> = {
   deep: "quality-optimized",
 };
 
-export default function init(ctx: PluginInitContext): void {
+export default function init(ctx: InitContext): void {
   const routable = new Set(
     getModelProfiles()
       .filter((p) => !p.isDisabled)

--- a/skills/plugin-builder/references/hooks.md
+++ b/skills/plugin-builder/references/hooks.md
@@ -30,7 +30,7 @@ These are the lifecycle hooks. The full set of wired hook names lives in the [`H
 
 ### `init`
 
-**Context:** `PluginInitContext`
+**Context:** `InitContext`
 **When:** Once, when the plugin is first registered (on boot or install).
 **Use it to:** Validate config and open resources. Throwing aborts the plugin's load.
 
@@ -143,7 +143,7 @@ These are the lifecycle hooks. The full set of wired hook names lives in the [`H
 
 ### `shutdown`
 
-**Context:** `PluginShutdownContext`
+**Context:** `ShutdownContext`
 **When:** Once, when the Assistant tears down the plugin (process exit, unload).
 **Use it to:** Best-effort cleanup. Do not rely on it for critical writes; persist durably during normal operation instead.
 
@@ -171,8 +171,8 @@ These are the hook-related exports from [`@vellumai/plugin-api`](https://github.
 | `HOOKS`                   | const | Wired hook names keyed by constant (INIT, PRE_MODEL_CALL, and so on). Reference hooks by this instead of free-form strings.       |
 | `HookName`                | type  | Union of every wired hook name declared in HOOKS.                                                                                 |
 | `PluginHookFn`            | type  | Signature every hook implements: `(ctx) => Promise<Partial<ctx> \| void>`.                                                        |
-| `PluginInitContext`       | type  | Passed to the init hook at bootstrap.                                                                                             |
-| `PluginShutdownContext`   | type  | Passed to the shutdown hook at teardown.                                                                                          |
+| `InitContext`             | type  | Passed to the init hook at bootstrap.                                                                                             |
+| `ShutdownContext`         | type  | Passed to the shutdown hook at teardown.                                                                                          |
 | `UserPromptSubmitContext` | type  | Passed to user-prompt-submit, before a turn's messages reach the agent loop.                                                      |
 | `PreModelCallContext`     | type  | Passed to pre-model-call, before each provider call.                                                                              |
 | `PostToolUseContext`      | type  | Passed to post-tool-use, once per tool result.                                                                                    |


### PR DESCRIPTION
## Why

The plugin lifecycle hook context types were inconsistently named. The init and shutdown contexts carried a `Plugin` prefix (`PluginInitContext`, `PluginShutdownContext`), while every other hook context — `UserPromptSubmitContext`, `PostToolUseContext`, `PreModelCallContext`, `PostModelCallContext`, `PostCompactContext`, `StopContext` — does not. The prefix is redundant: these types are already namespaced by `@vellumai/plugin-api`, and the asymmetry is a papercut for plugin authors reading the hook contract.

## What

Renames across the whole surface:

- `PluginInitContext` → `InitContext`
- `PluginShutdownContext` → `ShutdownContext`

Updated everywhere they're referenced: the public `@vellumai/plugin-api` exports (`plugin-api/types.ts`, `plugin-api/index.ts`), the internal re-export in `plugins/types.ts`, the host call sites (`hooks/hook-loader.ts`, `daemon/external-plugins-bootstrap.ts`, `plugins/mtime-cache.ts`), the plugin test suite, and the plugin-author docs (`plugins/README.md`, `skills/plugin-builder/references/hooks.md`).

## Breaking change

⚠️ **This is an intentional breaking change to the public `@vellumai/plugin-api`.** The old type names are *removed*, not aliased — no back-compat shim is kept. External plugins that import `PluginInitContext` / `PluginShutdownContext` must update their imports to the new names. This should be gated on a major version bump per the plugin-api compatibility policy (renaming/removing a public type is breaking).

## Verification

- `tsc --noEmit` clean on the touched files (pre-commit + pre-push type-check passed).
- `eslint` and `prettier` clean (pre-commit + pre-push lint passed).
- Plugin test suite green: 37 tests across `plugin-bootstrap`, `plugin-types`, `plugin-tool-contribution`, and `plugin-route-contribution`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015r81LE9PAJxCJunRgYcAT3

---
_Generated by [Claude Code](https://claude.ai/code/session_015r81LE9PAJxCJunRgYcAT3)_