### PR TITLE
Rename PluginHookFn → HookFunction and fix skills catalog CI

### DIFF
--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -25,8 +25,8 @@ import { join } from "node:path";
 import { getConfig } from "../config/loader.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type {
+  HookFunction,
   InitContext,
-  PluginHookFn,
   ShutdownContext,
 } from "../plugin-api/types.js";
 import { listSurfaceDir } from "../plugins/external-plugin-loader.js";
@@ -53,7 +53,7 @@ export const WORKSPACE_HOOKS_OWNER = "__workspace__";
  * mtime changes, the hook is re-imported and the entry is replaced.
  */
 interface CachedHook {
-  readonly hook: PluginHookFn;
+  readonly hook: HookFunction;
   /** mtimeMs of the source file this hook was imported from. */
   readonly sourceMtime: number;
 }
@@ -83,7 +83,7 @@ async function resolveCachedHook<TCtx>(
   ownerName: string,
   hookName: string,
   filePath: string,
-): Promise<PluginHookFn<TCtx> | undefined> {
+): Promise<HookFunction<TCtx> | undefined> {
   const key = hookKey(ownerName, hookName);
   const currentMtime = getMtime(filePath);
 
@@ -94,7 +94,7 @@ async function resolveCachedHook<TCtx>(
     cached.sourceMtime === currentMtime &&
     currentMtime > 0
   ) {
-    return cached.hook as PluginHookFn<TCtx>;
+    return cached.hook as HookFunction<TCtx>;
   }
 
   // Cache miss — re-import.
@@ -105,7 +105,7 @@ async function resolveCachedHook<TCtx>(
   }
 
   try {
-    const hook = await importWithTimeout<PluginHookFn>(filePath);
+    const hook = await importWithTimeout<HookFunction>(filePath);
     if (hook === undefined || typeof hook !== "function") {
       log.error(
         { plugin: ownerName, hook: hookName, path: filePath },
@@ -114,7 +114,7 @@ async function resolveCachedHook<TCtx>(
       return undefined;
     }
     hookCache.set(key, { hook, sourceMtime: currentMtime });
-    return hook as PluginHookFn<TCtx>;
+    return hook as HookFunction<TCtx>;
   } catch (err) {
     log.error(
       { err, plugin: ownerName, hook: hookName, path: filePath },
@@ -141,8 +141,8 @@ async function resolveCachedHook<TCtx>(
 export async function collectUserHooks<TCtx = unknown>(
   hookName: string,
   pluginDirs: Iterable<readonly [string, string]>,
-): Promise<PluginHookFn<TCtx>[]> {
-  const out: PluginHookFn<TCtx>[] = [];
+): Promise<HookFunction<TCtx>[]> {
+  const out: HookFunction<TCtx>[] = [];
 
   for (const [pluginDir, pluginName] of pluginDirs) {
     const hookFile = listSurfaceDir(join(pluginDir, "hooks")).find(
@@ -191,7 +191,7 @@ export async function preImportHooksDir(
     if (currentMtime === 0) continue;
 
     try {
-      const hook = await importWithTimeout<PluginHookFn>(file.path);
+      const hook = await importWithTimeout<HookFunction>(file.path);
       if (hook !== undefined && typeof hook === "function") {
         hookCache.set(key, { hook, sourceMtime: currentMtime });
       }

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -55,7 +55,7 @@
  * - {@link PostModelCallContext} — passed to `post-model-call` hook, fired at
  *   every model-call outcome (a finalized reply or a provider rejection) to
  *   transform content and decide whether to retry
- * - {@link PluginHookFn} — signature every lifecycle hook implements
+ * - {@link HookFunction} — signature every lifecycle hook implements
  * - {@link PluginLogger} — pino-compatible logger shape on the contexts
  * - {@link ToolDefinition} — author-facing tool spec (default-export shape
  *   for both plugin tool files and workspace tool files)
@@ -98,9 +98,9 @@ export type {
 export type { LLMCallSite } from "../config/schemas/llm.js";
 export type {
   AgentLoopExitReason,
+  HookFunction,
   InitContext,
   ModelProfileInfo,
-  PluginHookFn,
   PluginLogger,
   PostCompactContext,
   PostModelCallContext,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -65,7 +65,7 @@ export interface PluginLogger {
  *   - `stop` — {@link StopContext}
  *   - `post-model-call` — {@link PostModelCallContext}
  */
-export type PluginHookFn<TCtx = unknown> = (
+export type HookFunction<TCtx = unknown> = (
   ctx: TCtx,
 ) => Promise<Partial<TCtx> | void>;
 
@@ -151,7 +151,7 @@ export interface ShutdownContext {
  *
  * The hook may transform `latestMessages` either by mutating it in place
  * (`push` / `splice` / `length = 0`) or by returning a new context with
- * a fresh `latestMessages` array — see {@link PluginHookFn}'s polymorphic
+ * a fresh `latestMessages` array — see {@link HookFunction}'s polymorphic
  * return shape. The daemon threads the final `latestMessages` value into
  * `agentLoop.run()` as the run-messages argument.
  *
@@ -244,7 +244,7 @@ export interface UserPromptSubmitContext {
  * their own injected context the same way.
  *
  * The hook re-injects by mutating `history` in place (or returning a new
- * context with a replacement `history`) — see {@link PluginHookFn}'s
+ * context with a replacement `history`) — see {@link HookFunction}'s
  * polymorphic return shape. The agent loop reads the settled `history` back off
  * the context and resumes the turn from it. Multiple plugins' hooks chain in
  * registration order, each seeing the previous plugin's edits.
@@ -301,7 +301,7 @@ export interface PostCompactContext {
  *
  * The hook may transform the result either by mutating `toolResponse` in
  * place (e.g. reassigning `toolResponse.content`) or by returning a new
- * context with a fresh `toolResponse` — see {@link PluginHookFn}'s
+ * context with a fresh `toolResponse` — see {@link HookFunction}'s
  * polymorphic return shape. The daemon threads the final `toolResponse`
  * into the provider-bound history.
  *

--- a/assistant/src/plugins/defaults/advisor/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/advisor/hooks/post-model-call.ts
@@ -9,11 +9,11 @@
  * advisor's own `inference`-call-site sub-call — are ignored.
  */
 
-import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
 
 import { recordMessages } from "../advisor-state-store.js";
 
-const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   if (ctx.callSite !== "mainAgent") return;
   if (ctx.error) return;
   // `ctx.messages` is the pre-reply history; the turn the model just produced —

--- a/assistant/src/plugins/defaults/advisor/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/advisor/hooks/pre-model-call.ts
@@ -5,14 +5,14 @@
  * tool. Idempotent via the steering marker.
  */
 
-import type { PluginHookFn, PreModelCallContext } from "@vellumai/plugin-api";
+import type { HookFunction, PreModelCallContext } from "@vellumai/plugin-api";
 
 import { advisorEnabledForProfile } from "../advisor-gate.js";
 import { recordSystemPrompt } from "../advisor-state-store.js";
 import { ADVISOR_CONFIG } from "../config.js";
 import { appendSteering, stripSteering } from "../steering.js";
 
-const preModelCall: PluginHookFn<PreModelCallContext> = async (ctx) => {
+const preModelCall: HookFunction<PreModelCallContext> = async (ctx) => {
   if (ctx.callSite !== "mainAgent") return;
 
   recordSystemPrompt(ctx.conversationId, stripSteering(ctx.systemPrompt));

--- a/assistant/src/plugins/defaults/advisor/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/advisor/hooks/user-prompt-submit.ts
@@ -6,13 +6,13 @@
  */
 
 import type {
-  PluginHookFn,
+  HookFunction,
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
 import { seedCapture } from "../advisor-state-store.js";
 
-const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
+const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (ctx) => {
   seedCapture(ctx.conversationId, ctx.latestMessages);
 };
 

--- a/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
@@ -46,7 +46,7 @@
  * ignores the decision — so the hook returns early for both.
  */
 
-import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
 
 import type { ContentBlock, Message } from "../../../../providers/types.js";
 import {
@@ -112,7 +112,7 @@ function currentCycleMessages(
   return messages;
 }
 
-const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   // A provider rejection carries no turn content to assess (a recovery hook
   // owns the rejection); the sibling `stop` hook clears the mark when the turn
   // terminates.

--- a/assistant/src/plugins/defaults/empty-response/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/stop.ts
@@ -11,11 +11,11 @@
  * refused).
  */
 
-import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
 
 import { clearEmptyResponseNudged } from "../nudge-state-store.js";
 
-const stop: PluginHookFn<StopContext> = async (ctx) => {
+const stop: HookFunction<StopContext> = async (ctx) => {
   clearEmptyResponseNudged(ctx.conversationId);
 };
 

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -55,7 +55,7 @@
  * per-tool-result hot path.
  */
 
-import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
 
 import type { Message } from "../../../../providers/types.js";
 
@@ -233,7 +233,7 @@ function currentCallRepeatCount(
   return count;
 }
 
-const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+const postToolUse: HookFunction<PostToolUseContext> = async (ctx) => {
   const usesById = toolUsesById(ctx.messages);
   const currentUse = usesById.get(ctx.toolResponse.tool_use_id);
   if (currentUse === undefined || !EXPLORATION_TOOL_NAMES.has(currentUse.name))

--- a/assistant/src/plugins/defaults/history-repair/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/history-repair/hooks/post-model-call.ts
@@ -23,7 +23,7 @@
  * empty-response hook; only a provider rejection is this hook's to act on.
  */
 
-import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
 
 import {
   isOrderingRepairAttempted,
@@ -31,7 +31,7 @@ import {
 } from "../repair-state-store.js";
 import { deepRepairHistory, isRepairableOrderingError } from "../terminal.js";
 
-const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   if (
     ctx.error &&
     isRepairableOrderingError(ctx.error.message) &&

--- a/assistant/src/plugins/defaults/history-repair/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/history-repair/hooks/stop.ts
@@ -11,11 +11,11 @@
  * retry the loop's per-run backstop refused).
  */
 
-import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
 
 import { clearOrderingRepairAttempted } from "../repair-state-store.js";
 
-const stop: PluginHookFn<StopContext> = async (ctx) => {
+const stop: HookFunction<StopContext> = async (ctx) => {
   clearOrderingRepairAttempted(ctx.conversationId);
 };
 

--- a/assistant/src/plugins/defaults/history-repair/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/history-repair/hooks/user-prompt-submit.ts
@@ -10,13 +10,13 @@
  */
 
 import type {
-  PluginHookFn,
+  HookFunction,
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
 import { repairHistory } from "../terminal.js";
 
-const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
+const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (ctx) => {
   const { messages, stats } = repairHistory(ctx.latestMessages);
   ctx.latestMessages = messages;
   if (

--- a/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
@@ -17,14 +17,14 @@
 
 import {
   doesSupportVision,
-  type PluginHookFn,
+  type HookFunction,
   type PostToolUseContext,
 } from "@vellumai/plugin-api";
 
 import { captionImageBlocks } from "../src/caption-blocks.js";
 import { findVisionProfile } from "../src/vision-caption.js";
 
-const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+const postToolUse: HookFunction<PostToolUseContext> = async (ctx) => {
   // Cheapest gate first: bail unless the tool actually returned an image,
   // before touching the model catalog or resolving a vision profile.
   const blocks = ctx.toolResponse.contentBlocks;

--- a/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/user-prompt-submit.ts
@@ -23,7 +23,7 @@
  */
 
 import {
-  type PluginHookFn,
+  type HookFunction,
   type UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
@@ -33,7 +33,7 @@ import {
 } from "../src/caption-blocks.js";
 import { findVisionProfile } from "../src/vision-caption.js";
 
-const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
+const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (ctx) => {
   // If the turn's model already supports vision, nothing to do.
   if (!needsImageFallback(ctx.modelProfileKey)) return;
 

--- a/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
@@ -24,7 +24,7 @@
  * empty-response hook; only a provider rejection is this hook's to act on.
  */
 
-import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
 
 import { isImageDimensionsTooLargeError } from "../detect.js";
 import {
@@ -36,7 +36,7 @@ import {
   recoverOversizedImages,
 } from "../recover.js";
 
-const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   if (
     ctx.error &&
     isImageDimensionsTooLargeError(ctx.error.message) &&

--- a/assistant/src/plugins/defaults/image-recovery/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/image-recovery/hooks/stop.ts
@@ -11,11 +11,11 @@
  * retry the loop's per-run backstop refused).
  */
 
-import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
 
 import { clearImageRecoveryAttempted } from "../image-recovery-state-store.js";
 
-const stop: PluginHookFn<StopContext> = async (ctx) => {
+const stop: HookFunction<StopContext> = async (ctx) => {
   clearImageRecoveryAttempted(ctx.conversationId);
 };
 

--- a/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
@@ -30,7 +30,7 @@
  *   reject.
  */
 
-import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
 
 import { isMaxTokensStopReason } from "../../../../agent/loop.js";
 import {
@@ -45,7 +45,7 @@ import {
 export const MAX_TOKENS_CONTINUE_NUDGE_TEXT =
   "<system_notice>Your previous response was cut off because it reached the maximum output length. Continue exactly where you stopped — do not repeat content you already sent and do not start over.</system_notice>";
 
-const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   if (ctx.error) return;
   if (!isMaxTokensStopReason(ctx.stopReason)) return;
   if (ctx.callSite !== "mainAgent") return;

--- a/assistant/src/plugins/defaults/max-tokens-continue/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/max-tokens-continue/hooks/stop.ts
@@ -9,11 +9,11 @@
  * budget, no matter how the turn ended.
  */
 
-import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
 
 import { clearMaxTokensContinueBudget } from "../continue-state-store.js";
 
-const stop: PluginHookFn<StopContext> = async (ctx) => {
+const stop: HookFunction<StopContext> = async (ctx) => {
   clearMaxTokensContinueBudget(ctx.conversationId);
 };
 

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/post-compact.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/post-compact.ts
@@ -38,7 +38,7 @@
  * {@link PostCompactContext}.
  */
 
-import type { PluginHookFn, PostCompactContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostCompactContext } from "@vellumai/plugin-api";
 
 import { getConfig } from "../../../../config/loader.js";
 import { findConversationOrSubagent } from "../../../../daemon/conversation-registry.js";
@@ -53,7 +53,7 @@ import {
 import { getLiveGraphMemory } from "../../../../memory/graph/conversation-graph-memory.js";
 import { stripTailInjectionsForReinjection } from "../tail-reinjection-strip.js";
 
-const postCompact: PluginHookFn<PostCompactContext> = async (ctx) => {
+const postCompact: HookFunction<PostCompactContext> = async (ctx) => {
   const {
     history,
     requestId,

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -28,7 +28,7 @@
  */
 
 import type {
-  PluginHookFn,
+  HookFunction,
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
@@ -264,7 +264,7 @@ function persistInjectionBlocks(
  * slower turn. Cancellation still works via `ctx.signal`, which is threaded
  * into `prepareMemory`.
  */
-const userPromptSubmitMemoryRetrieval: PluginHookFn<
+const userPromptSubmitMemoryRetrieval: HookFunction<
   UserPromptSubmitContext
 > = async (ctx) => {
   // The conversation-scoped retrieval state — graph handle, abort signal, and

--- a/assistant/src/plugins/defaults/memory-v3-shadow/hooks/post-compact.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/hooks/post-compact.ts
@@ -7,8 +7,8 @@
  * `../injector.js` and re-apply it here. Until then this hook does nothing.
  */
 
-import type { PluginHookFn } from "@vellumai/plugin-api";
+import type { HookFunction } from "@vellumai/plugin-api";
 
-const postCompact: PluginHookFn = async () => {};
+const postCompact: HookFunction = async () => {};
 
 export default postCompact;

--- a/assistant/src/plugins/defaults/memory-v3-shadow/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/hooks/user-prompt-submit.ts
@@ -10,10 +10,10 @@
  */
 
 import type {
-  PluginHookFn,
+  HookFunction,
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
-const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async () => {};
+const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async () => {};
 
 export default userPromptSubmit;

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
@@ -45,7 +45,7 @@
  * the `post-model-call` chain — later hooks see (and may override) its decision.
  */
 
-import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
 
 import type { ContentBlock, Message } from "../../../../providers/types.js";
 import {
@@ -246,7 +246,7 @@ function hasDanglingProgressSurface(messages: ReadonlyArray<Message>): boolean {
   return false;
 }
 
-const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   // A provider rejection carries no turn content to assess (a recovery hook
   // owns the rejection).
   if (ctx.error) return;

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/stop.ts
@@ -11,11 +11,11 @@
  * refused).
  */
 
-import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
 
 import { clearSurfaceCompletionNudged } from "../nudge-state-store.js";
 
-const stop: PluginHookFn<StopContext> = async (ctx) => {
+const stop: HookFunction<StopContext> = async (ctx) => {
   clearSurfaceCompletionNudged(ctx.conversationId);
 };
 

--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -45,7 +45,7 @@
  * below it (a new turn restarts counting low).
  */
 
-import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
 
 import type { ContentBlock, Message } from "../../../../providers/types.js";
 import { isWeakOpenModel } from "../../../../providers/weak-open-model.js";
@@ -134,7 +134,7 @@ function scanTurn(messages: ReadonlyArray<Message>): {
   return { rounds, taskProgressShown };
 }
 
-const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+const postToolUse: HookFunction<PostToolUseContext> = async (ctx) => {
   if (!isWeakOpenModel(ctx.model)) return;
 
   const { rounds, taskProgressShown } = scanTurn(ctx.messages);

--- a/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
@@ -18,7 +18,7 @@
  * stateless and means a mid-run array rewrite (compaction) can't invalidate it.
  */
 
-import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
 
 import { getConfig } from "../../../../config/loader.js";
 import { getConversation } from "../../../../memory/conversation-crud.js";
@@ -65,7 +65,7 @@ function shouldRetryFallbackTitle(conversation: {
   );
 }
 
-const stop: PluginHookFn<StopContext> = async (ctx) => {
+const stop: HookFunction<StopContext> = async (ctx) => {
   // Re-title only at a genuine successful turn end (the model returned a reply
   // with no tool calls). Any other terminal — a provider rejection, abort, or
   // an output-limit cutoff — produced no new topic to re-title from.

--- a/assistant/src/plugins/defaults/title-generate/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/user-prompt-submit.ts
@@ -11,14 +11,14 @@
  */
 
 import type {
-  PluginHookFn,
+  HookFunction,
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
 import { getConversation } from "../../../../memory/conversation-crud.js";
 import { queueGenerateConversationTitle } from "../../../../memory/conversation-title-service.js";
 
-const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
+const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (ctx) => {
   // System conversations (background/scheduled) carry a deterministic title
   // from bootstrap. Their own job prompts arrive as non-interactive turns and
   // must not spend an LLM call on a title nobody reads — only a genuine user

--- a/assistant/src/plugins/defaults/tool-error/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/tool-error/hooks/post-tool-use.ts
@@ -22,7 +22,7 @@
  * result for the tool resets its streak.
  */
 
-import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
 
 import type { Message } from "../../../../providers/types.js";
 
@@ -85,7 +85,7 @@ function priorConsecutiveErrors(
   return streak;
 }
 
-const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+const postToolUse: HookFunction<PostToolUseContext> = async (ctx) => {
   if (ctx.toolResponse.is_error !== true) return;
 
   const namesById = toolNamesById(ctx.messages);

--- a/assistant/src/plugins/defaults/tool-result-truncate/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/tool-result-truncate/hooks/post-tool-use.ts
@@ -8,11 +8,11 @@
  * The hook mutates `toolResponse.content` in place.
  */
 
-import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
+import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
 
 import { truncateToolResult } from "../terminal.js";
 
-const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+const postToolUse: HookFunction<PostToolUseContext> = async (ctx) => {
   const { content, truncated } = truncateToolResult(
     ctx.toolResponse.content,
     ctx.maxInputTokens,

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -54,8 +54,8 @@ import type { Tool, ToolDefinition } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { registerPlugin } from "./registry.js";
 import type {
+  HookFunction,
   Plugin,
-  PluginHookFn,
   PluginHooks,
   PluginManifest,
 } from "./types.js";
@@ -195,7 +195,7 @@ async function loadHooks(
   if (files.length === 0) return undefined;
   const hooks: PluginHooks = {};
   for (const { name, path } of files) {
-    const fn = await importDefault<PluginHookFn>(path);
+    const fn = await importDefault<HookFunction>(path);
     if (typeof fn !== "function") {
       throw new Error(
         `external plugin ${pluginName}: hooks/${name} default export must be a function (got ${typeof fn})`,

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -35,7 +35,7 @@ import {
   runShutdownHook,
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
-import type { PluginHookFn, ShutdownContext } from "../plugin-api/types.js";
+import type { HookFunction, ShutdownContext } from "../plugin-api/types.js";
 import {
   registerPluginTools,
   unregisterPluginTools,
@@ -57,9 +57,9 @@ import {
   setSurfaceImportTimeout,
 } from "./surface-import.js";
 
-// Re-export for type compat — consumers that import PluginHookFn from
+// Re-export for type compat — consumers that import HookFunction from
 // the mtime cache module still resolve.
-export type { PluginHookFn } from "./types.js";
+export type { HookFunction } from "./types.js";
 
 const log = getLogger("plugin-mtime-cache");
 
@@ -181,7 +181,7 @@ const disabledPluginDirs = new Set<string>();
  */
 export async function getUserHooksFor<TCtx = unknown>(
   hookName: string,
-): Promise<PluginHookFn<TCtx>[]> {
+): Promise<HookFunction<TCtx>[]> {
   await scanPlugins();
   return collectUserHooks<TCtx>(hookName, discoveredPluginDirs);
 }

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -19,7 +19,7 @@
 import type { HookName } from "../plugin-api/constants.js";
 import { getLogger } from "../util/logger.js";
 import { getHooksFor } from "./registry.js";
-import type { PluginHookFn } from "./types.js";
+import type { HookFunction } from "./types.js";
 
 // ─── Hook runner ────────────────────────────────────────────────────────────
 
@@ -116,7 +116,7 @@ export async function runHook<TCtx>(
   name: HookName,
   initialCtx: TCtx,
 ): Promise<TCtx> {
-  let hooks: PluginHookFn<TCtx>[];
+  let hooks: HookFunction<TCtx>[];
   try {
     hooks = await getHooksFor<TCtx>(name);
   } catch (err) {

--- a/assistant/src/plugins/registry.ts
+++ b/assistant/src/plugins/registry.ts
@@ -21,9 +21,9 @@
 
 import { getUserHooksFor } from "./mtime-cache.js";
 import {
+  type HookFunction,
   type Plugin,
   PluginExecutionError,
-  type PluginHookFn,
 } from "./types.js";
 
 // ─── Internal state ──────────────────────────────────────────────────────────
@@ -151,20 +151,20 @@ export function getRegisteredPlugins(): Plugin[] {
  * files. First-party default plugin hooks are read synchronously from the
  * registry and prepended.
  *
- * The `TCtx` generic mirrors {@link PluginHookFn}'s — callers parameterize
+ * The `TCtx` generic mirrors {@link HookFunction}'s — callers parameterize
  * over the concrete context type their hook receives. Hooks that mutate
  * the context in place return `void`; hooks that return a new context
  * replace the threaded value for the next hook in the chain.
  */
 export async function getHooksFor<TCtx = unknown>(
   name: string,
-): Promise<PluginHookFn<TCtx>[]> {
+): Promise<HookFunction<TCtx>[]> {
   // First-party defaults from the registry (synchronous).
-  const defaultHooks: PluginHookFn<TCtx>[] = [];
+  const defaultHooks: HookFunction<TCtx>[] = [];
   for (const plugin of registeredPlugins.values()) {
     const hook = plugin.hooks?.[name];
     if (hook) {
-      defaultHooks.push(hook as PluginHookFn<TCtx>);
+      defaultHooks.push(hook as HookFunction<TCtx>);
     }
   }
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -19,7 +19,7 @@ import type {
 } from "../daemon/conversation-runtime-assembly.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
-import type { PluginHookFn } from "../plugin-api/types.js";
+import type { HookFunction } from "../plugin-api/types.js";
 import type { Message } from "../providers/types.js";
 import type { SkillRoute } from "../runtime/skill-route-registry.js";
 import type { Tool } from "../tools/types.js";
@@ -67,8 +67,8 @@ export interface PluginManifest {
 // existing internal call sites keep working. Plugin authors import these from
 // `@vellumai/plugin-api`.
 export type {
+  HookFunction,
   InitContext,
-  PluginHookFn,
   ShutdownContext,
 } from "../plugin-api/types.js";
 
@@ -343,14 +343,14 @@ export type PluginRouteRegistration = SkillRoute;
  * unknown keys are forward-compat scaffolding.
  *
  * See `assistant/src/daemon/external-plugins-bootstrap.ts` for the
- * full lifecycle, and {@link PluginHookFn} for the per-entry signature.
+ * full lifecycle, and {@link HookFunction} for the per-entry signature.
  */
 // The map stores hooks for arbitrary keys with arbitrary context shapes.
 // `any` (rather than `unknown`) is required so concrete plugin signatures
 // like `(ctx: InitContext) => Promise<void>` and `() => Promise<void>`
 // both assign in/out of slot entries under strict-function-types contravariance.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type PluginHooks = Record<string, PluginHookFn<any>>;
+export type PluginHooks = Record<string, HookFunction<any>>;
 
 /**
  * A registered plugin. Every field besides `manifest` is optional — a plugin

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -131,7 +131,7 @@ filename becomes the hook key. **One hook per file.**
 The hook signature is:
 
 ```ts
-type PluginHookFn<TCtx> = (ctx: TCtx) => Promise<Partial<TCtx> | void>;
+type HookFunction<TCtx> = (ctx: TCtx) => Promise<Partial<TCtx> | void>;
 ```
 
 The return shape means a hook can either **mutate `ctx` in place and

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -644,7 +644,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-24T19:18:59.000Z"
+      "updatedAt": "2026-06-25T11:46:21.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/plugin-builder/references/hooks.md
+++ b/skills/plugin-builder/references/hooks.md
@@ -170,7 +170,7 @@ These are the hook-related exports from [`@vellumai/plugin-api`](https://github.
 | ------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `HOOKS`                   | const | Wired hook names keyed by constant (INIT, PRE_MODEL_CALL, and so on). Reference hooks by this instead of free-form strings.       |
 | `HookName`                | type  | Union of every wired hook name declared in HOOKS.                                                                                 |
-| `PluginHookFn`            | type  | Signature every hook implements: `(ctx) => Promise<Partial<ctx> \| void>`.                                                        |
+| `HookFunction`            | type  | Signature every hook implements: `(ctx) => Promise<Partial<ctx> \| void>`.                                                        |
 | `InitContext`             | type  | Passed to the init hook at bootstrap.                                                                                             |
 | `ShutdownContext`         | type  | Passed to the shutdown hook at teardown.                                                                                          |
 | `UserPromptSubmitContext` | type  | Passed to user-prompt-submit, before a turn's messages reach the agent loop.                                                      |
@@ -187,7 +187,7 @@ These are the hook-related exports from [`@vellumai/plugin-api`](https://github.
 Every hook has the same shape: it receives a typed context and either mutates it in place and returns nothing, or returns a **partial** context. A returned partial is merged onto the threaded context - only the keys it includes are overwritten, every other field is preserved - so a hook can edit just the subset of fields it cares about without re-specifying the rest. The runtime threads the merged context to the next plugin and then to the Assistant.
 
 ```ts
-type PluginHookFn<TCtx> = (ctx: TCtx) => Promise<Partial<TCtx> | void>;
+type HookFunction<TCtx> = (ctx: TCtx) => Promise<Partial<TCtx> | void>;
 ```
 
 Because an omitted key means "keep the existing value", every context field is required and uses `| null` rather than `?` or `| undefined`: a present key always carries a concrete value, so a field absent from a returned partial is never ambiguous with one a hook meant to clear.

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -58,7 +58,7 @@ The marketplace catalog entry can point at a subdirectory of a repo using `sourc
 
 Plugins import everything they need from a single package, [`@vellumai/plugin-api`](https://github.com/vellum-ai/vellum-assistant/tree/main/assistant/src/plugin-api). It is the only supported contract: anything not exported from there is assistant-internal and can change without notice. Most of the surface is types (the contexts the host hands your code), with a small set of runtime handles that resolve to the assistant's live singletons.
 
-The hook-related exports (context types, `HOOKS` constant, `PluginHookFn` signature) are documented in `references/hooks.md`. The tool-related exports (`ToolDefinition`, `ToolContext`, `ToolExecutionResult`, `RiskLevel`) are documented in `references/tools.md`. The remaining exports are covered below.
+The hook-related exports (context types, `HOOKS` constant, `HookFunction` signature) are documented in `references/hooks.md`. The tool-related exports (`ToolDefinition`, `ToolContext`, `ToolExecutionResult`, `RiskLevel`) are documented in `references/tools.md`. The remaining exports are covered below.
 
 ### Logging
 


### PR DESCRIPTION
Follow-up to #36089. Two changes:

## 1. Fix the failing skills CI job

The **"Check catalog.json is up to date"** job failed on #36089. The catalog's per-skill `updatedAt` is derived from each skill directory's last git commit date (`git log -1 -- skills/<name>`). #36089 edited `skills/plugin-builder/references/hooks.md`, which bumped plugin-builder's date, but `skills/catalog.json` was not regenerated — so the committed catalog went stale and the check failed.

This PR regenerates the catalog. The diff is a single line: `plugin-builder.updatedAt` is refreshed to the commit that last touched the skill (the rename commit in this PR). Every other entry is unchanged, matching what CI computes from full history.

> Note: the catalog regeneration was committed **after** the rename commit so plugin-builder's `updatedAt` reflects the rename commit's authored date — i.e. the exact value CI recomputes — keeping the check green. Verified locally with `node scripts/skills/check-catalog.mjs` (→ "skills/catalog.json is up to date.").

## 2. Rename `PluginHookFn` → `HookFunction`

Same consistency cleanup as #36089's `PluginInitContext`/`PluginShutdownContext` rename. The `Plugin` prefix is redundant on a type already namespaced by `@vellumai/plugin-api`. Renamed across the public API surface (`plugin-api/types.ts`, `plugin-api/index.ts`), internal call sites (`plugins/types.ts`, `registry.ts`, `mtime-cache.ts`, `external-plugin-loader.ts`, `hook-loader.ts`, `pipeline.ts`), all 20+ default-plugin hook files, and the plugin-author docs (`plugins/README.md`, `skills/plugin-builder/references/*.md`).

### ⚠️ Breaking change

This is an **intentional breaking change** to the public `@vellumai/plugin-api`. The old `PluginHookFn` name is removed, not aliased — external plugins importing it must update to `HookFunction`. Should be gated on a major version bump per the plugin-api compatibility policy, alongside #36089.

## Verification

- `tsc --noEmit` clean on the touched files (pre-commit + pre-push type-check passed).
- `eslint` + `prettier` clean.
- Plugin test suite green: 37 tests across `plugin-bootstrap`, `plugin-types`, `plugin-tool-contribution`, `plugin-route-contribution`.
- `scripts/skills/check-catalog.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015r81LE9PAJxCJunRgYcAT3

---
_Generated by [Claude Code](https://claude.ai/code/session_015r81LE9PAJxCJunRgYcAT3)_