### PR TITLE
fix(web): correct research-onboarding mobile UI defects

### DIFF
--- a/clients/web/src/domains/onboarding/components/eye-bbox.ts
+++ b/clients/web/src/domains/onboarding/components/eye-bbox.ts
@@ -1,0 +1,104 @@
+/**
+ * Bounding-box helpers for the onboarding eye art.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * The peeking/motion eye components size and frame the chosen avatar's eye art
+ * from the union bounding box of its SVG paths. A naïve "grab every number and
+ * pair them as (x, y)" parser breaks on path commands that carry a single
+ * coordinate — `H`/`V` (horizontal/vertical lineto) — because the lone value
+ * desyncs every following x/y pair. The `grumpy` eye style is the only one that
+ * uses `H`, so it alone parsed to a bogus near-square box and rendered small and
+ * squished. This parser walks the path command-by-command, tracking the current
+ * point, so `H`/`V` update a single axis while every other command keeps
+ * extending by full (x, y) pairs — identical to the old behaviour for the eight
+ * styles that never used `H`/`V`.
+ */
+
+export type BBox = { x: number; y: number; w: number; h: number };
+
+const NUM = /-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?/gi;
+// One command letter plus the run of numbers that follows it.
+const SEGMENTS = /[MmLlHhVvCcSsQqTtAaZz][^MmLlHhVvCcSsQqTtAaZz]*/g;
+
+/**
+ * Tight bounding box of a path's geometry. Tracks the current point so
+ * single-axis commands (`H`/`V`) extend the box on the correct axis without
+ * desyncing the rest of the path. For every multi-coordinate command the values
+ * are treated as (x, y) pairs and each pair extends the box — including curve
+ * control points, matching the original parser so the existing eye styles size
+ * identically. The arc command (`A`) extends by its endpoint only (its leading
+ * radii/flags aren't points); no eye style uses it today.
+ */
+export function pathBBox(d: string): BBox {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let cx = 0;
+  let cy = 0;
+
+  const extend = (x: number, y: number) => {
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  };
+
+  const segments = d.match(SEGMENTS) ?? [];
+  for (const seg of segments) {
+    const code = seg[0]!;
+    const upper = code.toUpperCase();
+    if (upper === "Z") continue;
+    const relative = code !== upper;
+    const nums = (seg.slice(1).match(NUM) ?? []).map(Number);
+
+    if (upper === "H") {
+      for (const n of nums) {
+        cx = relative ? cx + n : n;
+        extend(cx, cy);
+      }
+    } else if (upper === "V") {
+      for (const n of nums) {
+        cy = relative ? cy + n : n;
+        extend(cx, cy);
+      }
+    } else if (upper === "A") {
+      // rx ry rot large sweep x y — only the trailing (x, y) is a point.
+      for (let i = 0; i + 7 <= nums.length; i += 7) {
+        const ex = nums[i + 5]!;
+        const ey = nums[i + 6]!;
+        cx = relative ? cx + ex : ex;
+        cy = relative ? cy + ey : ey;
+        extend(cx, cy);
+      }
+    } else {
+      // M/L/T/C/S/Q: extend by every (x, y) pair (control points included).
+      // For relative curves the control points are measured from the segment's
+      // start point; the current point only advances at the final pair.
+      const startX = cx;
+      const startY = cy;
+      for (let i = 0; i + 2 <= nums.length; i += 2) {
+        const px = relative ? startX + nums[i]! : nums[i]!;
+        const py = relative ? startY + nums[i + 1]! : nums[i + 1]!;
+        extend(px, py);
+        // Advance the current point to the last pair of the segment.
+        if (i + 2 >= nums.length - (nums.length % 2)) {
+          cx = px;
+          cy = py;
+        }
+      }
+    }
+  }
+
+  if (minX === Infinity) return { x: 0, y: 0, w: 0, h: 0 };
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
+export function unionBBox(boxes: BBox[]): BBox {
+  const minX = Math.min(...boxes.map((b) => b.x));
+  const minY = Math.min(...boxes.map((b) => b.y));
+  const maxX = Math.max(...boxes.map((b) => b.x + b.w));
+  const maxY = Math.max(...boxes.map((b) => b.y + b.h));
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}

--- a/clients/web/src/domains/onboarding/components/eye-bbox.ts
+++ b/clients/web/src/domains/onboarding/components/eye-bbox.ts
@@ -4,15 +4,12 @@
  * SPIKE — research-onboarding flow.
  *
  * The peeking/motion eye components size and frame the chosen avatar's eye art
- * from the union bounding box of its SVG paths. A naïve "grab every number and
- * pair them as (x, y)" parser breaks on path commands that carry a single
- * coordinate — `H`/`V` (horizontal/vertical lineto) — because the lone value
- * desyncs every following x/y pair. The `grumpy` eye style is the only one that
- * uses `H`, so it alone parsed to a bogus near-square box and rendered small and
- * squished. This parser walks the path command-by-command, tracking the current
- * point, so `H`/`V` update a single axis while every other command keeps
- * extending by full (x, y) pairs — identical to the old behaviour for the eight
- * styles that never used `H`/`V`.
+ * from the union bounding box of its SVG paths. This parser walks the path
+ * command-by-command, tracking the current point, so single-coordinate commands
+ * — `H`/`V` (horizontal/vertical lineto) — update one axis while every other
+ * command extends the box by full (x, y) pairs. Pairing every number as (x, y)
+ * without tracking commands would desync on the lone `H`/`V` value; the `grumpy`
+ * eye style is the only one that uses `H`, so correct handling matters for it.
  */
 
 export type BBox = { x: number; y: number; w: number; h: number };

--- a/clients/web/src/domains/onboarding/components/onboarding-character-stage.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-character-stage.tsx
@@ -19,10 +19,11 @@
  * that drive it live in the screen above). Reduced-motion safe.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { motion, useReducedMotion, type Easing } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
 /** Where the centered avatar sits, as viewport fractions. */
@@ -94,20 +95,6 @@ function offscreenPoint(
   return { x: from.x + (dx / len) * push, y: from.y + (dy / len) * push };
 }
 
-function useViewport() {
-  const [size, setSize] = useState(() => ({
-    w: typeof window === "undefined" ? 1280 : window.innerWidth,
-    h: typeof window === "undefined" ? 800 : window.innerHeight,
-  }));
-  useEffect(() => {
-    const onResize = () =>
-      setSize({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
-
 export interface OnboardingCharacterStageProps {
   components: CharacterComponents;
   characters: CharacterTraits[];
@@ -142,7 +129,7 @@ export function OnboardingCharacterStage({
   onEnterComplete,
   onSelectChar,
 }: OnboardingCharacterStageProps) {
-  const { w, h } = useViewport();
+  const { w, h } = useOnboardingStageSize();
   const reduce = useReducedMotion();
 
   // On narrow screens the side avatars sit behind the title/fields and feel
@@ -176,7 +163,7 @@ export function OnboardingCharacterStage({
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none fixed inset-0 z-0 overflow-hidden"
+      className="pointer-events-none absolute inset-0 z-0 overflow-hidden"
     >
       {/* Soft contact shadow under the centered avatar. */}
       <div

--- a/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
@@ -86,8 +86,8 @@ function CoinFace({ idSuffix }: { idSuffix: string }) {
 
       {/* Embossed dollar sign — soft emboss, bright gold. `textAnchor=middle`
           centers horizontally and `dy=0.355em` (~half the cap height) centers
-          vertically across browsers; we avoid `dominantBaseline` because iOS
-          WebKit renders it unreliably, which pushed the glyph off-center. */}
+          vertically across browsers; `dominantBaseline` is avoided because iOS
+          WebKit renders it unreliably. */}
       <g
         fontFamily="var(--font-sans), system-ui, sans-serif"
         fontWeight={900}

--- a/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-coin.tsx
@@ -84,17 +84,19 @@ function CoinFace({ idSuffix }: { idSuffix: string }) {
         strokeWidth="1.4"
       />
 
-      {/* Embossed dollar sign — soft emboss, bright gold. */}
+      {/* Embossed dollar sign — soft emboss, bright gold. `textAnchor=middle`
+          centers horizontally and `dy=0.355em` (~half the cap height) centers
+          vertically across browsers; we avoid `dominantBaseline` because iOS
+          WebKit renders it unreliably, which pushed the glyph off-center. */}
       <g
         fontFamily="var(--font-sans), system-ui, sans-serif"
         fontWeight={900}
         fontSize="58"
         textAnchor="middle"
-        dominantBaseline="central"
       >
-        <text x="50" y="52" fill="#C88E16" transform="translate(1.3 1.6)">$</text>
-        <text x="50" y="52" fill="#FFF6CF" opacity="0.7" transform="translate(-1.3 -1.5)">$</text>
-        <text x="50" y="52" fill="#F4C12A">$</text>
+        <text x="50" y="50" dy="0.355em" fill="#C88E16" transform="translate(1.3 1.6)">$</text>
+        <text x="50" y="50" dy="0.355em" fill="#FFF6CF" opacity="0.7" transform="translate(-1.3 -1.5)">$</text>
+        <text x="50" y="50" dy="0.355em" fill="#F4C12A">$</text>
       </g>
 
       {/* Gloss + hot-spot */}

--- a/clients/web/src/domains/onboarding/components/onboarding-motion-eyes.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-motion-eyes.tsx
@@ -9,58 +9,17 @@
  * `showBottomEyes={false}`) and swap in these without a visible jump.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { motion, useTransform, type MotionValue } from "motion/react";
 
+import { pathBBox, unionBBox, type BBox } from "@/domains/onboarding/components/eye-bbox";
+import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 const EYE_TARGET_HEIGHT = 0.3;
 const EYE_MAX_WIDTH = 0.85;
 const EYE_REST_CUTOFF = 0.25;
-
-type BBox = { x: number; y: number; w: number; h: number };
-
-/** Tight bounding box of a single path's absolute coords. */
-function pathBBox(d: string): BBox {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  const nums =
-    d.match(/-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?/gi)?.map(Number) ?? [];
-  for (let i = 0; i + 1 < nums.length; i += 2) {
-    const x = nums[i]!;
-    const y = nums[i + 1]!;
-    if (x < minX) minX = x;
-    if (y < minY) minY = y;
-    if (x > maxX) maxX = x;
-    if (y > maxY) maxY = y;
-  }
-  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
-}
-
-function unionBBox(boxes: BBox[]): BBox {
-  const minX = Math.min(...boxes.map((b) => b.x));
-  const minY = Math.min(...boxes.map((b) => b.y));
-  const maxX = Math.max(...boxes.map((b) => b.x + b.w));
-  const maxY = Math.max(...boxes.map((b) => b.y + b.h));
-  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
-}
-
-function useViewport() {
-  const [size, setSize] = useState(() => ({
-    w: typeof window === "undefined" ? 1280 : window.innerWidth,
-    h: typeof window === "undefined" ? 800 : window.innerHeight,
-  }));
-  useEffect(() => {
-    const onResize = () =>
-      setSize({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
 
 export interface OnboardingEyeArt {
   paths: { svgPath: string; color: string }[];
@@ -86,7 +45,7 @@ export function useOnboardingEyes(): OnboardingEyes {
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
-  const { w, h } = useViewport();
+  const { w, h } = useOnboardingStageSize();
 
   const art = useMemo<OnboardingEyeArt | null>(() => {
     if (!components || !chosen) return null;

--- a/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
@@ -16,37 +16,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 
+import { pathBBox, unionBBox } from "@/domains/onboarding/components/eye-bbox";
+import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
-
-type BBox = { x: number; y: number; w: number; h: number };
-
-/** Tight bounding box of a single path's absolute coords. */
-function pathBBox(d: string): BBox {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  const re = /-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?/gi;
-  const nums = d.match(re)?.map(Number) ?? [];
-  for (let i = 0; i + 1 < nums.length; i += 2) {
-    const x = nums[i]!;
-    const y = nums[i + 1]!;
-    if (x < minX) minX = x;
-    if (y < minY) minY = y;
-    if (x > maxX) maxX = x;
-    if (y > maxY) maxY = y;
-  }
-  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
-}
-
-function unionBBox(boxes: BBox[]): BBox {
-  const minX = Math.min(...boxes.map((b) => b.x));
-  const minY = Math.min(...boxes.map((b) => b.y));
-  const maxX = Math.max(...boxes.map((b) => b.x + b.w));
-  const maxY = Math.max(...boxes.map((b) => b.y + b.h));
-  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
-}
 
 /** How much of the eyes sits below the bottom edge — at rest, and at the dip. */
 const EYE_REST_CUTOFF = 0.25;
@@ -60,20 +33,6 @@ const PICKER_CENTER_VH = 40;
 /** Slight whole-eye cursor parallax. */
 const CURSOR_MAX_X = 14;
 const CURSOR_MAX_Y = 8;
-
-function useViewport() {
-  const [size, setSize] = useState(() => ({
-    w: typeof window === "undefined" ? 1280 : window.innerWidth,
-    h: typeof window === "undefined" ? 800 : window.innerHeight,
-  }));
-  useEffect(() => {
-    const onResize = () =>
-      setSize({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
 
 interface OnboardingPeekingEyesProps {
   /** Play the grow-in entrance (Introduction). Otherwise the eyes are at rest. */
@@ -102,7 +61,7 @@ export function OnboardingPeekingEyes({
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const reduce = useReducedMotion();
-  const { w, h } = useViewport();
+  const { w, h } = useOnboardingStageSize();
 
   const [pointer, setPointer] = useState({ x: 0, y: 0 });
   useEffect(() => {

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -14,27 +14,14 @@
  */
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboarding-peeking-eyes";
+import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { pickOverlayColors } from "@/domains/onboarding/onboarding-avatar-colors";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
-
-function useViewport() {
-  const [size, setSize] = useState(() => ({
-    w: typeof window === "undefined" ? 1280 : window.innerWidth,
-    h: typeof window === "undefined" ? 800 : window.innerHeight,
-  }));
-  useEffect(() => {
-    const onResize = () =>
-      setSize({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
 
 /**
  * The crowd that peeks in around the edges, in reveal order. The first few sit
@@ -103,7 +90,7 @@ export function OnboardingTonedBackdrop({
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const reduce = useReducedMotion();
-  const { w } = useViewport();
+  const { w } = useOnboardingStageSize();
   // Shrink the peeking characters on smaller screens (full size ≥ ~1100px wide).
   const peekScale = Math.max(0.42, Math.min(w / 1100, 1));
   // On narrow screens the content fills the middle, so the crowd retreats to a
@@ -201,7 +188,7 @@ export function OnboardingTonedBackdrop({
               <motion.div
                 key={`peek-${i}`}
                 aria-hidden="true"
-                className="pointer-events-none fixed z-[1]"
+                className="pointer-events-none absolute z-[1]"
                 style={{ ...position, width: size, height: size }}
                 initial={reduce ? false : { scale: 0, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}

--- a/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
+++ b/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
@@ -1,0 +1,104 @@
+/**
+ * Shared "stage size" for the research-onboarding decorative layers.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * The decorative layers (the avatar character stage, the edge/peeking crowd, the
+ * bottom eyes, the coin arc) used to measure `window.innerWidth/innerHeight` and
+ * position themselves `fixed`. On mobile that disagrees with the foreground
+ * content, which lives in the dvh-sized, safe-area-padded onboarding container
+ * (see `root-layout.tsx`): on iOS a `position: fixed` layer resolves against the
+ * full layout viewport while the container is shorter, so the centered avatar
+ * sat above the arrows, the edge cast didn't sit flush, and the page scrolled.
+ *
+ * Instead each onboarding screen measures its own `relative h-full` container
+ * (via `useElementSize`) and publishes that size here. The decorative layers
+ * read it with `useOnboardingStageSize()` and position themselves `absolute`
+ * inside that same container, so every layer shares one coordinate space. When
+ * no provider is present the hook falls back to the window size so standalone
+ * use never breaks.
+ */
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+export interface StageSize {
+  w: number;
+  h: number;
+}
+
+const FALLBACK: StageSize = { w: 1280, h: 800 };
+
+function windowSize(): StageSize {
+  if (typeof window === "undefined") return FALLBACK;
+  return { w: window.innerWidth, h: window.innerHeight };
+}
+
+export interface ElementSize {
+  /** Callback ref — attach to the element to measure (`<div ref={ref}>`). */
+  ref: (el: HTMLElement | null) => void;
+  size: StageSize;
+}
+
+/**
+ * Measure an element's box, kept live via `ResizeObserver`. Uses a callback ref
+ * (stored in state) so it re-measures whenever the element mounts/unmounts —
+ * robust to containers that appear after the first render (e.g. a step that's
+ * conditionally rendered). Returns the window size until the element mounts.
+ */
+export function useElementSize(): ElementSize {
+  const [el, setEl] = useState<HTMLElement | null>(null);
+  const [size, setSize] = useState<StageSize>(() => windowSize());
+
+  useLayoutEffect(() => {
+    if (!el) return;
+    const measure = () => {
+      const rect = el.getBoundingClientRect();
+      setSize({ w: rect.width, h: rect.height });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [el]);
+
+  return { ref: setEl, size };
+}
+
+const OnboardingStageSizeContext = createContext<StageSize | null>(null);
+
+export function OnboardingStageSizeProvider({
+  size,
+  children,
+}: {
+  size: StageSize;
+  children: ReactNode;
+}) {
+  return (
+    <OnboardingStageSizeContext.Provider value={size}>
+      {children}
+    </OnboardingStageSizeContext.Provider>
+  );
+}
+
+/**
+ * The size of the onboarding stage container. Falls back to the window size
+ * (kept live on resize) when used outside a provider.
+ */
+export function useOnboardingStageSize(): StageSize {
+  const ctx = useContext(OnboardingStageSizeContext);
+  const [fallback, setFallback] = useState<StageSize>(() => windowSize());
+  useEffect(() => {
+    if (ctx) return; // a provider supplies the size; no need to track the window
+    const onResize = () => setFallback(windowSize());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [ctx]);
+  return ctx ?? fallback;
+}

--- a/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
+++ b/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
@@ -4,19 +4,16 @@
  * SPIKE — research-onboarding flow.
  *
  * The decorative layers (the avatar character stage, the edge/peeking crowd, the
- * bottom eyes, the coin arc) used to measure `window.innerWidth/innerHeight` and
- * position themselves `fixed`. On mobile that disagrees with the foreground
- * content, which lives in the dvh-sized, safe-area-padded onboarding container
- * (see `root-layout.tsx`): on iOS a `position: fixed` layer resolves against the
- * full layout viewport while the container is shorter, so the centered avatar
- * sat above the arrows, the edge cast didn't sit flush, and the page scrolled.
- *
- * Instead each onboarding screen measures its own `relative h-full` container
- * (via `useElementSize`) and publishes that size here. The decorative layers
- * read it with `useOnboardingStageSize()` and position themselves `absolute`
- * inside that same container, so every layer shares one coordinate space. When
- * no provider is present the hook falls back to the window size so standalone
- * use never breaks.
+ * bottom eyes, the coin arc) and the foreground content must share one
+ * coordinate space. Each onboarding screen measures its own `relative h-full`
+ * container — the dvh-sized, safe-area-padded onboarding box (see
+ * `root-layout.tsx`) — via `useElementSize` and publishes that size here. The
+ * decorative layers read it with `useOnboardingStageSize()` and position
+ * themselves `absolute` inside that same container, so they line up with the
+ * `%`-positioned foreground regardless of mobile viewport quirks (on iOS a
+ * `position: fixed` layer measured from `window.innerHeight` resolves against
+ * the taller layout viewport, not this container). When no provider is present
+ * the hook falls back to the window size so standalone use never breaks.
  */
 
 import {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -56,6 +56,10 @@ import {
   SuggestionsStep,
 } from "@/domains/onboarding/screens/research-result-steps";
 import { OnboardingTonedBackdrop } from "@/domains/onboarding/components/onboarding-toned-backdrop";
+import {
+  OnboardingStageSizeProvider,
+  useElementSize,
+} from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 
 type ResearchStep =
   | "form"
@@ -89,6 +93,10 @@ export function ResearchOnboardingRoute() {
   // persistent backdrop so the avatars/eyes stay put. The handoff fires from
   // the "let's chat tomorrow" step (or the picker's skip).
   const [step, setStep] = useState<ResearchStep>("form");
+  // Measure the shared toned-step container so the persistent backdrop, eyes,
+  // peekers, and coin all position against the same box as the foreground
+  // content (see use-onboarding-stage-size).
+  const { ref: tonedStageRef, size: tonedStageSize } = useElementSize();
   // Forward-history (redo) stack: pushed when the user steps back, popped when
   // they step forward via the header's forward chevron. The chevron only shows
   // while this is non-empty — i.e. only after a back. A deliberate forward move
@@ -359,7 +367,8 @@ export function ResearchOnboardingRoute() {
       ? edgeAvatars
       : 0;
     return (
-      <div data-theme="dark" className="relative h-full overflow-hidden">
+      <div ref={tonedStageRef} data-theme="dark" className="relative h-full overflow-hidden">
+        <OnboardingStageSizeProvider size={tonedStageSize}>
         <OnboardingTonedBackdrop
           eyesBumpNonce={eyesBump}
           peekLevel={peekLevel}
@@ -449,6 +458,7 @@ export function ResearchOnboardingRoute() {
             onForward={onForward}
           />
         )}
+        </OnboardingStageSizeProvider>
       </div>
     );
   }

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -19,6 +19,10 @@ import { ArrowLeft, ArrowRight, Pencil } from "lucide-react";
 
 import { OnboardingCharacterStage } from "@/domains/onboarding/components/onboarding-character-stage";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import {
+  OnboardingStageSizeProvider,
+  useElementSize,
+} from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import type { CharacterTraits } from "@/types/avatar";
@@ -76,6 +80,10 @@ export function GiveMeAFaceScreen({
   // so their custom name survives cycling through avatars.
   const nameCustomized = useRef(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
+  // Measure this screen's container so the decorative stage shares the exact
+  // coordinate space as the foreground arrows/title/buttons (see
+  // use-onboarding-stage-size).
+  const { ref: stageRef, size: stageSize } = useElementSize();
   // The current swap: the newly selected char + the slot it came from
   // (entering), and the old center + the slot it's heading to (exiting).
   const [swap, setSwap] = useState<{
@@ -151,9 +159,11 @@ export function GiveMeAFaceScreen({
 
   return (
     <div
+      ref={stageRef}
       data-theme="dark"
       className="relative h-full overflow-hidden bg-[var(--surface-base)] text-[var(--content-default)]"
     >
+      <OnboardingStageSizeProvider size={stageSize}>
       {ready && (
         <OnboardingCharacterStage
           components={components}
@@ -256,6 +266,7 @@ export function GiveMeAFaceScreen({
           Continue
         </Button>
       </div>
+      </OnboardingStageSizeProvider>
     </div>
   );
 }

--- a/clients/web/src/domains/onboarding/screens/integration-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/integration-step.tsx
@@ -14,6 +14,7 @@ import { motion, useReducedMotion } from "motion/react";
 
 import { OnboardingCoin } from "@/domains/onboarding/components/onboarding-coin";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 
 interface IntegrationStepProps {
@@ -38,6 +39,7 @@ export function IntegrationStep({
 }: IntegrationStepProps) {
   const reduce = useReducedMotion();
   const tone = useOnboardingTone();
+  const { h: vh } = useOnboardingStageSize();
   const [claiming, setClaiming] = useState(false);
 
   function handleClaim() {
@@ -51,7 +53,6 @@ export function IntegrationStep({
     window.setTimeout(onBumpEyes, DROP * 1000);
   }
 
-  const vh = typeof window === "undefined" ? 800 : window.innerHeight;
   const dropY = vh * 0.42; // down to the eyes
   const apexY = -vh * 0.08; // bumped just a little above the start
   const fallY = vh * 0.9; // falls away off the bottom

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -143,9 +143,9 @@ export function PitchStep({
 
   // Push the text/Continue block up so it doesn't crowd the eyes peeking from
   // the bottom — more so on short viewports, where the three lines + button and
-  // the eyes are otherwise tight. The eye-wipe "above" target tracks this. On
-  // phones the previous 12% left the Continue button stranded high with a big
-  // gap above the eyes, so the short-screen block sits a touch lower now.
+  // the eyes are otherwise tight. The eye-wipe "above" target tracks this. The
+  // short-screen offset stays modest so the Continue button sits close to the
+  // text rather than stranded high above the eyes.
   const shortScreen = h > 0 && h <= 800;
   const contentTopFrac = shortScreen ? 0.17 : 0.22;
   const topClass = shortScreen ? "top-[17%]" : "top-[22%]";

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -143,10 +143,12 @@ export function PitchStep({
 
   // Push the text/Continue block up so it doesn't crowd the eyes peeking from
   // the bottom — more so on short viewports, where the three lines + button and
-  // the eyes are otherwise tight. The eye-wipe "above" target tracks this.
+  // the eyes are otherwise tight. The eye-wipe "above" target tracks this. On
+  // phones the previous 12% left the Continue button stranded high with a big
+  // gap above the eyes, so the short-screen block sits a touch lower now.
   const shortScreen = h > 0 && h <= 800;
-  const contentTopFrac = shortScreen ? 0.12 : 0.22;
-  const topClass = shortScreen ? "top-[12%]" : "top-[22%]";
+  const contentTopFrac = shortScreen ? 0.17 : 0.22;
+  const topClass = shortScreen ? "top-[17%]" : "top-[22%]";
 
   // The assistant's eyes rise to wipe the first lines in, then settle at rest.
   const eyeCy = useMotionValue(0);

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -11,13 +11,17 @@
  * greeting bounces in with the Continue button.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
 import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboarding-peeking-eyes";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import {
+  OnboardingStageSizeProvider,
+  useElementSize,
+} from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
@@ -36,20 +40,6 @@ interface IntroductionScreenProps {
 const PICKER_SIZE = 200;
 const PICKER_CENTER_VH = 40;
 
-function useViewport() {
-  const [size, setSize] = useState(() => ({
-    w: typeof window === "undefined" ? 1280 : window.innerWidth,
-    h: typeof window === "undefined" ? 800 : window.innerHeight,
-  }));
-  useEffect(() => {
-    const onResize = () =>
-      setSize({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
-
 export function IntroductionScreen({
   firstName,
   assistantName,
@@ -61,7 +51,12 @@ export function IntroductionScreen({
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const reduce = useReducedMotion();
-  const { w, h } = useViewport();
+  // Measure this screen's container so the body grow and the peeking eyes share
+  // one coordinate space (see use-onboarding-stage-size).
+  const {
+    ref: stageRef,
+    size: { w, h },
+  } = useElementSize();
   const tone = useOnboardingTone();
 
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
@@ -100,10 +95,11 @@ export function IntroductionScreen({
   return (
     // Starts on the picker's dark surface; the color layer below fades in.
     <div
+      ref={stageRef}
       data-theme="dark"
       className="relative h-full overflow-hidden"
       style={{ backgroundColor: "var(--surface-base)" }}
-    >
+    ><OnboardingStageSizeProvider size={{ w, h }}>
       {/* The avatar color fills in so coverage is end-to-end even where the
           body shape has gaps/spikes. */}
       <motion.div
@@ -184,6 +180,7 @@ export function IntroductionScreen({
           <ArrowRight className="h-4 w-4" />
         </motion.button>
       </div>
+      </OnboardingStageSizeProvider>
     </div>
   );
 }


### PR DESCRIPTION
## Context
iPhone (Chrome) QA on the SPIKE research-onboarding flow (`/assistant/onboarding/research`) surfaced several **purely visual** defects. This PR fixes them with **no behavioral change** and aims to avoid desktop regressions.

## Bugs fixed
1. **Picker ("Give me a face and a name")** — the selected avatar wasn't vertically centered between the arrows, edge characters weren't flush to the top/bottom, and the page scrolled.
2. **Pitch screen** — the Continue button sat too high with a large empty gap above the eyes.
3. **Flat-top / "lazy" (`grumpy`) eyes** rendered small/squished vs other eye styles (general, not mobile-only).
4. **Credits coin** — the `$` wasn't centered on iOS.

## Root causes & approach
- **Bugs 1+2 + scrolling — coordinate-space mismatch.** Decorative layers measured `window.innerHeight` and positioned `position: fixed`, which on iOS resolves to the *layout* viewport — taller than the `100dvh`/safe-area-padded onboarding container the foreground (`%` of `h-full`) uses. Unified them: each screen measures its own `relative h-full` container via a new `useElementSize` callback-ref hook and publishes it through `OnboardingStageSizeProvider`; the decorative layers now read that and position `absolute` inside the container. `overflow-hidden` then clips them (no scroll), and `0.4×containerH` (avatar) lines up with `top-[40%]` (arrows).
- **Bug 3 — bbox parser.** The naive "pair every number as (x, y)" parser desynced on the single-coordinate `H` lineto command, which **only** the `grumpy` style uses, so it alone parsed to a bogus near-square box. New command-aware parser in `eye-bbox.ts` (shared by peeking + motion eyes); the eight `M/C`-only styles parse identically to before.
- **Bug 4 — coin `$`.** Replaced `dominant-baseline="central"` (unreliable on iOS WebKit) with `text-anchor="middle"` + `dy="0.355em"`.
- **Bug 2 tuning** — nudged the pitch step's short-viewport content from `top-[12%]` to `top-[17%]`.

## New files
- `clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx`
- `clients/web/src/domains/onboarding/components/eye-bbox.ts`

## Out of scope (regression guard)
The form screen's `OnboardingEdgeCharacters` lives in a *scrollable* layout and had no reported bug — left untouched.

## Verification
- `bunx tsc --noEmit` — clean
- `eslint` on changed files — clean (only pre-existing warnings in untouched files)
- `vite build` — succeeds
- `audit:cross-domain:check` — clean
- Onboarding test suite: 7 failures are pre-existing on `main` (assistant repair/retire dialogs + an `ApiError` codegen link issue), unrelated to these changes.

⚠️ Still needs **device QA** (real iPhone Chrome + Safari) per the build-before-merge workflow — these are visual fixes and the exact `top-[17%]` value may want on-device tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)