### PR TITLE
fix(ci): correct truncated actions/checkout SHA in create-release-branch

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -248,7 +248,7 @@ jobs:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447e83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary
The pinned SHA for `actions/checkout` in `create-release-branch.yml` was truncated to 39 characters (`...5447e83dd`), causing the workflow to fail with `unable to resolve action`. Corrected to the full 40-char SHA (`...5447ce83dd` / v6.0.2) used by every other workflow in the repo.

## Verification
All 123 `actions/checkout` references across `.github/workflows/` now point to the same correct SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)