### PR TITLE
feat(profiles): managed Balanced profile reasoning effort high -> medium

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -52,7 +52,7 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
     maxTokens: 32000,
-    effort: "high",
+    effort: "medium",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
     topP: 0.95,


### PR DESCRIPTION
## Summary
- Change the managed `balanced` inference profile template's reasoning effort from `high` to `medium` in `seed-inference-profiles.ts`.
- Managed profiles are overwritten on every daemon boot, so this propagates to customers on the next release.

## Original prompt
Lower the managed Balanced profile's reasoning effort from high to medium. The Balanced profile (served by MiniMax M3 on Together AI via managed platform inference) currently runs at high reasoning effort; this dials it back to medium.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->