### PR TITLE
fix(profiles): show topP and effort controls for Together AI profiles

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -32,6 +32,7 @@ describe("resolveProfileParamVisibility", () => {
       resolveProfileParamVisibility("fireworks", "accounts/fireworks/models/minimax-m3").topP,
     ).toBe(true);
     expect(resolveProfileParamVisibility("openrouter", "anthropic/claude-fable-5").topP).toBe(true);
+    expect(resolveProfileParamVisibility("together", "MiniMaxAI/MiniMax-M3").topP).toBe(true);
     // Custom OpenAI-compatible connections route through the OpenAI adapter,
     // which forwards top_p — so the control must be visible for them too.
     expect(resolveProfileParamVisibility("openai-compatible", "some-custom-model").topP).toBe(true);
@@ -64,6 +65,17 @@ describe("resolveProfileParamVisibility", () => {
     const vis = resolveProfileParamVisibility("openrouter", "anthropic/claude-fable-5");
     expect(vis.effort).toBe(true);
     expect(vis.thinking).toBe(false);
+  });
+
+  test("together MiniMax M3 enables effort and topP", () => {
+    const vis = resolveProfileParamVisibility("together", "MiniMaxAI/MiniMax-M3");
+    // Together is an OpenAI-compatible endpoint whose chat-completions client
+    // forwards both top_p and reasoning_effort; MiniMax M3 is a reasoning model
+    // (supportsThinking in the catalog), so effort is adjustable too.
+    expect(vis.effort).toBe(true);
+    expect(vis.topP).toBe(true);
+    // Temperature stays Anthropic-wire only; Together doesn't get it.
+    expect(vis.temperature).toBe(false);
   });
 
   test("anthropic opus enables speed", () => {

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -133,6 +133,9 @@ function supportsEffort(provider: string, modelId: string, supportsThinking: boo
   if (provider === "fireworks") {
     return supportsThinking;
   }
+  if (provider === "together") {
+    return supportsThinking;
+  }
   return false;
 }
 
@@ -149,6 +152,7 @@ const TOP_P_OPENAI_COMPAT_PROVIDERS = new Set([
   "atlascloud",
   "ollama",
   "openrouter",
+  "together",
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Together AI profiles hid the **top P** and **effort** controls in the profile editor, even after duplicating to a custom profile. The cause was purely client-side gating: `resolveProfileParamVisibility` (`clients/web/src/domains/settings/ai/profile-param-visibility.ts`) never listed `"together"` in `TOP_P_OPENAI_COMPAT_PROVIDERS` nor gave it a branch in `supportsEffort`, so both resolved to `false`.
- Verified the daemon already forwards these params: `TogetherProvider` extends `OpenAIChatCompletionsProvider`, which sends `top_p` and `reasoning_effort` from the profile config, and sets `maxReasoningEffort: "high"`. The Together catalog entry for MiniMax M3 is `supportsThinking: true`, so effort is genuinely adjustable. The fix only unhides controls for params we already plumb.
- Added test coverage for Together (topP + effort visible, temperature still hidden as it's Anthropic-wire only).

## Original prompt
Investigating why some parameters weren't editable on the MiniMax-M3-on-Together model profile. Narrowed it to the parameter-visibility resolver (not the managed-profile lock): `top P` and `effort` were hidden because the `together` provider id was missing from both visibility allowlists, despite the OpenAI-compatible Together client forwarding both on the wire. Asked to fix it and confirm Together actually accepts and that we actually send these parameters.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->