### PR TITLE
fix(contacts): make ContactSummary.role optional to unbreak main typecheck

### DIFF
--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -588,7 +588,8 @@ export function ContactsPage({
           displayName: guardian.displayName.startsWith("vellum-principal-")
             ? ""
             : guardian.displayName,
-          role: guardian.role,
+          // Selected via role === "guardian"; .find doesn't narrow the payload's optional role.
+          role: guardian.role ?? "guardian",
           channelTypes: channelTypeLabels(guardian.channels, a2aChannel),
         }
       : null,

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -588,8 +588,7 @@ export function ContactsPage({
           displayName: guardian.displayName.startsWith("vellum-principal-")
             ? ""
             : guardian.displayName,
-          // Selected via role === "guardian"; .find doesn't narrow the payload's optional role.
-          role: guardian.role ?? "guardian",
+          role: guardian.role,
           channelTypes: channelTypeLabels(guardian.channels, a2aChannel),
         }
       : null,

--- a/clients/web/src/domains/contacts/types.ts
+++ b/clients/web/src/domains/contacts/types.ts
@@ -28,7 +28,8 @@ export type ContactSelection =
 export interface ContactSummary {
   id: string;
   displayName: string;
-  role: "guardian" | "assistant" | string;
+  // Optional to match the contacts payload, which does not guarantee a role.
+  role?: "guardian" | "assistant" | string;
   contactType?: string | null;
   channelTypes?: string[];
 }


### PR DESCRIPTION
## Summary

`main`'s web typecheck (`tsc --noEmit`) is **red on every push**: `contacts-page.tsx` builds the `ContactsList` `guardian` and `regularContacts` props from `ContactPayload` (whose `role` is **optional**), but `ContactSummary.role` was **required** — so `role` is `string | undefined` and fails the check. Introduced by the Contacts → Channels refactor (#36019).

## Fix

Make **`ContactSummary.role` optional** — one line in `types.ts`.

- **Matches the data:** `ContactPayload.role` is optional, so a contact summary's role isn't guaranteed.
- **Zero blast radius:** `ContactSummary` is consumed only by `ContactsList`, and both `.role` reads feed `<ContactRow>`, whose `role` prop is already `string | null | undefined`.
- **Fixes both sites at once** (`guardian` + `regularContacts`) with no invented call-site defaults — a regular contact has no sensible fallback for a missing role.

(First pushed a per-site coalesce on `guardian`; `tsc` then surfaced the same issue in `regularContacts`, which confirmed the type-level fix is the right one. Reverted the coalesce — final diff is the single `types.ts` line.)

## Why it surfaced now
#36019 merged green against its base, but the combination on `main` was never type-checked together (a stale-but-green merge), so `main`'s `tsc` has been red since — every push fails. Found via the post-merge run of an unrelated Sentry PR (#36030).

@noanflaherty — this is from your #36019 guardian wiring; I went with making the type optional rather than coalescing per-site (regularContacts had no sensible default, and the row component already handles optional role). Flagging in case you'd model it differently in your contacts work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC31UT45yjNX9m1CtLkFbr