### PR TITLE
feat(onboarding): per-step funnel events for research-onboarding flow

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -4,12 +4,15 @@ import {
   __resetOnboardingFunnelEventsForTests,
   buildOnboardingFunnelEvent,
   emitOnboardingFunnelStepCompleted,
+  emitResearchOnboardingStepCompleted,
   onboardingFunnelVariantFromExperiment,
   ONBOARDING_FUNNEL_STEPS,
   ONBOARDING_FUNNEL_VERSION,
   ONBOARDING_FUNNEL_VARIANTS,
   readOnboardingFunnelVariant,
   resolveOnboardingFunnelVariant,
+  RESEARCH_ONBOARDING_FUNNEL_STEPS,
+  RESEARCH_ONBOARDING_FUNNEL_VERSION,
 } from "@/domains/onboarding/funnel-events";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 
@@ -143,6 +146,73 @@ describe("onboarding funnel events", () => {
       funnel_version: ONBOARDING_FUNNEL_VERSION,
       ab_variant: "pared_down",
     });
+  });
+
+  test("stamps research-onboarding steps with the research funnel version", () => {
+    localStorage.setItem("device:share_analytics", "true");
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
+      userId: "user-123",
+    });
+    // Skipping a step is still a completion of that step (same as the pre-chat
+    // funnel — Continue and Skip both emit the step-completed event).
+    emitResearchOnboardingStepCompleted(
+      RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
+      { userId: "user-123" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const calls = fetchMock.mock.calls as Array<
+      [RequestInfo | URL, RequestInit | undefined]
+    >;
+    const firstEvent = (
+      JSON.parse(calls[0]?.[1]?.body as string) as {
+        events: Array<Record<string, unknown>>;
+      }
+    ).events[0];
+    const secondEvent = (
+      JSON.parse(calls[1]?.[1]?.body as string) as {
+        events: Array<Record<string, unknown>>;
+      }
+    ).events[0];
+
+    expect(calls[0]?.[0]).toBe("/v1/telemetry/ingest/");
+    expect(firstEvent).toMatchObject({
+      type: "onboarding",
+      screen: "research_form",
+      step_name: "research_form",
+      step_index: 0,
+      user_id: "user-123",
+      funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+      ab_variant: "control",
+    });
+    // Shares the funnel session id with the rest of the journey.
+    expect(secondEvent?.session_id).toBe(firstEvent?.session_id);
+    expect(secondEvent).toMatchObject({
+      step_name: "research_suggestions",
+      step_index: 9,
+      funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+    });
+  });
+
+  test("does not emit research telemetry until analytics sharing is opted in", () => {
+    useOnboardingStore.setState({ shareAnalytics: false });
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
+      userId: "user-123",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("does not emit telemetry until analytics sharing is explicitly opted in", () => {

--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -159,11 +159,10 @@ describe("onboarding funnel events", () => {
     emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
       userId: "user-123",
     });
-    // Skipping a step is still a completion of that step (same as the pre-chat
-    // funnel — Continue and Skip both emit the step-completed event).
+    // A skip is recorded against the same step, tagged outcome: "skipped".
     emitResearchOnboardingStepCompleted(
       RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-      { userId: "user-123" },
+      { userId: "user-123", outcome: "skipped" },
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -190,6 +189,8 @@ describe("onboarding funnel events", () => {
       user_id: "user-123",
       funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
       ab_variant: "control",
+      // Continue-only steps default to "completed".
+      outcome: "completed",
     });
     // Shares the funnel session id with the rest of the journey.
     expect(secondEvent?.session_id).toBe(firstEvent?.session_id);
@@ -197,6 +198,7 @@ describe("onboarding funnel events", () => {
       step_name: "research_suggestions",
       step_index: 9,
       funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+      outcome: "skipped",
     });
   });
 

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -1,5 +1,6 @@
 import { readShareAnalytics } from "@/domains/onboarding/prefs";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import type { ResearchStep } from "@/domains/onboarding/research-onboarding-persistence";
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
 const SESSION_STORAGE_KEY = "onboarding.funnelSessionId";
@@ -37,18 +38,54 @@ export type OnboardingFunnelStep =
 
 export type OnboardingFunnelStepName = OnboardingFunnelStep["stepName"];
 
+/**
+ * Structural shape every funnel step descriptor satisfies. Lets the emit/build
+ * helpers serve multiple funnels (the pre-chat funnel and the research-onboarding
+ * funnel below) without pinning the step-name union to one funnel's steps.
+ */
+export interface OnboardingFunnelStepDescriptor {
+  stepName: string;
+  stepIndex: number;
+}
+
+/**
+ * Research-onboarding funnel. A distinct funnel from the pre-chat one above — its
+ * own version string and step names — but it rides the same telemetry event shape
+ * and ingest path. The backend stores step_name/funnel_version as open strings, so
+ * these new values need no backend/terraform change.
+ */
+export const RESEARCH_ONBOARDING_FUNNEL_VERSION = "research_onboarding_v1_2026_06";
+
+export const RESEARCH_ONBOARDING_FUNNEL_STEPS = {
+  form: { stepName: "research_form", stepIndex: 0 },
+  face: { stepName: "research_face", stepIndex: 1 },
+  intro: { stepName: "research_intro", stepIndex: 2 },
+  different: { stepName: "research_pitch", stepIndex: 3 },
+  integration: { stepName: "research_integration", stepIndex: 4 },
+  letschat: { stepName: "research_calendar", stepIndex: 5 },
+  meeting: { stepName: "research_meeting", stepIndex: 6 },
+  looking: { stepName: "research_looking", stepIndex: 7 },
+  results: { stepName: "research_results", stepIndex: 8 },
+  suggestions: { stepName: "research_suggestions", stepIndex: 9 },
+} as const satisfies Record<ResearchStep, OnboardingFunnelStepDescriptor>;
+
+export type ResearchOnboardingFunnelStep =
+  (typeof RESEARCH_ONBOARDING_FUNNEL_STEPS)[keyof typeof RESEARCH_ONBOARDING_FUNNEL_STEPS];
+
 export interface OnboardingFunnelStepCompletedOptions {
   userId?: string | null;
   variant?: OnboardingFunnelVariant;
+  /** Funnel this step belongs to; defaults to the pre-chat funnel version. */
+  funnelVersion?: string;
 }
 
 export interface OnboardingFunnelEvent {
   type: "onboarding";
   daemon_event_id: string;
   recorded_at: number;
-  screen: OnboardingFunnelStepName;
+  screen: string;
   session_id: string;
-  step_name: OnboardingFunnelStepName;
+  step_name: string;
   step_index: number;
   completed_at: string;
   user_id: string | null;
@@ -114,7 +151,7 @@ export function resolveOnboardingFunnelVariant(
 }
 
 export function buildOnboardingFunnelEvent(
-  screen: OnboardingFunnelStep,
+  screen: OnboardingFunnelStepDescriptor,
   options: OnboardingFunnelStepCompletedOptions = {},
 ): OnboardingFunnelEvent {
   const now = Date.now();
@@ -132,13 +169,13 @@ export function buildOnboardingFunnelEvent(
     step_index: screen.stepIndex,
     completed_at: new Date(now).toISOString(),
     user_id: options.userId ?? null,
-    funnel_version: ONBOARDING_FUNNEL_VERSION,
+    funnel_version: options.funnelVersion ?? ONBOARDING_FUNNEL_VERSION,
     ab_variant: variant,
   };
 }
 
 export function emitOnboardingFunnelStepCompleted(
-  screen: OnboardingFunnelStep,
+  screen: OnboardingFunnelStepDescriptor,
   options: OnboardingFunnelStepCompletedOptions = {},
 ): void {
   if (typeof window === "undefined") return;
@@ -158,6 +195,26 @@ export function emitOnboardingFunnelStepCompleted(
     body: payload,
     keepalive: true,
   }).catch(() => {});
+}
+
+/**
+ * Emit a research-onboarding step as completed. Fired whenever the user leaves a
+ * step — whether by continuing or skipping — mirroring the pre-chat funnel, which
+ * emits the same step-completed event on both its Continue and Skip handlers.
+ *
+ * The research flow has no A/B arm, so events are stamped with the `control`
+ * variant (passed explicitly so this never reads the pre-chat funnel's stored
+ * variant) and the research funnel version.
+ */
+export function emitResearchOnboardingStepCompleted(
+  step: ResearchOnboardingFunnelStep,
+  options: { userId?: string | null } = {},
+): void {
+  emitOnboardingFunnelStepCompleted(step, {
+    userId: options.userId,
+    variant: ONBOARDING_FUNNEL_VARIANTS.control,
+    funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+  });
 }
 
 export function __resetOnboardingFunnelEventsForTests(): void {

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -72,11 +72,21 @@ export const RESEARCH_ONBOARDING_FUNNEL_STEPS = {
 export type ResearchOnboardingFunnelStep =
   (typeof RESEARCH_ONBOARDING_FUNNEL_STEPS)[keyof typeof RESEARCH_ONBOARDING_FUNNEL_STEPS];
 
+/**
+ * How the user left a step: `completed` (clicked the primary Continue/action) vs
+ * `skipped` (clicked Skip). Lets analytics tell a deliberate completion apart
+ * from a skip on steps that offer both. The pre-chat funnel omits this (it never
+ * distinguished the two), so it ingests as null there.
+ */
+export type OnboardingFunnelStepOutcome = "completed" | "skipped";
+
 export interface OnboardingFunnelStepCompletedOptions {
   userId?: string | null;
   variant?: OnboardingFunnelVariant;
   /** Funnel this step belongs to; defaults to the pre-chat funnel version. */
   funnelVersion?: string;
+  /** Completed vs skipped; omitted when the funnel doesn't distinguish. */
+  outcome?: OnboardingFunnelStepOutcome;
 }
 
 export interface OnboardingFunnelEvent {
@@ -91,6 +101,8 @@ export interface OnboardingFunnelEvent {
   user_id: string | null;
   funnel_version: string;
   ab_variant: OnboardingFunnelVariant;
+  /** Completed vs skipped; absent when the funnel doesn't distinguish. */
+  outcome?: OnboardingFunnelStepOutcome;
 }
 
 function stripUndefined(value: object): Record<string, unknown> {
@@ -171,6 +183,8 @@ export function buildOnboardingFunnelEvent(
     user_id: options.userId ?? null,
     funnel_version: options.funnelVersion ?? ONBOARDING_FUNNEL_VERSION,
     ab_variant: variant,
+    // Omitted (→ stripped before send) unless the caller distinguishes the two.
+    outcome: options.outcome,
   };
 }
 
@@ -205,15 +219,19 @@ export function emitOnboardingFunnelStepCompleted(
  * The research flow has no A/B arm, so events are stamped with the `control`
  * variant (passed explicitly so this never reads the pre-chat funnel's stored
  * variant) and the research funnel version.
+ *
+ * `outcome` records whether the step was completed (Continue) or skipped;
+ * defaults to `completed` for the Continue-only steps.
  */
 export function emitResearchOnboardingStepCompleted(
   step: ResearchOnboardingFunnelStep,
-  options: { userId?: string | null } = {},
+  options: { userId?: string | null; outcome?: OnboardingFunnelStepOutcome } = {},
 ): void {
   emitOnboardingFunnelStepCompleted(step, {
     userId: options.userId,
     variant: ONBOARDING_FUNNEL_VARIANTS.control,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+    outcome: options.outcome ?? "completed",
   });
 }
 

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -46,6 +46,7 @@ import {
 import {
   emitResearchOnboardingStepCompleted,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
+  type OnboardingFunnelStepOutcome,
 } from "@/domains/onboarding/funnel-events";
 import { scheduleCheckin } from "@/domains/onboarding/checkin-scheduler";
 import { GOOGLE_CALENDAR_EVENTS_SCOPE } from "@/domains/onboarding/hooks/use-google-calendar-connect";
@@ -131,13 +132,17 @@ export function ResearchOnboardingRoute() {
     setStep(next);
   }
   // Forward (Continue/Skip): a fresh forward move invalidates the redo stack.
-  // Every forward move records the step being LEFT as completed — matching the
-  // pre-chat funnel, which fires the same step-completed event from both its
-  // Continue and Skip handlers (so skips show up as completions of that step).
-  // Back/redo moves deliberately don't emit.
-  function goForwardTo(next: ResearchStep) {
+  // Every forward move records the step being LEFT, tagged with how it was left
+  // (`completed` for Continue, `skipped` for a Skip) so analytics can tell a
+  // deliberate completion apart from a skip. Defaults to `completed`; the skip
+  // affordances pass `skipped` explicitly. Back/redo moves deliberately don't emit.
+  function goForwardTo(
+    next: ResearchStep,
+    outcome: OnboardingFunnelStepOutcome = "completed",
+  ) {
     emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS[step], {
       userId,
+      outcome,
     });
     setForwardStack([]);
     navTo(next);
@@ -530,7 +535,7 @@ export function ResearchOnboardingRoute() {
             onRetry={() => setMissingCalendarScope(false)}
             onSkip={() => {
               setMissingCalendarScope(false);
-              goForwardTo("looking");
+              goForwardTo("looking", "skipped");
             }}
             onBack={() => goBackTo("integration")}
             onForward={onForward}
@@ -574,7 +579,7 @@ export function ResearchOnboardingRoute() {
               // pre-chat funnel emitting on its final step before completeFlow).
               emitResearchOnboardingStepCompleted(
                 RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-                { userId },
+                { userId, outcome: "completed" },
               );
               // Wait out any background capability installs so the new chat can
               // discover their skills (else it silently degrades to a generic
@@ -584,11 +589,10 @@ export function ResearchOnboardingRoute() {
               enterAssistant(formValues, faceValues, suggestion.prompt);
             }}
             onSkip={async () => {
-              // Skip is still a completion of the suggestions step (same as the
-              // pre-chat funnel, where Skip and Continue emit the same event).
+              // "Skip to Chat" — record the suggestions step as skipped.
               emitResearchOnboardingStepCompleted(
                 RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-                { userId },
+                { userId, outcome: "skipped" },
               );
               await research.awaitPluginInstalls();
               enterAssistant(formValues, faceValues, undefined, { skip: true });

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -43,6 +43,10 @@ import {
   writeResearchSnapshot,
   type ResearchStep,
 } from "@/domains/onboarding/research-onboarding-persistence";
+import {
+  emitResearchOnboardingStepCompleted,
+  RESEARCH_ONBOARDING_FUNNEL_STEPS,
+} from "@/domains/onboarding/funnel-events";
 import { scheduleCheckin } from "@/domains/onboarding/checkin-scheduler";
 import { GOOGLE_CALENDAR_EVENTS_SCOPE } from "@/domains/onboarding/hooks/use-google-calendar-connect";
 import { formatCheckinTime } from "@/domains/onboarding/format-checkin-time";
@@ -127,7 +131,14 @@ export function ResearchOnboardingRoute() {
     setStep(next);
   }
   // Forward (Continue/Skip): a fresh forward move invalidates the redo stack.
+  // Every forward move records the step being LEFT as completed — matching the
+  // pre-chat funnel, which fires the same step-completed event from both its
+  // Continue and Skip handlers (so skips show up as completions of that step).
+  // Back/redo moves deliberately don't emit.
   function goForwardTo(next: ResearchStep) {
+    emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS[step], {
+      userId,
+    });
     setForwardStack([]);
     navTo(next);
   }
@@ -558,6 +569,13 @@ export function ResearchOnboardingRoute() {
             loading={researchLoading}
             installedPlugins={research.installedPlugins}
             onSuggestionClick={async (suggestion) => {
+              // Terminal step: the handoff leaves via enterAssistant, not
+              // goForwardTo, so emit the suggestions completion here (mirrors the
+              // pre-chat funnel emitting on its final step before completeFlow).
+              emitResearchOnboardingStepCompleted(
+                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
+                { userId },
+              );
               // Wait out any background capability installs so the new chat can
               // discover their skills (else it silently degrades to a generic
               // prompt). Usually instant — installs kicked off while the user
@@ -566,6 +584,12 @@ export function ResearchOnboardingRoute() {
               enterAssistant(formValues, faceValues, suggestion.prompt);
             }}
             onSkip={async () => {
+              // Skip is still a completion of the suggestions step (same as the
+              // pre-chat funnel, where Skip and Continue emit the same event).
+              emitResearchOnboardingStepCompleted(
+                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
+                { userId },
+              );
               await research.awaitPluginInstalls();
               enterAssistant(formValues, faceValues, undefined, { skip: true });
             }}


### PR DESCRIPTION
## What

Adds per-step funnel telemetry to the **research-onboarding** flow, mirroring the existing pre-chat funnel. A step event fires whenever the user leaves a step — via either **Continue** or **Skip** — and is tagged with an **`outcome`** (`"completed"` vs `"skipped"`) so analytics can tell a deliberate completion apart from a skip.

## Changes

**`funnel-events.ts`**
- `RESEARCH_ONBOARDING_FUNNEL_VERSION = "research_onboarding_v1_2026_06"` (distinct funnel)
- `RESEARCH_ONBOARDING_FUNNEL_STEPS` — all 10 `ResearchStep`s → `{ stepName, stepIndex }`, `satisfies Record<ResearchStep, …>` so it stays in sync if a step is added/removed
- `OnboardingFunnelStepOutcome = "completed" | "skipped"` + `outcome` on the event/options
- `emitResearchOnboardingStepCompleted()` — stamps the research funnel version, an explicit `control` variant (no A/B arm; explicit so it never reads the pre-chat funnel's stored variant), and `outcome` (defaults to `completed`)
- Generalized `build`/`emit` to a structural step descriptor + optional `funnelVersion`/`outcome`. Existing pre-chat callers unchanged — they omit `outcome`, so it's stripped before send and ingests as null.

**`research-onboarding-route.tsx`**
- `goForwardTo(next, outcome = "completed")` emits the step being **left**; the calendar-step Skip passes `"skipped"`. Back/redo deliberately don't emit.
- The terminal `suggestions` step hands off via `enterAssistant` (not `goForwardTo`), so it's emitted directly: a suggestion click → `completed`, "Skip to Chat" → `skipped`.

Only the calendar step and the suggestions step have a Skip affordance today; every other step is Continue-only (`completed`).

**Tests** — `funnel-events.test.ts` covers research funnel version/variant/step-shape, shared session id, `outcome` (completed default + skipped), and analytics-opt-in gating. 8/8 pass; eslint + tsc clean for these files.

## Merge order (this is the last of three PRs)
Backend support for the `outcome` field is already in place:
1. ✅ vellum-ai/vellum-assistant-platform#8676 — Terraform BigQuery column — **merged + applied** (column exists in Dev/Staging/Prod).
2. ✅ vellum-ai/vellum-assistant-platform#8675 — Django serializer + dbt — **merged**.
3. 👉 **This PR** — web client emits `outcome`. Safe to merge now.

## Notes
- Intentional gap: the rare auto-skip effect (`results → suggestions` when research resolves empty *while* on results) bypasses `goForwardTo` and won't emit a `results` event — it's a programmatic correction, not a user action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)