### PR TITLE
Make stale/consumed confirmations a benign no-op instead of 404 (LUM-2542/2552)

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -388,7 +388,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await stopServer();
     });
 
-    test("returns 404 for unknown requestId", async () => {
+    test("returns a benign already-resolved result for unknown requestId", async () => {
       await startServer(() => makeIdleSession());
 
       const res = await fetch(url("confirm"), {
@@ -397,12 +397,18 @@ describe("standalone approval endpoints — HTTP layer", () => {
         body: JSON.stringify({ requestId: "nonexistent", decision: "allow" }),
       });
 
-      expect(res.status).toBe(404);
+      // Stale/unknown confirmations are a benign no-op, not a hard 404
+      // (LUM-2542/2552) — the card is merely stale, not an error condition.
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        accepted: false,
+        reason: "already_resolved",
+      });
 
       await stopServer();
     });
 
-    test("returns 404 for already-resolved requestId", async () => {
+    test("returns a benign already-resolved result for an already-consumed requestId", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
@@ -419,13 +425,18 @@ describe("standalone approval endpoints — HTTP layer", () => {
       });
       expect(res1.status).toBe(200);
 
-      // Second resolution fails (already consumed)
+      // Second resolution is a benign no-op (entry already consumed), not a 404 —
+      // a late/duplicate click on a stale card must not error (LUM-2542/2552).
       const res2 = await fetch(url("confirm"), {
         method: "POST",
         headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
         body: JSON.stringify({ requestId: "req-once", decision: "deny" }),
       });
-      expect(res2.status).toBe(404);
+      expect(res2.status).toBe(200);
+      expect(await res2.json()).toEqual({
+        accepted: false,
+        reason: "already_resolved",
+      });
 
       await stopServer();
     });

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -50,11 +50,17 @@ function handleConfirm({ body }: RouteHandlerArgs) {
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {
-    log.warn(
+    // Idempotent / benign: the interaction was already resolved — auto-denied
+    // when a newer message superseded it, timed out, or the turn aborted —
+    // before this late click landed. A hard 404 surfaces a scary error on a
+    // merely-stale card and leaves the conversation looking stuck
+    // (LUM-2542/2552). Return an already-resolved result so the client can drop
+    // the card without an error instead of throwing.
+    log.info(
       { requestId, decision },
-      "Confirmation POST for unknown requestId (already consumed or never registered)",
+      "Confirmation POST for already-resolved/unknown requestId — benign no-op",
     );
-    throw new NotFoundError("No pending interaction found for this requestId");
+    return { accepted: false, reason: "already_resolved" as const };
   }
 
   const effectiveDecision =
@@ -127,9 +133,7 @@ function handleSecret({ body }: RouteHandlerArgs) {
   // undefined) so the request settles cleanly rather than 400-ing and stranding
   // the pending interaction.
   const isCancel = delivery === "none";
-  const value = isCancel
-    ? undefined
-    : (body?.value as string | undefined);
+  const value = isCancel ? undefined : (body?.value as string | undefined);
 
   if (
     delivery !== undefined &&


### PR DESCRIPTION
## What & why

`LUM-2542` + `LUM-2552`. `POST /v1/confirm` hard-threw a 404 (`NotFoundError`) when the pending interaction was already gone — which happens routinely: a newer user message auto-denies and removes the pending confirmation, or it times out / the turn aborts, before a late **Allow** click lands. The user then saw **"no pending interaction found for this requestID"** (2542) on a merely-stale card, and the conversation looked **stuck behind a dead prompt** (2552).

## Fix

Return a benign already-resolved result (`{ accepted: false, reason: "already_resolved" }`, HTTP 200) on a tracker miss instead of throwing. A late/duplicate click on a stale card now no-ops cleanly.

## Note — web follow-up

Fully clearing a *raced-but-still-visible* card also needs the web client to treat this benign response (and the original `interaction_resolved` event) as terminal and drop the card. That's a small client-side follow-up; **this PR is the daemon half** — it kills the error and hands the client a clean "already resolved" signal.

## Tests

The two former 404 assertions in `approval-routes-http.test.ts` now assert the benign 200 result (unknown id + already-consumed id). Typecheck + lint clean; 18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtJTFw6vPz9mr2qoFFdjg1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtJTFw6vPz9mr2qoFFdjg1)_