### PR TITLE
feat(acp): forward usage_update as acp_session_usage (used/size/cost)

### DIFF
--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -218,6 +218,94 @@ describe("VellumAcpClientHandler seq + enriched fields", () => {
     });
   });
 
+  test("usage_update is forwarded as acp_session_usage with mapped fields and no seq", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 1200,
+        size: 200000,
+        cost: { amount: 0.42, currency: "USD" },
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: "acp_session_usage",
+      acpSessionId: ACP_SESSION_ID,
+      usedTokens: 1200,
+      contextSize: 200000,
+      costAmount: 0.42,
+      costCurrency: "USD",
+    });
+    // Usage is a side gauge, not part of the ordered timeline — no seq.
+    expect(sent[0]).not.toHaveProperty("seq");
+  });
+
+  test("usage_update without cost yields undefined costAmount/costCurrency", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 50,
+        size: 100,
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: "acp_session_usage",
+      usedTokens: 50,
+      contextSize: 100,
+      costAmount: undefined,
+      costCurrency: undefined,
+    });
+  });
+
+  test("usage_update does not advance the seq counter", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 1,
+        size: 2,
+      },
+    });
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "after usage" },
+      },
+    });
+
+    // The first real update must still start at seq 1.
+    expect((sent[1] as { seq: number }).seq).toBe(1);
+  });
+
+  test("usage_update is dropped during replay suppression", async () => {
+    const { handler, sent } = makeHandler();
+
+    handler.beginReplaySuppression();
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 10,
+        size: 20,
+        cost: { amount: 1, currency: "USD" },
+      },
+    });
+
+    expect(sent).toHaveLength(0);
+  });
+
   test("tool_call_update carries toolTitle and toolKind", async () => {
     const { handler, sent } = makeHandler();
 

--- a/assistant/src/acp/__tests__/session-manager-usage.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Verifies that an ACP `usage_update` flowing through a live session is
+ * recorded on the session's `latestUsage`, reachable via `getStatus()`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+
+import type { AcpSessionState } from "../types.js";
+
+// Captures the client-handler factory each fake process is constructed with
+// so tests can drive session updates through the real wiring (the wrapped
+// sender that records `latestUsage`).
+type HandlerFactory = (agent: unknown) => {
+  sessionUpdate(params: SessionNotification): Promise<void>;
+};
+const handlerFactories: HandlerFactory[] = [];
+
+mock.module("../agent-process.js", () => ({
+  AcpAgentProcess: class FakeAcpAgentProcess {
+    constructor(
+      public readonly agentId: string,
+      _config: unknown,
+      factory: HandlerFactory,
+    ) {
+      handlerFactories.push(factory);
+    }
+    spawn(_cwd: string): void {}
+    async initialize(): Promise<void> {}
+    async createSession(_cwd: string): Promise<string> {
+      return `proto-${this.agentId}`;
+    }
+    async prompt(): Promise<{ stopReason: string }> {
+      return new Promise(() => {});
+    }
+    async cancel(): Promise<void> {}
+    kill(): void {}
+  },
+}));
+
+const { AcpSessionManager } = await import("../session-manager.js");
+
+describe("AcpSessionManager — latestUsage tracking", () => {
+  const noopSend = () => {};
+
+  test("records latestUsage from a usage_update on the session state", async () => {
+    handlerFactories.length = 0;
+    const manager = new AcpSessionManager(5);
+
+    const { acpSessionId } = await manager.spawn(
+      "agent-usage",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-parent",
+      noopSend,
+    );
+
+    const handler = handlerFactories[handlerFactories.length - 1]?.(undefined);
+    expect(handler).toBeDefined();
+
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 1200,
+        size: 200000,
+        cost: { amount: 0.42, currency: "USD" },
+      },
+    });
+
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.latestUsage).toEqual({
+      usedTokens: 1200,
+      contextSize: 200000,
+      costAmount: 0.42,
+      costCurrency: "USD",
+    });
+  });
+
+  test("latestUsage omits cost fields when usage_update carries no cost", async () => {
+    handlerFactories.length = 0;
+    const manager = new AcpSessionManager(5);
+
+    const { acpSessionId } = await manager.spawn(
+      "agent-usage-nocost",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-parent",
+      noopSend,
+    );
+
+    const handler = handlerFactories[handlerFactories.length - 1]?.(undefined);
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 50,
+        size: 100,
+      },
+    });
+
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.latestUsage).toEqual({
+      usedTokens: 50,
+      contextSize: 100,
+      costAmount: undefined,
+      costCurrency: undefined,
+    });
+  });
+});

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -192,10 +192,24 @@ export class VellumAcpClientHandler implements Client {
         break;
       }
 
+      case "usage_update": {
+        // Side gauge of context-window usage; no seq (not part of the
+        // ordered timeline). UNSTABLE: cost may be absent.
+        this.sendToVellum({
+          type: "acp_session_usage",
+          acpSessionId: this.acpSessionId,
+          usedTokens: update.used,
+          contextSize: update.size,
+          costAmount: update.cost?.amount,
+          costCurrency: update.cost?.currency,
+        });
+        break;
+      }
+
       default: {
         // Other update types (available_commands_update, current_mode_update,
-        // config_option_update, session_info_update, usage_update) are not
-        // forwarded to Vellum.
+        // config_option_update, session_info_update) are not forwarded to
+        // Vellum.
         log.debug(
           {
             acpSessionId: this.acpSessionId,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -289,6 +289,18 @@ export class AcpSessionManager {
     const wrappedSend = (msg: ServerMessage) => {
       if (msg.type === "acp_session_update") {
         this.appendToBuffer(acpSessionId, msg);
+      } else if (msg.type === "acp_session_usage") {
+        // Track the latest usage gauge so a terminal transition can persist
+        // the final snapshot.
+        const state = this.sessions.get(acpSessionId)?.state;
+        if (state) {
+          state.latestUsage = {
+            usedTokens: msg.usedTokens,
+            contextSize: msg.contextSize,
+            costAmount: msg.costAmount,
+            costCurrency: msg.costCurrency,
+          };
+        }
       }
       opts.sendToVellum(msg);
     };

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -32,4 +32,14 @@ export interface AcpSessionState {
   task?: string;
   /** Tool-use id of the `acp_spawn` call that spawned this session, if any. */
   parentToolUseId?: string;
+  /** Latest context-window usage gauge, from the most recent `usage_update`. */
+  latestUsage?: AcpUsageSnapshot;
+}
+
+/** Context-window usage snapshot tracked from ACP `usage_update`. */
+export interface AcpUsageSnapshot {
+  usedTokens: number;
+  contextSize: number;
+  costAmount?: number;
+  costCurrency?: string;
 }

--- a/assistant/src/api/events/acp-session-usage.ts
+++ b/assistant/src/api/events/acp-session-usage.ts
@@ -1,0 +1,29 @@
+/**
+ * `acp_session_usage` SSE event.
+ *
+ * Server → client gauge of an ACP session's context-window usage,
+ * forwarded from the ACP `usage_update` notification. `usedTokens` is
+ * the tokens currently in context, `contextSize` the window size; the
+ * optional `costAmount`/`costCurrency` mirror the agent's cumulative
+ * cost. A side gauge, not part of the ordered update timeline — carries
+ * no `seq`.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AcpSessionUsageEventSchema = z
+  .object({
+    type: z.literal("acp_session_usage"),
+    acpSessionId: z.string(),
+    usedTokens: z.number(),
+    contextSize: z.number(),
+    costAmount: z.number().optional(),
+    costCurrency: z.string().optional(),
+  })
+  .strict();
+
+export type AcpSessionUsageEvent = z.infer<typeof AcpSessionUsageEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -4,6 +4,7 @@ import { AcpSessionCompletedEventSchema } from "./events/acp-session-completed.j
 import { AcpSessionErrorEventSchema } from "./events/acp-session-error.js";
 import { AcpSessionSpawnedEventSchema } from "./events/acp-session-spawned.js";
 import { AcpSessionUpdateEventSchema } from "./events/acp-session-update.js";
+import { AcpSessionUsageEventSchema } from "./events/acp-session-usage.js";
 import { AssistantActivityStateEventSchema } from "./events/assistant-activity-state.js";
 import { AssistantTextDeltaEventSchema } from "./events/assistant-text-delta.js";
 import { AssistantThinkingDeltaEventSchema } from "./events/assistant-thinking-delta.js";
@@ -91,6 +92,10 @@ export {
   type AcpSessionUpdateType,
   AcpSessionUpdateTypeSchema,
 } from "./events/acp-session-update.js";
+export {
+  type AcpSessionUsageEvent,
+  AcpSessionUsageEventSchema,
+} from "./events/acp-session-usage.js";
 export {
   type AssistantActivityAnchor,
   AssistantActivityAnchorSchema,
@@ -532,6 +537,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   AcpSessionErrorEventSchema,
   AcpSessionSpawnedEventSchema,
   AcpSessionUpdateEventSchema,
+  AcpSessionUsageEventSchema,
   AssistantActivityStateEventSchema,
   AssistantTextDeltaEventSchema,
   AssistantThinkingDeltaEventSchema,

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -51,10 +51,20 @@ export interface AcpSessionError {
   error: string;
 }
 
+export interface AcpSessionUsage {
+  type: "acp_session_usage";
+  acpSessionId: string;
+  usedTokens: number;
+  contextSize: number;
+  costAmount?: number;
+  costCurrency?: string;
+}
+
 // --- Domain-level union alias (consumed by message-protocol.ts) ---
 
 export type _AcpServerMessages =
   | AcpSessionSpawned
   | AcpSessionUpdate
   | AcpSessionCompleted
-  | AcpSessionError;
+  | AcpSessionError
+  | AcpSessionUsage;


### PR DESCRIPTION
## Summary
- Stop dropping the ACP usage_update event; forward it as a new acp_session_usage event ({usedTokens, contextSize, costAmount?, costCurrency?})
- Track latestUsage on the session for terminal persistence

Part of plan: acp-usage-meter-persistence.md (PR 1 of 5)