### PR TITLE
feat(acp): persist task/parentToolUseId/usage for terminal sessions

### DIFF
--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -22,6 +22,12 @@ export interface HistoryRow {
   error: string | null;
   event_log_json: string;
   cwd: string | null;
+  task: string | null;
+  parent_tool_use_id: string | null;
+  used_tokens: number | null;
+  context_size: number | null;
+  cost_amount: number | null;
+  cost_currency: string | null;
 }
 
 export function clearHistory(): void {
@@ -46,14 +52,21 @@ export function insertHistoryRow(row: {
   error?: string | null;
   eventLogJson?: string;
   cwd?: string | null;
+  task?: string | null;
+  parentToolUseId?: string | null;
+  usedTokens?: number | null;
+  contextSize?: number | null;
+  costAmount?: number | null;
+  costCurrency?: string | null;
 }): void {
   getSqlite()
     .query(
       `INSERT INTO acp_session_history (
          id, agent_id, acp_session_id, parent_conversation_id,
          started_at, completed_at, status, stop_reason, error,
-         event_log_json, cwd
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         event_log_json, cwd, task, parent_tool_use_id,
+         used_tokens, context_size, cost_amount, cost_currency
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       row.id,
@@ -67,6 +80,12 @@ export function insertHistoryRow(row: {
       row.error ?? null,
       row.eventLogJson ?? "[]",
       row.cwd === undefined ? "/tmp/proj" : row.cwd,
+      row.task ?? null,
+      row.parentToolUseId ?? null,
+      row.usedTokens ?? null,
+      row.contextSize ?? null,
+      row.costAmount ?? null,
+      row.costCurrency ?? null,
     );
 }
 
@@ -75,7 +94,8 @@ export function readHistoryRow(id: string): HistoryRow | null {
     .query(
       `SELECT id, agent_id, acp_session_id, parent_conversation_id,
               started_at, completed_at, status, stop_reason, error,
-              event_log_json, cwd
+              event_log_json, cwd, task, parent_tool_use_id,
+              used_tokens, context_size, cost_amount, cost_currency
        FROM acp_session_history WHERE id = ?`,
     )
     .get(id) as HistoryRow | null;

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -19,6 +19,7 @@ mock.module("../../util/logger.js", () => ({
 
 import { VellumAcpClientHandler } from "../../acp/client-handler.js";
 import { AcpSessionManager } from "../../acp/session-manager.js";
+import type { AcpUsageSnapshot } from "../../acp/types.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
 import { getSqlite } from "../../memory/db-connection.js";
@@ -40,6 +41,9 @@ function buildSessionWithFakeProcess(opts: {
   protocolSessionId: string;
   parentConversationId: string;
   cwd?: string;
+  task?: string;
+  parentToolUseId?: string;
+  latestUsage?: AcpUsageSnapshot;
 }): {
   manager: AcpSessionManager;
   resolvePrompt: (v: { stopReason: string }) => void;
@@ -100,6 +104,9 @@ function buildSessionWithFakeProcess(opts: {
       acpSessionId: opts.protocolSessionId,
       status: "running",
       startedAt: Date.now(),
+      task: opts.task,
+      parentToolUseId: opts.parentToolUseId,
+      latestUsage: opts.latestUsage,
     },
     clientHandler,
     sendToVellum: wrappedSend,
@@ -341,6 +348,61 @@ describe("AcpSessionManager — terminal persistence", () => {
     const row = readHistoryRow(id);
     expect(row).not.toBeNull();
     expect(row!.cwd).toBe("/Users/me/projects/widget");
+  });
+
+  test("persists task, parentToolUseId, and the latest usage snapshot on terminal transition", async () => {
+    const id = "session-usage-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-usage",
+      protocolSessionId: "proto-usage",
+      parentConversationId: "conv-usage",
+      task: "Summarize the report",
+      parentToolUseId: "tool-use-123",
+      latestUsage: {
+        usedTokens: 4200,
+        contextSize: 200_000,
+        costAmount: 0.0123,
+        costCurrency: "USD",
+      },
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.task).toBe("Summarize the report");
+    expect(row!.parent_tool_use_id).toBe("tool-use-123");
+    expect(row!.used_tokens).toBe(4200);
+    expect(row!.context_size).toBe(200_000);
+    expect(row!.cost_amount).toBe(0.0123);
+    expect(row!.cost_currency).toBe("USD");
+  });
+
+  test("persists NULL usage columns when latestUsage is undefined", async () => {
+    const id = "session-no-usage-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-no-usage",
+      protocolSessionId: "proto-no-usage",
+      parentConversationId: "conv-no-usage",
+      task: "Do work without usage",
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.task).toBe("Do work without usage");
+    expect(row!.parent_tool_use_id).toBeNull();
+    expect(row!.used_tokens).toBeNull();
+    expect(row!.context_size).toBeNull();
+    expect(row!.cost_amount).toBeNull();
+    expect(row!.cost_currency).toBeNull();
   });
 
   test("legacy rows without a cwd read back as null", () => {

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -103,6 +103,20 @@ class FakeAcpAgentProcess {
     });
   }
 
+  /** Drives a usage_update through the real client handler. */
+  async emitUsage(used: number, size: number, cost?: number): Promise<void> {
+    await this.clientFactory(this).sessionUpdate({
+      sessionId: "proto-old",
+      update: {
+        sessionUpdate: "usage_update",
+        used,
+        size,
+        cost:
+          cost === undefined ? undefined : { amount: cost, currency: "USD" },
+      },
+    });
+  }
+
   prompt(sessionId: string, text: string): Promise<{ stopReason: string }> {
     if (promptThrowsSync) {
       throw new Error("prompt transport dead");
@@ -621,6 +635,75 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(log).toHaveLength(2);
     expect(log[0]!.content).toBe("original-run-chunk");
     expect(log[1]!.content).toBe("resumed-run-chunk");
+  });
+
+  test("re-terminate after a resume preserves the persisted task/parentToolUseId/usage when no fresh usage_update fires", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({
+      id: "resume-meta-1",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+      task: "Summarize the report",
+      parentToolUseId: "tool-use-123",
+      usedTokens: 4200,
+      contextSize: 200_000,
+      costAmount: 0.0123,
+      costCurrency: "USD",
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-meta-1", () => {});
+    await manager.steer("resume-meta-1", "keep going");
+
+    const fake = fakeInstances[0]!;
+    // No usage_update emitted during the resumed run.
+    fake.resolvePrompt!({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow("resume-meta-1")!;
+    expect(row.status).toBe("completed");
+    // The metadata seeded from the prior row is re-persisted, not NULLed.
+    expect(row.task).toBe("Summarize the report");
+    expect(row.parent_tool_use_id).toBe("tool-use-123");
+    expect(row.used_tokens).toBe(4200);
+    expect(row.context_size).toBe(200_000);
+    expect(row.cost_amount).toBe(0.0123);
+    expect(row.cost_currency).toBe("USD");
+  });
+
+  test("re-terminate after a resume persists fresh usage from a usage_update during the resumed run", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({
+      id: "resume-meta-2",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+      task: "Summarize the report",
+      parentToolUseId: "tool-use-123",
+      usedTokens: 4200,
+      contextSize: 200_000,
+      costAmount: 0.0123,
+      costCurrency: "USD",
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-meta-2", () => {});
+    await manager.steer("resume-meta-2", "keep going");
+
+    const fake = fakeInstances[0]!;
+    // A fresh usage_update lands during the resumed run.
+    await fake.emitUsage(9000, 200_000, 0.05);
+
+    fake.resolvePrompt!({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow("resume-meta-2")!;
+    // Task/parentToolUseId still carried from the seeded state; usage updated.
+    expect(row.task).toBe("Summarize the report");
+    expect(row.parent_tool_use_id).toBe("tool-use-123");
+    expect(row.used_tokens).toBe(9000);
+    expect(row.context_size).toBe(200_000);
+    expect(row.cost_amount).toBe(0.05);
+    expect(row.cost_currency).toBe("USD");
   });
 
   test("concurrent resumes of the same id: one wins, the loser fails cleanly without leaking a process", async () => {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -484,6 +484,13 @@ export class AcpSessionManager {
       cwd: row.cwd,
       startedAt: row.startedAt,
       sendToVellum,
+      // Carry the persisted metadata onto the fresh in-memory state so the
+      // next terminal upsert rewrites the same values instead of NULLing
+      // them. A resumed run only emits a usage_update if it does fresh work;
+      // without seeding, a resume->re-terminate would clobber the stored
+      // task/parentToolUseId/usage.
+      task: row.task ?? undefined,
+      parentToolUseId: row.parentToolUseId ?? undefined,
     });
 
     log.info(
@@ -491,6 +498,19 @@ export class AcpSessionManager {
       "ACP resume from history requested",
     );
     const { process: agentProcess, state } = entry;
+
+    // Seed the latest usage snapshot from the persisted columns. A fresh
+    // usage_update during the resumed run overwrites this; if none fires the
+    // prior snapshot is re-persisted on terminal transition. Pre-migration
+    // rows have null token columns and leave latestUsage undefined.
+    if (row.usedTokens !== null && row.contextSize !== null) {
+      state.latestUsage = {
+        usedTokens: row.usedTokens,
+        contextSize: row.contextSize,
+        costAmount: row.costAmount ?? undefined,
+        costCurrency: row.costCurrency ?? undefined,
+      };
+    }
 
     // Re-seed the ring buffer from the persisted event log, routed through
     // appendToBuffer so the count/byte caps still apply. The terminal

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -877,6 +877,15 @@ export class AcpSessionManager {
     // Serialize only the wire-shaped updates — drop the byte-size accounting
     // metadata so persisted rows match the protocol shape clients receive.
     const eventLogJson = JSON.stringify(buffer.map((b) => b.update));
+    const usage = entry.state.latestUsage;
+    const usageColumns = {
+      task: entry.state.task ?? null,
+      parentToolUseId: entry.state.parentToolUseId ?? null,
+      usedTokens: usage?.usedTokens ?? null,
+      contextSize: usage?.contextSize ?? null,
+      costAmount: usage?.costAmount ?? null,
+      costCurrency: usage?.costCurrency ?? null,
+    };
     try {
       getDb()
         .insert(acpSessionHistory)
@@ -892,6 +901,7 @@ export class AcpSessionManager {
           error: entry.state.error ?? null,
           eventLogJson,
           cwd: entry.cwd,
+          ...usageColumns,
         })
         .onConflictDoUpdate({
           target: acpSessionHistory.id,
@@ -902,6 +912,7 @@ export class AcpSessionManager {
             error: entry.state.error ?? null,
             eventLogJson,
             cwd: entry.cwd,
+            ...usageColumns,
           },
         })
         .run();

--- a/assistant/src/runtime/routes/acp-routes-event-log.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-event-log.test.ts
@@ -52,7 +52,7 @@ function getListHandler() {
 function makeInMemoryState(
   id: string,
   parentConversationId: string,
-  extra?: Pick<AcpSessionState, "task" | "parentToolUseId">,
+  extra?: Pick<AcpSessionState, "task" | "parentToolUseId" | "latestUsage">,
 ): AcpSessionState {
   return {
     id,
@@ -153,8 +153,80 @@ describe("GET /v1/acp/sessions — eventLog", () => {
     expect(eventLog).toHaveLength(1);
     expect(eventLog[0]?.seq).toBe(7);
     expect(eventLog[0]?.content).toBe("persisted");
-    // No acp_session_history columns for these, so terminal rows omit them.
+  });
+
+  test("active in-memory session surfaces latestUsage as the usage fields", async () => {
+    inMemoryStates.set(
+      "active",
+      makeInMemoryState("active", "conv-1", {
+        latestUsage: {
+          usedTokens: 1234,
+          contextSize: 200_000,
+          costAmount: 0.5,
+          costCurrency: "USD",
+        },
+      }),
+    );
+
+    const handler = getListHandler();
+    const result = (await handler({
+      queryParams: { conversationId: "conv-1" },
+    })) as { sessions: Array<Record<string, unknown>> };
+
+    const session = result.sessions.find((s) => s.id === "active");
+    expect(session).toBeDefined();
+    expect(session?.usedTokens).toBe(1234);
+    expect(session?.contextSize).toBe(200_000);
+    expect(session?.costAmount).toBe(0.5);
+    expect(session?.costCurrency).toBe("USD");
+  });
+
+  test("terminal DB row returns persisted task, parentToolUseId, and usage", async () => {
+    insertHistoryRow({
+      id: "terminal-usage",
+      parentConversationId: "conv-1",
+      task: "Refactor the parser",
+      parentToolUseId: "tool-use-xyz",
+      usedTokens: 8000,
+      contextSize: 200_000,
+      costAmount: 0.0456,
+      costCurrency: "USD",
+    });
+
+    const handler = getListHandler();
+    const result = (await handler({
+      queryParams: { conversationId: "conv-1" },
+    })) as { sessions: Array<Record<string, unknown>> };
+
+    const session = result.sessions.find((s) => s.id === "terminal-usage");
+    expect(session).toBeDefined();
+    expect(session?.task).toBe("Refactor the parser");
+    expect(session?.parentToolUseId).toBe("tool-use-xyz");
+    expect(session?.usedTokens).toBe(8000);
+    expect(session?.contextSize).toBe(200_000);
+    expect(session?.costAmount).toBe(0.0456);
+    expect(session?.costCurrency).toBe("USD");
+  });
+
+  test("pre-migration terminal row (NULL usage columns) degrades to undefined", async () => {
+    insertHistoryRow({
+      id: "terminal-legacy",
+      parentConversationId: "conv-1",
+      // task/parentToolUseId/usage columns default to NULL.
+    });
+
+    const handler = getListHandler();
+    const result = (await handler({
+      queryParams: { conversationId: "conv-1" },
+    })) as { sessions: Array<Record<string, unknown>> };
+
+    const session = result.sessions.find((s) => s.id === "terminal-legacy");
+    expect(session).toBeDefined();
     expect(session?.task).toBeUndefined();
     expect(session?.parentToolUseId).toBeUndefined();
+    expect(session?.usedTokens).toBeUndefined();
+    expect(session?.contextSize).toBeUndefined();
+    expect(session?.costAmount).toBeUndefined();
+    expect(session?.costCurrency).toBeUndefined();
   });
 });

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -52,6 +52,10 @@ const sessionEntrySchema = z.object({
   stopReason: z.string().nullable().optional(),
   task: z.string().optional(),
   parentToolUseId: z.string().optional(),
+  usedTokens: z.number().optional(),
+  contextSize: z.number().optional(),
+  costAmount: z.number().optional(),
+  costCurrency: z.string().optional(),
   eventLog: z.array(z.unknown()).optional(),
 });
 
@@ -693,6 +697,10 @@ function listMergedSessions(opts: {
       stopReason: s.stopReason ?? null,
       task: s.task,
       parentToolUseId: s.parentToolUseId,
+      usedTokens: s.latestUsage?.usedTokens,
+      contextSize: s.latestUsage?.contextSize,
+      costAmount: s.latestUsage?.costAmount,
+      costCurrency: s.latestUsage?.costCurrency,
       eventLog: manager.getBufferedUpdates(s.id),
     });
   }
@@ -727,8 +735,8 @@ function listMergedSessions(opts: {
         "Failed to parse event_log_json for ACP session history row",
       );
     }
-    // Terminal rows omit task and parentToolUseId — acp_session_history has no
-    // columns for them, so they degrade to undefined here.
+    // Rows predating the usage migration carry NULLs for these columns and
+    // degrade to undefined.
     merged.set(row.id, {
       id: row.id,
       agentId: row.agentId,
@@ -739,6 +747,12 @@ function listMergedSessions(opts: {
       completedAt: row.completedAt,
       error: row.error,
       stopReason: row.stopReason,
+      task: row.task ?? undefined,
+      parentToolUseId: row.parentToolUseId ?? undefined,
+      usedTokens: row.usedTokens ?? undefined,
+      contextSize: row.contextSize ?? undefined,
+      costAmount: row.costAmount ?? undefined,
+      costCurrency: row.costCurrency ?? undefined,
       eventLog,
     });
   }


### PR DESCRIPTION
## Summary
- Persist task, parentToolUseId, and the latest usage snapshot to acp_session_history on terminal transition
- /acp/sessions returns task/parentToolUseId/usage for terminal rows (and active rows surface live usage); sessionEntrySchema declares the usage fields

Part of plan: acp-usage-meter-persistence.md (PR 4 of 5)