### PR TITLE
feat(web): wire ACP usage meter to used/size/cost

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -67,9 +67,10 @@ describe("spawnRun", () => {
     // Daemon emits `acp_session_spawned` only after the session is running.
     expect(entry.status).toBe("running");
     expect(entry.startedAt).toBe(NOW);
-    expect(entry.inputTokens).toBe(0);
-    expect(entry.outputTokens).toBe(0);
-    expect(entry.totalCost).toBe(0);
+    expect(entry.usedTokens).toBe(0);
+    expect(entry.contextSize).toBe(0);
+    expect(entry.costAmount).toBeUndefined();
+    expect(entry.costCurrency).toBeUndefined();
     expect(entry.events).toEqual([]);
   });
 
@@ -427,24 +428,25 @@ describe("updateUsage", () => {
     spawn();
     getState().updateUsage({
       acpSessionId: "acp-1",
-      inputTokens: 1500,
-      outputTokens: 500,
-      totalCost: 0.003,
+      usedTokens: 1500,
+      contextSize: 200000,
+      costAmount: 0.003,
+      costCurrency: "USD",
     });
 
     const entry = getState().byId["acp-1"]!;
-    expect(entry.inputTokens).toBe(1500);
-    expect(entry.outputTokens).toBe(500);
-    expect(entry.totalCost).toBe(0.003);
+    expect(entry.usedTokens).toBe(1500);
+    expect(entry.contextSize).toBe(200000);
+    expect(entry.costAmount).toBe(0.003);
+    expect(entry.costCurrency).toBe("USD");
   });
 
   it("ignores an unknown session", () => {
     const before = { ...getState().byId };
     getState().updateUsage({
       acpSessionId: "acp-missing",
-      inputTokens: 1,
-      outputTokens: 1,
-      totalCost: 1,
+      usedTokens: 1,
+      contextSize: 1,
     });
 
     expect(getState().byId).toEqual(before);
@@ -462,9 +464,8 @@ function historyEntry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
     parentConversationId: "conv-1",
     status: "completed",
     startedAt: NOW,
-    inputTokens: 0,
-    outputTokens: 0,
-    totalCost: 0,
+    usedTokens: 0,
+    contextSize: 0,
     events: [],
     ...overrides,
   };
@@ -581,9 +582,10 @@ describe("seedFromHistory", () => {
         status: "completed",
         completedAt: NOW + 5000,
         stopReason: "end_turn",
-        inputTokens: 1200,
-        outputTokens: 340,
-        totalCost: 0.012,
+        usedTokens: 1200,
+        contextSize: 200000,
+        costAmount: 0.012,
+        costCurrency: "USD",
         events: [event({ seq: 1, content: "stale" }), event({ seq: 2 })],
       }),
     ]);
@@ -596,9 +598,10 @@ describe("seedFromHistory", () => {
     expect(entry.status).toBe("completed");
     expect(entry.completedAt).toBe(NOW + 5000);
     expect(entry.stopReason).toBe("end_turn");
-    expect(entry.inputTokens).toBe(1200);
-    expect(entry.outputTokens).toBe(340);
-    expect(entry.totalCost).toBe(0.012);
+    expect(entry.usedTokens).toBe(1200);
+    expect(entry.contextSize).toBe(200000);
+    expect(entry.costAmount).toBe(0.012);
+    expect(entry.costCurrency).toBe("USD");
   });
 
   it("does not regress a live terminal entry with empty/non-terminal history metadata", () => {
@@ -611,18 +614,18 @@ describe("seedFromHistory", () => {
     });
     getState().updateUsage({
       acpSessionId: "acp-1",
-      inputTokens: 900,
-      outputTokens: 100,
-      totalCost: 0.005,
+      usedTokens: 900,
+      contextSize: 200000,
+      costAmount: 0.005,
+      costCurrency: "USD",
     });
 
     getState().seedFromHistory([
       historyEntry({
         acpSessionId: "acp-1",
         status: "running",
-        inputTokens: 0,
-        outputTokens: 0,
-        totalCost: 0,
+        usedTokens: 0,
+        contextSize: 0,
         events: [],
       }),
     ]);
@@ -630,9 +633,10 @@ describe("seedFromHistory", () => {
     const entry = getState().byId["acp-1"]!;
     expect(entry.status).toBe("completed");
     expect(entry.completedAt).toBe(NOW + 1000);
-    expect(entry.inputTokens).toBe(900);
-    expect(entry.outputTokens).toBe(100);
-    expect(entry.totalCost).toBe(0.005);
+    expect(entry.usedTokens).toBe(900);
+    expect(entry.contextSize).toBe(200000);
+    expect(entry.costAmount).toBe(0.005);
+    expect(entry.costCurrency).toBe("USD");
   });
 
   it("backfills a missing task from history", () => {

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -52,9 +52,13 @@ export interface AcpRunEntry {
    * Indexed in `byToolUseId`. Optional — older daemons omit it.
    */
   parentToolUseId?: string;
-  inputTokens: number;
-  outputTokens: number;
-  totalCost: number;
+  /** Tokens currently in the agent's context window. */
+  usedTokens: number;
+  /** Size of the agent's context window. */
+  contextSize: number;
+  /** Cumulative cost reported by the agent, when available. */
+  costAmount?: number;
+  costCurrency?: string;
   events: AcpRunRawEvent[];
 }
 
@@ -116,9 +120,10 @@ export interface AcpRunActions {
 
   updateUsage: (params: {
     acpSessionId: string;
-    inputTokens: number;
-    outputTokens: number;
-    totalCost: number;
+    usedTokens: number;
+    contextSize: number;
+    costAmount?: number;
+    costCurrency?: string;
   }) => void;
 
   /**
@@ -236,9 +241,10 @@ function mergeHistoryEntry(
     stopReason: incoming.stopReason ?? existing.stopReason,
     error: incoming.error ?? existing.error,
     completedAt: incoming.completedAt ?? existing.completedAt,
-    inputTokens: incoming.inputTokens || existing.inputTokens,
-    outputTokens: incoming.outputTokens || existing.outputTokens,
-    totalCost: incoming.totalCost || existing.totalCost,
+    usedTokens: incoming.usedTokens || existing.usedTokens,
+    contextSize: incoming.contextSize || existing.contextSize,
+    costAmount: incoming.costAmount ?? existing.costAmount,
+    costCurrency: incoming.costCurrency ?? existing.costCurrency,
     task: existing.task ?? incoming.task,
     parentToolUseId: existing.parentToolUseId ?? incoming.parentToolUseId,
   };
@@ -304,9 +310,8 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
       status: "running",
       startedAt: params.startedAt,
       parentToolUseId: params.parentToolUseId,
-      inputTokens: 0,
-      outputTokens: 0,
-      totalCost: 0,
+      usedTokens: 0,
+      contextSize: 0,
       events: [],
     };
 
@@ -404,9 +409,10 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         ...byId,
         [params.acpSessionId]: {
           ...existing,
-          inputTokens: params.inputTokens,
-          outputTokens: params.outputTokens,
-          totalCost: params.totalCost,
+          usedTokens: params.usedTokens,
+          contextSize: params.contextSize,
+          costAmount: params.costAmount,
+          costCurrency: params.costCurrency,
         },
       },
     });

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -121,6 +121,38 @@ describe("AcpRunDetailPanel — header + metrics + objective", () => {
     expect(screen.getByText("Research the thing")).toBeDefined();
   });
 
+  test("a sub-cent nonzero cost renders '<$0.01', not '$0.00'", () => {
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({
+          usedTokens: 1200,
+          contextSize: 200000,
+          costAmount: 0.003,
+          costCurrency: "USD",
+        })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByText("Cost")).toBeDefined();
+    expect(screen.getByText("<$0.01")).toBeDefined();
+    expect(screen.queryByText("$0.00")).toBeNull();
+  });
+
+  test("a cost at or above one cent uses standard currency formatting", () => {
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({
+          usedTokens: 1200,
+          contextSize: 200000,
+          costAmount: 1.23,
+          costCurrency: "USD",
+        })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByText("$1.23")).toBeDefined();
+  });
+
   test("shows the context metric but no cost when cost is absent", () => {
     render(
       <AcpRunDetailPanel

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -60,9 +60,8 @@ function makeEntry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
     task: "Research the thing",
     status: "running",
     startedAt: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    totalCost: 0,
+    usedTokens: 0,
+    contextSize: 0,
     events: [],
     ...overrides,
   };
@@ -102,30 +101,46 @@ describe("AcpRunDetailPanel — header + metrics + objective", () => {
   test("renders agent title, status, metrics, and objective", () => {
     render(
       <AcpRunDetailPanel
-        entry={makeEntry({ inputTokens: 1200, outputTokens: 340 })}
+        entry={makeEntry({
+          usedTokens: 1200,
+          contextSize: 200000,
+          costAmount: 0.012,
+          costCurrency: "USD",
+        })}
         onClose={noop}
       />,
     );
 
     expect(screen.getByText("claude")).toBeDefined();
     expect(screen.getByText("Running")).toBeDefined();
-    expect(screen.getByText("Input")).toBeDefined();
-    expect(screen.getByText("Output")).toBeDefined();
-    expect(screen.getByText("1.2K")).toBeDefined();
-    expect(screen.getByText("340")).toBeDefined();
+    expect(screen.getByText("Context")).toBeDefined();
+    expect(screen.getByText("1,200 / 200,000")).toBeDefined();
+    expect(screen.getByText("Cost")).toBeDefined();
+    expect(screen.getByText("$0.01")).toBeDefined();
     expect(screen.getByText("Objective")).toBeDefined();
     expect(screen.getByText("Research the thing")).toBeDefined();
+  });
+
+  test("shows the context metric but no cost when cost is absent", () => {
+    render(
+      <AcpRunDetailPanel
+        entry={makeEntry({ usedTokens: 1200, contextSize: 200000 })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByText("Context")).toBeDefined();
+    expect(screen.queryByText("Cost")).toBeNull();
   });
 
   test("hides the metric row when there is no usage data", () => {
     render(
       <AcpRunDetailPanel
-        entry={makeEntry({ inputTokens: 0, outputTokens: 0, totalCost: 0 })}
+        entry={makeEntry({ usedTokens: 0, contextSize: 0 })}
         onClose={noop}
       />,
     );
-    expect(screen.queryByText("Input")).toBeNull();
-    expect(screen.queryByText("Output")).toBeNull();
+    expect(screen.queryByText("Context")).toBeNull();
+    expect(screen.queryByText("Cost")).toBeNull();
   });
 
   test("empty events renders 'No events yet'", () => {

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -61,6 +61,20 @@ import { captureError } from "@/lib/sentry/capture-error";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
+ * Currency-aware cost label. A nonzero amount under one cent rounds to `$0.00`
+ * under standard 2-fraction-digit currency formatting, under-reporting real
+ * spend for short runs — render those as a "less than one cent" form instead.
+ */
+export function formatAcpCost(amount: number, currency: string): string {
+  const format = (value: number) =>
+    new Intl.NumberFormat(undefined, { style: "currency", currency }).format(
+      value,
+    );
+  if (amount > 0 && amount < 0.01) return `<${format(0.01)}`;
+  return format(amount);
+}
+
+/**
  * Live joined output for a running ACP tool, re-derived from the store so an
  * open detail streams as `tool_call_update` events land. Re-projects the run's
  * events to find the matching tool step and joins its `outputChunks`. Returns
@@ -437,10 +451,10 @@ export function AcpRunDetailPanel({
                         style={{ color: "var(--content-secondary)" }}
                       />
                     }
-                    value={new Intl.NumberFormat(undefined, {
-                      style: "currency",
-                      currency: entry.costCurrency,
-                    }).format(entry.costAmount)}
+                    value={formatAcpCost(
+                      entry.costAmount,
+                      entry.costCurrency,
+                    )}
                     label="Cost"
                   />
                 )}

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -13,14 +13,14 @@
  */
 
 import {
-  ArrowDownToLine,
   ArrowLeft,
-  ArrowUpFromLine,
   Brain,
   Check,
   ChevronDown,
   ChevronRight,
   Code,
+  DollarSign,
+  Gauge,
   ListChecks,
   MessageSquare,
   RotateCw,
@@ -39,10 +39,7 @@ import {
 import { Button, Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
-import {
-  AnimatedMetricCard,
-  formatNumber,
-} from "@/domains/chat/components/metric-card";
+import { MetricCard } from "@/domains/chat/components/metric-card";
 import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
 import { AcpRunPhaseTimeline } from "@/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline";
@@ -420,32 +417,33 @@ export function AcpRunDetailPanel({
 
             {/* Metrics row — gated on real usage so a run with no token/cost
                 data doesn't show a misleading all-zero meter. */}
-            {(entry.inputTokens > 0 ||
-              entry.outputTokens > 0 ||
-              entry.totalCost > 0) && (
+            {(entry.usedTokens > 0 || entry.costAmount != null) && (
               <div className="mb-5 grid grid-cols-2 gap-3">
-                <AnimatedMetricCard
+                <MetricCard
                   icon={
-                    <ArrowDownToLine
+                    <Gauge
                       className="h-4 w-4 shrink-0"
                       style={{ color: "var(--content-secondary)" }}
                     />
                   }
-                  target={entry.inputTokens}
-                  format={(n) => formatNumber(Math.round(n))}
-                  label="Input"
+                  value={`${entry.usedTokens.toLocaleString()} / ${entry.contextSize.toLocaleString()}`}
+                  label="Context"
                 />
-                <AnimatedMetricCard
-                  icon={
-                    <ArrowUpFromLine
-                      className="h-4 w-4 shrink-0"
-                      style={{ color: "var(--content-secondary)" }}
-                    />
-                  }
-                  target={entry.outputTokens}
-                  format={(n) => formatNumber(Math.round(n))}
-                  label="Output"
-                />
+                {entry.costAmount != null && entry.costCurrency && (
+                  <MetricCard
+                    icon={
+                      <DollarSign
+                        className="h-4 w-4 shrink-0"
+                        style={{ color: "var(--content-secondary)" }}
+                      />
+                    }
+                    value={new Intl.NumberFormat(undefined, {
+                      style: "currency",
+                      currency: entry.costCurrency,
+                    }).format(entry.costAmount)}
+                    label="Cost"
+                  />
+                )}
               </div>
             )}
 

--- a/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.test.tsx
@@ -37,9 +37,8 @@ function makeEntry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
     task: "Research the thing",
     status: "running",
     startedAt: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    totalCost: 0,
+    usedTokens: 0,
+    contextSize: 0,
     events: [],
     ...overrides,
   };

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
@@ -104,7 +104,12 @@ describe("rehydration — terminal session", () => {
         stopReason: "end_turn",
         startedAt: 1000,
         completedAt: 5000,
-        usage: { inputTokens: 1200, outputTokens: 340, totalCost: 0.012 },
+        usage: {
+          usedTokens: 1200,
+          contextSize: 200000,
+          costAmount: 0.012,
+          costCurrency: "USD",
+        },
         eventLog: [
           {
             type: "acp_session_update",
@@ -131,9 +136,10 @@ describe("rehydration — terminal session", () => {
     expect(entry.startedAt).toBe(1000);
     expect(entry.agent).toBe("claude");
     expect(entry.parentToolUseId).toBe("tool-1");
-    expect(entry.inputTokens).toBe(1200);
-    expect(entry.outputTokens).toBe(340);
-    expect(entry.totalCost).toBe(0.012);
+    expect(entry.usedTokens).toBe(1200);
+    expect(entry.contextSize).toBe(200000);
+    expect(entry.costAmount).toBe(0.012);
+    expect(entry.costCurrency).toBe("USD");
     expect(entry.events).toHaveLength(2);
     expect(entry.events[1]!.toolCallId).toBe("t-1");
     expect(getState().highWaterMark.get("acp-1")).toBe(7);

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -32,9 +32,10 @@ interface AcpSessionEventLogItem {
 }
 
 interface AcpSessionUsage {
-  inputTokens?: number;
-  outputTokens?: number;
-  totalCost?: number;
+  usedTokens?: number;
+  contextSize?: number;
+  costAmount?: number;
+  costCurrency?: string;
 }
 
 interface AcpSessionRow {
@@ -106,9 +107,10 @@ function toRunEntry(row: AcpSessionRow): AcpRunEntry {
     startedAt: row.startedAt ?? Date.now(),
     completedAt: isTerminal ? row.completedAt ?? undefined : undefined,
     parentToolUseId: row.parentToolUseId,
-    inputTokens: row.usage?.inputTokens ?? 0,
-    outputTokens: row.usage?.outputTokens ?? 0,
-    totalCost: row.usage?.totalCost ?? 0,
+    usedTokens: row.usage?.usedTokens ?? 0,
+    contextSize: row.usage?.contextSize ?? 0,
+    costAmount: row.usage?.costAmount,
+    costCurrency: row.usage?.costCurrency,
     events,
   };
 }

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -67,6 +67,7 @@ import {
 import {
   handleAcpSessionSpawned,
   handleAcpSessionUpdate,
+  handleAcpSessionUsage,
   handleAcpSessionCompleted,
   handleAcpSessionError,
 } from "@/domains/chat/utils/stream-handlers/acp-handlers";
@@ -399,6 +400,9 @@ export function useStreamEventHandler(
           break;
         case "acp_session_update":
           handleAcpSessionUpdate(event);
+          break;
+        case "acp_session_usage":
+          handleAcpSessionUsage(event);
           break;
         case "acp_session_completed":
           handleAcpSessionCompleted(event);

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -56,6 +56,7 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // conversation-id gate would otherwise drop them.
   "acp_session_spawned",
   "acp_session_update",
+  "acp_session_usage",
   "acp_session_completed",
   "acp_session_error",
 ] as const;

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -4,6 +4,7 @@ import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import {
   handleAcpSessionSpawned,
   handleAcpSessionUpdate,
+  handleAcpSessionUsage,
   handleAcpSessionCompleted,
   handleAcpSessionError,
 } from "@/domains/chat/utils/stream-handlers/acp-handlers";
@@ -70,6 +71,35 @@ describe("handleAcpSessionUpdate", () => {
     handleAcpSessionUpdate(update);
     expect(getState().byId["acp-1"]?.events).toHaveLength(1);
     expect(getState().highWaterMark.get("acp-1")).toBe(1);
+  });
+});
+
+describe("handleAcpSessionUsage", () => {
+  it("updates the run's used/size/cost usage", () => {
+    spawn();
+    handleAcpSessionUsage({
+      type: "acp_session_usage",
+      acpSessionId: "acp-1",
+      usedTokens: 1500,
+      contextSize: 200000,
+      costAmount: 0.003,
+      costCurrency: "USD",
+    });
+    const entry = getState().byId["acp-1"];
+    expect(entry?.usedTokens).toBe(1500);
+    expect(entry?.contextSize).toBe(200000);
+    expect(entry?.costAmount).toBe(0.003);
+    expect(entry?.costCurrency).toBe("USD");
+  });
+
+  it("ignores usage for an unknown session", () => {
+    handleAcpSessionUsage({
+      type: "acp_session_usage",
+      acpSessionId: "acp-missing",
+      usedTokens: 1,
+      contextSize: 1,
+    });
+    expect(getState().byId).toEqual({});
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -1,6 +1,7 @@
 import type {
   AcpSessionSpawnedEvent,
   AcpSessionUpdateEvent,
+  AcpSessionUsageEvent,
   AcpSessionCompletedEvent,
   AcpSessionErrorEvent,
 } from "@vellumai/assistant-api";
@@ -37,6 +38,16 @@ export function handleAcpSessionUpdate(event: AcpSessionUpdateEvent): void {
       toolStatus: event.toolStatus,
       messageId: event.messageId,
     },
+  });
+}
+
+export function handleAcpSessionUsage(event: AcpSessionUsageEvent): void {
+  useAcpRunStore.getState().updateUsage({
+    acpSessionId: event.acpSessionId,
+    usedTokens: event.usedTokens,
+    contextSize: event.contextSize,
+    costAmount: event.costAmount,
+    costCurrency: event.costCurrency,
   });
 }
 


### PR DESCRIPTION
## Summary
- Replace bogus inputTokens/outputTokens/totalCost with ACP's usedTokens/contextSize/costAmount/costCurrency across the store, handler, and rehydration
- Add handleAcpSessionUsage + register acp_session_usage as a global stream event
- Detail-panel meter shows 'used / size tokens' + currency-formatted cost, hidden when no usage

Part of plan: acp-usage-meter-persistence.md (PR 2 of 5)