### PR TITLE
feat(web): rehydrate ACP usage from /acp/sessions

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
@@ -104,12 +104,10 @@ describe("rehydration — terminal session", () => {
         stopReason: "end_turn",
         startedAt: 1000,
         completedAt: 5000,
-        usage: {
-          usedTokens: 1200,
-          contextSize: 200000,
-          costAmount: 0.012,
-          costCurrency: "USD",
-        },
+        usedTokens: 4200,
+        contextSize: 200000,
+        costAmount: 0.0123,
+        costCurrency: "USD",
         eventLog: [
           {
             type: "acp_session_update",
@@ -135,15 +133,39 @@ describe("rehydration — terminal session", () => {
     expect(entry.completedAt).toBe(5000);
     expect(entry.startedAt).toBe(1000);
     expect(entry.agent).toBe("claude");
+    expect(entry.task).toBe("research");
     expect(entry.parentToolUseId).toBe("tool-1");
-    expect(entry.usedTokens).toBe(1200);
+    expect(entry.usedTokens).toBe(4200);
     expect(entry.contextSize).toBe(200000);
-    expect(entry.costAmount).toBe(0.012);
+    expect(entry.costAmount).toBe(0.0123);
     expect(entry.costCurrency).toBe("USD");
     expect(entry.events).toHaveLength(2);
     expect(entry.events[1]!.toolCallId).toBe("t-1");
     expect(getState().highWaterMark.get("acp-1")).toBe(7);
+    // The transcript anchors the inline card off `parentToolUseId`.
     expect(getState().byToolUseId.get("tool-1")).toBe("acp-1");
+  });
+
+  test("a pre-migration row without usage hides the meter and degrades gracefully", async () => {
+    await seed([
+      {
+        acpSessionId: "acp-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "completed",
+        stopReason: "end_turn",
+        startedAt: 1000,
+        completedAt: 5000,
+        eventLog: [],
+      },
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.usedTokens).toBe(0);
+    expect(entry.contextSize).toBe(0);
+    expect(entry.costAmount).toBeUndefined();
+    expect(entry.costCurrency).toBeUndefined();
   });
 
   test("falls back to the array index when seq is absent", async () => {

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -31,13 +31,6 @@ interface AcpSessionEventLogItem {
   seq?: number;
 }
 
-interface AcpSessionUsage {
-  usedTokens?: number;
-  contextSize?: number;
-  costAmount?: number;
-  costCurrency?: string;
-}
-
 interface AcpSessionRow {
   acpSessionId: string;
   agentId?: string;
@@ -50,7 +43,10 @@ interface AcpSessionRow {
   error?: string | null;
   startedAt?: number;
   completedAt?: number | null;
-  usage?: AcpSessionUsage;
+  usedTokens?: number;
+  contextSize?: number;
+  costAmount?: number;
+  costCurrency?: string;
   eventLog?: AcpSessionEventLogItem[];
 }
 
@@ -107,10 +103,10 @@ function toRunEntry(row: AcpSessionRow): AcpRunEntry {
     startedAt: row.startedAt ?? Date.now(),
     completedAt: isTerminal ? row.completedAt ?? undefined : undefined,
     parentToolUseId: row.parentToolUseId,
-    usedTokens: row.usage?.usedTokens ?? 0,
-    contextSize: row.usage?.contextSize ?? 0,
-    costAmount: row.usage?.costAmount,
-    costCurrency: row.usage?.costCurrency,
+    usedTokens: row.usedTokens ?? 0,
+    contextSize: row.contextSize ?? 0,
+    costAmount: row.costAmount,
+    costCurrency: row.costCurrency,
     events,
   };
 }


### PR DESCRIPTION
## Summary
- Map terminal-row usage (used/size/cost) from /acp/sessions into the rehydrated store entry, so the meter survives refresh/restart alongside the already-restored objective + transcript anchor
- Pre-migration rows degrade gracefully (meter hidden)

Part of plan: acp-usage-meter-persistence.md (PR 5 of 5)