### PR TITLE
feat(chat): slide mobile sub-agent/workflow detail overlays up from the bottom

### DIFF
--- a/clients/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import type { SubagentEntry } from "@/domains/chat/subagent-store";
@@ -32,28 +33,35 @@ export function MobileSubagentDetailOverlay({
   onStop,
   onRequestDetail,
 }: MobileSubagentDetailOverlayProps) {
-  if (!entry) {
-    return null;
-  }
+  const reduce = useReducedMotion();
 
   return (
-    <div
-      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
-      style={{
-        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
-        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
-        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
-        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
-      }}
-    >
-      <LazyBoundary>
-        <SubagentDetailPanel
-          entry={entry}
-          onClose={onClose}
-          onStop={onStop}
-          onRequestDetail={onRequestDetail}
-        />
-      </LazyBoundary>
-    </div>
+    <AnimatePresence>
+      {entry && (
+        <motion.div
+          key="mobile-detail-overlay"
+          className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+          style={{
+            paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+            paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+            paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+            paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+          }}
+          initial={{ y: "100%", opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: "100%", opacity: 0 }}
+          transition={reduce ? { duration: 0 } : { duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <LazyBoundary>
+            <SubagentDetailPanel
+              entry={entry}
+              onClose={onClose}
+              onStop={onStop}
+              onRequestDetail={onRequestDetail}
+            />
+          </LazyBoundary>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/clients/web/src/domains/chat/components/mobile-workflow-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-workflow-detail-overlay.tsx
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import type { WorkflowEntry } from "@/domains/chat/workflow-store";
@@ -32,28 +33,35 @@ export function MobileWorkflowDetailOverlay({
   onStop,
   onRequestJournal,
 }: MobileWorkflowDetailOverlayProps) {
-  if (!entry) {
-    return null;
-  }
+  const reduce = useReducedMotion();
 
   return (
-    <div
-      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
-      style={{
-        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
-        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
-        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
-        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
-      }}
-    >
-      <LazyBoundary>
-        <WorkflowDetailPanel
-          entry={entry}
-          onClose={onClose}
-          onStop={onStop}
-          onRequestJournal={onRequestJournal}
-        />
-      </LazyBoundary>
-    </div>
+    <AnimatePresence>
+      {entry && (
+        <motion.div
+          key="mobile-detail-overlay"
+          className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+          style={{
+            paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+            paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+            paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+            paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+          }}
+          initial={{ y: "100%", opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: "100%", opacity: 0 }}
+          transition={reduce ? { duration: 0 } : { duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <LazyBoundary>
+            <WorkflowDetailPanel
+              entry={entry}
+              onClose={onClose}
+              onStop={onStop}
+              onRequestJournal={onRequestJournal}
+            />
+          </LazyBoundary>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap the mobile sub-agent and workflow detail overlays in AnimatePresence with a slide-up + fade enter/exit.
- Honors prefers-reduced-motion; portal mounting + safe-area insets unchanged.

Part of plan: subagent-workflow-animations.md (PR 3 of 8)