### PR TITLE
feat(chat): crossfade the tool-progress-card status indicator (loading -> terminal)

### DIFF
--- a/clients/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
@@ -274,7 +274,25 @@ export function ToolProgressCardShell({
         const titleCluster = (
           <span className="flex min-w-0 flex-1 items-center gap-1">
             {hideStatusIndicator ? null : (
-              <StatusIndicator state={state} testId={statusIndicatorTestId} />
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.span
+                  key={state}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={
+                    reduce
+                      ? { duration: 0 }
+                      : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
+                  }
+                  className="inline-flex shrink-0"
+                >
+                  <StatusIndicator
+                    state={state}
+                    testId={statusIndicatorTestId}
+                  />
+                </motion.span>
+              </AnimatePresence>
             )}
             {leadingIcon ? (
               // `mx-1` adds 4px on each side on top of the parent's `gap-1`


### PR DESCRIPTION
## Summary
- Crossfade the ToolProgressCardShell status indicator on state change (loading dots ↔ terminal icon).
- Blast radius: shared shell — also polishes web-search/skills tool cards in addition to sub-agent/workflow inline cards (intended, consistent).
- Testids/data-state preserved on the inner indicator. Honors prefers-reduced-motion.

Part of plan: subagent-workflow-animations.md (PR 7 of 8)