### PR TITLE
feat(chat): crossfade sub-agent avatar badge & workflow row status glyphs

### DIFF
--- a/clients/web/src/components/avatar/subagent-avatar-badge.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.tsx
@@ -2,6 +2,7 @@
 // indicator (running dots / green check / red !). Figma node 6063:148535.
 
 import { Check } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
@@ -43,6 +44,7 @@ export function SubagentAvatarBadge({
 }: SubagentAvatarBadgeProps) {
   // Atomic selector — re-render only when this subagent's status changes.
   const status = useSubagentStore((s) => s.byId[subagentId]?.status);
+  const reduce = useReducedMotion();
 
   // Spawn race: no entry yet → circle with no indicator.
   const badgeState = status ? deriveBadgeState(status) : undefined;
@@ -71,17 +73,32 @@ export function SubagentAvatarBadge({
             badgeState === "in-flight" ? "bottom-[6px]" : "bottom-[3px]"
           }`}
         >
-          {badgeState === "in-flight" && (
-            <ThreeDotIndicator dotSize={3} gap={2} />
-          )}
-          {badgeState === "completed" && (
-            <Check className="h-2.5 w-2.5 text-[var(--system-positive-strong)]" />
-          )}
-          {badgeState === "errored" && (
-            <span className="text-[11px] font-bold leading-none text-[var(--system-negative-strong)]">
-              !
-            </span>
-          )}
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.span
+              key={badgeState}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={
+                reduce
+                  ? { duration: 0 }
+                  : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
+              }
+              className="flex items-center justify-center"
+            >
+              {badgeState === "in-flight" && (
+                <ThreeDotIndicator dotSize={3} gap={2} />
+              )}
+              {badgeState === "completed" && (
+                <Check className="h-2.5 w-2.5 text-[var(--system-positive-strong)]" />
+              )}
+              {badgeState === "errored" && (
+                <span className="text-[11px] font-bold leading-none text-[var(--system-negative-strong)]">
+                  !
+                </span>
+              )}
+            </motion.span>
+          </AnimatePresence>
         </span>
       )}
     </div>

--- a/clients/web/src/domains/chat/components/workflow-subagent-row.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-subagent-row.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for `WorkflowSubagentRow`.
+ *
+ * Focuses on the lead indicator resolving differently per leaf status: the
+ * three-dot pulse while running vs. a terminal status glyph (e.g. the green
+ * check on `completed`). The glyph crossfades via `AnimatePresence`, but the
+ * active glyph is present synchronously on mount, so a plain render suffices.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+// Stub the avatar renderer so rows don't depend on the lazily-imported bundled
+// SVG chunk. (Mock the renderer, not `useBundledAvatarComponents` — Bun module
+// mocks are process-global and survive `mock.restore()`, so mocking the hook
+// here would leak into other files' tests that rely on the real one.)
+mock.module("@/components/avatar-renderer", () => ({
+  AvatarRenderer: () => <div data-testid="avatar" />,
+}));
+
+import { WorkflowSubagentRow } from "@/domains/chat/components/workflow-subagent-row";
+import type { WorkflowLeaf } from "@/domains/chat/workflow-store";
+
+const noop = () => {};
+
+function makeLeaf(
+  overrides: Partial<WorkflowLeaf> & { seq: number },
+): WorkflowLeaf {
+  return {
+    status: "running",
+    label: "Research Agent",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("WorkflowSubagentRow", () => {
+  test("running → three-dot pulse, no terminal glyph", () => {
+    const { container } = render(
+      <WorkflowSubagentRow
+        runId="run-1"
+        leaf={makeLeaf({ seq: 0, status: "running" })}
+        components={null}
+        onSelect={noop}
+      />,
+    );
+    // The running leaf shows the shared three-dot busy indicator.
+    expect(container.querySelectorAll(".busy-indicator").length).toBe(3);
+    // No terminal SVG glyph (CircleCheck / TriangleAlert / Ban).
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  test("completed → terminal glyph, no three-dot pulse", () => {
+    const { container } = render(
+      <WorkflowSubagentRow
+        runId="run-1"
+        leaf={makeLeaf({ seq: 0, status: "completed" })}
+        components={null}
+        onSelect={noop}
+      />,
+    );
+    // The terminal status renders a lucide SVG glyph instead of the dots.
+    expect(container.querySelectorAll(".busy-indicator").length).toBe(0);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
+++ b/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
@@ -1,4 +1,7 @@
+import type { ReactNode } from "react";
+
 import { Ban, CircleCheck, TriangleAlert } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { Typography } from "@vellumai/design-library";
 
@@ -13,35 +16,55 @@ import { subagentTraits } from "@/utils/avatar-subagent";
  * while the leaf is in flight, otherwise a compact terminal status icon.
  */
 function LeadIndicator({ status }: { status: WorkflowLeaf["status"] }) {
-  if (status === "running") {
-    return <ThreeDotIndicator className="shrink-0" dotSize={4} gap={2} />;
-  }
+  const reduce = useReducedMotion();
   const baseClass = "h-3.5 w-3.5 shrink-0";
-  switch (status) {
-    case "completed":
-      return (
-        <CircleCheck
-          className={baseClass}
-          style={{ color: "var(--system-positive-strong)" }}
-        />
-      );
-    case "failed":
-      return (
-        <TriangleAlert
-          className={baseClass}
-          style={{ color: "var(--system-negative-strong)" }}
-        />
-      );
-    default:
-      return (
-        <Ban
-          className={baseClass}
-          style={{ color: "var(--content-secondary)" }}
-          role="img"
-          aria-label="Cancelled"
-        />
-      );
+
+  let icon: ReactNode;
+  if (status === "running") {
+    icon = <ThreeDotIndicator className="shrink-0" dotSize={4} gap={2} />;
+  } else if (status === "completed") {
+    icon = (
+      <CircleCheck
+        className={baseClass}
+        style={{ color: "var(--system-positive-strong)" }}
+      />
+    );
+  } else if (status === "failed") {
+    icon = (
+      <TriangleAlert
+        className={baseClass}
+        style={{ color: "var(--system-negative-strong)" }}
+      />
+    );
+  } else {
+    icon = (
+      <Ban
+        className={baseClass}
+        style={{ color: "var(--content-secondary)" }}
+        role="img"
+        aria-label="Cancelled"
+      />
+    );
   }
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.span
+        key={status}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={
+          reduce
+            ? { duration: 0 }
+            : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
+        }
+        className="flex shrink-0 items-center"
+      >
+        {icon}
+      </motion.span>
+    </AnimatePresence>
+  );
 }
 
 export interface WorkflowSubagentRowProps {


### PR DESCRIPTION
## Summary
- Crossfade the status glyph (running dots ↔ check/alert) in SubagentAvatarBadge and the WorkflowSubagentRow lead indicator.
- Accessibility hooks (aria-label, data-status, testids) preserved on stable wrappers.
- Adds a minimal workflow-subagent-row test. Honors prefers-reduced-motion.

Part of plan: subagent-workflow-animations.md (PR 6 of 8)