### PR TITLE
feat(chat): animate sub-agent phase-timeline group expand/collapse

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -13,7 +13,7 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 import { useState } from "react";
 
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import * as phaseGroupedStepList from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
@@ -79,7 +79,7 @@ describe("SubagentPhaseTimeline — empty input", () => {
 });
 
 describe("SubagentPhaseTimeline — completed row", () => {
-  test("shows label + 'Worked for <dur>', hides pills by default, toggles on click", () => {
+  test("shows label + 'Worked for <dur>', hides pills by default, toggles on click", async () => {
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", "tc-a"),
       bash("pwd", "completed", "2s", "tc-b"),
@@ -104,9 +104,12 @@ describe("SubagentPhaseTimeline — completed row", () => {
     fireEvent.click(header);
     expect(queryAllByTestId("phase-step-pill").length).toBe(2);
 
-    // Toggling back hides them.
+    // Toggling back hides them — the collapse animates closed (height/opacity),
+    // so the pills stay mounted through the exit transition; await their removal.
     fireEvent.click(header);
-    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+    await waitFor(() =>
+      expect(queryAllByTestId("phase-step-pill").length).toBe(0),
+    );
   });
 });
 
@@ -695,7 +698,7 @@ describe("SubagentPhaseTimeline — phase grouping", () => {
   // Two same-label "Working" phases whose first steps both have empty
   // `toolCallId` must still get distinct section keys, so expanding one does
   // not expand the other.
-  test("same-label phases with empty toolCallId expand/collapse independently", () => {
+  test("same-label phases with empty toolCallId expand/collapse independently", async () => {
     const steps: ToolCallCardStep[] = [
       // First "Working" group — empty toolCallId on every step.
       bash("ls", "completed", "1s", ""),
@@ -732,9 +735,12 @@ describe("SubagentPhaseTimeline — phase grouping", () => {
     fireEvent.click(headerOf(working[1]!));
     expect(queryAllByTestId("phase-step-pill").length).toBe(4);
 
-    // Collapsing the first leaves the second's pills visible.
+    // Collapsing the first leaves the second's pills visible — the first row's
+    // pills animate closed, so await the exit transition removing just those two.
     fireEvent.click(headerOf(working[0]!));
-    expect(queryAllByTestId("phase-step-pill").length).toBe(2);
+    await waitFor(() =>
+      expect(queryAllByTestId("phase-step-pill").length).toBe(2),
+    );
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -14,6 +14,7 @@
  */
 
 import { Brain, Globe } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { memo, useCallback, useMemo, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
@@ -258,6 +259,7 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
   onToggle: (key: string) => void;
   onStepDetailClick?: (detailKey: string) => void;
 }) {
+  const reduce = useReducedMotion();
   const rawStatus = phaseHeaderStatus(section.steps);
   // Only the active tail — the last phase while the subagent is still running —
   // may read as in-flight. Steps are sequential, so any OTHER phase computing
@@ -495,115 +497,135 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
           row's 8px gap → 22px). No own bottom padding — the container's `pb-4`
           (non-last rows) is the only bottom spacing, so the last pill sits 16px
           from the next group rather than 12px (pb-3) + 16px. */}
-      {isExpandable && expanded && (
-        <div className="flex flex-col items-start gap-1 pl-[22px]">
-          {section.steps.map((step, stepIdx) => {
-            // A step with a detail key + a wired handler renders a clickable
-            // `ToolStepPill` that opens its nested detail; everything else keeps
-            // the non-interactive `DefaultStepPill`.
-            const detailKey = onStepDetailClick
-              ? stepDetailKey(step)
-              : undefined;
-            if (detailKey && onStepDetailClick) {
-              if (step.kind === "tool") {
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName={step.iconName}
-                    label={step.activity || step.info || step.title}
-                    riskLevel={step.riskLevel}
-                    tone={
-                      step.status === "error" || step.status === "denied"
-                        ? "error"
-                        : "default"
-                    }
-                    ariaLabel="View tool details"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
-              if (step.kind === "thinking") {
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName="brain"
-                    label={step.text}
-                    ariaLabel="View reasoning"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
-              if (step.kind === "web_search") {
-                // The search's query becomes a clickable pill; its result
-                // sources move into the nested detail (query + links), mirroring
-                // the thinking-pill → reasoning-detail pattern. Falls back to the
-                // inline query label + chips below when no detail handler is
-                // wired (deploy-safe).
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName="globe"
-                    label={step.query || step.title}
-                    ariaLabel="View search details"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
-              if (step.kind === "web_search_error") {
-                // A failed search becomes an error-toned pill that opens the
-                // full, untruncated provider error in the nested detail —
-                // parity with a failed tool. Falls back to the inline error chip
-                // below when no detail handler is wired (deploy-safe).
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName="globe"
-                    label={step.errorMessage}
-                    tone="error"
-                    ariaLabel="View search error"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
+      <AnimatePresence initial={false}>
+        {isExpandable && expanded && (
+          <motion.div
+            key="phase-steps"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={
+              reduce
+                ? { duration: 0 }
+                : { duration: 0.25, ease: [0.16, 1, 0.3, 1] }
             }
-            // Web steps render as their own chip clusters (favicon chips /
-            // error chip) rather than the title-only `DefaultStepPill`, matching
-            // main chat. `web_search` results are parsed from the tool result by
-            // `computeSubagentCardData`.
-            if (step.kind === "web_search") {
-              // Label each search with its query so multiple (unclamped)
-              // searches in one "Searching the web" group stay visually
-              // distinct — the "N steps" count then maps to N labelled clusters.
-              return (
-                <div
-                  key={stepKey(step, stepIdx)}
-                  className="flex w-full flex-col gap-1"
-                >
-                  {step.query ? (
-                    <Typography
-                      variant="body-small-default"
-                      className="text-[var(--content-secondary)]"
+            className="overflow-hidden"
+          >
+            <div className="flex flex-col items-start gap-1 pl-[22px]">
+              {section.steps.map((step, stepIdx) => {
+                // A step with a detail key + a wired handler renders a clickable
+                // `ToolStepPill` that opens its nested detail; everything else keeps
+                // the non-interactive `DefaultStepPill`.
+                const detailKey = onStepDetailClick
+                  ? stepDetailKey(step)
+                  : undefined;
+                if (detailKey && onStepDetailClick) {
+                  if (step.kind === "tool") {
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName={step.iconName}
+                        label={step.activity || step.info || step.title}
+                        riskLevel={step.riskLevel}
+                        tone={
+                          step.status === "error" || step.status === "denied"
+                            ? "error"
+                            : "default"
+                        }
+                        ariaLabel="View tool details"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                  if (step.kind === "thinking") {
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName="brain"
+                        label={step.text}
+                        ariaLabel="View reasoning"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                  if (step.kind === "web_search") {
+                    // The search's query becomes a clickable pill; its result
+                    // sources move into the nested detail (query + links), mirroring
+                    // the thinking-pill → reasoning-detail pattern. Falls back to the
+                    // inline query label + chips below when no detail handler is
+                    // wired (deploy-safe).
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName="globe"
+                        label={step.query || step.title}
+                        ariaLabel="View search details"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                  if (step.kind === "web_search_error") {
+                    // A failed search becomes an error-toned pill that opens the
+                    // full, untruncated provider error in the nested detail —
+                    // parity with a failed tool. Falls back to the inline error chip
+                    // below when no detail handler is wired (deploy-safe).
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName="globe"
+                        label={step.errorMessage}
+                        tone="error"
+                        ariaLabel="View search error"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                }
+                // Web steps render as their own chip clusters (favicon chips /
+                // error chip) rather than the title-only `DefaultStepPill`, matching
+                // main chat. `web_search` results are parsed from the tool result by
+                // `computeSubagentCardData`.
+                if (step.kind === "web_search") {
+                  // Label each search with its query so multiple (unclamped)
+                  // searches in one "Searching the web" group stay visually
+                  // distinct — the "N steps" count then maps to N labelled clusters.
+                  return (
+                    <div
+                      key={stepKey(step, stepIdx)}
+                      className="flex w-full flex-col gap-1"
                     >
-                      {`"${step.query}"`}
-                    </Typography>
-                  ) : null}
-                  <WebSearchStepRow step={step} />
-                </div>
-              );
-            }
-            if (step.kind === "web_search_error") {
-              return (
-                <WebSearchErrorRow key={stepKey(step, stepIdx)} step={step} />
-              );
-            }
-            return <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />;
-          })}
-        </div>
-      )}
+                      {step.query ? (
+                        <Typography
+                          variant="body-small-default"
+                          className="text-[var(--content-secondary)]"
+                        >
+                          {`"${step.query}"`}
+                        </Typography>
+                      ) : null}
+                      <WebSearchStepRow step={step} />
+                    </div>
+                  );
+                }
+                if (step.kind === "web_search_error") {
+                  return (
+                    <WebSearchErrorRow
+                      key={stepKey(step, stepIdx)}
+                      step={step}
+                    />
+                  );
+                }
+                return (
+                  <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- Height + opacity animate the sub-agent phase-timeline group expand/collapse, reusing the ToolProgressCardShell pattern.
- Honors prefers-reduced-motion.

Part of plan: subagent-workflow-animations.md (PR 4 of 8)