### PR TITLE
feat(chat): fade + scale the active sub-agents/workflows dropdown on open & close

### DIFF
--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 export interface ActiveOverlayShellProps {
   /** `data-testid` for the root container (e.g. `"active-workflows-overlay"`). */
@@ -30,6 +31,7 @@ export function ActiveOverlayShell({
 }: ActiveOverlayShellProps) {
   const [expanded, setExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
 
   // While open, dismiss on outside pointerdown or Escape.
   useEffect(() => {
@@ -72,21 +74,32 @@ export function ActiveOverlayShell({
     >
       {renderPill({ expanded, onToggle: () => setExpanded((v) => !v) })}
 
-      {expanded && (
-        // Absolute dropdown anchored under the pill so its 589px width no longer
-        // dictates the row's width (Figma 6063:149685).
-        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
-          <Typography
-            variant="title-small"
-            className="text-[var(--content-emphasised)]"
+      <AnimatePresence>
+        {expanded && (
+          // Absolute dropdown anchored under the pill so its 589px width no longer
+          // dictates the row's width (Figma 6063:149685).
+          <motion.div
+            className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
+            style={{ transformOrigin: "top center" }}
+            initial={{ opacity: 0, scale: 0.96, y: -4 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: -4 }}
+            transition={
+              reduce ? { duration: 0 } : { duration: 0.16, ease: [0.16, 1, 0.3, 1] }
+            }
           >
-            {title}
-          </Typography>
-          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-            {children}
-          </div>
-        </div>
-      )}
+            <Typography
+              variant="title-small"
+              className="text-[var(--content-emphasised)]"
+            >
+              {title}
+            </Typography>
+            <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -8,7 +8,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -138,7 +144,7 @@ describe("ActiveSubagentsOverlay — expanded", () => {
 });
 
 describe("ActiveSubagentsOverlay — dismissal", () => {
-  test("Escape collapses the open panel", () => {
+  test("Escape collapses the open panel", async () => {
     const ids = seedMany(2);
     const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
@@ -146,10 +152,15 @@ describe("ActiveSubagentsOverlay — dismissal", () => {
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.keyDown(document, { key: "Escape" });
-    expect(queryByText("2 Active Subagents")).toBeNull();
+    // The dropdown animates out via AnimatePresence, so it lingers for the
+    // exit animation before unmounting.
+    await waitFor(
+      () => expect(queryByText("2 Active Subagents")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 
-  test("pointerdown outside the container collapses the open panel", () => {
+  test("pointerdown outside the container collapses the open panel", async () => {
     const ids = seedMany(2);
     const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
@@ -157,6 +168,9 @@ describe("ActiveSubagentsOverlay — dismissal", () => {
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.pointerDown(document.body);
-    expect(queryByText("2 Active Subagents")).toBeNull();
+    await waitFor(
+      () => expect(queryByText("2 Active Subagents")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -8,7 +8,13 @@
  */
 
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 mock.module(
   "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card",
@@ -102,7 +108,7 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
 });
 
 describe("ActiveWorkflowsOverlay — dismissal", () => {
-  test("Escape collapses the open panel", () => {
+  test("Escape collapses the open panel", async () => {
     const ids = makeIds(2);
     const { queryByText } = render(
       <ActiveWorkflowsOverlay workflowRunIds={ids} />,
@@ -116,11 +122,16 @@ describe("ActiveWorkflowsOverlay — dismissal", () => {
     // ChatContentLayout's window keydown handler bails on defaultPrevented.
     // fireEvent returns false when the event was canceled.
     const notCanceled = fireEvent.keyDown(document, { key: "Escape" });
-    expect(queryByText("2 Active Workflows")).toBeNull();
     expect(notCanceled).toBe(false);
+    // The dropdown animates out via AnimatePresence, so it lingers for the
+    // exit animation before unmounting.
+    await waitFor(
+      () => expect(queryByText("2 Active Workflows")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 
-  test("pointerdown outside the container collapses the open panel", () => {
+  test("pointerdown outside the container collapses the open panel", async () => {
     const ids = makeIds(2);
     const { queryByText } = render(
       <ActiveWorkflowsOverlay workflowRunIds={ids} />,
@@ -130,6 +141,9 @@ describe("ActiveWorkflowsOverlay — dismissal", () => {
     expect(queryByText("2 Active Workflows")).toBeTruthy();
 
     fireEvent.pointerDown(document.body);
-    expect(queryByText("2 Active Workflows")).toBeNull();
+    await waitFor(
+      () => expect(queryByText("2 Active Workflows")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Wrap the shared ActiveOverlayShell dropdown in AnimatePresence with a fade+scale enter/exit (covers both active sub-agents and active workflows overlays).
- No scrim added — dismissal stays via document listeners; root stays pointer-events-none for transcript click-through.
- Honors prefers-reduced-motion.

Part of plan: subagent-workflow-animations.md (PR 2 of 8)