### PR TITLE
fix(macos): name mac-helper executable per-env for Privacy & Security

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
@@ -13,8 +13,15 @@
     -->
     <key>CFBundleIdentifier</key>
     <string>__HELPER_BUNDLE_ID__</string>
+    <!--
+      The executable filename is what System Settings → Privacy & Security shows
+      for this helper: it is spawned directly (not via LaunchServices), so TCC
+      attributes its grants by executable path and renders the binary's filename,
+      ignoring CFBundleName/CFBundleDisplayName. build-mac-helper.sh names the
+      binary per environment; this must match it or codesign rejects the bundle.
+    -->
     <key>CFBundleExecutable</key>
-    <string>vellum-mac-helper</string>
+    <string>__HELPER_EXEC_NAME__</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <!-- User-facing name + icon in System Settings → Privacy & Security. -->

--- a/clients/macos/scripts/build-mac-helper.sh
+++ b/clients/macos/scripts/build-mac-helper.sh
@@ -5,8 +5,9 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PACKAGE_DIR="$ROOT_DIR/native/mac-helper"
 OUTPUT_DIR="$ROOT_DIR/resources"
 OUTPUT_BUNDLE="$OUTPUT_DIR/vellum-mac-helper.app"
-OUTPUT="$OUTPUT_BUNDLE/Contents/MacOS/vellum-mac-helper"
 OUTPUT_INFO_PLIST="$OUTPUT_BUNDLE/Contents/Info.plist"
+# $OUTPUT (the installed executable path) is set after the env block below: its
+# filename is per-environment, since that filename is what Privacy & Security shows.
 TEMPLATE_PLIST="$PACKAGE_DIR/Sources/MacHelperExecutable/Info.plist"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
@@ -42,6 +43,16 @@ else
   HELPER_DISPLAY_NAME="Vellum Helper ${ENV_CAP}"
 fi
 
+# Name the executable itself, not just the bundle. The helper is spawned
+# directly (execve, not via LaunchServices), so TCC attributes its grants by
+# executable path and the Privacy & Security list shows the binary's filename —
+# CFBundleName/CFBundleDisplayName are never consulted for that pane. Renaming
+# the binary is the only lever that makes the Accessibility entry read
+# "Vellum Helper [Env]" instead of "vellum-mac-helper". CFBundleExecutable must
+# match the on-disk filename or codesign rejects the bundle.
+HELPER_EXEC_NAME="$HELPER_DISPLAY_NAME"
+OUTPUT="$OUTPUT_BUNDLE/Contents/MacOS/$HELPER_EXEC_NAME"
+
 mkdir -p "$OUTPUT_DIR"
 # Render the templated Info.plist, then embed it into the bare executable's
 # __info_plist section so TCC can attribute permission prompts for the
@@ -53,6 +64,7 @@ rm -f "$OUTPUT_DIR"/.vellum-mac-helper.*.Info.plist
 RENDERED_TMP="$(mktemp)"
 sed -e "s|__HELPER_BUNDLE_ID__|${HELPER_BUNDLE_ID}|g" \
     -e "s|__HELPER_DISPLAY_NAME__|${HELPER_DISPLAY_NAME}|g" \
+    -e "s|__HELPER_EXEC_NAME__|${HELPER_EXEC_NAME}|g" \
     "$TEMPLATE_PLIST" > "$RENDERED_TMP"
 RENDERED_PLIST="$OUTPUT_DIR/.vellum-mac-helper.$(shasum -a 256 "$RENDERED_TMP" | cut -c1-16).Info.plist"
 mv -f "$RENDERED_TMP" "$RENDERED_PLIST"

--- a/clients/macos/src/main/hotkey-helper.test.ts
+++ b/clients/macos/src/main/hotkey-helper.test.ts
@@ -72,7 +72,14 @@ mock.module("electron", () => ({
 }));
 
 let exists = true;
-mock.module("node:fs", () => ({ existsSync: () => exists }));
+// getMacHelperPath reads CFBundleExecutable from the bundle's Info.plist to
+// resolve the (per-environment) executable filename.
+let helperExecutableName = "vellum-mac-helper";
+mock.module("node:fs", () => ({
+  existsSync: () => exists,
+  readFileSync: () =>
+    `<plist><dict><key>CFBundleExecutable</key><string>${helperExecutableName}</string></dict></plist>`,
+}));
 
 let lastChild: FakeHotkeyChild | null = null;
 const spawnCalls: Array<[string, string[], object]> = [];
@@ -147,6 +154,7 @@ beforeEach(() => {
   spawnCalls.length = 0;
   lastChild = null;
   exists = true;
+  helperExecutableName = "vellum-mac-helper";
   appState.isPackaged = false;
   appState.appPath = "/repo/clients/macos";
   nextWebContentsId = 1;
@@ -181,6 +189,13 @@ describe("getMacHelperPath", () => {
     appState.isPackaged = true;
     expect(getMacHelperPath()).toBe(
       "/mock/resources/bin/vellum-mac-helper.app/Contents/MacOS/vellum-mac-helper",
+    );
+  });
+
+  test("resolves the per-environment executable name from CFBundleExecutable", () => {
+    helperExecutableName = "Vellum Helper Dev";
+    expect(getMacHelperPath()).toBe(
+      "/repo/clients/macos/resources/vellum-mac-helper.app/Contents/MacOS/Vellum Helper Dev",
     );
   });
 });

--- a/clients/macos/src/main/sidecar/mac-helper-path.ts
+++ b/clients/macos/src/main/sidecar/mac-helper-path.ts
@@ -6,6 +6,7 @@
  */
 
 import { app } from "electron";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 
 export const getMacHelperAppPath = (): string => {
@@ -15,5 +16,33 @@ export const getMacHelperAppPath = (): string => {
   return path.join(app.getAppPath(), "resources", "vellum-mac-helper.app");
 };
 
-export const getMacHelperPath = (): string =>
-  path.join(getMacHelperAppPath(), "Contents", "MacOS", "vellum-mac-helper");
+// build-mac-helper.sh names the executable per environment ("Vellum Helper",
+// "Vellum Helper Dev", …) so the macOS Privacy & Security list shows a friendly,
+// env-specific name. Read the bundle's own CFBundleExecutable rather than
+// hard-coding it, so this stays correct regardless of how the build named it.
+const DEFAULT_HELPER_EXECUTABLE = "vellum-mac-helper";
+
+const resolveHelperExecutableName = (appPath: string): string => {
+  try {
+    const infoPlist = readFileSync(
+      path.join(appPath, "Contents", "Info.plist"),
+      "utf8",
+    );
+    const match = infoPlist.match(
+      /<key>CFBundleExecutable<\/key>\s*<string>([^<]+)<\/string>/,
+    );
+    return match?.[1]?.trim() || DEFAULT_HELPER_EXECUTABLE;
+  } catch {
+    return DEFAULT_HELPER_EXECUTABLE;
+  }
+};
+
+export const getMacHelperPath = (): string => {
+  const appPath = getMacHelperAppPath();
+  return path.join(
+    appPath,
+    "Contents",
+    "MacOS",
+    resolveHelperExecutableName(appPath),
+  );
+};


### PR DESCRIPTION
## Summary
- Rename the macOS helper's **executable file** per environment (`Vellum Helper`, `Vellum Helper Dev`, `Vellum Helper Staging`) instead of `vellum-mac-helper`, so the System Settings → Privacy & Security entry shows a friendly, environment-specific name. The helper is spawned directly (`execve`, not via LaunchServices), so TCC attributes its grants by **executable path** and the pane renders the binary's filename — the `CFBundleName`/`CFBundleDisplayName` set by #35906 are never consulted for that list, which is why that rename didn't change the displayed name (it did fix the icon and the mic/speech prompt text).
- `build-mac-helper.sh` now names the installed binary after the per-env display name and templates `CFBundleExecutable` to match (codesign requires the on-disk filename and `CFBundleExecutable` to agree). The `.app` directory name (`vellum-mac-helper.app`) and the bundle id are unchanged, so packaging/`afterSign` and the `open`-based hotkey path are unaffected.
- `getMacHelperPath()` now reads `CFBundleExecutable` from the bundle's `Info.plist` instead of hard-coding the name, so the runtime spawn path stays correct regardless of environment.

## Original prompt
Follow-up to #35906: after reinstalling, the helper still appeared as `vellum-mac-helper` (and without the environment) in Privacy & Security → Accessibility. We diagnosed that for this directly-spawned helper the pane displays the **executable's filename** — bundle display-name/icon changes can't affect it — so the only lever is to rename the executable itself, per environment. The accepted trade-off is a **one-time re-grant** of Accessibility / Screen Recording / Microphone, because changing the executable path orphans the existing path-keyed TCC grants; after that one reset the new path is stable across future releases.

## Testing
- `VELLUM_ENVIRONMENT=dev bash scripts/build-mac-helper.sh`: bundle builds with `Contents/MacOS/Vellum Helper Dev`, `CFBundleExecutable=Vellum Helper Dev`, and `codesign --verify --strict` passes + satisfies its Designated Requirement (confirms a space-containing executable name signs cleanly).
- `bun test src/main/hotkey-helper.test.ts`: 23 pass, including new coverage that `getMacHelperPath()` resolves the per-env name from `CFBundleExecutable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)