### PR TITLE
refactor(contacts): remove the anchored-guardian local DB fallback

### DIFF
--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -12,7 +12,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
-import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
+import { getGuardianDeliveryFresh } from "../contacts/guardian-delivery-reader.js";
 import type { ChannelStatus } from "../contacts/types.js";
 import {
   createCanonicalGuardianRequest,
@@ -99,7 +99,7 @@ export async function notifyGuardianOfAccessRequest(
   // source-channel match validated against the vellum anchor, else the vellum
   // anchor).
   const anchored = resolveAnchoredGuardian({
-    guardians: await getGuardianDelivery(),
+    guardians: await getGuardianDeliveryFresh(),
     sourceChannel,
   });
   const guardianExternalUserId = anchored?.address ?? null;


### PR DESCRIPTION
## Summary
- Delete the anchored-guardian local DB fallback arm; resolve purely from the gateway guardians list
- Remove useLocalFallback from the input type and the access-request caller
- Access-request path now passes a force-fresh gateway delivery list

Part of plan: combo11-phase-b4-guardian-fallback-drain.md (PR 4 of 6)