### PR TITLE
feat(runtime): gate /readyz on runtime startup completion

### DIFF
--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -14,12 +14,28 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Silence logger before any imports that use it
+// Track health-logger warn calls so the CES soft-dependency path can be asserted.
+const healthWarn = mock(() => {});
+
+// Silence logger before any imports that use it. The "health" logger's warn is
+// captured so the /readyz CES soft-check can be verified.
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
+  getLogger: (name?: string) =>
     new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
+      get: (_target, prop) =>
+        name === "health" && prop === "warn" ? healthWarn : () => {},
     }),
+}));
+
+// Control runtime readiness independently per test. handleReadyz reads
+// isRuntimeReady(); mocking the module lets us flip the flag and reset it
+// between cases without a production reset export.
+let runtimeReadyFlag = false;
+mock.module("../runtime/ready-state.js", () => ({
+  isRuntimeReady: () => runtimeReadyFlag,
+  setRuntimeReady: () => {
+    runtimeReadyFlag = true;
+  },
 }));
 
 import {
@@ -191,17 +207,43 @@ describe("identity routes — health endpoint", () => {
     });
   });
 
-  describe("CES readiness", () => {
+  describe("readyz — runtime readiness gating", () => {
     beforeEach(() => {
       setCesClient(undefined);
+      runtimeReadyFlag = true;
+      healthWarn.mockClear();
     });
 
-    test("readyz returns 200 and logs warning when CES is unavailable", () => {
+    test("returns 503 {status:'starting'} before runtime startup completes", async () => {
+      runtimeReadyFlag = false;
+      const res = handleReadyz();
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toEqual({ status: "starting" });
+    });
+
+    test("returns 200 {status:'ok'} once the runtime is ready, even when CES reports not-ready", async () => {
+      const mockClient = {
+        isReady: () => false,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
+      setCesClient(mockClient);
+
       const res = handleReadyz();
       expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toEqual({ status: "ok" });
+      // CES is a soft dependency: not-ready is warned but does not gate readiness.
+      expect(healthWarn).toHaveBeenCalledTimes(1);
     });
 
-    test("readyz returns 200 when CES is connected and ready", () => {
+    test("returns 200 and logs warning when CES is unavailable", () => {
+      const res = handleReadyz();
+      expect(res.status).toBe(200);
+      expect(healthWarn).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns 200 without warning when CES is connected and ready", () => {
       const mockClient = {
         isReady: () => true,
         close: () => {},
@@ -209,16 +251,7 @@ describe("identity routes — health endpoint", () => {
       setCesClient(mockClient);
       const res = handleReadyz();
       expect(res.status).toBe(200);
-    });
-
-    test("readyz returns 200 when CES client exists but is not ready", () => {
-      const mockClient = {
-        isReady: () => false,
-        close: () => {},
-      } as unknown as import("../credential-execution/client.js").CesClient;
-      setCesClient(mockClient);
-      const res = handleReadyz();
-      expect(res.status).toBe(200);
+      expect(healthWarn).not.toHaveBeenCalled();
     });
 
     test("/v1/health reports ces.connected=true when CES is ready", async () => {

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -39,6 +39,7 @@ mock.module("../runtime/ready-state.js", () => ({
 }));
 
 import {
+  __resetReadyzCesStateForTest,
   handleDetailedHealth,
   handleReadyz,
   ROUTES,
@@ -211,6 +212,9 @@ describe("identity routes — health endpoint", () => {
     beforeEach(() => {
       setCesClient(undefined);
       runtimeReadyFlag = true;
+      // Reset the transition-tracking state so each case's first not-ready
+      // observation registers as a transition and warns once.
+      __resetReadyzCesStateForTest();
       healthWarn.mockClear();
     });
 
@@ -234,6 +238,22 @@ describe("identity routes — health endpoint", () => {
       const body = (await res.json()) as Record<string, unknown>;
       expect(body).toEqual({ status: "ok" });
       // CES is a soft dependency: not-ready is warned but does not gate readiness.
+      expect(healthWarn).toHaveBeenCalledTimes(1);
+    });
+
+    test("warns once on the first not-ready poll and not again on the next consecutive not-ready poll", () => {
+      const mockClient = {
+        isReady: () => false,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
+      setCesClient(mockClient);
+
+      // First not-ready observation is a transition → warns once.
+      expect(handleReadyz().status).toBe(200);
+      expect(healthWarn).toHaveBeenCalledTimes(1);
+
+      // Second consecutive not-ready observation is steady-state → no new warn.
+      expect(handleReadyz().status).toBe(200);
       expect(healthWarn).toHaveBeenCalledTimes(1);
     });
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -76,6 +76,7 @@ import {
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
+import { setRuntimeReady } from "../runtime/ready-state.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
 import {
   publishConfigChanged,
@@ -825,6 +826,14 @@ export async function runDaemon(): Promise<void> {
 
     await server.start();
     log.info("Daemon startup: DaemonServer started");
+
+    // Critical startup is complete: the runtime HTTP server is bound, the DB is
+    // initialized, and the daemon server is accepting requests. Mark the runtime
+    // ready so `/readyz` returns 200. This is the last REQUIRED init step — a
+    // failure earlier in init leaves the runtime not-ready. CES is intentionally
+    // NOT gated here: it is a soft dependency with a direct-credential-store
+    // fallback, so readiness must not depend on the CES handshake.
+    setRuntimeReady();
 
     // Warm the gateway guardian-delivery cache so the SSE eager-subscribe path
     // (sync, IO-free) resolves the local actor principal on the FIRST client

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -827,13 +827,25 @@ export async function runDaemon(): Promise<void> {
     await server.start();
     log.info("Daemon startup: DaemonServer started");
 
-    // Critical startup is complete: the runtime HTTP server is bound, the DB is
-    // initialized, and the daemon server is accepting requests. Mark the runtime
-    // ready so `/readyz` returns 200. This is the last REQUIRED init step — a
-    // failure earlier in init leaves the runtime not-ready. CES is intentionally
-    // NOT gated here: it is a soft dependency with a direct-credential-store
+    // Critical startup is complete: the runtime HTTP server is bound and the
+    // daemon server is accepting requests. Mark the runtime ready so `/readyz`
+    // returns 200 — but only when the DB initialized. CES is intentionally NOT
+    // gated here: it is a soft dependency with a direct-credential-store
     // fallback, so readiness must not depend on the CES handshake.
-    setRuntimeReady();
+    //
+    // Readiness is gated on `dbReady` because the contract for `/readyz` is
+    // "HTTP bound + DB initialized + daemon started". If `initializeDb()` failed
+    // we are in degraded mode: DB-backed endpoints would be degraded, so the pod
+    // must report not-ready (`/readyz` → 503) and be kept out of the Service's
+    // endpoint set. The process still stays alive and reachable for `/healthz`
+    // (liveness) so it is not killed/restart-looped while it serves diagnostics.
+    if (dbReady) {
+      setRuntimeReady();
+    } else {
+      log.warn(
+        "Daemon startup: DB not initialized — leaving runtime not-ready (/readyz will report 503)",
+      );
+    }
 
     // Warm the gateway guardian-delivery cache so the SSE eager-subscribe path
     // (sync, IO-free) resolves the local actor principal on the FIRST client

--- a/assistant/src/runtime/ready-state.ts
+++ b/assistant/src/runtime/ready-state.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime readiness flag: reflects that critical startup is complete
+ * (HTTP server bound + DB initialized + daemon server started). Read by
+ * `handleReadyz()` to gate the K8s readinessProbe (`/readyz`). Kept
+ * dependency-free so both `lifecycle.ts` and `identity-routes.ts` can
+ * import it without creating a module cycle.
+ */
+
+let runtimeReady = false;
+
+export function setRuntimeReady(): void {
+  runtimeReady = true;
+}
+
+export function isRuntimeReady(): boolean {
+  return runtimeReady;
+}

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -355,6 +355,22 @@ export function handleDetailedHealth(): Response {
   return Response.json(getDetailedHealth());
 }
 
+// Tracks the last observed CES-ready state across `/readyz` polls so the
+// soft-dependency warning fires only on a transition into "not ready" rather
+// than on every poll. Once the K8s readinessProbe points at `/readyz` this
+// handler runs ~6x/min indefinitely; for setups where CES never connects
+// (e.g. BYOK) a per-poll warn would flood the logs. `undefined` means we have
+// not observed CES yet, so the first not-ready observation always logs once.
+let lastCesReady: boolean | undefined = undefined;
+
+/**
+ * Test-only: reset the transition-tracking state so each case starts from a
+ * clean slate (first not-ready observation logs once). Not used in production.
+ */
+export function __resetReadyzCesStateForTest(): void {
+  lastCesReady = undefined;
+}
+
 export function handleReadyz(): Response {
   // Ready = critical startup complete (HTTP bound + DB initialized + daemon
   // started). CES is a soft dependency with a direct-credential-store fallback,
@@ -364,12 +380,15 @@ export function handleReadyz(): Response {
   }
 
   const cesClient = getCesClient();
-  if (!cesClient?.isReady()) {
+  const cesReady = cesClient?.isReady() ?? false;
+  // Only warn on a transition into not-ready so steady-state polling stays quiet.
+  if (!cesReady && cesReady !== lastCesReady) {
     getLogger("health").warn(
       { reason: cesClient ? "ces_not_ready" : "ces_unavailable" },
       "CES not ready — readiness unaffected (soft dependency with fallback)",
     );
   }
+  lastCesReady = cesReady;
   return Response.json({ status: "ok" });
 }
 

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -24,6 +24,7 @@ import { resolveHatchedAtReadOnly } from "../../workspace/hatched-date.js";
 import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
 import { getLastWorkspaceMigrationId } from "../../workspace/migrations/runner.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { isRuntimeReady } from "../ready-state.js";
 import { NotFoundError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 
@@ -355,13 +356,18 @@ export function handleDetailedHealth(): Response {
 }
 
 export function handleReadyz(): Response {
+  // Ready = critical startup complete (HTTP bound + DB initialized + daemon
+  // started). CES is a soft dependency with a direct-credential-store fallback,
+  // so it is logged/warned but does NOT gate readiness.
+  if (!isRuntimeReady()) {
+    return Response.json({ status: "starting" }, { status: 503 });
+  }
+
   const cesClient = getCesClient();
   if (!cesClient?.isReady()) {
-    // TODO: Return 503 once we confirm via logs that this won't cause
-    // regressions in the K8s readinessProbe.
     getLogger("health").warn(
       { reason: cesClient ? "ces_not_ready" : "ces_unavailable" },
-      "CES not ready — pod would be unready if 503 were enabled",
+      "CES not ready — readiness unaffected (soft dependency with fallback)",
     );
   }
   return Response.json({ status: "ok" });


### PR DESCRIPTION
## Summary
- Add runtime ready-state flag set after critical startup (HTTP bound + DB initialized + daemon started)
- /readyz returns 503 {status:starting} until ready, 200 after; CES stays a soft (non-gating) dependency
- Tests cover both readiness states incl. the CES-soft case

Part of plan: k8s-probe-resilience.md (PR 1 of 1, vellum-assistant half)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->