### PR TITLE
refactor(gateway): repoint findContactChannelByAddress off the assistant DB

### DIFF
--- a/gateway/src/__tests__/find-contact-channel-by-address.test.ts
+++ b/gateway/src/__tests__/find-contact-channel-by-address.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for findContactChannelByAddress: resolves the contact's display name
+ * from the gateway's own contact store (not the assistant DB), matching the
+ * (type, address) key case-insensitively.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "./test-preload.js";
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+import { findContactChannelByAddress } from "../verification/contact-helpers.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seed(opts: { displayName: string; type: string; address: string }) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: "c1",
+      displayName: opts.displayName,
+      role: "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: "ch1",
+      contactId: "c1",
+      type: opts.type,
+      address: opts.address,
+      isPrimary: false,
+      status: "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+describe("findContactChannelByAddress", () => {
+  test("returns the gateway contact's display name on an exact match", () => {
+    seed({ displayName: "Ada", type: "telegram", address: "U123" });
+    expect(findContactChannelByAddress("telegram", "U123")).toEqual({
+      displayName: "Ada",
+    });
+  });
+
+  test("matches address case-insensitively", () => {
+    seed({ displayName: "Ada", type: "telegram", address: "U123" });
+    expect(findContactChannelByAddress("telegram", "u123")).toEqual({
+      displayName: "Ada",
+    });
+  });
+
+  test("returns null when no gateway row matches", () => {
+    seed({ displayName: "Ada", type: "telegram", address: "U123" });
+    expect(findContactChannelByAddress("telegram", "other")).toBeNull();
+    expect(findContactChannelByAddress("slack", "U123")).toBeNull();
+  });
+});

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -1,8 +1,9 @@
 /**
  * Contact upsert/lookup helpers for gateway-owned verification.
  *
- * All operations go through assistantDbQuery/assistantDbRun (raw SQL via
- * IPC proxy). No IPC routes are used — only the direct SQL executor.
+ * Reads resolve from the gateway's own contact store (source of truth); writes
+ * land in the gateway DB and dual-write the assistant mirror via
+ * assistantDbRun. No IPC routes are used — only the direct SQL executor.
  *
  * These helpers cover the subset of contact operations needed by the
  * verification intercept flow. They are intentionally simpler than the
@@ -27,42 +28,32 @@ import { canonicalizeInboundIdentity } from "./identity.js";
 const log = getLogger("verification-contacts");
 
 // ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ContactChannelRow {
-  channelId: string;
-  contactId: string;
-  address: string;
-  externalChatId: string | null;
-  displayName: string | null;
-  status: string;
-}
-
-// ---------------------------------------------------------------------------
 // Lookup
 // ---------------------------------------------------------------------------
 
 /**
- * Find an existing contact channel by (type, address).
+ * Find an existing contact channel by (type, address), returning its contact's
+ * display name. Reads the gateway's own DB (source of truth); the m0006
+ * reconcile mirrors legacy assistant channels here by (type, address), so a
+ * missing row is the legitimate not-found case (no name to preserve).
  */
-export async function findContactChannelByAddress(
+export function findContactChannelByAddress(
   channelType: string,
   address: string,
-): Promise<ContactChannelRow | null> {
-  const rows = await assistantDbQuery<ContactChannelRow>(
-    `SELECT cc.id AS channelId, cc.contact_id AS contactId,
-            cc.address,
-            cc.external_chat_id AS externalChatId,
-            c.display_name AS displayName,
-            cc.status
-     FROM contact_channels cc
-     JOIN contacts c ON c.id = cc.contact_id
-     WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-     LIMIT 1`,
-    [channelType, address],
-  );
-  return rows[0] ?? null;
+): { displayName: string | null } | null {
+  const row = getGatewayDb()
+    .select({ displayName: gwContacts.displayName })
+    .from(gwContactChannels)
+    .innerJoin(gwContacts, eq(gwContacts.id, gwContactChannels.contactId))
+    .where(
+      and(
+        eq(gwContactChannels.type, channelType),
+        sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+      ),
+    )
+    .limit(1)
+    .get();
+  return row ? { displayName: row.displayName } : null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Read findContactChannelByAddress from the gateway's own contact store instead of the assistant DB via db_proxy
- No behavior change; data parity guaranteed by the m0006 reconcile

## Original prompt
Combo 11 quick win: repoint one of two obsolete gateway reads that still pull from the assistant DB, so the assistant ACL columns can later be dropped.

Part of: Combo 11 gateway obsolete-read repoint