### PR TITLE
Sub-agent & Workflow UI: open/close & expand/collapse animations

### DIFF
--- a/clients/web/src/components/avatar/subagent-avatar-badge.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.tsx
@@ -2,6 +2,7 @@
 // indicator (running dots / green check / red !). Figma node 6063:148535.
 
 import { Check } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
@@ -43,6 +44,7 @@ export function SubagentAvatarBadge({
 }: SubagentAvatarBadgeProps) {
   // Atomic selector — re-render only when this subagent's status changes.
   const status = useSubagentStore((s) => s.byId[subagentId]?.status);
+  const reduce = useReducedMotion();
 
   // Spawn race: no entry yet → circle with no indicator.
   const badgeState = status ? deriveBadgeState(status) : undefined;
@@ -71,17 +73,32 @@ export function SubagentAvatarBadge({
             badgeState === "in-flight" ? "bottom-[6px]" : "bottom-[3px]"
           }`}
         >
-          {badgeState === "in-flight" && (
-            <ThreeDotIndicator dotSize={3} gap={2} />
-          )}
-          {badgeState === "completed" && (
-            <Check className="h-2.5 w-2.5 text-[var(--system-positive-strong)]" />
-          )}
-          {badgeState === "errored" && (
-            <span className="text-[11px] font-bold leading-none text-[var(--system-negative-strong)]">
-              !
-            </span>
-          )}
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.span
+              key={badgeState}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={
+                reduce
+                  ? { duration: 0 }
+                  : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
+              }
+              className="flex items-center justify-center"
+            >
+              {badgeState === "in-flight" && (
+                <ThreeDotIndicator dotSize={3} gap={2} />
+              )}
+              {badgeState === "completed" && (
+                <Check className="h-2.5 w-2.5 text-[var(--system-positive-strong)]" />
+              )}
+              {badgeState === "errored" && (
+                <span className="text-[11px] font-bold leading-none text-[var(--system-negative-strong)]">
+                  !
+                </span>
+              )}
+            </motion.span>
+          </AnimatePresence>
         </span>
       )}
     </div>

--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 export interface ActiveOverlayShellProps {
   /** `data-testid` for the root container (e.g. `"active-workflows-overlay"`). */
@@ -30,6 +31,7 @@ export function ActiveOverlayShell({
 }: ActiveOverlayShellProps) {
   const [expanded, setExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
 
   // While open, dismiss on outside pointerdown or Escape.
   useEffect(() => {
@@ -72,21 +74,32 @@ export function ActiveOverlayShell({
     >
       {renderPill({ expanded, onToggle: () => setExpanded((v) => !v) })}
 
-      {expanded && (
-        // Absolute dropdown anchored under the pill so its 589px width no longer
-        // dictates the row's width (Figma 6063:149685).
-        <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg">
-          <Typography
-            variant="title-small"
-            className="text-[var(--content-emphasised)]"
+      <AnimatePresence>
+        {expanded && (
+          // Absolute dropdown anchored under the pill so its 589px width no longer
+          // dictates the row's width (Figma 6063:149685).
+          <motion.div
+            className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
+            style={{ transformOrigin: "top center" }}
+            initial={{ opacity: 0, scale: 0.96, y: -4 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: -4 }}
+            transition={
+              reduce ? { duration: 0 } : { duration: 0.16, ease: [0.16, 1, 0.3, 1] }
+            }
           >
-            {title}
-          </Typography>
-          <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-            {children}
-          </div>
-        </div>
-      )}
+            <Typography
+              variant="title-small"
+              className="text-[var(--content-emphasised)]"
+            >
+              {title}
+            </Typography>
+            <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -79,11 +79,15 @@ export function ActiveOverlayShell({
           // Absolute dropdown anchored under the pill so its 589px width no longer
           // dictates the row's width (Figma 6063:149685).
           <motion.div
-            className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
+            // Horizontal centering lives in motion's `x: "-50%"` (not a
+            // `-translate-x-1/2` class) so it composes with the animated
+            // `scale`/`y` in the same inline `transform` — version-independent
+            // of Tailwind's translate-property model.
+            className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
             style={{ transformOrigin: "top center" }}
-            initial={{ opacity: 0, scale: 0.96, y: -4 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.96, y: -4 }}
+            initial={{ opacity: 0, scale: 0.96, y: -4, x: "-50%" }}
+            animate={{ opacity: 1, scale: 1, y: 0, x: "-50%" }}
+            exit={{ opacity: 0, scale: 0.96, y: -4, x: "-50%" }}
             transition={
               reduce ? { duration: 0 } : { duration: 0.16, ease: [0.16, 1, 0.3, 1] }
             }

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -8,7 +8,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -138,7 +144,7 @@ describe("ActiveSubagentsOverlay — expanded", () => {
 });
 
 describe("ActiveSubagentsOverlay — dismissal", () => {
-  test("Escape collapses the open panel", () => {
+  test("Escape collapses the open panel", async () => {
     const ids = seedMany(2);
     const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
@@ -146,10 +152,15 @@ describe("ActiveSubagentsOverlay — dismissal", () => {
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.keyDown(document, { key: "Escape" });
-    expect(queryByText("2 Active Subagents")).toBeNull();
+    // The dropdown animates out via AnimatePresence, so it lingers for the
+    // exit animation before unmounting.
+    await waitFor(
+      () => expect(queryByText("2 Active Subagents")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 
-  test("pointerdown outside the container collapses the open panel", () => {
+  test("pointerdown outside the container collapses the open panel", async () => {
     const ids = seedMany(2);
     const { queryByText } = render(<ActiveSubagentsOverlay subagentIds={ids} />);
 
@@ -157,6 +168,9 @@ describe("ActiveSubagentsOverlay — dismissal", () => {
     expect(queryByText("2 Active Subagents")).toBeTruthy();
 
     fireEvent.pointerDown(document.body);
-    expect(queryByText("2 Active Subagents")).toBeNull();
+    await waitFor(
+      () => expect(queryByText("2 Active Subagents")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -8,7 +8,13 @@
  */
 
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 mock.module(
   "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card",
@@ -102,7 +108,7 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
 });
 
 describe("ActiveWorkflowsOverlay — dismissal", () => {
-  test("Escape collapses the open panel", () => {
+  test("Escape collapses the open panel", async () => {
     const ids = makeIds(2);
     const { queryByText } = render(
       <ActiveWorkflowsOverlay workflowRunIds={ids} />,
@@ -116,11 +122,16 @@ describe("ActiveWorkflowsOverlay — dismissal", () => {
     // ChatContentLayout's window keydown handler bails on defaultPrevented.
     // fireEvent returns false when the event was canceled.
     const notCanceled = fireEvent.keyDown(document, { key: "Escape" });
-    expect(queryByText("2 Active Workflows")).toBeNull();
     expect(notCanceled).toBe(false);
+    // The dropdown animates out via AnimatePresence, so it lingers for the
+    // exit animation before unmounting.
+    await waitFor(
+      () => expect(queryByText("2 Active Workflows")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 
-  test("pointerdown outside the container collapses the open panel", () => {
+  test("pointerdown outside the container collapses the open panel", async () => {
     const ids = makeIds(2);
     const { queryByText } = render(
       <ActiveWorkflowsOverlay workflowRunIds={ids} />,
@@ -130,6 +141,9 @@ describe("ActiveWorkflowsOverlay — dismissal", () => {
     expect(queryByText("2 Active Workflows")).toBeTruthy();
 
     fireEvent.pointerDown(document.body);
-    expect(queryByText("2 Active Workflows")).toBeNull();
+    await waitFor(
+      () => expect(queryByText("2 Active Workflows")).toBeNull(),
+      { timeout: 4000 },
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -37,14 +37,14 @@ const importSubagentDetailPanel = () =>
   import("@/domains/chat/components/subagent-detail-panel");
 const importToolDetailPanel = () =>
   import("@/domains/chat/components/tool-detail-panel");
+const importWorkflowDetailPanel = () =>
+  import("@/domains/chat/components/workflow-detail-panel");
 
 const SubagentDetailPanel = lazy(() =>
   importSubagentDetailPanel().then((m) => ({ default: m.SubagentDetailPanel })),
 );
 const WorkflowDetailPanel = lazy(() =>
-  import("@/domains/chat/components/workflow-detail-panel").then((m) => ({
-    default: m.WorkflowDetailPanel,
-  })),
+  importWorkflowDetailPanel().then((m) => ({ default: m.WorkflowDetailPanel })),
 );
 const ToolDetailPanel = lazy(() =>
   importToolDetailPanel().then((m) => ({ default: m.ToolDetailPanel })),
@@ -203,6 +203,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     const run = () => {
       importSubagentDetailPanel().catch(() => {});
       importToolDetailPanel().catch(() => {});
+      importWorkflowDetailPanel().catch(() => {});
     };
     if (typeof window.requestIdleCallback === "function") {
       const id = window.requestIdleCallback(run);
@@ -275,12 +276,12 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
 
   const chatContent = <ChatMainPanel {...props} />;
 
-  // Right-hand detail panels — document viewer, subagent detail, and tool
-  // detail — all share ONE AnimatedRightDrawer so the chat (`left`) keeps a
-  // stable position in the React tree and is NEVER unmounted when a panel
-  // opens, closes, or switches between them. Only the (lazy, lightweight)
-  // right-pane subtree changes; the transcript keeps its DOM and scroll
-  // position. The drawer eases its width 0 ⇄ target, so opening/closing
+  // Right-hand detail panels — document viewer, subagent detail, tool detail,
+  // and workflow detail — all share ONE AnimatedRightDrawer so the chat
+  // (`left`) keeps a stable position in the React tree and is NEVER unmounted
+  // when a panel opens, closes, or switches between them. Only the (lazy,
+  // lightweight) right-pane subtree changes; the transcript keeps its DOM and
+  // scroll position. The drawer eases its width 0 ⇄ target, so opening/closing
   // reflows the chat in lockstep; drag-to-resize + width persistence are
   // built in. On mobile these panels render via portal overlays, so the
   // drawer stays closed (`open=false`) and the chat fills the width.
@@ -335,36 +336,20 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
           />
         </LazyBoundary>
       );
-    }
-  }
-
-  // Workflow detail side panel — its own ResizablePanel split, not the unified
-  // AnimatedRightDrawer below. Living in a separate return branch, the chat
-  // (`left`) remounts when switching between this panel and the other right-hand
-  // panels, whereas document/subagent/tool-detail share the drawer and keep the
-  // chat mounted across switches.
-  if (mainView === "workflow-detail" && activeWorkflowRunId && !isMobile) {
-    const activeEntry = workflowById[activeWorkflowRunId];
-    if (activeEntry) {
-      return (
-        <ResizablePanel
-          storageKey="workflowDetailPanelWidth"
-          hideDivider
-          defaultRightWidth={400}
-          minLeftWidth={300}
-          minRightWidth={400}
-          left={chatContent}
-          right={
-            <LazyBoundary>
-              <WorkflowDetailPanel
-                entry={activeEntry}
-                onClose={onCloseWorkflowDetail}
-                onStop={onStopWorkflow}
-                onRequestJournal={onRequestWorkflowJournal}
-              />
-            </LazyBoundary>
-          }
-        />
+    } else if (
+      mainView === "workflow-detail" &&
+      activeWorkflowRunId &&
+      workflowById[activeWorkflowRunId]
+    ) {
+      rightPanel = (
+        <LazyBoundary>
+          <WorkflowDetailPanel
+            entry={workflowById[activeWorkflowRunId]}
+            onClose={onCloseWorkflowDetail}
+            onStop={onStopWorkflow}
+            onRequestJournal={onRequestWorkflowJournal}
+          />
+        </LazyBoundary>
       );
     }
   }

--- a/clients/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import type { SubagentEntry } from "@/domains/chat/subagent-store";
@@ -32,28 +33,35 @@ export function MobileSubagentDetailOverlay({
   onStop,
   onRequestDetail,
 }: MobileSubagentDetailOverlayProps) {
-  if (!entry) {
-    return null;
-  }
+  const reduce = useReducedMotion();
 
   return (
-    <div
-      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
-      style={{
-        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
-        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
-        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
-        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
-      }}
-    >
-      <LazyBoundary>
-        <SubagentDetailPanel
-          entry={entry}
-          onClose={onClose}
-          onStop={onStop}
-          onRequestDetail={onRequestDetail}
-        />
-      </LazyBoundary>
-    </div>
+    <AnimatePresence>
+      {entry && (
+        <motion.div
+          key="mobile-detail-overlay"
+          className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+          style={{
+            paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+            paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+            paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+            paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+          }}
+          initial={{ y: "100%", opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: "100%", opacity: 0 }}
+          transition={reduce ? { duration: 0 } : { duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <LazyBoundary>
+            <SubagentDetailPanel
+              entry={entry}
+              onClose={onClose}
+              onStop={onStop}
+              onRequestDetail={onRequestDetail}
+            />
+          </LazyBoundary>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/clients/web/src/domains/chat/components/mobile-workflow-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-workflow-detail-overlay.tsx
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import type { WorkflowEntry } from "@/domains/chat/workflow-store";
@@ -32,28 +33,35 @@ export function MobileWorkflowDetailOverlay({
   onStop,
   onRequestJournal,
 }: MobileWorkflowDetailOverlayProps) {
-  if (!entry) {
-    return null;
-  }
+  const reduce = useReducedMotion();
 
   return (
-    <div
-      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
-      style={{
-        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
-        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
-        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
-        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
-      }}
-    >
-      <LazyBoundary>
-        <WorkflowDetailPanel
-          entry={entry}
-          onClose={onClose}
-          onStop={onStop}
-          onRequestJournal={onRequestJournal}
-        />
-      </LazyBoundary>
-    </div>
+    <AnimatePresence>
+      {entry && (
+        <motion.div
+          key="mobile-detail-overlay"
+          className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+          style={{
+            paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+            paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+            paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+            paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+          }}
+          initial={{ y: "100%", opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: "100%", opacity: 0 }}
+          transition={reduce ? { duration: 0 } : { duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <LazyBoundary>
+            <WorkflowDetailPanel
+              entry={entry}
+              onClose={onClose}
+              onStop={onStop}
+              onRequestJournal={onRequestJournal}
+            />
+          </LazyBoundary>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -12,6 +12,8 @@ import {
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
+import { motion, useReducedMotion } from "motion/react";
+
 import { AvatarRenderer } from "@/components/avatar-renderer";
 import {
     AnimatedMetricCard,
@@ -96,6 +98,7 @@ export function SubagentDetailPanel({
   onRequestDetail,
 }: SubagentDetailPanelProps) {
   const isRunning = isActiveStatus(entry.status);
+  const reduce = useReducedMotion();
   const components = useBundledAvatarComponents();
   // Compute the avatar traits once per subagent instead of hashing the id
   // three separate times in the JSX below.
@@ -328,143 +331,164 @@ export function SubagentDetailPanel({
       {/* Scrollable body — swaps to a step's nested detail when one is selected,
           keeping the header above mounted in both views. */}
       <div className="flex-1 overflow-y-auto px-5 py-5">
-        {activeDetail ? (
-          <>
-            {/* Navigation back to the timeline lives in the header (Back button)
-                and the breadcrumb; this body only renders the step's detail.
-                Thinking steps render their full reasoning markdown statically
-                (subagent detail isn't a live chat-session source); web_search
-                steps render their query + source links; web_fetch gets a
-                result-shaped view; other tools fall back to the shared
-                technical-details/output body. */}
-            {activeDetail.kind === "thinking" ? (
-              <ChatMarkdownMessage
-                content={activeDetail.thinkingText ?? ""}
-                hardLineBreaks
-              />
-            ) : activeDetail.kind === "web_search" &&
-              activeDetail.status !== "error" ? (
-              // A successful search shows query + sources; a FAILED one falls
-              // through to `ToolDetailBody`, which renders its full, untruncated
-              // error in the Output section — parity with a failed tool.
-              <WebSearchDetailView detail={activeDetail} />
-            ) : activeDetail.toolName === "web_fetch" ? (
-              <WebFetchDetailView detail={activeDetail} />
-            ) : (
-              <ToolDetailBody
-                detail={activeDetail}
-                showTechnicalDetailsLabel={false}
-              />
-            )}
-          </>
-        ) : (
-          <>
-            {/* Metrics row */}
-            <div className="mb-5 grid grid-cols-2 gap-3">
-              <AnimatedMetricCard
-                icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-                target={entry.inputTokens}
-                format={(n) => formatNumber(Math.round(n))}
-                label="Input"
-              />
-              <AnimatedMetricCard
-                icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
-                target={entry.outputTokens}
-                format={(n) => formatNumber(Math.round(n))}
-                label="Output"
-              />
-            </div>
-
-            {/* Objective section */}
-            {entry.objective && (
-              <div className="mb-5">
-                <Typography
-                  variant="body-medium-default"
-                  as="h3"
-                  className="mb-2 text-[var(--content-emphasised)]"
-                >
-                  Objective
-                </Typography>
-                <Typography
-                  ref={objectiveBodyRef}
-                  variant="body-medium-lighter"
-                  as="p"
-                  className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
-                    objectiveExpanded ? "" : "line-clamp-5"
-                  }`}
-                >
-                  {entry.objective}
-                </Typography>
-                {objectiveOverflows && (
-                  <button
-                    type="button"
-                    onClick={() => setObjectiveExpanded((prev) => !prev)}
-                    className="mt-1.5 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
-                  >
-                    <Typography variant="label-small-default">
-                      {objectiveExpanded ? "Show less" : "Show more"}
-                    </Typography>
-                    <ChevronDown
-                      className={`h-3.5 w-3.5 transition-transform ${
-                        objectiveExpanded ? "rotate-180" : ""
-                      }`}
-                      aria-hidden
-                    />
-                  </button>
-                )}
-                <div className="mt-5 h-px w-full bg-[var(--border-hover)]" />
-              </div>
-            )}
-
-            {/* Timeline section */}
-            <div>
-              <Typography
-                variant="title-medium"
-                as="h3"
-                className="mb-4 text-[var(--content-emphasised)]"
-              >
-                Timeline
-              </Typography>
-              {/*
-               * Key by subagent id so the timeline remounts on subagent switch,
-               * resetting the expand/collapse state it holds. The drawer keeps this
-               * component mounted across switches, so without a per-subagent reset
-               * an expanded phase would leak its expanded state onto the next
-               * subagent's same-positioned phase.
-               */}
-              {/*
-               * Gate the empty state on the RAW `entry.events`, not on the
-               * projected `steps`. `computeSubagentSteps` can intentionally
-               * DROP events (e.g. a `tool_result` with no preceding in-flight
-               * `tool_call`), so `entry.events` can be non-empty while `steps`
-               * is empty. Gating on steps would show a false "No events yet"
-               * AND — because `entry.events.length !== 0` — the detail-refetch
-               * effect above wouldn't fire to recover. When the store has events
-               * we render the timeline (which returns null for zero steps, an
-               * acceptable no-op).
-               */}
-              {entry.events.length > 0 ? (
-                <SubagentPhaseTimeline
-                  key={entry.subagentId}
-                  steps={steps}
-                  expandedKeys={expandedSectionKeys}
-                  onExpandedKeysChange={setExpandedSectionKeys}
-                  onStepDetailClick={handleStepDetailClick}
-                  // Keeps the last phase's node pulsing while the subagent is
-                  // still active but its last phase has settled.
-                  isRunning={isRunning}
+        <motion.div
+          key={activeDetail ? "detail" : "list"}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={
+            reduce
+              ? { duration: 0 }
+              : { duration: 0.18, ease: [0.16, 1, 0.3, 1] }
+          }
+        >
+          {activeDetail ? (
+            <>
+              {/* Navigation back to the timeline lives in the header (Back button)
+              and the breadcrumb; this body only renders the step's detail.
+              Thinking steps render their full reasoning markdown statically
+              (subagent detail isn't a live chat-session source); web_search
+              steps render their query + source links; web_fetch gets a
+              result-shaped view; other tools fall back to the shared
+              technical-details/output body. */}
+              {activeDetail.kind === "thinking" ? (
+                <ChatMarkdownMessage
+                  content={activeDetail.thinkingText ?? ""}
+                  hardLineBreaks
                 />
+              ) : activeDetail.kind === "web_search" &&
+                activeDetail.status !== "error" ? (
+                // A successful search shows query + sources; a FAILED one falls
+                // through to `ToolDetailBody`, which renders its full, untruncated
+                // error in the Output section — parity with a failed tool.
+                <WebSearchDetailView detail={activeDetail} />
+              ) : activeDetail.toolName === "web_fetch" ? (
+                <WebFetchDetailView detail={activeDetail} />
               ) : (
-                <Typography
-                  variant="body-small-default"
-                  className="py-4 text-center text-[var(--content-tertiary)]"
-                >
-                  No events yet
-                </Typography>
+                <ToolDetailBody
+                  detail={activeDetail}
+                  showTechnicalDetailsLabel={false}
+                />
               )}
-            </div>
-          </>
-        )}
+            </>
+          ) : (
+            <>
+              {/* Metrics row */}
+              <div className="mb-5 grid grid-cols-2 gap-3">
+                <AnimatedMetricCard
+                  icon={
+                    <ArrowDownToLine
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
+                    />
+                  }
+                  target={entry.inputTokens}
+                  format={(n) => formatNumber(Math.round(n))}
+                  label="Input"
+                />
+                <AnimatedMetricCard
+                  icon={
+                    <ArrowUpFromLine
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
+                    />
+                  }
+                  target={entry.outputTokens}
+                  format={(n) => formatNumber(Math.round(n))}
+                  label="Output"
+                />
+              </div>
+
+              {/* Objective section */}
+              {entry.objective && (
+                <div className="mb-5">
+                  <Typography
+                    variant="body-medium-default"
+                    as="h3"
+                    className="mb-2 text-[var(--content-emphasised)]"
+                  >
+                    Objective
+                  </Typography>
+                  <Typography
+                    ref={objectiveBodyRef}
+                    variant="body-medium-lighter"
+                    as="p"
+                    className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
+                      objectiveExpanded ? "" : "line-clamp-5"
+                    }`}
+                  >
+                    {entry.objective}
+                  </Typography>
+                  {objectiveOverflows && (
+                    <button
+                      type="button"
+                      onClick={() => setObjectiveExpanded((prev) => !prev)}
+                      className="mt-1.5 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+                    >
+                      <Typography variant="label-small-default">
+                        {objectiveExpanded ? "Show less" : "Show more"}
+                      </Typography>
+                      <ChevronDown
+                        className={`h-3.5 w-3.5 transition-transform ${
+                          objectiveExpanded ? "rotate-180" : ""
+                        }`}
+                        aria-hidden
+                      />
+                    </button>
+                  )}
+                  <div className="mt-5 h-px w-full bg-[var(--border-hover)]" />
+                </div>
+              )}
+
+              {/* Timeline section */}
+              <div>
+                <Typography
+                  variant="title-medium"
+                  as="h3"
+                  className="mb-4 text-[var(--content-emphasised)]"
+                >
+                  Timeline
+                </Typography>
+                {/*
+                 * Key by subagent id so the timeline remounts on subagent switch,
+                 * resetting the expand/collapse state it holds. The drawer keeps this
+                 * component mounted across switches, so without a per-subagent reset
+                 * an expanded phase would leak its expanded state onto the next
+                 * subagent's same-positioned phase.
+                 */}
+                {/*
+                 * Gate the empty state on the RAW `entry.events`, not on the
+                 * projected `steps`. `computeSubagentSteps` can intentionally
+                 * DROP events (e.g. a `tool_result` with no preceding in-flight
+                 * `tool_call`), so `entry.events` can be non-empty while `steps`
+                 * is empty. Gating on steps would show a false "No events yet"
+                 * AND — because `entry.events.length !== 0` — the detail-refetch
+                 * effect above wouldn't fire to recover. When the store has events
+                 * we render the timeline (which returns null for zero steps, an
+                 * acceptable no-op).
+                 */}
+                {entry.events.length > 0 ? (
+                  <SubagentPhaseTimeline
+                    key={entry.subagentId}
+                    steps={steps}
+                    expandedKeys={expandedSectionKeys}
+                    onExpandedKeysChange={setExpandedSectionKeys}
+                    onStepDetailClick={handleStepDetailClick}
+                    // Keeps the last phase's node pulsing while the subagent is
+                    // still active but its last phase has settled.
+                    isRunning={isRunning}
+                  />
+                ) : (
+                  <Typography
+                    variant="body-small-default"
+                    className="py-4 text-center text-[var(--content-tertiary)]"
+                  >
+                    No events yet
+                  </Typography>
+                )}
+              </div>
+            </>
+          )}
+        </motion.div>
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
@@ -55,35 +55,37 @@ describe("SubagentSpawnGroup", () => {
     expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(0);
   });
 
-  test("Details expands to the row list plus a Collapse toggle", () => {
+  test("Details expands to the row list plus a Collapse toggle", async () => {
     const ids = spawnIds(3);
-    const { getByTestId, queryAllByTestId } = render(
+    const { getByTestId, findAllByTestId, queryAllByTestId } = render(
       <SubagentSpawnGroup subagentIds={ids} />,
     );
 
     fireEvent.click(getByTestId("subagent-avatar-row-details"));
 
-    // The summary is replaced by one inline card per id, capped by Collapse.
-    expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(3);
+    // The crossfade defers the incoming view (AnimatePresence mode="wait"),
+    // so wait for the inline cards to mount.
+    expect(await findAllByTestId("subagent-inline-progress-card")).toHaveLength(
+      3,
+    );
     expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(0);
     expect(getByTestId("subagent-spawn-group-collapse")).toBeTruthy();
   });
 
-  test("Collapse returns to the avatar summary", () => {
+  test("Collapse returns to the avatar summary", async () => {
     const ids = spawnIds(3);
-    const { getByTestId, queryAllByTestId, queryByTestId } = render(
-      <SubagentSpawnGroup subagentIds={ids} />,
-    );
+    const { getByTestId, findByTestId, findAllByTestId, queryAllByTestId, queryByTestId } =
+      render(<SubagentSpawnGroup subagentIds={ids} />);
 
     fireEvent.click(getByTestId("subagent-avatar-row-details"));
-    fireEvent.click(getByTestId("subagent-spawn-group-collapse"));
+    fireEvent.click(await findByTestId("subagent-spawn-group-collapse"));
 
-    expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(3);
+    expect(await findAllByTestId("subagent-avatar-badge")).toHaveLength(3);
     expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(0);
     expect(queryByTestId("subagent-spawn-group-collapse")).toBeNull();
   });
 
-  test("threads onSubagentClick and onStopSubagent to each expanded row", () => {
+  test("threads onSubagentClick and onStopSubagent to each expanded row", async () => {
     const ids = spawnIds(2);
     // Mark in-flight so the stop button renders on the rows.
     for (const id of ids) {
@@ -92,7 +94,7 @@ describe("SubagentSpawnGroup", () => {
 
     const clicked: string[] = [];
     const stopped: string[] = [];
-    const { getByTestId, getAllByTestId } = render(
+    const { getByTestId, getAllByTestId, findAllByTestId } = render(
       <SubagentSpawnGroup
         subagentIds={ids}
         onSubagentClick={(id) => clicked.push(id)}
@@ -102,7 +104,7 @@ describe("SubagentSpawnGroup", () => {
 
     fireEvent.click(getByTestId("subagent-avatar-row-details"));
 
-    const rows = getAllByTestId("subagent-inline-progress-card");
+    const rows = await findAllByTestId("subagent-inline-progress-card");
     // The open affordance lives on the leading cluster (a `role="button"`
     // element inside the row), not on the row container itself, so the stop
     // button is not nested inside it. Click the affordance, not the row.

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
@@ -2,6 +2,7 @@
 // summary when collapsed, the SubagentInlineProgressCard list when expanded.
 
 import { ChevronUp } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
@@ -22,46 +23,66 @@ export function SubagentSpawnGroup({
 }: SubagentSpawnGroupProps) {
   // Default collapsed — the avatar summary is the resting state in the mocks.
   const [expanded, setExpanded] = useState(false);
+  const reduce = useReducedMotion();
 
   if (subagentIds.length === 0) return null;
 
-  if (!expanded) {
-    return (
-      <SubagentAvatarRow
-        subagentIds={subagentIds}
-        onExpand={() => setExpanded(true)}
-      />
-    );
-  }
+  const transition = reduce
+    ? { duration: 0 }
+    : { duration: 0.2, ease: [0.16, 1, 0.3, 1] as const };
 
   return (
-    <div className="flex w-full flex-col">
-      <div className="flex w-full flex-col gap-1">
-        {subagentIds.map((id) => (
-          <SubagentInlineProgressCard
-            key={id}
-            subagentId={id}
-            onSubagentClick={onSubagentClick}
-            onStopSubagent={onStopSubagent}
-          />
-        ))}
-      </div>
-
-      <button
-        type="button"
-        onClick={() => setExpanded(false)}
-        aria-label="Collapse subagent details"
-        data-testid="subagent-spawn-group-collapse"
-        className="mt-2 flex cursor-pointer items-center gap-1"
-      >
-        <Typography
-          variant="body-medium-default"
-          className="text-[var(--content-tertiary)]"
+    <AnimatePresence mode="wait" initial={false}>
+      {!expanded ? (
+        <motion.div
+          key="collapsed"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={transition}
         >
-          Collapse
-        </Typography>
-        <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
-      </button>
-    </div>
+          <SubagentAvatarRow
+            subagentIds={subagentIds}
+            onExpand={() => setExpanded(true)}
+          />
+        </motion.div>
+      ) : (
+        <motion.div
+          key="expanded"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={transition}
+          className="flex w-full flex-col"
+        >
+          <div className="flex w-full flex-col gap-1">
+            {subagentIds.map((id) => (
+              <SubagentInlineProgressCard
+                key={id}
+                subagentId={id}
+                onSubagentClick={onSubagentClick}
+                onStopSubagent={onStopSubagent}
+              />
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            aria-label="Collapse subagent details"
+            data-testid="subagent-spawn-group-collapse"
+            className="mt-2 flex cursor-pointer items-center gap-1"
+          >
+            <Typography
+              variant="body-medium-default"
+              className="text-[var(--content-tertiary)]"
+            >
+              Collapse
+            </Typography>
+            <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -13,7 +13,7 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 import { useState } from "react";
 
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import * as phaseGroupedStepList from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
@@ -79,7 +79,7 @@ describe("SubagentPhaseTimeline — empty input", () => {
 });
 
 describe("SubagentPhaseTimeline — completed row", () => {
-  test("shows label + 'Worked for <dur>', hides pills by default, toggles on click", () => {
+  test("shows label + 'Worked for <dur>', hides pills by default, toggles on click", async () => {
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", "tc-a"),
       bash("pwd", "completed", "2s", "tc-b"),
@@ -104,9 +104,12 @@ describe("SubagentPhaseTimeline — completed row", () => {
     fireEvent.click(header);
     expect(queryAllByTestId("phase-step-pill").length).toBe(2);
 
-    // Toggling back hides them.
+    // Toggling back hides them — the collapse animates closed (height/opacity),
+    // so the pills stay mounted through the exit transition; await their removal.
     fireEvent.click(header);
-    expect(queryAllByTestId("phase-step-pill").length).toBe(0);
+    await waitFor(() =>
+      expect(queryAllByTestId("phase-step-pill").length).toBe(0),
+    );
   });
 });
 
@@ -695,7 +698,7 @@ describe("SubagentPhaseTimeline — phase grouping", () => {
   // Two same-label "Working" phases whose first steps both have empty
   // `toolCallId` must still get distinct section keys, so expanding one does
   // not expand the other.
-  test("same-label phases with empty toolCallId expand/collapse independently", () => {
+  test("same-label phases with empty toolCallId expand/collapse independently", async () => {
     const steps: ToolCallCardStep[] = [
       // First "Working" group — empty toolCallId on every step.
       bash("ls", "completed", "1s", ""),
@@ -732,9 +735,12 @@ describe("SubagentPhaseTimeline — phase grouping", () => {
     fireEvent.click(headerOf(working[1]!));
     expect(queryAllByTestId("phase-step-pill").length).toBe(4);
 
-    // Collapsing the first leaves the second's pills visible.
+    // Collapsing the first leaves the second's pills visible — the first row's
+    // pills animate closed, so await the exit transition removing just those two.
     fireEvent.click(headerOf(working[0]!));
-    expect(queryAllByTestId("phase-step-pill").length).toBe(2);
+    await waitFor(() =>
+      expect(queryAllByTestId("phase-step-pill").length).toBe(2),
+    );
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -14,6 +14,7 @@
  */
 
 import { Brain, Globe } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { memo, useCallback, useMemo, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
@@ -258,6 +259,7 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
   onToggle: (key: string) => void;
   onStepDetailClick?: (detailKey: string) => void;
 }) {
+  const reduce = useReducedMotion();
   const rawStatus = phaseHeaderStatus(section.steps);
   // Only the active tail — the last phase while the subagent is still running —
   // may read as in-flight. Steps are sequential, so any OTHER phase computing
@@ -495,115 +497,135 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
           row's 8px gap → 22px). No own bottom padding — the container's `pb-4`
           (non-last rows) is the only bottom spacing, so the last pill sits 16px
           from the next group rather than 12px (pb-3) + 16px. */}
-      {isExpandable && expanded && (
-        <div className="flex flex-col items-start gap-1 pl-[22px]">
-          {section.steps.map((step, stepIdx) => {
-            // A step with a detail key + a wired handler renders a clickable
-            // `ToolStepPill` that opens its nested detail; everything else keeps
-            // the non-interactive `DefaultStepPill`.
-            const detailKey = onStepDetailClick
-              ? stepDetailKey(step)
-              : undefined;
-            if (detailKey && onStepDetailClick) {
-              if (step.kind === "tool") {
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName={step.iconName}
-                    label={step.activity || step.info || step.title}
-                    riskLevel={step.riskLevel}
-                    tone={
-                      step.status === "error" || step.status === "denied"
-                        ? "error"
-                        : "default"
-                    }
-                    ariaLabel="View tool details"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
-              if (step.kind === "thinking") {
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName="brain"
-                    label={step.text}
-                    ariaLabel="View reasoning"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
-              if (step.kind === "web_search") {
-                // The search's query becomes a clickable pill; its result
-                // sources move into the nested detail (query + links), mirroring
-                // the thinking-pill → reasoning-detail pattern. Falls back to the
-                // inline query label + chips below when no detail handler is
-                // wired (deploy-safe).
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName="globe"
-                    label={step.query || step.title}
-                    ariaLabel="View search details"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
-              if (step.kind === "web_search_error") {
-                // A failed search becomes an error-toned pill that opens the
-                // full, untruncated provider error in the nested detail —
-                // parity with a failed tool. Falls back to the inline error chip
-                // below when no detail handler is wired (deploy-safe).
-                return (
-                  <ToolStepPill
-                    key={stepKey(step, stepIdx)}
-                    variant="tool"
-                    iconName="globe"
-                    label={step.errorMessage}
-                    tone="error"
-                    ariaLabel="View search error"
-                    onClick={() => onStepDetailClick(detailKey)}
-                  />
-                );
-              }
+      <AnimatePresence initial={false}>
+        {isExpandable && expanded && (
+          <motion.div
+            key="phase-steps"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={
+              reduce
+                ? { duration: 0 }
+                : { duration: 0.25, ease: [0.16, 1, 0.3, 1] }
             }
-            // Web steps render as their own chip clusters (favicon chips /
-            // error chip) rather than the title-only `DefaultStepPill`, matching
-            // main chat. `web_search` results are parsed from the tool result by
-            // `computeSubagentCardData`.
-            if (step.kind === "web_search") {
-              // Label each search with its query so multiple (unclamped)
-              // searches in one "Searching the web" group stay visually
-              // distinct — the "N steps" count then maps to N labelled clusters.
-              return (
-                <div
-                  key={stepKey(step, stepIdx)}
-                  className="flex w-full flex-col gap-1"
-                >
-                  {step.query ? (
-                    <Typography
-                      variant="body-small-default"
-                      className="text-[var(--content-secondary)]"
+            className="overflow-hidden"
+          >
+            <div className="flex flex-col items-start gap-1 pl-[22px]">
+              {section.steps.map((step, stepIdx) => {
+                // A step with a detail key + a wired handler renders a clickable
+                // `ToolStepPill` that opens its nested detail; everything else keeps
+                // the non-interactive `DefaultStepPill`.
+                const detailKey = onStepDetailClick
+                  ? stepDetailKey(step)
+                  : undefined;
+                if (detailKey && onStepDetailClick) {
+                  if (step.kind === "tool") {
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName={step.iconName}
+                        label={step.activity || step.info || step.title}
+                        riskLevel={step.riskLevel}
+                        tone={
+                          step.status === "error" || step.status === "denied"
+                            ? "error"
+                            : "default"
+                        }
+                        ariaLabel="View tool details"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                  if (step.kind === "thinking") {
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName="brain"
+                        label={step.text}
+                        ariaLabel="View reasoning"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                  if (step.kind === "web_search") {
+                    // The search's query becomes a clickable pill; its result
+                    // sources move into the nested detail (query + links), mirroring
+                    // the thinking-pill → reasoning-detail pattern. Falls back to the
+                    // inline query label + chips below when no detail handler is
+                    // wired (deploy-safe).
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName="globe"
+                        label={step.query || step.title}
+                        ariaLabel="View search details"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                  if (step.kind === "web_search_error") {
+                    // A failed search becomes an error-toned pill that opens the
+                    // full, untruncated provider error in the nested detail —
+                    // parity with a failed tool. Falls back to the inline error chip
+                    // below when no detail handler is wired (deploy-safe).
+                    return (
+                      <ToolStepPill
+                        key={stepKey(step, stepIdx)}
+                        variant="tool"
+                        iconName="globe"
+                        label={step.errorMessage}
+                        tone="error"
+                        ariaLabel="View search error"
+                        onClick={() => onStepDetailClick(detailKey)}
+                      />
+                    );
+                  }
+                }
+                // Web steps render as their own chip clusters (favicon chips /
+                // error chip) rather than the title-only `DefaultStepPill`, matching
+                // main chat. `web_search` results are parsed from the tool result by
+                // `computeSubagentCardData`.
+                if (step.kind === "web_search") {
+                  // Label each search with its query so multiple (unclamped)
+                  // searches in one "Searching the web" group stay visually
+                  // distinct — the "N steps" count then maps to N labelled clusters.
+                  return (
+                    <div
+                      key={stepKey(step, stepIdx)}
+                      className="flex w-full flex-col gap-1"
                     >
-                      {`"${step.query}"`}
-                    </Typography>
-                  ) : null}
-                  <WebSearchStepRow step={step} />
-                </div>
-              );
-            }
-            if (step.kind === "web_search_error") {
-              return (
-                <WebSearchErrorRow key={stepKey(step, stepIdx)} step={step} />
-              );
-            }
-            return <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />;
-          })}
-        </div>
-      )}
+                      {step.query ? (
+                        <Typography
+                          variant="body-small-default"
+                          className="text-[var(--content-secondary)]"
+                        >
+                          {`"${step.query}"`}
+                        </Typography>
+                      ) : null}
+                      <WebSearchStepRow step={step} />
+                    </div>
+                  );
+                }
+                if (step.kind === "web_search_error") {
+                  return (
+                    <WebSearchErrorRow
+                      key={stepKey(step, stepIdx)}
+                      step={step}
+                    />
+                  );
+                }
+                return (
+                  <DefaultStepPill key={stepKey(step, stepIdx)} step={step} />
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 });

--- a/clients/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
@@ -274,7 +274,25 @@ export function ToolProgressCardShell({
         const titleCluster = (
           <span className="flex min-w-0 flex-1 items-center gap-1">
             {hideStatusIndicator ? null : (
-              <StatusIndicator state={state} testId={statusIndicatorTestId} />
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.span
+                  key={state}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={
+                    reduce
+                      ? { duration: 0 }
+                      : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
+                  }
+                  className="inline-flex shrink-0"
+                >
+                  <StatusIndicator
+                    state={state}
+                    testId={statusIndicatorTestId}
+                  />
+                </motion.span>
+              </AnimatePresence>
             )}
             {leadingIcon ? (
               // `mx-1` adds 4px on each side on top of the parent's `gap-1`

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -11,6 +11,8 @@ import {
 
 import { useCallback, useEffect, useState } from "react";
 
+import { motion, useReducedMotion } from "motion/react";
+
 import { AvatarRenderer } from "@/components/avatar-renderer";
 import {
     AnimatedMetricCard,
@@ -51,6 +53,7 @@ export function WorkflowDetailPanel({
   onRequestJournal,
 }: WorkflowDetailPanelProps) {
   const isRunning = isActiveStatus(entry.status);
+  const reduce = useReducedMotion();
   const title = entry.label ?? entry.runId;
   const agentCount = entry.agentsSpawned || entry.leaves.size;
   const components = useBundledAvatarComponents();
@@ -193,79 +196,90 @@ export function WorkflowDetailPanel({
       {/* Scrollable body — swaps to a leaf's nested detail when one is open,
           keeping the header above mounted in both views. */}
       <div className="flex-1 overflow-y-auto px-5 py-5">
-        {selectedLeaf ? (
-          <WorkflowLeafDetail leaf={selectedLeaf} />
-        ) : (
-          <>
-            {/* Metrics row */}
-            <div className="mb-5 grid grid-cols-3 gap-3">
-              <AnimatedMetricCard
-                icon={
-                  <ArrowDownToLine
-                    className="h-4 w-4 shrink-0"
-                    style={{ color: "var(--content-secondary)" }}
-                  />
-                }
-                target={entry.inputTokens}
-                format={(n) => formatNumber(Math.round(n))}
-                label="Input"
-              />
-              <AnimatedMetricCard
-                icon={
-                  <ArrowUpFromLine
-                    className="h-4 w-4 shrink-0"
-                    style={{ color: "var(--content-secondary)" }}
-                  />
-                }
-                target={entry.outputTokens}
-                format={(n) => formatNumber(Math.round(n))}
-                label="Output"
-              />
-              <AnimatedMetricCard
-                icon={
-                  <Users
-                    className="h-4 w-4 shrink-0"
-                    style={{ color: "var(--content-secondary)" }}
-                  />
-                }
-                target={agentCount}
-                format={(n) => formatNumber(Math.round(n))}
-                label="Agents"
-              />
-            </div>
-
-            {/* Subagents section */}
-            <div>
-              <Typography
-                variant="body-medium-default"
-                as="h3"
-                className="mb-4 text-[var(--content-emphasised)]"
-              >
-                Subagents
-              </Typography>
-              {sortedLeaves.length === 0 ? (
-                <Typography
-                  variant="body-small-default"
-                  className="py-4 text-center text-[var(--content-tertiary)]"
-                >
-                  No subagents yet
-                </Typography>
-              ) : (
-                <div className="flex flex-col gap-1">
-                  {sortedLeaves.map((leaf) => (
-                    <WorkflowSubagentRow
-                      key={leaf.seq}
-                      runId={entry.runId}
-                      leaf={leaf}
-                      components={components}
-                      onSelect={() => setSelectedLeafSeq(leaf.seq)}
+        <motion.div
+          key={selectedLeaf ? String(selectedLeaf.seq) : "list"}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={
+            reduce
+              ? { duration: 0 }
+              : { duration: 0.18, ease: [0.16, 1, 0.3, 1] }
+          }
+        >
+          {selectedLeaf ? (
+            <WorkflowLeafDetail leaf={selectedLeaf} />
+          ) : (
+            <>
+              {/* Metrics row */}
+              <div className="mb-5 grid grid-cols-3 gap-3">
+                <AnimatedMetricCard
+                  icon={
+                    <ArrowDownToLine
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
                     />
-                  ))}
-                </div>
-              )}
-            </div>
-          </>
-        )}
+                  }
+                  target={entry.inputTokens}
+                  format={(n) => formatNumber(Math.round(n))}
+                  label="Input"
+                />
+                <AnimatedMetricCard
+                  icon={
+                    <ArrowUpFromLine
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
+                    />
+                  }
+                  target={entry.outputTokens}
+                  format={(n) => formatNumber(Math.round(n))}
+                  label="Output"
+                />
+                <AnimatedMetricCard
+                  icon={
+                    <Users
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
+                    />
+                  }
+                  target={agentCount}
+                  format={(n) => formatNumber(Math.round(n))}
+                  label="Agents"
+                />
+              </div>
+
+              {/* Subagents section */}
+              <div>
+                <Typography
+                  variant="body-medium-default"
+                  as="h3"
+                  className="mb-4 text-[var(--content-emphasised)]"
+                >
+                  Subagents
+                </Typography>
+                {sortedLeaves.length === 0 ? (
+                  <Typography
+                    variant="body-small-default"
+                    className="py-4 text-center text-[var(--content-tertiary)]"
+                  >
+                    No subagents yet
+                  </Typography>
+                ) : (
+                  <div className="flex flex-col gap-1">
+                    {sortedLeaves.map((leaf) => (
+                      <WorkflowSubagentRow
+                        key={leaf.seq}
+                        runId={entry.runId}
+                        leaf={leaf}
+                        components={components}
+                        onSelect={() => setSelectedLeafSeq(leaf.seq)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </motion.div>
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/workflow-subagent-row.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-subagent-row.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for `WorkflowSubagentRow`.
+ *
+ * Focuses on the lead indicator resolving differently per leaf status: the
+ * three-dot pulse while running vs. a terminal status glyph (e.g. the green
+ * check on `completed`). The glyph crossfades via `AnimatePresence`, but the
+ * active glyph is present synchronously on mount, so a plain render suffices.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+// Stub the avatar renderer so rows don't depend on the lazily-imported bundled
+// SVG chunk. (Mock the renderer, not `useBundledAvatarComponents` — Bun module
+// mocks are process-global and survive `mock.restore()`, so mocking the hook
+// here would leak into other files' tests that rely on the real one.)
+mock.module("@/components/avatar-renderer", () => ({
+  AvatarRenderer: () => <div data-testid="avatar" />,
+}));
+
+import { WorkflowSubagentRow } from "@/domains/chat/components/workflow-subagent-row";
+import type { WorkflowLeaf } from "@/domains/chat/workflow-store";
+
+const noop = () => {};
+
+function makeLeaf(
+  overrides: Partial<WorkflowLeaf> & { seq: number },
+): WorkflowLeaf {
+  return {
+    status: "running",
+    label: "Research Agent",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("WorkflowSubagentRow", () => {
+  test("running → three-dot pulse, no terminal glyph", () => {
+    const { container } = render(
+      <WorkflowSubagentRow
+        runId="run-1"
+        leaf={makeLeaf({ seq: 0, status: "running" })}
+        components={null}
+        onSelect={noop}
+      />,
+    );
+    // The running leaf shows the shared three-dot busy indicator.
+    expect(container.querySelectorAll(".busy-indicator").length).toBe(3);
+    // No terminal SVG glyph (CircleCheck / TriangleAlert / Ban).
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  test("completed → terminal glyph, no three-dot pulse", () => {
+    const { container } = render(
+      <WorkflowSubagentRow
+        runId="run-1"
+        leaf={makeLeaf({ seq: 0, status: "completed" })}
+        components={null}
+        onSelect={noop}
+      />,
+    );
+    // The terminal status renders a lucide SVG glyph instead of the dots.
+    expect(container.querySelectorAll(".busy-indicator").length).toBe(0);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
+++ b/clients/web/src/domains/chat/components/workflow-subagent-row.tsx
@@ -1,4 +1,7 @@
+import type { ReactNode } from "react";
+
 import { Ban, CircleCheck, TriangleAlert } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { Typography } from "@vellumai/design-library";
 
@@ -13,35 +16,55 @@ import { subagentTraits } from "@/utils/avatar-subagent";
  * while the leaf is in flight, otherwise a compact terminal status icon.
  */
 function LeadIndicator({ status }: { status: WorkflowLeaf["status"] }) {
-  if (status === "running") {
-    return <ThreeDotIndicator className="shrink-0" dotSize={4} gap={2} />;
-  }
+  const reduce = useReducedMotion();
   const baseClass = "h-3.5 w-3.5 shrink-0";
-  switch (status) {
-    case "completed":
-      return (
-        <CircleCheck
-          className={baseClass}
-          style={{ color: "var(--system-positive-strong)" }}
-        />
-      );
-    case "failed":
-      return (
-        <TriangleAlert
-          className={baseClass}
-          style={{ color: "var(--system-negative-strong)" }}
-        />
-      );
-    default:
-      return (
-        <Ban
-          className={baseClass}
-          style={{ color: "var(--content-secondary)" }}
-          role="img"
-          aria-label="Cancelled"
-        />
-      );
+
+  let icon: ReactNode;
+  if (status === "running") {
+    icon = <ThreeDotIndicator className="shrink-0" dotSize={4} gap={2} />;
+  } else if (status === "completed") {
+    icon = (
+      <CircleCheck
+        className={baseClass}
+        style={{ color: "var(--system-positive-strong)" }}
+      />
+    );
+  } else if (status === "failed") {
+    icon = (
+      <TriangleAlert
+        className={baseClass}
+        style={{ color: "var(--system-negative-strong)" }}
+      />
+    );
+  } else {
+    icon = (
+      <Ban
+        className={baseClass}
+        style={{ color: "var(--content-secondary)" }}
+        role="img"
+        aria-label="Cancelled"
+      />
+    );
   }
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.span
+        key={status}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={
+          reduce
+            ? { duration: 0 }
+            : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
+        }
+        className="flex shrink-0 items-center"
+      >
+        {icon}
+      </motion.span>
+    </AnimatePresence>
+  );
 }
 
 export interface WorkflowSubagentRowProps {

--- a/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
@@ -13,7 +13,7 @@
 
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 
 mock.module("@/domains/chat/components/chat-markdown-message", () => ({
   ChatMarkdownMessage: ({ content }: { content: string }) => (
@@ -88,14 +88,24 @@ const noop = () => {};
  * summary; clicking each "Details" toggle reveals the rows. A group already
  * expanded (e.g. across a rerender that preserves state) has no toggle and is
  * left untouched, so the helper is safe to re-run.
+ *
+ * The spawn group crossfades collapsed ↔ expanded with `AnimatePresence
+ * mode="wait"`, which defers mounting the expanded rows until the collapsed
+ * view finishes its exit animation. So after clicking we await the rows
+ * appearing rather than asserting synchronously.
  */
-function expandSubagentSummary(container: HTMLElement) {
+async function expandSubagentSummary(container: HTMLElement) {
   const toggles = container.querySelectorAll<HTMLButtonElement>(
     '[data-testid="subagent-avatar-row-details"]',
   );
-  act(() => {
-    toggles.forEach((toggle) => fireEvent.click(toggle));
-  });
+  if (toggles.length === 0) return; // already expanded — nothing to wait for
+  toggles.forEach((toggle) => fireEvent.click(toggle));
+  // mode="wait" defers mounting the expanded cards until the collapse exit completes
+  await waitFor(() =>
+    expect(
+      within(container).queryAllByTestId("subagent-inline-card").length,
+    ).toBeGreaterThan(0),
+  );
 }
 
 /**
@@ -261,7 +271,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     expect(queryAllByTestId("subagent-inline-card").length).toBe(0);
   });
 
-  test("expanding the summary renders one inline row per spawn, in spawn order", () => {
+  test("expanding the summary renders one inline row per spawn, in spawn order", async () => {
     const items: TranscriptItem[] = [
       userMessage("u1", "spawn two agents"),
       assistantMessageWithSpawn("a1", ["sa-1", "sa-2"]),
@@ -277,7 +287,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     );
 
     expect(queryAllByTestId("subagent-inline-card").length).toBe(0);
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
 
     const cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(2);
@@ -287,7 +297,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     ]);
   });
 
-  test("row open + stop fire the transcript callbacks end-to-end after expansion", () => {
+  test("row open + stop fire the transcript callbacks end-to-end after expansion", async () => {
     const opened: string[] = [];
     const stopped: string[] = [];
 
@@ -306,7 +316,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
       />,
     );
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
 
     act(() => {
       fireEvent.click(getByTestId("subagent-inline-card-open"));
@@ -366,7 +376,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
 });
 
 describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
-  test("renders inline card for a running spawn (no result) when store entry exists via parentMessageStableId", () => {
+  test("renders inline card for a running spawn (no result) when store entry exists via parentMessageStableId", async () => {
     useSubagentStore.getState().spawnSubagent({
       subagentId: "sa-running-1",
       label: "agent-0",
@@ -390,13 +400,13 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
       />,
     );
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     const cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(1);
     expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-running-1");
   });
 
-  test("renders both cards for a mixed running + completed spawn group, preserving spawn order", () => {
+  test("renders both cards for a mixed running + completed spawn group, preserving spawn order", async () => {
     // Running spawn was emitted first; the store entry exists by the time
     // the message renders even though its tool_result hasn't arrived.
     useSubagentStore.getState().spawnSubagent({
@@ -425,7 +435,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
       />,
     );
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     const cards = getAllByTestId("subagent-inline-card");
     expect(cards.map((c) => c.getAttribute("data-subagent-id"))).toEqual([
       "sa-running",
@@ -433,7 +443,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
     ]);
   });
 
-  test("renders inline card after reload via parentMessageId match", () => {
+  test("renders inline card after reload via parentMessageId match", async () => {
     // Simulates `use-conversation-history.ts` reconstructing the store from
     // history notifications, where the entry is keyed by `parentMessageId`.
     // Under single-id semantics that parent id is just the message's `id`.
@@ -474,7 +484,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
       />,
     );
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     const cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(1);
     expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-reloaded");
@@ -502,7 +512,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
 });
 
 describe("Transcript — toolUseId anchor (PR 3)", () => {
-  test("renders inline card via byToolUseId match with no result and a mismatched message id", () => {
+  test("renders inline card via byToolUseId match with no result and a mismatched message id", async () => {
     // Live + orphaned window: the spawn tool call has no result yet, and the
     // store entry is keyed under a stable id that does NOT match the rendered
     // message's id — so neither the result branch nor the positional byParent
@@ -554,7 +564,7 @@ describe("Transcript — toolUseId anchor (PR 3)", () => {
       container.querySelector('[data-testid="multi-activity-group"]'),
     ).toBeNull();
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     const cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(1);
     expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-anchored");
@@ -562,7 +572,7 @@ describe("Transcript — toolUseId anchor (PR 3)", () => {
 });
 
 describe("Transcript — cross-group claimed-set (fix-r1-c)", () => {
-  test("two non-consecutive running spawns in one message map 1:1 to distinct subagentIds without duplicates", () => {
+  test("two non-consecutive running spawns in one message map 1:1 to distinct subagentIds without duplicates", async () => {
     // Two store entries linked to the same parent message, neither with a
     // `result` on its tool call yet. Without the message-scope `claimed`
     // set, both tool-call groups would fall back positionally and resolve
@@ -630,7 +640,7 @@ describe("Transcript — cross-group claimed-set (fix-r1-c)", () => {
       container.querySelectorAll('[data-testid="subagent-avatar-row-details"]')
         .length,
     ).toBe(2);
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
 
     const cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(2);
@@ -678,7 +688,7 @@ describe("Transcript — live → reconcile card lifecycle (PR 6)", () => {
     );
   }
 
-  test("card survives optimistic→server id transition via the toolUseId anchor", () => {
+  test("card survives optimistic→server id transition via the toolUseId anchor", async () => {
     // Live: spawn under the optimistic bubble id "optimistic-1", anchored by
     // the spawning toolUseId "tu-1".
     useSubagentStore.getState().spawnSubagent({
@@ -702,7 +712,7 @@ describe("Transcript — live → reconcile card lifecycle (PR 6)", () => {
     // generic progress card for the spawn-only group (zero renderable steps
     // once the spawn is filtered out).
     expect(queryByTestId("multi-activity-group")).toBeNull();
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     let cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(1);
     expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-lifecycle");
@@ -723,14 +733,14 @@ describe("Transcript — live → reconcile card lifecycle (PR 6)", () => {
       ]),
     );
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(1);
     expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-lifecycle");
     expect(queryByTestId("multi-activity-group")).toBeNull();
   });
 
-  test("card survives reconcile via the byParent re-anchor when parentToolUseId is absent (older daemon)", () => {
+  test("card survives reconcile via the byParent re-anchor when parentToolUseId is absent (older daemon)", async () => {
     // Older daemon: no `parentToolUseId`, so the toolUseId anchor can't fire.
     // The card resolves positionally via the byParent bucket, and the
     // message-id re-anchor is what keeps that bucket reachable after the
@@ -751,7 +761,7 @@ describe("Transcript — live → reconcile card lifecycle (PR 6)", () => {
       ]),
     );
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     let cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(1);
     expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-byparent");
@@ -769,7 +779,7 @@ describe("Transcript — live → reconcile card lifecycle (PR 6)", () => {
       ]),
     );
 
-    expandSubagentSummary(container);
+    await expandSubagentSummary(container);
     cards = getAllByTestId("subagent-inline-card");
     expect(cards.length).toBe(1);
     expect(cards[0].getAttribute("data-subagent-id")).toBe("sa-byparent");


### PR DESCRIPTION
## Summary
Standardizes entrance/exit and expand/collapse motion across the sub-agent and workflow chat UI in `clients/web/src/domains/chat/`, reusing existing primitives (`AnimatedRightDrawer`, the `ToolProgressCardShell` height-collapse, `motion/react`) and honoring `prefers-reduced-motion` everywhere. Eight animation gaps closed; one self-review robustness fix applied.

## Self-review result
PASS (4 fresh-eyes passes: external feedback, plan faithfulness, repo integration, slop/reuse). 1 gap remediated (#36129); remaining findings triaged as deliberate decisions or advisory follow-ups (see below).

## PRs merged into this feature branch
- #36117 — workflow detail opens via the unified `AnimatedRightDrawer` (no static-split snap; chat no longer remounts on panel switch)
- #36119 — active sub-agents/workflows dropdown fades + scales on open/close (shared `ActiveOverlayShell`; no scrim, click-through preserved)
- #36113 — mobile sub-agent/workflow detail overlays slide up from the bottom
- #36118 — phase-timeline group expand/collapse height animation
- #36121 — detail panels fade between list and nested step/leaf view
- #36116 — sub-agent avatar badge + workflow row status glyphs crossfade
- #36115 — shared `ToolProgressCardShell` status indicator crossfades (also polishes web-search/skills cards — intended)
- #36114 — sub-agent spawn group crossfades between avatar summary and inline cards

### Self-review fix PR
- #36129 — harden active-overlay dropdown centering (motion `x:"-50%"` instead of a `-translate-x-1/2` class, Tailwind-version-independent)

## Triaged / deferred (not blocking)
- **PR #36121 is fade-in-on-swap, not a true simultaneous crossfade.** Deliberate: any true crossfade keeps both views mounted during the transition, reintroducing the deferred-mount/lingering-exit test fragility that failed CI 3× on this PR. It still animates the swap smoothly.
- **No dedicated test for the workflow-drawer routing** (`chat-content-layout.tsx`). The file lacks the routing-test harness; the new branch mirrors already-tested sub-agent/tool-detail branches.
- **Animation-wrapper duplication** (status-glyph ×3, detail fade ×2, mobile overlay ×2; transition ternary inlined). The plan deliberately inlined per-component to keep PRs independent and to match existing house style (easing already inlined in 6 pre-existing files). Candidate follow-up: extract `StatusGlyphCrossfade` / a shared bottom-sheet wrapper.

All animations respect `prefers-reduced-motion`. No new dependencies.

Part of plan: subagent-workflow-animations.md