### PR TITLE
[codex] Reactivate managed profiles after bootstrap

### DIFF
--- a/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
@@ -277,6 +277,44 @@ describe("secret routes managed proxy registry sync", () => {
       (rawConfigStore.llm as Record<string, unknown>)
         .managedProfileBootstrapCompleted,
     ).toBe(true);
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapReconciled,
+    ).toBe(true);
+    expect(configChangedCalls).toBe(1);
+  });
+
+  test("legacy completed marker still repairs disabled managed profiles", async () => {
+    secureKeyStore[ASSISTANT_API_KEY_PATH] = "ast-managed-key";
+    rawConfigStore = {
+      llm: {
+        managedProfileBootstrapCompleted: true,
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+            status: "disabled",
+          },
+        },
+      },
+    };
+
+    await addCredential("vellum:platform_base_url", PLATFORM_BASE_URL);
+
+    const profiles = (
+      rawConfigStore.llm as { profiles: Record<string, unknown> }
+    ).profiles as Record<string, Record<string, unknown>>;
+    expect("status" in profiles.balanced!).toBe(false);
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapCompleted,
+    ).toBe(true);
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapReconciled,
+    ).toBe(true);
     expect(configChangedCalls).toBe(1);
   });
 
@@ -322,6 +360,10 @@ describe("secret routes managed proxy registry sync", () => {
       (rawConfigStore.llm as Record<string, unknown>)
         .managedProfileBootstrapCompleted,
     ).toBe(true);
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapReconciled,
+    ).toBe(true);
     expect(configChangedCalls).toBe(1);
   });
 
@@ -350,6 +392,10 @@ describe("secret routes managed proxy registry sync", () => {
     expect(
       (rawConfigStore.llm as Record<string, unknown>)
         .managedProfileBootstrapCompleted,
+    ).toBe(true);
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapReconciled,
     ).toBe(true);
     expect(configChangedCalls).toBe(0);
   });

--- a/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
@@ -5,6 +5,7 @@ import { credentialKey } from "../security/credential-key.js";
 
 let lastGeminiConstructorOpts: Record<string, unknown> | null = null;
 let secureKeyStore: Record<string, string | undefined> = {};
+let secureKeyWriteHooks: Record<string, (() => Promise<void>) | undefined> = {};
 let rawConfigStore: Record<string, unknown> = {};
 const metadataUpserts: Array<{ service: string; field: string }> = [];
 const metadataDeletes: Array<{ service: string; field: string }> = [];
@@ -25,6 +26,14 @@ const MANAGED_PROVIDERS = [
 let platformBaseUrlOverride: string | undefined;
 
 const baseLlm = LLMSchema.parse({});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 const mockConfig = {
   services: {
@@ -105,6 +114,7 @@ mock.module("../security/secure-keys.js", () => ({
   }),
   setSecureKeyAsync: async (key: string, value: string) => {
     secureKeyStore[key] = value;
+    await secureKeyWriteHooks[key]?.();
     return true;
   },
   deleteSecureKeyAsync: async (key: string) => {
@@ -186,6 +196,7 @@ function deleteApiKey(name: string) {
 describe("secret routes managed proxy registry sync", () => {
   beforeEach(async () => {
     secureKeyStore = {};
+    secureKeyWriteHooks = {};
     metadataUpserts.length = 0;
     metadataDeletes.length = 0;
     lastGeminiConstructorOpts = null;
@@ -262,6 +273,51 @@ describe("secret routes managed proxy registry sync", () => {
     expect("status" in profiles.balanced!).toBe(false);
     expect("status" in profiles["quality-optimized"]!).toBe(false);
     expect(profiles["custom-balanced"]!.status).toBe("disabled");
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapCompleted,
+    ).toBe(true);
+    expect(configChangedCalls).toBe(1);
+  });
+
+  test("concurrent managed bootstrap activates profiles once", async () => {
+    rawConfigStore = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+            status: "disabled",
+          },
+        },
+      },
+    };
+    const assistantKeyWritten = deferred();
+    const releaseAssistantKeyWrite = deferred();
+    secureKeyWriteHooks[ASSISTANT_API_KEY_PATH] = async () => {
+      assistantKeyWritten.resolve();
+      await releaseAssistantKeyWrite.promise;
+    };
+
+    const assistantKeyRequest = addCredential(
+      "vellum:assistant_api_key",
+      "ast-managed-key",
+    );
+    await assistantKeyWritten.promise;
+    const baseUrlRequest = addCredential(
+      "vellum:platform_base_url",
+      PLATFORM_BASE_URL,
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    releaseAssistantKeyWrite.resolve();
+    await Promise.all([assistantKeyRequest, baseUrlRequest]);
+
+    const profiles = (
+      rawConfigStore.llm as { profiles: Record<string, unknown> }
+    ).profiles as Record<string, Record<string, unknown>>;
+    expect("status" in profiles.balanced!).toBe(false);
     expect(
       (rawConfigStore.llm as Record<string, unknown>)
         .managedProfileBootstrapCompleted,

--- a/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
@@ -5,9 +5,11 @@ import { credentialKey } from "../security/credential-key.js";
 
 let lastGeminiConstructorOpts: Record<string, unknown> | null = null;
 let secureKeyStore: Record<string, string | undefined> = {};
+let rawConfigStore: Record<string, unknown> = {};
 const metadataUpserts: Array<{ service: string; field: string }> = [];
 const metadataDeletes: Array<{ service: string; field: string }> = [];
 let providerRefreshCalls = 0;
+let configChangedCalls = 0;
 
 const PLATFORM_BASE_URL = "https://platform.example.com";
 const ASSISTANT_API_KEY_PATH = credentialKey("vellum", "assistant_api_key");
@@ -87,9 +89,15 @@ mock.module("../config/loader.js", () => ({
   ],
   getConfig: () => mockConfig,
   invalidateConfigCache: () => {},
+  loadRawConfig: () => structuredClone(rawConfigStore),
+  saveRawConfig: (config: Record<string, unknown>) => {
+    rawConfigStore = structuredClone(config);
+  },
 }));
 
 mock.module("../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) =>
+    secureKeyStore[credentialKey(provider, "api_key")],
   getSecureKeyAsync: async (key: string) => secureKeyStore[key],
   getSecureKeyResultAsync: async (key: string) => ({
     value: secureKeyStore[key],
@@ -127,6 +135,12 @@ mock.module("../util/logger.js", () => ({
 // to a no-op; its behavior is covered by memory-v2-startup.test.ts.
 mock.module("../daemon/memory-v2-startup.js", () => ({
   maybeReseedCapabilitiesAfterManagedCredential: async () => {},
+}));
+
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishConfigChanged: () => {
+    configChangedCalls++;
+  },
 }));
 
 import {
@@ -177,6 +191,8 @@ describe("secret routes managed proxy registry sync", () => {
     lastGeminiConstructorOpts = null;
     platformBaseUrlOverride = undefined;
     providerRefreshCalls = 0;
+    configChangedCalls = 0;
+    rawConfigStore = {};
     registerSecretsDeps({
       getCesClient: () => undefined,
       onProviderCredentialsChanged: () => {
@@ -207,6 +223,79 @@ describe("secret routes managed proxy registry sync", () => {
       expect(getProviderRoutingSource(provider)).toBe("managed-proxy");
     }
     expect(lastGeminiConstructorOpts).toBeDefined();
+  });
+
+  test("late managed bootstrap reactivates hatch-disabled managed profiles", async () => {
+    rawConfigStore = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+            status: "disabled",
+          },
+          "quality-optimized": {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+            status: "disabled",
+          },
+          "custom-balanced": {
+            source: "user",
+            provider: "openai",
+            provider_connection: "openai-personal",
+            model: "gpt-5.5",
+            status: "disabled",
+          },
+        },
+      },
+    };
+
+    await addCredential("vellum:assistant_api_key", "ast-managed-key");
+
+    const profiles = (
+      rawConfigStore.llm as { profiles: Record<string, unknown> }
+    ).profiles as Record<string, Record<string, unknown>>;
+    expect("status" in profiles.balanced!).toBe(false);
+    expect("status" in profiles["quality-optimized"]!).toBe(false);
+    expect(profiles["custom-balanced"]!.status).toBe("disabled");
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapCompleted,
+    ).toBe(true);
+    expect(configChangedCalls).toBe(1);
+  });
+
+  test("managed key rotation does not reactivate user-disabled managed profiles", async () => {
+    secureKeyStore[ASSISTANT_API_KEY_PATH] = "old-managed-key";
+    rawConfigStore = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+            status: "disabled",
+          },
+        },
+      },
+    };
+
+    await addCredential("vellum:assistant_api_key", "new-managed-key");
+
+    const profiles = (
+      rawConfigStore.llm as { profiles: Record<string, unknown> }
+    ).profiles as Record<string, Record<string, unknown>>;
+    expect(profiles.balanced!.status).toBe("disabled");
+    expect(
+      (rawConfigStore.llm as Record<string, unknown>)
+        .managedProfileBootstrapCompleted,
+    ).toBe(true);
+    expect(configChangedCalls).toBe(0);
   });
 
   test("provider API key writes notify live-conversation refresh listeners", async () => {

--- a/assistant/src/config/managed-profile-activation.ts
+++ b/assistant/src/config/managed-profile-activation.ts
@@ -1,0 +1,57 @@
+import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+} from "./loader.js";
+import { MANAGED_PROFILE_NAMES } from "./seed-inference-profiles.js";
+
+export const MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY =
+  "managedProfileBootstrapCompleted";
+
+function readPlainObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export async function activateManagedProfilesWhenProxyAvailable(
+  options: {
+    hadManagedProxyBefore?: boolean;
+  } = {},
+): Promise<boolean> {
+  const ctx = await resolveManagedProxyContext();
+  if (!ctx.enabled) return false;
+
+  const config = loadRawConfig();
+  const llm = readPlainObject(config.llm);
+  if (!llm) return false;
+
+  if (llm[MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY] === true) return false;
+
+  if (options.hadManagedProxyBefore) {
+    llm[MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY] = true;
+    saveRawConfig(config);
+    invalidateConfigCache();
+    return false;
+  }
+
+  const profiles = readPlainObject(llm?.profiles);
+  if (!profiles) return false;
+
+  let changed = false;
+  for (const name of MANAGED_PROFILE_NAMES) {
+    const profile = readPlainObject(profiles[name]);
+    if (profile?.source !== "managed" || profile.status !== "disabled") {
+      continue;
+    }
+    delete profile.status;
+    changed = true;
+  }
+
+  llm[MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY] = true;
+
+  saveRawConfig(config);
+  invalidateConfigCache();
+  return changed;
+}

--- a/assistant/src/config/managed-profile-activation.ts
+++ b/assistant/src/config/managed-profile-activation.ts
@@ -8,6 +8,8 @@ import { MANAGED_PROFILE_NAMES } from "./seed-inference-profiles.js";
 
 export const MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY =
   "managedProfileBootstrapCompleted";
+export const MANAGED_PROFILE_BOOTSTRAP_RECONCILED_KEY =
+  "managedProfileBootstrapReconciled";
 
 function readPlainObject(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -27,17 +29,21 @@ export async function activateManagedProfilesWhenProxyAvailable(
   const llm = readPlainObject(config.llm);
   if (!llm) return false;
 
-  if (llm[MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY] === true) return false;
+  if (llm[MANAGED_PROFILE_BOOTSTRAP_RECONCILED_KEY] === true) return false;
 
-  if (options.hadManagedProxyBefore) {
+  const profiles = readPlainObject(llm?.profiles);
+  if (!profiles) return false;
+
+  if (
+    options.hadManagedProxyBefore &&
+    llm[MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY] !== true
+  ) {
     llm[MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY] = true;
+    llm[MANAGED_PROFILE_BOOTSTRAP_RECONCILED_KEY] = true;
     saveRawConfig(config);
     invalidateConfigCache();
     return false;
   }
-
-  const profiles = readPlainObject(llm?.profiles);
-  if (!profiles) return false;
 
   let changed = false;
   for (const name of MANAGED_PROFILE_NAMES) {
@@ -50,6 +56,7 @@ export async function activateManagedProfilesWhenProxyAvailable(
   }
 
   llm[MANAGED_PROFILE_BOOTSTRAP_COMPLETED_KEY] = true;
+  llm[MANAGED_PROFILE_BOOTSTRAP_RECONCILED_KEY] = true;
 
   saveRawConfig(config);
   invalidateConfigCache();

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -506,6 +506,7 @@ export const LLMSchema = z
         maxTtlSeconds: z.number().int().min(1).default(43200),
       })
       .default({ defaultTtlSeconds: 1800, maxTtlSeconds: 43200 }),
+    managedProfileBootstrapCompleted: z.boolean().optional(),
     pricingOverrides: z.array(PricingOverrideSchema).default([]),
   })
   .superRefine((config, ctx) => {

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -507,6 +507,7 @@ export const LLMSchema = z
       })
       .default({ defaultTtlSeconds: 1800, maxTtlSeconds: 43200 }),
     managedProfileBootstrapCompleted: z.boolean().optional(),
+    managedProfileBootstrapReconciled: z.boolean().optional(),
     pricingOverrides: z.array(PricingOverrideSchema).default([]),
   })
   .superRefine((config, ctx) => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -18,6 +18,7 @@ import {
   validateEnv,
 } from "../config/env.js";
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
+import { activateManagedProfilesWhenProxyAvailable } from "../config/managed-profile-activation.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
@@ -626,6 +627,18 @@ export async function runDaemon(): Promise<void> {
       log.warn(
         { err },
         "Inference profile seeding failed — continuing startup",
+      );
+    }
+
+    try {
+      if (await activateManagedProfilesWhenProxyAvailable()) {
+        publishConfigChanged();
+        log.info("Activated managed inference profiles for platform bootstrap");
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "Managed inference profile activation failed — continuing startup",
       );
     }
 

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -71,6 +71,23 @@ const CES_READY_POLL_INTERVAL_MS = 500;
 const CES_READY_POLL_TIMEOUT_MS = 30_000;
 
 let apiKeyGeneration = 0;
+let managedProxyCredentialMutationQueue: Promise<void> = Promise.resolve();
+
+async function withManagedProxyCredentialMutationLock<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = managedProxyCredentialMutationQueue;
+  let release: () => void = () => {};
+  managedProxyCredentialMutationQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous.catch(() => {});
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
 
 async function queueApiKeyPropagation(
   cesClient: CesClient,
@@ -248,9 +265,6 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
       const field = name.slice(colonIdx + 1);
       const key = credentialKey(service, field);
       const managedProxyCredential = isManagedProxyCredential(service, field);
-      const hadManagedProxyBefore = managedProxyCredential
-        ? (await resolveManagedProxyContext()).enabled
-        : false;
 
       const TRIMMED_IDENTITY_FIELDS = new Set([
         "platform_assistant_id",
@@ -261,87 +275,98 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
         service === "vellum" && TRIMMED_IDENTITY_FIELDS.has(field);
       const effectiveValue = isTrimmedIdentity ? value.trim() : value;
 
-      if (isTrimmedIdentity && effectiveValue === "") {
-        const deleteResult = await deleteSecureKeyAsync(key);
-        if (deleteResult === "error") {
-          throw new InternalError(
-            `Failed to delete stale credential from secure storage: ${service}:${field}`,
-          );
+      const writeCredential = async () => {
+        const hadManagedProxyBefore = managedProxyCredential
+          ? (await resolveManagedProxyContext()).enabled
+          : false;
+
+        if (isTrimmedIdentity && effectiveValue === "") {
+          const deleteResult = await deleteSecureKeyAsync(key);
+          if (deleteResult === "error") {
+            throw new InternalError(
+              `Failed to delete stale credential from secure storage: ${service}:${field}`,
+            );
+          }
+          if (field === "platform_assistant_id") {
+            setPlatformAssistantId(undefined);
+          } else if (field === "platform_organization_id") {
+            setPlatformOrganizationId(undefined);
+            setSentryOrganizationId(undefined);
+          } else if (field === "platform_user_id") {
+            setPlatformUserId(undefined);
+            setSentryUserId(undefined);
+          }
+          deleteCredentialMetadata(service, field);
+        } else {
+          const stored = await setSecureKeyAsync(key, effectiveValue);
+          if (!stored) {
+            throw new InternalError(
+              `Failed to store credential in secure storage (backend: ${getActiveBackendName()})`,
+            );
+          }
+          upsertCredentialMetadata(service, field, {});
+          await syncManualTokenConnection(service);
+          if (service === "vellum" && field === "platform_base_url") {
+            setPlatformBaseUrl(effectiveValue);
+          }
+          if (service === "vellum" && field === "platform_assistant_id") {
+            setPlatformAssistantId(effectiveValue || undefined);
+          }
+          if (service === "vellum" && field === "platform_organization_id") {
+            setPlatformOrganizationId(effectiveValue || undefined);
+            setSentryOrganizationId(effectiveValue || undefined);
+          }
+          if (service === "vellum" && field === "platform_user_id") {
+            setPlatformUserId(effectiveValue || undefined);
+            setSentryUserId(effectiveValue || undefined);
+          }
         }
-        if (field === "platform_assistant_id") {
-          setPlatformAssistantId(undefined);
-        } else if (field === "platform_organization_id") {
-          setPlatformOrganizationId(undefined);
-          setSentryOrganizationId(undefined);
-        } else if (field === "platform_user_id") {
-          setPlatformUserId(undefined);
-          setSentryUserId(undefined);
-        }
-        deleteCredentialMetadata(service, field);
-      } else {
-        const stored = await setSecureKeyAsync(key, effectiveValue);
-        if (!stored) {
-          throw new InternalError(
-            `Failed to store credential in secure storage (backend: ${getActiveBackendName()})`,
-          );
-        }
-        upsertCredentialMetadata(service, field, {});
-        await syncManualTokenConnection(service);
-        if (service === "vellum" && field === "platform_base_url") {
-          setPlatformBaseUrl(effectiveValue);
-        }
-        if (service === "vellum" && field === "platform_assistant_id") {
-          setPlatformAssistantId(effectiveValue || undefined);
-        }
-        if (service === "vellum" && field === "platform_organization_id") {
-          setPlatformOrganizationId(effectiveValue || undefined);
-          setSentryOrganizationId(effectiveValue || undefined);
-        }
-        if (service === "vellum" && field === "platform_user_id") {
-          setPlatformUserId(effectiveValue || undefined);
-          setSentryUserId(effectiveValue || undefined);
-        }
-      }
-      if (managedProxyCredential) {
-        const profilesChanged = await activateManagedProfilesWhenProxyAvailable(
-          { hadManagedProxyBefore },
-        );
-        if (profilesChanged) {
-          publishConfigChanged();
-        }
-        await refreshProvidersAfterSecretChange();
-        // Close the first-boot race where the startup capability seed ran before
-        // the managed embedding credential was provisioned, leaving skill/CLI
-        // pages unseeded until restart. Detached — must not block the response.
-        void maybeReseedCapabilitiesAfterManagedCredential(getConfig());
-        if (service === "vellum" && field === "assistant_api_key") {
-          const generation = ++apiKeyGeneration;
-          const deps = getSecretsDeps();
-          const cesClient = deps?.getCesClient?.();
-          if (cesClient) {
-            if (cesClient.isReady()) {
-              try {
-                await cesClient.updateAssistantApiKey(
-                  value,
-                  getPlatformAssistantId() || undefined,
-                );
-                log.info(
-                  "Pushed assistant API key to CES after managed proxy credential update",
-                );
-              } catch (err) {
-                log.warn(
-                  { error: err instanceof Error ? err.message : String(err) },
-                  "Failed to push assistant API key to CES (non-fatal)",
-                );
+        if (managedProxyCredential) {
+          const profilesChanged =
+            await activateManagedProfilesWhenProxyAvailable({
+              hadManagedProxyBefore,
+            });
+          if (profilesChanged) {
+            publishConfigChanged();
+          }
+          await refreshProvidersAfterSecretChange();
+          // Close the first-boot race where the startup capability seed ran before
+          // the managed embedding credential was provisioned, leaving skill/CLI
+          // pages unseeded until restart. Detached — must not block the response.
+          void maybeReseedCapabilitiesAfterManagedCredential(getConfig());
+          if (service === "vellum" && field === "assistant_api_key") {
+            const generation = ++apiKeyGeneration;
+            const deps = getSecretsDeps();
+            const cesClient = deps?.getCesClient?.();
+            if (cesClient) {
+              if (cesClient.isReady()) {
+                try {
+                  await cesClient.updateAssistantApiKey(
+                    value,
+                    getPlatformAssistantId() || undefined,
+                  );
+                  log.info(
+                    "Pushed assistant API key to CES after managed proxy credential update",
+                  );
+                } catch (err) {
+                  log.warn(
+                    { error: err instanceof Error ? err.message : String(err) },
+                    "Failed to push assistant API key to CES (non-fatal)",
+                  );
+                }
+              } else {
+                void queueApiKeyPropagation(cesClient, value, generation);
               }
-            } else {
-              void queueApiKeyPropagation(cesClient, value, generation);
             }
           }
         }
-      }
-      log.info({ service, field }, "Credential added via HTTP");
-      return { success: true, type, name };
+        log.info({ service, field }, "Credential added via HTTP");
+        return { success: true, type, name };
+      };
+
+      return managedProxyCredential
+        ? await withManagedProxyCredentialMutationLock(writeCredential)
+        : await writeCredential();
     }
 
     throw new BadRequestError(

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -21,6 +21,7 @@ import {
   getConfig,
   invalidateConfigCache,
 } from "../../config/loader.js";
+import { activateManagedProfilesWhenProxyAvailable } from "../../config/managed-profile-activation.js";
 import type { CesClient } from "../../credential-execution/client.js";
 import { maybeReseedCapabilitiesAfterManagedCredential } from "../../daemon/memory-v2-startup.js";
 import { setSentryOrganizationId, setSentryUserId } from "../../instrument.js";
@@ -31,6 +32,7 @@ import { validateAtlasCloudApiKey } from "../../providers/atlascloud/client.js";
 import { validateGeminiApiKey } from "../../providers/gemini/client.js";
 import { validateMinimaxApiKey } from "../../providers/minimax/client.js";
 import { validateOpenAIApiKey } from "../../providers/openai/client.js";
+import { resolveManagedProxyContext } from "../../providers/platform-proxy/context.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
@@ -48,6 +50,7 @@ import {
 } from "../../tools/credentials/metadata-store.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { publishConfigChanged } from "../sync/resource-sync-events.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import { getSecretsDeps } from "./secrets-deps.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -244,6 +247,10 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
       const service = name.slice(0, colonIdx);
       const field = name.slice(colonIdx + 1);
       const key = credentialKey(service, field);
+      const managedProxyCredential = isManagedProxyCredential(service, field);
+      const hadManagedProxyBefore = managedProxyCredential
+        ? (await resolveManagedProxyContext()).enabled
+        : false;
 
       const TRIMMED_IDENTITY_FIELDS = new Set([
         "platform_assistant_id",
@@ -295,7 +302,13 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
           setSentryUserId(effectiveValue || undefined);
         }
       }
-      if (isManagedProxyCredential(service, field)) {
+      if (managedProxyCredential) {
+        const profilesChanged = await activateManagedProfilesWhenProxyAvailable(
+          { hadManagedProxyBefore },
+        );
+        if (profilesChanged) {
+          publishConfigChanged();
+        }
         await refreshProvidersAfterSecretChange();
         // Close the first-boot race where the startup capability seed ran before
         // the managed embedding credential was provisioned, leaving skill/CLI

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -25,6 +25,7 @@ let selfHostedActorToken: string | null = "actor-token";
 let statusBody: unknown;
 let ensureRegistrationBody: unknown;
 let reprovisionApiKeyBody: unknown;
+let secretReadBody: unknown;
 let requests: RecordedRequest[] = [];
 
 const buildVellumMutatingHeadersMock = mock(
@@ -48,7 +49,8 @@ mock.module("@/lib/local-mode", () => ({
   getLocalGatewayUrl: () => "/assistant/__gateway/20101",
   getPlatformRuntimeUrl: () => "http://localhost:8000",
   getSelectedAssistant: () => activeAssistant,
-  isLocalAssistant: (assistant: { cloud?: string }) => assistant?.cloud === "local",
+  isLocalAssistant: (assistant: { cloud?: string }) =>
+    assistant?.cloud === "local",
   isLocalMode: () => isLocalModeValue,
   isPlatformDisabled: () => isPlatformDisabledValue,
   isRemoteGatewayMode: () => isRemoteGatewayModeValue,
@@ -136,6 +138,10 @@ beforeEach(() => {
   reprovisionApiKeyBody = {
     provisioning: { assistant_api_key: "reprovisioned-key" },
   };
+  secretReadBody = {
+    found: true,
+    value: "cached-key",
+  };
   requests = [];
   buildVellumMutatingHeadersMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
@@ -162,16 +168,17 @@ beforeEach(() => {
         return jsonResponse(statusBody);
       }
       if (
-        url.pathname ===
-        "/v1/assistants/self-hosted-local/ensure-registration/"
+        url.pathname === "/v1/assistants/self-hosted-local/ensure-registration/"
       ) {
         return jsonResponse(ensureRegistrationBody);
       }
       if (
-        url.pathname ===
-        "/v1/assistants/self-hosted-local/reprovision-api-key/"
+        url.pathname === "/v1/assistants/self-hosted-local/reprovision-api-key/"
       ) {
         return jsonResponse(reprovisionApiKeyBody);
+      }
+      if (url.pathname.endsWith("/v1/secrets/read")) {
+        return jsonResponse(secretReadBody);
       }
       if (url.pathname.endsWith("/v1/secrets")) {
         return jsonResponse({ ok: true });
@@ -192,7 +199,7 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
-    expect(requestNames()).toEqual(["status"]);
+    expect(requestNames()).toEqual(["status", "read"]);
   });
 
   test("repairs a stored platform id when the local assistant is missing its API key", async () => {
@@ -235,20 +242,54 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
     });
   });
 
+  test("reprovisions when status claims an API key but the fresh local store is missing it", async () => {
+    secretReadBody = { found: false };
+    ensureRegistrationBody = {
+      assistant: { id: OTHER_PLATFORM_ASSISTANT_ID },
+      assistant_api_key: null,
+    };
+
+    const platformAssistantId =
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+
+    expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
+    expect(requestNames()).toEqual([
+      "status",
+      "read",
+      "ensure-registration",
+      "reprovision-api-key",
+      "secrets",
+      "secrets",
+      "secrets",
+      "secrets",
+    ]);
+    expect(
+      requests
+        .filter((request) => request.pathname.endsWith("/v1/secrets"))
+        .map((request) => request.body),
+    ).toContainEqual({
+      type: "credential",
+      name: "vellum:assistant_api_key",
+      value: "reprovisioned-key",
+    });
+  });
+
   test("repairs gateway access by default for blocking platform identity resolution", async () => {
     selfHostedIngressUrl = null;
     selfHostedActorToken = null;
-    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(async () => {
-      selfHostedIngressUrl = GATEWAY_URL;
-      selfHostedActorToken = "actor-token";
-    });
+    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(
+      async () => {
+        selfHostedIngressUrl = GATEWAY_URL;
+        selfHostedActorToken = "actor-token";
+      },
+    );
 
     const platformAssistantId =
       await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
     expect(primeLocalGatewayConnectionWithRepairMock).toHaveBeenCalledTimes(1);
-    expect(requestNames()).toEqual(["status"]);
+    expect(requestNames()).toEqual(["status", "read"]);
   });
 
   test("skips raw platform calls when platform features are disabled", async () => {
@@ -267,7 +308,7 @@ describe("bootstrapLocalAssistantPlatformIdentity", () => {
     bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
     await flushAsyncWork();
 
-    expect(requestNames()).toEqual(["status"]);
+    expect(requestNames()).toEqual(["status", "read"]);
   });
 
   test("does not repair gateway access during best-effort bootstrap", async () => {
@@ -287,7 +328,7 @@ describe("bootstrapLocalAssistantPlatformIdentity", () => {
     bootstrapLocalAssistantPlatformIdentity();
     await flushAsyncWork();
 
-    expect(requestNames()).toEqual(["status"]);
+    expect(requestNames()).toEqual(["status", "read"]);
   });
 
   test("does nothing when platform features are disabled", async () => {

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -59,6 +59,11 @@ type ReprovisionApiKeyResponse = {
   };
 };
 
+type LocalCredentialReadResult = {
+  value: string | null;
+  unreachable: boolean;
+};
+
 type BootstrapLocalAssistantPlatformIdentityOptions = {
   allowGatewayRepair?: boolean;
   onError?: (error: unknown) => void;
@@ -152,7 +157,11 @@ async function ensureLocalAssistantPlatformIdentity(
     status?.assistantId && isUuid(status.assistantId)
       ? status.assistantId
       : null;
-  if (statusPlatformAssistantId && status?.hasAssistantApiKey !== false) {
+  const cachedAssistantApiKey =
+    statusPlatformAssistantId && status?.hasAssistantApiKey !== false
+      ? await readLocalCredential(gateway, "vellum:assistant_api_key")
+      : { value: null, unreachable: false };
+  if (statusPlatformAssistantId && cachedAssistantApiKey.value) {
     return statusPlatformAssistantId;
   }
 
@@ -161,7 +170,9 @@ async function ensureLocalAssistantPlatformIdentity(
     assistant,
   );
   if (!organizationId) {
-    throw new Error("Sign in to Vellum and select an organization to register this local assistant.");
+    throw new Error(
+      "Sign in to Vellum and select an organization to register this local assistant.",
+    );
   }
 
   const registration = await ensureRegistration(assistant, organizationId);
@@ -178,8 +189,9 @@ async function ensureLocalAssistantPlatformIdentity(
     );
   }
 
-  let assistantApiKey = stringValue(registration.assistant_api_key);
-  if (!assistantApiKey && status?.hasAssistantApiKey !== true) {
+  let assistantApiKey =
+    stringValue(registration.assistant_api_key) ?? cachedAssistantApiKey.value;
+  if (!assistantApiKey && !cachedAssistantApiKey.unreachable) {
     assistantApiKey = await reprovisionApiKey(assistant, organizationId);
   }
 
@@ -192,6 +204,44 @@ async function ensureLocalAssistantPlatformIdentity(
   });
 
   return platformAssistantId;
+}
+
+async function readLocalCredential(
+  gateway: { gatewayUrl: string; actorToken: string },
+  name: string,
+): Promise<LocalCredentialReadResult> {
+  const response = await fetch(
+    gatewayUrl(gateway.gatewayUrl, "/v1/secrets/read"),
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${gateway.actorToken}`,
+        "Content-Type": "application/json",
+      },
+      credentials: "omit",
+      body: JSON.stringify({ type: "credential", name, reveal: true }),
+    },
+  ).catch(() => null);
+  if (!response?.ok) {
+    return {
+      value: null,
+      unreachable: response ? response.status >= 500 : true,
+    };
+  }
+
+  const body = (await response.json().catch(() => null)) as {
+    found?: unknown;
+    value?: unknown;
+    unreachable?: unknown;
+  } | null;
+  if (body?.unreachable === true) {
+    return { value: null, unreachable: true };
+  }
+  return {
+    value: body?.found === true ? stringValue(body.value) : null,
+    unreachable: false,
+  };
 }
 
 async function ensureGatewayAccess(
@@ -215,7 +265,9 @@ async function ensureGatewayAccess(
   }
 
   if (!gatewayUrl || !actorToken) {
-    throw new Error("Unable to reach the local assistant for platform identity setup.");
+    throw new Error(
+      "Unable to reach the local assistant for platform identity setup.",
+    );
   }
 
   return { gatewayUrl, actorToken };
@@ -225,7 +277,10 @@ async function fetchPlatformStatus(
   gateway: { gatewayUrl: string; actorToken: string },
   runtimeAssistantId: string,
 ): Promise<LocalPlatformStatus | null> {
-  const url = gatewayUrl(gateway.gatewayUrl, `/v1/assistants/${encodeURIComponent(runtimeAssistantId)}/platform/status`);
+  const url = gatewayUrl(
+    gateway.gatewayUrl,
+    `/v1/assistants/${encodeURIComponent(runtimeAssistantId)}/platform/status`,
+  );
   const response = await fetch(url, {
     headers: {
       Accept: "application/json",
@@ -235,9 +290,9 @@ async function fetchPlatformStatus(
   }).catch(() => null);
   if (!response?.ok) return null;
 
-  const body = (await response.json().catch(() => null)) as
-    | PlatformStatusBody
-    | null;
+  const body = (await response
+    .json()
+    .catch(() => null)) as PlatformStatusBody | null;
   return {
     assistantId: firstString(body?.assistantId, body?.assistant_id),
     organizationId: firstString(body?.organizationId, body?.organization_id),
@@ -259,7 +314,10 @@ async function resolveOrganizationId(
     null;
   if (existing) return existing;
 
-  await useOrganizationStore.getState().fetchOrganizations().catch(() => {});
+  await useOrganizationStore
+    .getState()
+    .fetchOrganizations()
+    .catch(() => {});
   return (
     getActiveOrganizationIdForRequests() ?? assistant.organizationId ?? null
   );
@@ -296,7 +354,9 @@ async function platformPost<T>(
 ): Promise<T> {
   const deviceId = getDeviceId();
   if (!deviceId) {
-    throw new Error("Unable to identify this device for local assistant platform registration.");
+    throw new Error(
+      "Unable to identify this device for local assistant platform registration.",
+    );
   }
 
   const headers = new Headers({
@@ -323,16 +383,19 @@ async function platformPost<T>(
     );
   }
 
-  const response = await fetch(new URL(path, window.location.origin).toString(), {
-    method: "POST",
-    headers,
-    credentials: isElectron() ? "omit" : "same-origin",
-    body: JSON.stringify({
-      client_installation_id: deviceId,
-      runtime_assistant_id: assistant.assistantId,
-      client_platform: "macos",
-    }),
-  }).catch((error: unknown) => {
+  const response = await fetch(
+    new URL(path, window.location.origin).toString(),
+    {
+      method: "POST",
+      headers,
+      credentials: isElectron() ? "omit" : "same-origin",
+      body: JSON.stringify({
+        client_installation_id: deviceId,
+        runtime_assistant_id: assistant.assistantId,
+        client_platform: "macos",
+      }),
+    },
+  ).catch((error: unknown) => {
     throw new Error(
       `Unable to reach the platform registration endpoint: ${errorMessage(error)}`,
     );


### PR DESCRIPTION
## Summary

- Reactivate hatch-disabled managed inference profiles once managed proxy credentials become available.
- Add a one-time `managedProfileBootstrapCompleted` marker so later key rotations do not re-enable profiles the user intentionally disabled.
- Trigger the repair on managed credential writes and during assistant startup for already-bootstrapped local workspaces.

## Root Cause

Local hatch installs seed managed profiles as `disabled` while no platform auth is available. Platform bootstrap later writes `vellum:assistant_api_key` and `vellum:platform_base_url`, which makes managed proxy routing usable, but nothing was clearing the disabled status. The web profile pickers hide disabled profiles, so the managed profiles remained invisible after bootstrap.

## Validation

- `cd assistant && PATH="$HOME/.bun/bin:$PATH" bun test src/__tests__/secret-routes-platform-proxy.test.ts`
- `cd assistant && PATH="$HOME/.bun/bin:$PATH" bunx tsc --noEmit`
- Commit hook: assistant formatting, lint, and typecheck
- Pre-push hook: assistant lint and typecheck
