### PR TITLE
fix(settings): restart platform-hosted assistant via platform API, not CLI

### DIFF
--- a/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -98,7 +98,10 @@ export function DebugControlsPanel() {
               </p>
             </div>
             <div className="ml-4 shrink-0">
-              <RestartAssistant assistantId={assistant.id} />
+              <RestartAssistant
+                assistantId={assistant.id}
+                isLocal={assistant.is_local}
+              />
             </div>
           </div>
 

--- a/clients/web/src/domains/settings/components/restart-assistant.tsx
+++ b/clients/web/src/domains/settings/components/restart-assistant.tsx
@@ -26,7 +26,13 @@ async function restartLocalAssistant(
   return { ok: true };
 }
 
-export function RestartAssistant({ assistantId }: { assistantId: string }) {
+export function RestartAssistant({
+  assistantId,
+  isLocal,
+}: {
+  assistantId: string;
+  isLocal: boolean;
+}) {
   const [restarting, setRestarting] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -34,11 +40,15 @@ export function RestartAssistant({ assistantId }: { assistantId: string }) {
     setConfirmOpen(false);
     setRestarting(true);
     try {
-      // CLI restart (sleep + wake) only when a local host is present to run it
-      // and the assistant is one wake operates on; otherwise the platform API.
-      // Mirrors the wake-affordance gating in status-banner / connect-recovery.
+      // A platform-hosted assistant (`is_local === false`) is always restarted
+      // through the platform API — running the local CLI sleep/wake against it
+      // would target a non-existent on-machine assistant. The CLI path is only
+      // taken for a local-kind assistant when a host is present to run it and
+      // wake operates on it. Mirrors the web-UI restart behavior.
       const isCli =
-        isLocalModeHostAvailable() && isCliWakeableAssistant(assistantId);
+        isLocal &&
+        isLocalModeHostAvailable() &&
+        isCliWakeableAssistant(assistantId);
 
       if (isCli) {
         const result = await restartLocalAssistant(assistantId);


### PR DESCRIPTION
## Summary
- The debug-settings **Restart** button chose between the local CLI sleep/wake path and the platform restart API based only on the lockfile (`isCliWakeableAssistant`). In the macOS Electron app a local host is always present, so a platform-hosted assistant could be sent down the CLI path and try to restart a non-existent on-machine assistant.
- Gate the CLI path on the authoritative `is_local` flag from the assistant API: when `is_local === false` (platform-hosted) the platform restart API is always used, mirroring the web-UI behavior. The local CLI path now requires `isLocal && isLocalModeHostAvailable() && isCliWakeableAssistant(...)`.
- `DebugControlsPanel` already fetches the full assistant, so it just forwards `assistant.is_local` into `RestartAssistant`.

## Original prompt
In the macOS Electron app, the Restart button on the debug settings page was restarting a platform-hosted assistant by calling the CLI (which only restarts a *local* assistant). The local-vs-platform check was wrong; the fix should detect whether the assistant is platform-hosted and, if so, call the platform restart API the same way the web UI does.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->