### PR TITLE
refactor(runtime): simplify /readyz CES warning + document 503

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -30,9 +30,37 @@ paths:
   /readyz:
     get:
       operationId: readyz_get
+      summary: Readiness probe
+      description:
+        Returns 200 once critical startup is complete (HTTP bound, DB initialized, daemon started). Returns 503
+        while startup is still in progress. CES is a soft dependency and does not gate readiness.
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ok
+                required:
+                  - status
+        "503":
+          description: Runtime is still starting up and not yet ready.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - starting
+                required:
+                  - status
   /v1/acp/{id}/cancel:
     post:
       operationId: acp_by_id_cancel_post

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -220,9 +220,40 @@ async function collectRoutesFromModules(): Promise<RouteEntry[]> {
  * Top-level routes outside the /v1/ namespace.
  * These are added to the spec separately.
  */
-const NON_V1_ROUTES: Array<{ method: string; path: string }> = [
+const NON_V1_ROUTES: Array<{
+  method: string;
+  path: string;
+  summary?: string;
+  description?: string;
+  responseBody?: unknown;
+  additionalResponses?: Record<
+    string,
+    { description: string; schema?: unknown }
+  >;
+}> = [
   { method: "GET", path: "/healthz" },
-  { method: "GET", path: "/readyz" },
+  {
+    method: "GET",
+    path: "/readyz",
+    summary: "Readiness probe",
+    description:
+      "Returns 200 once critical startup is complete (HTTP bound, DB initialized, daemon started). Returns 503 while startup is still in progress. CES is a soft dependency and does not gate readiness.",
+    responseBody: {
+      type: "object",
+      properties: { status: { type: "string", enum: ["ok"] } },
+      required: ["status"],
+    },
+    additionalResponses: {
+      "503": {
+        description: "Runtime is still starting up and not yet ready.",
+        schema: {
+          type: "object",
+          properties: { status: { type: "string", enum: ["starting"] } },
+          required: ["status"],
+        },
+      },
+    },
+  },
   { method: "GET", path: "/pages/{id}" },
 ];
 
@@ -322,7 +353,16 @@ function buildSpec(
         path: r.path,
         method: r.method,
         endpoint: r.path,
-        entry: { method: r.method, endpoint: r.path },
+        entry: {
+          method: r.method,
+          endpoint: r.path,
+          ...(r.summary ? { summary: r.summary } : {}),
+          ...(r.description ? { description: r.description } : {}),
+          ...(r.responseBody ? { responseBody: r.responseBody } : {}),
+          ...(r.additionalResponses
+            ? { additionalResponses: r.additionalResponses }
+            : {}),
+        },
       });
     }
   }

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -39,9 +39,7 @@ mock.module("../runtime/ready-state.js", () => ({
 }));
 
 import {
-  __resetReadyzCesStateForTest,
   handleDetailedHealth,
-  handleReadyz,
   ROUTES,
 } from "../runtime/routes/identity-routes.js";
 import { setCesClient } from "../security/secure-keys.js";
@@ -209,12 +207,19 @@ describe("identity routes — health endpoint", () => {
   });
 
   describe("readyz — runtime readiness gating", () => {
-    beforeEach(() => {
+    // The CES soft-dependency warning is a process-global one-way latch
+    // (`cesWarned`) inside identity-routes, so a fresh module instance is
+    // imported per test to start each case from an un-latched state without a
+    // production reset export.
+    let handleReadyz: () => Response;
+
+    beforeEach(async () => {
       setCesClient(undefined);
       runtimeReadyFlag = true;
-      // Reset the transition-tracking state so each case's first not-ready
-      // observation registers as a transition and warns once.
-      __resetReadyzCesStateForTest();
+      const mod = await import(
+        `../runtime/routes/identity-routes.js?fresh=${Math.random()}`
+      );
+      handleReadyz = mod.handleReadyz as () => Response;
       healthWarn.mockClear();
     });
 
@@ -248,11 +253,11 @@ describe("identity routes — health endpoint", () => {
       } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
 
-      // First not-ready observation is a transition → warns once.
+      // First not-ready observation latches → warns once.
       expect(handleReadyz().status).toBe(200);
       expect(healthWarn).toHaveBeenCalledTimes(1);
 
-      // Second consecutive not-ready observation is steady-state → no new warn.
+      // Second not-ready observation is already latched → no new warn.
       expect(handleReadyz().status).toBe(200);
       expect(healthWarn).toHaveBeenCalledTimes(1);
     });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -830,8 +830,7 @@ export async function runDaemon(): Promise<void> {
     // Critical startup is complete: the runtime HTTP server is bound and the
     // daemon server is accepting requests. Mark the runtime ready so `/readyz`
     // returns 200 — but only when the DB initialized. CES is intentionally NOT
-    // gated here: it is a soft dependency with a direct-credential-store
-    // fallback, so readiness must not depend on the CES handshake.
+    // gated here (see `handleReadyz` for the soft-dependency rationale).
     //
     // Readiness is gated on `dbReady` because the contract for `/readyz` is
     // "HTTP bound + DB initialized + daemon started". If `initializeDb()` failed

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -355,21 +355,11 @@ export function handleDetailedHealth(): Response {
   return Response.json(getDetailedHealth());
 }
 
-// Tracks the last observed CES-ready state across `/readyz` polls so the
-// soft-dependency warning fires only on a transition into "not ready" rather
-// than on every poll. Once the K8s readinessProbe points at `/readyz` this
-// handler runs ~6x/min indefinitely; for setups where CES never connects
-// (e.g. BYOK) a per-poll warn would flood the logs. `undefined` means we have
-// not observed CES yet, so the first not-ready observation always logs once.
-let lastCesReady: boolean | undefined = undefined;
-
-/**
- * Test-only: reset the transition-tracking state so each case starts from a
- * clean slate (first not-ready observation logs once). Not used in production.
- */
-export function __resetReadyzCesStateForTest(): void {
-  lastCesReady = undefined;
-}
+// One-way latch so the CES soft-dependency warning fires at most once per
+// process. Once the K8s readinessProbe points at `/readyz` this handler runs
+// ~6x/min indefinitely; for setups where CES never connects (e.g. BYOK) a
+// per-poll warn would flood the logs, so a single warning is sufficient.
+let cesWarned = false;
 
 export function handleReadyz(): Response {
   // Ready = critical startup complete (HTTP bound + DB initialized + daemon
@@ -381,14 +371,13 @@ export function handleReadyz(): Response {
 
   const cesClient = getCesClient();
   const cesReady = cesClient?.isReady() ?? false;
-  // Only warn on a transition into not-ready so steady-state polling stays quiet.
-  if (!cesReady && cesReady !== lastCesReady) {
+  if (!cesReady && !cesWarned) {
+    cesWarned = true;
     getLogger("health").warn(
       { reason: cesClient ? "ces_not_ready" : "ces_unavailable" },
       "CES not ready — readiness unaffected (soft dependency with fallback)",
     );
   }
-  lastCesReady = cesReady;
   return Response.json({ status: "ok" });
 }
 


### PR DESCRIPTION
## Summary
Fixes self-review gaps for k8s-probe-resilience.md (PR 1).
- Replace CES warn transition-tracking + production test-only reset export with a one-shot `cesWarned` latch
- Document the new 503 (`{status:starting}`) response for assistant /readyz in the OpenAPI spec
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->