### PR TITLE
feat(gateway): add m0008 one-time ACL backfill from the assistant DB

### DIFF
--- a/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
+++ b/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for m0008-upsert-acl-columns-from-assistant.
+ *
+ * Verifies the gateway DB is UPSERTed from the assistant ACL source: missing
+ * contacts/channels are inserted with full ACL, existing rows have only their
+ * ACL columns updated (display_name + gateway-owned INFO/telemetry untouched),
+ * channels are keyed on (type, address) so an id mismatch updates in place
+ * without a UNIQUE error, orphan channels are skipped (no FK error), the
+ * migration is idempotent, and an unreachable assistant DB yields "skip" with no
+ * writes. Uses the same fake-assistant-DB + real in-memory gateway-DB pattern as
+ * the m0006/m0007 tests.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+
+import "./test-preload.js";
+
+// ── Fake assistant DB ───────────────────────────────────────────────────────
+
+type FakeContact = {
+  id: string;
+  display_name: string;
+  role: string;
+  principal_id: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+type FakeChannel = {
+  id: string;
+  contact_id: string;
+  type: string;
+  address: string;
+  is_primary: number;
+  external_chat_id: string | null;
+  status: string;
+  policy: string;
+  verified_at: number | null;
+  verified_via: string | null;
+  invite_id: string | null;
+  revoked_reason: string | null;
+  blocked_reason: string | null;
+  created_at: number;
+  updated_at: number | null;
+};
+
+const fakeAssistantDb = {
+  contacts: new Map<string, FakeContact>(),
+  channels: new Map<string, FakeChannel>(),
+  hasContactsTable: true,
+  hasChannelsTable: true,
+  reset(): void {
+    this.contacts.clear();
+    this.channels.clear();
+    this.hasContactsTable = true;
+    this.hasChannelsTable = true;
+  },
+};
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(async (sql: string) => {
+    const lower = sql.toLowerCase();
+    if (lower.includes("sqlite_master")) {
+      if (lower.includes("'contacts'")) {
+        return fakeAssistantDb.hasContactsTable ? [{ "1": 1 }] : [];
+      }
+      if (lower.includes("'contact_channels'")) {
+        return fakeAssistantDb.hasChannelsTable ? [{ "1": 1 }] : [];
+      }
+      return [];
+    }
+    if (lower.includes("from contact_channels")) {
+      return Array.from(fakeAssistantDb.channels.values());
+    }
+    if (lower.includes("from contacts")) {
+      return Array.from(fakeAssistantDb.contacts.values());
+    }
+    return [];
+  }),
+  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
+  assistantDbExec: mock(async () => undefined),
+}));
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+import {
+  up as m0008Up,
+  down as m0008Down,
+} from "../db/data-migrations/m0008-upsert-acl-columns-from-assistant.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  fakeAssistantDb.reset();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function seedGatewayContact(opts: { id: string } & Partial<FakeContact>): void {
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: opts.display_name ?? `gw-${opts.id}`,
+      role: opts.role ?? "contact",
+      principalId: opts.principal_id ?? null,
+      createdAt: opts.created_at ?? 500,
+      updatedAt: opts.updated_at ?? 500,
+    })
+    .run();
+}
+
+function seedGatewayChannel(opts: {
+  id: string;
+  contactId: string;
+  type: string;
+  address: string;
+} & Partial<{
+  isPrimary: boolean;
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+  verifiedVia: string | null;
+  lastSeenAt: number | null;
+  interactionCount: number;
+  lastInteraction: number | null;
+}>): void {
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: opts.id,
+      contactId: opts.contactId,
+      type: opts.type,
+      address: opts.address,
+      isPrimary: opts.isPrimary ?? false,
+      status: opts.status ?? "unverified",
+      policy: opts.policy ?? "allow",
+      verifiedAt: opts.verifiedAt ?? null,
+      verifiedVia: opts.verifiedVia ?? null,
+      lastSeenAt: opts.lastSeenAt ?? null,
+      interactionCount: opts.interactionCount ?? 0,
+      lastInteraction: opts.lastInteraction ?? null,
+      createdAt: 500,
+      updatedAt: 500,
+    })
+    .run();
+}
+
+function seedAssistantContact(
+  opts: { id: string } & Partial<FakeContact>,
+): void {
+  fakeAssistantDb.contacts.set(opts.id, {
+    display_name: `as-${opts.id}`,
+    role: "contact",
+    principal_id: null,
+    created_at: 100,
+    updated_at: 200,
+    ...opts,
+  });
+}
+
+function seedAssistantChannel(
+  opts: { id: string; contact_id: string; type: string; address: string } & Partial<FakeChannel>,
+): void {
+  fakeAssistantDb.channels.set(opts.id, {
+    is_primary: 0,
+    external_chat_id: null,
+    status: "unverified",
+    policy: "allow",
+    verified_at: null,
+    verified_via: null,
+    invite_id: null,
+    revoked_reason: null,
+    blocked_reason: null,
+    created_at: 100,
+    updated_at: 200,
+    ...opts,
+  });
+}
+
+function gwContact(id: string): Record<string, unknown> | undefined {
+  return getGatewayDb().$client
+    .prepare("SELECT * FROM contacts WHERE id = ?")
+    .get(id) as Record<string, unknown> | undefined;
+}
+
+function gwChannelByAddress(
+  type: string,
+  address: string,
+): Record<string, unknown> | undefined {
+  return getGatewayDb().$client
+    .prepare("SELECT * FROM contact_channels WHERE type = ? AND address = ?")
+    .get(type, address) as Record<string, unknown> | undefined;
+}
+
+function gwChannelCount(): number {
+  return (
+    getGatewayDb().$client
+      .prepare("SELECT count(*) AS n FROM contact_channels")
+      .get() as { n: number }
+  ).n;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("m0008-upsert-acl-columns-from-assistant", () => {
+  test("updates ACL on an existing gateway row; display_name + INFO untouched", async () => {
+    seedGatewayContact({
+      id: "c1",
+      display_name: "gateway-name",
+      role: "guardian",
+      principal_id: null,
+    });
+    seedGatewayChannel({
+      id: "ch1",
+      contactId: "c1",
+      type: "telegram",
+      address: "addr-1",
+      status: "unverified",
+      policy: "allow",
+      isPrimary: true,
+      interactionCount: 9,
+      lastSeenAt: 4242,
+      lastInteraction: 4243,
+    });
+
+    seedAssistantContact({
+      id: "c1",
+      display_name: "assistant-name",
+      role: "contact",
+      principal_id: "prin-1",
+    });
+    seedAssistantChannel({
+      id: "ch1",
+      contact_id: "c1",
+      type: "telegram",
+      address: "addr-1",
+      status: "verified",
+      policy: "deny",
+      verified_at: 777,
+      verified_via: "invite",
+    });
+
+    const result = await m0008Up();
+    expect(result).toBe("done");
+
+    const c = gwContact("c1")!;
+    expect(c.role).toBe("contact");
+    expect(c.principal_id).toBe("prin-1");
+    // display_name + timestamps never overwritten.
+    expect(c.display_name).toBe("gateway-name");
+    expect(c.created_at).toBe(500);
+
+    const ch = gwChannelByAddress("telegram", "addr-1")!;
+    expect(ch.status).toBe("verified");
+    expect(ch.policy).toBe("deny");
+    expect(ch.verified_at).toBe(777);
+    expect(ch.verified_via).toBe("invite");
+    // INFO/telemetry never overwritten.
+    expect(ch.is_primary).toBe(1);
+    expect(ch.interaction_count).toBe(9);
+    expect(ch.last_seen_at).toBe(4242);
+    expect(ch.last_interaction).toBe(4243);
+  });
+
+  test("inserts a contact + channel the gateway lacks with full ACL", async () => {
+    seedAssistantContact({
+      id: "c2",
+      display_name: "new-contact",
+      role: "guardian",
+      principal_id: "prin-2",
+    });
+    seedAssistantChannel({
+      id: "ch2",
+      contact_id: "c2",
+      type: "slack",
+      address: "addr-2",
+      status: "verified",
+      policy: "allow",
+      verified_at: 999,
+      verified_via: "manual",
+    });
+
+    const result = await m0008Up();
+    expect(result).toBe("done");
+
+    const c = gwContact("c2")!;
+    expect(c.display_name).toBe("new-contact");
+    expect(c.role).toBe("guardian");
+    expect(c.principal_id).toBe("prin-2");
+
+    const ch = gwChannelByAddress("slack", "addr-2")!;
+    expect(ch.contact_id).toBe("c2");
+    expect(ch.status).toBe("verified");
+    expect(ch.verified_at).toBe(999);
+    expect(ch.verified_via).toBe("manual");
+    // Schema-safe INFO defaults on insert.
+    expect(ch.is_primary).toBe(0);
+    expect(ch.interaction_count).toBe(0);
+    expect(ch.last_seen_at).toBeNull();
+    expect(ch.last_interaction).toBeNull();
+  });
+
+  test("channel id mismatch updates the existing (type,address) row, no duplicate", async () => {
+    seedGatewayContact({ id: "c3" });
+    seedGatewayChannel({
+      id: "gw-id",
+      contactId: "c3",
+      type: "telegram",
+      address: "shared",
+      status: "unverified",
+    });
+
+    seedAssistantContact({ id: "c3" });
+    seedAssistantChannel({
+      id: "assistant-id",
+      contact_id: "c3",
+      type: "telegram",
+      address: "shared",
+      status: "verified",
+    });
+
+    const result = await m0008Up();
+    expect(result).toBe("done");
+
+    expect(gwChannelCount()).toBe(1);
+    const ch = gwChannelByAddress("telegram", "shared")!;
+    expect(ch.id).toBe("gw-id");
+    expect(ch.status).toBe("verified");
+  });
+
+  test("orphan channel (contact absent) is skipped without throwing", async () => {
+    seedAssistantChannel({
+      id: "orphan",
+      contact_id: "ghost",
+      type: "telegram",
+      address: "orphan-addr",
+    });
+
+    const result = await m0008Up();
+    expect(result).toBe("done");
+    expect(gwChannelCount()).toBe(0);
+  });
+
+  test("idempotent: two runs yield identical gateway state", async () => {
+    seedGatewayContact({ id: "c4", role: "guardian" });
+    seedGatewayChannel({
+      id: "ch4",
+      contactId: "c4",
+      type: "telegram",
+      address: "addr-4",
+    });
+    seedAssistantContact({ id: "c4", role: "contact", principal_id: "p4" });
+    seedAssistantChannel({
+      id: "ch4",
+      contact_id: "c4",
+      type: "telegram",
+      address: "addr-4",
+      status: "verified",
+    });
+
+    await m0008Up();
+    const after1 = {
+      contact: gwContact("c4"),
+      channel: gwChannelByAddress("telegram", "addr-4"),
+      count: gwChannelCount(),
+    };
+
+    await m0008Up();
+    const after2 = {
+      contact: gwContact("c4"),
+      channel: gwChannelByAddress("telegram", "addr-4"),
+      count: gwChannelCount(),
+    };
+
+    expect(after2).toEqual(after1);
+  });
+
+  test("returns skip and writes nothing when the assistant DB is unreachable", async () => {
+    fakeAssistantDb.hasContactsTable = false;
+    seedAssistantContact({ id: "ignored" });
+
+    const result = await m0008Up();
+    expect(result).toBe("skip");
+    expect(gwContact("ignored") ?? undefined).toBeUndefined();
+    expect(gwChannelCount()).toBe(0);
+  });
+
+  test("down is a no-op (returns skip)", () => {
+    expect(m0008Down()).toBe("skip");
+  });
+});

--- a/gateway/src/db/data-migrations/index.ts
+++ b/gateway/src/db/data-migrations/index.ts
@@ -26,6 +26,7 @@ import * as m0004 from "./m0004-actor-token-hash-index-unfiltered.js";
 import * as m0005 from "./m0005-normalize-contact-channel-addresses.js";
 import * as m0006 from "./m0006-reconcile-contacts-from-assistant.js";
 import * as m0007 from "./m0007-backfill-ingress-invites.js";
+import * as m0008 from "./m0008-upsert-acl-columns-from-assistant.js";
 
 const log = getLogger("data-migrations");
 
@@ -44,6 +45,7 @@ const MIGRATIONS: { key: string; mod: MigrationModule }[] = [
   { key: "m0005-normalize-contact-channel-addresses", mod: m0005 },
   { key: "m0006-reconcile-contacts-from-assistant", mod: m0006 },
   { key: "m0007-backfill-ingress-invites", mod: m0007 },
+  { key: "m0008-upsert-acl-columns-from-assistant", mod: m0008 },
 ];
 
 /**

--- a/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
@@ -1,0 +1,185 @@
+/**
+ * One-time migration: UPSERT the ACL columns from the assistant DB onto the
+ * gateway DB. Inserts contacts/contact_channels that exist only in the assistant
+ * DB, and updates the ACL columns (role, principalId; channel status, policy,
+ * verification, revoked/blocked reasons) on rows that already exist in the
+ * gateway.
+ *
+ * Channels are keyed on the logical (type, address) — the gateway has a UNIQUE
+ * index there — because gateway-first mints its own ids, so the same channel can
+ * carry different ids across the two DBs.
+ *
+ * Never overwrites display_name, timestamps, or the gateway-owned INFO/telemetry
+ * columns (is_primary, last_seen_at, interaction_count, last_interaction).
+ *
+ * "skip" on an unreachable assistant DB so the runner retries on next boot.
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getGatewayDb } from "../connection.js";
+import { getLogger } from "../../logger.js";
+import { assistantDbQuery } from "../assistant-db-proxy.js";
+
+import type { MigrationResult } from "./index.js";
+
+const log = getLogger("m0008-upsert-acl-columns");
+
+function getRawGatewayDb(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+interface AssistantContactRow {
+  id: string;
+  display_name: string;
+  role: string;
+  principal_id: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface AssistantChannelRow {
+  id: string;
+  contact_id: string;
+  type: string;
+  address: string;
+  is_primary: number;
+  external_chat_id: string | null;
+  status: string;
+  policy: string;
+  verified_at: number | null;
+  verified_via: string | null;
+  invite_id: string | null;
+  revoked_reason: string | null;
+  blocked_reason: string | null;
+  created_at: number;
+  updated_at: number | null;
+}
+
+export async function up(): Promise<MigrationResult> {
+  const gwDb = getRawGatewayDb();
+
+  try {
+    // ── 1. Bail if the assistant tables don't exist (fresh install) ────────
+    const hasContactsTable = await assistantDbQuery<{ "1": number }>(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'contacts'`,
+    );
+    const hasChannelsTable = await assistantDbQuery<{ "1": number }>(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'contact_channels'`,
+    );
+    if (hasContactsTable.length === 0 || hasChannelsTable.length === 0) {
+      log.info(
+        "Assistant DB missing contacts/contact_channels — retrying next boot",
+      );
+      return "skip";
+    }
+
+    // ── 2. Read the assistant ACL source rows ──────────────────────────────
+    const assistantContacts = await assistantDbQuery<AssistantContactRow>(
+      `SELECT id, display_name, role, principal_id, created_at, updated_at
+         FROM contacts`,
+    );
+    const assistantChannels = await assistantDbQuery<AssistantChannelRow>(
+      `SELECT id, contact_id, type, address, is_primary, external_chat_id,
+              status, policy, verified_at, verified_via, invite_id,
+              revoked_reason, blocked_reason, created_at, updated_at
+         FROM contact_channels`,
+    );
+
+    // ── 3. Upsert contacts (insert missing, update ACL on conflict) ────────
+    const upsertContact = gwDb.prepare(
+      `INSERT INTO contacts
+         (id, display_name, role, principal_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         role = excluded.role,
+         principal_id = excluded.principal_id`,
+    );
+    const contactsTxn = gwDb.transaction(() => {
+      for (const c of assistantContacts) {
+        upsertContact.run(
+          c.id,
+          c.display_name,
+          c.role,
+          c.principal_id,
+          c.created_at,
+          c.updated_at,
+        );
+      }
+    });
+    contactsTxn();
+
+    // ── 4. Upsert channels keyed on (type, address) ────────────────────────
+    // Skip any channel whose parent contact is not among the assistant
+    // contacts we just upserted, to avoid an FK violation.
+    const contactIds = new Set(assistantContacts.map((c) => c.id));
+
+    const upsertChannel = gwDb.prepare(
+      `INSERT INTO contact_channels
+         (id, contact_id, type, address, is_primary, external_chat_id,
+          status, policy, verified_at, verified_via, invite_id,
+          revoked_reason, blocked_reason, last_seen_at,
+          interaction_count, last_interaction, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 0, NULL, ?, ?)
+       ON CONFLICT(type, address) DO UPDATE SET
+         status = excluded.status,
+         policy = excluded.policy,
+         verified_at = excluded.verified_at,
+         verified_via = excluded.verified_via,
+         revoked_reason = excluded.revoked_reason,
+         blocked_reason = excluded.blocked_reason`,
+    );
+
+    let upsertedChannels = 0;
+    let skippedOrphans = 0;
+    const channelsTxn = gwDb.transaction(() => {
+      for (const ch of assistantChannels) {
+        if (!contactIds.has(ch.contact_id)) {
+          skippedOrphans += 1;
+          continue;
+        }
+        upsertChannel.run(
+          ch.id,
+          ch.contact_id,
+          ch.type,
+          ch.address,
+          ch.is_primary ? 1 : 0,
+          ch.external_chat_id,
+          ch.status,
+          ch.policy,
+          ch.verified_at,
+          ch.verified_via,
+          ch.invite_id,
+          ch.revoked_reason,
+          ch.blocked_reason,
+          ch.created_at,
+          ch.updated_at,
+        );
+        upsertedChannels += 1;
+      }
+    });
+    channelsTxn();
+
+    log.info(
+      {
+        upsertedContacts: assistantContacts.length,
+        upsertedChannels,
+        skippedOrphans,
+      },
+      "m0008: upserted ACL columns from assistant DB into gateway",
+    );
+
+    return "done";
+  } catch (err) {
+    log.error(
+      { err },
+      "m0008: ACL backfill failed — will retry on next startup",
+    );
+    return "skip";
+  }
+}
+
+export function down(): MigrationResult {
+  // No-op: ACL in the gateway DB is legitimate data; never roll back.
+  return "skip";
+}


### PR DESCRIPTION
## Summary
- Add m0008 one-time data-migration that UPSERTs all 8 ACL columns from the assistant DB onto the gateway DB (inserts missing rows, updates ACL on existing rows)
- Channel conflict target is (type, address); INFO columns and display_name are never overwritten on conflict
- Unblocks removing the two assistant-DB heal reads

Part of plan: combo11-acl-backfill-heal-removal.md (PR 1 of 3)