### PR TITLE
refactor(channels): move Slack binding deep links onto a per-channel builder

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -493,6 +493,34 @@ describe("channel-delivery-store", () => {
     });
   });
 
+  test("conversation detail omits Slack metadata for non-Slack channels", () => {
+    const result = recordInbound("telegram", "tg-chat-1", "msg-1", {
+      sourceThreadId: "9001",
+    });
+
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel: "telegram",
+      externalChatId: "tg-chat-1",
+      externalChatName: "Family",
+      externalThreadId: "9001",
+    });
+
+    const detail = buildConversationDetailResponse(result.conversationId);
+    const binding = detail?.conversation.channelBinding;
+
+    // The channel-neutral fields pass through for any source channel...
+    expect(binding).toMatchObject({
+      sourceChannel: "telegram",
+      externalChatId: "tg-chat-1",
+      externalChatName: "Family",
+      externalThreadId: "9001",
+    });
+    // ...but Slack-only deep-link metadata is not synthesized.
+    expect(binding).not.toHaveProperty("slackThread");
+    expect(binding).not.toHaveProperty("slackChannel");
+  });
+
   test("binding upsert preserves existing chat name when incoming name is missing", () => {
     const result = recordInbound("slack", "C0123ABCDEF", "msg-1", {
       sourceThreadId: "1710000000.000100",

--- a/assistant/src/messaging/channel-binding-metadata.ts
+++ b/assistant/src/messaging/channel-binding-metadata.ts
@@ -1,0 +1,31 @@
+import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
+import type { ChannelBindingMetadata } from "./provider-types.js";
+import { buildSlackBindingMetadata } from "./providers/slack/binding-metadata.js";
+
+type BindingMetadataBuilder = (
+  binding: ExternalConversationBinding,
+) => ChannelBindingMetadata | undefined;
+
+/**
+ * Per-channel binding-metadata builders, keyed by source-channel id. A channel
+ * that can enrich a serialized conversation binding (e.g. with deep links back
+ * to the source message) registers its builder here; channels without an entry
+ * contribute nothing.
+ *
+ * Wired statically on purpose: conversation serialization runs in contexts that
+ * never boot the daemon (unit tests, CLI tooling), so this must not depend on
+ * the lifecycle-registered messaging-provider registry.
+ */
+const BINDING_METADATA_BUILDERS: Record<string, BindingMetadataBuilder> = {
+  slack: buildSlackBindingMetadata,
+};
+
+/**
+ * Channel-specific fields to merge onto a serialized channel binding, or
+ * `undefined` when the source channel contributes none.
+ */
+export function buildChannelBindingMetadata(
+  binding: ExternalConversationBinding,
+): ChannelBindingMetadata | undefined {
+  return BINDING_METADATA_BUILDERS[binding.sourceChannel]?.(binding);
+}

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -1,5 +1,13 @@
 /** Platform-agnostic types for the messaging provider abstraction. */
 
+/**
+ * Extra, channel-specific fields a channel contributes to a serialized
+ * conversation channel binding (e.g. deep links back to the source message).
+ * Additive by design: each channel returns its own fields, so this is an open
+ * record rather than a committed cross-channel schema.
+ */
+export type ChannelBindingMetadata = Record<string, unknown>;
+
 export interface Conversation {
   id: string;
   name: string;

--- a/assistant/src/messaging/providers/slack/binding-metadata.ts
+++ b/assistant/src/messaging/providers/slack/binding-metadata.ts
@@ -1,0 +1,60 @@
+import { getConfig } from "../../../config/loader.js";
+import type { ExternalConversationBinding } from "../../../memory/external-conversation-store.js";
+import type { ChannelBindingMetadata } from "../../provider-types.js";
+import {
+  buildSlackMessageDeepLinks,
+  buildSlackWebChannelUrl,
+} from "./deep-link.js";
+
+/**
+ * Slack's contribution to a serialized conversation channel binding: a
+ * human-readable channel name (falling back to the channel id) plus deep
+ * links that jump back to the source thread and channel in the Slack app or
+ * web client.
+ *
+ * The returned fields are spread onto the channel-neutral binding by the
+ * serializer — Slack is the only channel that can currently produce
+ * message-level deep links, because the link inputs (workspace team id/url +
+ * a stable per-message timestamp) only exist for Slack.
+ */
+export function buildSlackBindingMetadata(
+  binding: ExternalConversationBinding,
+): ChannelBindingMetadata {
+  const externalChatName =
+    binding.externalChatName?.trim() || binding.externalChatId;
+  const slackConfig = getConfig().slack;
+
+  const threadLink =
+    slackConfig && binding.externalThreadId
+      ? buildSlackMessageDeepLinks({
+          teamId: slackConfig.teamId,
+          teamUrl: slackConfig.teamUrl,
+          channelId: binding.externalChatId,
+          messageTs: binding.externalThreadId,
+        })
+      : undefined;
+  const slackThread = binding.externalThreadId
+    ? {
+        channelId: binding.externalChatId,
+        threadTs: binding.externalThreadId,
+        ...(threadLink ? { link: threadLink } : {}),
+      }
+    : undefined;
+
+  const channelWebUrl = slackConfig
+    ? buildSlackWebChannelUrl({
+        teamUrl: slackConfig.teamUrl,
+        channelId: binding.externalChatId,
+      })
+    : undefined;
+
+  return {
+    externalChatName,
+    ...(slackThread ? { slackThread } : {}),
+    slackChannel: {
+      channelId: binding.externalChatId,
+      name: externalChatName,
+      ...(channelWebUrl ? { link: { webUrl: channelWebUrl } } : {}),
+    },
+  };
+}

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -8,7 +8,6 @@
  */
 
 import { parseChannelId } from "../../channels/types.js";
-import { getConfig } from "../../config/loader.js";
 import { normalizeConversationType } from "../../daemon/message-types/shared.js";
 import {
   type AttentionState,
@@ -24,10 +23,7 @@ import {
 } from "../../memory/conversation-crud.js";
 import type { ExternalConversationBinding } from "../../memory/external-conversation-store.js";
 import { getBindingsForConversations } from "../../memory/external-conversation-store.js";
-import {
-  buildSlackMessageDeepLinks,
-  buildSlackWebChannelUrl,
-} from "../../messaging/providers/slack/deep-link.js";
+import { buildChannelBindingMetadata } from "../../messaging/channel-binding-metadata.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -126,48 +122,7 @@ function resolveSerializedGroupId(
 }
 
 function buildChannelBinding(binding: ExternalConversationBinding) {
-  const externalChatName =
-    binding.externalChatName?.trim() ||
-    (binding.sourceChannel === "slack" ? binding.externalChatId : undefined);
-  const slackConfig =
-    binding.sourceChannel === "slack" ? getConfig().slack : undefined;
-  const slackThreadLink =
-    slackConfig && binding.externalThreadId
-      ? buildSlackMessageDeepLinks({
-          teamId: slackConfig.teamId,
-          teamUrl: slackConfig.teamUrl,
-          channelId: binding.externalChatId,
-          messageTs: binding.externalThreadId,
-        })
-      : undefined;
-  const slackThread =
-    binding.sourceChannel === "slack" && binding.externalThreadId
-      ? {
-          channelId: binding.externalChatId,
-          threadTs: binding.externalThreadId,
-          ...(slackThreadLink ? { link: slackThreadLink } : {}),
-        }
-      : undefined;
-  const slackChannelWebUrl = slackConfig
-    ? buildSlackWebChannelUrl({
-        teamUrl: slackConfig.teamUrl,
-        channelId: binding.externalChatId,
-      })
-    : undefined;
-  const slackChannel =
-    binding.sourceChannel === "slack"
-      ? {
-          channelId: binding.externalChatId,
-          name: externalChatName,
-          ...(slackChannelWebUrl
-            ? {
-                link: {
-                  webUrl: slackChannelWebUrl,
-                },
-              }
-            : {}),
-        }
-      : undefined;
+  const externalChatName = binding.externalChatName?.trim() || undefined;
 
   return {
     sourceChannel: binding.sourceChannel,
@@ -179,8 +134,10 @@ function buildChannelBinding(binding: ExternalConversationBinding) {
     externalUserId: binding.externalUserId,
     displayName: binding.displayName,
     username: binding.username,
-    ...(slackThread ? { slackThread } : {}),
-    ...(slackChannel ? { slackChannel } : {}),
+    // Channel-specific enrichment (e.g. Slack deep links) is contributed by
+    // the source channel's binding-metadata builder, keeping this serializer
+    // channel-agnostic.
+    ...buildChannelBindingMetadata(binding),
   };
 }
 


### PR DESCRIPTION
## Summary

Stage 1 of the channel-adapter generalization (LUM-2598). `buildChannelBinding()` in the conversation serializer inlined Slack-only deep-link / thread / channel metadata behind `if (sourceChannel === "slack")` — the one "switch waiting to grow" in the daemon's binding serialization. This extracts that logic onto a per-channel binding-metadata builder so the serializer is channel-agnostic and the Slack logic lives in the Slack provider folder.

No behaviour change — existing wire-level assertions still pass; a new test covers the non-Slack path.

## What changed

- **`messaging/providers/slack/binding-metadata.ts`** (new) — `buildSlackBindingMetadata()`, the deep-link / `slackThread` / `slackChannel` assembly moved out of the serializer.
- **`messaging/channel-binding-metadata.ts`** (new) — `buildChannelBindingMetadata()`, a per-channel builder map keyed by source channel.
- **`messaging/provider-types.ts`** — adds the `ChannelBindingMetadata` type.
- **`runtime/services/conversation-serializer.ts`** — `buildChannelBinding()` now spreads `...buildChannelBindingMetadata(binding)` and no longer imports anything Slack.

## Design decisions worth a look

1. **Static dispatch map, not the lifecycle `MessagingProvider` registry.** Hanging this off `getMessagingProvider()` would couple serialization to daemon-startup registration — and `channel-delivery-store.test.ts` serializes bindings *without* booting the daemon, so the deep links would silently vanish in tests (and any non-daemon context). The builder map is wired by static import instead.
2. **Open, additive contract.** `ChannelBindingMetadata` is an open record — "a channel contributes its own fields," not a committed cross-channel schema. A second channel just implements its builder; no interface rework, nothing guessed.
3. **Dropped the originally-planned `slackThreadTs` / `slackChannelName` rename.** On inspection those inbound-handler locals are genuinely Slack-gated extractions (both guard on `sourceChannel === "slack"` and read Slack-only metadata), so renaming them to generic names would *reduce* clarity, not improve it.

## Verification

- `tsc --noEmit` ✅ (pre-commit + pre-push)
- `eslint` ✅
- `bun test channel-delivery-store.test.ts conversation-serializer.test.ts` → **53 pass, 0 fail** (existing Slack `channelBinding` assertions preserved + new non-Slack test)
- circular-deps: the new modules appear in **zero** cycles (the repo's pre-existing 394 are untouched)

## Scope

- **This PR / LUM-2577** — Stage 1 only.
- **LUM-2598** — future-direction epic; Stage 2 (unify delivery/send/normalize behind the adapter) and Stage 3 (channels as plugin Integrations/Webhooks surfaces) are deliberately deferred until a real driver defines their shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_