### PR TITLE
feat(runtime): deliberate /readyz readiness gate (k8s probe resilience)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -30,9 +30,37 @@ paths:
   /readyz:
     get:
       operationId: readyz_get
+      summary: Readiness probe
+      description:
+        Returns 200 once critical startup is complete (HTTP bound, DB initialized, daemon started). Returns 503
+        while startup is still in progress. CES is a soft dependency and does not gate readiness.
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ok
+                required:
+                  - status
+        "503":
+          description: Runtime is still starting up and not yet ready.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - starting
+                required:
+                  - status
   /v1/acp/{id}/cancel:
     post:
       operationId: acp_by_id_cancel_post

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -220,9 +220,40 @@ async function collectRoutesFromModules(): Promise<RouteEntry[]> {
  * Top-level routes outside the /v1/ namespace.
  * These are added to the spec separately.
  */
-const NON_V1_ROUTES: Array<{ method: string; path: string }> = [
+const NON_V1_ROUTES: Array<{
+  method: string;
+  path: string;
+  summary?: string;
+  description?: string;
+  responseBody?: unknown;
+  additionalResponses?: Record<
+    string,
+    { description: string; schema?: unknown }
+  >;
+}> = [
   { method: "GET", path: "/healthz" },
-  { method: "GET", path: "/readyz" },
+  {
+    method: "GET",
+    path: "/readyz",
+    summary: "Readiness probe",
+    description:
+      "Returns 200 once critical startup is complete (HTTP bound, DB initialized, daemon started). Returns 503 while startup is still in progress. CES is a soft dependency and does not gate readiness.",
+    responseBody: {
+      type: "object",
+      properties: { status: { type: "string", enum: ["ok"] } },
+      required: ["status"],
+    },
+    additionalResponses: {
+      "503": {
+        description: "Runtime is still starting up and not yet ready.",
+        schema: {
+          type: "object",
+          properties: { status: { type: "string", enum: ["starting"] } },
+          required: ["status"],
+        },
+      },
+    },
+  },
   { method: "GET", path: "/pages/{id}" },
 ];
 
@@ -322,7 +353,16 @@ function buildSpec(
         path: r.path,
         method: r.method,
         endpoint: r.path,
-        entry: { method: r.method, endpoint: r.path },
+        entry: {
+          method: r.method,
+          endpoint: r.path,
+          ...(r.summary ? { summary: r.summary } : {}),
+          ...(r.description ? { description: r.description } : {}),
+          ...(r.responseBody ? { responseBody: r.responseBody } : {}),
+          ...(r.additionalResponses
+            ? { additionalResponses: r.additionalResponses }
+            : {}),
+        },
       });
     }
   }

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -39,9 +39,7 @@ mock.module("../runtime/ready-state.js", () => ({
 }));
 
 import {
-  __resetReadyzCesStateForTest,
   handleDetailedHealth,
-  handleReadyz,
   ROUTES,
 } from "../runtime/routes/identity-routes.js";
 import { setCesClient } from "../security/secure-keys.js";
@@ -209,12 +207,19 @@ describe("identity routes — health endpoint", () => {
   });
 
   describe("readyz — runtime readiness gating", () => {
-    beforeEach(() => {
+    // The CES soft-dependency warning is a process-global one-way latch
+    // (`cesWarned`) inside identity-routes, so a fresh module instance is
+    // imported per test to start each case from an un-latched state without a
+    // production reset export.
+    let handleReadyz: () => Response;
+
+    beforeEach(async () => {
       setCesClient(undefined);
       runtimeReadyFlag = true;
-      // Reset the transition-tracking state so each case's first not-ready
-      // observation registers as a transition and warns once.
-      __resetReadyzCesStateForTest();
+      const mod = await import(
+        `../runtime/routes/identity-routes.js?fresh=${Math.random()}`
+      );
+      handleReadyz = mod.handleReadyz as () => Response;
       healthWarn.mockClear();
     });
 
@@ -248,11 +253,11 @@ describe("identity routes — health endpoint", () => {
       } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
 
-      // First not-ready observation is a transition → warns once.
+      // First not-ready observation latches → warns once.
       expect(handleReadyz().status).toBe(200);
       expect(healthWarn).toHaveBeenCalledTimes(1);
 
-      // Second consecutive not-ready observation is steady-state → no new warn.
+      // Second not-ready observation is already latched → no new warn.
       expect(handleReadyz().status).toBe(200);
       expect(healthWarn).toHaveBeenCalledTimes(1);
     });

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -14,15 +14,32 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Silence logger before any imports that use it
+// Track health-logger warn calls so the CES soft-dependency path can be asserted.
+const healthWarn = mock(() => {});
+
+// Silence logger before any imports that use it. The "health" logger's warn is
+// captured so the /readyz CES soft-check can be verified.
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
+  getLogger: (name?: string) =>
     new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
+      get: (_target, prop) =>
+        name === "health" && prop === "warn" ? healthWarn : () => {},
     }),
 }));
 
+// Control runtime readiness independently per test. handleReadyz reads
+// isRuntimeReady(); mocking the module lets us flip the flag and reset it
+// between cases without a production reset export.
+let runtimeReadyFlag = false;
+mock.module("../runtime/ready-state.js", () => ({
+  isRuntimeReady: () => runtimeReadyFlag,
+  setRuntimeReady: () => {
+    runtimeReadyFlag = true;
+  },
+}));
+
 import {
+  __resetReadyzCesStateForTest,
   handleDetailedHealth,
   handleReadyz,
   ROUTES,
@@ -191,17 +208,62 @@ describe("identity routes — health endpoint", () => {
     });
   });
 
-  describe("CES readiness", () => {
+  describe("readyz — runtime readiness gating", () => {
     beforeEach(() => {
       setCesClient(undefined);
+      runtimeReadyFlag = true;
+      // Reset the transition-tracking state so each case's first not-ready
+      // observation registers as a transition and warns once.
+      __resetReadyzCesStateForTest();
+      healthWarn.mockClear();
     });
 
-    test("readyz returns 200 and logs warning when CES is unavailable", () => {
+    test("returns 503 {status:'starting'} before runtime startup completes", async () => {
+      runtimeReadyFlag = false;
+      const res = handleReadyz();
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toEqual({ status: "starting" });
+    });
+
+    test("returns 200 {status:'ok'} once the runtime is ready, even when CES reports not-ready", async () => {
+      const mockClient = {
+        isReady: () => false,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
+      setCesClient(mockClient);
+
       const res = handleReadyz();
       expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toEqual({ status: "ok" });
+      // CES is a soft dependency: not-ready is warned but does not gate readiness.
+      expect(healthWarn).toHaveBeenCalledTimes(1);
     });
 
-    test("readyz returns 200 when CES is connected and ready", () => {
+    test("warns once on the first not-ready poll and not again on the next consecutive not-ready poll", () => {
+      const mockClient = {
+        isReady: () => false,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
+      setCesClient(mockClient);
+
+      // First not-ready observation is a transition → warns once.
+      expect(handleReadyz().status).toBe(200);
+      expect(healthWarn).toHaveBeenCalledTimes(1);
+
+      // Second consecutive not-ready observation is steady-state → no new warn.
+      expect(handleReadyz().status).toBe(200);
+      expect(healthWarn).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns 200 and logs warning when CES is unavailable", () => {
+      const res = handleReadyz();
+      expect(res.status).toBe(200);
+      expect(healthWarn).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns 200 without warning when CES is connected and ready", () => {
       const mockClient = {
         isReady: () => true,
         close: () => {},
@@ -209,16 +271,7 @@ describe("identity routes — health endpoint", () => {
       setCesClient(mockClient);
       const res = handleReadyz();
       expect(res.status).toBe(200);
-    });
-
-    test("readyz returns 200 when CES client exists but is not ready", () => {
-      const mockClient = {
-        isReady: () => false,
-        close: () => {},
-      } as unknown as import("../credential-execution/client.js").CesClient;
-      setCesClient(mockClient);
-      const res = handleReadyz();
-      expect(res.status).toBe(200);
+      expect(healthWarn).not.toHaveBeenCalled();
     });
 
     test("/v1/health reports ces.connected=true when CES is ready", async () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -830,8 +830,7 @@ export async function runDaemon(): Promise<void> {
     // Critical startup is complete: the runtime HTTP server is bound and the
     // daemon server is accepting requests. Mark the runtime ready so `/readyz`
     // returns 200 — but only when the DB initialized. CES is intentionally NOT
-    // gated here: it is a soft dependency with a direct-credential-store
-    // fallback, so readiness must not depend on the CES handshake.
+    // gated here (see `handleReadyz` for the soft-dependency rationale).
     //
     // Readiness is gated on `dbReady` because the contract for `/readyz` is
     // "HTTP bound + DB initialized + daemon started". If `initializeDb()` failed

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -76,6 +76,7 @@ import {
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
+import { setRuntimeReady } from "../runtime/ready-state.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
 import {
   publishConfigChanged,
@@ -825,6 +826,26 @@ export async function runDaemon(): Promise<void> {
 
     await server.start();
     log.info("Daemon startup: DaemonServer started");
+
+    // Critical startup is complete: the runtime HTTP server is bound and the
+    // daemon server is accepting requests. Mark the runtime ready so `/readyz`
+    // returns 200 — but only when the DB initialized. CES is intentionally NOT
+    // gated here: it is a soft dependency with a direct-credential-store
+    // fallback, so readiness must not depend on the CES handshake.
+    //
+    // Readiness is gated on `dbReady` because the contract for `/readyz` is
+    // "HTTP bound + DB initialized + daemon started". If `initializeDb()` failed
+    // we are in degraded mode: DB-backed endpoints would be degraded, so the pod
+    // must report not-ready (`/readyz` → 503) and be kept out of the Service's
+    // endpoint set. The process still stays alive and reachable for `/healthz`
+    // (liveness) so it is not killed/restart-looped while it serves diagnostics.
+    if (dbReady) {
+      setRuntimeReady();
+    } else {
+      log.warn(
+        "Daemon startup: DB not initialized — leaving runtime not-ready (/readyz will report 503)",
+      );
+    }
 
     // Warm the gateway guardian-delivery cache so the SSE eager-subscribe path
     // (sync, IO-free) resolves the local actor principal on the FIRST client

--- a/assistant/src/runtime/ready-state.ts
+++ b/assistant/src/runtime/ready-state.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime readiness flag: reflects that critical startup is complete
+ * (HTTP server bound + DB initialized + daemon server started). Read by
+ * `handleReadyz()` to gate the K8s readinessProbe (`/readyz`). Kept
+ * dependency-free so both `lifecycle.ts` and `identity-routes.ts` can
+ * import it without creating a module cycle.
+ */
+
+let runtimeReady = false;
+
+export function setRuntimeReady(): void {
+  runtimeReady = true;
+}
+
+export function isRuntimeReady(): boolean {
+  return runtimeReady;
+}

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -355,21 +355,11 @@ export function handleDetailedHealth(): Response {
   return Response.json(getDetailedHealth());
 }
 
-// Tracks the last observed CES-ready state across `/readyz` polls so the
-// soft-dependency warning fires only on a transition into "not ready" rather
-// than on every poll. Once the K8s readinessProbe points at `/readyz` this
-// handler runs ~6x/min indefinitely; for setups where CES never connects
-// (e.g. BYOK) a per-poll warn would flood the logs. `undefined` means we have
-// not observed CES yet, so the first not-ready observation always logs once.
-let lastCesReady: boolean | undefined = undefined;
-
-/**
- * Test-only: reset the transition-tracking state so each case starts from a
- * clean slate (first not-ready observation logs once). Not used in production.
- */
-export function __resetReadyzCesStateForTest(): void {
-  lastCesReady = undefined;
-}
+// One-way latch so the CES soft-dependency warning fires at most once per
+// process. Once the K8s readinessProbe points at `/readyz` this handler runs
+// ~6x/min indefinitely; for setups where CES never connects (e.g. BYOK) a
+// per-poll warn would flood the logs, so a single warning is sufficient.
+let cesWarned = false;
 
 export function handleReadyz(): Response {
   // Ready = critical startup complete (HTTP bound + DB initialized + daemon
@@ -381,14 +371,13 @@ export function handleReadyz(): Response {
 
   const cesClient = getCesClient();
   const cesReady = cesClient?.isReady() ?? false;
-  // Only warn on a transition into not-ready so steady-state polling stays quiet.
-  if (!cesReady && cesReady !== lastCesReady) {
+  if (!cesReady && !cesWarned) {
+    cesWarned = true;
     getLogger("health").warn(
       { reason: cesClient ? "ces_not_ready" : "ces_unavailable" },
       "CES not ready — readiness unaffected (soft dependency with fallback)",
     );
   }
-  lastCesReady = cesReady;
   return Response.json({ status: "ok" });
 }
 

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -24,6 +24,7 @@ import { resolveHatchedAtReadOnly } from "../../workspace/hatched-date.js";
 import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
 import { getLastWorkspaceMigrationId } from "../../workspace/migrations/runner.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { isRuntimeReady } from "../ready-state.js";
 import { NotFoundError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 
@@ -354,16 +355,40 @@ export function handleDetailedHealth(): Response {
   return Response.json(getDetailedHealth());
 }
 
+// Tracks the last observed CES-ready state across `/readyz` polls so the
+// soft-dependency warning fires only on a transition into "not ready" rather
+// than on every poll. Once the K8s readinessProbe points at `/readyz` this
+// handler runs ~6x/min indefinitely; for setups where CES never connects
+// (e.g. BYOK) a per-poll warn would flood the logs. `undefined` means we have
+// not observed CES yet, so the first not-ready observation always logs once.
+let lastCesReady: boolean | undefined = undefined;
+
+/**
+ * Test-only: reset the transition-tracking state so each case starts from a
+ * clean slate (first not-ready observation logs once). Not used in production.
+ */
+export function __resetReadyzCesStateForTest(): void {
+  lastCesReady = undefined;
+}
+
 export function handleReadyz(): Response {
+  // Ready = critical startup complete (HTTP bound + DB initialized + daemon
+  // started). CES is a soft dependency with a direct-credential-store fallback,
+  // so it is logged/warned but does NOT gate readiness.
+  if (!isRuntimeReady()) {
+    return Response.json({ status: "starting" }, { status: 503 });
+  }
+
   const cesClient = getCesClient();
-  if (!cesClient?.isReady()) {
-    // TODO: Return 503 once we confirm via logs that this won't cause
-    // regressions in the K8s readinessProbe.
+  const cesReady = cesClient?.isReady() ?? false;
+  // Only warn on a transition into not-ready so steady-state polling stays quiet.
+  if (!cesReady && cesReady !== lastCesReady) {
     getLogger("health").warn(
       { reason: cesClient ? "ces_not_ready" : "ces_unavailable" },
-      "CES not ready — pod would be unready if 503 were enabled",
+      "CES not ready — readiness unaffected (soft dependency with fallback)",
     );
   }
+  lastCesReady = cesReady;
   return Response.json({ status: "ok" });
 }
 


### PR DESCRIPTION
## Summary
Makes the assistant runtime's `/readyz` a deliberate readiness signal so the K8s **readiness** probe reflects real responsiveness, while **startup/liveness** are decoupled from the blocked-event-loop problem in the platform repo (tcpSocket probes — separate plan). `/readyz` returns 503 `{status:"starting"}` until the runtime finishes critical startup (HTTP bound + DB initialized + daemon started) and 200 after. CES stays a soft, non-gating dependency (fallback to direct credential store), and a DB-init failure leaves the pod not-ready (kept out of Service endpoints) while `/healthz`/liveness keep it alive instead of restart-looping.

This is the **vellum-assistant half** of a cross-repo plan. The platform half (StatefulSet `tcpSocket` startup/liveness probes, repointing the assistant readinessProbe `/healthz`→`/readyz`, threshold/timeout retuning, and two latent probe bug fixes) lives in `vellum-assistant-platform/.private/plans/k8s-probe-resilience.md` and must be run from that repo.

## Self-review result
PASS — 2 minor gaps found and fixed across 1 fix PR (CES warn simplified to a one-shot latch + production test-only export removed; OpenAPI `/readyz` 503 documented). Re-review round 2 clean.

## PRs merged into feature branch
- #36125: feat(runtime): gate /readyz on runtime startup completion
- #36135: refactor(runtime): simplify /readyz CES warn to one-shot latch; document 503 in openapi

## Deliberate behavior notes
- On a *permanent* DB-init failure, hatch/upgrade/Electron-onboarding flows now time out rather than completing degraded — intended (a DB-broken instance must not report ready).
- Platform liveness probes intentionally stay on `tcpSocket`/`/healthz` (never `/readyz`), so a DB-failure 503 parks the pod degraded instead of restart-looping it.

Part of plan: k8s-probe-resilience.md