### PR TITLE
refactor(gateway): remove the assistant-DB guardian adoption heal

### DIFF
--- a/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
@@ -1,14 +1,13 @@
 /**
- * Tests for guardian-bootstrap pure guardian lookups
- * (findVellumGuardian + findGuardianForChannelActor) after they were
- * repointed to read the gateway DB directly, plus the adopt-before-mint
- * path in resolveOrCreateVellumGuardian (via ensureVellumGuardianBinding /
- * bootstrapGuardian).
+ * Tests for guardian-bootstrap guardian lookups
+ * (findVellumGuardian + findGuardianForChannelActor), which read the gateway
+ * DB directly, plus the resolve-or-mint path in resolveOrCreateVellumGuardian
+ * (via ensureVellumGuardianBinding / bootstrapGuardian).
  *
  * Guardian rows are seeded ONLY in the gateway DB. By default the assistant
- * DB proxy is swapped for a backend that throws, proving the pure lookups no
- * longer depend on the assistant mirror; adopt/mint tests install a real
- * in-memory assistant store instead.
+ * DB proxy is swapped for a backend that throws, proving the lookups never
+ * read the assistant mirror; mint tests install a real in-memory assistant
+ * store so the mirror dual-write succeeds.
  */
 
 import { Database } from "bun:sqlite";
@@ -27,8 +26,8 @@ import {
 
 import "./test-preload.js";
 
-// Swappable assistant-DB backend. Default: throw (the pure gateway reads must
-// not touch the assistant mirror). Adopt/mint tests install an in-memory DB.
+// Swappable assistant-DB backend. Default: throw (the gateway reads must
+// not touch the assistant mirror). Mint tests install an in-memory DB.
 type AssistantBackend = {
   query: (sql: string, params?: unknown[]) => unknown[];
   run: (sql: string, params?: unknown[]) => { changes: number };
@@ -100,38 +99,6 @@ function makeAssistantBackend(): AssistantBackend {
     },
     exec: (sql) => db.exec(sql),
   };
-}
-
-function seedAssistantGuardian(
-  backend: AssistantBackend,
-  opts: {
-    principalId: string;
-    address: string;
-    deliveryChatId?: string;
-    displayName?: string;
-    verifiedAt?: number;
-  },
-): void {
-  const now = opts.verifiedAt ?? Date.now();
-  backend.run(
-    `INSERT INTO contacts (id, display_name, role, principal_id, created_at, updated_at)
-     VALUES (?, ?, 'guardian', ?, ?, ?)`,
-    ["asst-contact", opts.displayName ?? null, opts.principalId, now, now],
-  );
-  backend.run(
-    `INSERT INTO contact_channels
-       (id, contact_id, type, address, external_chat_id, is_primary, status,
-        policy, verified_at, interaction_count, created_at, updated_at)
-     VALUES (?, 'asst-contact', 'vellum', ?, ?, 1, 'active', 'allow', ?, 0, ?, ?)`,
-    [
-      "asst-channel",
-      opts.address,
-      opts.deliveryChatId ?? "local",
-      now,
-      now,
-      now,
-    ],
-  );
 }
 
 function seedGuardianChannel(opts: {
@@ -293,7 +260,7 @@ describe("findGuardianForChannelActor (gateway DB)", () => {
   });
 });
 
-describe("adopt-before-mint (resolveOrCreateVellumGuardian)", () => {
+describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
   function gatewayVellumGuardians() {
     return getGatewayDb()
       .select({
@@ -309,48 +276,32 @@ describe("adopt-before-mint (resolveOrCreateVellumGuardian)", () => {
       .all();
   }
 
-  test("adopts the assistant guardian when the gateway DB lacks it", async () => {
-    const backend = makeAssistantBackend();
-    seedAssistantGuardian(backend, {
-      principalId: "principal-existing",
+  test("returns the existing guardian on a gateway fast-path hit", async () => {
+    seedGuardianChannel({
+      type: "vellum",
       address: "vellum-principal-existing",
-      deliveryChatId: "local",
-      displayName: "Owner",
+      principalId: "principal-existing",
     });
-    assistantBackend = backend;
 
     const principalId = await ensureVellumGuardianBinding();
 
-    // Existing principal returned — no fresh vellum-principal-<uuid> minted.
     expect(principalId).toBe("principal-existing");
-
-    // Gateway mirror is repaired under the existing principal.
-    const gwRows = gatewayVellumGuardians();
-    expect(gwRows).toHaveLength(1);
-    expect(gwRows[0]).toMatchObject({
-      principalId: "principal-existing",
-      address: "vellum-principal-existing",
-      status: "active",
-    });
-  });
-
-  test("second call hits the gateway fast path (idempotent)", async () => {
-    const backend = makeAssistantBackend();
-    seedAssistantGuardian(backend, {
-      principalId: "principal-existing",
-      address: "vellum-principal-existing",
-    });
-    assistantBackend = backend;
-
-    expect(await ensureVellumGuardianBinding()).toBe("principal-existing");
-
-    // Gateway now has the row; the assistant DB must not be read again.
-    assistantBackend = throwingBackend;
-    expect(await ensureVellumGuardianBinding()).toBe("principal-existing");
     expect(gatewayVellumGuardians()).toHaveLength(1);
   });
 
-  test("mints a fresh principal when neither DB has a guardian", async () => {
+  test("second call hits the gateway fast path (idempotent)", async () => {
+    assistantBackend = makeAssistantBackend();
+
+    const principalId = await ensureVellumGuardianBinding();
+    expect(principalId).toMatch(/^vellum-principal-/);
+
+    // Gateway now has the row; the assistant DB must not be read again.
+    assistantBackend = throwingBackend;
+    expect(await ensureVellumGuardianBinding()).toBe(principalId);
+    expect(gatewayVellumGuardians()).toHaveLength(1);
+  });
+
+  test("mints a fresh principal when the gateway DB has no guardian", async () => {
     assistantBackend = makeAssistantBackend();
 
     const principalId = await ensureVellumGuardianBinding();
@@ -361,13 +312,12 @@ describe("adopt-before-mint (resolveOrCreateVellumGuardian)", () => {
     expect(gwRows[0]?.principalId).toBe(principalId);
   });
 
-  test("bootstrapGuardian adopts the assistant guardian (isNew=false)", async () => {
-    const backend = makeAssistantBackend();
-    seedAssistantGuardian(backend, {
-      principalId: "principal-existing",
+  test("bootstrapGuardian returns the existing guardian (isNew=false)", async () => {
+    seedGuardianChannel({
+      type: "vellum",
       address: "vellum-principal-existing",
+      principalId: "principal-existing",
     });
-    assistantBackend = backend;
 
     const result = await bootstrapGuardian({
       platform: "macos",
@@ -380,7 +330,7 @@ describe("adopt-before-mint (resolveOrCreateVellumGuardian)", () => {
     expect(result.refreshToken).toBeTruthy();
   });
 
-  test("bootstrapGuardian mints a fresh principal when neither DB has one (isNew=true)", async () => {
+  test("bootstrapGuardian mints a fresh principal when the gateway has none (isNew=true)", async () => {
     assistantBackend = makeAssistantBackend();
 
     const result = await bootstrapGuardian({

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -10,10 +10,12 @@ import { initSigningKey } from "../auth/token-service.js";
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
 const mockQuery = mock();
+const mockRun = mock();
+const mockExec = mock();
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbQuery: mockQuery,
-  assistantDbRun: mock(),
-  assistantDbExec: mock(),
+  assistantDbRun: mockRun,
+  assistantDbExec: mockExec,
 }));
 
 const { hashToken, mintAndRecordDeviceBoundTokenPair } =
@@ -171,6 +173,8 @@ function activeRefreshTokens() {
 beforeEach(async () => {
   resetRemoteWebPairingChallengesForTests();
   mockQuery.mockResolvedValue([{ principal_id: GUARDIAN_ID }]);
+  mockRun.mockReset();
+  mockExec.mockReset();
   testRoot = mkdtempSync(join(tmpdir(), "remote-web-pairing-token-test-"));
   const securityDir = join(testRoot, "protected");
   mkdirSync(securityDir, { recursive: true });
@@ -524,15 +528,16 @@ describe("remote web pairing token exchange", () => {
       "approved",
     );
 
-    // No gateway guardian: ensureVellumGuardianBinding() falls through to
-    // createGuardianBinding(), whose assistant-DB query fails this once.
+    // No gateway guardian: resolveOrCreateVellumGuardian mints fresh via
+    // createGuardianBinding, whose assistant-DB mirror write fails this once
+    // (before the gateway write and token mint), so nothing is consumed.
     clearGatewayGuardian();
-    mockQuery.mockRejectedValueOnce(new Error("temporary guardian lookup"));
+    mockRun.mockRejectedValueOnce(new Error("temporary guardian mirror write"));
     await expect(
       handleRemoteWebPairingToken(
         makeTokenRequest({ deviceCode: challenge.deviceCode }),
       ),
-    ).rejects.toThrow("temporary guardian lookup");
+    ).rejects.toThrow("temporary guardian mirror write");
 
     expect(
       getRemoteWebPairingChallengeForTests(challenge.userCode)?.status,

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -1,7 +1,7 @@
 /**
  * Gateway-native guardian bootstrap — mints credentials using the
- * gateway's own SQLite database for token persistence and the
- * assistant's database (via IPC proxy) for contact lookups and writes.
+ * gateway's own SQLite database for token persistence and mirror-writes
+ * contact bindings to the assistant's database via IPC proxy.
  *
  * Uses the gateway's own signing key for JWT minting.
  */
@@ -11,11 +11,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
-import {
-  assistantDbQuery,
-  assistantDbRun,
-  assistantDbExec,
-} from "../db/assistant-db-proxy.js";
+import { assistantDbRun, assistantDbExec } from "../db/assistant-db-proxy.js";
 import {
   actorRefreshTokenRecords,
   actorTokenRecords,
@@ -116,43 +112,6 @@ export async function findVellumGuardian(): Promise<{
     .get();
 
   return row?.principalId ? { principalId: row.principalId } : null;
-}
-
-/**
- * Pre-repoint assistant-DB lookup for an active vellum guardian. Used to
- * adopt an existing guardian whose row never reached the gateway mirror
- * (skipped m0006 or a dropped dual-write), so we repair instead of minting
- * a duplicate principal. Returns null when no row or no principalId.
- */
-export async function findVellumGuardianFromAssistant(): Promise<{
-  principalId: string;
-  address: string;
-  deliveryChatId: string | null;
-  displayName: string | null;
-} | null> {
-  const rows = await assistantDbQuery<{
-    principalId: string | null;
-    address: string;
-    deliveryChatId: string | null;
-    displayName: string | null;
-  }>(
-    `SELECT c.principal_id AS principalId, cc.address AS address,
-            cc.external_chat_id AS deliveryChatId, c.display_name AS displayName
-     FROM contacts c
-     INNER JOIN contact_channels cc ON cc.contact_id = c.id
-     WHERE c.role = 'guardian' AND cc.type = 'vellum' AND cc.status = 'active'
-     ORDER BY cc.verified_at DESC
-     LIMIT 1`,
-  );
-
-  const row = rows[0];
-  if (!row?.principalId) return null;
-  return {
-    principalId: row.principalId,
-    address: row.address,
-    deliveryChatId: row.deliveryChatId,
-    displayName: row.displayName,
-  };
 }
 
 /**
@@ -746,10 +705,8 @@ async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
 }
 
 /**
- * Resolve the vellum guardian principal, in order: (a) gateway fast path,
- * (b) adopt an assistant guardian the gateway is missing — repairs the
- * gateway row under its EXISTING principal via the logical-key dual-write,
- * (c) mint a fresh principal when neither DB has a guardian.
+ * Resolve the vellum guardian principal: (a) gateway fast path, then
+ * (b) mint a fresh principal when the gateway has no guardian.
  *
  * Shared by ensureVellumGuardianBinding + bootstrapGuardian. `isNew` is true
  * only on the mint path.
@@ -767,25 +724,7 @@ async function resolveOrCreateVellumGuardian(): Promise<{
     return { guardianPrincipalId: gw.principalId, isNew: false };
   }
 
-  // Adopt an assistant guardian the gateway mirror is missing.
-  const asst = await findVellumGuardianFromAssistant();
-  if (asst) {
-    log.info(
-      { guardianPrincipalId: asst.principalId },
-      "Adopting assistant guardian — repairing gateway mirror",
-    );
-    await createGuardianBinding({
-      channel: "vellum",
-      externalUserId: asst.address,
-      deliveryChatId: asst.deliveryChatId ?? "local",
-      guardianPrincipalId: asst.principalId,
-      verifiedVia: "bootstrap",
-      ...(asst.displayName ? { displayName: asst.displayName } : {}),
-    });
-    return { guardianPrincipalId: asst.principalId, isNew: false };
-  }
-
-  // Neither DB has a guardian — mint a fresh principal.
+  // No gateway guardian — mint a fresh principal.
   const displayName = await fetchPlatformOwnerDisplayName();
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
   await createGuardianBinding({
@@ -801,7 +740,7 @@ async function resolveOrCreateVellumGuardian(): Promise<{
 
 /**
  * Ensure a vellum guardian binding exists, returning its principalId.
- * Adopts an existing assistant guardian before minting (see
+ * Resolves from the gateway DB, minting a fresh principal on a miss (see
  * resolveOrCreateVellumGuardian).
  *
  * Called during gateway startup to backfill existing installations.
@@ -822,7 +761,7 @@ export async function bootstrapGuardian(params: {
   platform: string;
   deviceId: string;
 }): Promise<GuardianBootstrapResult> {
-  // 1. Resolve (or adopt/mint) the guardian principal.
+  // 1. Resolve (or mint) the guardian principal.
   const { guardianPrincipalId, isNew } = await resolveOrCreateVellumGuardian();
 
   // 2. Revoke existing credentials for this device and mint a fresh pair.


### PR DESCRIPTION
## Summary
- Delete findVellumGuardianFromAssistant; resolveOrCreateVellumGuardian resolves from the gateway DB then mints fresh on a miss
- m0008 backfill seeds the gateway guardian at startup, so the assistant-DB adoption read is redundant

Part of plan: combo11-acl-backfill-heal-removal.md (PR 2 of 3)