### PR TITLE
fix(onboarding): drop dead export + document plugins-marker emit decision

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -77,7 +77,7 @@ export type ResearchOnboardingFunnelStep =
  * Kept OUT of RESEARCH_ONBOARDING_FUNNEL_STEPS (its `satisfies Record<ResearchStep,…>`
  * would break) because this is not a navigational step.
  */
-export const RESEARCH_ONBOARDING_PLUGINS_INSTALLED_STEP = {
+const RESEARCH_ONBOARDING_PLUGINS_INSTALLED_STEP = {
   stepName: "research_plugins_installed",
   stepIndex: 10,
 } as const satisfies OnboardingFunnelStepDescriptor;

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -327,6 +327,11 @@ export function ResearchOnboardingRoute() {
   // research turn settles. installedPlugins is final by the time status flips
   // to "done". Fires once, and only for a live run — a refresh that resumes a
   // finished journey (hydrate) leaves liveRunRef false, so it stays silent.
+  // Gating on "done" is deliberate: the marker reports only genuine live
+  // completions, so an errored or abandoned run never emits. Emission also stays
+  // in THIS effect rather than the terminal suggestion/skip handlers so it always
+  // reads the final installedPlugins (from the effect deps) instead of a set
+  // captured mid-stream off a still-running turn.
   useEffect(() => {
     if (research.status !== "done") return;
     if (!liveRunRef.current || pluginsReportedRef.current) return;


### PR DESCRIPTION
## Summary
Addresses self-review findings on the auto-installed-plugins telemetry (plan: plugin-install-telemetry.md):
- Make `RESEARCH_ONBOARDING_PLUGINS_INSTALLED_STEP` module-local (it had no external consumer).
- Document that the `research_plugins_installed` marker intentionally emits only on genuine live completions (responding to Codex P2), and why emission stays in the effect (fresh `installedPlugins`) rather than the terminal handlers.

No behavior change.