### PR TITLE
fix(memory): bound migration 209 sweep window so it can't loop on the 1h timeout

### DIFF
--- a/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
+++ b/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
@@ -18,11 +18,30 @@ const WATERMARK_KEY = "migration_209_strip_thinking_watermark";
 
 /**
  * Number of `rowid` values swept per `runAsyncSqlite` dispatch. Each window is
- * one off-thread subprocess transaction, so the size bounds both the WAL growth
- * per statement and how long a single write lock is held, while keeping the
- * number of subprocess spawns low on a large table.
+ * one off-thread subprocess transaction. The size stays well below the row
+ * count of a typical `messages` table so the whole table is never swept in a
+ * single subprocess: a window must finish inside {@link WINDOW_TIMEOUT_MS} for
+ * the per-window watermark to advance, and only an advancing watermark lets an
+ * interrupted run resume from the last completed window instead of re-running
+ * the same window forever. A smaller window also bounds WAL growth per statement
+ * and how long a single write lock is held, at the cost of more (cheap)
+ * subprocess spawns.
+ *
+ * Exported for the regression test that asserts the table is swept across
+ * multiple bounded windows rather than one table-sized sweep.
  */
-const ROWID_WINDOW = 100_000;
+export const ROWID_WINDOW = 2_000;
+
+/**
+ * Per-window wall-clock cap for the sweep subprocess. Set well above the time a
+ * {@link ROWID_WINDOW}-sized window needs even on a multi-GB table with large
+ * content blobs, so it trips only on a genuinely stuck subprocess (e.g. one
+ * blocked on a stale write lock) rather than on legitimately slow progress.
+ * Far below `runAsyncSqlite`'s one-hour whole-process default so a stuck window
+ * surfaces in minutes and the runner retries from the last completed window on
+ * the next boot.
+ */
+export const WINDOW_TIMEOUT_MS = 15 * 60 * 1000;
 
 /** SQL predicate: this `json_each` element is an internal reasoning block. */
 const IS_THINKING = `json_extract(value, '$.type') IN ('thinking', 'redacted_thinking')`;
@@ -127,7 +146,10 @@ export async function migrateStripThinkingFromConsolidated(
   while (lo < maxRow) {
     const hi = Math.min(lo + ROWID_WINDOW, maxRow);
 
-    const res = await runAsyncSqlite(windowSql(lo, hi), { dbPath });
+    const res = await runAsyncSqlite(windowSql(lo, hi), {
+      dbPath,
+      timeoutMs: WINDOW_TIMEOUT_MS,
+    });
     if (!res.ok) {
       // Leave the watermark at the last completed window; throwing reports the
       // step failed so the runner retries it (from the watermark) next boot

--- a/assistant/src/memory/migrations/__tests__/209-strip-thinking-from-consolidated.test.ts
+++ b/assistant/src/memory/migrations/__tests__/209-strip-thinking-from-consolidated.test.ts
@@ -12,8 +12,11 @@ import { describe, expect, test } from "bun:test";
 
 const { getDb, getSqlite } = await import("../../db-connection.js");
 const { initializeDb } = await import("../../db-init.js");
-const { migrateStripThinkingFromConsolidated } =
-  await import("../209-strip-thinking-from-consolidated.js");
+const {
+  migrateStripThinkingFromConsolidated,
+  ROWID_WINDOW,
+  WINDOW_TIMEOUT_MS,
+} = await import("../209-strip-thinking-from-consolidated.js");
 
 await initializeDb();
 
@@ -40,6 +43,22 @@ function insert(role: string, content: string): { id: string; rowid: number } {
   return { id, rowid };
 }
 
+/** Insert at an explicit rowid so a test can place rows on either side of a
+ *  window boundary without materializing every intervening row. */
+function insertAt(
+  rowid: number,
+  role: string,
+  content: string,
+): { id: string; rowid: number } {
+  const id = `m209-at-${rowid}`;
+  getSqlite()
+    .query(
+      `INSERT INTO messages (rowid, id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(rowid, id, CONV, role, content, Date.now());
+  return { id, rowid };
+}
+
 function content(id: string): string {
   return (
     getSqlite().query(`SELECT content FROM messages WHERE id = ?`).get(id) as {
@@ -50,6 +69,13 @@ function content(id: string): string {
 
 function blocks(id: string): Array<Record<string, unknown>> {
   return JSON.parse(content(id));
+}
+
+/** The persisted resume watermark, or null once the sweep has cleared it. */
+function watermark(): unknown {
+  return getSqlite()
+    .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
+    .get("migration_209_strip_thinking_watermark");
 }
 
 describe("migration 209 — strip thinking from consolidated assistant messages", () => {
@@ -216,9 +242,56 @@ describe("migration 209 — strip thinking from consolidated assistant messages"
     expect(blocks(above.id)).toEqual([{ type: "text", text: "above" }]);
 
     // The watermark is cleared once the sweep reaches the end of the table.
-    const wm = getSqlite()
-      .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
-      .get("migration_209_strip_thinking_watermark");
-    expect(wm).toBeNull();
+    expect(watermark()).toBeNull();
+  });
+
+  test("sweeps a rowid span wider than one window across multiple windows", async () => {
+    // Place rows on either side of a window boundary so the sweep must iterate
+    // the window loop more than once to reach them. The original 100k window
+    // collapsed any table smaller than itself into a single subprocess sweep —
+    // this exercises the bounded-window loop that replaces it.
+    const base =
+      (
+        getSqlite().query(`SELECT MAX(rowid) AS m FROM messages`).get() as {
+          m: number | null;
+        }
+      ).m ?? 0;
+    const first = insertAt(
+      base + ROWID_WINDOW,
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "a", signature: "s" },
+        { type: "text", text: "first" },
+      ]),
+    );
+    const second = insertAt(
+      base + 2 * ROWID_WINDOW + 1,
+      "assistant",
+      JSON.stringify([
+        { type: "thinking", thinking: "b", signature: "s" },
+        { type: "text", text: "second" },
+      ]),
+    );
+
+    await migrateStripThinkingFromConsolidated(getDb());
+
+    // Both rows are cleaned even though they sit in different windows, and the
+    // sweep runs to completion (watermark cleared) rather than stalling on the
+    // first window.
+    expect(blocks(first.id)).toEqual([{ type: "text", text: "first" }]);
+    expect(blocks(second.id)).toEqual([{ type: "text", text: "second" }]);
+    expect(watermark()).toBeNull();
+  });
+
+  test("keeps the sweep window and timeout bounded so it cannot overrun a whole table", () => {
+    // Regression guard: ROWID_WINDOW was 100_000, larger than a typical
+    // messages table, so the entire table swept in one subprocess that overran
+    // runAsyncSqlite's 1h cap, never advanced the watermark, and re-ran the
+    // identical doomed window every boot. The window must stay small enough that
+    // a single window finishes well within its timeout, and the per-window cap
+    // must stay below the 1h whole-process default so a stuck window surfaces in
+    // minutes instead of blocking startup for an hour.
+    expect(ROWID_WINDOW).toBeLessThanOrEqual(10_000);
+    expect(WINDOW_TIMEOUT_MS).toBeLessThan(60 * 60 * 1000);
   });
 });


### PR DESCRIPTION
## Summary

- Migration 209 (`migrateStripThinkingFromConsolidated`) used a 100k-rowid sweep window, so any `messages` table smaller than that (the common case) was rewritten in a **single** `sqlite3` subprocess that overran `runAsyncSqlite`'s 1-hour cap, was SIGKILL'd, and threw **before the per-window watermark advanced** — re-running the identical full-table window on every boot. Each boot also blocked `DaemonServer` startup for an hour and held the write lock, so live requests hit `SQLITE_BUSY`.
- Shrink `ROWID_WINDOW` `100_000 → 2_000` and pass an explicit 15-minute per-window `timeoutMs`, so each window finishes well under the cap, the watermark advances, and an interrupted sweep resumes from the last completed window instead of restarting.
- Add regression tests: a multi-window sweep across a rowid span wider than one window, and a guard that the window size and per-window timeout stay bounded below the 1h whole-process default.

## Original prompt

Debugging a user's feedback bundle showed their assistant's startup repeatedly failing on memory migration 209 with `strip-thinking window (0, 94776] failed: sqlite3 subprocess timed out after 3600000ms` — a crash loop where the whole ~95k-row table was swept in one over-long window, so the watermark never advanced and every reboot re-ran the same doomed window (with ~1h of degraded startup and `SQLITE_BUSY` each time). The ask was to fix the migration so each window completes under the timeout and the watermark genuinely resumes, plus add a regression test for the small-table/large-content case. Root cause traced to `ROWID_WINDOW=100_000` (introduced by #35794) exceeding typical table sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)