### PR TITLE
feat(onboarding): emit telemetry for auto-installed plugins (research flow)

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -4,6 +4,7 @@ import {
   __resetOnboardingFunnelEventsForTests,
   buildOnboardingFunnelEvent,
   emitOnboardingFunnelStepCompleted,
+  emitResearchOnboardingPluginsInstalled,
   emitResearchOnboardingStepCompleted,
   onboardingFunnelVariantFromExperiment,
   ONBOARDING_FUNNEL_STEPS,
@@ -200,6 +201,118 @@ describe("onboarding funnel events", () => {
       funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
       outcome: "skipped",
     });
+  });
+
+  test("emits the plugins-installed marker carrying the installed set", () => {
+    localStorage.setItem("device:share_analytics", "true");
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // Emit a normal step first so we can assert the marker shares its session id.
+    emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
+      userId: "user-123",
+    });
+    emitResearchOnboardingPluginsInstalled(["gmail-triage", "calendar-prep"], {
+      userId: "user-123",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const calls = fetchMock.mock.calls as Array<
+      [RequestInfo | URL, RequestInit | undefined]
+    >;
+    const stepEvent = (
+      JSON.parse(calls[0]?.[1]?.body as string) as {
+        events: Array<Record<string, unknown>>;
+      }
+    ).events[0];
+    const markerEvent = (
+      JSON.parse(calls[1]?.[1]?.body as string) as {
+        events: Array<Record<string, unknown>>;
+      }
+    ).events[0];
+
+    expect(calls[1]?.[0]).toBe("/v1/telemetry/ingest/");
+    expect(markerEvent).toMatchObject({
+      type: "onboarding",
+      step_name: "research_plugins_installed",
+      step_index: 10,
+      funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+      ab_variant: "control",
+      user_id: "user-123",
+      plugins: ["gmail-triage", "calendar-prep"],
+    });
+    // Shares the funnel session id with the rest of the journey.
+    expect(markerEvent?.session_id).toBe(stepEvent?.session_id);
+    // The marker carries no outcome (it's not a navigational step).
+    expect(markerEvent).not.toHaveProperty("outcome");
+  });
+
+  test("emits the plugins-installed marker with an empty set preserved", () => {
+    localStorage.setItem("device:share_analytics", "true");
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    emitResearchOnboardingPluginsInstalled([], { userId: "user-123" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calls = fetchMock.mock.calls as Array<
+      [RequestInfo | URL, RequestInit | undefined]
+    >;
+    const markerEvent = (
+      JSON.parse(calls[0]?.[1]?.body as string) as {
+        events: Array<Record<string, unknown>>;
+      }
+    ).events[0];
+
+    // An explicit empty array is preserved (not stripped).
+    expect(markerEvent).toHaveProperty("plugins");
+    expect(markerEvent?.plugins).toEqual([]);
+  });
+
+  test("a normal research step event carries no plugins key", () => {
+    localStorage.setItem("device:share_analytics", "true");
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
+      userId: "user-123",
+    });
+
+    const calls = fetchMock.mock.calls as Array<
+      [RequestInfo | URL, RequestInit | undefined]
+    >;
+    const stepEvent = (
+      JSON.parse(calls[0]?.[1]?.body as string) as {
+        events: Array<Record<string, unknown>>;
+      }
+    ).events[0];
+
+    // stripUndefined removes the undefined `plugins` field on ordinary events.
+    expect(stepEvent).not.toHaveProperty("plugins");
+  });
+
+  test("does not emit the plugins marker until analytics sharing is opted in", () => {
+    useOnboardingStore.setState({ shareAnalytics: false });
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    emitResearchOnboardingPluginsInstalled(["gmail-triage"], {
+      userId: "user-123",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("does not emit research telemetry until analytics sharing is opted in", () => {

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -73,6 +73,16 @@ export type ResearchOnboardingFunnelStep =
   (typeof RESEARCH_ONBOARDING_FUNNEL_STEPS)[keyof typeof RESEARCH_ONBOARDING_FUNNEL_STEPS];
 
 /**
+ * Marker event for the persona plugins auto-installed during the research flow.
+ * Kept OUT of RESEARCH_ONBOARDING_FUNNEL_STEPS (its `satisfies Record<ResearchStep,…>`
+ * would break) because this is not a navigational step.
+ */
+export const RESEARCH_ONBOARDING_PLUGINS_INSTALLED_STEP = {
+  stepName: "research_plugins_installed",
+  stepIndex: 10,
+} as const satisfies OnboardingFunnelStepDescriptor;
+
+/**
  * How the user left a step: `completed` (clicked the primary Continue/action) vs
  * `skipped` (clicked Skip). Lets analytics tell a deliberate completion apart
  * from a skip on steps that offer both. The pre-chat funnel omits this (it never
@@ -87,6 +97,11 @@ export interface OnboardingFunnelStepCompletedOptions {
   funnelVersion?: string;
   /** Completed vs skipped; omitted when the funnel doesn't distinguish. */
   outcome?: OnboardingFunnelStepOutcome;
+  /**
+   * Auto-installed persona plugins. Carried only by the research flow's
+   * plugins-installed marker event; omitted (→ stripped) everywhere else.
+   */
+  plugins?: string[];
 }
 
 export interface OnboardingFunnelEvent {
@@ -103,6 +118,11 @@ export interface OnboardingFunnelEvent {
   ab_variant: OnboardingFunnelVariant;
   /** Completed vs skipped; absent when the funnel doesn't distinguish. */
   outcome?: OnboardingFunnelStepOutcome;
+  /**
+   * Auto-installed persona plugins. Carried only by the research flow's
+   * plugins-installed marker event; absent (→ stripped) everywhere else.
+   */
+  plugins?: string[];
 }
 
 function stripUndefined(value: object): Record<string, unknown> {
@@ -185,6 +205,9 @@ export function buildOnboardingFunnelEvent(
     ab_variant: variant,
     // Omitted (→ stripped before send) unless the caller distinguishes the two.
     outcome: options.outcome,
+    // Omitted (→ stripped before send) unless the caller carries plugins; an
+    // explicit array (incl. []) is preserved.
+    plugins: options.plugins,
   };
 }
 
@@ -233,6 +256,27 @@ export function emitResearchOnboardingStepCompleted(
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
     outcome: options.outcome ?? "completed",
   });
+}
+
+/**
+ * Emit the research-onboarding marker event carrying the persona plugins
+ * auto-installed for the assistant. Mirrors emitResearchOnboardingStepCompleted
+ * (control variant passed explicitly, research funnel version) but carries
+ * `plugins` and no `outcome`.
+ */
+export function emitResearchOnboardingPluginsInstalled(
+  plugins: string[],
+  options: { userId?: string | null } = {},
+): void {
+  emitOnboardingFunnelStepCompleted(
+    RESEARCH_ONBOARDING_PLUGINS_INSTALLED_STEP,
+    {
+      userId: options.userId,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
+      funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+      plugins,
+    },
+  );
 }
 
 export function __resetOnboardingFunnelEventsForTests(): void {

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -77,7 +77,7 @@ export type ResearchOnboardingFunnelStep =
  * Kept OUT of RESEARCH_ONBOARDING_FUNNEL_STEPS (its `satisfies Record<ResearchStep,…>`
  * would break) because this is not a navigational step.
  */
-export const RESEARCH_ONBOARDING_PLUGINS_INSTALLED_STEP = {
+const RESEARCH_ONBOARDING_PLUGINS_INSTALLED_STEP = {
   stepName: "research_plugins_installed",
   stepIndex: 10,
 } as const satisfies OnboardingFunnelStepDescriptor;

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -17,7 +17,7 @@
  * then clicks "Continue" to drop into the full workspace on the same conversation.
  */
 
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -44,6 +44,7 @@ import {
   type ResearchStep,
 } from "@/domains/onboarding/research-onboarding-persistence";
 import {
+  emitResearchOnboardingPluginsInstalled,
   emitResearchOnboardingStepCompleted,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
   type OnboardingFunnelStepOutcome,
@@ -127,6 +128,13 @@ export function ResearchOnboardingRoute() {
   // (or re-fire research before adopting saved results). Flips true once the
   // restore has run — whether it found a snapshot or not.
   const [restored, setRestored] = useState(false);
+  // True once a research turn has been started live THIS session (form submit
+  // or mid-flow resume re-fire). A completed-journey resume hydrates status to
+  // "done" WITHOUT a live start, so this stays false there and we don't
+  // re-report plugins already reported in the original session.
+  const liveRunRef = useRef(false);
+  // Guards the plugins report to once per session.
+  const pluginsReportedRef = useRef(false);
 
   function navTo(next: ResearchStep) {
     setStep(next);
@@ -304,6 +312,7 @@ export function ResearchOnboardingRoute() {
       subject: researchSubjectFrom(formValues),
       conversationTitle: researchTitleFor(formValues),
     });
+    liveRunRef.current = true;
   }, [
     restored,
     enabled,
@@ -313,6 +322,19 @@ export function ResearchOnboardingRoute() {
     startResearch,
     awaitHatchReady,
   ]);
+
+  // Report the persona plugins auto-installed for this assistant once the live
+  // research turn settles. installedPlugins is final by the time status flips
+  // to "done". Fires once, and only for a live run — a refresh that resumes a
+  // finished journey (hydrate) leaves liveRunRef false, so it stays silent.
+  useEffect(() => {
+    if (research.status !== "done") return;
+    if (!liveRunRef.current || pluginsReportedRef.current) return;
+    pluginsReportedRef.current = true;
+    emitResearchOnboardingPluginsInstalled(research.installedPlugins, {
+      userId,
+    });
+  }, [research.status, research.installedPlugins, userId]);
 
   // If we're sitting on the results step when the research turn resolves empty
   // (it was still streaming when we arrived), skip ahead to the suggestions.
@@ -415,6 +437,7 @@ export function ResearchOnboardingRoute() {
       subject: researchSubjectFrom(values),
       conversationTitle: researchTitleFor(values),
     });
+    liveRunRef.current = true;
     goForwardTo("face");
   }
 

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -133,7 +133,10 @@ export function ResearchOnboardingRoute() {
   // "done" WITHOUT a live start, so this stays false there and we don't
   // re-report plugins already reported in the original session.
   const liveRunRef = useRef(false);
-  // Guards the plugins report to once per session.
+  // Guards the plugins report to once per LIVE RUN, not once per component
+  // session: re-armed (set false) wherever a new live run starts, so an
+  // edited-subject rerun (back to the form → resubmit) reports its own
+  // installed set instead of being suppressed by the abandoned first run.
   const pluginsReportedRef = useRef(false);
 
   function navTo(next: ResearchStep) {
@@ -313,6 +316,8 @@ export function ResearchOnboardingRoute() {
       conversationTitle: researchTitleFor(formValues),
     });
     liveRunRef.current = true;
+    // Re-arm the per-run plugins marker so this fresh live run can emit its own.
+    pluginsReportedRef.current = false;
   }, [
     restored,
     enabled,
@@ -443,6 +448,10 @@ export function ResearchOnboardingRoute() {
       conversationTitle: researchTitleFor(values),
     });
     liveRunRef.current = true;
+    // Re-arm the per-run plugins marker so this fresh live run can emit its own
+    // (e.g. an edited-subject rerun after backing to the form), not be suppressed
+    // by a prior run's report.
+    pluginsReportedRef.current = false;
     goForwardTo("face");
   }
 

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -327,6 +327,11 @@ export function ResearchOnboardingRoute() {
   // research turn settles. installedPlugins is final by the time status flips
   // to "done". Fires once, and only for a live run — a refresh that resumes a
   // finished journey (hydrate) leaves liveRunRef false, so it stays silent.
+  // Gating on "done" is deliberate: the marker reports only genuine live
+  // completions, so an errored or abandoned run never emits. Emission also stays
+  // in THIS effect rather than the terminal suggestion/skip handlers so it always
+  // reads the final installedPlugins (from the effect deps) instead of a set
+  // captured mid-stream off a still-running turn.
   useEffect(() => {
     if (research.status !== "done") return;
     if (!liveRunRef.current || pluginsReportedRef.current) return;


### PR DESCRIPTION
## Summary
Emit a `research_plugins_installed` onboarding funnel telemetry event recording which plugins were auto-installed during the research-onboarding flow, fired once per genuine live research completion (never on a refresh/resume).

This is the **web** half of a cross-repo change. The platform half (ingest serializer field + BigQuery schema column + dbt source) ships in `vellum-assistant-platform` under the same `alex-nork/plugin-install-telemetry` branch.

## Self-review result
PASS — 1 remediation PR (drop a dead export + document the emit-on-genuine-completion design decision, responding to Codex P2). Test-deletion and by-design staleness findings were triaged as decline-with-rationale.

## PRs merged into this feature branch
- #36133: feat(onboarding): emit telemetry for auto-installed plugins in research flow
- #36143: fix(onboarding): drop dead export + document plugins-marker emit decision

Part of plan: plugin-install-telemetry.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)