### PR TITLE
feat(heartbeat): enable by default and raise daily run cap to 10

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -5,10 +5,7 @@ export const HeartbeatConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "heartbeat.enabled must be a boolean" })
-      // Heartbeats are opt-in for new workspaces. Workspaces created while
-      // the default was true keep their behavior via workspace migration
-      // 102-preserve-heartbeat-enabled-for-existing-workspaces.
-      .default(false)
+      .default(true)
       .describe("Whether periodic heartbeat checks are enabled"),
     intervalMs: z
       .number({ error: "heartbeat.intervalMs must be a number" })
@@ -64,7 +61,7 @@ export const HeartbeatConfigSchema = z
       .int("heartbeat.maxDailyRuns must be an integer")
       .positive("heartbeat.maxDailyRuns must be a positive integer")
       .nullable()
-      .default(2)
+      .default(10)
       .describe(
         "Maximum heartbeats that can run per calendar day. Resets at midnight local time. Set to null for unlimited.",
       ),


### PR DESCRIPTION
## Summary

- Flip the `heartbeat.enabled` schema default from `false` back to `true` — heartbeats are on by default again, reverting the opt-in behavior introduced in #34755 (2026-06-12).
- Raise the `heartbeat.maxDailyRuns` default from `2` to `10`.
- Remove the now-stale comment on `enabled` that described the opt-in default and referenced workspace migration 102.

## Notes

- Defaults resolve dynamically at config-load time (they are not persisted), so this re-enables heartbeats for workspaces created during the ~13-day opt-in window that never explicitly set `heartbeat.enabled`. Workspaces with an explicit value are untouched. Re-enabling that cohort is the intended effect of reverting the opt-in change.
- Workspace migration `102-preserve-heartbeat-enabled-for-existing-workspaces` is intentionally left in place (migrations are append-only history). It pinned `enabled: true` for pre-06-12 workspaces, which now matches the restored default — harmless.
- `maxDailyRuns: 2 → 10` only raises the per-day cap; installs with an explicit value (e.g. `null` for unlimited) are unaffected.

## Original prompt

This followed a question about whether heartbeats are disabled by default — they were, as of #34755. The ask was to change the `heartbeat.enabled` default back to `true` and bump the `maxDailyRuns` default to `10`.