### PR TITLE
fix(gateway): m0008 must converge channel ownership when backfilling ACL

### DIFF
--- a/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
+++ b/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
@@ -385,6 +385,49 @@ describe("m0008-upsert-acl-columns-from-assistant", () => {
     expect(gwChannelByAddress("telegram", "u123") ?? undefined).toBeUndefined();
   });
 
+  test("reparents a split channel onto the assistant contact that carries the role", async () => {
+    // Gateway has the channel under a regular contact (a prior split mint); the
+    // assistant owns it under the real guardian contact. The backfill must move
+    // the channel to the guardian contact so guardian/trust joins through
+    // contact_id resolve the imported role, not the stale gateway contact.
+    seedGatewayContact({ id: "regular", role: "contact" });
+    seedGatewayChannel({
+      id: "gw-ch",
+      contactId: "regular",
+      type: "telegram",
+      address: "U999",
+      status: "unverified",
+    });
+
+    seedAssistantContact({
+      id: "guardian",
+      role: "guardian",
+      principal_id: "p-g",
+    });
+    seedAssistantChannel({
+      id: "as-ch",
+      contact_id: "guardian",
+      type: "telegram",
+      address: "U999",
+      status: "verified",
+    });
+
+    const result = await m0008Up();
+    expect(result).toBe("done");
+
+    // One channel row, now parented to the guardian contact, ACL updated.
+    expect(gwChannelCount()).toBe(1);
+    const ch = gwChannelByAddress("telegram", "U999")!;
+    expect(ch.id).toBe("gw-ch");
+    expect(ch.contact_id).toBe("guardian");
+    expect(ch.status).toBe("verified");
+
+    // The imported guardian role joins through the reparented channel.
+    const guardian = gwContact("guardian")!;
+    expect(guardian.role).toBe("guardian");
+    expect(guardian.principal_id).toBe("p-g");
+  });
+
   test("orphan channel (contact absent) is skipped without throwing", async () => {
     seedAssistantChannel({
       id: "orphan",

--- a/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
@@ -117,8 +117,12 @@ export async function up(): Promise<MigrationResult> {
     // channel key and COLLATE NOCASE lookups treat address case-insensitively.
     // Match existing gateway rows on lower(address) and UPDATE their ACL in
     // place; INSERT only genuinely-new channels so a case-variant address never
-    // forks a second row for the same actor. Skip any channel whose parent
-    // contact is not among the assistant contacts we just upserted (FK safety).
+    // forks a second row for the same actor. The update also converges
+    // contact_id onto the assistant contact that carries the imported
+    // role/principal_id, so a split channel (parented to a different gateway
+    // contact) joins back to the contact whose ACL we just backfilled. Skip any
+    // channel whose parent contact is not among the assistant contacts we just
+    // upserted (FK safety).
     const contactIds = new Set(assistantContacts.map((c) => c.id));
 
     const channelKey = (type: string, address: string): string =>
@@ -133,6 +137,7 @@ export async function up(): Promise<MigrationResult> {
 
     const updateChannelAcl = gwDb.prepare(
       `UPDATE contact_channels SET
+         contact_id = ?,
          status = ?, policy = ?, verified_at = ?, verified_via = ?,
          revoked_reason = ?, blocked_reason = ?
        WHERE id = ?`,
@@ -158,6 +163,7 @@ export async function up(): Promise<MigrationResult> {
         const existingId = existingChannelIdByKey.get(key);
         if (existingId) {
           updateChannelAcl.run(
+            ch.contact_id,
             ch.status,
             ch.policy,
             ch.verified_at,


### PR DESCRIPTION
## Summary
- Addresses Codex P1 on #36146: when an assistant channel matches an existing gateway row by (type,address) but that row belongs to a different gateway contact (a prior split), m0008 previously updated only the ACL fields and left contact_id pointing at the stale contact — so the role/principal_id imported onto the assistant contact were never consulted (e.g. a guardian channel staying attached to a regular contact, classifying non-guardian).
- The channel UPDATE now also sets contact_id to the assistant channel's contact (the one carrying the imported role/principal), converging ownership so guardian/trust joins resolve the backfilled ACL.
- Adds a regression test (split guardian channel → reparented; guardian role joins through it).

Part of plan: combo11-acl-backfill-heal-removal.md (fix for PR 1 of 3)

Note: local test run was blocked by the worktree node_modules @vellumai workspace-link state; CI does a clean install and exercises the full m0008 suite.