### PR TITLE
fix(memory): inherit compaction by event time via a compaction ledger

### DIFF
--- a/assistant/src/__tests__/compaction-ledger-store.test.ts
+++ b/assistant/src/__tests__/compaction-ledger-store.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import {
+  appendCompactionEvent,
+  forkCompactionLedger,
+  getLatestCompactionEventAtOrBefore,
+} from "../memory/compaction-ledger-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import {
+  conversationCompactionEvents,
+  conversations,
+} from "../memory/schema.js";
+
+await initializeDb();
+
+function reset(): void {
+  const db = getDb();
+  db.delete(conversationCompactionEvents).run();
+  db.delete(conversations).run();
+}
+
+function makeConversation(id: string): void {
+  const now = Date.now();
+  getDb()
+    .insert(conversations)
+    .values({ id, title: id, createdAt: now, updatedAt: now })
+    .run();
+}
+
+function forkEventsFor(conversationId: string) {
+  return getDb()
+    .select()
+    .from(conversationCompactionEvents)
+    .where(eq(conversationCompactionEvents.conversationId, conversationId))
+    .all();
+}
+
+describe("compaction-ledger-store", () => {
+  beforeEach(reset);
+
+  test("getLatestCompactionEventAtOrBefore returns the newest event at-or-before the cutoff", () => {
+    makeConversation("conv");
+    appendCompactionEvent("conv", {
+      compactedAt: 100,
+      summary: "s100",
+      compactedMessageCount: 1,
+    });
+    appendCompactionEvent("conv", {
+      compactedAt: 200,
+      summary: "s200",
+      compactedMessageCount: 3,
+    });
+    appendCompactionEvent("conv", {
+      compactedAt: 300,
+      summary: "s300",
+      compactedMessageCount: 5,
+    });
+
+    expect(getLatestCompactionEventAtOrBefore("conv", 50)).toBeNull();
+    expect(
+      getLatestCompactionEventAtOrBefore("conv", 100)?.compactedMessageCount,
+    ).toBe(1);
+    expect(
+      getLatestCompactionEventAtOrBefore("conv", 250)?.compactedMessageCount,
+    ).toBe(3);
+    expect(
+      getLatestCompactionEventAtOrBefore("conv", 999)?.compactedMessageCount,
+    ).toBe(5);
+    expect(getLatestCompactionEventAtOrBefore("conv", null)).toBeNull();
+  });
+
+  test("getLatestCompactionEventAtOrBefore is scoped per conversation", () => {
+    makeConversation("a");
+    makeConversation("b");
+    appendCompactionEvent("a", {
+      compactedAt: 100,
+      summary: "a",
+      compactedMessageCount: 1,
+    });
+
+    expect(getLatestCompactionEventAtOrBefore("b", 999)).toBeNull();
+  });
+
+  test("forkCompactionLedger copies only events at-or-before the boundary", () => {
+    makeConversation("src");
+    makeConversation("fork");
+    appendCompactionEvent("src", {
+      compactedAt: 100,
+      summary: "s100",
+      compactedMessageCount: 1,
+    });
+    appendCompactionEvent("src", {
+      compactedAt: 300,
+      summary: "s300",
+      compactedMessageCount: 5,
+    });
+
+    forkCompactionLedger(getDb(), "src", "fork", 200);
+
+    const copied = forkEventsFor("fork");
+    expect(copied).toHaveLength(1);
+    expect(copied[0]?.compactedAt).toBe(100);
+    expect(copied[0]?.summary).toBe("s100");
+  });
+
+  test("forkCompactionLedger with a null boundary copies nothing", () => {
+    makeConversation("src");
+    makeConversation("fork");
+    appendCompactionEvent("src", {
+      compactedAt: 100,
+      summary: "s100",
+      compactedMessageCount: 1,
+    });
+
+    forkCompactionLedger(getDb(), "src", "fork", null);
+
+    expect(forkEventsFor("fork")).toHaveLength(0);
+  });
+});

--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -26,6 +26,7 @@ import {
   linkAttachmentToMessage,
   uploadAttachment,
 } from "../memory/attachments-store.js";
+import { appendCompactionEvent } from "../memory/compaction-ledger-store.js";
 import {
   getAttentionStateByConversationIds,
   markConversationUnread,
@@ -54,6 +55,7 @@ import {
   activationState,
   channelInboundEvents,
   conversationAssistantAttentionState,
+  conversationCompactionEvents,
   conversationGraphMemoryState,
   conversations,
   externalConversationBindings,
@@ -78,6 +80,7 @@ function resetTables(): void {
   db.delete(externalConversationBindings).run();
   db.delete(conversationAssistantAttentionState).run();
   db.delete(activationState).run();
+  db.delete(conversationCompactionEvents).run();
   db.delete(conversationGraphMemoryState).run();
   db.delete(memoryRetrospectiveState).run();
   getLogsDb()!.delete(llmRequestLogs).run();
@@ -346,24 +349,37 @@ describe("forkConversation", () => {
     expect(toolResultUserRow.id).not.toBe(anchor.id);
   });
 
-  test("preserves compacted context when forking from the visible window", async () => {
+  test("inherits the most recent compaction at-or-before the forked-from message", async () => {
     const source = createConversation("Compacted thread");
-    await addMessage(source.id, "user", "Message 1", {
+    const m1 = await addMessage(source.id, "user", "Message 1", {
       skipIndexing: true,
     });
-    await addMessage(source.id, "assistant", "Message 2", {
+    const m2 = await addMessage(source.id, "assistant", "Message 2", {
       skipIndexing: true,
     });
     const branchPoint = await addMessage(source.id, "user", "Message 3", {
       skipIndexing: true,
     });
-    await addMessage(source.id, "assistant", "Message 4", {
+    const m4 = await addMessage(source.id, "assistant", "Message 4", {
       skipIndexing: true,
     });
 
-    const compactedAt = Date.now();
-    getDb()
-      .update(conversations)
+    // Pin timestamps so the compaction event sits strictly between M2 and M3:
+    // it covers M1+M2 and ran before M3 was sent.
+    const db = getDb();
+    const base = Date.now();
+    db.run(`UPDATE messages SET created_at = ${base} WHERE id = '${m1.id}'`);
+    db.run(
+      `UPDATE messages SET created_at = ${base + 1} WHERE id = '${m2.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 3} WHERE id = '${branchPoint.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 4} WHERE id = '${m4.id}'`,
+    );
+    const compactedAt = base + 2;
+    db.update(conversations)
       .set({
         contextSummary: "Compacted summary",
         contextCompactedMessageCount: 2,
@@ -371,7 +387,14 @@ describe("forkConversation", () => {
       })
       .where(eq(conversations.id, source.id))
       .run();
+    appendCompactionEvent(source.id, {
+      compactedAt,
+      summary: "Compacted summary",
+      compactedMessageCount: 2,
+    });
 
+    // M3 was sent after the compaction, so forking through it reproduces the
+    // compacted working context.
     const fork = forkConversation({
       conversationId: source.id,
       throughMessageId: branchPoint.id,
@@ -382,6 +405,67 @@ describe("forkConversation", () => {
     expect(fork.contextCompactedAt).toBe(compactedAt);
     expect(fork.forkParentConversationId).toBe(source.id);
     expect(fork.forkParentMessageId).toBe(branchPoint.id);
+  });
+
+  test("does not inherit a compaction that ran after the forked-from message", async () => {
+    const source = createConversation("Compacted thread");
+    const m1 = await addMessage(source.id, "user", "Message 1", {
+      skipIndexing: true,
+    });
+    const m2 = await addMessage(source.id, "assistant", "Message 2", {
+      skipIndexing: true,
+    });
+    const m3 = await addMessage(source.id, "user", "Message 3", {
+      skipIndexing: true,
+    });
+    const m4 = await addMessage(source.id, "assistant", "Message 4", {
+      skipIndexing: true,
+    });
+
+    // `/compact` ran after M4 — the compaction postdates every message.
+    const db = getDb();
+    const base = Date.now();
+    db.run(`UPDATE messages SET created_at = ${base} WHERE id = '${m1.id}'`);
+    db.run(
+      `UPDATE messages SET created_at = ${base + 1} WHERE id = '${m2.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 2} WHERE id = '${m3.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 3} WHERE id = '${m4.id}'`,
+    );
+    const compactedAt = base + 10;
+    db.update(conversations)
+      .set({
+        contextSummary: "Compacted summary",
+        contextCompactedMessageCount: 2,
+        contextCompactedAt: compactedAt,
+      })
+      .where(eq(conversations.id, source.id))
+      .run();
+    appendCompactionEvent(source.id, {
+      compactedAt,
+      summary: "Compacted summary",
+      compactedMessageCount: 2,
+    });
+
+    // Forking through the final message yields the full uncompacted history:
+    // the compaction did not exist when M4 was the latest turn.
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: m4.id,
+    });
+
+    expect(fork.contextSummary).toBeNull();
+    expect(fork.contextCompactedMessageCount).toBe(0);
+    expect(fork.contextCompactedAt).toBeNull();
+    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
+      "Message 1",
+      "Message 2",
+      "Message 3",
+      "Message 4",
+    ]);
   });
 
   test("forks from the compacted-away prefix without inheriting source compaction state", async () => {
@@ -399,15 +483,21 @@ describe("forkConversation", () => {
       skipIndexing: true,
     });
 
+    const compactedAt = Date.now();
     getDb()
       .update(conversations)
       .set({
         contextSummary: "Compacted summary",
         contextCompactedMessageCount: 2,
-        contextCompactedAt: Date.now(),
+        contextCompactedAt: compactedAt,
       })
       .where(eq(conversations.id, source.id))
       .run();
+    appendCompactionEvent(source.id, {
+      compactedAt,
+      summary: "Compacted summary",
+      compactedMessageCount: 2,
+    });
 
     const fork = forkConversation({
       conversationId: source.id,
@@ -1000,35 +1090,70 @@ describe("forkConversation", () => {
 
   test("truncated fork ignores attachments behind an inherited compaction boundary", async () => {
     const source = createConversation("Compacted truncated thread");
-    await addMessage(source.id, "user", "compacted turn", {
-      metadata: {
-        memoryInjectedBlock:
-          "# memory/concepts/topics/page-compacted.md\nOld summary",
+    const compactedTurn = await addMessage(
+      source.id,
+      "user",
+      "compacted turn",
+      {
+        metadata: {
+          memoryInjectedBlock:
+            "# memory/concepts/topics/page-compacted.md\nOld summary",
+        },
+        skipIndexing: true,
       },
-      skipIndexing: true,
-    });
-    await addMessage(source.id, "assistant", "compacted reply", {
-      skipIndexing: true,
-    });
+    );
+    const compactedReply = await addMessage(
+      source.id,
+      "assistant",
+      "compacted reply",
+      { skipIndexing: true },
+    );
     const boundaryMessage = await addMessage(source.id, "user", "live turn", {
       metadata: {
         memoryInjectedBlock: "# memory/concepts/topics/page-live.md\nSummary",
       },
       skipIndexing: true,
     });
-    await addMessage(source.id, "assistant", "live reply", {
+    const liveReply = await addMessage(source.id, "assistant", "live reply", {
       skipIndexing: true,
     });
-    await addMessage(source.id, "user", "past boundary", {
+    const pastBoundary = await addMessage(source.id, "user", "past boundary", {
       skipIndexing: true,
     });
-    // First two messages sit behind the compaction boundary: their
-    // attachments are not rendered, so the fork must not claim them.
-    getDb()
-      .update(conversations)
-      .set({ contextCompactedMessageCount: 2 })
+    // First two messages sit behind a compaction that ran before the live
+    // turn: their injected blocks are not rendered, so the fork must not
+    // claim them.
+    const db = getDb();
+    const base = Date.now();
+    db.run(
+      `UPDATE messages SET created_at = ${base} WHERE id = '${compactedTurn.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 1} WHERE id = '${compactedReply.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 3} WHERE id = '${boundaryMessage.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 4} WHERE id = '${liveReply.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 5} WHERE id = '${pastBoundary.id}'`,
+    );
+    const compactedAt = base + 2;
+    db.update(conversations)
+      .set({
+        contextSummary: "Compacted summary",
+        contextCompactedMessageCount: 2,
+        contextCompactedAt: compactedAt,
+      })
       .where(eq(conversations.id, source.id))
       .run();
+    appendCompactionEvent(source.id, {
+      compactedAt,
+      summary: "Compacted summary",
+      compactedMessageCount: 2,
+    });
 
     const fork = forkConversation({
       conversationId: source.id,
@@ -1381,5 +1506,101 @@ describe("forkConversation + memory_retrospective_state", () => {
     const fork = forkConversation({ conversationId: source.id });
 
     expect(getRetrospectiveState(fork.id)?.lastRunAt).toBe(1_700_000_000_000);
+  });
+
+  test("inherits the earlier of two compactions when forking between them", async () => {
+    const source = createConversation("Twice-compacted thread");
+    const m1 = await addMessage(source.id, "user", "Message 1", {
+      skipIndexing: true,
+    });
+    const m2 = await addMessage(source.id, "assistant", "Message 2", {
+      skipIndexing: true,
+    });
+    const m3 = await addMessage(source.id, "user", "Message 3", {
+      skipIndexing: true,
+    });
+    const m4 = await addMessage(source.id, "assistant", "Message 4", {
+      skipIndexing: true,
+    });
+
+    const db = getDb();
+    const base = Date.now();
+    db.run(`UPDATE messages SET created_at = ${base} WHERE id = '${m1.id}'`);
+    db.run(
+      `UPDATE messages SET created_at = ${base + 2} WHERE id = '${m2.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 4} WHERE id = '${m3.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 6} WHERE id = '${m4.id}'`,
+    );
+    // C1 ran after M1 (covers 1 message); C2 ran after M3 (covers 3).
+    appendCompactionEvent(source.id, {
+      compactedAt: base + 1,
+      summary: "Summary 1",
+      compactedMessageCount: 1,
+    });
+    appendCompactionEvent(source.id, {
+      compactedAt: base + 5,
+      summary: "Summary 2",
+      compactedMessageCount: 3,
+    });
+
+    // Forking through M3 lands between the two compactions, so it inherits the
+    // earlier one — the capability a single stored pointer cannot provide.
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: m3.id,
+    });
+    expect(fork.contextSummary).toBe("Summary 1");
+    expect(fork.contextCompactedMessageCount).toBe(1);
+    expect(fork.contextCompactedAt).toBe(base + 1);
+  });
+
+  test("carries a ledger into the fork so re-forks resolve compaction", async () => {
+    const source = createConversation("Re-fork thread");
+    const m1 = await addMessage(source.id, "user", "Message 1", {
+      skipIndexing: true,
+    });
+    const m2 = await addMessage(source.id, "assistant", "Message 2", {
+      skipIndexing: true,
+    });
+    const m3 = await addMessage(source.id, "user", "Message 3", {
+      skipIndexing: true,
+    });
+
+    const db = getDb();
+    const base = Date.now();
+    db.run(`UPDATE messages SET created_at = ${base} WHERE id = '${m1.id}'`);
+    db.run(
+      `UPDATE messages SET created_at = ${base + 1} WHERE id = '${m2.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 3} WHERE id = '${m3.id}'`,
+    );
+    const compactedAt = base + 2; // covers M1+M2, before M3
+    db.update(conversations)
+      .set({
+        contextSummary: "Compacted summary",
+        contextCompactedMessageCount: 2,
+        contextCompactedAt: compactedAt,
+      })
+      .where(eq(conversations.id, source.id))
+      .run();
+    appendCompactionEvent(source.id, {
+      compactedAt,
+      summary: "Compacted summary",
+      compactedMessageCount: 2,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+    expect(fork.contextCompactedMessageCount).toBe(2);
+
+    // The fork owns a copy of the ledger, so a re-fork resolves the inherited
+    // compaction without walking back to the original source.
+    const reFork = forkConversation({ conversationId: fork.id });
+    expect(reFork.contextSummary).toBe("Compacted summary");
+    expect(reFork.contextCompactedMessageCount).toBe(2);
   });
 });

--- a/assistant/src/__tests__/db-compaction-events-migration.test.ts
+++ b/assistant/src/__tests__/db-compaction-events-migration.test.ts
@@ -1,0 +1,129 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateCreateCompactionEvents } from "../memory/migrations/302-create-compaction-events.js";
+import * as schema from "../memory/schema.js";
+
+interface EventRow {
+  conversation_id: string;
+  compacted_at: number;
+  summary: string;
+  compacted_message_count: number;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapCheckpointsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function bootstrapConversations(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      context_summary TEXT,
+      context_compacted_message_count INTEGER NOT NULL DEFAULT 0,
+      context_compacted_at INTEGER
+    )
+  `);
+}
+
+function insertConversation(
+  raw: Database,
+  id: string,
+  summary: string | null,
+  count: number,
+  compactedAt: number | null,
+): void {
+  raw
+    .query(
+      /*sql*/ `
+        INSERT INTO conversations (
+          id, title, created_at, updated_at,
+          context_summary, context_compacted_message_count, context_compacted_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `,
+    )
+    .run(id, id, 1000, 2000, summary, count, compactedAt);
+}
+
+function getEvents(raw: Database): EventRow[] {
+  return raw
+    .query(
+      /*sql*/ `
+        SELECT conversation_id, compacted_at, summary, compacted_message_count
+        FROM conversation_compaction_events
+        ORDER BY conversation_id
+      `,
+    )
+    .all() as EventRow[];
+}
+
+describe("migrateCreateCompactionEvents", () => {
+  test("creates the ledger and backfills one event per compacted conversation", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapConversations(raw);
+
+    insertConversation(raw, "compacted", "Summary text", 5, 3000);
+    insertConversation(raw, "uncompacted", null, 0, null);
+    // count>0 but never actually compacted (no timestamp) — must be skipped.
+    insertConversation(raw, "count-without-at", "Orphan summary", 4, null);
+
+    migrateCreateCompactionEvents(db);
+
+    expect(getEvents(raw)).toEqual([
+      {
+        conversation_id: "compacted",
+        compacted_at: 3000,
+        summary: "Summary text",
+        compacted_message_count: 5,
+      },
+    ]);
+  });
+
+  test("is idempotent — re-running does not duplicate backfilled events", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapConversations(raw);
+    insertConversation(raw, "compacted", "Summary text", 5, 3000);
+
+    migrateCreateCompactionEvents(db);
+    migrateCreateCompactionEvents(db);
+
+    expect(getEvents(raw)).toHaveLength(1);
+  });
+
+  test("the NOT EXISTS guard prevents duplicates even if the checkpoint is lost", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapConversations(raw);
+    insertConversation(raw, "compacted", "Summary text", 5, 3000);
+
+    migrateCreateCompactionEvents(db);
+    raw.exec(`DELETE FROM memory_checkpoints`);
+    migrateCreateCompactionEvents(db);
+
+    expect(getEvents(raw)).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/compaction-ledger-store.ts
+++ b/assistant/src/memory/compaction-ledger-store.ts
@@ -1,0 +1,107 @@
+import { and, desc, eq, lte } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { type DrizzleDb, getDb } from "./db-connection.js";
+import { conversationCompactionEvents } from "./schema.js";
+
+export interface CompactionEvent {
+  /** Wall-clock time the compaction ran (= `conversations.context_compacted_at`). */
+  compactedAt: number;
+  summary: string;
+  /** Count of leading persisted messages behind this compaction's summary. */
+  compactedMessageCount: number;
+}
+
+/**
+ * Append a compaction event to the ledger. Called alongside the
+ * `conversations` cache update on every compaction.
+ */
+export function appendCompactionEvent(
+  conversationId: string,
+  event: CompactionEvent,
+): void {
+  const db = getDb();
+  db.insert(conversationCompactionEvents)
+    .values({
+      id: uuid(),
+      conversationId,
+      compactedAt: event.compactedAt,
+      summary: event.summary,
+      compactedMessageCount: event.compactedMessageCount,
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+/**
+ * The most recent compaction event whose `compactedAt` is at-or-before
+ * `atOrBefore`, or null if none (or `atOrBefore` is null). This is the fork
+ * inheritance rule: a compaction applies to a fork only if it happened before
+ * the message being forked from.
+ */
+export function getLatestCompactionEventAtOrBefore(
+  conversationId: string,
+  atOrBefore: number | null,
+): CompactionEvent | null {
+  if (atOrBefore == null) return null;
+  const db = getDb();
+  const row = db
+    .select({
+      compactedAt: conversationCompactionEvents.compactedAt,
+      summary: conversationCompactionEvents.summary,
+      compactedMessageCount: conversationCompactionEvents.compactedMessageCount,
+    })
+    .from(conversationCompactionEvents)
+    .where(
+      and(
+        eq(conversationCompactionEvents.conversationId, conversationId),
+        lte(conversationCompactionEvents.compactedAt, atOrBefore),
+      ),
+    )
+    .orderBy(desc(conversationCompactionEvents.compactedAt))
+    .limit(1)
+    .get();
+  return row ?? null;
+}
+
+/**
+ * Copy the source conversation's ledger events with `compactedAt <=
+ * boundaryCreatedAt` into the fork, so the fork owns a correct ledger for its
+ * own future forks/compactions. Takes the active `db` so the copy joins the
+ * caller's transaction. No-op when the boundary is null.
+ */
+export function forkCompactionLedger(
+  db: DrizzleDb,
+  sourceConversationId: string,
+  forkConversationId: string,
+  boundaryCreatedAt: number | null,
+): void {
+  if (boundaryCreatedAt == null) return;
+  const events = db
+    .select({
+      compactedAt: conversationCompactionEvents.compactedAt,
+      summary: conversationCompactionEvents.summary,
+      compactedMessageCount: conversationCompactionEvents.compactedMessageCount,
+    })
+    .from(conversationCompactionEvents)
+    .where(
+      and(
+        eq(conversationCompactionEvents.conversationId, sourceConversationId),
+        lte(conversationCompactionEvents.compactedAt, boundaryCreatedAt),
+      ),
+    )
+    .all();
+  const now = Date.now();
+  for (const event of events) {
+    db.insert(conversationCompactionEvents)
+      .values({
+        id: uuid(),
+        conversationId: forkConversationId,
+        compactedAt: event.compactedAt,
+        summary: event.summary,
+        compactedMessageCount: event.compactedMessageCount,
+        createdAt: now,
+      })
+      .run();
+  }
+}

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -46,6 +46,11 @@ import {
 } from "./attachments-store.js";
 import { AUTO_ANALYSIS_SOURCE } from "./auto-analysis-constants.js";
 import {
+  appendCompactionEvent,
+  forkCompactionLedger,
+  getLatestCompactionEventAtOrBefore,
+} from "./compaction-ledger-store.js";
+import {
   projectAssistantMessage,
   seedForkedConversationAttention,
 } from "./conversation-attention-store.js";
@@ -928,16 +933,6 @@ export function forkConversation(params: {
     initialBoundaryIndex,
   );
 
-  const visibleWindowStartIndex = Math.max(
-    0,
-    Math.min(
-      sourceConversation.contextCompactedMessageCount,
-      sourceMessages.length,
-    ),
-  );
-  const preserveSourceCompactionState =
-    copyBoundaryIndex >= visibleWindowStartIndex;
-
   const messagesToCopy =
     copyBoundaryIndex >= 0
       ? sourceMessages.slice(0, copyBoundaryIndex + 1)
@@ -953,6 +948,15 @@ export function forkConversation(params: {
     sourceHistoryStrippedAt != null &&
     boundaryMessageCreatedAt != null &&
     boundaryMessageCreatedAt >= sourceHistoryStrippedAt;
+
+  // Inherit compaction by the same temporal rule: apply the most recent
+  // compaction whose event time is at-or-before the forked-from message. A
+  // compaction that ran after the boundary message did not exist at that point
+  // in the conversation, so the fork branches from full uncompacted history.
+  const inheritedCompaction = getLatestCompactionEventAtOrBefore(
+    sourceConversation.id,
+    boundaryMessageCreatedAt,
+  );
   const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
   const forkTitle =
     params.title ?? `${sourceConversation.title ?? "Untitled"} (Fork)`;
@@ -984,21 +988,18 @@ export function forkConversation(params: {
       .set({
         forkParentConversationId: sourceConversation.id,
         forkParentMessageId,
-        contextSummary: preserveSourceCompactionState
-          ? sourceConversation.contextSummary
-          : null,
-        contextCompactedMessageCount: preserveSourceCompactionState
-          ? sourceConversation.contextCompactedMessageCount
-          : 0,
-        contextCompactedAt: preserveSourceCompactionState
-          ? sourceConversation.contextCompactedAt
-          : null,
-        slackContextCompactionWatermarkTs: preserveSourceCompactionState
-          ? sourceConversation.slackContextCompactionWatermarkTs
-          : null,
-        slackContextCompactionWatermarkAt: preserveSourceCompactionState
-          ? sourceConversation.slackContextCompactionWatermarkAt
-          : null,
+        contextSummary: inheritedCompaction?.summary ?? null,
+        contextCompactedMessageCount:
+          inheritedCompaction?.compactedMessageCount ?? 0,
+        contextCompactedAt: inheritedCompaction?.compactedAt ?? null,
+        slackContextCompactionWatermarkTs:
+          inheritedCompaction != null
+            ? sourceConversation.slackContextCompactionWatermarkTs
+            : null,
+        slackContextCompactionWatermarkAt:
+          inheritedCompaction != null
+            ? sourceConversation.slackContextCompactionWatermarkAt
+            : null,
         historyStrippedAt: inheritsHistoryStrippedAt
           ? sourceHistoryStrippedAt
           : null,
@@ -1042,8 +1043,8 @@ export function forkConversation(params: {
       forkedMessageIds,
       latestForkedAssistant,
       isFullHistoryFork: copyBoundaryIndex === sourceMessages.length - 1,
-      preserveSourceCompactionState,
-      visibleWindowStartIndex,
+      inheritedCompactedMessageCount:
+        inheritedCompaction?.compactedMessageCount ?? 0,
       diskSyncQueue,
     });
 
@@ -1076,8 +1077,13 @@ interface PopulateForkContentsArgs {
   latestForkedAssistant: { messageId: string; messageAt: number } | null;
   /** `copyBoundaryIndex === sourceMessages.length - 1` for the source. */
   isFullHistoryFork: boolean;
-  preserveSourceCompactionState: boolean;
-  visibleWindowStartIndex: number;
+  /**
+   * Count of leading messages behind the compaction event this fork inherits
+   * (0 when the fork branches from uncompacted history). Memory-slug seeding
+   * skips this prefix, since rows behind the fork's summary are not rendered
+   * and must stay re-injectable.
+   */
+  inheritedCompactedMessageCount: number;
   /**
    * When provided, a disk-sync entry is appended per copied message for the
    * caller to flush after commit. Omitted by the retrospective fork, whose
@@ -1109,8 +1115,7 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
     forkedMessageIds,
     latestForkedAssistant,
     isFullHistoryFork,
-    preserveSourceCompactionState,
-    visibleWindowStartIndex,
+    inheritedCompactedMessageCount,
     diskSyncQueue,
   } = args;
   const db = getDb();
@@ -1218,9 +1223,10 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
     // The v2 and v3 layers persist under separate metadata keys with the
     // same `# memory/concepts/<slug>.md` header convention, so each seeds
     // its own dedup record from its own blocks.
-    const visibleStartIndex = preserveSourceCompactionState
-      ? visibleWindowStartIndex
-      : 0;
+    const visibleStartIndex = Math.min(
+      inheritedCompactedMessageCount,
+      messagesToCopy.length,
+    );
     const inheritedSlugs = new Set<string>();
     const inheritedV3Slugs = new Set<string>();
     for (const message of messagesToCopy.slice(visibleStartIndex)) {
@@ -1256,6 +1262,15 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
     forkedMessageIds,
     lastCopiedSourceMessageId: messagesToCopy.at(-1)?.id ?? null,
   });
+
+  // Carry the source's compaction events that predate the fork boundary so the
+  // fork owns a correct ledger for its own future forks/compactions.
+  forkCompactionLedger(
+    db,
+    sourceConversationId,
+    fork.id,
+    messagesToCopy.at(-1)?.createdAt ?? null,
+  );
 }
 
 /**
@@ -1345,15 +1360,6 @@ export async function forkConversationForRetrospective(params: {
     sourceMessages,
     initialBoundaryIndex,
   );
-  const visibleWindowStartIndex = Math.max(
-    0,
-    Math.min(
-      sourceConversation.contextCompactedMessageCount,
-      sourceMessages.length,
-    ),
-  );
-  const preserveSourceCompactionState =
-    copyBoundaryIndex >= visibleWindowStartIndex;
   const messagesToCopy =
     copyBoundaryIndex >= 0
       ? sourceMessages.slice(0, copyBoundaryIndex + 1)
@@ -1365,6 +1371,12 @@ export async function forkConversationForRetrospective(params: {
     sourceHistoryStrippedAt != null &&
     boundaryMessageCreatedAt != null &&
     boundaryMessageCreatedAt >= sourceHistoryStrippedAt;
+  // Inherit the most recent compaction whose event time is at-or-before the
+  // forked-from message (see `forkConversation`).
+  const inheritedCompaction = getLatestCompactionEventAtOrBefore(
+    sourceConversation.id,
+    boundaryMessageCreatedAt,
+  );
   const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
   const forkTitle =
     params.title ?? `${sourceConversation.title ?? "Untitled"} (Fork)`;
@@ -1393,21 +1405,18 @@ export async function forkConversationForRetrospective(params: {
       .set({
         forkParentConversationId: sourceConversation.id,
         forkParentMessageId,
-        contextSummary: preserveSourceCompactionState
-          ? sourceConversation.contextSummary
-          : null,
-        contextCompactedMessageCount: preserveSourceCompactionState
-          ? sourceConversation.contextCompactedMessageCount
-          : 0,
-        contextCompactedAt: preserveSourceCompactionState
-          ? sourceConversation.contextCompactedAt
-          : null,
-        slackContextCompactionWatermarkTs: preserveSourceCompactionState
-          ? sourceConversation.slackContextCompactionWatermarkTs
-          : null,
-        slackContextCompactionWatermarkAt: preserveSourceCompactionState
-          ? sourceConversation.slackContextCompactionWatermarkAt
-          : null,
+        contextSummary: inheritedCompaction?.summary ?? null,
+        contextCompactedMessageCount:
+          inheritedCompaction?.compactedMessageCount ?? 0,
+        contextCompactedAt: inheritedCompaction?.compactedAt ?? null,
+        slackContextCompactionWatermarkTs:
+          inheritedCompaction != null
+            ? sourceConversation.slackContextCompactionWatermarkTs
+            : null,
+        slackContextCompactionWatermarkAt:
+          inheritedCompaction != null
+            ? sourceConversation.slackContextCompactionWatermarkAt
+            : null,
         historyStrippedAt: inheritsHistoryStrippedAt
           ? sourceHistoryStrippedAt
           : null,
@@ -1445,8 +1454,8 @@ export async function forkConversationForRetrospective(params: {
         forkedMessageIds,
         latestForkedAssistant,
         isFullHistoryFork: copyBoundaryIndex === sourceMessages.length - 1,
-        preserveSourceCompactionState,
-        visibleWindowStartIndex,
+        inheritedCompactedMessageCount:
+          inheritedCompaction?.compactedMessageCount ?? 0,
       });
     });
 
@@ -2117,15 +2126,27 @@ export function updateConversationContextWindow(
   contextCompactedMessageCount: number,
 ): void {
   const db = getDb();
-  db.update(conversations)
-    .set({
-      contextSummary,
-      contextCompactedMessageCount,
-      contextCompactedAt: Date.now(),
-      updatedAt: Date.now(),
-    })
-    .where(eq(conversations.id, id))
-    .run();
+  const now = Date.now();
+  // Update the hot-path cache columns and append the event to the ledger in a
+  // single transaction so the latest ledger event always matches the cache.
+  db.transaction(() => {
+    db.update(conversations)
+      .set({
+        contextSummary,
+        contextCompactedMessageCount,
+        contextCompactedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(conversations.id, id))
+      .run();
+    if (contextCompactedMessageCount > 0) {
+      appendCompactionEvent(id, {
+        compactedAt: now,
+        summary: contextSummary,
+        compactedMessageCount: contextCompactedMessageCount,
+      });
+    }
+  });
 }
 
 export function setConversationHistoryStrippedAt(

--- a/assistant/src/memory/migrations/302-create-compaction-events.ts
+++ b/assistant/src/memory/migrations/302-create-compaction-events.ts
@@ -1,0 +1,107 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Create the append-only `conversation_compaction_events` ledger and backfill
+ * one event per already-compacted conversation from its current cache columns.
+ *
+ * The `conversations` row keeps the latest compaction
+ * (`context_summary` / `context_compacted_message_count` /
+ * `context_compacted_at`) as the hot-path cache the load path reads; this table
+ * preserves the full history so a fork can inherit the most recent compaction
+ * whose event time predates the message it forks from. Pre-feature history
+ * beyond the latest compaction is unrecoverable, so existing rows seed exactly
+ * one event.
+ *
+ * Idempotent: table creation is guarded on sqlite_master; the backfill is
+ * guarded by a memory_checkpoints key and a per-conversation NOT EXISTS so a
+ * lost checkpoint cannot duplicate rows.
+ */
+export function migrateCreateCompactionEvents(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversation_compaction_events'`,
+    )
+    .get();
+
+  if (!tableExists) {
+    try {
+      raw.exec("BEGIN");
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE conversation_compaction_events (
+          id                       TEXT PRIMARY KEY,
+          conversation_id          TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+          compacted_at             INTEGER NOT NULL,
+          summary                  TEXT NOT NULL,
+          compacted_message_count  INTEGER NOT NULL,
+          created_at               INTEGER NOT NULL
+        )
+      `);
+
+      raw.exec(/*sql*/ `
+        CREATE INDEX idx_compaction_events_conv_at
+          ON conversation_compaction_events(conversation_id, compacted_at)
+      `);
+
+      raw.exec("COMMIT");
+    } catch (e) {
+      try {
+        raw.exec("ROLLBACK");
+      } catch {
+        /* no active transaction */
+      }
+      throw e;
+    }
+  }
+
+  const checkpointKey = "backfill_conversation_compaction_events_v1";
+  const checkpoint = raw
+    .query(`SELECT 1 FROM memory_checkpoints WHERE key = ?`)
+    .get(checkpointKey);
+  if (checkpoint) return;
+
+  try {
+    raw.exec("BEGIN");
+
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO conversation_compaction_events
+          (id, conversation_id, compacted_at, summary, compacted_message_count, created_at)
+        SELECT
+          lower(hex(randomblob(16))),
+          c.id,
+          c.context_compacted_at,
+          c.context_summary,
+          c.context_compacted_message_count,
+          ?
+        FROM conversations c
+        WHERE c.context_compacted_message_count > 0
+          AND c.context_compacted_at IS NOT NULL
+          AND c.context_summary IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM conversation_compaction_events e
+            WHERE e.conversation_id = c.id
+          )
+      `,
+      )
+      .run(Date.now());
+
+    raw
+      .query(
+        `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+      )
+      .run(checkpointKey, Date.now());
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  }
+}

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -170,6 +170,34 @@ export const conversationGraphMemoryState = sqliteTable(
   },
 );
 
+/**
+ * Append-only ledger of every compaction event for a conversation. The
+ * `conversations` row keeps only the latest compaction (`context_summary` /
+ * `context_compacted_message_count` / `context_compacted_at`) as the hot-path
+ * cache the load path reads; this table preserves the full history so a fork
+ * can inherit the most recent compaction whose event time (`compacted_at`)
+ * is at-or-before the boundary message it forks from.
+ */
+export const conversationCompactionEvents = sqliteTable(
+  "conversation_compaction_events",
+  {
+    id: text("id").primaryKey(),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    compactedAt: integer("compacted_at").notNull(),
+    summary: text("summary").notNull(),
+    compactedMessageCount: integer("compacted_message_count").notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_compaction_events_conv_at").on(
+      table.conversationId,
+      table.compactedAt,
+    ),
+  ],
+);
+
 export const channelInboundEvents = sqliteTable("channel_inbound_events", {
   id: text("id").primaryKey(),
   sourceChannel: text("source_channel").notNull(),

--- a/assistant/src/memory/steps.ts
+++ b/assistant/src/memory/steps.ts
@@ -11,15 +11,36 @@ import { backfillAppConversationIds } from "./app-store.js";
 // Forward migration + down function imports
 import { migrateToolCreatedItems } from "./graph/bootstrap.js";
 import { migrateCoreTables } from "./migrations/000-core-tables.js";
-import { downJobDeferrals, migrateJobDeferrals } from "./migrations/001-job-deferrals.js";
+import {
+  downJobDeferrals,
+  migrateJobDeferrals,
+} from "./migrations/001-job-deferrals.js";
 import { migrateToolInvocationsFk } from "./migrations/002-tool-invocations-fk.js";
 import { migrateMemoryFtsBackfill } from "./migrations/003-memory-fts-backfill.js";
-import { downMemoryEntityRelationDedup, migrateMemoryEntityRelationDedup } from "./migrations/004-entity-relation-dedup.js";
-import { downMemoryItemsFingerprintScopeUnique, migrateMemoryItemsFingerprintScopeUnique } from "./migrations/005-fingerprint-scope-unique.js";
-import { downMemoryItemsScopeSaltedFingerprints, migrateMemoryItemsScopeSaltedFingerprints } from "./migrations/006-scope-salted-fingerprints.js";
-import { downAssistantIdToSelf, migrateAssistantIdToSelf } from "./migrations/007-assistant-id-to-self.js";
-import { downRemoveAssistantIdColumns, migrateRemoveAssistantIdColumns } from "./migrations/008-remove-assistant-id-columns.js";
-import { downLlmUsageEventsDropAssistantId, migrateLlmUsageEventsDropAssistantId } from "./migrations/009-llm-usage-events-drop-assistant-id.js";
+import {
+  downMemoryEntityRelationDedup,
+  migrateMemoryEntityRelationDedup,
+} from "./migrations/004-entity-relation-dedup.js";
+import {
+  downMemoryItemsFingerprintScopeUnique,
+  migrateMemoryItemsFingerprintScopeUnique,
+} from "./migrations/005-fingerprint-scope-unique.js";
+import {
+  downMemoryItemsScopeSaltedFingerprints,
+  migrateMemoryItemsScopeSaltedFingerprints,
+} from "./migrations/006-scope-salted-fingerprints.js";
+import {
+  downAssistantIdToSelf,
+  migrateAssistantIdToSelf,
+} from "./migrations/007-assistant-id-to-self.js";
+import {
+  downRemoveAssistantIdColumns,
+  migrateRemoveAssistantIdColumns,
+} from "./migrations/008-remove-assistant-id-columns.js";
+import {
+  downLlmUsageEventsDropAssistantId,
+  migrateLlmUsageEventsDropAssistantId,
+} from "./migrations/009-llm-usage-events-drop-assistant-id.js";
 import { migrateGuardianActionTables } from "./migrations/013-guardian-action-tables.js";
 import { downBackfillInboxThreadState } from "./migrations/014-backfill-inbox-thread-state.js";
 import { downDropActiveSearchIndex } from "./migrations/015-drop-active-search-index.js";
@@ -27,14 +48,23 @@ import { migrateMemorySegmentsIndexes } from "./migrations/016-memory-segments-i
 import { migrateMemoryItemsIndexes } from "./migrations/017-memory-items-indexes.js";
 import { migrateRemainingTableIndexes } from "./migrations/018-remaining-table-indexes.js";
 import { downNotificationTablesSchema } from "./migrations/019-notification-tables-schema-migration.js";
-import { downRenameChannelToVellum, migrateRenameChannelToVellum } from "./migrations/020-rename-macos-ios-channel-to-vellum.js";
+import {
+  downRenameChannelToVellum,
+  migrateRenameChannelToVellum,
+} from "./migrations/020-rename-macos-ios-channel-to-vellum.js";
 import { migrateConversationStatusIndexes } from "./migrations/021-conversation-status-indexes.js";
 import { migrateAddOriginInterface } from "./migrations/022-add-origin-interface.js";
 import { migrateMemoryItemSourcesIndexes } from "./migrations/023-memory-item-sources-indexes.js";
-import { downEmbeddingVectorBlob, migrateEmbeddingVectorBlob } from "./migrations/024-embedding-vector-blob.js";
+import {
+  downEmbeddingVectorBlob,
+  migrateEmbeddingVectorBlob,
+} from "./migrations/024-embedding-vector-blob.js";
 import { migrateMessagesFtsBackfill } from "./migrations/025-messages-fts-backfill.js";
 import { migrateGuardianVerificationSessions } from "./migrations/026-guardian-verification-sessions.js";
-import { downEmbeddingsNullableVectorJson, migrateEmbeddingsNullableVectorJson } from "./migrations/026a-embeddings-nullable-vector-json.js";
+import {
+  downEmbeddingsNullableVectorJson,
+  migrateEmbeddingsNullableVectorJson,
+} from "./migrations/026a-embeddings-nullable-vector-json.js";
 import { migrateGuardianBootstrapToken } from "./migrations/027a-guardian-bootstrap-token.js";
 import { migrateCallSessionMode } from "./migrations/028-call-session-mode.js";
 import { migrateChannelInboundDeliveredSegments } from "./migrations/029-channel-inbound-delivered-segments.js";
@@ -46,7 +76,10 @@ import { migrateNotificationDeliveryThreadDecision } from "./migrations/032-noti
 import { createScopedApprovalGrantsTable } from "./migrations/033-scoped-approval-grants.js";
 import { migrateGuardianActionToolMetadata } from "./migrations/034-guardian-action-tool-metadata.js";
 import { migrateGuardianActionSupersession } from "./migrations/035-guardian-action-supersession.js";
-import { downNormalizePhoneIdentities, migrateNormalizePhoneIdentities } from "./migrations/036-normalize-phone-identities.js";
+import {
+  downNormalizePhoneIdentities,
+  migrateNormalizePhoneIdentities,
+} from "./migrations/036-normalize-phone-identities.js";
 import { migrateVoiceInviteColumns } from "./migrations/037-voice-invite-columns.js";
 import { migrateInviteCodeHashColumn } from "./migrations/040-invite-code-hash-column.js";
 import { createApprovalPromptTsTrackerTable } from "./migrations/041-approval-prompt-ts-tracker.js";
@@ -73,30 +106,72 @@ import { migrateCanonicalGuardianRequesterChatId } from "./migrations/122-canoni
 import { migrateCanonicalGuardianDeliveriesDestinationIndex } from "./migrations/123-canonical-guardian-deliveries-destination-index.js";
 import { migrateVoiceInviteDisplayMetadata } from "./migrations/124-voice-invite-display-metadata.js";
 import { migrateGuardianPrincipalIdColumns } from "./migrations/125-guardian-principal-id-columns.js";
-import { downBackfillGuardianPrincipalId, migrateBackfillGuardianPrincipalId } from "./migrations/126-backfill-guardian-principal-id.js";
-import { downGuardianPrincipalIdNotNull, migrateGuardianPrincipalIdNotNull } from "./migrations/127-guardian-principal-id-not-null.js";
+import {
+  downBackfillGuardianPrincipalId,
+  migrateBackfillGuardianPrincipalId,
+} from "./migrations/126-backfill-guardian-principal-id.js";
+import {
+  downGuardianPrincipalIdNotNull,
+  migrateGuardianPrincipalIdNotNull,
+} from "./migrations/127-guardian-principal-id-not-null.js";
 import { migrateContactsRolePrincipal } from "./migrations/128-contacts-role-principal.js";
 import { migrateContactChannelsAccessFields } from "./migrations/129-contact-channels-access-fields.js";
 import { migrateContactChannelsTypeChatIdIndex } from "./migrations/130-contact-channels-type-ext-chat-id-index.js";
 import { migrateDropLegacyMemberGuardianTables } from "./migrations/131-drop-legacy-member-guardian-tables.js";
 import { migrateContactsAssistantId } from "./migrations/132-contacts-assistant-id.js";
 import { migrateAssistantContactMetadata } from "./migrations/133-assistant-contact-metadata.js";
-import { downContactsNotesColumn, migrateContactsNotesColumn } from "./migrations/134-contacts-notes-column.js";
-import { downBackfillContactInteractionStats, migrateBackfillContactInteractionStats } from "./migrations/135-backfill-contact-interaction-stats.js";
-import { downDropAssistantIdColumns, migrateDropAssistantIdColumns } from "./migrations/136-drop-assistant-id-columns.js";
+import {
+  downContactsNotesColumn,
+  migrateContactsNotesColumn,
+} from "./migrations/134-contacts-notes-column.js";
+import {
+  downBackfillContactInteractionStats,
+  migrateBackfillContactInteractionStats,
+} from "./migrations/135-backfill-contact-interaction-stats.js";
+import {
+  downDropAssistantIdColumns,
+  migrateDropAssistantIdColumns,
+} from "./migrations/136-drop-assistant-id-columns.js";
 import { migrateUsageDashboardIndexes } from "./migrations/137-usage-dashboard-indexes.js";
 import { migrateDropUsageCompositeIndexes } from "./migrations/139-drop-usage-composite-indexes.js";
-import { downBackfillUsageCacheAccounting, migrateBackfillUsageCacheAccounting } from "./migrations/140-backfill-usage-cache-accounting.js";
-import { downRenameVerificationTable, migrateRenameVerificationTable } from "./migrations/141-rename-verification-table.js";
-import { downRenameVerificationSessionIdColumn, migrateRenameVerificationSessionIdColumn } from "./migrations/142-rename-verification-session-id-column.js";
-import { downRenameGuardianVerificationValues, migrateRenameGuardianVerificationValues } from "./migrations/143-rename-guardian-verification-values.js";
-import { downRenameVoiceToPhone, migrateRenameVoiceToPhone } from "./migrations/144-rename-voice-to-phone.js";
-import { migrateDropAccountsTable, migrateDropAccountsTableDown } from "./migrations/145-drop-accounts-table.js";
+import {
+  downBackfillUsageCacheAccounting,
+  migrateBackfillUsageCacheAccounting,
+} from "./migrations/140-backfill-usage-cache-accounting.js";
+import {
+  downRenameVerificationTable,
+  migrateRenameVerificationTable,
+} from "./migrations/141-rename-verification-table.js";
+import {
+  downRenameVerificationSessionIdColumn,
+  migrateRenameVerificationSessionIdColumn,
+} from "./migrations/142-rename-verification-session-id-column.js";
+import {
+  downRenameGuardianVerificationValues,
+  migrateRenameGuardianVerificationValues,
+} from "./migrations/143-rename-guardian-verification-values.js";
+import {
+  downRenameVoiceToPhone,
+  migrateRenameVoiceToPhone,
+} from "./migrations/144-rename-voice-to-phone.js";
+import {
+  migrateDropAccountsTable,
+  migrateDropAccountsTableDown,
+} from "./migrations/145-drop-accounts-table.js";
 import { migrateScheduleOneShotRouting } from "./migrations/146-schedule-oneshot-routing.js";
-import { migrateRemindersToSchedules, migrateRemindersToSchedulesDown } from "./migrations/147-migrate-reminders-to-schedules.js";
-import { migrateDropRemindersTable, migrateDropRemindersTableDown } from "./migrations/148-drop-reminders-table.js";
+import {
+  migrateRemindersToSchedules,
+  migrateRemindersToSchedulesDown,
+} from "./migrations/147-migrate-reminders-to-schedules.js";
+import {
+  migrateDropRemindersTable,
+  migrateDropRemindersTableDown,
+} from "./migrations/148-drop-reminders-table.js";
 import { createOAuthTables } from "./migrations/149-oauth-tables.js";
-import { migrateOAuthAppsClientSecretPath, migrateOAuthAppsClientSecretPathDown } from "./migrations/150-oauth-apps-client-secret-path.js";
+import {
+  migrateOAuthAppsClientSecretPath,
+  migrateOAuthAppsClientSecretPathDown,
+} from "./migrations/150-oauth-apps-client-secret-path.js";
 import { migrateOAuthProvidersPingUrl } from "./migrations/151-oauth-providers-ping-url.js";
 import { migrateMemoryItemSupersession } from "./migrations/152-memory-item-supersession.js";
 import { migrateDropEntityTables } from "./migrations/153-drop-entity-tables.js";
@@ -108,39 +183,67 @@ import { migrateChannelInteractionColumns } from "./migrations/158-channel-inter
 import { migrateDropContactInteractionColumns } from "./migrations/159-drop-contact-interaction-columns.js";
 import { migrateDropLoopbackPortColumn } from "./migrations/160-drop-loopback-port-column.js";
 import { migrateDropOrphanedMediaTables } from "./migrations/161-drop-orphaned-media-tables.js";
-import { migrateGuardianTimestampsEpochMs, migrateGuardianTimestampsEpochMsDown, migrateGuardianTimestampsRebuildDown } from "./migrations/162-guardian-timestamps-epoch-ms.js";
+import {
+  migrateGuardianTimestampsEpochMs,
+  migrateGuardianTimestampsEpochMsDown,
+  migrateGuardianTimestampsRebuildDown,
+} from "./migrations/162-guardian-timestamps-epoch-ms.js";
 import { migrateRenameNotificationThreadColumns } from "./migrations/163-rename-notification-thread-columns.js";
 import { migrateRenameConversationTypeColumn } from "./migrations/164-rename-conversation-type-column.js";
 import { migrateRenameInboxThreadStateTable } from "./migrations/165-rename-inbox-thread-state-table.js";
 import { migrateRenameFollowupsThreadIdColumn } from "./migrations/166-rename-followups-thread-id.js";
 import { migrateRenameSequenceEnrollmentsThreadIdColumn } from "./migrations/167-rename-sequence-enrollments-thread-id.js";
 import { migrateRenameSequenceStepsReplyKey } from "./migrations/168-rename-sequence-steps-reply-key.js";
-import { migrateRenameGmailProviderKeyToGoogle, migrateRenameGmailProviderKeyToGoogleDown } from "./migrations/169-rename-gmail-provider-key-to-google.js";
+import {
+  migrateRenameGmailProviderKeyToGoogle,
+  migrateRenameGmailProviderKeyToGoogleDown,
+} from "./migrations/169-rename-gmail-provider-key-to-google.js";
 import { migrateCreateThreadStartersTable } from "./migrations/170-thread-starters-table.js";
 import { migrateCapabilityCardColumns } from "./migrations/171-capability-card-columns.js";
 import { migrateRenameCreatedBySessionIdColumns } from "./migrations/172-rename-created-by-session-id.js";
 import { migrateRenameSourceSessionIdColumn } from "./migrations/173-rename-source-session-id.js";
-import { migrateRenameThreadStartersTable, migrateRenameThreadStartersTableDown } from "./migrations/174-rename-thread-starters-table.js";
+import {
+  migrateRenameThreadStartersTable,
+  migrateRenameThreadStartersTableDown,
+} from "./migrations/174-rename-thread-starters-table.js";
 import { createLifecycleEventsTable } from "./migrations/175-create-lifecycle-events.js";
-import { migrateDropCapabilityCardState, migrateDropCapabilityCardStateDown } from "./migrations/176-drop-capability-card-state.js";
+import {
+  migrateDropCapabilityCardState,
+  migrateDropCapabilityCardStateDown,
+} from "./migrations/176-drop-capability-card-state.js";
 import { migrateCreateTraceEventsTable } from "./migrations/177-create-trace-events-table.js";
 import { migrateOAuthProvidersManagedServiceConfigKey } from "./migrations/178-oauth-providers-managed-service-config-key.js";
 import { migrateLlmRequestLogMessageId } from "./migrations/179-llm-request-log-message-id.js";
-import { migrateBackfillInlineAttachmentsToDisk, migrateBackfillInlineAttachmentsToDiskDown } from "./migrations/180-backfill-inline-attachments-to-disk.js";
-import { migrateRenameThreadStartersCheckpoints, migrateRenameThreadStartersCheckpointsDown } from "./migrations/181-rename-thread-starters-checkpoints.js";
+import {
+  migrateBackfillInlineAttachmentsToDisk,
+  migrateBackfillInlineAttachmentsToDiskDown,
+} from "./migrations/180-backfill-inline-attachments-to-disk.js";
+import {
+  migrateRenameThreadStartersCheckpoints,
+  migrateRenameThreadStartersCheckpointsDown,
+} from "./migrations/181-rename-thread-starters-checkpoints.js";
 import { migrateOAuthProvidersDisplayMetadata } from "./migrations/182-oauth-providers-display-metadata.js";
 import { migrateConversationForkLineage } from "./migrations/183-add-conversation-fork-lineage.js";
 import { migrateLlmRequestLogProvider } from "./migrations/184-llm-request-log-provider.js";
 import { migrateScheduleQuietFlag } from "./migrations/188-schedule-quiet-flag.js";
 import { migrateDropSimplifiedMemory } from "./migrations/189-drop-simplified-memory.js";
 import { migrateCallSessionSkipDisclosure } from "./migrations/190-call-session-skip-disclosure.js";
-import { migrateBackfillAudioAttachmentMimeTypes, migrateBackfillAudioAttachmentMimeTypesDown } from "./migrations/191-backfill-audio-attachment-mime-types.js";
+import {
+  migrateBackfillAudioAttachmentMimeTypes,
+  migrateBackfillAudioAttachmentMimeTypesDown,
+} from "./migrations/191-backfill-audio-attachment-mime-types.js";
 import { migrateContactsUserFileColumn } from "./migrations/192-contacts-user-file-column.js";
-import { migrateAddSourceTypeColumns, migrateAddSourceTypeColumnsDown } from "./migrations/193-add-source-type-columns.js";
+import {
+  migrateAddSourceTypeColumns,
+  migrateAddSourceTypeColumnsDown,
+} from "./migrations/193-add-source-type-columns.js";
 import { migrateCreateMemoryRecallLogs } from "./migrations/194-memory-recall-logs.js";
 import { migrateOAuthProvidersPingConfig } from "./migrations/195-oauth-providers-ping-config.js";
 import { migrateMessagesConversationCreatedAtIndex } from "./migrations/196-messages-conversation-created-at-index.js";
-import { migrateStripIntegrationPrefixFromProviderKeys, migrateStripIntegrationPrefixFromProviderKeysDown } from "./migrations/196-strip-integration-prefix-from-provider-keys.js";
+import {
+  migrateStripIntegrationPrefixFromProviderKeys,
+  migrateStripIntegrationPrefixFromProviderKeysDown,
+} from "./migrations/196-strip-integration-prefix-from-provider-keys.js";
 import { migrateOAuthProvidersBehaviorColumns } from "./migrations/197-oauth-providers-behavior-columns.js";
 import { migrateDropSetupSkillIdColumn } from "./migrations/198-drop-setup-skill-id-column.js";
 import { migrateGuardianRequestEnrichmentColumns } from "./migrations/199-guardian-request-enrichment-columns.js";
@@ -149,10 +252,16 @@ import { migrateOAuthProvidersFeatureFlag } from "./migrations/201-oauth-provide
 import { migrateDropCallbackTransportColumn } from "./migrations/202-drop-callback-transport-column.js";
 import { migrateCreateMemoryGraphTables } from "./migrations/202-memory-graph-tables.js";
 import { migrateDropMemoryItemsTables } from "./migrations/203-drop-memory-items-tables.js";
-import { migrateRenameMemoryGraphTypeValues, migrateRenameMemoryGraphTypeValuesDown } from "./migrations/204-rename-memory-graph-type-values.js";
+import {
+  migrateRenameMemoryGraphTypeValues,
+  migrateRenameMemoryGraphTypeValuesDown,
+} from "./migrations/204-rename-memory-graph-type-values.js";
 import { migrateMemoryGraphImageRefs } from "./migrations/205-memory-graph-image-refs.js";
 import { migrateCreateMemoryGraphNodeEdits } from "./migrations/206-memory-graph-node-edits.js";
-import { migrateScrubCorruptedImageAttachments, migrateScrubCorruptedImageAttachmentsDown } from "./migrations/206-scrub-corrupted-image-attachments.js";
+import {
+  migrateScrubCorruptedImageAttachments,
+  migrateScrubCorruptedImageAttachmentsDown,
+} from "./migrations/206-scrub-corrupted-image-attachments.js";
 import { migrateCreateConversationGraphMemoryState } from "./migrations/207-conversation-graph-memory-state.js";
 import { migrateConversationsLastMessageAt } from "./migrations/208-conversations-last-message-at.js";
 import { migrateStripThinkingFromConsolidated } from "./migrations/209-strip-thinking-from-consolidated.js";
@@ -163,10 +272,16 @@ import { migrateOAuthProvidersScopeSeparator } from "./migrations/213-oauth-prov
 import { migrateOAuthProvidersRefreshUrl } from "./migrations/214-oauth-providers-refresh-url.js";
 import { migrateOAuthProvidersRevoke } from "./migrations/215-oauth-providers-revoke.js";
 import { migrateOAuthProvidersTokenAuthMethodDefault } from "./migrations/216-oauth-providers-token-auth-method.js";
-import { downConversationHostAccess, migrateConversationHostAccess } from "./migrations/217-conversation-host-access.js";
+import {
+  downConversationHostAccess,
+  migrateConversationHostAccess,
+} from "./migrations/217-conversation-host-access.js";
 import { migrateOAuthProvidersLogoUrl } from "./migrations/218-oauth-providers-logo-url.js";
 import { migrateOAuthProvidersTokenExchangeBodyFormat } from "./migrations/219-oauth-providers-token-exchange-body-format.js";
-import { downNormalizeUserFileByPrincipal, migrateNormalizeUserFileByPrincipal } from "./migrations/220-normalize-user-file-by-principal.js";
+import {
+  downNormalizeUserFileByPrincipal,
+  migrateNormalizeUserFileByPrincipal,
+} from "./migrations/220-normalize-user-file-by-principal.js";
 import { migrateConversationsArchivedAt } from "./migrations/221-conversations-archived-at.js";
 import { migrateStripPlaceholderSentinelsFromMessages } from "./migrations/222-strip-placeholder-sentinels-from-messages.js";
 import { migrateScheduleScriptColumn } from "./migrations/223-schedule-script-column.js";
@@ -178,13 +293,28 @@ import { migrateRenameInferenceProfileSnakeCase } from "./migrations/228-rename-
 import { migrateDeletePrivateConversations } from "./migrations/229-delete-private-conversations.js";
 import { migrate230AcpSessionHistory } from "./migrations/230-acp-session-history.js";
 import { migrate231RepairMemoryGraphEventDates } from "./migrations/231-repair-memory-graph-event-dates.js";
-import { downActivationState, migrateActivationState } from "./migrations/232-activation-state.js";
+import {
+  downActivationState,
+  migrateActivationState,
+} from "./migrations/232-activation-state.js";
 import { migrateCreateDocumentConversations } from "./migrations/233-document-conversations.js";
-import { downMemoryV2ActivationLogs, migrateMemoryV2ActivationLogs } from "./migrations/234-memory-v2-activation-logs.js";
+import {
+  downMemoryV2ActivationLogs,
+  migrateMemoryV2ActivationLogs,
+} from "./migrations/234-memory-v2-activation-logs.js";
 import { migrateLlmUsageAttribution } from "./migrations/235-llm-usage-attribution.js";
-import { downSlackCompactionWatermark, migrateSlackCompactionWatermark } from "./migrations/235-slack-compaction-watermark.js";
-import { downToolInvocationsMatchedRuleId, migrateToolInvocationsMatchedRuleId } from "./migrations/236-tool-invocations-matched-rule-id.js";
-import { downHeartbeatRuns, migrateHeartbeatRuns } from "./migrations/237-heartbeat-runs.js";
+import {
+  downSlackCompactionWatermark,
+  migrateSlackCompactionWatermark,
+} from "./migrations/235-slack-compaction-watermark.js";
+import {
+  downToolInvocationsMatchedRuleId,
+  migrateToolInvocationsMatchedRuleId,
+} from "./migrations/236-tool-invocations-matched-rule-id.js";
+import {
+  downHeartbeatRuns,
+  migrateHeartbeatRuns,
+} from "./migrations/237-heartbeat-runs.js";
 import { migrateScheduleRetryPolicy } from "./migrations/238-schedule-retry-policy.js";
 import { migrateTraceEventsCreatedAtIndex } from "./migrations/239-trace-events-created-at-index.js";
 import { migrateConversationInferenceProfileSession } from "./migrations/240-conversation-inference-profile-session.js";
@@ -196,22 +326,46 @@ import { migrateMemoryRetrospectiveState } from "./migrations/245-memory-retrosp
 import { migrateBackfillProviderConnectionLabel } from "./migrations/246-backfill-provider-connection-label.js";
 import { migrateExternalConversationBindingThreadId } from "./migrations/247-external-conversation-binding-thread-id.js";
 import { createOnboardingEventsTable } from "./migrations/248-create-onboarding-events.js";
-import { downNormalizeSlackExternalContent, migrateNormalizeSlackExternalContent } from "./migrations/249-normalize-slack-external-content.js";
+import {
+  downNormalizeSlackExternalContent,
+  migrateNormalizeSlackExternalContent,
+} from "./migrations/249-normalize-slack-external-content.js";
 import { migrateProviderConnectionBaseUrlAndModels } from "./migrations/250-provider-connection-base-url-and-models.js";
 import { downA2ATasks, migrateA2ATasks } from "./migrations/251-a2a-tasks.js";
 import { migrateLlmRequestLogAgentLoopExitReason } from "./migrations/252-llm-request-log-agent-loop-exit-reason.js";
 import { migrateConversationLastNotifiedProfile } from "./migrations/253-conversation-last-notified-profile.js";
 import { migrateCreateDocumentComments } from "./migrations/253-document-comments.js";
-import { downExternalConversationBindingChatName, migrateExternalConversationBindingChatName } from "./migrations/254-external-conversation-binding-chat-name.js";
+import {
+  downExternalConversationBindingChatName,
+  migrateExternalConversationBindingChatName,
+} from "./migrations/254-external-conversation-binding-chat-name.js";
 import { migrateChannelInboundDeliveryAttempts } from "./migrations/255-channel-inbound-delivery-attempts.js";
-import { downMemoryV2InjectionEvents, migrateMemoryV2InjectionEvents } from "./migrations/256-memory-v2-injection-events.js";
+import {
+  downMemoryV2InjectionEvents,
+  migrateMemoryV2InjectionEvents,
+} from "./migrations/256-memory-v2-injection-events.js";
 import { migrateStripBaseUrlNonOpenaiCompatible } from "./migrations/257-strip-base-url-non-openai-compatible.js";
 import { migrateOnboardingEventsPriorAssistants } from "./migrations/258-onboarding-events-prior-assistants.js";
-import { downConversationCleanedAt, migrateConversationCleanedAt } from "./migrations/259-conversation-cleaned-at.js";
-import { downRenameCleanedAt, migrateRenameCleanedAt } from "./migrations/260-rename-cleaned-at.js";
-import { downLlmUsageAddRawUsage, migrateLlmUsageAddRawUsage } from "./migrations/261-llm-usage-add-raw-usage.js";
-import { downMemoryV3Coactivation, migrateMemoryV3Coactivation } from "./migrations/262-memory-v3-coactivation.js";
-import { downMemoryV3AutoEdges, migrateMemoryV3AutoEdges } from "./migrations/263-memory-v3-auto-edges.js";
+import {
+  downConversationCleanedAt,
+  migrateConversationCleanedAt,
+} from "./migrations/259-conversation-cleaned-at.js";
+import {
+  downRenameCleanedAt,
+  migrateRenameCleanedAt,
+} from "./migrations/260-rename-cleaned-at.js";
+import {
+  downLlmUsageAddRawUsage,
+  migrateLlmUsageAddRawUsage,
+} from "./migrations/261-llm-usage-add-raw-usage.js";
+import {
+  downMemoryV3Coactivation,
+  migrateMemoryV3Coactivation,
+} from "./migrations/262-memory-v3-coactivation.js";
+import {
+  downMemoryV3AutoEdges,
+  migrateMemoryV3AutoEdges,
+} from "./migrations/263-memory-v3-auto-edges.js";
 import { migrateLlmRequestLogCallSite } from "./migrations/264-llm-request-log-call-site.js";
 import { migrateDropProviderConnectionStatus } from "./migrations/265-drop-provider-connection-status.js";
 import { migrateMessagesClientMessageId } from "./migrations/266-messages-client-message-id.js";
@@ -219,7 +373,10 @@ import { migrateLlmUsageEventsAddAssistantVersion } from "./migrations/267-llm-u
 import { migrateAddMemoryV3Selections } from "./migrations/268-add-memory-v3-selections.js";
 import { migrateScheduleScriptTimeout } from "./migrations/269-schedule-script-timeout.js";
 import { migrateMessagesRoleCreatedAtIndex } from "./migrations/270-messages-role-created-at-index.js";
-import { downScheduleDescription, migrateScheduleDescription } from "./migrations/270-schedule-description.js";
+import {
+  downScheduleDescription,
+  migrateScheduleDescription,
+} from "./migrations/270-schedule-description.js";
 import { migrateScheduleSourceConversation } from "./migrations/270-schedule-source-conversation.js";
 import { createAuthFallbackEventsTable } from "./migrations/271-create-auth-fallback-events.js";
 import { migrateAcpSessionHistoryCwd } from "./migrations/272-acp-session-history-cwd.js";
@@ -252,322 +409,886 @@ import { migrateMoveMemoryJobsToMemoryDb } from "./migrations/298-move-memory-jo
 import { migrateCanonicalGuardianDeliveriesConversationIndex } from "./migrations/299-canonical-guardian-deliveries-conversation-index.js";
 import { migrateAddProcessingStartedAt } from "./migrations/300-add-processing-started-at.js";
 import { createWatchdogEventsTable } from "./migrations/301-create-watchdog-events.js";
+import { migrateCreateCompactionEvents } from "./migrations/302-create-compaction-events.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
-    migrateCoreTables,
-    createWatchersAndLogsTables,
-    addCoreColumns,
-    { name: "migrateJobDeferrals", run: migrateJobDeferrals,
-      rollback: [        { version: 1, description: "Reconcile legacy deferral history from attempts column into deferrals column", down: downJobDeferrals }] },
-    migrateToolInvocationsFk,
-    { name: "migrateMemoryEntityRelationDedup", run: migrateMemoryEntityRelationDedup,
-      rollback: [        { version: 2, description: "Deduplicate entity relation edges before enforcing the (source, target, relation) unique index", down: downMemoryEntityRelationDedup }] },
-    { name: "migrateMemoryItemsFingerprintScopeUnique", run: migrateMemoryItemsFingerprintScopeUnique,
-      rollback: [        { version: 3, description: "Replace column-level UNIQUE on fingerprint with compound (fingerprint, scope_id) unique index", down: downMemoryItemsFingerprintScopeUnique }] },
-    { name: "migrateMemoryItemsScopeSaltedFingerprints", run: migrateMemoryItemsScopeSaltedFingerprints,
-      dependsOn: ["migrateMemoryItemsFingerprintScopeUnique"],
-      rollback: [        { version: 4, description: "Recompute memory item fingerprints to include scope_id prefix after schema change", down: downMemoryItemsScopeSaltedFingerprints }] },
-    { name: "migrateAssistantIdToSelf", run: migrateAssistantIdToSelf,
-      rollback: [        { version: 5, description: "Normalize all assistant_id values in scoped tables to the implicit \"self\" single-tenant identity", down: downAssistantIdToSelf }] },
-    { name: "migrateRemoveAssistantIdColumns", run: migrateRemoveAssistantIdColumns,
-      dependsOn: ["migrateAssistantIdToSelf"],
-      rollback: [        { version: 6, description: "Rebuild four tables to drop the assistant_id column after normalization", down: downRemoveAssistantIdColumns }] },
-    { name: "migrateLlmUsageEventsDropAssistantId", run: migrateLlmUsageEventsDropAssistantId,
-      dependsOn: ["migrateAssistantIdToSelf"],
-      rollback: [        { version: 7, description: "Remove assistant_id column from llm_usage_events (separate checkpoint from the four-table migration)", down: downLlmUsageEventsDropAssistantId }] },
-    { name: "createCoreIndexes", run: createCoreIndexes,
-      rollback: [        { version: 9, description: "Drop old idx_memory_items_active_search so it can be recreated with updated covering columns", down: downDropActiveSearchIndex }] },
-    createContactsAndTriageTables,
-    createCallSessionsTables,
-    migrateCallSessionMode,
-    createFollowupsTables,
-    createTasksAndWorkItemsTables,
-    createExternalConversationBindingsTables,
-    createChannelGuardianTables,
-    migrateGuardianVerificationSessions,
-    migrateGuardianBootstrapToken,
-    migrateGuardianVerificationPurpose,
-    createMediaAssetsTables,
-    { name: "createAssistantInboxTables", run: createAssistantInboxTables,
-      rollback: [        { version: 8, description: "Seed assistant_inbox_thread_state from external_conversation_bindings", down: downBackfillInboxThreadState }] },
-    migrateGuardianActionTables,
-    migrateMemoryFtsBackfill,
-    migrateMemorySegmentsIndexes,
-    migrateMemoryItemsIndexes,
-    migrateRemainingTableIndexes,
-    { name: "migrateRenameChannelToVellum", run: migrateRenameChannelToVellum,
-      rollback: [        { version: 11, description: "Rename macos and ios channel identifiers to vellum across all tables", down: downRenameChannelToVellum }] },
-    migrateConversationStatusIndexes,
-    migrateAddOriginInterface,
-    migrateMemoryItemSourcesIndexes,
-    { name: "migrateEmbeddingVectorBlob", run: migrateEmbeddingVectorBlob,
-      rollback: [        { version: 12, description: "Add vector_blob BLOB column to memory_embeddings and backfill from vector_json for compact binary storage", down: downEmbeddingVectorBlob }] },
-    { name: "migrateEmbeddingsNullableVectorJson", run: migrateEmbeddingsNullableVectorJson,
-      dependsOn: ["migrateEmbeddingVectorBlob"],
-      rollback: [        { version: 13, description: "Rebuild memory_embeddings to make vector_json nullable (pre-100 DBs had NOT NULL)", down: downEmbeddingsNullableVectorJson }] },
-    migrateChannelInboundDeliveredSegments,
-    migrateGuardianActionFollowup,
-    migrateGuardianActionToolMetadata,
-    migrateGuardianActionSupersession,
-    migrateConversationsThreadTypeIndex,
-    migrateGuardianDeliveryConversationIndex,
-    { name: "createNotificationTables", run: createNotificationTables,
-      rollback: [        { version: 10, description: "Drop legacy enum-based notification tables so they can be recreated with the new signal-contract schema", down: downNotificationTablesSchema }] },
-    createSequenceTables,
-    createMessagesFts,
-    migrateMessagesFtsBackfill,
-    createConversationAttentionTables,
-    migrateReminderRoutingIntent,
-    migrateSchemaIndexesAndColumns,
-    migrateFkCascadeRebuilds,
-    createScopedApprovalGrantsTable,
-    migrateNotificationDeliveryThreadDecision,
-    createCanonicalGuardianTables,
-    migrateCanonicalGuardianRequesterChatId,
-    migrateCanonicalGuardianDeliveriesDestinationIndex,
-    { name: "migrateNormalizePhoneIdentities", run: migrateNormalizePhoneIdentities,
-      rollback: [        { version: 14, description: "Normalize phone-like identity fields to E.164 format across guardian bindings, verification challenges, canonical requests, ingress members, and rate limits", down: downNormalizePhoneIdentities }] },
-    migrateVoiceInviteColumns,
-    migrateVoiceInviteDisplayMetadata,
-    migrateInviteCodeHashColumn,
-    createApprovalPromptTsTrackerTable,
-    migrateGuardianPrincipalIdColumns,
-    { name: "migrateBackfillGuardianPrincipalId", run: migrateBackfillGuardianPrincipalId,
-      rollback: [        { version: 15, description: "Backfill guardianPrincipalId for existing channel_guardian_bindings and canonical_guardian_requests rows, expire unresolvable pending requests", down: downBackfillGuardianPrincipalId }] },
-    { name: "migrateGuardianPrincipalIdNotNull", run: migrateGuardianPrincipalIdNotNull,
-      dependsOn: ["migrateBackfillGuardianPrincipalId"],
-      rollback: [        { version: 16, description: "Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id after backfill", down: downGuardianPrincipalIdNotNull }] },
-    migrateContactsRolePrincipal,
-    migrateContactChannelsAccessFields,
-    migrateContactChannelsTypeChatIdIndex,
-    migrateDropLegacyMemberGuardianTables,
-    migrateContactsAssistantId,
-    migrateAssistantContactMetadata,
-    { name: "migrateContactsNotesColumn", run: migrateContactsNotesColumn,
-      rollback: [        { version: 17, description: "Consolidate relationship/importance/response_expectation/preferred_tone into a single notes TEXT column, then drop the legacy columns", down: downContactsNotesColumn }] },
-    { name: "migrateBackfillContactInteractionStats", run: migrateBackfillContactInteractionStats,
-      rollback: [        { version: 18, description: "Backfill contacts.last_interaction from the max lastSeenAt across each contact's channels", down: downBackfillContactInteractionStats }] },
-    { name: "migrateDropAssistantIdColumns", run: migrateDropAssistantIdColumns,
-      dependsOn: ["migrateAssistantIdToSelf"],
-      rollback: [        { version: 19, description: "Drop assistant_id columns from all 16 daemon tables after normalization to single-tenant identity", down: downDropAssistantIdColumns }] },
-    migrateUsageDashboardIndexes,
-    migrateDropUsageCompositeIndexes,
-    { name: "migrateBackfillUsageCacheAccounting", run: migrateBackfillUsageCacheAccounting,
-      rollback: [        { version: 20, description: "Backfill historical Anthropic llm_usage_events rows from llm_request_logs with cache-aware pricing", down: downBackfillUsageCacheAccounting }] },
-    { name: "migrateRenameVerificationTable", run: migrateRenameVerificationTable,
-      rollback: [        { version: 21, description: "Rename channel_guardian_verification_challenges table to channel_verification_sessions and update indexes", down: downRenameVerificationTable }] },
-    { name: "migrateRenameVerificationSessionIdColumn", run: migrateRenameVerificationSessionIdColumn,
-      rollback: [        { version: 22, description: "Rename guardian_verification_session_id column in call_sessions to verification_session_id", down: downRenameVerificationSessionIdColumn }] },
-    { name: "migrateRenameGuardianVerificationValues", run: migrateRenameGuardianVerificationValues,
-      rollback: [        { version: 23, description: "Rename persisted guardian_verification call_mode and guardian_voice_verification_* event_type values to drop the guardian_ prefix", down: downRenameGuardianVerificationValues }] },
-    { name: "migrateRenameVoiceToPhone", run: migrateRenameVoiceToPhone,
-      rollback: [        { version: 24, description: "Rename stored \"voice\" channel values to \"phone\" across all tables with channel text columns", down: downRenameVoiceToPhone }] },
-    { name: "migrateDropAccountsTable", run: migrateDropAccountsTable,
-      rollback: [        { version: 25, description: "Drop the unused legacy accounts table and its leftover indexes after account_manage removal", down: migrateDropAccountsTableDown }] },
-    migrateScheduleOneShotRouting,
-    { name: "migrateRemindersToSchedules", run: migrateRemindersToSchedules,
-      rollback: [        { version: 26, description: "Copy all existing reminders into cron_jobs as one-shot schedules with correct status and field mapping", down: migrateRemindersToSchedulesDown }] },
-    { name: "migrateDropRemindersTable", run: migrateDropRemindersTable,
-      dependsOn: ["migrateRemindersToSchedules"],
-      rollback: [        { version: 27, description: "Drop the legacy reminders table and its index after data migration to cron_jobs", down: migrateDropRemindersTableDown }] },
-    createOAuthTables,
-    { name: "migrateOAuthAppsClientSecretPath", run: migrateOAuthAppsClientSecretPath,
-      rollback: [        { version: 28, description: "Add client_secret_credential_path column to oauth_apps and backfill existing rows with convention-based paths", down: migrateOAuthAppsClientSecretPathDown }] },
-    migrateOAuthProvidersPingUrl,
-    migrateMemoryItemSupersession,
-    migrateDropEntityTables,
-    migrateDropMemorySegmentFts,
-    migrateDropConflicts,
-    migrateCallSessionInviteMetadata,
-    migrateInviteContactId,
-    migrateChannelInteractionColumns,
-    migrateDropContactInteractionColumns,
-    migrateDropLoopbackPortColumn,
-    migrateDropOrphanedMediaTables,
-    { name: "migrateGuardianTimestampsEpochMs", run: migrateGuardianTimestampsEpochMs,
-      rollback: [
-        { version: 29, description: "Convert guardian table timestamps from ISO 8601 text to epoch ms integers for consistency with all other tables", down: migrateGuardianTimestampsEpochMsDown },
-        { version: 30, description: "Rebuild guardian tables so timestamp columns have INTEGER affinity instead of TEXT", down: migrateGuardianTimestampsRebuildDown }
-      ] },
-    migrateRenameInboxThreadStateTable,
-    migrateRenameConversationTypeColumn,
-    migrateRenameNotificationThreadColumns,
-    migrateRenameFollowupsThreadIdColumn,
-    migrateRenameSequenceEnrollmentsThreadIdColumn,
-    migrateRenameSequenceStepsReplyKey,
-    { name: "migrateRenameGmailProviderKeyToGoogle", run: migrateRenameGmailProviderKeyToGoogle,
-      rollback: [        { version: 31, description: "Rename integration:gmail provider key to integration:google across oauth_providers, oauth_apps, and oauth_connections", down: migrateRenameGmailProviderKeyToGoogleDown }] },
-    migrateCreateThreadStartersTable,
-    migrateCapabilityCardColumns,
-    migrateRenameCreatedBySessionIdColumns,
-    migrateRenameSourceSessionIdColumn,
-    { name: "migrateRenameThreadStartersTable", run: migrateRenameThreadStartersTable,
-      rollback: [        { version: 32, description: "Rename thread_starters table to conversation_starters and recreate indexes with new names", down: migrateRenameThreadStartersTableDown }] },
-    { name: "migrateRenameThreadStartersCheckpoints", run: migrateRenameThreadStartersCheckpoints,
-      dependsOn: ["migrateRenameThreadStartersTable"],
-      rollback: [        { version: 35, description: "Rename checkpoint keys from thread_starters: to conversation_starters: prefix so renamed code paths find existing generation state", down: migrateRenameThreadStartersCheckpointsDown }] },
-    createLifecycleEventsTable,
-    { name: "migrateDropCapabilityCardState", run: migrateDropCapabilityCardState,
-      dependsOn: ["migrateRenameThreadStartersTable"],
-      rollback: [        { version: 33, description: "Remove deleted capability-card rows, jobs, checkpoints, and category state", down: migrateDropCapabilityCardStateDown }] },
-    migrateCreateTraceEventsTable,
-    migrateOAuthProvidersManagedServiceConfigKey,
-    migrateOAuthProvidersDisplayMetadata,
-    migrateLlmRequestLogMessageId,
-    migrateLlmRequestLogProvider,
-    { name: "migrateBackfillInlineAttachmentsToDisk", run: migrateBackfillInlineAttachmentsToDisk,
-      rollback: [        { version: 34, description: "Backfill existing inline base64 attachments to on-disk storage and clear dataBase64", down: migrateBackfillInlineAttachmentsToDiskDown }] },
-    migrateConversationForkLineage,
-    migrateScheduleQuietFlag,
-    migrateDropSimplifiedMemory,
-    migrateCallSessionSkipDisclosure,
-    { name: "migrateBackfillAudioAttachmentMimeTypes", run: migrateBackfillAudioAttachmentMimeTypes,
-      rollback: [        { version: 36, description: "Backfill correct MIME types for audio attachments stored as application/octet-stream due to missing extension map entries", down: migrateBackfillAudioAttachmentMimeTypesDown }] },
-    migrateContactsUserFileColumn,
-    { name: "migrateAddSourceTypeColumns", run: migrateAddSourceTypeColumns,
-      rollback: [        { version: 37, description: "Add source_type and source_message_role columns to memory_items with backfill from verification_state and source messages", down: migrateAddSourceTypeColumnsDown }] },
-    migrateCreateMemoryRecallLogs,
-    migrateOAuthProvidersPingConfig,
-    { name: "migrateStripIntegrationPrefixFromProviderKeys", run: migrateStripIntegrationPrefixFromProviderKeys,
-      rollback: [        { version: 38, description: "Strip integration: prefix from provider_key across oauth_providers, oauth_apps, and oauth_connections", down: migrateStripIntegrationPrefixFromProviderKeysDown }] },
-    migrateMessagesConversationCreatedAtIndex,
-    migrateOAuthProvidersBehaviorColumns,
-    migrateDropSetupSkillIdColumn,
-    migrateGuardianRequestEnrichmentColumns,
-    migrateUsageLlmCallCount,
-    migrateOAuthProvidersFeatureFlag,
-    migrateDropCallbackTransportColumn,
-    migrateCreateMemoryGraphTables,
-    migrateMemoryGraphImageRefs,
-    // 101b. Migrate tool-created items from legacy memory_items → graph nodes.
-    // Must run before migrateDropMemoryItemsTables so data is preserved.
-    migrateToolCreatedItems,
-    migrateDropMemoryItemsTables,
-    { name: "migrateRenameMemoryGraphTypeValues", run: migrateRenameMemoryGraphTypeValues,
-      rollback: [        { version: 39, description: "Rename legacy memory graph node type values: style → behavioral, relationship → semantic", down: migrateRenameMemoryGraphTypeValuesDown }] },
-    migrateCreateMemoryGraphNodeEdits,
-    { name: "migrateScrubCorruptedImageAttachments", run: migrateScrubCorruptedImageAttachments,
-      rollback: [        { version: 40, description: "Remove image attachments containing HTML error pages instead of image data", down: migrateScrubCorruptedImageAttachmentsDown }] },
-    migrateCreateConversationGraphMemoryState,
-    migrateConversationsLastMessageAt,
-    migrateStripThinkingFromConsolidated,
-    migrateScheduleReuseConversation,
-    migrateScheduleScriptColumn,
-    migrateMemoryRecallLogsQueryContext,
-    migrateLlmRequestLogsCreatedAtIndex,
-    migrateOAuthProvidersScopeSeparator,
-    migrateOAuthProvidersRefreshUrl,
-    migrateOAuthProvidersRevoke,
-    migrateOAuthProvidersTokenAuthMethodDefault,
-    { name: "migrateConversationHostAccess", run: migrateConversationHostAccess,
-      rollback: [        { version: 41, description: "Add a host_access column to conversations so computer access is persisted per conversation with a safe default of disabled", down: downConversationHostAccess }] },
-    migrateOAuthProvidersLogoUrl,
-    migrateOAuthProvidersTokenExchangeBodyFormat,
-    { name: "migrateNormalizeUserFileByPrincipal", run: migrateNormalizeUserFileByPrincipal,
-      rollback: [        { version: 42, description: "Normalize contacts.user_file across rows sharing the same principal_id so every channel for one principal loads the same users/<slug>.md persona and journal directory", down: downNormalizeUserFileByPrincipal }] },
-    migrateConversationsArchivedAt,
-    migrateStripPlaceholderSentinelsFromMessages,
-    migrateOAuthProvidersManagedServiceIsPaid,
-    migrateOAuthProvidersAvailableScopes,
-    migrateScheduleWakeConversationId,
-    migrateAddConversationInferenceProfile,
-    migrateRenameInferenceProfileSnakeCase,
-    migrateDeletePrivateConversations,
-    migrate230AcpSessionHistory,
-    migrate231RepairMemoryGraphEventDates,
-    { name: "migrateActivationState", run: migrateActivationState,
-      rollback: [        { version: 43, description: "Create activation_state table for memory v2", down: downActivationState }] },
-    migrateActivationStateFkCascade,
-    { name: "migrateMemoryV2ActivationLogs", run: migrateMemoryV2ActivationLogs,
-      rollback: [        { version: 44, description: "Create memory_v2_activation_logs table for per-turn v2 activation telemetry consumed by the LLM Context Inspector", down: downMemoryV2ActivationLogs }] },
-    migrateCreateDocumentConversations,
-    migrateLlmUsageAttribution,
-    { name: "migrateSlackCompactionWatermark", run: migrateSlackCompactionWatermark,
-      rollback: [        { version: 45, description: "Add Slack-specific compaction watermark columns to conversations", down: downSlackCompactionWatermark }] },
-    { name: "migrateToolInvocationsMatchedRuleId", run: migrateToolInvocationsMatchedRuleId,
-      rollback: [        { version: 46, description: "Add matched_trust_rule_id column to tool_invocations for trust rule audit and rule editor UI", down: downToolInvocationsMatchedRuleId }] },
-    { name: "migrateHeartbeatRuns", run: migrateHeartbeatRuns,
-      rollback: [        { version: 47, description: "Create heartbeat_runs table for tracking heartbeat execution lifecycle with CAS state transitions", down: downHeartbeatRuns }] },
-    function migrateBackfillAppConversationIds() {
-      backfillAppConversationIds();
-    },
-    migrateScheduleRetryPolicy,
-    migrateTraceEventsCreatedAtIndex,
-    migrateConversationInferenceProfileSession,
-    migrateMessageBookmarks,
-    migrateCreateProviderConnections,
-    migrateProviderConnectionStatusLabel,
-    migrateMemoryRetrospectiveState,
-    migrateBackfillProviderConnectionLabel,
-    migrateExternalConversationBindingThreadId,
-    createOnboardingEventsTable,
-    { name: "migrateNormalizeSlackExternalContent", run: migrateNormalizeSlackExternalContent,
-      rollback: [        { version: 48, description: "Normalize legacy persisted Slack external_content wrappers back to raw message content", down: downNormalizeSlackExternalContent }] },
-    migrateProviderConnectionBaseUrlAndModels,
-    { name: "migrateA2ATasks", run: migrateA2ATasks,
-      rollback: [        { version: 49, description: "Create a2a_tasks table for tracking A2A request/response lifecycle", down: downA2ATasks }] },
-    migrateLlmRequestLogAgentLoopExitReason,
-    migrateCreateDocumentComments,
-    { name: "migrateExternalConversationBindingChatName", run: migrateExternalConversationBindingChatName,
-      rollback: [        { version: 50, description: "Add external_chat_name to external conversation bindings for channel footer metadata", down: downExternalConversationBindingChatName }] },
-    migrateChannelInboundDeliveryAttempts,
-    { name: "migrateMemoryV2InjectionEvents", run: migrateMemoryV2InjectionEvents,
-      dependsOn: ["migrateMemoryV2ActivationLogs"],
-      rollback: [        { version: 51, description: "Create memory_v2_injection_events table and backfill from activation logs for EMA-based tier 2 routing", down: downMemoryV2InjectionEvents }] },
-    migrateConversationLastNotifiedProfile,
-    migrateStripBaseUrlNonOpenaiCompatible,
-    migrateOnboardingEventsPriorAssistants,
-    { name: "migrateConversationCleanedAt", run: migrateConversationCleanedAt,
-      rollback: [        { version: 52, description: "Add cleaned_at timestamp to conversations so /clean survives reload and forks inherit conditionally on fork point", down: downConversationCleanedAt }] },
-    { name: "migrateRenameCleanedAt", run: migrateRenameCleanedAt,
-      dependsOn: ["migrateConversationCleanedAt"],
-      rollback: [        { version: 53, description: "Rename conversations.cleaned_at to history_stripped_at; the marker now records any injection-strip event (including compaction), not just /clean", down: downRenameCleanedAt }] },
-    { name: "migrateLlmUsageAddRawUsage", run: migrateLlmUsageAddRawUsage,
-      rollback: [        { version: 54, description: "Add raw_usage TEXT column to llm_usage_events for storing the provider's untouched usage block as JSON (Anthropic TTL breakdown, OpenAI prompt/completion token details, etc.) so downstream consumers can extract provider-specific detail without per-field schema changes", down: downLlmUsageAddRawUsage }] },
-    { name: "migrateMemoryV3Coactivation", run: migrateMemoryV3Coactivation,
-      rollback: [        { version: 55, description: "Create memory_v3_coactivation table — append-only log of pass-1 → pass-N co-activation pairs (gradient signal) emitted by the v3 retrieval loop and reconciled later by edge-learning", down: downMemoryV3Coactivation }] },
-    { name: "migrateMemoryV3AutoEdges", run: migrateMemoryV3AutoEdges,
-      rollback: [        { version: 56, description: "Create memory_v3_auto_edges table — weighted, decaying learned association graph (distinct from curated edges:) accrued by the edge-learning job from used co-activations and consumed above-threshold by edge expansion", down: downMemoryV3AutoEdges }] },
-    migrateLlmRequestLogCallSite,
-    migrateDropProviderConnectionStatus,
-    migrateMessagesClientMessageId,
-    migrateLlmUsageEventsAddAssistantVersion,
-    migrateAddMemoryV3Selections,
-    migrateScheduleScriptTimeout,
-    { name: "migrateScheduleDescription", run: migrateScheduleDescription,
-      rollback: [        { version: 57, description: "Backfill authored schedule descriptions for legacy non-defer schedules from their existing names", down: downScheduleDescription }] },
-    migrateScheduleSourceConversation,
-    migrateMessagesRoleCreatedAtIndex,
-    createAuthFallbackEventsTable,
-    migrateAcpSessionHistoryCwd,
-    migrateOnboardingEventsFunnelColumns,
-    createActivationSessionsTable,
-    migrateToolInvocationsSkillId,
-    migrateToolInvocationsCreatedAtIdIndex,
-    migrateAddMemoryV3EverInjected,
-    migrateToolInvocationsTelemetryColumns,
-    createSkillLoadedEventsTable,
-    migrateConversationsSurfacedAt,
-    migrateMemoryRetrospectiveRememberedLog,
-    migrateScheduleInferenceProfile,
-    migrateMemoryV3SelectionsMessageIdAndSections,
-    migrateWorkflowRuns,
-    migrateScheduleWorkflowMode,
-    migrateWorkflowRunTrust,
-    migrateConversationOriginChannelIndex,
-    migrateBackfillOriginChannelFromBindings,
-    migrateContactChannelsUniqueExtUser,
-    migrateScheduleCapabilities,
-    migrateContactChannelsRenormalizeAddresses,
-    migrateScheduleDefaultNoReuseConversation,
-    migrateWorkflowJournalLeafTokens,
-    migrateDropExternalUserId,
-    dropApprovalPromptTsTrackerTable,
-    migrateRewriteBalancedEconomyProfilePins,
-    migrateMoveLlmRequestLogsToLogsDb,
-    migrateMoveMemoryJobsToMemoryDb,
-    migrateCanonicalGuardianDeliveriesConversationIndex,
-    migrateAddProcessingStartedAt,
-    createWatchdogEventsTable
+  migrateCoreTables,
+  createWatchersAndLogsTables,
+  addCoreColumns,
+  {
+    name: "migrateJobDeferrals",
+    run: migrateJobDeferrals,
+    rollback: [
+      {
+        version: 1,
+        description:
+          "Reconcile legacy deferral history from attempts column into deferrals column",
+        down: downJobDeferrals,
+      },
+    ],
+  },
+  migrateToolInvocationsFk,
+  {
+    name: "migrateMemoryEntityRelationDedup",
+    run: migrateMemoryEntityRelationDedup,
+    rollback: [
+      {
+        version: 2,
+        description:
+          "Deduplicate entity relation edges before enforcing the (source, target, relation) unique index",
+        down: downMemoryEntityRelationDedup,
+      },
+    ],
+  },
+  {
+    name: "migrateMemoryItemsFingerprintScopeUnique",
+    run: migrateMemoryItemsFingerprintScopeUnique,
+    rollback: [
+      {
+        version: 3,
+        description:
+          "Replace column-level UNIQUE on fingerprint with compound (fingerprint, scope_id) unique index",
+        down: downMemoryItemsFingerprintScopeUnique,
+      },
+    ],
+  },
+  {
+    name: "migrateMemoryItemsScopeSaltedFingerprints",
+    run: migrateMemoryItemsScopeSaltedFingerprints,
+    dependsOn: ["migrateMemoryItemsFingerprintScopeUnique"],
+    rollback: [
+      {
+        version: 4,
+        description:
+          "Recompute memory item fingerprints to include scope_id prefix after schema change",
+        down: downMemoryItemsScopeSaltedFingerprints,
+      },
+    ],
+  },
+  {
+    name: "migrateAssistantIdToSelf",
+    run: migrateAssistantIdToSelf,
+    rollback: [
+      {
+        version: 5,
+        description:
+          'Normalize all assistant_id values in scoped tables to the implicit "self" single-tenant identity',
+        down: downAssistantIdToSelf,
+      },
+    ],
+  },
+  {
+    name: "migrateRemoveAssistantIdColumns",
+    run: migrateRemoveAssistantIdColumns,
+    dependsOn: ["migrateAssistantIdToSelf"],
+    rollback: [
+      {
+        version: 6,
+        description:
+          "Rebuild four tables to drop the assistant_id column after normalization",
+        down: downRemoveAssistantIdColumns,
+      },
+    ],
+  },
+  {
+    name: "migrateLlmUsageEventsDropAssistantId",
+    run: migrateLlmUsageEventsDropAssistantId,
+    dependsOn: ["migrateAssistantIdToSelf"],
+    rollback: [
+      {
+        version: 7,
+        description:
+          "Remove assistant_id column from llm_usage_events (separate checkpoint from the four-table migration)",
+        down: downLlmUsageEventsDropAssistantId,
+      },
+    ],
+  },
+  {
+    name: "createCoreIndexes",
+    run: createCoreIndexes,
+    rollback: [
+      {
+        version: 9,
+        description:
+          "Drop old idx_memory_items_active_search so it can be recreated with updated covering columns",
+        down: downDropActiveSearchIndex,
+      },
+    ],
+  },
+  createContactsAndTriageTables,
+  createCallSessionsTables,
+  migrateCallSessionMode,
+  createFollowupsTables,
+  createTasksAndWorkItemsTables,
+  createExternalConversationBindingsTables,
+  createChannelGuardianTables,
+  migrateGuardianVerificationSessions,
+  migrateGuardianBootstrapToken,
+  migrateGuardianVerificationPurpose,
+  createMediaAssetsTables,
+  {
+    name: "createAssistantInboxTables",
+    run: createAssistantInboxTables,
+    rollback: [
+      {
+        version: 8,
+        description:
+          "Seed assistant_inbox_thread_state from external_conversation_bindings",
+        down: downBackfillInboxThreadState,
+      },
+    ],
+  },
+  migrateGuardianActionTables,
+  migrateMemoryFtsBackfill,
+  migrateMemorySegmentsIndexes,
+  migrateMemoryItemsIndexes,
+  migrateRemainingTableIndexes,
+  {
+    name: "migrateRenameChannelToVellum",
+    run: migrateRenameChannelToVellum,
+    rollback: [
+      {
+        version: 11,
+        description:
+          "Rename macos and ios channel identifiers to vellum across all tables",
+        down: downRenameChannelToVellum,
+      },
+    ],
+  },
+  migrateConversationStatusIndexes,
+  migrateAddOriginInterface,
+  migrateMemoryItemSourcesIndexes,
+  {
+    name: "migrateEmbeddingVectorBlob",
+    run: migrateEmbeddingVectorBlob,
+    rollback: [
+      {
+        version: 12,
+        description:
+          "Add vector_blob BLOB column to memory_embeddings and backfill from vector_json for compact binary storage",
+        down: downEmbeddingVectorBlob,
+      },
+    ],
+  },
+  {
+    name: "migrateEmbeddingsNullableVectorJson",
+    run: migrateEmbeddingsNullableVectorJson,
+    dependsOn: ["migrateEmbeddingVectorBlob"],
+    rollback: [
+      {
+        version: 13,
+        description:
+          "Rebuild memory_embeddings to make vector_json nullable (pre-100 DBs had NOT NULL)",
+        down: downEmbeddingsNullableVectorJson,
+      },
+    ],
+  },
+  migrateChannelInboundDeliveredSegments,
+  migrateGuardianActionFollowup,
+  migrateGuardianActionToolMetadata,
+  migrateGuardianActionSupersession,
+  migrateConversationsThreadTypeIndex,
+  migrateGuardianDeliveryConversationIndex,
+  {
+    name: "createNotificationTables",
+    run: createNotificationTables,
+    rollback: [
+      {
+        version: 10,
+        description:
+          "Drop legacy enum-based notification tables so they can be recreated with the new signal-contract schema",
+        down: downNotificationTablesSchema,
+      },
+    ],
+  },
+  createSequenceTables,
+  createMessagesFts,
+  migrateMessagesFtsBackfill,
+  createConversationAttentionTables,
+  migrateReminderRoutingIntent,
+  migrateSchemaIndexesAndColumns,
+  migrateFkCascadeRebuilds,
+  createScopedApprovalGrantsTable,
+  migrateNotificationDeliveryThreadDecision,
+  createCanonicalGuardianTables,
+  migrateCanonicalGuardianRequesterChatId,
+  migrateCanonicalGuardianDeliveriesDestinationIndex,
+  {
+    name: "migrateNormalizePhoneIdentities",
+    run: migrateNormalizePhoneIdentities,
+    rollback: [
+      {
+        version: 14,
+        description:
+          "Normalize phone-like identity fields to E.164 format across guardian bindings, verification challenges, canonical requests, ingress members, and rate limits",
+        down: downNormalizePhoneIdentities,
+      },
+    ],
+  },
+  migrateVoiceInviteColumns,
+  migrateVoiceInviteDisplayMetadata,
+  migrateInviteCodeHashColumn,
+  createApprovalPromptTsTrackerTable,
+  migrateGuardianPrincipalIdColumns,
+  {
+    name: "migrateBackfillGuardianPrincipalId",
+    run: migrateBackfillGuardianPrincipalId,
+    rollback: [
+      {
+        version: 15,
+        description:
+          "Backfill guardianPrincipalId for existing channel_guardian_bindings and canonical_guardian_requests rows, expire unresolvable pending requests",
+        down: downBackfillGuardianPrincipalId,
+      },
+    ],
+  },
+  {
+    name: "migrateGuardianPrincipalIdNotNull",
+    run: migrateGuardianPrincipalIdNotNull,
+    dependsOn: ["migrateBackfillGuardianPrincipalId"],
+    rollback: [
+      {
+        version: 16,
+        description:
+          "Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id after backfill",
+        down: downGuardianPrincipalIdNotNull,
+      },
+    ],
+  },
+  migrateContactsRolePrincipal,
+  migrateContactChannelsAccessFields,
+  migrateContactChannelsTypeChatIdIndex,
+  migrateDropLegacyMemberGuardianTables,
+  migrateContactsAssistantId,
+  migrateAssistantContactMetadata,
+  {
+    name: "migrateContactsNotesColumn",
+    run: migrateContactsNotesColumn,
+    rollback: [
+      {
+        version: 17,
+        description:
+          "Consolidate relationship/importance/response_expectation/preferred_tone into a single notes TEXT column, then drop the legacy columns",
+        down: downContactsNotesColumn,
+      },
+    ],
+  },
+  {
+    name: "migrateBackfillContactInteractionStats",
+    run: migrateBackfillContactInteractionStats,
+    rollback: [
+      {
+        version: 18,
+        description:
+          "Backfill contacts.last_interaction from the max lastSeenAt across each contact's channels",
+        down: downBackfillContactInteractionStats,
+      },
+    ],
+  },
+  {
+    name: "migrateDropAssistantIdColumns",
+    run: migrateDropAssistantIdColumns,
+    dependsOn: ["migrateAssistantIdToSelf"],
+    rollback: [
+      {
+        version: 19,
+        description:
+          "Drop assistant_id columns from all 16 daemon tables after normalization to single-tenant identity",
+        down: downDropAssistantIdColumns,
+      },
+    ],
+  },
+  migrateUsageDashboardIndexes,
+  migrateDropUsageCompositeIndexes,
+  {
+    name: "migrateBackfillUsageCacheAccounting",
+    run: migrateBackfillUsageCacheAccounting,
+    rollback: [
+      {
+        version: 20,
+        description:
+          "Backfill historical Anthropic llm_usage_events rows from llm_request_logs with cache-aware pricing",
+        down: downBackfillUsageCacheAccounting,
+      },
+    ],
+  },
+  {
+    name: "migrateRenameVerificationTable",
+    run: migrateRenameVerificationTable,
+    rollback: [
+      {
+        version: 21,
+        description:
+          "Rename channel_guardian_verification_challenges table to channel_verification_sessions and update indexes",
+        down: downRenameVerificationTable,
+      },
+    ],
+  },
+  {
+    name: "migrateRenameVerificationSessionIdColumn",
+    run: migrateRenameVerificationSessionIdColumn,
+    rollback: [
+      {
+        version: 22,
+        description:
+          "Rename guardian_verification_session_id column in call_sessions to verification_session_id",
+        down: downRenameVerificationSessionIdColumn,
+      },
+    ],
+  },
+  {
+    name: "migrateRenameGuardianVerificationValues",
+    run: migrateRenameGuardianVerificationValues,
+    rollback: [
+      {
+        version: 23,
+        description:
+          "Rename persisted guardian_verification call_mode and guardian_voice_verification_* event_type values to drop the guardian_ prefix",
+        down: downRenameGuardianVerificationValues,
+      },
+    ],
+  },
+  {
+    name: "migrateRenameVoiceToPhone",
+    run: migrateRenameVoiceToPhone,
+    rollback: [
+      {
+        version: 24,
+        description:
+          'Rename stored "voice" channel values to "phone" across all tables with channel text columns',
+        down: downRenameVoiceToPhone,
+      },
+    ],
+  },
+  {
+    name: "migrateDropAccountsTable",
+    run: migrateDropAccountsTable,
+    rollback: [
+      {
+        version: 25,
+        description:
+          "Drop the unused legacy accounts table and its leftover indexes after account_manage removal",
+        down: migrateDropAccountsTableDown,
+      },
+    ],
+  },
+  migrateScheduleOneShotRouting,
+  {
+    name: "migrateRemindersToSchedules",
+    run: migrateRemindersToSchedules,
+    rollback: [
+      {
+        version: 26,
+        description:
+          "Copy all existing reminders into cron_jobs as one-shot schedules with correct status and field mapping",
+        down: migrateRemindersToSchedulesDown,
+      },
+    ],
+  },
+  {
+    name: "migrateDropRemindersTable",
+    run: migrateDropRemindersTable,
+    dependsOn: ["migrateRemindersToSchedules"],
+    rollback: [
+      {
+        version: 27,
+        description:
+          "Drop the legacy reminders table and its index after data migration to cron_jobs",
+        down: migrateDropRemindersTableDown,
+      },
+    ],
+  },
+  createOAuthTables,
+  {
+    name: "migrateOAuthAppsClientSecretPath",
+    run: migrateOAuthAppsClientSecretPath,
+    rollback: [
+      {
+        version: 28,
+        description:
+          "Add client_secret_credential_path column to oauth_apps and backfill existing rows with convention-based paths",
+        down: migrateOAuthAppsClientSecretPathDown,
+      },
+    ],
+  },
+  migrateOAuthProvidersPingUrl,
+  migrateMemoryItemSupersession,
+  migrateDropEntityTables,
+  migrateDropMemorySegmentFts,
+  migrateDropConflicts,
+  migrateCallSessionInviteMetadata,
+  migrateInviteContactId,
+  migrateChannelInteractionColumns,
+  migrateDropContactInteractionColumns,
+  migrateDropLoopbackPortColumn,
+  migrateDropOrphanedMediaTables,
+  {
+    name: "migrateGuardianTimestampsEpochMs",
+    run: migrateGuardianTimestampsEpochMs,
+    rollback: [
+      {
+        version: 29,
+        description:
+          "Convert guardian table timestamps from ISO 8601 text to epoch ms integers for consistency with all other tables",
+        down: migrateGuardianTimestampsEpochMsDown,
+      },
+      {
+        version: 30,
+        description:
+          "Rebuild guardian tables so timestamp columns have INTEGER affinity instead of TEXT",
+        down: migrateGuardianTimestampsRebuildDown,
+      },
+    ],
+  },
+  migrateRenameInboxThreadStateTable,
+  migrateRenameConversationTypeColumn,
+  migrateRenameNotificationThreadColumns,
+  migrateRenameFollowupsThreadIdColumn,
+  migrateRenameSequenceEnrollmentsThreadIdColumn,
+  migrateRenameSequenceStepsReplyKey,
+  {
+    name: "migrateRenameGmailProviderKeyToGoogle",
+    run: migrateRenameGmailProviderKeyToGoogle,
+    rollback: [
+      {
+        version: 31,
+        description:
+          "Rename integration:gmail provider key to integration:google across oauth_providers, oauth_apps, and oauth_connections",
+        down: migrateRenameGmailProviderKeyToGoogleDown,
+      },
+    ],
+  },
+  migrateCreateThreadStartersTable,
+  migrateCapabilityCardColumns,
+  migrateRenameCreatedBySessionIdColumns,
+  migrateRenameSourceSessionIdColumn,
+  {
+    name: "migrateRenameThreadStartersTable",
+    run: migrateRenameThreadStartersTable,
+    rollback: [
+      {
+        version: 32,
+        description:
+          "Rename thread_starters table to conversation_starters and recreate indexes with new names",
+        down: migrateRenameThreadStartersTableDown,
+      },
+    ],
+  },
+  {
+    name: "migrateRenameThreadStartersCheckpoints",
+    run: migrateRenameThreadStartersCheckpoints,
+    dependsOn: ["migrateRenameThreadStartersTable"],
+    rollback: [
+      {
+        version: 35,
+        description:
+          "Rename checkpoint keys from thread_starters: to conversation_starters: prefix so renamed code paths find existing generation state",
+        down: migrateRenameThreadStartersCheckpointsDown,
+      },
+    ],
+  },
+  createLifecycleEventsTable,
+  {
+    name: "migrateDropCapabilityCardState",
+    run: migrateDropCapabilityCardState,
+    dependsOn: ["migrateRenameThreadStartersTable"],
+    rollback: [
+      {
+        version: 33,
+        description:
+          "Remove deleted capability-card rows, jobs, checkpoints, and category state",
+        down: migrateDropCapabilityCardStateDown,
+      },
+    ],
+  },
+  migrateCreateTraceEventsTable,
+  migrateOAuthProvidersManagedServiceConfigKey,
+  migrateOAuthProvidersDisplayMetadata,
+  migrateLlmRequestLogMessageId,
+  migrateLlmRequestLogProvider,
+  {
+    name: "migrateBackfillInlineAttachmentsToDisk",
+    run: migrateBackfillInlineAttachmentsToDisk,
+    rollback: [
+      {
+        version: 34,
+        description:
+          "Backfill existing inline base64 attachments to on-disk storage and clear dataBase64",
+        down: migrateBackfillInlineAttachmentsToDiskDown,
+      },
+    ],
+  },
+  migrateConversationForkLineage,
+  migrateScheduleQuietFlag,
+  migrateDropSimplifiedMemory,
+  migrateCallSessionSkipDisclosure,
+  {
+    name: "migrateBackfillAudioAttachmentMimeTypes",
+    run: migrateBackfillAudioAttachmentMimeTypes,
+    rollback: [
+      {
+        version: 36,
+        description:
+          "Backfill correct MIME types for audio attachments stored as application/octet-stream due to missing extension map entries",
+        down: migrateBackfillAudioAttachmentMimeTypesDown,
+      },
+    ],
+  },
+  migrateContactsUserFileColumn,
+  {
+    name: "migrateAddSourceTypeColumns",
+    run: migrateAddSourceTypeColumns,
+    rollback: [
+      {
+        version: 37,
+        description:
+          "Add source_type and source_message_role columns to memory_items with backfill from verification_state and source messages",
+        down: migrateAddSourceTypeColumnsDown,
+      },
+    ],
+  },
+  migrateCreateMemoryRecallLogs,
+  migrateOAuthProvidersPingConfig,
+  {
+    name: "migrateStripIntegrationPrefixFromProviderKeys",
+    run: migrateStripIntegrationPrefixFromProviderKeys,
+    rollback: [
+      {
+        version: 38,
+        description:
+          "Strip integration: prefix from provider_key across oauth_providers, oauth_apps, and oauth_connections",
+        down: migrateStripIntegrationPrefixFromProviderKeysDown,
+      },
+    ],
+  },
+  migrateMessagesConversationCreatedAtIndex,
+  migrateOAuthProvidersBehaviorColumns,
+  migrateDropSetupSkillIdColumn,
+  migrateGuardianRequestEnrichmentColumns,
+  migrateUsageLlmCallCount,
+  migrateOAuthProvidersFeatureFlag,
+  migrateDropCallbackTransportColumn,
+  migrateCreateMemoryGraphTables,
+  migrateMemoryGraphImageRefs,
+  // 101b. Migrate tool-created items from legacy memory_items → graph nodes.
+  // Must run before migrateDropMemoryItemsTables so data is preserved.
+  migrateToolCreatedItems,
+  migrateDropMemoryItemsTables,
+  {
+    name: "migrateRenameMemoryGraphTypeValues",
+    run: migrateRenameMemoryGraphTypeValues,
+    rollback: [
+      {
+        version: 39,
+        description:
+          "Rename legacy memory graph node type values: style → behavioral, relationship → semantic",
+        down: migrateRenameMemoryGraphTypeValuesDown,
+      },
+    ],
+  },
+  migrateCreateMemoryGraphNodeEdits,
+  {
+    name: "migrateScrubCorruptedImageAttachments",
+    run: migrateScrubCorruptedImageAttachments,
+    rollback: [
+      {
+        version: 40,
+        description:
+          "Remove image attachments containing HTML error pages instead of image data",
+        down: migrateScrubCorruptedImageAttachmentsDown,
+      },
+    ],
+  },
+  migrateCreateConversationGraphMemoryState,
+  migrateConversationsLastMessageAt,
+  migrateStripThinkingFromConsolidated,
+  migrateScheduleReuseConversation,
+  migrateScheduleScriptColumn,
+  migrateMemoryRecallLogsQueryContext,
+  migrateLlmRequestLogsCreatedAtIndex,
+  migrateOAuthProvidersScopeSeparator,
+  migrateOAuthProvidersRefreshUrl,
+  migrateOAuthProvidersRevoke,
+  migrateOAuthProvidersTokenAuthMethodDefault,
+  {
+    name: "migrateConversationHostAccess",
+    run: migrateConversationHostAccess,
+    rollback: [
+      {
+        version: 41,
+        description:
+          "Add a host_access column to conversations so computer access is persisted per conversation with a safe default of disabled",
+        down: downConversationHostAccess,
+      },
+    ],
+  },
+  migrateOAuthProvidersLogoUrl,
+  migrateOAuthProvidersTokenExchangeBodyFormat,
+  {
+    name: "migrateNormalizeUserFileByPrincipal",
+    run: migrateNormalizeUserFileByPrincipal,
+    rollback: [
+      {
+        version: 42,
+        description:
+          "Normalize contacts.user_file across rows sharing the same principal_id so every channel for one principal loads the same users/<slug>.md persona and journal directory",
+        down: downNormalizeUserFileByPrincipal,
+      },
+    ],
+  },
+  migrateConversationsArchivedAt,
+  migrateStripPlaceholderSentinelsFromMessages,
+  migrateOAuthProvidersManagedServiceIsPaid,
+  migrateOAuthProvidersAvailableScopes,
+  migrateScheduleWakeConversationId,
+  migrateAddConversationInferenceProfile,
+  migrateRenameInferenceProfileSnakeCase,
+  migrateDeletePrivateConversations,
+  migrate230AcpSessionHistory,
+  migrate231RepairMemoryGraphEventDates,
+  {
+    name: "migrateActivationState",
+    run: migrateActivationState,
+    rollback: [
+      {
+        version: 43,
+        description: "Create activation_state table for memory v2",
+        down: downActivationState,
+      },
+    ],
+  },
+  migrateActivationStateFkCascade,
+  {
+    name: "migrateMemoryV2ActivationLogs",
+    run: migrateMemoryV2ActivationLogs,
+    rollback: [
+      {
+        version: 44,
+        description:
+          "Create memory_v2_activation_logs table for per-turn v2 activation telemetry consumed by the LLM Context Inspector",
+        down: downMemoryV2ActivationLogs,
+      },
+    ],
+  },
+  migrateCreateDocumentConversations,
+  migrateLlmUsageAttribution,
+  {
+    name: "migrateSlackCompactionWatermark",
+    run: migrateSlackCompactionWatermark,
+    rollback: [
+      {
+        version: 45,
+        description:
+          "Add Slack-specific compaction watermark columns to conversations",
+        down: downSlackCompactionWatermark,
+      },
+    ],
+  },
+  {
+    name: "migrateToolInvocationsMatchedRuleId",
+    run: migrateToolInvocationsMatchedRuleId,
+    rollback: [
+      {
+        version: 46,
+        description:
+          "Add matched_trust_rule_id column to tool_invocations for trust rule audit and rule editor UI",
+        down: downToolInvocationsMatchedRuleId,
+      },
+    ],
+  },
+  {
+    name: "migrateHeartbeatRuns",
+    run: migrateHeartbeatRuns,
+    rollback: [
+      {
+        version: 47,
+        description:
+          "Create heartbeat_runs table for tracking heartbeat execution lifecycle with CAS state transitions",
+        down: downHeartbeatRuns,
+      },
+    ],
+  },
+  function migrateBackfillAppConversationIds() {
+    backfillAppConversationIds();
+  },
+  migrateScheduleRetryPolicy,
+  migrateTraceEventsCreatedAtIndex,
+  migrateConversationInferenceProfileSession,
+  migrateMessageBookmarks,
+  migrateCreateProviderConnections,
+  migrateProviderConnectionStatusLabel,
+  migrateMemoryRetrospectiveState,
+  migrateBackfillProviderConnectionLabel,
+  migrateExternalConversationBindingThreadId,
+  createOnboardingEventsTable,
+  {
+    name: "migrateNormalizeSlackExternalContent",
+    run: migrateNormalizeSlackExternalContent,
+    rollback: [
+      {
+        version: 48,
+        description:
+          "Normalize legacy persisted Slack external_content wrappers back to raw message content",
+        down: downNormalizeSlackExternalContent,
+      },
+    ],
+  },
+  migrateProviderConnectionBaseUrlAndModels,
+  {
+    name: "migrateA2ATasks",
+    run: migrateA2ATasks,
+    rollback: [
+      {
+        version: 49,
+        description:
+          "Create a2a_tasks table for tracking A2A request/response lifecycle",
+        down: downA2ATasks,
+      },
+    ],
+  },
+  migrateLlmRequestLogAgentLoopExitReason,
+  migrateCreateDocumentComments,
+  {
+    name: "migrateExternalConversationBindingChatName",
+    run: migrateExternalConversationBindingChatName,
+    rollback: [
+      {
+        version: 50,
+        description:
+          "Add external_chat_name to external conversation bindings for channel footer metadata",
+        down: downExternalConversationBindingChatName,
+      },
+    ],
+  },
+  migrateChannelInboundDeliveryAttempts,
+  {
+    name: "migrateMemoryV2InjectionEvents",
+    run: migrateMemoryV2InjectionEvents,
+    dependsOn: ["migrateMemoryV2ActivationLogs"],
+    rollback: [
+      {
+        version: 51,
+        description:
+          "Create memory_v2_injection_events table and backfill from activation logs for EMA-based tier 2 routing",
+        down: downMemoryV2InjectionEvents,
+      },
+    ],
+  },
+  migrateConversationLastNotifiedProfile,
+  migrateStripBaseUrlNonOpenaiCompatible,
+  migrateOnboardingEventsPriorAssistants,
+  {
+    name: "migrateConversationCleanedAt",
+    run: migrateConversationCleanedAt,
+    rollback: [
+      {
+        version: 52,
+        description:
+          "Add cleaned_at timestamp to conversations so /clean survives reload and forks inherit conditionally on fork point",
+        down: downConversationCleanedAt,
+      },
+    ],
+  },
+  {
+    name: "migrateRenameCleanedAt",
+    run: migrateRenameCleanedAt,
+    dependsOn: ["migrateConversationCleanedAt"],
+    rollback: [
+      {
+        version: 53,
+        description:
+          "Rename conversations.cleaned_at to history_stripped_at; the marker now records any injection-strip event (including compaction), not just /clean",
+        down: downRenameCleanedAt,
+      },
+    ],
+  },
+  {
+    name: "migrateLlmUsageAddRawUsage",
+    run: migrateLlmUsageAddRawUsage,
+    rollback: [
+      {
+        version: 54,
+        description:
+          "Add raw_usage TEXT column to llm_usage_events for storing the provider's untouched usage block as JSON (Anthropic TTL breakdown, OpenAI prompt/completion token details, etc.) so downstream consumers can extract provider-specific detail without per-field schema changes",
+        down: downLlmUsageAddRawUsage,
+      },
+    ],
+  },
+  {
+    name: "migrateMemoryV3Coactivation",
+    run: migrateMemoryV3Coactivation,
+    rollback: [
+      {
+        version: 55,
+        description:
+          "Create memory_v3_coactivation table — append-only log of pass-1 → pass-N co-activation pairs (gradient signal) emitted by the v3 retrieval loop and reconciled later by edge-learning",
+        down: downMemoryV3Coactivation,
+      },
+    ],
+  },
+  {
+    name: "migrateMemoryV3AutoEdges",
+    run: migrateMemoryV3AutoEdges,
+    rollback: [
+      {
+        version: 56,
+        description:
+          "Create memory_v3_auto_edges table — weighted, decaying learned association graph (distinct from curated edges:) accrued by the edge-learning job from used co-activations and consumed above-threshold by edge expansion",
+        down: downMemoryV3AutoEdges,
+      },
+    ],
+  },
+  migrateLlmRequestLogCallSite,
+  migrateDropProviderConnectionStatus,
+  migrateMessagesClientMessageId,
+  migrateLlmUsageEventsAddAssistantVersion,
+  migrateAddMemoryV3Selections,
+  migrateScheduleScriptTimeout,
+  {
+    name: "migrateScheduleDescription",
+    run: migrateScheduleDescription,
+    rollback: [
+      {
+        version: 57,
+        description:
+          "Backfill authored schedule descriptions for legacy non-defer schedules from their existing names",
+        down: downScheduleDescription,
+      },
+    ],
+  },
+  migrateScheduleSourceConversation,
+  migrateMessagesRoleCreatedAtIndex,
+  createAuthFallbackEventsTable,
+  migrateAcpSessionHistoryCwd,
+  migrateOnboardingEventsFunnelColumns,
+  createActivationSessionsTable,
+  migrateToolInvocationsSkillId,
+  migrateToolInvocationsCreatedAtIdIndex,
+  migrateAddMemoryV3EverInjected,
+  migrateToolInvocationsTelemetryColumns,
+  createSkillLoadedEventsTable,
+  migrateConversationsSurfacedAt,
+  migrateMemoryRetrospectiveRememberedLog,
+  migrateScheduleInferenceProfile,
+  migrateMemoryV3SelectionsMessageIdAndSections,
+  migrateWorkflowRuns,
+  migrateScheduleWorkflowMode,
+  migrateWorkflowRunTrust,
+  migrateConversationOriginChannelIndex,
+  migrateBackfillOriginChannelFromBindings,
+  migrateContactChannelsUniqueExtUser,
+  migrateScheduleCapabilities,
+  migrateContactChannelsRenormalizeAddresses,
+  migrateScheduleDefaultNoReuseConversation,
+  migrateWorkflowJournalLeafTokens,
+  migrateDropExternalUserId,
+  dropApprovalPromptTsTrackerTable,
+  migrateRewriteBalancedEconomyProfilePins,
+  migrateMoveLlmRequestLogsToLogsDb,
+  migrateMoveMemoryJobsToMemoryDb,
+  migrateCanonicalGuardianDeliveriesConversationIndex,
+  migrateAddProcessingStartedAt,
+  createWatchdogEventsTable,
+  migrateCreateCompactionEvents,
 ];


### PR DESCRIPTION
## Summary
- Add an append-only `conversation_compaction_events` ledger (one row per `/compact`); the `conversations` compaction columns stay as the hot-path "latest" cache, so the load path is unchanged.
- Fork inheritance now resolves the most recent compaction whose event time is at-or-before the forked-from message — the same temporal rule as `historyStrippedAt` — replacing the positional `copyBoundaryIndex >= contextCompactedMessageCount` check. Forking through a message that predates a compaction yields the full uncompacted history; forking between two compactions inherits the earlier one.
- Forks copy the ledger slice that predates the boundary so re-forking resolves correctly; migration 302 creates the table and backfills one event per already-compacted conversation.

## Original prompt
Investigated why forking a conversation after `/compact` didn't return the uncompacted version: fork inheritance used a positional check that treated tail messages (which predate the compaction event) as already-compacted, so the copied-but-masked raw history stayed hidden behind the summary. The agreed fix is a temporal rule — a fork inherits the most recent compaction that happened before the forked-from message — implemented as a full "compaction ledger" so even multiply-compacted threads reproduce the exact historical view at any fork point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)