### PR TITLE
test: align migration-102 heartbeat assertions with enable-by-default

### DIFF
--- a/assistant/src/__tests__/workspace-migration-102-preserve-heartbeat-enabled-for-existing-workspaces.test.ts
+++ b/assistant/src/__tests__/workspace-migration-102-preserve-heartbeat-enabled-for-existing-workspaces.test.ts
@@ -55,11 +55,11 @@ describe("102-preserve-heartbeat-enabled-for-existing-workspaces migration", () 
     ).toContain("heartbeat.enabled");
   });
 
-  test("schema default is disabled (the flip this migration compensates for)", () => {
-    expect(HeartbeatConfigSchema.parse({}).enabled).toBe(false);
+  test("schema default is enabled", () => {
+    expect(HeartbeatConfigSchema.parse({}).enabled).toBe(true);
   });
 
-  test("skips fresh workspaces so new users get the opt-in default", () => {
+  test("skips fresh workspaces so new users inherit the schema default", () => {
     preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
       workspaceDir,
       NEW_WORKSPACE_CTX,


### PR DESCRIPTION
## Summary
- `feat(heartbeat): enable by default` (#36147) flipped the `heartbeat.enabled` schema default from `false` back to `true`, but left `workspace-migration-102`'s test still asserting the old `false` default — failing the Test job in CI.
- Flip the schema-default assertion to `true` and refresh two now-stale test names (the migration no longer "compensates for a flip"; fresh workspaces "inherit the schema default" rather than an opt-in default).
- No migration behavior change: the migration still writes `enabled: true` for upgrading workspaces, which is consistent with the reverted default.

## Original prompt
Fix only the specific CI failure in the Test job of run 28191463737. That job failed because `workspace-migration-102-preserve-heartbeat-enabled-for-existing-workspaces.test.ts:59` asserted the heartbeat schema default was `false`, which went stale after the enable-by-default revert in #36147. The code change is intentional, so the test is what needed updating.