### PR TITLE
fix(web): stop refresh from collapsing a finished reply to a thinking bubble

### DIFF
--- a/clients/web/src/domains/chat/transcript/select-transcript-messages.test.ts
+++ b/clients/web/src/domains/chat/transcript/select-transcript-messages.test.ts
@@ -5,6 +5,7 @@ import type { DisplayMessage } from "@/domains/chat/types/types";
 import {
   messageText,
   textBody,
+  thinkingBodyWithBlocks,
 } from "@/domains/chat/utils/message-test-helpers";
 
 function makeRow(
@@ -163,6 +164,102 @@ describe("selectTranscriptMessages", () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.id).toBe("a2");
     expect(messageText(result[0])).toBe("live copy");
+  });
+
+  test("folds the persisted prefix into a prefix-less re-attach bubble instead of letting it shadow the answer", () => {
+    // Regression: messages disappearing on refresh. A tab reconnects mid-turn
+    // and the daemon replays the in-flight LLM call's thinking deltas under
+    // that call's own id (`call-2`). The persisted turn row is anchored on an
+    // EARLIER call's id (`call-1`) with `call-2` folded in as a merged alias,
+    // and it already holds the full answer. The first replayed delta beat the
+    // history fetch, so the live bubble opened prefix-less — it holds only the
+    // post-reconnect thinking and carries NO knowledge of `call-1`.
+    const history = [
+      makeRow({ id: "u1", role: "user", ...textBody("hi"), timestamp: 1000 }),
+      makeRow({
+        id: "call-1",
+        mergedMessageIds: ["call-2"],
+        role: "assistant",
+        ...textBody("the full dashboard answer"),
+        timestamp: 1001,
+      }),
+    ];
+    const live = [
+      makeRow({
+        id: "call-2",
+        role: "assistant",
+        ...thinkingBodyWithBlocks("reconsidering the design"),
+        timestamp: 2000,
+      }),
+    ];
+
+    const result = selectTranscriptMessages(history, live);
+
+    // The user row plus ONE merged assistant row — the answer is not shadowed.
+    expect(result.map((m) => m.id)).toEqual(["u1", "call-1"]);
+    // Persisted answer survives, and the replayed thinking suffix extends it.
+    expect(messageText(result[1])).toBe("the full dashboard answer");
+    expect(result[1]!.thinkingSegments).toEqual(["reconsidering the design"]);
+    // The replayed id stays resolvable on the folded row.
+    expect(result[1]!.mergedMessageIds).toContain("call-2");
+  });
+
+  test("does not fold when the live row carries history's id as its own alias (it legitimately supersedes)", () => {
+    // Mirror of the prefix-less case but with the alias on the LIVE side: the
+    // live row folded `a1` in during streaming, so it already contains that
+    // content and must win outright — no double-counting via a fold.
+    const history = [
+      makeRow({
+        id: "a1",
+        role: "assistant",
+        ...textBody("history copy"),
+        timestamp: 1000,
+      }),
+    ];
+    const live = [
+      makeRow({
+        id: "a2",
+        mergedMessageIds: ["a1"],
+        role: "assistant",
+        ...textBody("live copy"),
+        timestamp: 1000,
+      }),
+    ];
+
+    const result = selectTranscriptMessages(history, live);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("a2");
+    expect(messageText(result[0])).toBe("live copy");
+  });
+
+  test("does not fold a prefix-less match across roles", () => {
+    // A user history row aliased to a live assistant row must never fold — the
+    // guard is assistant-only. (Defensive: this shape shouldn't occur, but the
+    // fold must not fire if it does.)
+    const history = [
+      makeRow({
+        id: "u-srv",
+        mergedMessageIds: ["live-x"],
+        role: "user",
+        ...textBody("a question"),
+        timestamp: 1000,
+      }),
+    ];
+    const live = [
+      makeRow({
+        id: "live-x",
+        role: "assistant",
+        ...textBody("an answer"),
+        timestamp: 2000,
+      }),
+    ];
+
+    const result = selectTranscriptMessages(history, live);
+
+    // Matched in place, live wins — no cross-role fold.
+    expect(result.map((m) => m.id)).toEqual(["live-x"]);
+    expect(messageText(result[0])).toBe("an answer");
   });
 
   test("a live row that matches more than one history row still renders once", () => {

--- a/clients/web/src/domains/chat/transcript/select-transcript-messages.ts
+++ b/clients/web/src/domains/chat/transcript/select-transcript-messages.ts
@@ -11,6 +11,24 @@
 // a fresh optimistic send, a still-streaming bubble — is appended after
 // history in live order.
 //
+// One exception breaks "live wins on content": a *prefix-less re-attach*
+// bubble. When a tab reconnects mid-turn, the daemon replays the in-flight
+// LLM call's deltas under that call's own `messageId` — but the persisted
+// turn row carries an *earlier* call's id as its primary, with the replayed
+// id folded in as a merged alias. If the first replayed delta beats the
+// initial history fetch, the live bubble opens with no history twin to seed
+// from (see `resolveHistoryTwin`), so it holds only the post-reconnect suffix
+// and knows nothing of the persisted prefix. The overlay then matches it to
+// the rich history row *via that history-side alias* and, under the plain
+// "live wins" rule, the content-poor live bubble would shadow the full
+// answer — the bug where a complete reply collapses to a bare "thinking…"
+// bubble on refresh. We detect this exact shape — the live row was matched
+// only because history lists its id, while the live row itself carries no
+// knowledge of history's primary id — and fold history⊕live instead, so the
+// persisted prefix survives and the live suffix extends it. A live row that
+// *does* carry history's id among its own keys (the normal seeded / merged
+// case) still wins outright.
+//
 // Order is structural: server-history order, then the live turn (always the
 // newest). There is deliberately no timestamp sort — history rows are stamped
 // by the server clock and live rows by the client clock, so ordering them by
@@ -18,7 +36,34 @@
 // transcript.
 
 import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import {
+  canFoldAdjacentAssistant,
+  foldAdjacentAssistant,
+} from "@/domains/chat/utils/message-merge";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+
+/**
+ * A live row is a *prefix-less re-attach* bubble relative to the history row
+ * it matched when: both are assistant rows, the match was made only through a
+ * history-side alias (the live row's own identity keys do not include
+ * history's primary id), and the two are foldable. In that shape the live row
+ * is the replayed suffix of a turn whose persisted prefix lives in the
+ * history row — so its content must extend history's, not replace it.
+ *
+ * The normal seeded / client-merged case (the live row carries history's id as
+ * its own id or merged alias) returns false here, preserving "live wins".
+ */
+function isPrefixlessReattach(
+  historyRow: DisplayMessage,
+  liveRow: DisplayMessage,
+): boolean {
+  return (
+    historyRow.role === "assistant" &&
+    liveRow.role === "assistant" &&
+    !messageMatchKeys(liveRow).includes(historyRow.id) &&
+    canFoldAdjacentAssistant(historyRow, liveRow)
+  );
+}
 
 /**
  * Merge cached server history with the client-owned in-flight turn into the
@@ -60,7 +105,14 @@ export function selectTranscriptMessages(
       // to the same live row is a collapsed cluster the live turn owns — drop
       // it rather than render the row twice.
       if (!placed.has(liveRow)) {
-        merged.push(liveRow);
+        // Prefix-less re-attach: the live row is the replayed suffix of a turn
+        // whose persisted prefix sits in this history row. Fold so the prefix
+        // survives instead of letting the suffix-only row shadow it.
+        merged.push(
+          isPrefixlessReattach(historyRow, liveRow)
+            ? foldAdjacentAssistant(historyRow, liveRow)
+            : liveRow,
+        );
         placed.add(liveRow);
       }
       continue;

--- a/clients/web/src/domains/chat/utils/message-merge.ts
+++ b/clients/web/src/domains/chat/utils/message-merge.ts
@@ -147,7 +147,7 @@ function pickContentOrderOffset(
   return 0;
 }
 
-function canFoldAdjacentAssistant(
+export function canFoldAdjacentAssistant(
   survivor: DisplayMessage,
   donor: DisplayMessage,
 ): boolean {
@@ -166,7 +166,7 @@ function canFoldAdjacentAssistant(
   return true;
 }
 
-function foldAdjacentAssistant(
+export function foldAdjacentAssistant(
   survivor: DisplayMessage,
   donor: DisplayMessage,
 ): DisplayMessage {


### PR DESCRIPTION
## What

Fixes the **"messages disappearing on refresh"** report. After a refresh/reconnect mid-turn, a completed assistant reply collapses to a bare "thinking…" bubble — the answer the user already had vanishes from the transcript until the turn fully finishes.

## Root cause

The transcript is rendered as the overlay of two sources: persisted **history** (TanStack Query cache) ⊕ the **live turn** (`selectTranscriptMessages`). The overlay's rule is "a live row replaces the history row it shares identity with — live wins on content," which assumes the live row is a superset of history (history prefix + fresh deltas). `resolveHistoryTwin` maintains that invariant by seeding a re-attaching live bubble from its persisted prefix.

The diagnostics from the report show that invariant being violated by a race:

1. On refresh the daemon replays the in-flight LLM call's `assistant_thinking_delta`s under that call's own `messageId` (`8c2a761a`). The persisted turn row is anchored on an **earlier** call's id (`80f8f08c`, ~50 KB, 2 tool calls), with `8c2a761a` recorded as a `mergedMessageIds` alias.
2. The **first replayed delta lands ~130 ms before the initial history page fetch completes** — so `resolveHistoryTwin` finds nothing to seed from and opens a fresh, **prefix-less** bubble holding only the post-reconnect thinking.
3. When history then loads, the overlay matches that content-poor live bubble to the rich history row **via the history-side alias** and, under "live wins," the thinking-only bubble **shadows the full answer**.

Confirmed against the attached triage: the rendered transcript (`transcriptItems`) holds only `[user, 8c2a761a(thinking)]` while history holds the full `80f8f08c` answer, and `reconciliation_applied` reports `messagesAdded: 0`.

## The fix

In `selectTranscriptMessages`, detect this exact shape — the live row was matched **only** because history lists its id as an alias, while the live row itself carries **no knowledge of history's primary id** — and **fold `history ⊕ live`** instead of replacing, so the persisted prefix survives and the replayed suffix extends it.

The discriminator is `!messageMatchKeys(liveRow).includes(historyRow.id)`:
- **Prefix-less re-attach** (bug): live `8c2a761a` matched via history's alias, doesn't carry `80f8f08c` → **fold**.
- **Normal seeded / client-merged streaming**: the live row carries history's id as its own id or merged alias → unchanged, **live wins outright**.

Reuses the existing `foldAdjacentAssistant` (which already mirrors the daemon's `mergeConsecutiveAssistantMessages`), so no new merge logic. The fold is assistant-only and gated on `canFoldAdjacentAssistant`, so optimistic/subagent/user rows are untouched.

## Tests

`select-transcript-messages.test.ts` adds coverage for the prefix-less re-attach fold (answer survives, suffix extends it, alias stays resolvable), the legitimate-supersede case (no double-count), and the cross-role guard. Existing overlay/merge/stream-updater suites pass unchanged. Typecheck and lint clean.

> Note: 7 failures in the broader chat suite are pre-existing and environmental (missing transitive deps `@radix-ui/react-slot`, `zod` in sibling monorepo packages) — present on `main` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_