### PR TITLE
fix(memory): drop stale Slack watermark on older-compaction forks

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -1603,4 +1603,113 @@ describe("forkConversation + memory_retrospective_state", () => {
     expect(reFork.contextSummary).toBe("Compacted summary");
     expect(reFork.contextCompactedMessageCount).toBe(2);
   });
+
+  test("drops the stale Slack watermark when forking inherits an older compaction", async () => {
+    const source = createConversation("Slack twice-compacted thread");
+    const m1 = await addMessage(source.id, "user", "Message 1", {
+      skipIndexing: true,
+    });
+    const m2 = await addMessage(source.id, "assistant", "Message 2", {
+      skipIndexing: true,
+    });
+    const m3 = await addMessage(source.id, "user", "Message 3", {
+      skipIndexing: true,
+    });
+    const m4 = await addMessage(source.id, "assistant", "Message 4", {
+      skipIndexing: true,
+    });
+
+    const db = getDb();
+    const base = Date.now();
+    db.run(`UPDATE messages SET created_at = ${base} WHERE id = '${m1.id}'`);
+    db.run(
+      `UPDATE messages SET created_at = ${base + 2} WHERE id = '${m2.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 4} WHERE id = '${m3.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 6} WHERE id = '${m4.id}'`,
+    );
+    appendCompactionEvent(source.id, {
+      compactedAt: base + 1,
+      summary: "Summary 1",
+      compactedMessageCount: 1,
+    });
+    appendCompactionEvent(source.id, {
+      compactedAt: base + 5,
+      summary: "Summary 2",
+      compactedMessageCount: 3,
+    });
+    // The source's single-valued watermark reflects only the latest compaction.
+    db.update(conversations)
+      .set({
+        contextSummary: "Summary 2",
+        contextCompactedMessageCount: 3,
+        contextCompactedAt: base + 5,
+        slackContextCompactionWatermarkTs: "ts-latest",
+        slackContextCompactionWatermarkAt: base + 5,
+      })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    // Forking through M3 inherits the OLDER compaction (Summary 1); the latest
+    // watermark must not ride along, or it would hide Slack messages the older
+    // summary does not cover.
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: m3.id,
+    });
+    expect(fork.contextSummary).toBe("Summary 1");
+    expect(fork.contextCompactedMessageCount).toBe(1);
+    expect(fork.slackContextCompactionWatermarkTs).toBeNull();
+    expect(fork.slackContextCompactionWatermarkAt).toBeNull();
+  });
+
+  test("carries the Slack watermark when forking inherits the latest compaction", async () => {
+    const source = createConversation("Slack compacted thread");
+    const m1 = await addMessage(source.id, "user", "Message 1", {
+      skipIndexing: true,
+    });
+    const m2 = await addMessage(source.id, "assistant", "Message 2", {
+      skipIndexing: true,
+    });
+    const m3 = await addMessage(source.id, "user", "Message 3", {
+      skipIndexing: true,
+    });
+
+    const db = getDb();
+    const base = Date.now();
+    db.run(`UPDATE messages SET created_at = ${base} WHERE id = '${m1.id}'`);
+    db.run(
+      `UPDATE messages SET created_at = ${base + 1} WHERE id = '${m2.id}'`,
+    );
+    db.run(
+      `UPDATE messages SET created_at = ${base + 3} WHERE id = '${m3.id}'`,
+    );
+    const compactedAt = base + 2; // latest (and only) compaction, covers M1+M2
+    appendCompactionEvent(source.id, {
+      compactedAt,
+      summary: "Compacted summary",
+      compactedMessageCount: 2,
+    });
+    db.update(conversations)
+      .set({
+        contextSummary: "Compacted summary",
+        contextCompactedMessageCount: 2,
+        contextCompactedAt: compactedAt,
+        slackContextCompactionWatermarkTs: "ts-latest",
+        slackContextCompactionWatermarkAt: compactedAt,
+      })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: m3.id,
+    });
+    expect(fork.contextCompactedMessageCount).toBe(2);
+    expect(fork.slackContextCompactionWatermarkTs).toBe("ts-latest");
+    expect(fork.slackContextCompactionWatermarkAt).toBe(compactedAt);
+  });
 });

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -957,6 +957,14 @@ export function forkConversation(params: {
     sourceConversation.id,
     boundaryMessageCreatedAt,
   );
+  // The Slack chronological-context watermark is single-valued on the source
+  // row and reflects only the latest compaction, so carry it only when the
+  // fork inherits that latest compaction. Pairing the latest watermark with an
+  // older inherited summary (a fork between two compactions) would filter out
+  // Slack messages the older summary does not cover.
+  const inheritsLatestCompaction =
+    inheritedCompaction != null &&
+    inheritedCompaction.compactedAt === sourceConversation.contextCompactedAt;
   const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
   const forkTitle =
     params.title ?? `${sourceConversation.title ?? "Untitled"} (Fork)`;
@@ -992,14 +1000,12 @@ export function forkConversation(params: {
         contextCompactedMessageCount:
           inheritedCompaction?.compactedMessageCount ?? 0,
         contextCompactedAt: inheritedCompaction?.compactedAt ?? null,
-        slackContextCompactionWatermarkTs:
-          inheritedCompaction != null
-            ? sourceConversation.slackContextCompactionWatermarkTs
-            : null,
-        slackContextCompactionWatermarkAt:
-          inheritedCompaction != null
-            ? sourceConversation.slackContextCompactionWatermarkAt
-            : null,
+        slackContextCompactionWatermarkTs: inheritsLatestCompaction
+          ? sourceConversation.slackContextCompactionWatermarkTs
+          : null,
+        slackContextCompactionWatermarkAt: inheritsLatestCompaction
+          ? sourceConversation.slackContextCompactionWatermarkAt
+          : null,
         historyStrippedAt: inheritsHistoryStrippedAt
           ? sourceHistoryStrippedAt
           : null,
@@ -1377,6 +1383,11 @@ export async function forkConversationForRetrospective(params: {
     sourceConversation.id,
     boundaryMessageCreatedAt,
   );
+  // Carry the Slack watermark only when inheriting the latest compaction
+  // (see `forkConversation`).
+  const inheritsLatestCompaction =
+    inheritedCompaction != null &&
+    inheritedCompaction.compactedAt === sourceConversation.contextCompactedAt;
   const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
   const forkTitle =
     params.title ?? `${sourceConversation.title ?? "Untitled"} (Fork)`;
@@ -1409,14 +1420,12 @@ export async function forkConversationForRetrospective(params: {
         contextCompactedMessageCount:
           inheritedCompaction?.compactedMessageCount ?? 0,
         contextCompactedAt: inheritedCompaction?.compactedAt ?? null,
-        slackContextCompactionWatermarkTs:
-          inheritedCompaction != null
-            ? sourceConversation.slackContextCompactionWatermarkTs
-            : null,
-        slackContextCompactionWatermarkAt:
-          inheritedCompaction != null
-            ? sourceConversation.slackContextCompactionWatermarkAt
-            : null,
+        slackContextCompactionWatermarkTs: inheritsLatestCompaction
+          ? sourceConversation.slackContextCompactionWatermarkTs
+          : null,
+        slackContextCompactionWatermarkAt: inheritsLatestCompaction
+          ? sourceConversation.slackContextCompactionWatermarkAt
+          : null,
         historyStrippedAt: inheritsHistoryStrippedAt
           ? sourceHistoryStrippedAt
           : null,


### PR DESCRIPTION
## Summary
- Follow-up to #36149 (compaction ledger). The ledger lets a fork inherit an *older* compaction's summary/count, but `slackContextCompactionWatermark{Ts,At}` is single-valued on the `conversations` row and reflects only the *latest* compaction. Pairing the latest watermark with an older inherited summary (a fork taken between two compactions in a Slack conversation) made the Slack loaders filter out messages the older summary doesn't cover.
- Gate the Slack watermark on `inheritsLatestCompaction` (the inherited event's `compactedAt` equals the source's current `contextCompactedAt`) in both fork paths; when an older compaction is inherited, the watermark is dropped (null) instead of over-filtering.
- Adds tests for both branches (older-inherit → watermark null; latest-inherit → watermark carried).

## Original prompt
Addressing the Codex P2 on #36149: forking between two compactions in a Slack conversation inherited the older summary but copied the latest Slack watermark, hiding Slack messages the older summary doesn't cover. This is the cheap fix (no Slack-watermark ledgering) — carry the watermark only when the fork inherits the latest compaction. Full per-event Slack-watermark ledgering remains the documented future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)