### PR TITLE
Avoid sleeping banner after confirmed assistant healthz

### DIFF
--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -36,6 +36,7 @@ let operationalStatusQueryMock: {
         state: string;
         detail_state?: string;
         detail?: { reason?: string | null; message?: string | null };
+        runtime?: { healthz_ok?: boolean | null };
       }
     | null
     | undefined;
@@ -472,8 +473,65 @@ describe("StatusBanner", () => {
     expect(maintenanceHtml).toContain("Resume Assistant");
   });
 
-  test("shows sleeping banner instead of unreachable when transitioning from active to unreachable", async () => {
-    // GIVEN the operational status is active
+  test("does not render sleeping when runtime healthz is ok", () => {
+    operationalStatusQueryMock = {
+      data: { state: "sleeping", runtime: { healthz_ok: true } },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toBe("");
+  });
+
+  test("does not show waking after sleeping with confirmed runtime healthz", async () => {
+    // GIVEN the operational status is sleeping with confirmed runtime healthz
+    operationalStatusQueryMock = {
+      data: { state: "sleeping", runtime: { healthz_ok: true } },
+      isError: false,
+    };
+
+    const { rerender } = render(<StatusBanner />);
+
+    // WHEN the next status poll is unreachable
+    operationalStatusQueryMock = {
+      data: { state: "unreachable" },
+      isError: false,
+    };
+    rerender(<StatusBanner />);
+
+    // THEN the wake-smoothing path does not synthesize a waking banner
+    await waitFor(() => {
+      expect(screen.getByText("Assistant is unreachable")).toBeTruthy();
+    });
+    expect(screen.queryByText("Assistant is waking")).toBeNull();
+  });
+
+  test("does not show sleeping after a confirmed runtime healthz success", async () => {
+    // GIVEN the operational status is active with a confirmed runtime healthz
+    operationalStatusQueryMock = {
+      data: { state: "active", runtime: { healthz_ok: true } },
+      isError: false,
+    };
+
+    const { rerender } = render(<StatusBanner />);
+
+    // WHEN the operational status transitions directly to unreachable
+    operationalStatusQueryMock = {
+      data: { state: "unreachable" },
+      isError: false,
+    };
+    rerender(<StatusBanner />);
+
+    // THEN the banner shows the actual status instead of synthesizing sleep
+    await waitFor(() => {
+      expect(screen.getByText("Assistant is unreachable")).toBeTruthy();
+    });
+    expect(screen.queryByText("Assistant is sleeping")).toBeNull();
+  });
+
+  test("shows sleeping banner instead of unreachable when transitioning from unconfirmed active to unreachable", async () => {
+    // GIVEN the operational status is active without runtime healthz detail
     operationalStatusQueryMock = {
       data: { state: "active" },
       isError: false,
@@ -488,7 +546,7 @@ describe("StatusBanner", () => {
     };
     rerender(<StatusBanner />);
 
-    // THEN the banner shows "sleeping" instead of "unreachable"
+    // THEN the legacy smoothing still applies for unconfirmed active statuses
     await waitFor(() => {
       expect(screen.getByText("Assistant is sleeping")).toBeTruthy();
     });

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -303,6 +303,9 @@ function operationalStatusBannerConfig(
   onDismissFailedOperation?: () => void,
 ): BannerConfig | null {
   if (!status || isHealthyOperationalStatus(status)) return null;
+  if (status.state === "sleeping" && status.runtime?.healthz_ok === true) {
+    return null;
+  }
 
   // A transient operation (upgrade, resize, restart, …) can fail while the
   // reported `state` is still the in-progress operation. The platform signals
@@ -494,6 +497,8 @@ function useAssistantBannerConfig(): BannerConfig | null {
     isError: operationalStatusIsError,
     refetch: refetchOperationalStatus,
   } = statusQuery;
+  const hasConfirmedRuntimeHealthz =
+    operationalStatus?.runtime?.healthz_ok === true;
 
   // Track whether the assistant was recently sleeping so we can suppress
   // the brief "unreachable" flash that occurs during the tail end of a
@@ -501,7 +506,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
   const [wasRecentlySleeping, setWasRecentlySleeping] = useState(false);
   useEffect(() => {
     if (operationalStatus?.state === "sleeping") {
-      setWasRecentlySleeping(true);
+      setWasRecentlySleeping(!hasConfirmedRuntimeHealthz);
     } else if (
       operationalStatus?.state === "active" ||
       operationalStatus?.state === "crash_loop" ||
@@ -509,7 +514,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
     ) {
       setWasRecentlySleeping(false);
     }
-  }, [operationalStatus?.state]);
+  }, [hasConfirmedRuntimeHealthz, operationalStatus?.state]);
 
   // Auto-clear the override after 60s so a genuinely failed wake surfaces
   // the real "unreachable" error with the Doctor action.
@@ -524,31 +529,39 @@ function useAssistantBannerConfig(): BannerConfig | null {
   }, [wasRecentlySleeping, operationalStatus?.state]);
 
   // Suppress the brief "unreachable" flash during the active → sleeping
-  // transition. When the pod is shutting down, healthz fails before the
-  // backend registers the sleep, causing a transient unreachable state.
-  const [wasRecentlyActive, setWasRecentlyActive] = useState(false);
+  // transition, but only when the prior active status did not include a
+  // confirmed runtime healthz result. A confirmed healthz-ok poll means the
+  // assistant was recently serving traffic, so showing "sleeping" for a later
+  // status blip is misleading.
+  const [
+    wasRecentlyActiveWithoutConfirmedHealthz,
+    setWasRecentlyActiveWithoutConfirmedHealthz,
+  ] = useState(false);
   useEffect(() => {
     if (operationalStatus?.state === "active") {
-      setWasRecentlyActive(true);
+      setWasRecentlyActiveWithoutConfirmedHealthz(!hasConfirmedRuntimeHealthz);
     } else if (
       operationalStatus?.state === "sleeping" ||
       operationalStatus?.state === "crash_loop" ||
       operationalStatus?.state === "not_found"
     ) {
-      setWasRecentlyActive(false);
+      setWasRecentlyActiveWithoutConfirmedHealthz(false);
     }
-  }, [operationalStatus?.state]);
+  }, [hasConfirmedRuntimeHealthz, operationalStatus?.state]);
 
   // Auto-clear after 15s so a genuinely unreachable assistant surfaces.
   useEffect(() => {
-    if (!wasRecentlyActive || operationalStatus?.state !== "unreachable") {
+    if (
+      !wasRecentlyActiveWithoutConfirmedHealthz ||
+      operationalStatus?.state !== "unreachable"
+    ) {
       return;
     }
     const timeout = setTimeout(() => {
-      setWasRecentlyActive(false);
+      setWasRecentlyActiveWithoutConfirmedHealthz(false);
     }, 15_000);
     return () => clearTimeout(timeout);
-  }, [wasRecentlyActive, operationalStatus?.state]);
+  }, [wasRecentlyActiveWithoutConfirmedHealthz, operationalStatus?.state]);
   // Track dismissed failed-operation banners so the user can clear
   // terminal error messages (e.g. "Assistant upgrade failed"). The
   // dismissal is keyed on the operation state so it auto-resets when
@@ -782,7 +795,8 @@ function useAssistantBannerConfig(): BannerConfig | null {
   const effectiveStatus =
     operationalStatus?.state === "unreachable" && wasRecentlySleeping
       ? { ...operationalStatus, state: "waking" as AssistantOperationalState }
-      : operationalStatus?.state === "unreachable" && wasRecentlyActive
+      : operationalStatus?.state === "unreachable" &&
+          wasRecentlyActiveWithoutConfirmedHealthz
         ? { ...operationalStatus, state: "sleeping" as AssistantOperationalState }
         : operationalStatus;
 


### PR DESCRIPTION
## Summary
- Treat confirmed runtime healthz success as authoritative when smoothing operational status transitions.
- Avoid rendering "Assistant is sleeping" when status data reports runtime.healthz_ok.
- Add regression coverage for confirmed-healthz active-to-unreachable transitions.

## Verification
- bun test src/components/status-banner.test.tsx

## Original prompt
We investigated spurious global "Assistant is sleeping" banners that appeared while the assistant was actively streaming content. The likely cause was the web client smoothing an active to unreachable operational-status transition into a sleeping banner, even when vembda had recently confirmed runtime healthz. The requested fix was to ensure a good vembda assistant healthz result prevents the sleeping banner from showing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->