### PR TITLE
fix(memory): reword migration rollback description to satisfy assistant-id 'self' guard

### DIFF
--- a/assistant/src/memory/steps.ts
+++ b/assistant/src/memory/steps.ts
@@ -473,7 +473,7 @@ export const migrationSteps: MigrationStep[] = [
       {
         version: 5,
         description:
-          'Normalize all assistant_id values in scoped tables to the implicit "self" single-tenant identity',
+          "Normalize all assistant_id values in scoped tables to the implicit single-tenant identity",
         down: downAssistantIdToSelf,
       },
     ],


### PR DESCRIPTION
## Summary
- Reword the `migrateAssistantIdToSelf` rollback description in `assistant/src/memory/steps.ts` to drop the quoted literal `"self"`, which tripped the `assistant-id-boundary-guard` test on `main`.
- The string is descriptive prose for a DB migration rollback, not assistant-scoping logic — the migration's actual `down` SQL lives in excluded `/migrations/` files. Dropping the redundant bareword (the implicit single-tenant identity *is* self) keeps the guard meaningful and unblocks the Test job.

## Original prompt
Fix only the specific CI failure in the "Test" job of run 28193761542 on `main`. That job failed because `assistant-id-boundary-guard.test.ts` flagged a hardcoded `"self"` adjacent to `assistant_id` at `assistant/src/memory/steps.ts:476`. The ask was scoped narrowly to that one failure.