### PR TITLE
combo11: phone-guardian revoke reads and writes the gateway DB only

### DIFF
--- a/gateway/src/http/routes/twilio-voice-verify-callback.ts
+++ b/gateway/src/http/routes/twilio-voice-verify-callback.ts
@@ -12,8 +12,6 @@
  * calls from callers whose identity the gateway has already confirmed.
  */
 
-import { eq } from "drizzle-orm";
-
 import type { GatewayConfig } from "../../config.js";
 import { credentialKey } from "../../credential-key.js";
 import { getLogger } from "../../logger.js";
@@ -33,12 +31,8 @@ import {
   failureTwiml,
 } from "../../voice/verification.js";
 import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
-import { getGatewayDb } from "../../db/connection.js";
-import { contactChannels as gwContactChannels } from "../../db/schema.js";
-import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../../db/assistant-db-proxy.js";
+import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
+import { revokeExistingChannelGuardian } from "../../verification/binding-helpers.js";
 import { upsertVerifiedContactChannel } from "../../verification/contact-helpers.js";
 
 const log = getLogger("twilio-voice-verify-callback");
@@ -166,7 +160,7 @@ export function createTwilioVoiceVerifyCallbackHandler(
         } else {
           // Revoke existing phone guardian binding before creating new one
           if (existingGuardian) {
-            await revokeExistingPhoneGuardian();
+            await revokeExistingChannelGuardian("phone");
           }
 
           await createGuardianBinding({
@@ -237,51 +231,6 @@ export function createTwilioVoiceVerifyCallbackHandler(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Revoke the existing phone guardian binding by setting status to 'revoked'.
- * Dual-writes to both assistant DB and gateway DB.
- */
-async function revokeExistingPhoneGuardian(): Promise<void> {
-  const now = Date.now();
-
-  const revokedRows = await assistantDbQuery<{ id: string }>(
-    `SELECT cc.id
-     FROM contacts c
-     JOIN contact_channels cc ON cc.contact_id = c.id
-     WHERE c.role = 'guardian' AND cc.type = 'phone' AND cc.status = 'active'`,
-    [],
-  );
-
-  if (revokedRows.length === 0) return;
-
-  const ids = revokedRows.map((r) => r.id);
-  const placeholders = ids.map(() => "?").join(", ");
-
-  await assistantDbRun(
-    `UPDATE contact_channels
-     SET status = 'revoked', policy = 'deny', updated_at = ?
-     WHERE id IN (${placeholders})`,
-    [now, ...ids],
-  );
-
-  // Gateway DB dual-write (best-effort)
-  try {
-    const gwDb = getGatewayDb();
-    for (const id of ids) {
-      gwDb
-        .update(gwContactChannels)
-        .set({ status: "revoked", policy: "deny", updatedAt: now })
-        .where(eq(gwContactChannels.id, id))
-        .run();
-    }
-  } catch (gwErr) {
-    log.warn(
-      { err: gwErr },
-      "Gateway DB revoke dual-write failed (best-effort)",
-    );
-  }
-}
 
 /**
  * Build the action URL for the next Gather attempt, preserving the base

--- a/gateway/src/http/routes/twilio-voice-verify-callback.ts
+++ b/gateway/src/http/routes/twilio-voice-verify-callback.ts
@@ -31,8 +31,11 @@ import {
   failureTwiml,
 } from "../../voice/verification.js";
 import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
-import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
-import { revokeExistingChannelGuardian } from "../../verification/binding-helpers.js";
+import {
+  getExistingGuardianBinding,
+  resolveCanonicalPrincipal,
+  revokeExistingChannelGuardian,
+} from "../../verification/binding-helpers.js";
 import { upsertVerifiedContactChannel } from "../../verification/contact-helpers.js";
 
 const log = getLogger("twilio-voice-verify-callback");
@@ -121,33 +124,14 @@ export function createTwilioVoiceVerifyCallbackHandler(
     // Verification succeeded — create guardian binding if this is a guardian verification
     if (result.verificationType === "guardian") {
       try {
-        // Resolve the canonical principal from the vellum channel guardian binding
-        const vellumGuardians = await assistantDbQuery<{
-          principalId: string | null;
-        }>(
-          `SELECT c.principal_id AS principalId
-           FROM contacts c
-           JOIN contact_channels cc ON cc.contact_id = c.id
-           WHERE c.role = 'guardian' AND cc.type = 'vellum' AND cc.status = 'active'
-           LIMIT 1`,
-          [],
-        );
-        const canonicalPrincipal =
-          vellumGuardians[0]?.principalId ?? fromNumber;
+        // Resolve the canonical principal from the gateway DB (ACL source of
+        // truth) via the vellum channel guardian binding.
+        const canonicalPrincipal = await resolveCanonicalPrincipal(fromNumber);
 
-        // Check for existing phone guardian binding conflict
-        const existingPhoneGuardians = await assistantDbQuery<{
-          address: string;
-        }>(
-          `SELECT cc.address
-           FROM contacts c
-           JOIN contact_channels cc ON cc.contact_id = c.id
-           WHERE c.role = 'guardian' AND cc.type = 'phone' AND cc.status = 'active'
-           LIMIT 1`,
-          [],
-        );
-
-        const existingGuardian = existingPhoneGuardians[0];
+        // Check for an existing phone guardian binding conflict against the
+        // gateway DB so the revoke below never displaces a real gateway
+        // binding based on a stale assistant mirror.
+        const existingGuardian = await getExistingGuardianBinding("phone");
         if (existingGuardian && existingGuardian.address !== fromNumber) {
           log.warn(
             {


### PR DESCRIPTION
## Summary
- Rewrite revokeExistingPhoneGuardian to read and revoke guardian phone channels in the gateway DB only (delegating to the shared revokeExistingChannelGuardian('phone'))
- Drop the assistant-DB SELECT (role/status predicate) and the assistant-DB status/policy mirror write

Part of plan: remove-gateway-acl-mirror-writes.md (PR 4 of 7)