### PR TITLE
combo11: stop mirroring channel ACL columns from the verification path

### DIFF
--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -42,6 +42,9 @@ let gwSelectStatus: string | null = null;
 // Whether the insert-mirror reports a written row (`.returning().all()`).
 // false models a (type,address) conflict with a blocked/revoked row.
 let gwInsertWrote = true;
+// When true, the authoritative gateway channel write throws (infra failure):
+// the verified-set update lands a throw so the fail-closed path is exercised.
+let gwWriteThrows = false;
 
 mock.module("../db/connection.js", () => ({
   getGatewayDb: () => ({
@@ -59,6 +62,7 @@ mock.module("../db/connection.js", () => ({
           returning: () => ({
             all: () => {
               void table;
+              if (gwWriteThrows) throw new Error("gateway write failed");
               gwUpdates.push({ set, where });
               const n = gwUpdateChanges.shift() ?? 0;
               return Array.from({ length: n }, () => ({ id: "x" }));
@@ -80,6 +84,7 @@ mock.module("../db/connection.js", () => ({
           },
           returning: () => ({
             all: () => {
+              if (gwWriteThrows) throw new Error("gateway write failed");
               gwInserts.push({ table, values });
               return gwInsertWrote ? [{ id: "x" }] : [];
             },
@@ -151,6 +156,7 @@ beforeEach(() => {
   // Default: no authoritative gateway row (legacy/unmirrored happy path).
   gwSelectStatus = null;
   gwInsertWrote = true;
+  gwWriteThrows = false;
   runThrowOnSql = null;
   writeFileSync(TEST_SOCKET_PATH, "");
 });
@@ -164,14 +170,16 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
-  test("skips update when existing channel is revoked", async () => {
+  test("skips update when the authoritative gateway channel is revoked", async () => {
+    // The mirror is stale-active; the gateway row (source of truth) is revoked.
     queryRows = [
       {
         channelId: "ch-1",
         contactId: "co-1",
-        channelStatus: "revoked",
+        channelStatus: "active",
       },
     ];
+    gwSelectStatus = "revoked";
 
     await upsertVerifiedContactChannel({
       sourceChannel: "phone",
@@ -182,14 +190,15 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(runCalls.filter((c) => c.sql.includes("UPDATE"))).toHaveLength(0);
   });
 
-  test("skips update when channel is blocked", async () => {
+  test("skips update when the authoritative gateway channel is blocked", async () => {
     queryRows = [
       {
         channelId: "ch-2",
         contactId: "co-2",
-        channelStatus: "blocked",
+        channelStatus: "active",
       },
     ];
+    gwSelectStatus = "blocked";
 
     await upsertVerifiedContactChannel({
       sourceChannel: "phone",
@@ -200,7 +209,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(runCalls.filter((c) => c.sql.includes("UPDATE"))).toHaveLength(0);
   });
 
-  test("skips update when a guardian's channel is revoked", async () => {
+  test("proceeds when only the assistant mirror is revoked but the gateway row is active", async () => {
+    // A gateway reactivation can leave a stale revoked mirror. The verification
+    // decision follows the gateway (active here), so the activation proceeds.
     queryRows = [
       {
         channelId: "ch-3",
@@ -208,14 +219,22 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
         channelStatus: "revoked",
       },
     ];
+    gwSelectStatus = "active";
 
-    await upsertVerifiedContactChannel({
+    const result = await upsertVerifiedContactChannel({
       sourceChannel: "phone",
       externalUserId: "+15550001111",
       externalChatId: "+15550001111",
     });
 
-    expect(runCalls.filter((c) => c.sql.includes("UPDATE"))).toHaveLength(0);
+    expect(result).toEqual({ verified: true });
+    expect(
+      runCalls.filter(
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
+      ),
+    ).toHaveLength(1);
   });
 
   test("updates an active channel belonging to a guardian contact", async () => {
@@ -615,6 +634,48 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(assistantActivate).toBeUndefined();
   });
 
+  test("fails closed (verified:false) when the gateway write throws on the existing-channel path", async () => {
+    // The pre-check passes, but the authoritative gateway write throws (infra
+    // failure). The mirror no longer records ACL state, so falling through to
+    // verified:true would reply success with no DB recording an active channel.
+    queryRows = [
+      { channelId: "ch-throw", contactId: "co-throw", channelStatus: "active" },
+    ];
+    gwSelectStatus = "active";
+    gwWriteThrows = true;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550002020",
+      externalChatId: "+15550002020",
+    });
+
+    expect(result).toEqual({ verified: false });
+    // The assistant mirror activation must NOT fire on a lost gateway write.
+    const activate = runCalls.find(
+      (c) =>
+        c.sql.includes("UPDATE contact_channels") &&
+        c.sql.includes("external_chat_id = ?"),
+    );
+    expect(activate).toBeUndefined();
+  });
+
+  test("fails closed (verified:false) when the gateway write throws on the new-insert path", async () => {
+    queryRows = [];
+    gwSelectStatus = null;
+    gwWriteThrows = true;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550002121",
+      externalChatId: "+15550002121",
+    });
+
+    expect(result).toEqual({ verified: false });
+    // No assistant mirror INSERT for an actor whose gateway write was lost.
+    expect(runCalls.filter((c) => c.sql.includes("INSERT"))).toHaveLength(0);
+  });
+
   test("allowRevokedReactivation: a revoked authoritative gateway row is reactivated and the activation update fires", async () => {
     // Stale assistant mirror is active so we reach the existing-channel branch;
     // the authoritative gateway row is revoked. With the flag, the invite path
@@ -670,15 +731,16 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(gwInserts).toHaveLength(0);
   });
 
-  test("allowRevokedReactivation: a revoked assistant-mirror row in the existing-channel branch is reactivated", async () => {
-    // No authoritative gateway row; the assistant mirror itself is revoked. With
-    // the flag the mirror guard is relaxed and the activation proceeds.
+  test("reactivation: a gateway-revoked channel is reactivated with the flag and later verification succeeds", async () => {
+    // The gateway row is revoked. With the flag the invite path reactivates it
+    // (the gateway write lands), the activation UPDATE fires, and the result is
+    // verified:true even though the assistant mirror is itself stale-revoked.
     queryRows = [
-      { channelId: "ch-mirror", contactId: "co-mirror", channelStatus: "revoked" },
+      { channelId: "ch-rev", contactId: "co-rev", channelStatus: "revoked" },
     ];
-    gwSelectStatus = null;
+    gwSelectStatus = "revoked";
 
-    const result = await upsertVerifiedContactChannel({
+    const reactivate = await upsertVerifiedContactChannel({
       sourceChannel: "phone",
       externalUserId: "+15550001515",
       externalChatId: "+15550001515",
@@ -686,7 +748,7 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       allowRevokedReactivation: true,
     });
 
-    expect(result).toEqual({ verified: true });
+    expect(reactivate).toEqual({ verified: true });
     const activate = runCalls.find(
       (c) =>
         c.sql.includes("UPDATE contact_channels") &&
@@ -694,13 +756,27 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     );
     expect(activate).toBeTruthy();
     expect(activate!.params).toContain("+15550001515");
+
+    // A later plain verification (no flag) against the now-active gateway row
+    // must succeed: the decision follows the gateway, not the stale mirror.
+    runCalls.length = 0;
+    gwUpdates.length = 0;
+    gwSelectStatus = "active";
+
+    const reverify = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550001515",
+      externalChatId: "+15550001515",
+    });
+
+    expect(reverify).toEqual({ verified: true });
   });
 
-  test("allowRevokedReactivation: without the flag a revoked assistant-mirror row is still refused", async () => {
+  test("without the flag a gateway-revoked channel is still refused", async () => {
     queryRows = [
-      { channelId: "ch-mirror", contactId: "co-mirror", channelStatus: "revoked" },
+      { channelId: "ch-mirror", contactId: "co-mirror", channelStatus: "active" },
     ];
-    gwSelectStatus = null;
+    gwSelectStatus = "revoked";
 
     const result = await upsertVerifiedContactChannel({
       sourceChannel: "phone",

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -347,7 +347,7 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(runCalls.filter((c) => c.sql.includes("INSERT"))).toHaveLength(2);
   });
 
-  test("update path stamps verified_at + verified_via='challenge'", async () => {
+  test("update path stamps verified state on the gateway, not the assistant mirror", async () => {
     queryRows = [
       { channelId: "ch-6", contactId: "co-6", channelStatus: "active" },
     ];
@@ -358,20 +358,31 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       externalChatId: "+15550001111",
     });
 
+    // Gateway DB owns the verified ACL state.
+    const gwActivate = gwUpdates.find(
+      (u) => (u.set as { status?: string }).status === "active",
+    );
+    expect(gwActivate).toBeTruthy();
+    expect(gwActivate!.set).toMatchObject({ verifiedVia: "challenge" });
+    expect(gwActivate!.set.verifiedAt).toEqual(expect.any(Number));
+
+    // The assistant mirror UPDATE carries identity/info only — no ACL columns.
     const update = runCalls.find((c) =>
       c.sql.includes("UPDATE contact_channels"),
     );
     expect(update).toBeTruthy();
-    expect(update!.sql).toContain("status = 'active'");
-    expect(update!.sql).toContain("verified_at = ?");
-    expect(update!.sql).toContain("verified_via = ?");
-    expect(update!.params).toContain("challenge");
-    // verified_at uses a numeric timestamp
-    expect(update!.params.some((p) => typeof p === "number")).toBe(true);
+    expect(update!.sql).not.toContain("status =");
+    expect(update!.sql).not.toContain("policy =");
+    expect(update!.sql).not.toContain("verified_at");
+    expect(update!.sql).not.toContain("verified_via");
+    expect(update!.sql).not.toContain("revoked_reason");
+    expect(update!.sql).not.toContain("blocked_reason");
   });
 
-  test("insert path stamps verified_at + verified_via='challenge'", async () => {
+  test("insert path stamps verified state on the gateway, not the assistant mirror", async () => {
     queryRows = [];
+    // Force the insert-mirror path so the gateway channel row is created here.
+    gwUpdateChanges = [0, 0];
 
     await upsertVerifiedContactChannel({
       sourceChannel: "phone",
@@ -379,14 +390,23 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       externalChatId: "+15550009999",
     });
 
+    // Gateway DB owns the verified ACL state.
+    const gwChannelInsert = gwInserts.find(
+      (i) => i.values.type === "phone" && i.values.status === "active",
+    );
+    expect(gwChannelInsert).toBeTruthy();
+    expect(gwChannelInsert!.values).toMatchObject({ verifiedVia: "challenge" });
+
+    // The assistant mirror INSERT carries identity/info only — no ACL columns.
     const channelInsert = runCalls.find((c) =>
       c.sql.includes("INSERT OR IGNORE INTO contact_channels"),
     );
     expect(channelInsert).toBeTruthy();
-    expect(channelInsert!.sql).toContain("'active'");
-    expect(channelInsert!.sql).toContain("verified_at");
-    expect(channelInsert!.sql).toContain("verified_via");
-    expect(channelInsert!.params).toContain("challenge");
+    expect(channelInsert!.sql).not.toContain("status");
+    expect(channelInsert!.sql).not.toContain("policy");
+    expect(channelInsert!.sql).not.toContain("verified_at");
+    expect(channelInsert!.sql).not.toContain("verified_via");
+    expect(channelInsert!.sql).not.toContain("'active'");
   });
 
   test("resolves the gateway row by (type,address) when the id-keyed update misses", async () => {
@@ -497,7 +517,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(result).toEqual({ verified: false });
     expect(
       runCalls.filter(
-        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
       ),
     ).toHaveLength(0);
     // Gateway write never attempted (returned before the dual-write).
@@ -520,7 +542,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(result).toEqual({ verified: false });
     expect(
       runCalls.filter(
-        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
       ),
     ).toHaveLength(0);
     expect(gwUpdates).toHaveLength(0);
@@ -586,7 +610,7 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     const assistantActivate = runCalls.find(
       (c) =>
         /UPDATE contact_channels/i.test(c.sql) &&
-        c.sql.includes("status = 'active'"),
+        c.sql.includes("external_chat_id = ?"),
     );
     expect(assistantActivate).toBeUndefined();
   });
@@ -612,7 +636,7 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     const activate = runCalls.find(
       (c) =>
         c.sql.includes("UPDATE contact_channels") &&
-        c.sql.includes("status = 'active'"),
+        c.sql.includes("external_chat_id = ?"),
     );
     expect(activate).toBeTruthy();
     // The gateway reactivation guard excludes only 'blocked', allowing the
@@ -637,7 +661,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(result).toEqual({ verified: false });
     expect(
       runCalls.filter(
-        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
       ),
     ).toHaveLength(0);
     expect(gwUpdates).toHaveLength(0);
@@ -664,7 +690,7 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     const activate = runCalls.find(
       (c) =>
         c.sql.includes("UPDATE contact_channels") &&
-        c.sql.includes("status = 'active'"),
+        c.sql.includes("external_chat_id = ?"),
     );
     expect(activate).toBeTruthy();
     expect(activate!.params).toContain("+15550001515");
@@ -699,10 +725,11 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       verifiedVia: "manual",
     });
 
-    const update = runCalls.find((c) =>
-      c.sql.includes("UPDATE contact_channels"),
+    // verifiedVia is gateway-owned; the assistant mirror no longer carries it.
+    const gwActivate = gwUpdates.find(
+      (u) => (u.set as { status?: string }).status === "active",
     );
-    expect(update!.params).toContain("manual");
+    expect(gwActivate!.set).toMatchObject({ verifiedVia: "manual" });
   });
 });
 

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -116,8 +116,7 @@ function writeVerifiedGatewayChannel(params: {
   };
 
   // Blocked is never reactivated. Revoked is reactivated only on the invite
-  // path (allowRevokedReactivation); otherwise the caller's guard only inspects
-  // the assistant mirror, which may be stale relative to the gateway status.
+  // path (allowRevokedReactivation); otherwise the gateway row stays revoked.
   const reactivatable = allowRevokedReactivation
     ? sql`${gwContactChannels.status} not in ('blocked')`
     : sql`${gwContactChannels.status} not in ('blocked', 'revoked')`;
@@ -296,10 +295,11 @@ export function getGatewayChannelByKey(
  * it handles the verification-specific case only (single channel, no
  * reassignment, no invite binding).
  *
- * Returns `{ verified: false }` when the verification is rejected because the
- * authoritative gateway row (or the assistant mirror) is blocked/revoked, so
- * the caller can suppress the success reply. Returns `{ verified: true }` on
- * the normal activate/insert paths.
+ * Returns `{ verified: false }` when the authoritative gateway row is
+ * blocked/revoked, or when the authoritative gateway write fails, so the caller
+ * suppresses the success reply (the mirror no longer records ACL state, so a
+ * lost gateway write must fail closed). Returns `{ verified: true }` on the
+ * normal activate/insert paths.
  */
 export async function upsertVerifiedContactChannel(params: {
   sourceChannel: string;
@@ -327,13 +327,14 @@ export async function upsertVerifiedContactChannel(params: {
     params.externalUserId;
   const contactDisplayName = displayName ?? username ?? address;
 
-  // Check if a channel for this actor already exists.
+  // Resolve the existing channel's identity (id, parent contact) only. The
+  // ACL/status decision is owned by the gateway pre-check below; cc.status is
+  // used solely to prefer the most-relevant mirror row, not to gate the upsert.
   const existing = await assistantDbQuery<{
     channelId: string;
     contactId: string;
-    channelStatus: string;
   }>(
-    `SELECT cc.id AS channelId, cc.contact_id AS contactId, cc.status AS channelStatus
+    `SELECT cc.id AS channelId, cc.contact_id AS contactId
      FROM contact_channels cc
      WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
      ORDER BY
@@ -366,18 +367,10 @@ export async function upsertVerifiedContactChannel(params: {
   if (existing.length > 0) {
     const row = existing[0];
 
-    // Blocked is never overwritten; revoked only on the invite path
-    // (assistant mirror guard).
-    if (
-      row.channelStatus === "blocked" ||
-      (row.channelStatus === "revoked" && !allowRevokedReactivation)
-    ) {
-      log.warn(
-        { sourceChannel, address, status: row.channelStatus },
-        "Skipping upsert: channel is blocked or revoked",
-      );
-      return { verified: false };
-    }
+    // The block/revoke decision is owned by the authoritative gateway row,
+    // already gated above. The assistant mirror's status is not consulted: it
+    // can lag the gateway (e.g. a gateway reactivation leaves a stale revoked
+    // mirror), and gating on it would falsely reject a gateway-active channel.
 
     // Bind to the invite's target contact when supplied: an invite can attach a
     // redeemer's existing channel to a different contact, so reassign the
@@ -437,13 +430,14 @@ export async function upsertVerifiedContactChannel(params: {
         gatewayRejected = true;
       }
     } catch (gwErr) {
-      // A thrown gateway DB error is an infra failure, not a rejection: the
-      // code already matched, so fall through and activate the assistant mirror
-      // best-effort rather than failing a legitimate verification.
-      log.warn(
+      // The gateway is the source of truth and the mirror no longer records ACL
+      // state, so a thrown write means NO DB recorded an active verified channel.
+      // Fail closed rather than reply success off a stale best-effort mirror.
+      log.error(
         { err: gwErr },
-        "Gateway DB contact channel update dual-write failed",
+        "Gateway DB contact channel update failed; failing verification closed",
       );
+      gatewayRejected = true;
     }
 
     if (gatewayRejected) {
@@ -525,9 +519,14 @@ export async function upsertVerifiedContactChannel(params: {
       gatewayRejected = true;
     }
   } catch (gwErr) {
-    // A thrown gateway DB error is an infra failure, not a rejection: fall
-    // through and create the assistant mirror best-effort.
-    log.warn({ err: gwErr }, "Gateway DB contact create dual-write failed");
+    // The gateway is the source of truth and the mirror no longer records ACL
+    // state, so a thrown write means NO DB recorded an active verified channel.
+    // Fail closed rather than reply success off a stale best-effort mirror.
+    log.error(
+      { err: gwErr },
+      "Gateway DB contact create failed; failing verification closed",
+    );
+    gatewayRejected = true;
   }
 
   if (gatewayRejected) {

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -450,17 +450,15 @@ export async function upsertVerifiedContactChannel(params: {
       return { verified: false };
     }
 
-    // Activate the assistant mirror.
+    // Activate the assistant mirror. ACL columns are gateway-owned and no
+    // longer mirrored; only identity/info columns are written here.
     await assistantDbRun(
       `UPDATE contact_channels
        SET address = ?,
-           status = 'active', policy = 'allow',
            external_chat_id = ?,
-           verified_at = ?, verified_via = ?,
-           revoked_reason = NULL, blocked_reason = NULL,
            updated_at = ?
        WHERE id = ?`,
-      [address, externalChatId, now, verifiedVia, now, row.channelId],
+      [address, externalChatId, now, row.channelId],
     );
 
     return { verified: true };
@@ -539,28 +537,19 @@ export async function upsertVerifiedContactChannel(params: {
   // Create the assistant mirror. OR IGNORE for idempotency under retries; if the
   // channel insert fails mid-flight, the orphan contact row is harmless.
   await assistantDbRun(
-    `INSERT OR IGNORE INTO contacts (id, display_name, role, created_at, updated_at)
-     VALUES (?, ?, 'contact', ?, ?)`,
+    `INSERT OR IGNORE INTO contacts (id, display_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?)`,
     [contactId, contactDisplayName, now, now],
   );
 
+  // ACL columns are gateway-owned; the mirror carries identity/info only and
+  // relies on the schema defaults (status='unverified', policy='allow').
   await assistantDbRun(
     `INSERT OR IGNORE INTO contact_channels
        (id, contact_id, type, address, is_primary, external_chat_id,
-        status, policy, verified_at, verified_via, interaction_count,
-        created_at, updated_at)
-     VALUES (?, ?, ?, ?, 0, ?, 'active', 'allow', ?, ?, 0, ?, ?)`,
-    [
-      channelId,
-      contactId,
-      sourceChannel,
-      address,
-      externalChatId,
-      now,
-      verifiedVia,
-      now,
-      now,
-    ],
+        interaction_count, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 0, ?, 0, ?, ?)`,
+    [channelId, contactId, sourceChannel, address, externalChatId, now, now],
   );
 
   return { verified: true };
@@ -576,11 +565,14 @@ export async function upsertVerifiedContactChannel(params: {
  * first seen on a channel.
  *
  * - Existing channel: updates display name, external_chat_id.
- *   Status and policy are left unchanged so blocked/revoked channels stay that way.
- * - New channel: inserts contact + channel with status='unverified', policy='allow'.
+ *   Status and policy live in the gateway DB and are left unchanged so
+ *   blocked/revoked channels stay that way.
+ * - New channel: inserts contact + channel. ACL columns (status, policy) are
+ *   gateway-owned; the gateway DB seeds status='unverified', policy='allow'.
  *
- * Dual-writes to both the assistant DB (source of truth) and the gateway DB.
- * Skips silently when the assistant IPC socket is unavailable (test environments).
+ * Dual-writes to both the assistant DB (identity/info mirror) and the gateway
+ * DB (ACL source of truth). Skips silently when the assistant IPC socket is
+ * unavailable (test environments).
  */
 export async function upsertContactChannel(params: {
   sourceChannel: string;
@@ -661,15 +653,17 @@ export async function upsertContactChannel(params: {
   const channelId = crypto.randomUUID();
 
   await assistantDbRun(
-    `INSERT OR IGNORE INTO contacts (id, display_name, role, created_at, updated_at)
-     VALUES (?, ?, 'contact', ?, ?)`,
+    `INSERT OR IGNORE INTO contacts (id, display_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?)`,
     [contactId, contactDisplayName, now, now],
   );
+  // ACL columns are gateway-owned; the mirror carries identity/info only and
+  // relies on the schema defaults (status='unverified', policy='allow').
   await assistantDbRun(
     `INSERT OR IGNORE INTO contact_channels
        (id, contact_id, type, address, is_primary, external_chat_id,
-        status, policy, interaction_count, created_at, updated_at)
-     VALUES (?, ?, ?, ?, 0, ?, 'unverified', 'allow', 0, ?, ?)`,
+        interaction_count, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 0, ?, 0, ?, ?)`,
     [
       channelId,
       contactId,


### PR DESCRIPTION
## Summary
- Strip the 8 ACL columns from contact-helpers' assistant-DB mirror writes (upsertVerifiedContactChannel + upsertContactChannel), keeping identity/info columns
- Gateway DB remains the source of truth for channel ACL state

Part of plan: remove-gateway-acl-mirror-writes.md (PR 3 of 7)