### PR TITLE
combo11: drop the contact-store ACL dual-writes to the assistant DB

### DIFF
--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -65,17 +65,9 @@ const fakeAssistantDb = {
 // Mock the assistant DB proxy before importing ContactStore. The fake
 // honors `SELECT ... FROM contact_channels WHERE id = ?` and
 // `SELECT ... FROM contacts WHERE id = ?`; all other SELECTs return [].
-// When set, the next id-keyed `UPDATE ... WHERE id = ?` reports 0 changes so
-// the logical-key fallback path is exercised. Cleared after one such update.
-let nextIdUpdateMisses = false;
-
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbRun: mock(async (sql: string, bind?: unknown[]) => {
     fakeAssistantDb.runCalls.push({ sql, bind });
-    if (nextIdUpdateMisses && /where id = \?/i.test(sql)) {
-      nextIdUpdateMisses = false;
-      return { changes: 0, lastInsertRowid: 0 };
-    }
     return { changes: 1, lastInsertRowid: 0 };
   }),
   assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
@@ -114,7 +106,6 @@ beforeEach(() => {
   db.delete(contactChannels).run();
   db.delete(contacts).run();
   fakeAssistantDb.reset();
-  nextIdUpdateMisses = false;
 });
 
 function seedAssistantContact(id: string, role: string = "guardian"): void {
@@ -290,7 +281,7 @@ describe("ContactStore.markChannelVerified", () => {
     expect(b!.channel.verifiedAt).toBe(a!.channel.verifiedAt);
   });
 
-  test("writes verifiedVia=challenge to gateway + assistant when passed", async () => {
+  test("writes verifiedVia=challenge to gateway; no assistant ACL write", async () => {
     seedContact("c1");
     seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
 
@@ -303,13 +294,13 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.channel.status).toBe("active");
     expect(result!.channel.verifiedVia).toBe("challenge");
 
-    // The assistant DB dual-write bound the same verifiedVia.
-    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
-      c.sql.includes("UPDATE contact_channels"),
-    );
-    expect(dualWrite).toBeTruthy();
-    expect(dualWrite!.bind).toContain("challenge");
-    expect(dualWrite!.bind).not.toContain("manual");
+    // The gateway DB is the source of truth; the assistant DB receives no
+    // ACL mirror write.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
   });
 
   test("is idempotent per-verifiedVia: a repeated challenge call is a no-op", async () => {
@@ -330,7 +321,7 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.didWrite).toBe(false);
     expect(result!.channel.verifiedAt).toBe(1000);
     expect(result!.channel.verifiedVia).toBe("challenge");
-    // No-op skips the assistant dual-write.
+    // No assistant-DB ACL mirror write.
     expect(
       fakeAssistantDb.runCalls.some((c) =>
         c.sql.includes("UPDATE contact_channels"),
@@ -346,10 +337,12 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.didWrite).toBe(true);
     expect(result!.channel.verifiedVia).toBe("manual");
 
-    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
-      c.sql.includes("UPDATE contact_channels"),
-    );
-    expect(dualWrite!.bind).toContain("manual");
+    // The verifiedVia is persisted to the gateway DB only.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
   });
 
   test("mirrors channel + contact from assistant DB when gateway is empty, then verifies", async () => {
@@ -416,16 +409,12 @@ describe("ContactStore.markChannelVerified", () => {
         .get(),
     ).toBeUndefined();
 
-    // The assistant-side mirror targets the ORIGINAL assistant id, not the
-    // resolved gateway id — otherwise the UPDATE no-ops on the split-id path.
-    const mirror = fakeAssistantDb.runCalls.find(
-      (c) =>
-        c.sql.includes("UPDATE contact_channels") &&
-        c.sql.includes("WHERE id = ?"),
-    );
-    expect(mirror).toBeTruthy();
-    expect(mirror!.bind?.[mirror!.bind!.length - 1]).toBe("asst-ch");
-    expect(mirror!.bind).not.toContain("gw-ch");
+    // The gateway DB holds the verified ACL state; no assistant-DB ACL mirror.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
   });
 
   test("refuses to mirror when assistant channel references a missing contact", async () => {
@@ -536,37 +525,6 @@ describe("ContactStore.markChannelVerified", () => {
     expect(
       getGatewayDb().select().from(contactChannels).all().length,
     ).toBe(1);
-  });
-
-  test("assistant dual-write falls back to the logical key when the id-keyed update misses", async () => {
-    // Legacy mismatch: the caller's id resolves the gateway row, but the
-    // id-keyed assistant UPDATE affects 0 rows (the assistant mirror lives
-    // under a different UUID). The dual-write must then resolve by logical key.
-    seedContact("c1");
-    seedChannel({
-      id: "gw-uuid",
-      contactId: "c1",
-      status: "unverified",
-      address: "shared-addr",
-    });
-    nextIdUpdateMisses = true;
-
-    const result = await new ContactStore().markChannelVerified("gw-uuid");
-    expect(result!.didWrite).toBe(true);
-
-    const idUpdate = fakeAssistantDb.runCalls.find((c) =>
-      /UPDATE contact_channels[\s\S]*WHERE id = \?/i.test(c.sql),
-    );
-    expect(idUpdate).toBeTruthy();
-
-    const keyUpdate = fakeAssistantDb.runCalls.find((c) =>
-      /WHERE type = \? AND address = \? COLLATE NOCASE/i.test(c.sql),
-    );
-    expect(keyUpdate).toBeTruthy();
-    // Logical-key update binds the gateway unique key (type, address) — not
-    // contactId, since the assistant row may sit under a different contact.
-    expect(keyUpdate!.bind).toContain("vellum");
-    expect(keyUpdate!.bind).toContain("shared-addr");
   });
 
   test("legacy cross-contact: resolves the gateway row by (type,address) even under a different contact", async () => {

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -1,4 +1,12 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  mock,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { initSigningKey } from "../auth/token-service.js";
 
@@ -57,8 +65,9 @@ mock.module("../ipc/assistant-client.js", () => ({
 }));
 
 // ── ContactStore mock ─────────────────────────────────────────────────────────
-// upsertContact is now async and returns a full ContactWithChannels shape; the
-// service layer owns the assistant-DB dual-write internally.
+// upsertContact is async and returns a ContactWithInfo shape whose ACL fields
+// (role/principalId, channel status/policy) come from the gateway-DB read-back;
+// the service layer owns the assistant-DB dual-write internally.
 const DEFAULT_MOCK_CONTACT = {
   id: "ct_mock",
   displayName: "Mock Contact",
@@ -72,6 +81,7 @@ const DEFAULT_MOCK_CONTACT = {
   interactionCount: 0,
   lastInteraction: null as number | null,
   channels: [] as unknown[],
+  assistantMetadata: null as Record<string, unknown> | null,
 };
 
 type UpsertResult = { contact: typeof DEFAULT_MOCK_CONTACT; created: boolean };
@@ -223,6 +233,22 @@ mock.module("../db/contact-store.js", () => ({
 
 const { createContactsControlPlaneProxyHandler } =
   await import("../http/routes/contacts-control-plane-proxy.js");
+
+// The delete-contact guard reads the guardian role from the gateway DB (source
+// of truth), so the delete tests below run against a real in-memory gateway DB.
+// ContactStore is fully mocked, so other tests never touch it.
+const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
+  "../db/connection.js"
+);
+const { contacts: gwContacts } = await import("../db/schema.js");
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -1335,6 +1361,75 @@ describe("handleMergeContacts (gateway-native)", () => {
     expect(body.error.message).toMatch(/guardian/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+describe("handleDeleteContact (gateway-native)", () => {
+  function seedGatewayContact(id: string, role: "guardian" | "contact") {
+    const now = Date.now();
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({
+        id,
+        displayName: `name-${id}`,
+        role,
+        principalId: role === "guardian" ? `prin-${id}` : null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  afterEach(() => {
+    getGatewayDb().delete(gwContacts).run();
+  });
+
+  test("rejects deleting a guardian whose role lives only in the gateway DB", async () => {
+    seedGatewayContact("ct_guardian", "guardian");
+    // The assistant row is missing/defaulted (dual-write gap): the guard must
+    // not fall back to the assistant role, which would default to contact.
+    assistantDbQueryMock = mock(async () => []);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleDeleteContact("ct_guardian");
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+    // Neither DB was deleted from.
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .all(),
+    ).toHaveLength(1);
+  });
+
+  test("deletes a non-guardian contact from both DBs", async () => {
+    seedGatewayContact("ct_regular", "contact");
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleDeleteContact("ct_regular");
+
+    expect(res.status).toBe(204);
+    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .all(),
+    ).toHaveLength(0);
+  });
+
+  test("returns 404 when the contact is absent from the gateway DB", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleDeleteContact("ct_missing");
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("handleCreateInvite (gateway-native)", () => {
   test("returns the assistant's minted invite payload (one-time codes), not the gateway row", async () => {

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -97,9 +97,6 @@ type UpdateChannelFn = (channelId: string, params: {
 }) => { id: string; contactId: string; status: string; policy: string } | null;
 let contactStoreUpdateChannelMock: ReturnType<typeof mock<UpdateChannelFn>> = mock(() => null);
 
-type DualWriteChannelFn = (channelId: string, params: Record<string, unknown>) => Promise<void>;
-let contactStoreDualWriteChannelMock: ReturnType<typeof mock<DualWriteChannelFn>> = mock(async () => {});
-
 type MergeFn = (keepId: string, mergeId: string) => Promise<typeof DEFAULT_MOCK_CONTACT | null>;
 let contactStoreMergeMock: ReturnType<typeof mock<MergeFn>> = mock(async () => null);
 
@@ -204,12 +201,6 @@ mock.module("../db/contact-store.js", () => ({
     }) {
       return contactStoreUpdateChannelMock(channelId, params);
     }
-    async dualWriteChannelStatusToAssistantDb(
-      channelId: string,
-      params: Record<string, unknown>,
-    ) {
-      return contactStoreDualWriteChannelMock(channelId, params);
-    }
     async mergeContacts(keepId: string, mergeId: string) {
       return contactStoreMergeMock(keepId, mergeId);
     }
@@ -273,7 +264,6 @@ afterEach(() => {
   contactStoreListMock = mock(async () => []);
   contactStoreGetMock = mock(async () => null);
   contactStoreUpdateChannelMock = mock(() => null);
-  contactStoreDualWriteChannelMock = mock(async () => {});
   contactStoreMergeMock = mock(async () => null);
   contactStoreGetContactMock = mock(() => ({ id: "ct_1" }));
   contactStoreListInvitesMock = mock(() => []);
@@ -983,7 +973,6 @@ describe("handleUpdateContactChannel (gateway-native)", () => {
     expect(channelId).toBe("ch_1");
     expect(params.status).toBe("revoked");
     expect(params.reason).toBe("user request");
-    expect(contactStoreDualWriteChannelMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -1134,31 +1123,6 @@ describe("handleUpdateContactChannel (gateway-native)", () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error.code).toBe("INTERNAL_ERROR");
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("continues even if assistant DB dual-write fails", async () => {
-    contactStoreUpdateChannelMock = mock(() => ({
-      ...MOCK_CHANNEL,
-      status: "blocked",
-    }));
-    contactStoreDualWriteChannelMock = mock(async () => {
-      throw new Error("assistant DB down");
-    });
-    contactStoreGetMock = mock(async () => DEFAULT_MOCK_CONTACT);
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleUpdateContactChannel(
-      new Request("http://localhost:7830/v1/contact-channels/ch_1", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ status: "blocked", reason: "spam" }),
-      }),
-      "ch_1",
-    );
-
-    // Should still succeed — dual-write is best-effort.
-    expect(res.status).toBe(200);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -737,6 +737,40 @@ describe("IPC contact routes", () => {
     ).toBe(false);
   });
 
+  test("upsertContact read-back sources ACL from the gateway DB, not assistant defaults", async () => {
+    // The assistant mirror defaults a fresh channel to unverified/allow and a
+    // contact to role=contact. The read-back must reflect the gateway DB (the
+    // just-written source of truth): an active channel and a guardian role.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "guard-1",
+        displayName: "Guardian",
+        role: "guardian",
+        principalId: "prin-guard",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // Assistant DB info-join degrades to null (default mock returns []); ACL
+    // fields still come from the real gateway DB.
+    const store = new ContactStore(db);
+    const { contact } = await store.upsertContact({
+      id: "guard-1",
+      channels: [
+        { type: "email", address: "g@example.com", status: "active" },
+      ],
+    });
+
+    expect(contact.role).toBe("guardian");
+    expect(contact.principalId).toBe("prin-guard");
+    expect(contact.channels).toHaveLength(1);
+    expect(contact.channels[0].status).toBe("active");
+    expect(contact.channels[0].policy).toBe("allow");
+  });
+
   test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {
     await startServerAndConnect();
     const res = await sendRequest(client, "create_contact", {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -161,7 +161,7 @@ export class ContactStore {
         sql`${contacts.role} = 'guardian' DESC`,
         desc(contacts.updatedAt),
         // Primary channel first, then by creation time — mirrors the daemon
-        // (assistant/src/contacts/contact-store.ts:141) and readAssistantContact.
+        // (assistant/src/contacts/contact-store.ts:141).
         sql`${contactChannels.isPrimary} DESC`,
         contactChannels.createdAt,
       )
@@ -182,7 +182,7 @@ export class ContactStore {
       .where(eq(contacts.id, contactId))
       .orderBy(
         // Primary channel first, then by creation time — mirrors the daemon
-        // (assistant/src/contacts/contact-store.ts:141) and readAssistantContact.
+        // (assistant/src/contacts/contact-store.ts:141).
         sql`${contactChannels.isPrimary} DESC`,
         contactChannels.createdAt,
       )
@@ -454,7 +454,7 @@ export class ContactStore {
    *   - status unchanged → reasons left untouched (pass undefined)
    *
    * Channel ID resolution: the caller may pass an assistant-side channel ID
-   * (the UI gets these from `readAssistantContact`). If the ID isn't found
+   * (legacy clients reading the assistant DB). If the ID isn't found
    * in the gateway DB, we resolve it from the assistant DB by
    * (contactId, type, address) and then find the matching gateway channel.
    */
@@ -1065,7 +1065,7 @@ export class ContactStore {
       revokedReason?: string | null;
       blockedReason?: string | null;
     }>;
-  }): Promise<{ contact: ContactWithChannels; created: boolean }> {
+  }): Promise<{ contact: ContactWithInfo; created: boolean }> {
     const now = Date.now();
     let contactId = params.id;
     let created = false;
@@ -1182,15 +1182,17 @@ export class ContactStore {
     }
 
     // ── 6. Read back full contact shape (best-effort) ─────────────────
-    const fullContact = await this.readAssistantContact(contactId).catch(
-      (err) => {
-        log.warn(
-          { contactId, err },
-          "upsertContact: assistant DB read-back failed; returning gateway fallback",
-        );
-        return null;
-      },
-    );
+    // Source ACL (role/principalId, channel status/policy/verified_*) from the
+    // gateway DB — the just-written source of truth — and overlay assistant-
+    // owned info. readAssistantContact would return assistant-mirror defaults
+    // (unverified/allow, role=contact), misreporting fresh creates.
+    const fullContact = await this.getContactWithInfo(contactId).catch((err) => {
+      log.warn(
+        { contactId, err },
+        "upsertContact: gateway read-back failed; returning gateway fallback",
+      );
+      return null;
+    });
 
     if (fullContact) {
       return { contact: fullContact, created };
@@ -1216,6 +1218,7 @@ export class ContactStore {
         interactionCount: 0,
         lastInteraction: null,
         channels: [],
+        assistantMetadata: null,
       },
       created,
     };
@@ -1767,97 +1770,6 @@ export class ContactStore {
     return `${slug}-${crypto.randomUUID().slice(0, 8)}.md`;
   }
 
-  /**
-   * Read a contact + channels from the assistant DB and return the full
-   * `ContactWithChannels` shape used in API responses. Returns null if the
-   * contact is not found in the assistant DB.
-   */
-  private async readAssistantContact(
-    contactId: string,
-  ): Promise<ContactWithChannels | null> {
-    const rows = await assistantDbQuery<AssistantContactRow>(
-      `SELECT c.id,
-              c.display_name      AS displayName,
-              c.notes,
-              c.role,
-              c.contact_type      AS contactType,
-              c.principal_id      AS principalId,
-              c.user_file         AS userFile,
-              c.created_at        AS createdAt,
-              c.updated_at        AS updatedAt,
-              cc.id               AS channelId,
-              cc.type             AS channelType,
-              cc.address,
-              cc.is_primary       AS isPrimary,
-              cc.external_chat_id AS externalChatId,
-              cc.status           AS channelStatus,
-              cc.policy           AS channelPolicy,
-              cc.verified_at      AS verifiedAt,
-              cc.verified_via     AS verifiedVia,
-              cc.invite_id        AS inviteId,
-              cc.revoked_reason   AS revokedReason,
-              cc.blocked_reason   AS blockedReason,
-              cc.last_seen_at     AS lastSeenAt,
-              cc.interaction_count AS interactionCount,
-              cc.last_interaction  AS lastInteraction,
-              cc.created_at       AS channelCreatedAt,
-              cc.updated_at       AS channelUpdatedAt
-         FROM contacts c
-         LEFT JOIN contact_channels cc ON cc.contact_id = c.id
-        WHERE c.id = ?
-        ORDER BY cc.is_primary DESC, cc.created_at ASC`,
-      [contactId],
-    );
-
-    if (!rows.length) return null;
-
-    const first = rows[0];
-    const channels = rows
-      .filter((r) => r.channelId !== null)
-      .map((r) => ({
-        id: r.channelId!,
-        contactId,
-        type: r.channelType!,
-        address: r.address!,
-        isPrimary: Boolean(r.isPrimary),
-        externalChatId: r.externalChatId,
-        status: r.channelStatus,
-        policy: r.channelPolicy,
-        verifiedAt: r.verifiedAt,
-        verifiedVia: r.verifiedVia,
-        inviteId: r.inviteId,
-        revokedReason: r.revokedReason,
-        blockedReason: r.blockedReason,
-        lastSeenAt: r.lastSeenAt,
-        interactionCount: r.interactionCount ?? 0,
-        lastInteraction: r.lastInteraction,
-        createdAt: r.channelCreatedAt,
-        updatedAt: r.channelUpdatedAt,
-      }));
-
-    const interactionCount = channels.reduce(
-      (sum, ch) => sum + (ch.interactionCount ?? 0),
-      0,
-    );
-    const lastInteraction =
-      channels.reduce((max, ch) => Math.max(max, ch.lastInteraction ?? 0), 0) ||
-      null;
-
-    return {
-      id: first.id,
-      displayName: first.displayName,
-      notes: first.notes,
-      role: first.role,
-      contactType: first.contactType,
-      principalId: first.principalId,
-      userFile: first.userFile,
-      createdAt: first.createdAt,
-      updatedAt: first.updatedAt,
-      interactionCount,
-      lastInteraction,
-      channels,
-    };
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1883,21 +1795,6 @@ export interface ContactChannelShape {
   lastInteraction: number | null;
   createdAt: number | null;
   updatedAt: number | null;
-}
-
-export interface ContactWithChannels {
-  id: string;
-  displayName: string;
-  notes: string | null;
-  role: string;
-  contactType: string;
-  principalId: string | null;
-  userFile: string | null;
-  createdAt: number;
-  updatedAt: number;
-  interactionCount: number;
-  lastInteraction: number | null;
-  channels: ContactChannelShape[];
 }
 
 /**
@@ -1927,35 +1824,6 @@ export interface ContactWithInfo {
     species: string;
     metadata: Record<string, unknown> | null;
   } | null;
-}
-
-interface AssistantContactRow {
-  id: string;
-  displayName: string;
-  notes: string | null;
-  role: string;
-  contactType: string;
-  principalId: string | null;
-  userFile: string | null;
-  createdAt: number;
-  updatedAt: number;
-  channelId: string | null;
-  channelType: string | null;
-  address: string | null;
-  isPrimary: number | null;
-  externalChatId: string | null;
-  channelStatus: string | null;
-  channelPolicy: string | null;
-  verifiedAt: number | null;
-  verifiedVia: string | null;
-  inviteId: string | null;
-  revokedReason: string | null;
-  blockedReason: string | null;
-  lastSeenAt: number | null;
-  interactionCount: number | null;
-  lastInteraction: number | null;
-  channelCreatedAt: number | null;
-  channelUpdatedAt: number | null;
 }
 
 /**

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -529,84 +529,6 @@ export class ContactStore {
   }
 
   /**
-   * Best-effort dual-write of a channel status/policy update to the
-   * assistant DB. The gateway DB is the source of truth; the assistant
-   * copy is a best-effort mirror. Failures are logged, not thrown.
-   */
-  async dualWriteChannelStatusToAssistantDb(
-    channelId: string,
-    params: {
-      status?: string;
-      policy?: string;
-      revokedReason?: string | null;
-      blockedReason?: string | null;
-      verifiedAt?: number | null;
-      verifiedVia?: string | null;
-    },
-  ): Promise<boolean> {
-    const setClauses: string[] = [];
-    const bind: (string | number | null)[] = [];
-
-    if (params.status !== undefined) {
-      setClauses.push("status = ?");
-      bind.push(params.status);
-    }
-    if (params.policy !== undefined) {
-      setClauses.push("policy = ?");
-      bind.push(params.policy);
-    }
-    if (params.revokedReason !== undefined) {
-      setClauses.push("revoked_reason = ?");
-      bind.push(params.revokedReason);
-    }
-    if (params.blockedReason !== undefined) {
-      setClauses.push("blocked_reason = ?");
-      bind.push(params.blockedReason);
-    }
-    if (params.verifiedAt !== undefined) {
-      setClauses.push("verified_at = ?");
-      bind.push(params.verifiedAt);
-    }
-    if (params.verifiedVia !== undefined) {
-      setClauses.push("verified_via = ?");
-      bind.push(params.verifiedVia);
-    }
-
-    if (setClauses.length === 0) return false;
-
-    setClauses.push("updated_at = ?");
-    bind.push(String(Date.now()));
-    bind.push(channelId);
-
-    const result = await assistantDbRun(
-      `UPDATE contact_channels SET ${setClauses.join(", ")} WHERE id = ?`,
-      bind,
-    );
-    if (result.changes > 0) return true;
-
-    // Legacy channels may have a different assistant-side ID. If the ID-keyed
-    // update touched zero rows, resolve by the unique (type, address) key and
-    // retry so the assistant mirror stays consistent. The assistant row may sit
-    // under a different contact than the gateway row (m0006 reconcile), so
-    // contactId is excluded.
-    const gwChannel = this.db
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
-    if (!gwChannel) return false;
-
-    const logicalBind = bind.slice(0, -1); // drop the channelId
-    logicalBind.push(gwChannel.type, gwChannel.address);
-    const retry = await assistantDbRun(
-      `UPDATE contact_channels SET ${setClauses.join(", ")}
-         WHERE type = ? AND address = ? COLLATE NOCASE`,
-      logicalBind,
-    );
-    return retry.changes > 0;
-  }
-
-  /**
    * Increment interaction count and set lastInteraction timestamp
    * (gateway DB only).
    */
@@ -809,9 +731,9 @@ export class ContactStore {
    * Returns the channel after the write, or `null` if neither the gateway
    * DB nor the assistant DB has a channel with that id.
    *
-   * Gateway DB (source of truth) + best-effort assistant DB dual-write.
-   * When the channel is missing on the gateway but present on the assistant,
-   * it (plus its parent contact) is mirrored into the gateway first.
+   * Gateway DB is the source of truth. When the channel is missing on the
+   * gateway but present on the assistant, it (plus its parent contact) is
+   * mirrored into the gateway first.
    */
   async markChannelVerified(
     channelId: string,
@@ -855,37 +777,12 @@ export class ContactStore {
     if (!after) return null;
     const didWrite = result.changes > 0;
 
-    // Mirror the write to the assistant DB only when the gateway actually
-    // wrote (best-effort dual-write). Skipping the no-op case prevents
-    // spurious verified_at/updated_at drift in the assistant DB on idempotent
-    // calls. The gateway DB remains source of truth.
-    //
-    // Key the mirror by the ORIGINAL assistant channel id, not the resolved
-    // gateway `gwChannelId`: on the split-id path they differ and the assistant
-    // row is keyed by the original id, so mirroring by the gateway id would
-    // no-op. The dual-write's logical (type, address) fallback covers rows
-    // keyed differently from the id.
-    if (didWrite) {
-      try {
-        await this.dualWriteChannelStatusToAssistantDb(channelId, {
-          status: "active",
-          verifiedAt: now,
-          verifiedVia,
-        });
-      } catch (err) {
-        log.warn(
-          { channelId, gwChannelId, err },
-          "markChannelVerified: assistant DB dual-write failed (best-effort)",
-        );
-      }
-    }
-
     return { channel: after, didWrite };
   }
 
   /**
-   * Downgrade a channel to `revoked` (verification-revoke outcome), then
-   * best-effort dual-write to the assistant DB. Gateway DB is source of truth.
+   * Downgrade a channel to `revoked` (verification-revoke outcome).
+   * Gateway DB is source of truth.
    *
    * Guardian guard (invariant 4): a guardian contact's channel may only be
    * downgraded via the sanctioned guardian-binding teardown
@@ -957,19 +854,6 @@ export class ContactStore {
       .where(eq(contactChannels.id, gwChannelId))
       .get();
     if (!after) return null;
-
-    try {
-      await this.dualWriteChannelStatusToAssistantDb(gwChannelId, {
-        status: "revoked",
-        revokedReason: reason ?? null,
-        blockedReason: null,
-      });
-    } catch (err) {
-      log.warn(
-        { channelId, err },
-        "markChannelRevoked: assistant DB dual-write failed (best-effort)",
-      );
-    }
 
     return { channel: after, didWrite: true };
   }
@@ -1433,7 +1317,6 @@ export class ContactStore {
         keepId,
         mergeId,
         keep.displayName,
-        keep.role,
         keep.principalId,
       );
     } catch (err) {
@@ -1491,7 +1374,6 @@ export class ContactStore {
     keepId: string,
     mergeId: string,
     keepDisplayName: string,
-    keepRole: string,
     keepPrincipalId: string | null,
   ): Promise<void> {
     const now = Date.now();
@@ -1514,21 +1396,17 @@ export class ContactStore {
 
     if (updateResult.changes === 0) {
       // Survivor row missing from assistant DB — create it with combined notes.
-      // Use the gateway survivor's role/principalId so a guardian survivor
-      // isn't downgraded to role=contact in the assistant mirror.
       const userFile = await this.resolveAssistantUserFileSlug(
         keepDisplayName,
         keepPrincipalId,
       );
       await assistantDbRun(
-        `INSERT INTO contacts (id, display_name, notes, role, contact_type, principal_id, user_file, created_at, updated_at)
-         VALUES (?, ?, ?, ?, 'human', ?, ?, ?, ?)`,
+        `INSERT INTO contacts (id, display_name, notes, contact_type, user_file, created_at, updated_at)
+         VALUES (?, ?, ?, 'human', ?, ?, ?)`,
         [
           keepId,
           keepDisplayName,
           combined,
-          keepRole,
-          keepPrincipalId,
           userFile,
           String(now),
           String(now),
@@ -1737,16 +1615,14 @@ export class ContactStore {
       );
       await assistantDbRun(
         `INSERT INTO contacts
-           (id, display_name, notes, role, contact_type, principal_id,
+           (id, display_name, notes, contact_type,
             user_file, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
         [
           contactId,
           displayName,
           params.notes ?? null,
-          "contact",
           params.contactType ?? "human",
-          null,
           userFile,
           now,
           now,
@@ -1774,13 +1650,12 @@ export class ContactStore {
 
     // Sync channels to the assistant DB.
     for (const ch of params.channels ?? []) {
-      const existingCh = await assistantDbQuery<{ id: string; status: string }>(
-        "SELECT id, status FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
+      const existingCh = await assistantDbQuery<{ id: string }>(
+        "SELECT id FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
         [contactId, ch.type, ch.address],
       );
 
       if (existingCh.length) {
-        const isBlocked = existingCh[0].status === "blocked";
         // Omit-to-preserve: only overwrite external_chat_id when the caller
         // supplied one, mirroring syncChannels (gateway DB). A sparse upsert
         // (no externalChatId) must not clear an existing delivery chat id.
@@ -1789,16 +1664,6 @@ export class ContactStore {
         if (ch.externalChatId !== undefined) {
           setParts.push("external_chat_id = ?");
           setParams.push(ch.externalChatId);
-        }
-        if (!isBlocked) {
-          if (ch.status !== undefined) {
-            setParts.push("status = ?");
-            setParams.push(ch.status);
-          }
-          if (ch.policy !== undefined) {
-            setParts.push("policy = ?");
-            setParams.push(ch.policy);
-          }
         }
         setParams.push(existingCh[0].id);
         await assistantDbRun(
@@ -1832,8 +1697,8 @@ export class ContactStore {
           `INSERT INTO contact_channels
              (id, contact_id, type, address, is_primary,
               external_chat_id,
-              status, policy, interaction_count, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+              interaction_count, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
           [
             channelId,
             contactId,
@@ -1841,8 +1706,6 @@ export class ContactStore {
             ch.address,
             ch.isPrimary ? 1 : 0,
             ch.externalChatId ?? null,
-            ch.status ?? "unverified",
-            ch.policy ?? "allow",
             now,
             now,
           ],

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -1123,7 +1123,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
         { contactId: contact.id, created },
         "upsert_contact: handled natively",
       );
-      return Response.json({ ok: true, contact });
+      // ACL (role/principalId, channel status/policy) is sourced from the
+      // gateway DB inside upsertContact's read-back, so this response reflects
+      // the just-written source of truth, not assistant-mirror defaults.
+      return Response.json({ ok: true, contact: toContactPayload(contact) });
     },
 
     /**
@@ -1171,11 +1174,14 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     },
 
     async handleDeleteContact(contactId: string): Promise<Response> {
-      const rows = await assistantDbQuery<{ role: string }>(
-        "SELECT role FROM contacts WHERE id = ?",
-        [contactId],
-      );
-      if (rows.length === 0) {
+      // Guardian role is gateway-DB source of truth: a dual-write-gap survivor
+      // whose assistant row is missing/defaulted must not bypass this guard.
+      const row = getGatewayDb()
+        .select({ role: contacts.role })
+        .from(contacts)
+        .where(eq(contacts.id, contactId))
+        .get();
+      if (!row) {
         log.warn({ contactId }, "delete_contact: not found");
         return Response.json(
           {
@@ -1187,7 +1193,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
           { status: 404 },
         );
       }
-      if (rows[0].role === "guardian") {
+      if (row.role === "guardian") {
         log.warn({ contactId }, "delete_contact: attempted to delete guardian");
         return Response.json(
           {

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -744,32 +744,6 @@ export async function updateContactChannelCore(params: {
     );
   }
 
-  // Best-effort dual-write to assistant DB.
-  const dualWriteParams: {
-    status?: string;
-    policy?: string;
-    revokedReason?: string | null;
-    blockedReason?: string | null;
-  } = {};
-  if (status !== undefined) {
-    dualWriteParams.status = status;
-    dualWriteParams.revokedReason = status === "revoked" ? reason : null;
-    dualWriteParams.blockedReason = status === "blocked" ? reason : null;
-  }
-  if (policy !== undefined) dualWriteParams.policy = policy;
-
-  try {
-    await store.dualWriteChannelStatusToAssistantDb(
-      contactChannelId,
-      dualWriteParams,
-    );
-  } catch (err) {
-    log.warn(
-      { contactChannelId, err },
-      "update_channel: assistant DB dual-write failed (best-effort)",
-    );
-  }
-
   // Emit contacts_changed so connected clients refresh.
   void ipcCallAssistant("emit_event", {
     body: { kind: "contacts_changed" },


### PR DESCRIPTION
## Summary
- Delete dualWriteChannelStatusToAssistantDb (pure ACL mirror) and its 3 call sites
- Strip role/principal_id/status/policy from dualWriteContactToAssistantDb and mergeInAssistantDb assistant-DB writes; gateway DB remains the source of truth

Part of plan: remove-gateway-acl-mirror-writes.md (PR 6 of 7)