### PR TITLE
fix(chat): re-prune orphaned live-turn rows on reconcile

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -15,9 +15,11 @@ import { selectTranscriptMessages } from "@/domains/chat/transcript/select-trans
 import { mergeAdjacentAssistantMessages } from "@/domains/chat/utils/message-merge";
 import { conversationHistoryQueryKey } from "@/domains/chat/transcript/use-history-pagination";
 import {
+  liveRowsSupersededByServer,
   serverHasAssistantProgress,
   serverSnapshotHasNewContent,
 } from "@/domains/chat/utils/reconcile-detection";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { fetchConversationMessages } from "@/domains/chat/api/messages";
 import type { ConversationMessage } from "@vellumai/assistant-api";
@@ -128,12 +130,13 @@ export function useMessageReconciliation({
       // Advance the local seq frontier — we've observed this server snapshot.
       recordLocalSeq(conversationId, serverSeq);
 
+      const sending = isSending(useTurnStore.getState().phase);
       const localView = currentLocalView(conversationId);
       const serverView = serverMessages.map(mapRuntimeToDisplayMessage);
       const assistantProgress = serverHasAssistantProgress(
         localView,
         serverView,
-        isSending(useTurnStore.getState().phase),
+        sending,
       );
       const changed = serverSnapshotHasNewContent(serverView, localView);
       const messagesAdded = serverView.length - localView.length;
@@ -151,11 +154,42 @@ export function useMessageReconciliation({
         }
       }
 
+      // Self-healing live-turn→history handoff. The handoff in
+      // `use-conversation-history` only prunes on the sending→idle edge; when
+      // that edge is missed (a mid-turn SSE abort whose replayed terminal
+      // events land on an already-idle turn — the "didn't respond" report),
+      // the graduated row is orphaned in the live turn and shadows the
+      // complete server copy on every render. Reconcile is the recurring
+      // authoritative refresh, so re-run the prune here against the snapshot we
+      // just fetched: once terminal, drop any live row the server already
+      // carries so its copy renders.
+      const supersededLiveRows = liveRowsSupersededByServer(
+        useChatSessionStore.getState().liveTurn,
+        serverView,
+        !sending,
+      );
+      if (supersededLiveRows.length > 0) {
+        const dropKeys = new Set(
+          supersededLiveRows.flatMap((row) => messageMatchKeys(row)),
+        );
+        useChatSessionStore
+          .getState()
+          .setLiveTurn((prev) =>
+            prev.filter(
+              (row) => !messageMatchKeys(row).some((k) => dropKeys.has(k)),
+            ),
+          );
+        recordDiagnostic("reconcile_pruned_orphaned_live_rows", {
+          count: supersededLiveRows.length,
+        });
+      }
+
       recordDiagnostic("reconciliation_applied", {
         changed,
         assistantProgress,
         messagesAdded,
         authoritative,
+        prunedOrphanedLiveRows: supersededLiveRows.length,
         oldestPageTimestamp: initialPageOldestTsRef.current,
         server: summarizeRuntimeMessages(serverMessages),
       });

--- a/clients/web/src/domains/chat/utils/reconcile-detection.test.ts
+++ b/clients/web/src/domains/chat/utils/reconcile-detection.test.ts
@@ -1,17 +1,28 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  liveRowsSupersededByServer,
   serverHasAssistantProgress,
   serverSnapshotHasNewContent,
 } from "@/domains/chat/utils/reconcile-detection";
 import type { DisplayMessage } from "@/domains/chat/types/types";
-import { textBody } from "@/domains/chat/utils/message-test-helpers";
+import {
+  textBody,
+  thinkingBodyWithBlocks,
+} from "@/domains/chat/utils/message-test-helpers";
 
 function userRow(id: string, text: string): DisplayMessage {
   return { id, role: "user", ...textBody(text) } as DisplayMessage;
 }
 function assistantRow(id: string, text: string): DisplayMessage {
   return { id, role: "assistant", ...textBody(text) } as DisplayMessage;
+}
+function thinkingOnlyRow(id: string, thinking: string): DisplayMessage {
+  return {
+    id,
+    role: "assistant",
+    ...thinkingBodyWithBlocks(thinking),
+  } as DisplayMessage;
 }
 
 // ---------------------------------------------------------------------------
@@ -82,5 +93,80 @@ describe("serverHasAssistantProgress", () => {
         true,
       ),
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// liveRowsSupersededByServer — the self-healing live-turn prune that recovers
+// the "I said yo and it didn't respond" orphan: a thinking-only live row left
+// behind by a mid-turn abort, shadowing the server's finished reply.
+// ---------------------------------------------------------------------------
+
+describe("liveRowsSupersededByServer", () => {
+  test("drops a terminal-turn orphan the server has finished (the yo bug)", () => {
+    const orphan = thinkingOnlyRow("a1", "let me think about yo");
+    const superseded = liveRowsSupersededByServer(
+      [orphan],
+      [userRow("u1", "yo"), assistantRow("a1", "yo, what's up")],
+      true,
+    );
+    expect(superseded).toEqual([orphan]);
+  });
+
+  test("keeps every live row while the turn is still streaming", () => {
+    const orphan = thinkingOnlyRow("a1", "thinking");
+    expect(
+      liveRowsSupersededByServer(
+        [orphan],
+        [userRow("u1", "yo"), assistantRow("a1", "yo, what's up")],
+        false,
+      ),
+    ).toEqual([]);
+  });
+
+  test("keeps a live row the server snapshot does not yet carry", () => {
+    expect(
+      liveRowsSupersededByServer(
+        [assistantRow("a2", "streamed reply")],
+        [userRow("u1", "yo"), assistantRow("a1", "older reply")],
+        true,
+      ),
+    ).toEqual([]);
+  });
+
+  test("keeps a live row whose text is ahead of the lagging server copy", () => {
+    // Server persistence briefly trails the live row — dropping it would flash
+    // the transcript backward, so it must survive until the server catches up.
+    expect(
+      liveRowsSupersededByServer(
+        [assistantRow("a1", "full streamed answer")],
+        [assistantRow("a1", "full")],
+        true,
+      ),
+    ).toEqual([]);
+  });
+
+  test("matches on the client nonce when the server adopted the id", () => {
+    const optimistic = {
+      id: "client-temp",
+      clientMessageId: "nonce-1",
+      role: "user",
+      ...textBody("yo"),
+    } as DisplayMessage;
+    const serverEcho = {
+      id: "server-1",
+      clientMessageId: "nonce-1",
+      role: "user",
+      ...textBody("yo"),
+    } as DisplayMessage;
+    expect(
+      liveRowsSupersededByServer([optimistic], [serverEcho], true),
+    ).toEqual([optimistic]);
+  });
+
+  test("no-ops on an empty live turn", () => {
+    expect(
+      liveRowsSupersededByServer([], [assistantRow("a1", "reply")], true),
+    ).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/utils/reconcile-detection.ts
+++ b/clients/web/src/domains/chat/utils/reconcile-detection.ts
@@ -13,7 +13,10 @@
  * missed terminal event.
  */
 
-import { messageIdentityKeys } from "@/domains/chat/utils/message-identity";
+import {
+  messageIdentityKeys,
+  messageMatchKeys,
+} from "@/domains/chat/utils/message-identity";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import { liveAssistantRowId } from "@/domains/chat/utils/stream-updaters/shared";
 import type { DisplayMessage } from "@/domains/chat/types/types";
@@ -112,4 +115,60 @@ export function serverHasAssistantProgress(
   }
 
   return false;
+}
+
+/**
+ * Live-turn rows the authoritative server snapshot has already superseded.
+ *
+ * The live-turn→history handoff (`use-conversation-history`) drops graduated
+ * rows on the single sending→idle edge. If that edge is missed or races the
+ * server persisting the turn — the failure mode behind "I said yo and it
+ * didn't respond": the stream is aborted mid-turn by a visibility change, and
+ * the replayed terminal events land on an already-idle turn, so the handoff
+ * never re-runs — the graduated row is orphaned in the live turn. There it
+ * shadows the complete server copy forever, because `selectTranscriptMessages`
+ * lets the live copy win on content: the user keeps seeing a truncated
+ * thinking-only bubble while the server holds the finished reply.
+ *
+ * Reconcile is the recurring authoritative refresh, so it re-runs the same
+ * prune the handoff does: once the turn is terminal, any live row the server
+ * snapshot already carries is stale and must be dropped so the server copy
+ * renders. Returns the live rows to drop; the caller filters them out.
+ *
+ * Gated on `terminal`: while the turn is still streaming the live copy is
+ * legitimately ahead of the server, and dropping it would flash the partial
+ * server copy backward. The text-length guard is the matching safety net for a
+ * terminal turn whose server persistence briefly lags the live row — only drop
+ * when the server copy is no shorter than what we'd be removing.
+ */
+export function liveRowsSupersededByServer(
+  live: DisplayMessage[],
+  serverMessages: DisplayMessage[],
+  terminal: boolean,
+): DisplayMessage[] {
+  if (!terminal || live.length === 0) return [];
+
+  const serverByKey = new Map<string, DisplayMessage>();
+  for (const sm of serverMessages) {
+    for (const key of messageMatchKeys(sm)) {
+      if (!serverByKey.has(key)) serverByKey.set(key, sm);
+    }
+  }
+
+  const superseded: DisplayMessage[] = [];
+  for (const row of live) {
+    let serverTwin: DisplayMessage | undefined;
+    for (const key of messageMatchKeys(row)) {
+      const found = serverByKey.get(key);
+      if (found) {
+        serverTwin = found;
+        break;
+      }
+    }
+    if (!serverTwin) continue;
+    if (messagePlainText(serverTwin).length >= messagePlainText(row).length) {
+      superseded.push(row);
+    }
+  }
+  return superseded;
 }


### PR DESCRIPTION
## What the user reported

> "I said Yo and Becky didn't respond"

## What actually happened

The feedback bundle tells a clear story — and it's not what it looks like. **The assistant did respond.** The daemon generated, completed, and persisted the full reply `yo, what's up 🫡` (confirmed in the platform-logs `messages.jsonl`, and in the server snapshot the client itself refetched: `textSegmentCount: 1`, `contentOrderCount: 2`). The web client simply never rendered it.

### Timeline (from the triage bundle)

| Time (UTC) | Event |
|---|---|
| 19:46:59.967 | User sends "yo" (conversation `120b8941…`) |
| 19:47:00–19:47:11 | Assistant streams **thinking** over SSE stream `sse-9` (ends mid-sentence: "…release notes being") |
| 19:47:11.603 | `app.hidden` (window backgrounded) → `sse-9` aborted (`endReason: cancelled`, `aborted: true`) at the exact same ms |
| 19:47:31.195 | `app.resume` → `sse-10` reconnects (epoch 14) |
| 19:47:31.56–57 | Daemon **replays** the rest of the turn: 16 thinking deltas + `assistant_text_delta("yo, what's up 🫡")` + `assistant_activity_state(idle)` + `message_complete` |
| 19:47:57 / 19:48:02 / 19:48:07 | Client reconciles 3× — each pulls the **complete** server message, `changed: true`, `assistantProgress: true`, but `messagesAdded: 0`. Transcript still shows only the truncated thinking. |

## Root cause

The transcript is the union of server history and the client-owned live turn (`selectTranscriptMessages`), where **the live copy wins on content**. Graduated rows are removed from the live turn by the live-turn→history handoff in `use-conversation-history`, which only fires on the **single `sending → idle` edge**.

The mid-turn abort broke that invariant: the terminal events (`message_complete` / activity-idle) were replayed onto an **already-idle** turn, so the handoff edge never re-fired. The stale, thinking-only live row was orphaned in the live turn — and from then on it **shadowed the complete server copy on every render**. Reconciliation kept correctly detecting "server has content we don't show" and refreshing history, but nothing ever pruned the orphan, so the refresh had no visible effect.

## The fix

Make the handoff **self-healing**. Reconcile is the recurring authoritative refresh, so it now re-runs the same prune via a new pure helper, `liveRowsSupersededByServer`: once the turn is terminal, drop any live row the freshly-fetched server snapshot already carries, so the server's copy renders.

Two guards keep it safe:
- **Terminal-only** (`!isSending`) — while a turn is still streaming the live copy is legitimately ahead of the server, so it's never dropped.
- **Server-not-shorter** (`messagePlainText` length check) — if server persistence briefly lags the live row, we don't flash the transcript backward.

In steady state the helper early-returns (`live` empty, or turn still sending), so the hot path is untouched. A `reconcile_pruned_orphaned_live_rows` diagnostic + a `prunedOrphanedLiveRows` field on `reconciliation_applied` make recoveries observable.

## Testing

- New unit tests for `liveRowsSupersededByServer` covering the yo-bug orphan, the still-streaming case, the not-yet-on-server case, the lagging-server guard, client-nonce matching, and the empty live turn.
- `bunx tsc --noEmit` clean; `eslint` clean on all changed files.
- Full `reconcile-detection.test.ts` suite green (12/12). The 8 failures seen when running multiple stream test files together reproduce identically on `main` (a pre-existing cross-file test-isolation issue — each file passes in isolation) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0162U8sw52n76PUNPeZFvmVa)_