### PR TITLE
refactor(channels): derive channel-binding builder types from the Zod schema

### DIFF
--- a/assistant/src/messaging/channel-binding-metadata.ts
+++ b/assistant/src/messaging/channel-binding-metadata.ts
@@ -1,5 +1,5 @@
 import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
-import type { ChannelBindingMetadata } from "./provider-types.js";
+import type { ChannelBindingMetadata } from "./channel-binding-schema.js";
 import { buildSlackBindingMetadata } from "./providers/slack/binding-metadata.js";
 
 type BindingMetadataBuilder = (

--- a/assistant/src/messaging/channel-binding-schema.ts
+++ b/assistant/src/messaging/channel-binding-schema.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+const slackThreadSchema = z.object({
+  channelId: z.string(),
+  threadTs: z.string(),
+  link: z
+    .object({
+      appUrl: z.string().optional(),
+      webUrl: z.string().optional(),
+    })
+    .optional(),
+});
+
+const slackChannelSchema = z.object({
+  channelId: z.string(),
+  name: z.string().optional(),
+  link: z.object({ webUrl: z.string() }).optional(),
+});
+
+/**
+ * Wire shape of a serialized conversation channel binding — the single source
+ * of truth for this contract.
+ *
+ * Consumed as a route `responseBody` (which drives `openapi.yaml` generation
+ * and, in turn, the web client's generated daemon types), and the server-side
+ * builders derive their TypeScript types from it via `z.infer`. The shape is
+ * therefore declared exactly once.
+ */
+export const channelBindingSchema = z.object({
+  sourceChannel: z.string(),
+  externalChatId: z.string(),
+  externalChatName: z.string().optional(),
+  externalThreadId: z.string().optional(),
+  externalUserId: z.string().nullable(),
+  displayName: z.string().nullable(),
+  username: z.string().nullable(),
+  slackThread: slackThreadSchema.optional(),
+  slackChannel: slackChannelSchema.optional(),
+});
+
+type ChannelBinding = z.infer<typeof channelBindingSchema>;
+
+/**
+ * The channel-specific fields a per-channel builder contributes to a binding
+ * (everything beyond the channel-neutral base). Picked from the schema above
+ * so a builder's output can never drift from the wire contract.
+ */
+export type ChannelBindingMetadata = Pick<
+  ChannelBinding,
+  "externalChatName" | "slackThread" | "slackChannel"
+>;

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -1,13 +1,5 @@
 /** Platform-agnostic types for the messaging provider abstraction. */
 
-/**
- * Extra, channel-specific fields a channel contributes to a serialized
- * conversation channel binding (e.g. deep links back to the source message).
- * Additive by design: each channel returns its own fields, so this is an open
- * record rather than a committed cross-channel schema.
- */
-export type ChannelBindingMetadata = Record<string, unknown>;
-
 export interface Conversation {
   id: string;
   name: string;

--- a/assistant/src/messaging/providers/slack/binding-metadata.ts
+++ b/assistant/src/messaging/providers/slack/binding-metadata.ts
@@ -1,6 +1,6 @@
 import { getConfig } from "../../../config/loader.js";
 import type { ExternalConversationBinding } from "../../../memory/external-conversation-store.js";
-import type { ChannelBindingMetadata } from "../../provider-types.js";
+import type { ChannelBindingMetadata } from "../../channel-binding-schema.js";
 import {
   buildSlackMessageDeepLinks,
   buildSlackWebChannelUrl,
@@ -12,10 +12,12 @@ import {
  * links that jump back to the source thread and channel in the Slack app or
  * web client.
  *
- * The returned fields are spread onto the channel-neutral binding by the
- * serializer — Slack is the only channel that can currently produce
- * message-level deep links, because the link inputs (workspace team id/url +
- * a stable per-message timestamp) only exist for Slack.
+ * The return type is derived from the channel-binding Zod schema
+ * (`ChannelBindingMetadata`) — the single source of truth that also drives
+ * `openapi.yaml` and the web client's generated types — so this builder cannot
+ * drift from the wire contract. Slack is the only channel that can currently
+ * produce message-level deep links, because the link inputs (workspace team
+ * id/url + a stable per-message timestamp) only exist for Slack.
  */
 export function buildSlackBindingMetadata(
   binding: ExternalConversationBinding,

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -31,6 +31,7 @@ import {
 import type { ConversationType } from "../../memory/conversation-types.js";
 import { getBindingsForConversations } from "../../memory/external-conversation-store.js";
 import { listGroups } from "../../memory/group-crud.js";
+import { channelBindingSchema } from "../../messaging/channel-binding-schema.js";
 import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -84,35 +85,6 @@ const assistantAttentionSchema = z.object({
       "slack_callback",
     ])
     .optional(),
-});
-
-const slackThreadSchema = z.object({
-  channelId: z.string(),
-  threadTs: z.string(),
-  link: z
-    .object({
-      appUrl: z.string().optional(),
-      webUrl: z.string().optional(),
-    })
-    .optional(),
-});
-
-const slackChannelSchema = z.object({
-  channelId: z.string(),
-  name: z.string().optional(),
-  link: z.object({ webUrl: z.string() }).optional(),
-});
-
-const channelBindingSchema = z.object({
-  sourceChannel: z.string(),
-  externalChatId: z.string(),
-  externalChatName: z.string().optional(),
-  externalThreadId: z.string().optional(),
-  externalUserId: z.string().nullable(),
-  displayName: z.string().nullable(),
-  username: z.string().nullable(),
-  slackThread: slackThreadSchema.optional(),
-  slackChannel: slackChannelSchema.optional(),
 });
 
 const forkParentSchema = z.object({


### PR DESCRIPTION
## Summary

Follow-up to #36137 (Stage 1 of the channel-adapter generalization). The conversation `channelBinding` wire shape is defined once by a **Zod schema** whose `responseBody` drives `openapi.yaml` generation and, in turn, the web client's generated types. The Slack binding builder, though, hand-wrote its own copy of that shape — a disconnected declaration that could silently drift from the contract.

This makes the Zod schema the single source of truth on the server side too.

## What changed
- **New** `messaging/channel-binding-schema.ts` — the channel-binding Zod schemas, moved out of `conversation-list-routes.ts` into a shared **leaf** module so the lower `messaging/` layer can derive from them without a `routes → serializer → messaging → routes` import cycle.
- **`conversation-list-routes.ts`** imports `channelBindingSchema` for its `responseBody` — so `openapi.yaml` regenerates **byte-for-byte identically** (drift check passes).
- **`ChannelBindingMetadata`** is now `z.infer` of a `Pick` of the schema, replacing the hand-written type and the earlier open `Record<string, unknown>`. The Slack builder and the dispatch derive from it.

## Why
On the server, the Zod schema *is* the generator's source of truth. Deriving the builder/dispatch types from it (instead of hand-writing) makes a drift between the builder and the contract a **compile error**, not a runtime/test-only surprise.

(The matching client-side gap — the web app hand-maintaining `conversation-types.ts` instead of consuming its own generated daemon types — is tracked separately in **LUM-2610**.)

## Verification
- `tsc --noEmit` ✅
- `bun run generate:openapi -- --check` ✅ (no spec drift)
- `eslint` ✅
- `bun test channel-delivery-store.test.ts conversation-serializer.test.ts` → **53 pass, 0 fail**

Structural change only — wire shape unchanged. Follow-up to #36137 / LUM-2577. Related: **LUM-2598**, **LUM-2610**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv