### PR TITLE
Default BYOK provider connections to personal aliases

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-prefill.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-prefill.test.ts
@@ -76,6 +76,26 @@ describe("deriveProviderDefaults", () => {
     });
   });
 
+  test("uses the personal alias for API-key provider connections", () => {
+    expect(
+      deriveProviderDefaults("anthropic", [], { authType: "api_key" }),
+    ).toEqual({
+      name: "Anthropic",
+      key: "anthropic-personal",
+    });
+  });
+
+  test("dedupes API-key personal aliases against existing connection names", () => {
+    expect(
+      deriveProviderDefaults("anthropic", ["anthropic-personal"], {
+        authType: "api_key",
+      }),
+    ).toEqual({
+      name: "Anthropic",
+      key: "anthropic-personal-2",
+    });
+  });
+
   test("falls back to the provider type when no display name exists", () => {
     expect(deriveProviderDefaults("custom-provider", [])).toEqual({
       name: "custom-provider",

--- a/clients/web/src/domains/settings/ai/profile-prefill.ts
+++ b/clients/web/src/domains/settings/ai/profile-prefill.ts
@@ -1,4 +1,5 @@
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import type { AuthType } from "@/domains/settings/ai/provider-editor-constants";
 import { toKebabCase } from "@/domains/settings/ai/slugify";
 
 /**
@@ -37,10 +38,17 @@ function dedupeKey(base: string, existing: string[]): string {
 export function deriveProviderDefaults(
   providerType: string,
   existingConnectionNames: string[],
+  options: { authType?: AuthType } = {},
 ): { name: string; key: string } {
+  const keyBase =
+    options.authType === "api_key" &&
+    providerType !== "ollama" &&
+    providerType !== "openai-compatible"
+      ? `${providerType}-personal`
+      : providerType;
   return {
     name: PROVIDER_DISPLAY_NAMES[providerType] ?? providerType,
-    key: dedupeKey(slugify(providerType), existingConnectionNames),
+    key: dedupeKey(slugify(keyBase), existingConnectionNames),
   };
 }
 

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -341,6 +341,9 @@ describe("ProviderCreateForm submit sequence", () => {
     // confirms the form initialized on the "bring your own credential" path
     // (instead of the managed-capable provider's default `platform`).
     expect(getInputByPlaceholder("Enter your API key")).toBeDefined();
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "anthropic-personal",
+    );
   });
 
   test("a provider without platform auth (e.g. openrouter) seeds api_key, not platform", () => {
@@ -462,6 +465,30 @@ describe("ProviderCreateForm submit sequence", () => {
     );
     expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
       "anthropic-2",
+    );
+  });
+
+  test("switching to API Key auth reseeds a clean Key to the personal alias", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "anthropic",
+    );
+
+    selectDropdownOption("Auth type", "API Key");
+
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "anthropic-personal",
     );
   });
 

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -31,6 +31,30 @@ import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
 
+function defaultAuthTypeForProvider(
+  provider: ConnectionProvider,
+  requested?: AuthType,
+): AuthType {
+  if (requested) return requested;
+  if (provider === "ollama") return "none";
+  return providerSupportsPlatformAuth(provider) ? "platform" : "api_key";
+}
+
+function nextAuthTypeForProvider(
+  provider: ConnectionProvider,
+  current: AuthType,
+): AuthType {
+  if (provider === "ollama") return "none";
+  if (current === "none") return "api_key";
+  if (current === "oauth_subscription" && provider !== "openai") {
+    return "api_key";
+  }
+  if (current === "platform" && !providerSupportsPlatformAuth(provider)) {
+    return "api_key";
+  }
+  return current;
+}
+
 // ---------------------------------------------------------------------------
 // ProviderCreateForm
 // ---------------------------------------------------------------------------
@@ -73,26 +97,23 @@ export function ProviderCreateForm({
   variant = "modal",
 }: ProviderCreateFormProps) {
   const initialProvider: ConnectionProvider = defaultProviderType ?? "anthropic";
+  const initialAuthType = defaultAuthTypeForProvider(
+    initialProvider,
+    defaultAuthType,
+  );
 
-  // Seed Display Name (label) + Key (name) from the initial provider type so
-  // the form opens pre-filled (e.g. Anthropic → "Anthropic" / "anthropic"),
-  // deduped against existing connection names. The user can override both, and
-  // a provider-type change re-seeds only while they haven't edited the fields
-  // (see the dirty guard in the Provider dropdown's onChange below).
-  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames);
+  // Seed Display Name (label) + Key (name) from the initial provider and auth
+  // type, deduped against existing connection names. The user can override
+  // both, and a provider-type change re-seeds only while they haven't edited
+  // the fields (see the dirty guard in the Provider dropdown's onChange below).
+  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames, {
+    authType: initialAuthType,
+  });
 
   const [label, setLabel] = useState(initialDefaults.name);
   const [name, setName] = useState(initialDefaults.key);
   const [provider, setProvider] = useState<ConnectionProvider>(initialProvider);
-  const [authType, setAuthType] = useState<AuthType>(
-    () =>
-      defaultAuthType ??
-      (initialProvider === "ollama"
-        ? "none"
-        : providerSupportsPlatformAuth(initialProvider)
-          ? "platform"
-          : "api_key"),
-  );
+  const [authType, setAuthType] = useState<AuthType>(initialAuthType);
   const [credential, setCredential] = useState(() =>
     initialProvider === "ollama" ? "" : `credential/${initialProvider}/api_key`,
   );
@@ -322,6 +343,7 @@ export function ProviderCreateForm({
           aria-label="Provider"
           value={provider}
           onChange={(newProvider) => {
+            const nextAuthType = nextAuthTypeForProvider(newProvider, authType);
             setProvider(newProvider);
             // Re-seed Name + Key from the newly selected provider type, but
             // only while the user hasn't manually edited either field (dirty
@@ -331,34 +353,17 @@ export function ProviderCreateForm({
               const { name: seedName, key: seedKey } = deriveProviderDefaults(
                 newProvider,
                 existingNames,
+                { authType: nextAuthType },
               );
               setLabel(seedName);
               setName(seedKey);
             }
             if (newProvider === "ollama") {
-              setAuthType("none");
               setCredential("");
             } else {
-              setAuthType((prev) => {
-                if (prev === "none") {
-                  return "api_key";
-                }
-                if (
-                  prev === "oauth_subscription" &&
-                  newProvider !== "openai"
-                ) {
-                  return "api_key";
-                }
-                if (
-                  prev === "platform" &&
-                  !providerSupportsPlatformAuth(newProvider)
-                ) {
-                  return "api_key";
-                }
-                return prev;
-              });
               setCredential(`credential/${newProvider}/api_key`);
             }
+            setAuthType(nextAuthType);
             // Credential ref changes above trigger a new TQ query key,
             // so the presence check auto-refetches for the new provider.
           }}
@@ -413,6 +418,14 @@ export function ProviderCreateForm({
           aria-label="Auth type"
           value={authType}
           onChange={(v) => {
+            if (!getDirty()) {
+              const { key: seedKey } = deriveProviderDefaults(
+                provider,
+                existingNames,
+                { authType: v },
+              );
+              setName(seedKey);
+            }
             setAuthType(v);
             setError(null);
           }}


### PR DESCRIPTION
## Summary
- Default BYOK provider connection keys to the canonical `*-personal` alias, e.g. `anthropic-personal`.
- When a clean provider-create form switches from Platform-managed proxying to a local provider credential, reseed the Key field to the BYOK alias.
- Add focused web coverage for BYOK alias defaulting.

## Notes
- This does not clean up existing duplicate connections.
- Managed proxy connections such as `anthropic-managed` remain separate from BYOK/local provider-credential connections.

## Tests
- `cd clients/web && bun test src/domains/settings/ai/profile-prefill.test.ts src/domains/settings/ai/provider-create-form.test.tsx`
- `cd clients/web && bunx eslint src/domains/settings/ai/profile-prefill.ts src/domains/settings/ai/profile-prefill.test.ts src/domains/settings/ai/provider-create-form.tsx src/domains/settings/ai/provider-create-form.test.tsx`
