### PR TITLE
fix(chat): cap the expanded subagent objective height (bounded scroll)

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -413,7 +413,9 @@ export function SubagentDetailPanel({
                     variant="body-medium-lighter"
                     as="p"
                     className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
-                      objectiveExpanded ? "" : "line-clamp-5"
+                      objectiveExpanded
+                        ? "max-h-[280px] overflow-y-auto"
+                        : "line-clamp-5"
                     }`}
                   >
                     {entry.objective}


### PR DESCRIPTION
## Summary
- The subagent detail panel's **Objective** section expanded unbounded on "Show more" (`line-clamp-5` → no clamp), pushing the **Timeline** (the live content you're watching) down within the panel's single scroll container.
- Option A: cap the expanded objective at `max-h-[280px]` with its own `overflow-y-auto`, so a long objective scrolls inside its own box and the Timeline is displaced by at most that bounded amount instead of unbounded.

## Notes
- CSS-only change (className swap) in `subagent-detail-panel.tsx`. The "Show more"/"Show less" toggle and the overflow detection are unchanged.
- Follow-up candidate: apply the same bounded-expand pattern to the workflow/tool detail panels.