### PR TITLE
fix(chat): make expanded subagent objective keyboard-scrollable (a11y follow-up to #36172)

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -412,6 +412,12 @@ export function SubagentDetailPanel({
                     ref={objectiveBodyRef}
                     variant="body-medium-lighter"
                     as="p"
+                    // When expanded the text becomes its own scroll container, so
+                    // make it a focusable, labelled region — otherwise keyboard
+                    // users can't reach the overflowed objective content.
+                    tabIndex={objectiveExpanded ? 0 : undefined}
+                    role={objectiveExpanded ? "region" : undefined}
+                    aria-label={objectiveExpanded ? "Objective" : undefined}
                     className={`whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)] ${
                       objectiveExpanded
                         ? "max-h-[280px] overflow-y-auto"


### PR DESCRIPTION
## Summary
- Follow-up to #36172 (already merged) addressing Codex's P2 accessibility review.
- In #36172 the expanded **Objective** became its own scroll container (`max-h-[280px] overflow-y-auto`), but the rendered `<p>` was not focusable. After a keyboard user activates "Show more", focus stays on the toggle below the text, so arrow/PageDown scrolling moves the outer panel rather than the overflowed objective — the rest of the objective was only reachable with a pointer.
- Fix: while expanded, make the objective a focusable, labelled scroll region (`tabIndex={0}` + `role="region"` + `aria-label="Objective"`). Collapsed state is line-clamped (not scrollable), so the props are omitted there.

## Notes
- Matches the `role="region"` scroll-container pattern already used in web (e.g. `terminal-console.tsx`).
- `Typography` forwards arbitrary DOM props (`...rest` over `HTMLAttributes<HTMLElement>`), so no design-library change is needed.
- CSS/prop-only change in `subagent-detail-panel.tsx`; clamp threshold and overflow detection unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)