### PR TITLE
fix(chat): size the active-overlay dropdown to the available column, not the viewport

### DIFF
--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -3,6 +3,21 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Typography } from "@vellumai/design-library";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
+/** Design max width of the dropdown (Figma 6063:149685). */
+const DROPDOWN_MAX_PX = 589;
+/** Min gutter (2rem) kept on each side of the chat column so it never clips. */
+const DROPDOWN_GUTTER_PX = 32;
+
+/** Geometry of the dropdown's positioning context, measured from the DOM. */
+interface ShellMetrics {
+  /** `clientWidth` of the offsetParent (the chat column / positioned ancestor). */
+  available: number;
+  /** Pill (shell root) left edge, relative to the offsetParent's content box. */
+  containerLeft: number;
+  /** Pill (shell root) width — the anchor the dropdown centers on. */
+  containerWidth: number;
+}
+
 export interface ActiveOverlayShellProps {
   /** `data-testid` for the root container (e.g. `"active-workflows-overlay"`). */
   testId: string;
@@ -32,6 +47,81 @@ export function ActiveOverlayShell({
   const [expanded, setExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const reduce = useReducedMotion();
+  // Measured geometry of the bounding chat column. `null` until measured
+  // (happy-dom/SSR have no layout) — see the fitted-width fallback below.
+  const [metrics, setMetrics] = useState<ShellMetrics | null>(null);
+
+  // Measure the chat column (the shell root's offsetParent — the nearest
+  // positioned ancestor) so the dropdown fits the available width instead of
+  // the viewport. Re-measure on open, on column resize (live detail-panel
+  // width + sidebar collapse both reflow it), and on window resize.
+  useEffect(() => {
+    const measure = () => {
+      const el = containerRef.current;
+      const parent = el?.offsetParent as HTMLElement | null;
+      const available = parent?.clientWidth ?? 0;
+      if (!el || !parent || available <= 0) {
+        setMetrics((prev) => (prev === null ? prev : null));
+        return;
+      }
+      const elRect = el.getBoundingClientRect();
+      const parentRect = parent.getBoundingClientRect();
+      const containerLeft = elRect.left - parentRect.left;
+      const containerWidth = elRect.width;
+      // Skip no-op updates: the observer fires on every reflow pixel while a
+      // detail panel is dragged, but downstream only cares when a value changed.
+      setMetrics((prev) =>
+        prev &&
+        prev.available === available &&
+        prev.containerLeft === containerLeft &&
+        prev.containerWidth === containerWidth
+          ? prev
+          : { available, containerLeft, containerWidth },
+      );
+    };
+
+    measure();
+
+    const parent = containerRef.current?.offsetParent as HTMLElement | null;
+    let observer: ResizeObserver | undefined;
+    if (parent && typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(measure);
+      observer.observe(parent);
+    }
+    window.addEventListener("resize", measure);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [expanded]);
+
+  // Fitted width: cap at the design max, shrink to the column minus gutters.
+  // Unmeasured (happy-dom / pre-measure / detached) → keep the requested max,
+  // mirroring `animated-right-drawer`'s "unmeasured container keeps requested
+  // width" fallback. Never produce a width <= 0.
+  const fittedWidth = metrics
+    ? Math.max(1, Math.min(DROPDOWN_MAX_PX, metrics.available - DROPDOWN_GUTTER_PX))
+    : DROPDOWN_MAX_PX;
+
+  // Horizontal placement. The transform keeps `x: "-50%"` (centering on the
+  // pill); we only adjust the `left` anchor so a far-off-center pill (two
+  // pills side by side) can't push the box past either column gutter.
+  // Unmeasured → fall back to the `left-1/2` (50%) anchor.
+  let dropdownLeft: number | string = "50%";
+  if (metrics) {
+    const pillCenter = metrics.containerLeft + metrics.containerWidth / 2;
+    const boxLeftDefault = pillCenter - fittedWidth / 2;
+    const lo = DROPDOWN_GUTTER_PX;
+    const hi = metrics.available - DROPDOWN_GUTTER_PX - fittedWidth;
+    // When the box can't fit both gutters (very narrow column) center it.
+    const boxLeft =
+      hi >= lo
+        ? Math.max(lo, Math.min(boxLeftDefault, hi))
+        : (metrics.available - fittedWidth) / 2;
+    // Convert the parent-relative box-left back to the `left` value that, with
+    // the `x: "-50%"` transform, lands the box there: left = boxLeft - C + w/2.
+    dropdownLeft = boxLeft - metrics.containerLeft + fittedWidth / 2;
+  }
 
   // While open, dismiss on outside pointerdown or Escape.
   useEffect(() => {
@@ -76,15 +166,19 @@ export function ActiveOverlayShell({
 
       <AnimatePresence>
         {expanded && (
-          // Absolute dropdown anchored under the pill so its 589px width no longer
-          // dictates the row's width (Figma 6063:149685).
+          // Absolute dropdown anchored under the pill so its width no longer
+          // dictates the row's width (Figma 6063:149685). Width is fitted to the
+          // chat column (see `fittedWidth`) rather than the viewport.
           <motion.div
             // Horizontal centering lives in motion's `x: "-50%"` (not a
             // `-translate-x-1/2` class) so it composes with the animated
             // `scale`/`y` in the same inline `transform` — version-independent
             // of Tailwind's translate-property model.
-            className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
-            style={{ transformOrigin: "top center" }}
+            className="pointer-events-auto absolute top-full z-20 mt-2 flex flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
+            // Width fits the chat column (not the viewport) so a detail panel +
+            // sidebar can't clip it; `left` is the clamped anchor that pairs
+            // with the `x: "-50%"` transform below.
+            style={{ width: fittedWidth, left: dropdownLeft, transformOrigin: "top center" }}
             initial={{ opacity: 0, scale: 0.96, y: -4, x: "-50%" }}
             animate={{ opacity: 1, scale: 1, y: 0, x: "-50%" }}
             exit={{ opacity: 0, scale: 0.96, y: -4, x: "-50%" }}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -96,6 +96,12 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     const panel = title.parentElement;
     expect(panel?.className).toContain("absolute");
     expect(panel?.className).toContain("pointer-events-auto");
+
+    // Width is driven by the measured-column fallback (happy-dom has no layout),
+    // so it must resolve to a finite, positive px value — not 0 or NaN.
+    const fittedWidth = Number.parseFloat(panel?.style.width ?? "");
+    expect(Number.isFinite(fittedWidth)).toBe(true);
+    expect(fittedWidth).toBeGreaterThan(0);
   });
 
   test("clicking a collapsed avatar expands the panel", () => {

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -94,6 +94,12 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
     const panel = title.parentElement;
     expect(panel?.className).toContain("absolute");
     expect(panel?.className).toContain("pointer-events-auto");
+
+    // Width is driven by the measured-column fallback (happy-dom has no layout),
+    // so it must resolve to a finite, positive px value — not 0 or NaN.
+    const fittedWidth = Number.parseFloat(panel?.style.width ?? "");
+    expect(Number.isFinite(fittedWidth)).toBe(true);
+    expect(fittedWidth).toBeGreaterThan(0);
   });
 
   test("uses the singular noun when exactly one workflow is active", () => {


### PR DESCRIPTION
## Summary
- Measure the chat column (ResizeObserver on the shell's positioning context) and cap the active-overlay dropdown width at min(589, available-32) so it never clips when a detail panel + sidebar are open; unmeasured fallback = 589.
- Preserves the existing fade+scale animation, reduced-motion, no-scrim click-through, dismiss, and internal scroll.

Part of plan: active-overlay-fit-drill-in.md (PR 1 of 2)