### PR TITLE
feat(chat): close the active-overlay dropdown when a subagent/workflow is opened

### DIFF
--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -25,8 +25,12 @@ export interface ActiveOverlayShellProps {
   title: string;
   /** Renders the pill; receives the current expand state + a toggle handler. */
   renderPill: (args: { expanded: boolean; onToggle: () => void }) => ReactNode;
-  /** The mapped inline-card rows shown inside the expanded dropdown. */
-  children: ReactNode;
+  /**
+   * Renders the mapped inline-card rows shown inside the expanded dropdown.
+   * Receives `close()` so a row can drill into its detail panel and dismiss the
+   * dropdown in one click (both heavy layers stop competing for column width).
+   */
+  children: (api: { close: () => void }) => ReactNode;
 }
 
 /**
@@ -193,7 +197,7 @@ export function ActiveOverlayShell({
               {title}
             </Typography>
             <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-              {children}
+              {children({ close: () => setExpanded(false) })}
             </div>
           </motion.div>
         )}

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -149,6 +149,53 @@ describe("ActiveSubagentsOverlay — expanded", () => {
   });
 });
 
+describe("ActiveSubagentsOverlay — drill-in", () => {
+  test("opening a row fires onSubagentClick and closes the dropdown", async () => {
+    const ids = seedMany(2);
+    const opened: string[] = [];
+    const { queryByText } = render(
+      <ActiveSubagentsOverlay
+        subagentIds={ids}
+        onSubagentClick={(id) => opened.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /open subagent/i })[0],
+    );
+
+    // The detail panel still opens (existing behavior).
+    expect(opened).toEqual(["sa-0"]);
+    // ...and the dropdown then closes so the two layers stop competing. It
+    // animates out via AnimatePresence (~1.8s in happy-dom), so wait it out.
+    await waitFor(
+      () => expect(queryByText("2 Active Subagents")).toBeNull(),
+      { timeout: 4000 },
+    );
+  });
+
+  test("stopping a row does NOT close the dropdown", () => {
+    const ids = seedMany(2);
+    const stopped: string[] = [];
+    const { queryByText } = render(
+      <ActiveSubagentsOverlay
+        subagentIds={ids}
+        onStopSubagent={(id) => stopped.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
+    fireEvent.click(screen.getAllByTestId("subagent-inline-card-stop")[0]);
+
+    expect(stopped).toEqual(["sa-0"]);
+    // Stopping keeps the list open so you can stop another / keep watching.
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+  });
+});
+
 describe("ActiveSubagentsOverlay — dismissal", () => {
   test("Escape collapses the open panel", async () => {
     const ids = seedMany(2);

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -29,14 +29,25 @@ export function ActiveSubagentsOverlay({
         />
       )}
     >
-      {subagentIds.map((id) => (
-        <SubagentInlineProgressCard
-          key={id}
-          subagentId={id}
-          onSubagentClick={onSubagentClick}
-          onStopSubagent={onStopSubagent}
-        />
-      ))}
+      {({ close }) =>
+        subagentIds.map((id) => (
+          <SubagentInlineProgressCard
+            key={id}
+            subagentId={id}
+            // Opening drills into the detail panel and dismisses the dropdown
+            // so the two layers stop competing for width; stopping keeps it open.
+            onSubagentClick={
+              onSubagentClick
+                ? (sid) => {
+                    onSubagentClick(sid);
+                    close();
+                  }
+                : undefined
+            }
+            onStopSubagent={onStopSubagent}
+          />
+        ))
+      }
     </ActiveOverlayShell>
   );
 }

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -19,8 +19,34 @@ import {
 mock.module(
   "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card",
   () => ({
-    WorkflowInlineProgressCard: ({ runId }: { runId: string }) => (
-      <div data-testid="wf-card" data-run-id={runId} />
+    // Mirrors the real card's affordances (open present only when clickable,
+    // stop present only when stoppable) so the overlay's drill-in/stop wiring
+    // can be exercised without hydrating the workflow store.
+    WorkflowInlineProgressCard: ({
+      runId,
+      onWorkflowClick,
+      onStopWorkflow,
+    }: {
+      runId: string;
+      onWorkflowClick?: (runId: string) => void;
+      onStopWorkflow?: (runId: string) => void;
+    }) => (
+      <div data-testid="wf-card" data-run-id={runId}>
+        {onWorkflowClick ? (
+          <button
+            type="button"
+            aria-label="Open workflow"
+            onClick={() => onWorkflowClick(runId)}
+          />
+        ) : null}
+        {onStopWorkflow ? (
+          <button
+            type="button"
+            aria-label="Stop workflow"
+            onClick={() => onStopWorkflow(runId)}
+          />
+        ) : null}
+      </div>
     ),
   }),
 );
@@ -110,6 +136,55 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
 
     expect(screen.getByText("1 Active Workflow")).toBeTruthy();
     expect(screen.queryByText("1 Active Workflows")).toBeNull();
+  });
+});
+
+describe("ActiveWorkflowsOverlay — drill-in", () => {
+  test("opening a row fires onWorkflowClick and closes the dropdown", async () => {
+    const ids = makeIds(2);
+    const opened: string[] = [];
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay
+        workflowRunIds={ids}
+        onWorkflowClick={(id) => opened.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /open workflow/i })[0],
+    );
+
+    // The detail panel still opens (existing behavior).
+    expect(opened).toEqual(["wf-0"]);
+    // ...and the dropdown then closes so the two layers stop competing. It
+    // animates out via AnimatePresence (~1.8s in happy-dom), so wait it out.
+    await waitFor(
+      () => expect(queryByText("2 Active Workflows")).toBeNull(),
+      { timeout: 4000 },
+    );
+  });
+
+  test("stopping a row does NOT close the dropdown", () => {
+    const ids = makeIds(2);
+    const stopped: string[] = [];
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay
+        workflowRunIds={ids}
+        onStopWorkflow={(id) => stopped.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /stop workflow/i })[0],
+    );
+
+    expect(stopped).toEqual(["wf-0"]);
+    // Stopping keeps the list open so you can stop another / keep watching.
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
   });
 });
 

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -29,14 +29,25 @@ export function ActiveWorkflowsOverlay({
         />
       )}
     >
-      {workflowRunIds.map((runId) => (
-        <WorkflowInlineProgressCard
-          key={runId}
-          runId={runId}
-          onWorkflowClick={onWorkflowClick}
-          onStopWorkflow={onStopWorkflow}
-        />
-      ))}
+      {({ close }) =>
+        workflowRunIds.map((runId) => (
+          <WorkflowInlineProgressCard
+            key={runId}
+            runId={runId}
+            // Opening drills into the detail panel and dismisses the dropdown
+            // so the two layers stop competing for width; stopping keeps it open.
+            onWorkflowClick={
+              onWorkflowClick
+                ? (id) => {
+                    onWorkflowClick(id);
+                    close();
+                  }
+                : undefined
+            }
+            onStopWorkflow={onStopWorkflow}
+          />
+        ))
+      }
     </ActiveOverlayShell>
   );
 }


### PR DESCRIPTION
## Summary
- The active subagents/workflows overlay now closes when you select a row (which already opens the detail panel), so the two layers stop competing for horizontal space.
- Shell children become a render-prop exposing close(); stop actions do not close. Honors prefers-reduced-motion.

Part of plan: active-overlay-fit-drill-in.md (PR 2 of 2)