### PR TITLE
Combo 11: remove gateway ACL mirror writes to the assistant DB (+ repoint coupled reads)

### DIFF
--- a/gateway/src/__tests__/assistant-acl-write-drain.test.ts
+++ b/gateway/src/__tests__/assistant-acl-write-drain.test.ts
@@ -13,14 +13,16 @@ import { join } from "node:path";
  *   contact_channels.{status, policy, verified_at, verified_via,
  *                     revoked_reason, blocked_reason}
  *
- * RESIDUAL ASSISTANT-DB ACL READS still pending before the DROP (PR-7 inventory):
+ * RESIDUAL ASSISTANT-DB ACL READS still pending before the DROP:
  *   - gateway/src/db/data-migrations/m0006-*: one-time reconcile reads assistant
  *     ACL columns to seed the gateway DB.
  *   - gateway/src/db/data-migrations/m0008-*: one-time backfill reads assistant
  *     ACL columns.
- *   These are append-only one-time migrations and must be drained (no longer
- *   reading assistant ACL) before migration 302 drops the columns. The
- *   WRITE side is now clean — this guard asserts and protects that.
+ *   These append-only one-time migrations are the ONLY remaining assistant-DB
+ *   ACL reads; they are retired at the assistant DROP-COLUMN migration (302).
+ *   The heal/seed reads (the channel-mirror heal and the inbound contact-seed
+ *   blocked-check) are drained — they read identity/info only and resolve ACL
+ *   from the gateway DB. The WRITE side is clean — this guard asserts that.
  */
 
 // Deliberate, greppable exceptions. Must stay empty: every entry is an

--- a/gateway/src/__tests__/assistant-acl-write-drain.test.ts
+++ b/gateway/src/__tests__/assistant-acl-write-drain.test.ts
@@ -1,0 +1,215 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * DROP-safety guard: the gateway no longer WRITES the 8 ACL columns into the
+ * assistant DB (the gateway DB is the source of truth). This source scan fails
+ * if any assistantDbRun(/assistantDbExec( call site writes one of those columns,
+ * so the assistant-side DROP-COLUMN migration (302) stays safe.
+ *
+ * 8 ACL columns (gateway-owned, assistant-mirror dropped):
+ *   contacts.role, contacts.principal_id
+ *   contact_channels.{status, policy, verified_at, verified_via,
+ *                     revoked_reason, blocked_reason}
+ *
+ * RESIDUAL ASSISTANT-DB ACL READS still pending before the DROP (PR-7 inventory):
+ *   - gateway/src/db/data-migrations/m0006-*: one-time reconcile reads assistant
+ *     ACL columns to seed the gateway DB.
+ *   - gateway/src/db/data-migrations/m0008-*: one-time backfill reads assistant
+ *     ACL columns.
+ *   These are append-only one-time migrations and must be drained (no longer
+ *   reading assistant ACL) before migration 302 drops the columns. The
+ *   WRITE side is now clean — this guard asserts and protects that.
+ */
+
+// Deliberate, greppable exceptions. Must stay empty: every entry is an
+// assistant-DB ACL write that the DROP migration would break.
+const ACL_WRITE_ALLOWLIST: string[] = [];
+
+const ACL_COLUMNS = [
+  "role",
+  "principal_id",
+  "status",
+  "policy",
+  "verified_at",
+  "verified_via",
+  "revoked_reason",
+  "blocked_reason",
+] as const;
+
+// Info columns are assistant-owned and intentionally NOT flagged.
+const INFO_COLUMNS = ["last_seen_at", "interaction_count", "last_interaction"];
+
+const GATEWAY_SRC = join(import.meta.dirname!, "..");
+
+const EXCLUDED_DIRS = new Set(["__tests__", "data-migrations"]);
+const EXCLUDED_FILES = new Set(["assistant-db-proxy.ts"]);
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry)) continue;
+      out.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (!entry.endsWith(".ts")) continue;
+    if (entry.endsWith(".test.ts")) continue;
+    if (EXCLUDED_FILES.has(entry)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Extract the SQL string literal argument of an assistantDbRun/assistantDbExec
+ * call starting at `callStart`. Handles template literals and quoted strings
+ * spanning multiple lines. Returns the literal text (without delimiters) and
+ * the index just past it, or null if no string literal follows the open paren.
+ */
+function extractSqlArg(
+  src: string,
+  callStart: number,
+): { sql: string; end: number } | null {
+  const open = src.indexOf("(", callStart);
+  if (open === -1) return null;
+  let i = open + 1;
+  // Skip whitespace to the first argument.
+  while (i < src.length && /\s/.test(src[i])) i++;
+  const quote = src[i];
+  if (quote !== "`" && quote !== '"' && quote !== "'") return null;
+  const start = i + 1;
+  i = start;
+  while (i < src.length) {
+    if (src[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (src[i] === quote) {
+      return { sql: src.slice(start, i), end: i + 1 };
+    }
+    i++;
+  }
+  return null;
+}
+
+// Only writes to these tables carry the dropped ACL columns. status/policy
+// etc. on other tables (channel_verification_sessions, *_ingress_invites) are
+// unrelated and must not be flagged.
+const ACL_TABLES = ["contacts", "contact_channels"];
+
+/** True if `sql` writes one of the 8 ACL columns into contacts/contact_channels. */
+function sqlWritesAclColumn(sql: string): boolean {
+  const normalized = sql.replace(/\s+/g, " ").toLowerCase();
+
+  // INSERT INTO <table> (col, col, ...) — an ACL column named for an ACL table.
+  const insertMatch = normalized.match(
+    /insert(?:\s+or\s+\w+)?\s+into\s+([a-z_]+)\s*\(([^)]*)\)/,
+  );
+  if (insertMatch && ACL_TABLES.includes(insertMatch[1])) {
+    const cols = insertMatch[2].split(",").map((c) => c.trim());
+    if (cols.some((c) => (ACL_COLUMNS as readonly string[]).includes(c))) {
+      return true;
+    }
+  }
+
+  // UPDATE <table> SET <acl_col> = — an ACL column assigned on an ACL table.
+  // Scope to the SET clause (up to WHERE) so a WHERE-clause ACL column isn't
+  // mistaken for an assignment.
+  const updateMatch = normalized.match(
+    /update\s+([a-z_]+)\s+set\s+(.*?)(?:\swhere\s|$)/,
+  );
+  if (updateMatch && ACL_TABLES.includes(updateMatch[1])) {
+    const setClause = updateMatch[2];
+    for (const col of ACL_COLUMNS) {
+      // Require an assignment to avoid flagging references, and word-boundary
+      // so principal_id doesn't match as a substring.
+      const re = new RegExp(`\\b${col}\\s*=`, "i");
+      if (re.test(setClause)) return true;
+    }
+  }
+
+  return false;
+}
+
+describe("assistant-DB ACL write drain guard", () => {
+  test("no assistantDbRun/assistantDbExec call writes a dropped ACL column", () => {
+    const files = collectSourceFiles(GATEWAY_SRC);
+    const violations: string[] = [];
+
+    const callRe = /assistantDb(?:Run|Exec)\s*\(/g;
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf-8");
+      let m: RegExpExecArray | null;
+      callRe.lastIndex = 0;
+      while ((m = callRe.exec(src)) !== null) {
+        const arg = extractSqlArg(src, m.index);
+        if (!arg) continue;
+        if (sqlWritesAclColumn(arg.sql)) {
+          const rel = file.slice(GATEWAY_SRC.length + 1);
+          if (ACL_WRITE_ALLOWLIST.includes(rel)) continue;
+          violations.push(`${rel}: ${arg.sql.replace(/\s+/g, " ").trim()}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("matcher flags ACL writes but not info-column or read SQL", () => {
+    // ACL writes (must be flagged)
+    expect(
+      sqlWritesAclColumn("UPDATE contacts SET role = ? WHERE id = ?"),
+    ).toBe(true);
+    expect(
+      sqlWritesAclColumn(
+        "UPDATE contact_channels SET status = ?, policy = ? WHERE id = ?",
+      ),
+    ).toBe(true);
+    expect(
+      sqlWritesAclColumn(
+        "INSERT INTO contacts (id, role, principal_id) VALUES (?, ?, ?)",
+      ),
+    ).toBe(true);
+
+    // Info-column writes (must NOT be flagged)
+    expect(
+      sqlWritesAclColumn(
+        "UPDATE contact_channels SET last_seen_at = ?, interaction_count = ? WHERE id = ?",
+      ),
+    ).toBe(false);
+    expect(
+      sqlWritesAclColumn(
+        "INSERT INTO contact_channels (id, last_seen_at, interaction_count, last_interaction) VALUES (?, ?, ?, ?)",
+      ),
+    ).toBe(false);
+
+    // Identity/info-only writes (must NOT be flagged)
+    expect(
+      sqlWritesAclColumn(
+        "UPDATE contacts SET display_name = ?, updated_at = ? WHERE id = ?",
+      ),
+    ).toBe(false);
+
+    // Reads referencing ACL columns (must NOT be flagged)
+    expect(
+      sqlWritesAclColumn(
+        "SELECT cc.status FROM contact_channels cc WHERE cc.status = 'active'",
+      ),
+    ).toBe(false);
+  });
+
+  test("allowlist is empty (no sanctioned ACL writes remain)", () => {
+    expect(ACL_WRITE_ALLOWLIST).toEqual([]);
+    // Guard that INFO_COLUMNS and ACL_COLUMNS stay disjoint.
+    expect(
+      INFO_COLUMNS.filter((c) =>
+        (ACL_COLUMNS as readonly string[]).includes(c),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/gateway/src/__tests__/binding-helpers.test.ts
+++ b/gateway/src/__tests__/binding-helpers.test.ts
@@ -1,9 +1,8 @@
 /**
- * Tests for the guardian binding-helper lookups, which read the gateway DB
+ * Tests for the guardian binding helpers, which read and write the gateway DB
  * (source of truth for ACL). The gateway DB is a real (file-backed) DB seeded
- * per test; the assistant DB proxy is mocked and throws on read so the tests
- * prove the lookups never touch the assistant mirror. revokeExistingChannel
- * Guardian still writes both the assistant UPDATE and the gateway dual-write.
+ * per test; the assistant DB proxy is mocked and throws on every call so the
+ * tests prove the helpers never touch the assistant mirror.
  */
 
 import {
@@ -18,59 +17,14 @@ import {
 
 import "./test-preload.js";
 
-// Assistant DB proxy: reads throw (lookups must not touch it); the revoke
-// UPDATE is captured so we can assert the assistant mirror write still fires.
-// A simple in-memory `contact_channels` model lets us prove the id-keyed
-// update vs. the (type,address) logical-key fallback under id-divergence.
-const assistantRunCalls: { sql: string; bind?: unknown[] }[] = [];
-
-type AsstChannel = {
-  id: string;
-  type: string;
-  address: string;
-  status: string;
-  policy: string;
-};
-const asstChannels: AsstChannel[] = [];
-
-function seedAsstChannel(c: AsstChannel): void {
-  asstChannels.push(c);
-}
-
-let throwOnAsstRun = false;
-
+// Assistant DB proxy: every call throws so the tests prove the helpers read
+// and write only the gateway DB.
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbQuery: mock(async () => {
-    throw new Error("assistant DB read not expected in binding lookups");
+    throw new Error("assistant DB read not expected in binding helpers");
   }),
-  assistantDbRun: mock(async (sql: string, bind?: unknown[]) => {
-    assistantRunCalls.push({ sql, bind });
-    if (throwOnAsstRun) throw new Error("assistant DB proxy unavailable");
-    let changes = 0;
-    if (/WHERE id = \?/.test(sql)) {
-      const id = bind?.[1];
-      for (const ch of asstChannels) {
-        if (ch.id === id) {
-          ch.status = "revoked";
-          ch.policy = "deny";
-          changes++;
-        }
-      }
-    } else if (/WHERE type = \? AND address = \?/.test(sql)) {
-      const type = bind?.[1];
-      const address = bind?.[2];
-      for (const ch of asstChannels) {
-        if (
-          ch.type === type &&
-          ch.address.toLowerCase() === String(address).toLowerCase()
-        ) {
-          ch.status = "revoked";
-          ch.policy = "deny";
-          changes++;
-        }
-      }
-    }
-    return { changes, lastInsertRowid: 0 };
+  assistantDbRun: mock(async () => {
+    throw new Error("assistant DB write not expected in binding helpers");
   }),
   assistantDbExec: mock(async () => undefined),
 }));
@@ -96,8 +50,6 @@ beforeEach(() => {
   const db = getGatewayDb();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
-  assistantRunCalls.length = 0;
-  asstChannels.length = 0;
 });
 
 afterAll(() => {
@@ -248,7 +200,7 @@ describe("resolveCanonicalPrincipal", () => {
 });
 
 describe("revokeExistingChannelGuardian", () => {
-  test("revokes the gateway channel and mirrors the write to the assistant DB", async () => {
+  test("revokes the active guardian channel in the gateway DB only", async () => {
     seedContact({ id: "g1", role: "guardian" });
     const chId = seedChannel({
       contactId: "g1",
@@ -256,18 +208,9 @@ describe("revokeExistingChannelGuardian", () => {
       address: "U_OWNER",
       status: "active",
     });
-    // Assistant row shares the same id — the id-keyed update matches.
-    seedAsstChannel({
-      id: chId,
-      type: "slack",
-      address: "U_OWNER",
-      status: "active",
-      policy: "allow",
-    });
 
     await revokeExistingChannelGuardian("slack");
 
-    // Gateway DB status flipped to revoked.
     const after = getGatewayDb()
       .select()
       .from(contactChannels)
@@ -275,79 +218,48 @@ describe("revokeExistingChannelGuardian", () => {
       .find((r) => r.id === chId);
     expect(after?.status).toBe("revoked");
     expect(after?.policy).toBe("deny");
-
-    // Assistant mirror revoked via the id-keyed update (no fallback needed).
-    expect(assistantRunCalls.length).toBe(1);
-    expect(assistantRunCalls[0]!.sql).toContain("WHERE id = ?");
-    expect(assistantRunCalls[0]!.bind).toContain(chId);
-    expect(asstChannels[0]!.status).toBe("revoked");
-    expect(asstChannels[0]!.policy).toBe("deny");
   });
 
-  test("revokes the assistant mirror by (type,address) when ids diverge", async () => {
+  test("revokes every active guardian channel for the type", async () => {
     seedContact({ id: "g1", role: "guardian" });
-    // Gateway guardian channel under id G.
-    seedChannel({
-      id: "G",
+    const a = seedChannel({
       contactId: "g1",
       type: "slack",
-      address: "U_OWNER",
+      address: "U_A",
       status: "active",
     });
-    // Assistant row shares (type,address) but sits under a DIFFERENT id A.
-    seedAsstChannel({
-      id: "A",
+    const b = seedChannel({
+      contactId: "g1",
       type: "slack",
-      address: "U_OWNER",
+      address: "U_B",
       status: "active",
-      policy: "allow",
     });
 
     await revokeExistingChannelGuardian("slack");
 
-    // id-keyed update missed; logical-key fallback revoked row A.
-    expect(asstChannels[0]!.status).toBe("revoked");
-    expect(asstChannels[0]!.policy).toBe("deny");
-    expect(assistantRunCalls.length).toBe(2);
-    expect(assistantRunCalls[0]!.sql).toContain("WHERE id = ?");
-    expect(assistantRunCalls[1]!.sql).toContain(
-      "WHERE type = ? AND address = ? COLLATE NOCASE",
-    );
-  });
-
-  test("no-ops (no writes) when no active guardian binding exists", async () => {
-    seedContact({ id: "g1", role: "guardian" });
-    seedChannel({ contactId: "g1", type: "slack", status: "revoked" });
-
-    await revokeExistingChannelGuardian("slack");
-
-    expect(assistantRunCalls.length).toBe(0);
-  });
-
-  test("revokes the gateway row even when the assistant mirror fails", async () => {
-    seedContact({ id: "g1", role: "guardian" });
-    const chId = seedChannel({
-      contactId: "g1",
-      type: "slack",
-      address: "U_OWNER",
-      status: "active",
-    });
-
-    throwOnAsstRun = true;
-    try {
-      // Must not throw — the best-effort mirror failure is swallowed.
-      await revokeExistingChannelGuardian("slack");
-    } finally {
-      throwOnAsstRun = false;
+    const rows = getGatewayDb().select().from(contactChannels).all();
+    for (const id of [a, b]) {
+      const row = rows.find((r) => r.id === id);
+      expect(row?.status).toBe("revoked");
+      expect(row?.policy).toBe("deny");
     }
+  });
 
-    // Gateway (source of truth) is revoked despite the mirror failure.
+  test("no-ops when no active guardian binding exists", async () => {
+    seedContact({ id: "g1", role: "guardian" });
+    const chId = seedChannel({
+      contactId: "g1",
+      type: "slack",
+      status: "revoked",
+    });
+
+    await revokeExistingChannelGuardian("slack");
+
     const after = getGatewayDb()
       .select()
       .from(contactChannels)
       .all()
       .find((r) => r.id === chId);
     expect(after?.status).toBe("revoked");
-    expect(after?.policy).toBe("deny");
   });
 });

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -233,26 +233,23 @@ describe("mark_channel_verified IPC handler", () => {
     ).rejects.toThrow(/not found/);
   });
 
-  test("inherits assistant-mirror behavior: a gateway-absent channel is mirrored then verified", async () => {
+  test("does not verify a channel absent from the gateway DB", async () => {
     seedAssistantContact("c1");
     seedAssistantChannel({ id: "ch1", contactId: "c1", status: "unverified" });
 
-    const res = (await markChannelVerifiedHandler({
-      contactChannelId: "ch1",
-    })) as { ok: boolean; didWrite: boolean; channel: { status: string } };
+    // The channel lives only in the assistant DB. The gateway DB is the source
+    // of truth and does not heal from the assistant, so verification reports
+    // not found and nothing lands in the gateway DB.
+    await expect(
+      markChannelVerifiedHandler({ contactChannelId: "ch1" }),
+    ).rejects.toThrow(/not found/);
 
-    expect(res.ok).toBe(true);
-    expect(res.didWrite).toBe(true);
-    expect(res.channel.status).toBe("active");
-
-    // Channel + parent contact were materialized into the gateway DB.
     const channelInGateway = getGatewayDb()
       .select()
       .from(contactChannels)
       .where(eq(contactChannels.id, "ch1"))
       .get();
-    expect(channelInGateway).toBeTruthy();
-    expect(channelInGateway!.contactId).toBe("c1");
+    expect(channelInGateway).toBeUndefined();
   });
 });
 

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -704,65 +704,7 @@ describe("handleContactPromptSubmit", () => {
     expect(ipcCall.body.error).toBeUndefined();
   });
 
-  test("guardian bootstrap-create — assistant mirror keeps role='guardian' even if create-mirror INSERT fails", async () => {
-    // No guardian seeded: handler mints one gateway-first. Make the
-    // bootstrap-create assistant mirror INSERT (role='guardian') fail, so the
-    // assistant DB has no guardian row when Phase-2 upsertContact runs. Without
-    // the role re-assert, that upsert would INSERT the id with role='contact',
-    // downgrading the guardian in the mirror.
-    const realDb = testAssistantDb!;
-    let failNextGuardianInsert = true;
-    testAssistantDb = {
-      prepare(sql: string) {
-        if (
-          failNextGuardianInsert &&
-          /INSERT INTO contacts/i.test(sql) &&
-          /'guardian'/.test(sql)
-        ) {
-          failNextGuardianInsert = false;
-          throw new Error("assistant DB guardian INSERT unavailable");
-        }
-        return realDb.prepare(sql);
-      },
-    } as unknown as Database;
-
-    let res: Response;
-    try {
-      res = await handleContactPromptSubmit(
-        makeRequest({
-          requestId: "req-boot-downgrade",
-          address: "+15552223333",
-          channelType: "phone",
-          role: "guardian",
-          displayName: "Mirror Guardian",
-        }),
-      );
-    } finally {
-      testAssistantDb = realDb;
-    }
-
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as Record<string, unknown>;
-    expect(body.accepted).toBe(true);
-
-    // Gateway DB: guardian minted with role=guardian (authoritative).
-    const gwGuardians = getGatewayDb()
-      .select()
-      .from(gwContacts)
-      .where(eq(gwContacts.role, "guardian"))
-      .all();
-    expect(gwGuardians).toHaveLength(1);
-
-    // Assistant mirror: the role re-assert healed any Phase-2 downgrade — the
-    // row exists and is role='guardian', NOT 'contact'.
-    const asContacts = testAssistantDb!
-      .prepare(`SELECT role FROM contacts WHERE id = ?`)
-      .all(gwGuardians[0].id) as { role: string }[];
-    expect(asContacts).toHaveLength(1);
-    expect(asContacts[0].role).toBe("guardian");
-  });
-
-  test("guardian bootstrap-create — assistant mirror row is role='guardian'", async () => {
+  test("guardian bootstrap-create — gateway is authoritative; assistant mirror row exists without ACL role", async () => {
     const res = await handleContactPromptSubmit(
       makeRequest({
         requestId: "req-boot-role",
@@ -776,6 +718,7 @@ describe("handleContactPromptSubmit", () => {
     expect(res.status).toBe(200);
     expect(((await res.json()) as Record<string, unknown>).accepted).toBe(true);
 
+    // Gateway DB is the source of truth for the guardian ACL role.
     const gwGuardians = getGatewayDb()
       .select()
       .from(gwContacts)
@@ -783,11 +726,13 @@ describe("handleContactPromptSubmit", () => {
       .all();
     expect(gwGuardians).toHaveLength(1);
 
+    // Assistant mirror is an identity mirror only — the row exists but no ACL
+    // role is written through, so it falls back to the schema default 'contact'.
     const asContacts = testAssistantDb!
       .prepare(`SELECT role FROM contacts WHERE id = ?`)
       .all(gwGuardians[0].id) as { role: string }[];
     expect(asContacts).toHaveLength(1);
-    expect(asContacts[0].role).toBe("guardian");
+    expect(asContacts[0].role).toBe("contact");
   });
 
   test("non-guardian prompt — 500 + daemon error when channel can't be resolved (no empty channelId)", async () => {

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -65,17 +65,9 @@ const fakeAssistantDb = {
 // Mock the assistant DB proxy before importing ContactStore. The fake
 // honors `SELECT ... FROM contact_channels WHERE id = ?` and
 // `SELECT ... FROM contacts WHERE id = ?`; all other SELECTs return [].
-// When set, the next id-keyed `UPDATE ... WHERE id = ?` reports 0 changes so
-// the logical-key fallback path is exercised. Cleared after one such update.
-let nextIdUpdateMisses = false;
-
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbRun: mock(async (sql: string, bind?: unknown[]) => {
     fakeAssistantDb.runCalls.push({ sql, bind });
-    if (nextIdUpdateMisses && /where id = \?/i.test(sql)) {
-      nextIdUpdateMisses = false;
-      return { changes: 0, lastInsertRowid: 0 };
-    }
     return { changes: 1, lastInsertRowid: 0 };
   }),
   assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
@@ -114,7 +106,6 @@ beforeEach(() => {
   db.delete(contactChannels).run();
   db.delete(contacts).run();
   fakeAssistantDb.reset();
-  nextIdUpdateMisses = false;
 });
 
 function seedAssistantContact(id: string, role: string = "guardian"): void {
@@ -290,7 +281,7 @@ describe("ContactStore.markChannelVerified", () => {
     expect(b!.channel.verifiedAt).toBe(a!.channel.verifiedAt);
   });
 
-  test("writes verifiedVia=challenge to gateway + assistant when passed", async () => {
+  test("writes verifiedVia=challenge to gateway; no assistant ACL write", async () => {
     seedContact("c1");
     seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
 
@@ -303,13 +294,13 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.channel.status).toBe("active");
     expect(result!.channel.verifiedVia).toBe("challenge");
 
-    // The assistant DB dual-write bound the same verifiedVia.
-    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
-      c.sql.includes("UPDATE contact_channels"),
-    );
-    expect(dualWrite).toBeTruthy();
-    expect(dualWrite!.bind).toContain("challenge");
-    expect(dualWrite!.bind).not.toContain("manual");
+    // The gateway DB is the source of truth; the assistant DB receives no
+    // ACL mirror write.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
   });
 
   test("is idempotent per-verifiedVia: a repeated challenge call is a no-op", async () => {
@@ -330,7 +321,7 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.didWrite).toBe(false);
     expect(result!.channel.verifiedAt).toBe(1000);
     expect(result!.channel.verifiedVia).toBe("challenge");
-    // No-op skips the assistant dual-write.
+    // No assistant-DB ACL mirror write.
     expect(
       fakeAssistantDb.runCalls.some((c) =>
         c.sql.includes("UPDATE contact_channels"),
@@ -346,10 +337,12 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.didWrite).toBe(true);
     expect(result!.channel.verifiedVia).toBe("manual");
 
-    const dualWrite = fakeAssistantDb.runCalls.find((c) =>
-      c.sql.includes("UPDATE contact_channels"),
-    );
-    expect(dualWrite!.bind).toContain("manual");
+    // The verifiedVia is persisted to the gateway DB only.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
   });
 
   test("mirrors channel + contact from assistant DB when gateway is empty, then verifies", async () => {
@@ -416,16 +409,12 @@ describe("ContactStore.markChannelVerified", () => {
         .get(),
     ).toBeUndefined();
 
-    // The assistant-side mirror targets the ORIGINAL assistant id, not the
-    // resolved gateway id — otherwise the UPDATE no-ops on the split-id path.
-    const mirror = fakeAssistantDb.runCalls.find(
-      (c) =>
-        c.sql.includes("UPDATE contact_channels") &&
-        c.sql.includes("WHERE id = ?"),
-    );
-    expect(mirror).toBeTruthy();
-    expect(mirror!.bind?.[mirror!.bind!.length - 1]).toBe("asst-ch");
-    expect(mirror!.bind).not.toContain("gw-ch");
+    // The gateway DB holds the verified ACL state; no assistant-DB ACL mirror.
+    expect(
+      fakeAssistantDb.runCalls.some((c) =>
+        c.sql.includes("UPDATE contact_channels"),
+      ),
+    ).toBe(false);
   });
 
   test("refuses to mirror when assistant channel references a missing contact", async () => {
@@ -536,37 +525,6 @@ describe("ContactStore.markChannelVerified", () => {
     expect(
       getGatewayDb().select().from(contactChannels).all().length,
     ).toBe(1);
-  });
-
-  test("assistant dual-write falls back to the logical key when the id-keyed update misses", async () => {
-    // Legacy mismatch: the caller's id resolves the gateway row, but the
-    // id-keyed assistant UPDATE affects 0 rows (the assistant mirror lives
-    // under a different UUID). The dual-write must then resolve by logical key.
-    seedContact("c1");
-    seedChannel({
-      id: "gw-uuid",
-      contactId: "c1",
-      status: "unverified",
-      address: "shared-addr",
-    });
-    nextIdUpdateMisses = true;
-
-    const result = await new ContactStore().markChannelVerified("gw-uuid");
-    expect(result!.didWrite).toBe(true);
-
-    const idUpdate = fakeAssistantDb.runCalls.find((c) =>
-      /UPDATE contact_channels[\s\S]*WHERE id = \?/i.test(c.sql),
-    );
-    expect(idUpdate).toBeTruthy();
-
-    const keyUpdate = fakeAssistantDb.runCalls.find((c) =>
-      /WHERE type = \? AND address = \? COLLATE NOCASE/i.test(c.sql),
-    );
-    expect(keyUpdate).toBeTruthy();
-    // Logical-key update binds the gateway unique key (type, address) — not
-    // contactId, since the assistant row may sit under a different contact.
-    expect(keyUpdate!.bind).toContain("vellum");
-    expect(keyUpdate!.bind).toContain("shared-addr");
   });
 
   test("legacy cross-contact: resolves the gateway row by (type,address) even under a different contact", async () => {

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -3,9 +3,9 @@
  * flow used by the /v1/contact-channels/:id/verify endpoint.
  *
  * The assistant DB proxy is mocked behind a per-test fake (`fakeAssistantDb`)
- * so tests can stage either an empty assistant DB (most cases) or a
- * pre-populated one (mirror-from-assistant cases) without spinning up a
- * daemon.
+ * so tests can stage an empty or pre-populated assistant DB — used to resolve
+ * a legacy gateway row by its logical (type,address) key — without spinning up
+ * a daemon.
  */
 
 import {
@@ -345,7 +345,7 @@ describe("ContactStore.markChannelVerified", () => {
     ).toBe(false);
   });
 
-  test("mirrors channel + contact from assistant DB when gateway is empty, then verifies", async () => {
+  test("returns null when the channel is absent from the gateway, even if the assistant has it", async () => {
     seedAssistantContact("c1");
     seedAssistantChannel({
       id: "ch1",
@@ -353,31 +353,22 @@ describe("ContactStore.markChannelVerified", () => {
       status: "unverified",
     });
 
-    const before = Date.now();
     const result = await new ContactStore().markChannelVerified("ch1");
-    expect(result).not.toBeNull();
-    expect(result!.didWrite).toBe(true);
-    expect(result!.channel.status).toBe("active");
-    expect(result!.channel.verifiedVia).toBe("manual");
-    expect(result!.channel.verifiedAt!).toBeGreaterThanOrEqual(before);
+    expect(result).toBeNull();
 
-    // Channel + contact were materialized in the gateway DB.
+    // Nothing is seeded into the gateway from the assistant copy.
     const channelInGateway = getGatewayDb()
       .select()
       .from(contactChannels)
       .where(eq(contactChannels.id, "ch1"))
       .get();
-    expect(channelInGateway).toBeTruthy();
-    expect(channelInGateway!.contactId).toBe("c1");
-    expect(channelInGateway!.type).toBe("vellum");
+    expect(channelInGateway).toBeUndefined();
     const contactInGateway = getGatewayDb()
       .select()
       .from(contacts)
       .where(eq(contacts.id, "c1"))
       .get();
-    expect(contactInGateway).toBeTruthy();
-    expect(contactInGateway!.displayName).toBe("name-c1");
-    expect(contactInGateway!.role).toBe("guardian");
+    expect(contactInGateway).toBeUndefined();
   });
 
   test("verifies the existing gateway row when (type,address) lives under a different id", async () => {
@@ -417,46 +408,7 @@ describe("ContactStore.markChannelVerified", () => {
     ).toBe(false);
   });
 
-  test("refuses to mirror when assistant channel references a missing contact", async () => {
-    // Channel present, parent contact absent — broken state, refuse silently.
-    seedAssistantChannel({
-      id: "ch1",
-      contactId: "orphan",
-      status: "unverified",
-    });
-
-    const result = await new ContactStore().markChannelVerified("ch1");
-    expect(result).toBeNull();
-
-    // Nothing landed in the gateway.
-    const channelInGateway = getGatewayDb()
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, "ch1"))
-      .get();
-    expect(channelInGateway).toBeUndefined();
-  });
-
-  test("mirror is idempotent across successive calls", async () => {
-    seedAssistantContact("c1");
-    seedAssistantChannel({
-      id: "ch1",
-      contactId: "c1",
-      status: "unverified",
-    });
-
-    const store = new ContactStore();
-    const first = await store.markChannelVerified("ch1");
-    const second = await store.markChannelVerified("ch1");
-    expect(first!.didWrite).toBe(true);
-    expect(second!.didWrite).toBe(false);
-    expect(second!.channel.verifiedAt).toBe(first!.channel.verifiedAt);
-    // Mirror INSERT OR IGNORE: still exactly one channel row, one contact row.
-    expect(getGatewayDb().select().from(contactChannels).all().length).toBe(1);
-    expect(getGatewayDb().select().from(contacts).all().length).toBe(1);
-  });
-
-  test("gateway-present channel takes precedence over assistant copy (no mirror, no overwrite)", async () => {
+  test("gateway-present channel takes precedence over assistant copy (no overwrite)", async () => {
     // Gateway has the row (with a custom display_name for the contact);
     // assistant has a different display_name. We should verify the gateway
     // row in place — not overwrite gateway state with the assistant copy.
@@ -520,8 +472,8 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.channel.status).toBe("active");
     expect(result!.channel.verifiedVia).toBe("manual");
 
-    // Still exactly one gateway channel row — the mirror's ON CONFLICT
-    // DO NOTHING did not insert a duplicate.
+    // Exactly one gateway channel row: the existing gateway row is verified in
+    // place, keyed by (type,address).
     expect(
       getGatewayDb().select().from(contactChannels).all().length,
     ).toBe(1);
@@ -597,15 +549,16 @@ describe("ContactStore.markChannelRevoked", () => {
     expect(result!.channel.status).toBe("revoked");
     expect(result!.channel.revokedReason).toBe("spam");
 
-    // No duplicate gateway row inserted by the mirror.
+    // Exactly one gateway channel row: the existing gateway row is revoked in
+    // place, keyed by (type,address).
     expect(
       getGatewayDb().select().from(contactChannels).all().length,
     ).toBe(1);
   });
 });
 
-describe("ContactStore.updateChannelStatus (assistant-only backfill)", () => {
-  test("backfills a legacy assistant-only channel into the gateway, then revokes", async () => {
+describe("ContactStore.updateChannelStatus", () => {
+  test("returns null for a channel absent from the gateway, even if the assistant has it", async () => {
     seedAssistantContact("c1", "contact");
     seedAssistantChannel({ id: "ch1", contactId: "c1", status: "active" });
 
@@ -613,23 +566,21 @@ describe("ContactStore.updateChannelStatus (assistant-only backfill)", () => {
       status: "revoked",
       reason: "spam",
     });
-    expect(updated).not.toBeNull();
-    expect(updated!.status).toBe("revoked");
-    expect(updated!.revokedReason).toBe("spam");
+    expect(updated).toBeNull();
 
-    // Channel + parent contact were materialized in the gateway DB.
+    // Nothing is seeded into the gateway from the assistant copy.
     const channelInGateway = getGatewayDb()
       .select()
       .from(contactChannels)
       .where(eq(contactChannels.id, "ch1"))
       .get();
-    expect(channelInGateway!.status).toBe("revoked");
+    expect(channelInGateway).toBeUndefined();
     const contactInGateway = getGatewayDb()
       .select()
       .from(contacts)
       .where(eq(contacts.id, "c1"))
       .get();
-    expect(contactInGateway).toBeTruthy();
+    expect(contactInGateway).toBeUndefined();
   });
 
   test("updates the existing gateway row when (type,address) lives under a different contact id", async () => {
@@ -668,36 +619,19 @@ describe("ContactStore.updateChannelStatus (assistant-only backfill)", () => {
     ).toBeUndefined();
   });
 
-  test("revoke-of-blocked still 409s after backfill", async () => {
-    seedAssistantContact("c1", "contact");
-    seedAssistantChannel({ id: "ch1", contactId: "c1", status: "blocked" });
+  test("revoke-of-blocked 409s on a blocked gateway channel", async () => {
+    seedContact("c1", "contact");
+    seedChannel({ id: "ch1", contactId: "c1", status: "blocked" });
 
     await expect(
       new ContactStore().updateChannelStatus("ch1", { status: "revoked" }),
     ).rejects.toThrow("Cannot revoke a blocked channel");
   });
 
-  test("returns null when neither DB has the channel", async () => {
+  test("returns null when the gateway lacks the channel", async () => {
     const updated = await new ContactStore().updateChannelStatus("missing", {
       status: "revoked",
     });
     expect(updated).toBeNull();
-  });
-
-  test("degrades to null when the assistant channel references a missing contact", async () => {
-    // Backfill can't complete (orphan channel) → soft-fail to 404, never throw.
-    seedAssistantChannel({ id: "ch1", contactId: "orphan", status: "active" });
-
-    const updated = await new ContactStore().updateChannelStatus("ch1", {
-      status: "revoked",
-    });
-    expect(updated).toBeNull();
-
-    const channelInGateway = getGatewayDb()
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, "ch1"))
-      .get();
-    expect(channelInGateway).toBeUndefined();
   });
 });

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -1,4 +1,12 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  mock,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { initSigningKey } from "../auth/token-service.js";
 
@@ -57,8 +65,9 @@ mock.module("../ipc/assistant-client.js", () => ({
 }));
 
 // ── ContactStore mock ─────────────────────────────────────────────────────────
-// upsertContact is now async and returns a full ContactWithChannels shape; the
-// service layer owns the assistant-DB dual-write internally.
+// upsertContact is async and returns a ContactWithInfo shape whose ACL fields
+// (role/principalId, channel status/policy) come from the gateway-DB read-back;
+// the service layer owns the assistant-DB dual-write internally.
 const DEFAULT_MOCK_CONTACT = {
   id: "ct_mock",
   displayName: "Mock Contact",
@@ -72,6 +81,7 @@ const DEFAULT_MOCK_CONTACT = {
   interactionCount: 0,
   lastInteraction: null as number | null,
   channels: [] as unknown[],
+  assistantMetadata: null as Record<string, unknown> | null,
 };
 
 type UpsertResult = { contact: typeof DEFAULT_MOCK_CONTACT; created: boolean };
@@ -96,9 +106,6 @@ type UpdateChannelFn = (channelId: string, params: {
   reason?: string | null;
 }) => { id: string; contactId: string; status: string; policy: string } | null;
 let contactStoreUpdateChannelMock: ReturnType<typeof mock<UpdateChannelFn>> = mock(() => null);
-
-type DualWriteChannelFn = (channelId: string, params: Record<string, unknown>) => Promise<void>;
-let contactStoreDualWriteChannelMock: ReturnType<typeof mock<DualWriteChannelFn>> = mock(async () => {});
 
 type MergeFn = (keepId: string, mergeId: string) => Promise<typeof DEFAULT_MOCK_CONTACT | null>;
 let contactStoreMergeMock: ReturnType<typeof mock<MergeFn>> = mock(async () => null);
@@ -204,12 +211,6 @@ mock.module("../db/contact-store.js", () => ({
     }) {
       return contactStoreUpdateChannelMock(channelId, params);
     }
-    async dualWriteChannelStatusToAssistantDb(
-      channelId: string,
-      params: Record<string, unknown>,
-    ) {
-      return contactStoreDualWriteChannelMock(channelId, params);
-    }
     async mergeContacts(keepId: string, mergeId: string) {
       return contactStoreMergeMock(keepId, mergeId);
     }
@@ -232,6 +233,22 @@ mock.module("../db/contact-store.js", () => ({
 
 const { createContactsControlPlaneProxyHandler } =
   await import("../http/routes/contacts-control-plane-proxy.js");
+
+// The delete-contact guard reads the guardian role from the gateway DB (source
+// of truth), so the delete tests below run against a real in-memory gateway DB.
+// ContactStore is fully mocked, so other tests never touch it.
+const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
+  "../db/connection.js"
+);
+const { contacts: gwContacts } = await import("../db/schema.js");
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -273,7 +290,6 @@ afterEach(() => {
   contactStoreListMock = mock(async () => []);
   contactStoreGetMock = mock(async () => null);
   contactStoreUpdateChannelMock = mock(() => null);
-  contactStoreDualWriteChannelMock = mock(async () => {});
   contactStoreMergeMock = mock(async () => null);
   contactStoreGetContactMock = mock(() => ({ id: "ct_1" }));
   contactStoreListInvitesMock = mock(() => []);
@@ -983,7 +999,6 @@ describe("handleUpdateContactChannel (gateway-native)", () => {
     expect(channelId).toBe("ch_1");
     expect(params.status).toBe("revoked");
     expect(params.reason).toBe("user request");
-    expect(contactStoreDualWriteChannelMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -1134,31 +1149,6 @@ describe("handleUpdateContactChannel (gateway-native)", () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error.code).toBe("INTERNAL_ERROR");
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("continues even if assistant DB dual-write fails", async () => {
-    contactStoreUpdateChannelMock = mock(() => ({
-      ...MOCK_CHANNEL,
-      status: "blocked",
-    }));
-    contactStoreDualWriteChannelMock = mock(async () => {
-      throw new Error("assistant DB down");
-    });
-    contactStoreGetMock = mock(async () => DEFAULT_MOCK_CONTACT);
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleUpdateContactChannel(
-      new Request("http://localhost:7830/v1/contact-channels/ch_1", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ status: "blocked", reason: "spam" }),
-      }),
-      "ch_1",
-    );
-
-    // Should still succeed — dual-write is best-effort.
-    expect(res.status).toBe(200);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -1371,6 +1361,75 @@ describe("handleMergeContacts (gateway-native)", () => {
     expect(body.error.message).toMatch(/guardian/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+describe("handleDeleteContact (gateway-native)", () => {
+  function seedGatewayContact(id: string, role: "guardian" | "contact") {
+    const now = Date.now();
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({
+        id,
+        displayName: `name-${id}`,
+        role,
+        principalId: role === "guardian" ? `prin-${id}` : null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  afterEach(() => {
+    getGatewayDb().delete(gwContacts).run();
+  });
+
+  test("rejects deleting a guardian whose role lives only in the gateway DB", async () => {
+    seedGatewayContact("ct_guardian", "guardian");
+    // The assistant row is missing/defaulted (dual-write gap): the guard must
+    // not fall back to the assistant role, which would default to contact.
+    assistantDbQueryMock = mock(async () => []);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleDeleteContact("ct_guardian");
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+    // Neither DB was deleted from.
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .all(),
+    ).toHaveLength(1);
+  });
+
+  test("deletes a non-guardian contact from both DBs", async () => {
+    seedGatewayContact("ct_regular", "contact");
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleDeleteContact("ct_regular");
+
+    expect(res.status).toBe(204);
+    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .all(),
+    ).toHaveLength(0);
+  });
+
+  test("returns 404 when the contact is absent from the gateway DB", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleDeleteContact("ct_missing");
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("handleCreateInvite (gateway-native)", () => {
   test("returns the assistant's minted invite payload (one-time codes), not the gateway row", async () => {

--- a/gateway/src/__tests__/guardian-init-lockfile.test.ts
+++ b/gateway/src/__tests__/guardian-init-lockfile.test.ts
@@ -445,7 +445,7 @@ describe("guardian/init one-time-use lockfile", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    // Verify contact records were written to the assistant DB
+    // Assistant DB mirrors identity only — no ACL columns (gateway-owned).
     const assistantDb = new Database(
       join(testRoot, "data", "db", "assistant.db"),
       {
@@ -455,21 +455,20 @@ describe("guardian/init one-time-use lockfile", () => {
 
     const contact = assistantDb
       .query<
-        { role: string; principal_id: string },
+        { id: string; display_name: string },
         []
-      >("SELECT role, principal_id FROM contacts WHERE role = 'guardian'")
+      >("SELECT id, display_name FROM contacts")
       .get();
     expect(contact).toBeTruthy();
-    expect(contact!.principal_id).toBe(body.guardianPrincipalId);
 
     const channel = assistantDb
       .query<
-        { type: string; status: string },
+        { type: string; contact_id: string },
         []
-      >("SELECT type, status FROM contact_channels WHERE type = 'vellum'")
+      >("SELECT type, contact_id FROM contact_channels WHERE type = 'vellum'")
       .get();
     expect(channel).toBeTruthy();
-    expect(channel!.status).toBe("active");
+    expect(channel!.contact_id).toBe(contact!.id);
 
     assistantDb.close();
 
@@ -477,6 +476,26 @@ describe("guardian/init one-time-use lockfile", () => {
     const gwDb = new Database(join(securityDir, "gateway.sqlite"), {
       readonly: true,
     });
+
+    // Gateway DB owns the ACL state for the guardian binding.
+    const gwContact = gwDb
+      .query<
+        { role: string; principal_id: string },
+        []
+      >("SELECT role, principal_id FROM contacts WHERE role = 'guardian'")
+      .get();
+    expect(gwContact).toBeTruthy();
+    expect(gwContact!.principal_id).toBe(body.guardianPrincipalId);
+
+    const gwChannel = gwDb
+      .query<
+        { status: string; policy: string },
+        []
+      >("SELECT status, policy FROM contact_channels WHERE type = 'vellum'")
+      .get();
+    expect(gwChannel).toBeTruthy();
+    expect(gwChannel!.status).toBe("active");
+    expect(gwChannel!.policy).toBe("allow");
 
     const tokenCount = gwDb
       .query<

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -737,6 +737,40 @@ describe("IPC contact routes", () => {
     ).toBe(false);
   });
 
+  test("upsertContact read-back sources ACL from the gateway DB, not assistant defaults", async () => {
+    // The assistant mirror defaults a fresh channel to unverified/allow and a
+    // contact to role=contact. The read-back must reflect the gateway DB (the
+    // just-written source of truth): an active channel and a guardian role.
+    const db = getGatewayDb();
+    const now = Date.now();
+    db.insert(contacts)
+      .values({
+        id: "guard-1",
+        displayName: "Guardian",
+        role: "guardian",
+        principalId: "prin-guard",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // Assistant DB info-join degrades to null (default mock returns []); ACL
+    // fields still come from the real gateway DB.
+    const store = new ContactStore(db);
+    const { contact } = await store.upsertContact({
+      id: "guard-1",
+      channels: [
+        { type: "email", address: "g@example.com", status: "active" },
+      ],
+    });
+
+    expect(contact.role).toBe("guardian");
+    expect(contact.principalId).toBe("prin-guard");
+    expect(contact.channels).toHaveLength(1);
+    expect(contact.channels[0].status).toBe("active");
+    expect(contact.channels[0].policy).toBe("allow");
+  });
+
   test("create_contact defaults a brand-new contact's displayName to the canonical address", async () => {
     await startServerAndConnect();
     const res = await sendRequest(client, "create_contact", {

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -522,22 +522,71 @@ describe("remote web pairing token exchange", () => {
     expect(refreshTokens[0].browserRefreshCookiePath).toBeNull();
   });
 
-  test("failed credential mint leaves the approved device code retryable", async () => {
+  test("assistant mirror failure does not fail the gateway-committed binding", async () => {
     const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
 
     // No gateway guardian: resolveOrCreateVellumGuardian mints fresh via
-    // createGuardianBinding, whose assistant-DB mirror write fails this once
-    // (before the gateway write and token mint), so nothing is consumed.
+    // createGuardianBinding, which writes the authoritative gateway binding
+    // first, then mirrors identity to the assistant DB. The mirror write fails
+    // this once; the gateway binding is now authoritative so the mint succeeds.
     clearGatewayGuardian();
     mockRun.mockRejectedValueOnce(new Error("temporary guardian mirror write"));
-    await expect(
-      handleRemoteWebPairingToken(
-        makeTokenRequest({ deviceCode: challenge.deviceCode }),
-      ),
-    ).rejects.toThrow("temporary guardian mirror write");
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(setCookies(res)).toHaveLength(1);
+    expect(activeTokens()).toHaveLength(1);
+    expect(activeRefreshTokens()).toHaveLength(1);
+
+    // Gateway carries the authoritative guardian binding despite the mirror
+    // failure.
+    const gwGuardian = getGatewayDb()
+      .select()
+      .from(contacts)
+      .where(eq(contacts.role, "guardian"))
+      .all();
+    expect(gwGuardian).toHaveLength(1);
+    expect(gwGuardian[0].principalId).toMatch(/^vellum-principal-/);
+  });
+
+  test("gateway binding write failure fails the mint and leaves the code retryable", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    // No gateway guardian: createGuardianBinding must write the authoritative
+    // gateway binding. Force that write to throw and confirm it propagates so
+    // nothing is consumed.
+    clearGatewayGuardian();
+    const gwDb = getGatewayDb();
+    const realTransaction = gwDb.transaction.bind(gwDb);
+    let failedOnce = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (gwDb as any).transaction = (...args: unknown[]) => {
+      if (!failedOnce) {
+        failedOnce = true;
+        throw new Error("gateway binding write failed");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (realTransaction as any)(...args);
+    };
+
+    try {
+      await expect(
+        handleRemoteWebPairingToken(
+          makeTokenRequest({ deviceCode: challenge.deviceCode }),
+        ),
+      ).rejects.toThrow("gateway binding write failed");
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (gwDb as any).transaction = realTransaction;
+    }
 
     expect(
       getRemoteWebPairingChallengeForTests(challenge.userCode)?.status,

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -42,6 +42,9 @@ let gwSelectStatus: string | null = null;
 // Whether the insert-mirror reports a written row (`.returning().all()`).
 // false models a (type,address) conflict with a blocked/revoked row.
 let gwInsertWrote = true;
+// When true, the authoritative gateway channel write throws (infra failure):
+// the verified-set update lands a throw so the fail-closed path is exercised.
+let gwWriteThrows = false;
 
 mock.module("../db/connection.js", () => ({
   getGatewayDb: () => ({
@@ -59,6 +62,7 @@ mock.module("../db/connection.js", () => ({
           returning: () => ({
             all: () => {
               void table;
+              if (gwWriteThrows) throw new Error("gateway write failed");
               gwUpdates.push({ set, where });
               const n = gwUpdateChanges.shift() ?? 0;
               return Array.from({ length: n }, () => ({ id: "x" }));
@@ -80,6 +84,7 @@ mock.module("../db/connection.js", () => ({
           },
           returning: () => ({
             all: () => {
+              if (gwWriteThrows) throw new Error("gateway write failed");
               gwInserts.push({ table, values });
               return gwInsertWrote ? [{ id: "x" }] : [];
             },
@@ -151,6 +156,7 @@ beforeEach(() => {
   // Default: no authoritative gateway row (legacy/unmirrored happy path).
   gwSelectStatus = null;
   gwInsertWrote = true;
+  gwWriteThrows = false;
   runThrowOnSql = null;
   writeFileSync(TEST_SOCKET_PATH, "");
 });
@@ -164,14 +170,16 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
-  test("skips update when existing channel is revoked", async () => {
+  test("skips update when the authoritative gateway channel is revoked", async () => {
+    // The mirror is stale-active; the gateway row (source of truth) is revoked.
     queryRows = [
       {
         channelId: "ch-1",
         contactId: "co-1",
-        channelStatus: "revoked",
+        channelStatus: "active",
       },
     ];
+    gwSelectStatus = "revoked";
 
     await upsertVerifiedContactChannel({
       sourceChannel: "phone",
@@ -182,14 +190,15 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(runCalls.filter((c) => c.sql.includes("UPDATE"))).toHaveLength(0);
   });
 
-  test("skips update when channel is blocked", async () => {
+  test("skips update when the authoritative gateway channel is blocked", async () => {
     queryRows = [
       {
         channelId: "ch-2",
         contactId: "co-2",
-        channelStatus: "blocked",
+        channelStatus: "active",
       },
     ];
+    gwSelectStatus = "blocked";
 
     await upsertVerifiedContactChannel({
       sourceChannel: "phone",
@@ -200,7 +209,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(runCalls.filter((c) => c.sql.includes("UPDATE"))).toHaveLength(0);
   });
 
-  test("skips update when a guardian's channel is revoked", async () => {
+  test("proceeds when only the assistant mirror is revoked but the gateway row is active", async () => {
+    // A gateway reactivation can leave a stale revoked mirror. The verification
+    // decision follows the gateway (active here), so the activation proceeds.
     queryRows = [
       {
         channelId: "ch-3",
@@ -208,14 +219,22 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
         channelStatus: "revoked",
       },
     ];
+    gwSelectStatus = "active";
 
-    await upsertVerifiedContactChannel({
+    const result = await upsertVerifiedContactChannel({
       sourceChannel: "phone",
       externalUserId: "+15550001111",
       externalChatId: "+15550001111",
     });
 
-    expect(runCalls.filter((c) => c.sql.includes("UPDATE"))).toHaveLength(0);
+    expect(result).toEqual({ verified: true });
+    expect(
+      runCalls.filter(
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
+      ),
+    ).toHaveLength(1);
   });
 
   test("updates an active channel belonging to a guardian contact", async () => {
@@ -347,7 +366,7 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(runCalls.filter((c) => c.sql.includes("INSERT"))).toHaveLength(2);
   });
 
-  test("update path stamps verified_at + verified_via='challenge'", async () => {
+  test("update path stamps verified state on the gateway, not the assistant mirror", async () => {
     queryRows = [
       { channelId: "ch-6", contactId: "co-6", channelStatus: "active" },
     ];
@@ -358,20 +377,31 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       externalChatId: "+15550001111",
     });
 
+    // Gateway DB owns the verified ACL state.
+    const gwActivate = gwUpdates.find(
+      (u) => (u.set as { status?: string }).status === "active",
+    );
+    expect(gwActivate).toBeTruthy();
+    expect(gwActivate!.set).toMatchObject({ verifiedVia: "challenge" });
+    expect(gwActivate!.set.verifiedAt).toEqual(expect.any(Number));
+
+    // The assistant mirror UPDATE carries identity/info only — no ACL columns.
     const update = runCalls.find((c) =>
       c.sql.includes("UPDATE contact_channels"),
     );
     expect(update).toBeTruthy();
-    expect(update!.sql).toContain("status = 'active'");
-    expect(update!.sql).toContain("verified_at = ?");
-    expect(update!.sql).toContain("verified_via = ?");
-    expect(update!.params).toContain("challenge");
-    // verified_at uses a numeric timestamp
-    expect(update!.params.some((p) => typeof p === "number")).toBe(true);
+    expect(update!.sql).not.toContain("status =");
+    expect(update!.sql).not.toContain("policy =");
+    expect(update!.sql).not.toContain("verified_at");
+    expect(update!.sql).not.toContain("verified_via");
+    expect(update!.sql).not.toContain("revoked_reason");
+    expect(update!.sql).not.toContain("blocked_reason");
   });
 
-  test("insert path stamps verified_at + verified_via='challenge'", async () => {
+  test("insert path stamps verified state on the gateway, not the assistant mirror", async () => {
     queryRows = [];
+    // Force the insert-mirror path so the gateway channel row is created here.
+    gwUpdateChanges = [0, 0];
 
     await upsertVerifiedContactChannel({
       sourceChannel: "phone",
@@ -379,14 +409,23 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       externalChatId: "+15550009999",
     });
 
+    // Gateway DB owns the verified ACL state.
+    const gwChannelInsert = gwInserts.find(
+      (i) => i.values.type === "phone" && i.values.status === "active",
+    );
+    expect(gwChannelInsert).toBeTruthy();
+    expect(gwChannelInsert!.values).toMatchObject({ verifiedVia: "challenge" });
+
+    // The assistant mirror INSERT carries identity/info only — no ACL columns.
     const channelInsert = runCalls.find((c) =>
       c.sql.includes("INSERT OR IGNORE INTO contact_channels"),
     );
     expect(channelInsert).toBeTruthy();
-    expect(channelInsert!.sql).toContain("'active'");
-    expect(channelInsert!.sql).toContain("verified_at");
-    expect(channelInsert!.sql).toContain("verified_via");
-    expect(channelInsert!.params).toContain("challenge");
+    expect(channelInsert!.sql).not.toContain("status");
+    expect(channelInsert!.sql).not.toContain("policy");
+    expect(channelInsert!.sql).not.toContain("verified_at");
+    expect(channelInsert!.sql).not.toContain("verified_via");
+    expect(channelInsert!.sql).not.toContain("'active'");
   });
 
   test("resolves the gateway row by (type,address) when the id-keyed update misses", async () => {
@@ -497,7 +536,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(result).toEqual({ verified: false });
     expect(
       runCalls.filter(
-        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
       ),
     ).toHaveLength(0);
     // Gateway write never attempted (returned before the dual-write).
@@ -520,7 +561,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(result).toEqual({ verified: false });
     expect(
       runCalls.filter(
-        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
       ),
     ).toHaveLength(0);
     expect(gwUpdates).toHaveLength(0);
@@ -586,9 +629,51 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     const assistantActivate = runCalls.find(
       (c) =>
         /UPDATE contact_channels/i.test(c.sql) &&
-        c.sql.includes("status = 'active'"),
+        c.sql.includes("external_chat_id = ?"),
     );
     expect(assistantActivate).toBeUndefined();
+  });
+
+  test("fails closed (verified:false) when the gateway write throws on the existing-channel path", async () => {
+    // The pre-check passes, but the authoritative gateway write throws (infra
+    // failure). The mirror no longer records ACL state, so falling through to
+    // verified:true would reply success with no DB recording an active channel.
+    queryRows = [
+      { channelId: "ch-throw", contactId: "co-throw", channelStatus: "active" },
+    ];
+    gwSelectStatus = "active";
+    gwWriteThrows = true;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550002020",
+      externalChatId: "+15550002020",
+    });
+
+    expect(result).toEqual({ verified: false });
+    // The assistant mirror activation must NOT fire on a lost gateway write.
+    const activate = runCalls.find(
+      (c) =>
+        c.sql.includes("UPDATE contact_channels") &&
+        c.sql.includes("external_chat_id = ?"),
+    );
+    expect(activate).toBeUndefined();
+  });
+
+  test("fails closed (verified:false) when the gateway write throws on the new-insert path", async () => {
+    queryRows = [];
+    gwSelectStatus = null;
+    gwWriteThrows = true;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550002121",
+      externalChatId: "+15550002121",
+    });
+
+    expect(result).toEqual({ verified: false });
+    // No assistant mirror INSERT for an actor whose gateway write was lost.
+    expect(runCalls.filter((c) => c.sql.includes("INSERT"))).toHaveLength(0);
   });
 
   test("allowRevokedReactivation: a revoked authoritative gateway row is reactivated and the activation update fires", async () => {
@@ -612,7 +697,7 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     const activate = runCalls.find(
       (c) =>
         c.sql.includes("UPDATE contact_channels") &&
-        c.sql.includes("status = 'active'"),
+        c.sql.includes("external_chat_id = ?"),
     );
     expect(activate).toBeTruthy();
     // The gateway reactivation guard excludes only 'blocked', allowing the
@@ -637,22 +722,25 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     expect(result).toEqual({ verified: false });
     expect(
       runCalls.filter(
-        (c) => c.sql.includes("UPDATE") && c.sql.includes("status = 'active'"),
+        (c) =>
+          c.sql.includes("UPDATE contact_channels") &&
+          c.sql.includes("external_chat_id = ?"),
       ),
     ).toHaveLength(0);
     expect(gwUpdates).toHaveLength(0);
     expect(gwInserts).toHaveLength(0);
   });
 
-  test("allowRevokedReactivation: a revoked assistant-mirror row in the existing-channel branch is reactivated", async () => {
-    // No authoritative gateway row; the assistant mirror itself is revoked. With
-    // the flag the mirror guard is relaxed and the activation proceeds.
+  test("reactivation: a gateway-revoked channel is reactivated with the flag and later verification succeeds", async () => {
+    // The gateway row is revoked. With the flag the invite path reactivates it
+    // (the gateway write lands), the activation UPDATE fires, and the result is
+    // verified:true even though the assistant mirror is itself stale-revoked.
     queryRows = [
-      { channelId: "ch-mirror", contactId: "co-mirror", channelStatus: "revoked" },
+      { channelId: "ch-rev", contactId: "co-rev", channelStatus: "revoked" },
     ];
-    gwSelectStatus = null;
+    gwSelectStatus = "revoked";
 
-    const result = await upsertVerifiedContactChannel({
+    const reactivate = await upsertVerifiedContactChannel({
       sourceChannel: "phone",
       externalUserId: "+15550001515",
       externalChatId: "+15550001515",
@@ -660,21 +748,35 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       allowRevokedReactivation: true,
     });
 
-    expect(result).toEqual({ verified: true });
+    expect(reactivate).toEqual({ verified: true });
     const activate = runCalls.find(
       (c) =>
         c.sql.includes("UPDATE contact_channels") &&
-        c.sql.includes("status = 'active'"),
+        c.sql.includes("external_chat_id = ?"),
     );
     expect(activate).toBeTruthy();
     expect(activate!.params).toContain("+15550001515");
+
+    // A later plain verification (no flag) against the now-active gateway row
+    // must succeed: the decision follows the gateway, not the stale mirror.
+    runCalls.length = 0;
+    gwUpdates.length = 0;
+    gwSelectStatus = "active";
+
+    const reverify = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550001515",
+      externalChatId: "+15550001515",
+    });
+
+    expect(reverify).toEqual({ verified: true });
   });
 
-  test("allowRevokedReactivation: without the flag a revoked assistant-mirror row is still refused", async () => {
+  test("without the flag a gateway-revoked channel is still refused", async () => {
     queryRows = [
-      { channelId: "ch-mirror", contactId: "co-mirror", channelStatus: "revoked" },
+      { channelId: "ch-mirror", contactId: "co-mirror", channelStatus: "active" },
     ];
-    gwSelectStatus = null;
+    gwSelectStatus = "revoked";
 
     const result = await upsertVerifiedContactChannel({
       sourceChannel: "phone",
@@ -699,10 +801,11 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
       verifiedVia: "manual",
     });
 
-    const update = runCalls.find((c) =>
-      c.sql.includes("UPDATE contact_channels"),
+    // verifiedVia is gateway-owned; the assistant mirror no longer carries it.
+    const gwActivate = gwUpdates.find(
+      (u) => (u.set as { status?: string }).status === "active",
     );
-    expect(update!.params).toContain("manual");
+    expect(gwActivate!.set).toMatchObject({ verifiedVia: "manual" });
   });
 });
 

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -191,8 +191,8 @@ export async function createGuardianBinding(
   const displayName = params.displayName ?? params.externalUserId;
   const verifiedVia = params.verifiedVia ?? "challenge";
 
-  // Resolve ids from the gateway DB; the dual-write keeps both DBs in sync, so
-  // a gateway-resolved id matches the assistant row in normal operation.
+  // The gateway DB is the source of truth for contact ids; resolve them
+  // directly from it.
   const gwReadDb = getGatewayDb();
 
   const existingGuardianContact = gwReadDb

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -179,8 +179,8 @@ export interface CreateGuardianBindingResult {
 /**
  * Create or update a guardian contact + channel binding.
  *
- * Writes to both the assistant DB (via IPC proxy, primary) and gateway DB
- * (secondary). Uses upsert semantics: looks up an existing contact by
+ * Writes the gateway DB (authoritative) first, then mirrors identity to the
+ * assistant DB (best-effort, via IPC proxy). Uses upsert semantics: looks up an existing contact by
  * principalId, then claims any preseeded channel for the same actor before
  * falling back to an existing guardian channel by (contactId, type).
  */
@@ -248,162 +248,160 @@ export async function createGuardianBinding(
 
   const channelId = claimableChannel?.id ?? existingChannel?.id ?? uuid();
 
-  // --- Assistant DB write (primary, via IPC proxy) ---
-  await assistantDbExec("BEGIN IMMEDIATE");
-  try {
-    if (existingGuardianContact || claimableChannel) {
-      await assistantDbRun(
-        `UPDATE contacts
-         SET display_name = ?, role = 'guardian', principal_id = ?, updated_at = ?
-         WHERE id = ?`,
-        [displayName, params.guardianPrincipalId, now, contactId],
-      );
-    } else {
-      await assistantDbRun(
-        `INSERT INTO contacts (id, display_name, role, principal_id, notes, created_at, updated_at)
-         VALUES (?, ?, 'guardian', ?, 'guardian', ?, ?)`,
-        [contactId, displayName, params.guardianPrincipalId, now, now],
-      );
-    }
-
-    if (claimableChannel || existingChannel) {
-      // Remove duplicate channels with the same address (defensive).
-      await assistantDbRun(
-        `DELETE FROM contact_channels
-         WHERE type = ? AND address = ? COLLATE NOCASE AND id != ? AND status != 'blocked'`,
-        [params.channel, params.externalUserId, channelId],
-      );
-
-      await assistantDbRun(
-        `UPDATE contact_channels
-         SET contact_id = ?, address = ?, external_chat_id = ?,
-             is_primary = 1,
-             status = 'active', policy = 'allow', verified_at = ?,
-             verified_via = ?, revoked_reason = NULL, blocked_reason = NULL,
-             updated_at = ?
-         WHERE id = ?`,
-        [
-          contactId,
-          params.externalUserId,
-          params.deliveryChatId,
-          now,
-          verifiedVia,
-          now,
-          channelId,
-        ],
-      );
-    } else {
-      await assistantDbRun(
-        `INSERT INTO contact_channels
-           (id, contact_id, type, address, external_chat_id,
-            is_primary, status, policy, verified_at, verified_via, interaction_count, created_at)
-         VALUES (?, ?, ?, ?, ?, 1, 'active', 'allow', ?, ?, 0, ?)`,
-        [
-          channelId,
-          contactId,
-          params.channel,
-          params.externalUserId,
-          params.deliveryChatId,
-          now,
-          verifiedVia,
-          now,
-        ],
-      );
-    }
-
-    await assistantDbExec("COMMIT");
-  } catch (err) {
-    try {
-      await assistantDbExec("ROLLBACK");
-    } catch {
-      // best effort
-    }
-    throw err;
-  }
-
-  // --- Gateway DB dual-write (best-effort, transactional) ---
-  try {
-    const gwDb = getGatewayDb();
-    gwDb.transaction((tx) => {
-      tx.insert(gwContacts)
-        .values({
-          id: contactId,
+  // --- Gateway DB write (authoritative, transactional) ---
+  // The gateway owns the guardian ACL; a failure here means the binding failed,
+  // so let it propagate.
+  const gwDb = getGatewayDb();
+  gwDb.transaction((tx) => {
+    tx.insert(gwContacts)
+      .values({
+        id: contactId,
+        displayName,
+        role: "guardian",
+        principalId: params.guardianPrincipalId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: gwContacts.id,
+        set: {
           displayName,
           role: "guardian",
           principalId: params.guardianPrincipalId,
-          createdAt: now,
           updatedAt: now,
-        })
-        .onConflictDoUpdate({
-          target: gwContacts.id,
-          set: {
-            displayName,
-            role: "guardian",
-            principalId: params.guardianPrincipalId,
-            updatedAt: now,
-          },
-        })
-        .run();
+        },
+      })
+      .run();
 
-      const channelSet = {
-        contactId,
-        address: params.externalUserId,
-        externalChatId: params.deliveryChatId,
-        isPrimary: true,
-        status: "active",
-        policy: "allow",
-        verifiedAt: now,
-        verifiedVia,
-        revokedReason: null,
-        blockedReason: null,
-        updatedAt: now,
-      };
+    const channelSet = {
+      contactId,
+      address: params.externalUserId,
+      externalChatId: params.deliveryChatId,
+      isPrimary: true,
+      status: "active",
+      policy: "allow",
+      verifiedAt: now,
+      verifiedVia,
+      revokedReason: null,
+      blockedReason: null,
+      updatedAt: now,
+    };
 
-      // Heal a divergent (type,address) row (m0006): adopt it by its own id
-      // rather than insert and throw on idx_contact_channels_type_address_unique.
-      const existingGw = tx
-        .select({
-          id: gwContactChannels.id,
-          status: gwContactChannels.status,
-        })
-        .from(gwContactChannels)
-        .where(
-          and(
-            eq(gwContactChannels.type, params.channel),
-            sql`${gwContactChannels.address} = ${params.externalUserId} COLLATE NOCASE`,
-          ),
-        )
-        .get();
+    // Heal a divergent (type,address) row (m0006): adopt it by its own id
+    // rather than insert and throw on idx_contact_channels_type_address_unique.
+    const existingGw = tx
+      .select({
+        id: gwContactChannels.id,
+        status: gwContactChannels.status,
+      })
+      .from(gwContactChannels)
+      .where(
+        and(
+          eq(gwContactChannels.type, params.channel),
+          sql`${gwContactChannels.address} = ${params.externalUserId} COLLATE NOCASE`,
+        ),
+      )
+      .get();
 
-      if (existingGw) {
-        // Never reactivate a blocked gateway row by code-match — leave it
-        // intact (mirrors text-verification / contact-helpers guards).
-        if (existingGw.status !== "blocked") {
-          tx.update(gwContactChannels)
-            .set(channelSet)
-            .where(eq(gwContactChannels.id, existingGw.id))
-            .run();
-        }
-      } else {
-        tx.insert(gwContactChannels)
-          .values({
-            id: channelId,
-            type: params.channel,
-            interactionCount: 0,
-            createdAt: now,
-            ...channelSet,
-          })
-          .onConflictDoUpdate({
-            target: gwContactChannels.id,
-            set: channelSet,
-          })
+    if (existingGw) {
+      // Never reactivate a blocked gateway row by code-match — leave it
+      // intact (mirrors text-verification / contact-helpers guards).
+      if (existingGw.status !== "blocked") {
+        tx.update(gwContactChannels)
+          .set(channelSet)
+          .where(eq(gwContactChannels.id, existingGw.id))
           .run();
       }
-    });
-  } catch (gwErr) {
+    } else {
+      tx.insert(gwContactChannels)
+        .values({
+          id: channelId,
+          type: params.channel,
+          interactionCount: 0,
+          createdAt: now,
+          ...channelSet,
+        })
+        .onConflictDoUpdate({
+          target: gwContactChannels.id,
+          set: channelSet,
+        })
+        .run();
+    }
+  });
+
+  // --- Assistant DB identity mirror (best-effort, via IPC proxy) ---
+  // A non-authoritative convenience copy; its failure must not undo or abort
+  // the committed gateway binding.
+  try {
+    await assistantDbExec("BEGIN IMMEDIATE");
+    try {
+      if (existingGuardianContact || claimableChannel) {
+        await assistantDbRun(
+          `UPDATE contacts
+           SET display_name = ?, updated_at = ?
+           WHERE id = ?`,
+          [displayName, now, contactId],
+        );
+      } else {
+        await assistantDbRun(
+          `INSERT INTO contacts (id, display_name, notes, created_at, updated_at)
+           VALUES (?, ?, 'guardian', ?, ?)`,
+          [contactId, displayName, now, now],
+        );
+      }
+
+      if (claimableChannel || existingChannel) {
+        // Remove duplicate channels with the same address (defensive).
+        await assistantDbRun(
+          `DELETE FROM contact_channels
+           WHERE type = ? AND address = ? COLLATE NOCASE AND id != ?`,
+          [params.channel, params.externalUserId, channelId],
+        );
+
+        await assistantDbRun(
+          `UPDATE contact_channels
+           SET contact_id = ?, address = ?, external_chat_id = ?,
+               is_primary = 1,
+               updated_at = ?
+           WHERE id = ?`,
+          [
+            contactId,
+            params.externalUserId,
+            params.deliveryChatId,
+            now,
+            channelId,
+          ],
+        );
+      } else {
+        await assistantDbRun(
+          `INSERT INTO contact_channels
+             (id, contact_id, type, address, external_chat_id,
+              is_primary, interaction_count, created_at)
+           VALUES (?, ?, ?, ?, ?, 1, 0, ?)`,
+          [
+            channelId,
+            contactId,
+            params.channel,
+            params.externalUserId,
+            params.deliveryChatId,
+            now,
+          ],
+        );
+      }
+
+      await assistantDbExec("COMMIT");
+    } catch (err) {
+      try {
+        await assistantDbExec("ROLLBACK");
+      } catch {
+        // best effort
+      }
+      throw err;
+    }
+  } catch (mirrorErr) {
     log.warn(
-      { err: gwErr },
-      "Failed to dual-write guardian binding to gateway DB",
+      { err: mirrorErr },
+      "Failed to mirror guardian binding identity to assistant DB",
     );
   }
 

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1184,8 +1184,8 @@ export class ContactStore {
     // ── 6. Read back full contact shape (best-effort) ─────────────────
     // Source ACL (role/principalId, channel status/policy/verified_*) from the
     // gateway DB — the just-written source of truth — and overlay assistant-
-    // owned info. readAssistantContact would return assistant-mirror defaults
-    // (unverified/allow, role=contact), misreporting fresh creates.
+    // owned info. The assistant mirror would report stale unverified/allow/
+    // contact defaults for fresh creates.
     const fullContact = await this.getContactWithInfo(contactId).catch((err) => {
       log.warn(
         { contactId, err },
@@ -1732,16 +1732,28 @@ export class ContactStore {
     principalId: string | null,
   ): Promise<string> {
     if (principalId) {
-      const sibling = await assistantDbQuery<{ userFile: string | null }>(
-        `SELECT user_file AS userFile
-           FROM contacts
-          WHERE principal_id = ?
-            AND user_file IS NOT NULL
-          LIMIT 1`,
-        [principalId],
-      );
-      if (sibling.length && sibling[0].userFile) {
-        return sibling[0].userFile;
+      // principalId is gateway-owned: resolve sibling contact ids from the
+      // gateway DB (source of truth), then read the assistant-owned user_file
+      // for those ids from the assistant DB.
+      const siblingIds = getGatewayDb()
+        .select({ id: contacts.id })
+        .from(contacts)
+        .where(eq(contacts.principalId, principalId))
+        .all()
+        .map((r) => r.id);
+      if (siblingIds.length) {
+        const placeholders = siblingIds.map(() => "?").join(", ");
+        const sibling = await assistantDbQuery<{ userFile: string | null }>(
+          `SELECT user_file AS userFile
+             FROM contacts
+            WHERE id IN (${placeholders})
+              AND user_file IS NOT NULL
+            LIMIT 1`,
+          siblingIds,
+        );
+        if (sibling.length && sibling[0].userFile) {
+          return sibling[0].userFile;
+        }
       }
     }
 

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -453,10 +453,8 @@ export class ContactStore {
    *   - any other status → both reasons cleared to null
    *   - status unchanged → reasons left untouched (pass undefined)
    *
-   * Channel ID resolution: the caller may pass an assistant-side channel ID
-   * (legacy clients reading the assistant DB). If the ID isn't found
-   * in the gateway DB, we resolve it from the assistant DB by
-   * (contactId, type, address) and then find the matching gateway channel.
+   * Gateway DB is the source of truth; a channel absent from the gateway
+   * returns null.
    */
   async updateChannelStatus(
     channelId: string,
@@ -466,27 +464,10 @@ export class ContactStore {
       reason?: string | null;
     },
   ): Promise<ContactChannel | null> {
-    let gwChannel = await this.resolveGatewayChannel(channelId);
+    const gwChannel = await this.resolveGatewayChannel(channelId);
 
-    // Still absent → legacy assistant-only channel. Mirror it (plus its parent
-    // contact) into the gateway DB so the status write resolves instead of
-    // 404ing — matching the verify path. The mirror reuses the assistant-side
-    // id; soft-fails to null when the assistant DB is unreachable.
-    if (!gwChannel) {
-      const mirrored = await this.mirrorChannelFromAssistantIfMissing(
-        channelId,
-      ).catch((err) => {
-        log.warn(
-          { channelId, err },
-          "updateChannelStatus: assistant-only backfill failed (best-effort)",
-        );
-        return false;
-      });
-      if (mirrored) {
-        gwChannel = await this.resolveGatewayChannel(channelId);
-      }
-    }
-
+    // Gateway DB is the source of truth; a channel absent from the gateway
+    // has no status to update.
     if (!gwChannel) return null;
 
     // Guard: cannot revoke a blocked channel.
@@ -546,135 +527,6 @@ export class ContactStore {
   }
 
   /**
-   * Migration-window backfill: ensure a channel exists in the gateway DB
-   * by mirroring it (plus its parent contact) from the assistant DB when
-   * absent. Returns `true` when the channel is present in the gateway DB
-   * after the call (pre-existing or just mirrored), `false` when neither
-   * side has it.
-   *
-   * Why this exists: during the gateway-security-migration the assistant
-   * DB is the present-day source of truth for contacts. The gateway DB is
-   * back-filled lazily as contacts are touched. Without this hop, any
-   * channel created before the dual-write was wired would 404 from
-   * gateway-native channel mutators even though the user sees it in the
-   * assistant UI.
-   *
-   * Idempotent — both INSERTs are `INSERT ... ON CONFLICT DO NOTHING`, so
-   * concurrent mirrors converge without conflict.
-   */
-  private async mirrorChannelFromAssistantIfMissing(
-    channelId: string,
-  ): Promise<boolean> {
-    const existing = this.db
-      .select({ id: contactChannels.id })
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
-    if (existing) return true;
-
-    type ChannelRow = {
-      id: string;
-      contact_id: string;
-      type: string;
-      address: string;
-      is_primary: number;
-      external_chat_id: string | null;
-      status: string;
-      policy: string;
-      verified_at: number | null;
-      verified_via: string | null;
-      invite_id: string | null;
-      revoked_reason: string | null;
-      blocked_reason: string | null;
-      last_seen_at: number | null;
-      interaction_count: number;
-      last_interaction: number | null;
-      created_at: number;
-      updated_at: number | null;
-    };
-    const channelRows = await assistantDbQuery<ChannelRow>(
-      `SELECT id, contact_id, type, address, is_primary,
-              external_chat_id, status, policy, verified_at, verified_via,
-              invite_id, revoked_reason, blocked_reason, last_seen_at,
-              interaction_count, last_interaction, created_at, updated_at
-         FROM contact_channels WHERE id = ?`,
-      [channelId],
-    );
-    if (channelRows.length === 0) return false;
-    const channelRow = channelRows[0]!;
-
-    type ContactRow = {
-      id: string;
-      display_name: string;
-      role: string | null;
-      principal_id: string | null;
-      created_at: number;
-      updated_at: number | null;
-    };
-    const contactRows = await assistantDbQuery<ContactRow>(
-      `SELECT id, display_name, role, principal_id, created_at, updated_at
-         FROM contacts WHERE id = ?`,
-      [channelRow.contact_id],
-    );
-    if (contactRows.length === 0) {
-      log.warn(
-        { channelId, contactId: channelRow.contact_id },
-        "mirrorChannelFromAssistantIfMissing: assistant channel references missing contact — refusing to mirror",
-      );
-      return false;
-    }
-    const contactRow = contactRows[0]!;
-
-    // Parent contact first so the channel's FK lands. Both INSERTs are
-    // conflict-tolerant: contact may already exist (e.g. a sibling channel
-    // mirrored earlier), and a concurrent mirror of this channel by another
-    // request must not collide.
-    this.db
-      .insert(contacts)
-      .values({
-        id: contactRow.id,
-        displayName: contactRow.display_name,
-        role: contactRow.role ?? "contact",
-        principalId: contactRow.principal_id,
-        createdAt: contactRow.created_at,
-        updatedAt: contactRow.updated_at ?? contactRow.created_at,
-      })
-      .onConflictDoNothing()
-      .run();
-
-    this.db
-      .insert(contactChannels)
-      .values({
-        id: channelRow.id,
-        contactId: channelRow.contact_id,
-        type: channelRow.type,
-        address: channelRow.address,
-        isPrimary: Boolean(channelRow.is_primary),
-        externalChatId: channelRow.external_chat_id,
-        status: channelRow.status,
-        policy: channelRow.policy,
-        verifiedAt: channelRow.verified_at,
-        verifiedVia: channelRow.verified_via,
-        inviteId: channelRow.invite_id,
-        revokedReason: channelRow.revoked_reason,
-        blockedReason: channelRow.blocked_reason,
-        lastSeenAt: channelRow.last_seen_at,
-        interactionCount: channelRow.interaction_count,
-        lastInteraction: channelRow.last_interaction,
-        createdAt: channelRow.created_at,
-        updatedAt: channelRow.updated_at,
-      })
-      .onConflictDoNothing()
-      .run();
-
-    log.info(
-      { channelId, contactId: channelRow.contact_id },
-      "mirrorChannelFromAssistantIfMissing: mirrored channel + parent contact from assistant DB",
-    );
-    return true;
-  }
-
-  /**
    * Resolve a gateway channel row by id, falling back to its logical
    * (type, address) key when the id-based lookup misses. Legacy channels can
    * live under a different gateway UUID than the assistant id, so the id
@@ -728,12 +580,8 @@ export class ContactStore {
    * and the other will see `changes=0`. Both still return the post-state
    * row.
    *
-   * Returns the channel after the write, or `null` if neither the gateway
-   * DB nor the assistant DB has a channel with that id.
-   *
-   * Gateway DB is the source of truth. When the channel is missing on the
-   * gateway but present on the assistant, it (plus its parent contact) is
-   * mirrored into the gateway first.
+   * Gateway DB is the source of truth; a channel absent from the gateway
+   * returns `null`.
    */
   async markChannelVerified(
     channelId: string,
@@ -742,17 +590,10 @@ export class ContactStore {
     channel: ContactChannel;
     didWrite: boolean;
   } | null> {
-    // Migration-window backfill: if the gateway DB has never seen this
-    // channel, but the assistant DB has it, mirror channel + parent contact
-    // into the gateway DB before attempting the verify write. Without this,
-    // any contact channel created before the dual-write was wired would
-    // 404 here even though the user can see the channel in their UI.
-    const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
-    if (!mirrored) return null;
-
     // Legacy channels may live under a different gateway id than the assistant
     // channel id passed in; resolve the gateway row (by id, then by logical
-    // (type,address) key) before keying writes on it.
+    // (type,address) key) before keying writes on it. Gateway DB is the source
+    // of truth; a channel absent from the gateway returns null.
     const gwChannel = await this.resolveGatewayChannel(channelId);
     if (!gwChannel) return null;
     const gwChannelId = gwChannel.id;
@@ -789,21 +630,17 @@ export class ContactStore {
    * (`reason="guardian_binding_revoked"`). Any other reason on a guardian
    * channel is rejected here at the boundary rather than silently applied.
    *
-   * Mirrors `markChannelVerified`: when the channel is missing on the gateway
-   * but present on the assistant, it (plus its parent contact) is mirrored in
-   * first so a UI-visible channel id doesn't 404.
-   *
-   * Returns the channel after the write, or `null` if neither DB has the id.
+   * Gateway DB is the source of truth; a channel absent from the gateway
+   * returns `null`.
    */
   async markChannelRevoked(
     channelId: string,
     reason?: string,
   ): Promise<{ channel: ContactChannel; didWrite: boolean } | null> {
-    const mirrored = await this.mirrorChannelFromAssistantIfMissing(channelId);
-    if (!mirrored) return null;
-
     // Legacy channels may live under a different gateway id than the assistant
     // channel id passed in; resolve the gateway row before keying writes on it.
+    // Gateway DB is the source of truth; a channel absent from the gateway
+    // returns null.
     const channel = await this.resolveGatewayChannel(channelId);
     if (!channel) return null;
     const gwChannelId = channel.id;

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -161,7 +161,7 @@ export class ContactStore {
         sql`${contacts.role} = 'guardian' DESC`,
         desc(contacts.updatedAt),
         // Primary channel first, then by creation time — mirrors the daemon
-        // (assistant/src/contacts/contact-store.ts:141) and readAssistantContact.
+        // (assistant/src/contacts/contact-store.ts:141).
         sql`${contactChannels.isPrimary} DESC`,
         contactChannels.createdAt,
       )
@@ -182,7 +182,7 @@ export class ContactStore {
       .where(eq(contacts.id, contactId))
       .orderBy(
         // Primary channel first, then by creation time — mirrors the daemon
-        // (assistant/src/contacts/contact-store.ts:141) and readAssistantContact.
+        // (assistant/src/contacts/contact-store.ts:141).
         sql`${contactChannels.isPrimary} DESC`,
         contactChannels.createdAt,
       )
@@ -454,7 +454,7 @@ export class ContactStore {
    *   - status unchanged → reasons left untouched (pass undefined)
    *
    * Channel ID resolution: the caller may pass an assistant-side channel ID
-   * (the UI gets these from `readAssistantContact`). If the ID isn't found
+   * (legacy clients reading the assistant DB). If the ID isn't found
    * in the gateway DB, we resolve it from the assistant DB by
    * (contactId, type, address) and then find the matching gateway channel.
    */
@@ -526,84 +526,6 @@ export class ContactStore {
       .from(contactChannels)
       .where(eq(contactChannels.id, gwChannel.id))
       .get()!;
-  }
-
-  /**
-   * Best-effort dual-write of a channel status/policy update to the
-   * assistant DB. The gateway DB is the source of truth; the assistant
-   * copy is a best-effort mirror. Failures are logged, not thrown.
-   */
-  async dualWriteChannelStatusToAssistantDb(
-    channelId: string,
-    params: {
-      status?: string;
-      policy?: string;
-      revokedReason?: string | null;
-      blockedReason?: string | null;
-      verifiedAt?: number | null;
-      verifiedVia?: string | null;
-    },
-  ): Promise<boolean> {
-    const setClauses: string[] = [];
-    const bind: (string | number | null)[] = [];
-
-    if (params.status !== undefined) {
-      setClauses.push("status = ?");
-      bind.push(params.status);
-    }
-    if (params.policy !== undefined) {
-      setClauses.push("policy = ?");
-      bind.push(params.policy);
-    }
-    if (params.revokedReason !== undefined) {
-      setClauses.push("revoked_reason = ?");
-      bind.push(params.revokedReason);
-    }
-    if (params.blockedReason !== undefined) {
-      setClauses.push("blocked_reason = ?");
-      bind.push(params.blockedReason);
-    }
-    if (params.verifiedAt !== undefined) {
-      setClauses.push("verified_at = ?");
-      bind.push(params.verifiedAt);
-    }
-    if (params.verifiedVia !== undefined) {
-      setClauses.push("verified_via = ?");
-      bind.push(params.verifiedVia);
-    }
-
-    if (setClauses.length === 0) return false;
-
-    setClauses.push("updated_at = ?");
-    bind.push(String(Date.now()));
-    bind.push(channelId);
-
-    const result = await assistantDbRun(
-      `UPDATE contact_channels SET ${setClauses.join(", ")} WHERE id = ?`,
-      bind,
-    );
-    if (result.changes > 0) return true;
-
-    // Legacy channels may have a different assistant-side ID. If the ID-keyed
-    // update touched zero rows, resolve by the unique (type, address) key and
-    // retry so the assistant mirror stays consistent. The assistant row may sit
-    // under a different contact than the gateway row (m0006 reconcile), so
-    // contactId is excluded.
-    const gwChannel = this.db
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, channelId))
-      .get();
-    if (!gwChannel) return false;
-
-    const logicalBind = bind.slice(0, -1); // drop the channelId
-    logicalBind.push(gwChannel.type, gwChannel.address);
-    const retry = await assistantDbRun(
-      `UPDATE contact_channels SET ${setClauses.join(", ")}
-         WHERE type = ? AND address = ? COLLATE NOCASE`,
-      logicalBind,
-    );
-    return retry.changes > 0;
   }
 
   /**
@@ -809,9 +731,9 @@ export class ContactStore {
    * Returns the channel after the write, or `null` if neither the gateway
    * DB nor the assistant DB has a channel with that id.
    *
-   * Gateway DB (source of truth) + best-effort assistant DB dual-write.
-   * When the channel is missing on the gateway but present on the assistant,
-   * it (plus its parent contact) is mirrored into the gateway first.
+   * Gateway DB is the source of truth. When the channel is missing on the
+   * gateway but present on the assistant, it (plus its parent contact) is
+   * mirrored into the gateway first.
    */
   async markChannelVerified(
     channelId: string,
@@ -855,37 +777,12 @@ export class ContactStore {
     if (!after) return null;
     const didWrite = result.changes > 0;
 
-    // Mirror the write to the assistant DB only when the gateway actually
-    // wrote (best-effort dual-write). Skipping the no-op case prevents
-    // spurious verified_at/updated_at drift in the assistant DB on idempotent
-    // calls. The gateway DB remains source of truth.
-    //
-    // Key the mirror by the ORIGINAL assistant channel id, not the resolved
-    // gateway `gwChannelId`: on the split-id path they differ and the assistant
-    // row is keyed by the original id, so mirroring by the gateway id would
-    // no-op. The dual-write's logical (type, address) fallback covers rows
-    // keyed differently from the id.
-    if (didWrite) {
-      try {
-        await this.dualWriteChannelStatusToAssistantDb(channelId, {
-          status: "active",
-          verifiedAt: now,
-          verifiedVia,
-        });
-      } catch (err) {
-        log.warn(
-          { channelId, gwChannelId, err },
-          "markChannelVerified: assistant DB dual-write failed (best-effort)",
-        );
-      }
-    }
-
     return { channel: after, didWrite };
   }
 
   /**
-   * Downgrade a channel to `revoked` (verification-revoke outcome), then
-   * best-effort dual-write to the assistant DB. Gateway DB is source of truth.
+   * Downgrade a channel to `revoked` (verification-revoke outcome).
+   * Gateway DB is source of truth.
    *
    * Guardian guard (invariant 4): a guardian contact's channel may only be
    * downgraded via the sanctioned guardian-binding teardown
@@ -957,19 +854,6 @@ export class ContactStore {
       .where(eq(contactChannels.id, gwChannelId))
       .get();
     if (!after) return null;
-
-    try {
-      await this.dualWriteChannelStatusToAssistantDb(gwChannelId, {
-        status: "revoked",
-        revokedReason: reason ?? null,
-        blockedReason: null,
-      });
-    } catch (err) {
-      log.warn(
-        { channelId, err },
-        "markChannelRevoked: assistant DB dual-write failed (best-effort)",
-      );
-    }
 
     return { channel: after, didWrite: true };
   }
@@ -1181,7 +1065,7 @@ export class ContactStore {
       revokedReason?: string | null;
       blockedReason?: string | null;
     }>;
-  }): Promise<{ contact: ContactWithChannels; created: boolean }> {
+  }): Promise<{ contact: ContactWithInfo; created: boolean }> {
     const now = Date.now();
     let contactId = params.id;
     let created = false;
@@ -1298,15 +1182,17 @@ export class ContactStore {
     }
 
     // ── 6. Read back full contact shape (best-effort) ─────────────────
-    const fullContact = await this.readAssistantContact(contactId).catch(
-      (err) => {
-        log.warn(
-          { contactId, err },
-          "upsertContact: assistant DB read-back failed; returning gateway fallback",
-        );
-        return null;
-      },
-    );
+    // Source ACL (role/principalId, channel status/policy/verified_*) from the
+    // gateway DB — the just-written source of truth — and overlay assistant-
+    // owned info. readAssistantContact would return assistant-mirror defaults
+    // (unverified/allow, role=contact), misreporting fresh creates.
+    const fullContact = await this.getContactWithInfo(contactId).catch((err) => {
+      log.warn(
+        { contactId, err },
+        "upsertContact: gateway read-back failed; returning gateway fallback",
+      );
+      return null;
+    });
 
     if (fullContact) {
       return { contact: fullContact, created };
@@ -1332,6 +1218,7 @@ export class ContactStore {
         interactionCount: 0,
         lastInteraction: null,
         channels: [],
+        assistantMetadata: null,
       },
       created,
     };
@@ -1433,7 +1320,6 @@ export class ContactStore {
         keepId,
         mergeId,
         keep.displayName,
-        keep.role,
         keep.principalId,
       );
     } catch (err) {
@@ -1491,7 +1377,6 @@ export class ContactStore {
     keepId: string,
     mergeId: string,
     keepDisplayName: string,
-    keepRole: string,
     keepPrincipalId: string | null,
   ): Promise<void> {
     const now = Date.now();
@@ -1514,21 +1399,17 @@ export class ContactStore {
 
     if (updateResult.changes === 0) {
       // Survivor row missing from assistant DB — create it with combined notes.
-      // Use the gateway survivor's role/principalId so a guardian survivor
-      // isn't downgraded to role=contact in the assistant mirror.
       const userFile = await this.resolveAssistantUserFileSlug(
         keepDisplayName,
         keepPrincipalId,
       );
       await assistantDbRun(
-        `INSERT INTO contacts (id, display_name, notes, role, contact_type, principal_id, user_file, created_at, updated_at)
-         VALUES (?, ?, ?, ?, 'human', ?, ?, ?, ?)`,
+        `INSERT INTO contacts (id, display_name, notes, contact_type, user_file, created_at, updated_at)
+         VALUES (?, ?, ?, 'human', ?, ?, ?)`,
         [
           keepId,
           keepDisplayName,
           combined,
-          keepRole,
-          keepPrincipalId,
           userFile,
           String(now),
           String(now),
@@ -1737,16 +1618,14 @@ export class ContactStore {
       );
       await assistantDbRun(
         `INSERT INTO contacts
-           (id, display_name, notes, role, contact_type, principal_id,
+           (id, display_name, notes, contact_type,
             user_file, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
         [
           contactId,
           displayName,
           params.notes ?? null,
-          "contact",
           params.contactType ?? "human",
-          null,
           userFile,
           now,
           now,
@@ -1774,13 +1653,12 @@ export class ContactStore {
 
     // Sync channels to the assistant DB.
     for (const ch of params.channels ?? []) {
-      const existingCh = await assistantDbQuery<{ id: string; status: string }>(
-        "SELECT id, status FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
+      const existingCh = await assistantDbQuery<{ id: string }>(
+        "SELECT id FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
         [contactId, ch.type, ch.address],
       );
 
       if (existingCh.length) {
-        const isBlocked = existingCh[0].status === "blocked";
         // Omit-to-preserve: only overwrite external_chat_id when the caller
         // supplied one, mirroring syncChannels (gateway DB). A sparse upsert
         // (no externalChatId) must not clear an existing delivery chat id.
@@ -1789,16 +1667,6 @@ export class ContactStore {
         if (ch.externalChatId !== undefined) {
           setParts.push("external_chat_id = ?");
           setParams.push(ch.externalChatId);
-        }
-        if (!isBlocked) {
-          if (ch.status !== undefined) {
-            setParts.push("status = ?");
-            setParams.push(ch.status);
-          }
-          if (ch.policy !== undefined) {
-            setParts.push("policy = ?");
-            setParams.push(ch.policy);
-          }
         }
         setParams.push(existingCh[0].id);
         await assistantDbRun(
@@ -1832,8 +1700,8 @@ export class ContactStore {
           `INSERT INTO contact_channels
              (id, contact_id, type, address, is_primary,
               external_chat_id,
-              status, policy, interaction_count, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+              interaction_count, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
           [
             channelId,
             contactId,
@@ -1841,8 +1709,6 @@ export class ContactStore {
             ch.address,
             ch.isPrimary ? 1 : 0,
             ch.externalChatId ?? null,
-            ch.status ?? "unverified",
-            ch.policy ?? "allow",
             now,
             now,
           ],
@@ -1904,97 +1770,6 @@ export class ContactStore {
     return `${slug}-${crypto.randomUUID().slice(0, 8)}.md`;
   }
 
-  /**
-   * Read a contact + channels from the assistant DB and return the full
-   * `ContactWithChannels` shape used in API responses. Returns null if the
-   * contact is not found in the assistant DB.
-   */
-  private async readAssistantContact(
-    contactId: string,
-  ): Promise<ContactWithChannels | null> {
-    const rows = await assistantDbQuery<AssistantContactRow>(
-      `SELECT c.id,
-              c.display_name      AS displayName,
-              c.notes,
-              c.role,
-              c.contact_type      AS contactType,
-              c.principal_id      AS principalId,
-              c.user_file         AS userFile,
-              c.created_at        AS createdAt,
-              c.updated_at        AS updatedAt,
-              cc.id               AS channelId,
-              cc.type             AS channelType,
-              cc.address,
-              cc.is_primary       AS isPrimary,
-              cc.external_chat_id AS externalChatId,
-              cc.status           AS channelStatus,
-              cc.policy           AS channelPolicy,
-              cc.verified_at      AS verifiedAt,
-              cc.verified_via     AS verifiedVia,
-              cc.invite_id        AS inviteId,
-              cc.revoked_reason   AS revokedReason,
-              cc.blocked_reason   AS blockedReason,
-              cc.last_seen_at     AS lastSeenAt,
-              cc.interaction_count AS interactionCount,
-              cc.last_interaction  AS lastInteraction,
-              cc.created_at       AS channelCreatedAt,
-              cc.updated_at       AS channelUpdatedAt
-         FROM contacts c
-         LEFT JOIN contact_channels cc ON cc.contact_id = c.id
-        WHERE c.id = ?
-        ORDER BY cc.is_primary DESC, cc.created_at ASC`,
-      [contactId],
-    );
-
-    if (!rows.length) return null;
-
-    const first = rows[0];
-    const channels = rows
-      .filter((r) => r.channelId !== null)
-      .map((r) => ({
-        id: r.channelId!,
-        contactId,
-        type: r.channelType!,
-        address: r.address!,
-        isPrimary: Boolean(r.isPrimary),
-        externalChatId: r.externalChatId,
-        status: r.channelStatus,
-        policy: r.channelPolicy,
-        verifiedAt: r.verifiedAt,
-        verifiedVia: r.verifiedVia,
-        inviteId: r.inviteId,
-        revokedReason: r.revokedReason,
-        blockedReason: r.blockedReason,
-        lastSeenAt: r.lastSeenAt,
-        interactionCount: r.interactionCount ?? 0,
-        lastInteraction: r.lastInteraction,
-        createdAt: r.channelCreatedAt,
-        updatedAt: r.channelUpdatedAt,
-      }));
-
-    const interactionCount = channels.reduce(
-      (sum, ch) => sum + (ch.interactionCount ?? 0),
-      0,
-    );
-    const lastInteraction =
-      channels.reduce((max, ch) => Math.max(max, ch.lastInteraction ?? 0), 0) ||
-      null;
-
-    return {
-      id: first.id,
-      displayName: first.displayName,
-      notes: first.notes,
-      role: first.role,
-      contactType: first.contactType,
-      principalId: first.principalId,
-      userFile: first.userFile,
-      createdAt: first.createdAt,
-      updatedAt: first.updatedAt,
-      interactionCount,
-      lastInteraction,
-      channels,
-    };
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2020,21 +1795,6 @@ export interface ContactChannelShape {
   lastInteraction: number | null;
   createdAt: number | null;
   updatedAt: number | null;
-}
-
-export interface ContactWithChannels {
-  id: string;
-  displayName: string;
-  notes: string | null;
-  role: string;
-  contactType: string;
-  principalId: string | null;
-  userFile: string | null;
-  createdAt: number;
-  updatedAt: number;
-  interactionCount: number;
-  lastInteraction: number | null;
-  channels: ContactChannelShape[];
 }
 
 /**
@@ -2064,35 +1824,6 @@ export interface ContactWithInfo {
     species: string;
     metadata: Record<string, unknown> | null;
   } | null;
-}
-
-interface AssistantContactRow {
-  id: string;
-  displayName: string;
-  notes: string | null;
-  role: string;
-  contactType: string;
-  principalId: string | null;
-  userFile: string | null;
-  createdAt: number;
-  updatedAt: number;
-  channelId: string | null;
-  channelType: string | null;
-  address: string | null;
-  isPrimary: number | null;
-  externalChatId: string | null;
-  channelStatus: string | null;
-  channelPolicy: string | null;
-  verifiedAt: number | null;
-  verifiedVia: string | null;
-  inviteId: string | null;
-  revokedReason: string | null;
-  blockedReason: string | null;
-  lastSeenAt: number | null;
-  interactionCount: number | null;
-  lastInteraction: number | null;
-  channelCreatedAt: number | null;
-  channelUpdatedAt: number | null;
 }
 
 /**

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -167,8 +167,8 @@ export async function handleContactPromptSubmit(
           .run();
         try {
           await assistantDbRun(
-            `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-             VALUES (?, ?, 'guardian', 'human', ?, ?)`,
+            `INSERT INTO contacts (id, display_name, contact_type, created_at, updated_at)
+             VALUES (?, ?, 'human', ?, ?)`,
             [contactId, effectiveDisplayName, now, now],
           );
         } catch (mirrorErr) {
@@ -355,25 +355,6 @@ export async function handleContactPromptSubmit(
         { channelType, address: normalizedAddress, contactId, channelId },
         "contact-prompt-submit: created new channel",
       );
-    }
-
-    // Re-assert role="guardian" in the best-effort assistant mirror: if the
-    // bootstrap-create mirror INSERT failed, the Phase-2 upsertContact INSERTs
-    // this id with a hardcoded role="contact", downgrading the guardian in the
-    // mirror (gateway stays authoritative, so ACL is unaffected). Heal only
-    // when this request minted the guardian; never fails the request.
-    if (createdNewContact) {
-      try {
-        await assistantDbRun(
-          "UPDATE contacts SET role = 'guardian', updated_at = ? WHERE id = ?",
-          [now, contactId],
-        );
-      } catch (roleErr) {
-        log.warn(
-          { err: roleErr, contactId },
-          "contact-prompt-submit: assistant DB guardian role re-assert failed (best-effort)",
-        );
-      }
     }
   } catch (err) {
     log.error({ err, requestId }, "contact-prompt-submit: DB error");

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -132,8 +132,8 @@ export async function handleContactPromptSubmit(
     let createdNewContact = false;
 
     if (isGuardian) {
-      // Guardian lives in the gateway DB (source of truth) — bootstrap
-      // dual-writes it there. Resolve from there, not the assistant mirror.
+      // Guardian lives in the gateway DB (source of truth). Resolve from the
+      // gateway DB, not the assistant mirror.
       const guardianRow = getGatewayDb()
         .select({ id: gwContacts.id })
         .from(gwContacts)
@@ -244,10 +244,10 @@ export async function handleContactPromptSubmit(
     if (existingChannel && existingChannel.contactId === contactId) {
       // Reuse is success-guaranteed: the gateway channel already belongs to
       // this guardian. Best-effort heal the assistant-DB mirror (passing the
-      // guardian's id preserves role="guardian" via upsertContact's id-path
-      // role preservation). The gateway-side syncChannels UPDATE here is
-      // incidental — the real purpose is recovering a stale mirror — so a
-      // transient gateway error must never fail the request.
+      // guardian's id keeps the gateway DB authoritative for role="guardian").
+      // The gateway-side syncChannels UPDATE here is incidental — the real
+      // purpose is recovering a stale mirror — so a transient gateway error
+      // must never fail the request.
       try {
         await getStore().upsertContact({
           id: contactId,
@@ -314,9 +314,8 @@ export async function handleContactPromptSubmit(
 
       try {
         // Bind gateway-first. Passing the guardian's id keys the update to the
-        // existing guardian and preserves role="guardian" (upsertContact's
-        // id-path role preservation); the gateway channel is the source of
-        // truth, the assistant mirror is dual-written best-effort.
+        // existing guardian; the gateway DB is authoritative for role="guardian"
+        // and the channel, and the assistant mirror carries identity/info only.
         await getStore().upsertContact({
           id: contactId,
           channels: [

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -744,32 +744,6 @@ export async function updateContactChannelCore(params: {
     );
   }
 
-  // Best-effort dual-write to assistant DB.
-  const dualWriteParams: {
-    status?: string;
-    policy?: string;
-    revokedReason?: string | null;
-    blockedReason?: string | null;
-  } = {};
-  if (status !== undefined) {
-    dualWriteParams.status = status;
-    dualWriteParams.revokedReason = status === "revoked" ? reason : null;
-    dualWriteParams.blockedReason = status === "blocked" ? reason : null;
-  }
-  if (policy !== undefined) dualWriteParams.policy = policy;
-
-  try {
-    await store.dualWriteChannelStatusToAssistantDb(
-      contactChannelId,
-      dualWriteParams,
-    );
-  } catch (err) {
-    log.warn(
-      { contactChannelId, err },
-      "update_channel: assistant DB dual-write failed (best-effort)",
-    );
-  }
-
   // Emit contacts_changed so connected clients refresh.
   void ipcCallAssistant("emit_event", {
     body: { kind: "contacts_changed" },
@@ -1149,7 +1123,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
         { contactId: contact.id, created },
         "upsert_contact: handled natively",
       );
-      return Response.json({ ok: true, contact });
+      // ACL (role/principalId, channel status/policy) is sourced from the
+      // gateway DB inside upsertContact's read-back, so this response reflects
+      // the just-written source of truth, not assistant-mirror defaults.
+      return Response.json({ ok: true, contact: toContactPayload(contact) });
     },
 
     /**
@@ -1197,11 +1174,14 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     },
 
     async handleDeleteContact(contactId: string): Promise<Response> {
-      const rows = await assistantDbQuery<{ role: string }>(
-        "SELECT role FROM contacts WHERE id = ?",
-        [contactId],
-      );
-      if (rows.length === 0) {
+      // Guardian role is gateway-DB source of truth: a dual-write-gap survivor
+      // whose assistant row is missing/defaulted must not bypass this guard.
+      const row = getGatewayDb()
+        .select({ role: contacts.role })
+        .from(contacts)
+        .where(eq(contacts.id, contactId))
+        .get();
+      if (!row) {
         log.warn({ contactId }, "delete_contact: not found");
         return Response.json(
           {
@@ -1213,7 +1193,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
           { status: 404 },
         );
       }
-      if (rows[0].role === "guardian") {
+      if (row.role === "guardian") {
         log.warn({ contactId }, "delete_contact: attempted to delete guardian");
         return Response.json(
           {

--- a/gateway/src/http/routes/twilio-voice-verify-callback.ts
+++ b/gateway/src/http/routes/twilio-voice-verify-callback.ts
@@ -12,8 +12,6 @@
  * calls from callers whose identity the gateway has already confirmed.
  */
 
-import { eq } from "drizzle-orm";
-
 import type { GatewayConfig } from "../../config.js";
 import { credentialKey } from "../../credential-key.js";
 import { getLogger } from "../../logger.js";
@@ -33,12 +31,11 @@ import {
   failureTwiml,
 } from "../../voice/verification.js";
 import { createGuardianBinding } from "../../auth/guardian-bootstrap.js";
-import { getGatewayDb } from "../../db/connection.js";
-import { contactChannels as gwContactChannels } from "../../db/schema.js";
 import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../../db/assistant-db-proxy.js";
+  getExistingGuardianBinding,
+  resolveCanonicalPrincipal,
+  revokeExistingChannelGuardian,
+} from "../../verification/binding-helpers.js";
 import { upsertVerifiedContactChannel } from "../../verification/contact-helpers.js";
 
 const log = getLogger("twilio-voice-verify-callback");
@@ -127,33 +124,14 @@ export function createTwilioVoiceVerifyCallbackHandler(
     // Verification succeeded — create guardian binding if this is a guardian verification
     if (result.verificationType === "guardian") {
       try {
-        // Resolve the canonical principal from the vellum channel guardian binding
-        const vellumGuardians = await assistantDbQuery<{
-          principalId: string | null;
-        }>(
-          `SELECT c.principal_id AS principalId
-           FROM contacts c
-           JOIN contact_channels cc ON cc.contact_id = c.id
-           WHERE c.role = 'guardian' AND cc.type = 'vellum' AND cc.status = 'active'
-           LIMIT 1`,
-          [],
-        );
-        const canonicalPrincipal =
-          vellumGuardians[0]?.principalId ?? fromNumber;
+        // Resolve the canonical principal from the gateway DB (ACL source of
+        // truth) via the vellum channel guardian binding.
+        const canonicalPrincipal = await resolveCanonicalPrincipal(fromNumber);
 
-        // Check for existing phone guardian binding conflict
-        const existingPhoneGuardians = await assistantDbQuery<{
-          address: string;
-        }>(
-          `SELECT cc.address
-           FROM contacts c
-           JOIN contact_channels cc ON cc.contact_id = c.id
-           WHERE c.role = 'guardian' AND cc.type = 'phone' AND cc.status = 'active'
-           LIMIT 1`,
-          [],
-        );
-
-        const existingGuardian = existingPhoneGuardians[0];
+        // Check for an existing phone guardian binding conflict against the
+        // gateway DB so the revoke below never displaces a real gateway
+        // binding based on a stale assistant mirror.
+        const existingGuardian = await getExistingGuardianBinding("phone");
         if (existingGuardian && existingGuardian.address !== fromNumber) {
           log.warn(
             {
@@ -166,7 +144,7 @@ export function createTwilioVoiceVerifyCallbackHandler(
         } else {
           // Revoke existing phone guardian binding before creating new one
           if (existingGuardian) {
-            await revokeExistingPhoneGuardian();
+            await revokeExistingChannelGuardian("phone");
           }
 
           await createGuardianBinding({
@@ -237,51 +215,6 @@ export function createTwilioVoiceVerifyCallbackHandler(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Revoke the existing phone guardian binding by setting status to 'revoked'.
- * Dual-writes to both assistant DB and gateway DB.
- */
-async function revokeExistingPhoneGuardian(): Promise<void> {
-  const now = Date.now();
-
-  const revokedRows = await assistantDbQuery<{ id: string }>(
-    `SELECT cc.id
-     FROM contacts c
-     JOIN contact_channels cc ON cc.contact_id = c.id
-     WHERE c.role = 'guardian' AND cc.type = 'phone' AND cc.status = 'active'`,
-    [],
-  );
-
-  if (revokedRows.length === 0) return;
-
-  const ids = revokedRows.map((r) => r.id);
-  const placeholders = ids.map(() => "?").join(", ");
-
-  await assistantDbRun(
-    `UPDATE contact_channels
-     SET status = 'revoked', policy = 'deny', updated_at = ?
-     WHERE id IN (${placeholders})`,
-    [now, ...ids],
-  );
-
-  // Gateway DB dual-write (best-effort)
-  try {
-    const gwDb = getGatewayDb();
-    for (const id of ids) {
-      gwDb
-        .update(gwContactChannels)
-        .set({ status: "revoked", policy: "deny", updatedAt: now })
-        .where(eq(gwContactChannels.id, id))
-        .run();
-    }
-  } catch (gwErr) {
-    log.warn(
-      { err: gwErr },
-      "Gateway DB revoke dual-write failed (best-effort)",
-    );
-  }
-}
 
 /**
  * Build the action URL for the next Gather attempt, preserving the base

--- a/gateway/src/verification/binding-helpers.ts
+++ b/gateway/src/verification/binding-helpers.ts
@@ -2,8 +2,8 @@
  * Guardian binding helpers for gateway-owned verification.
  *
  * Provides lookup, conflict detection, and revocation of existing bindings.
- * Binding creation uses the existing createGuardianBinding from
- * gateway/src/auth/guardian-bootstrap.ts which already dual-writes.
+ * Binding creation uses createGuardianBinding from
+ * gateway/src/auth/guardian-bootstrap.ts (gateway-authoritative).
  *
  * Guardian lookups and revokes read and write the gateway DB, the source of
  * truth for ACL.

--- a/gateway/src/verification/binding-helpers.ts
+++ b/gateway/src/verification/binding-helpers.ts
@@ -5,21 +5,17 @@
  * Binding creation uses the existing createGuardianBinding from
  * gateway/src/auth/guardian-bootstrap.ts which already dual-writes.
  *
- * Guardian lookups read the gateway DB (source of truth for ACL). Only the
- * revoke path's status write mirrors into the assistant DB (best-effort).
+ * Guardian lookups and revokes read and write the gateway DB, the source of
+ * truth for ACL.
  */
 
 import { and, eq, inArray, sql } from "drizzle-orm";
 
-import { assistantDbRun } from "../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../db/connection.js";
 import {
   contacts as gwContacts,
   contactChannels as gwContactChannels,
 } from "../db/schema.js";
-import { getLogger } from "../logger.js";
-
-const log = getLogger("verification-bindings");
 
 // ---------------------------------------------------------------------------
 // Lookup
@@ -116,7 +112,7 @@ export async function resolveCanonicalPrincipal(
 }
 
 // ---------------------------------------------------------------------------
-// Revocation (dual-write)
+// Revocation
 // ---------------------------------------------------------------------------
 
 /**
@@ -146,8 +142,7 @@ export async function revokeExistingChannelGuardian(
 
   if (revokedRows.length === 0) return;
 
-  // Gateway DB is the source of truth — revoke it first so revocation never
-  // depends on the best-effort assistant mirror succeeding.
+  // Gateway DB is the source of truth.
   const gwDb = getGatewayDb();
   for (const { id } of revokedRows) {
     gwDb
@@ -155,32 +150,5 @@ export async function revokeExistingChannelGuardian(
       .set({ status: "revoked", policy: "deny", updatedAt: now })
       .where(eq(gwContactChannels.id, id))
       .run();
-  }
-
-  // Assistant mirror (best-effort): id-keyed update, then heal divergent
-  // (type,address) rows whose assistant-side id differs (m0006 divergence).
-  // A mirror failure must not abort the authoritative gateway revoke above.
-  try {
-    for (const gwChannel of revokedRows) {
-      const result = await assistantDbRun(
-        `UPDATE contact_channels
-         SET status = 'revoked', policy = 'deny', updated_at = ?
-         WHERE id = ?`,
-        [now, gwChannel.id],
-      );
-      if (result.changes === 0) {
-        await assistantDbRun(
-          `UPDATE contact_channels
-           SET status = 'revoked', policy = 'deny', updated_at = ?
-           WHERE type = ? AND address = ? COLLATE NOCASE`,
-          [now, channel, gwChannel.address],
-        );
-      }
-    }
-  } catch (mirrorErr) {
-    log.warn(
-      { err: mirrorErr },
-      "Assistant mirror revoke failed (best-effort)",
-    );
   }
 }

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -116,8 +116,7 @@ function writeVerifiedGatewayChannel(params: {
   };
 
   // Blocked is never reactivated. Revoked is reactivated only on the invite
-  // path (allowRevokedReactivation); otherwise the caller's guard only inspects
-  // the assistant mirror, which may be stale relative to the gateway status.
+  // path (allowRevokedReactivation); otherwise the gateway row stays revoked.
   const reactivatable = allowRevokedReactivation
     ? sql`${gwContactChannels.status} not in ('blocked')`
     : sql`${gwContactChannels.status} not in ('blocked', 'revoked')`;
@@ -296,10 +295,11 @@ export function getGatewayChannelByKey(
  * it handles the verification-specific case only (single channel, no
  * reassignment, no invite binding).
  *
- * Returns `{ verified: false }` when the verification is rejected because the
- * authoritative gateway row (or the assistant mirror) is blocked/revoked, so
- * the caller can suppress the success reply. Returns `{ verified: true }` on
- * the normal activate/insert paths.
+ * Returns `{ verified: false }` when the authoritative gateway row is
+ * blocked/revoked, or when the authoritative gateway write fails, so the caller
+ * suppresses the success reply (the mirror no longer records ACL state, so a
+ * lost gateway write must fail closed). Returns `{ verified: true }` on the
+ * normal activate/insert paths.
  */
 export async function upsertVerifiedContactChannel(params: {
   sourceChannel: string;
@@ -327,13 +327,14 @@ export async function upsertVerifiedContactChannel(params: {
     params.externalUserId;
   const contactDisplayName = displayName ?? username ?? address;
 
-  // Check if a channel for this actor already exists.
+  // Resolve the existing channel's identity (id, parent contact) only. The
+  // ACL/status decision is owned by the gateway pre-check below; cc.status is
+  // used solely to prefer the most-relevant mirror row, not to gate the upsert.
   const existing = await assistantDbQuery<{
     channelId: string;
     contactId: string;
-    channelStatus: string;
   }>(
-    `SELECT cc.id AS channelId, cc.contact_id AS contactId, cc.status AS channelStatus
+    `SELECT cc.id AS channelId, cc.contact_id AS contactId
      FROM contact_channels cc
      WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
      ORDER BY
@@ -366,18 +367,10 @@ export async function upsertVerifiedContactChannel(params: {
   if (existing.length > 0) {
     const row = existing[0];
 
-    // Blocked is never overwritten; revoked only on the invite path
-    // (assistant mirror guard).
-    if (
-      row.channelStatus === "blocked" ||
-      (row.channelStatus === "revoked" && !allowRevokedReactivation)
-    ) {
-      log.warn(
-        { sourceChannel, address, status: row.channelStatus },
-        "Skipping upsert: channel is blocked or revoked",
-      );
-      return { verified: false };
-    }
+    // The block/revoke decision is owned by the authoritative gateway row,
+    // already gated above. The assistant mirror's status is not consulted: it
+    // can lag the gateway (e.g. a gateway reactivation leaves a stale revoked
+    // mirror), and gating on it would falsely reject a gateway-active channel.
 
     // Bind to the invite's target contact when supplied: an invite can attach a
     // redeemer's existing channel to a different contact, so reassign the
@@ -437,30 +430,29 @@ export async function upsertVerifiedContactChannel(params: {
         gatewayRejected = true;
       }
     } catch (gwErr) {
-      // A thrown gateway DB error is an infra failure, not a rejection: the
-      // code already matched, so fall through and activate the assistant mirror
-      // best-effort rather than failing a legitimate verification.
-      log.warn(
+      // The gateway is the source of truth and the mirror no longer records ACL
+      // state, so a thrown write means NO DB recorded an active verified channel.
+      // Fail closed rather than reply success off a stale best-effort mirror.
+      log.error(
         { err: gwErr },
-        "Gateway DB contact channel update dual-write failed",
+        "Gateway DB contact channel update failed; failing verification closed",
       );
+      gatewayRejected = true;
     }
 
     if (gatewayRejected) {
       return { verified: false };
     }
 
-    // Activate the assistant mirror.
+    // Activate the assistant mirror. ACL columns are gateway-owned and no
+    // longer mirrored; only identity/info columns are written here.
     await assistantDbRun(
       `UPDATE contact_channels
        SET address = ?,
-           status = 'active', policy = 'allow',
            external_chat_id = ?,
-           verified_at = ?, verified_via = ?,
-           revoked_reason = NULL, blocked_reason = NULL,
            updated_at = ?
        WHERE id = ?`,
-      [address, externalChatId, now, verifiedVia, now, row.channelId],
+      [address, externalChatId, now, row.channelId],
     );
 
     return { verified: true };
@@ -527,9 +519,14 @@ export async function upsertVerifiedContactChannel(params: {
       gatewayRejected = true;
     }
   } catch (gwErr) {
-    // A thrown gateway DB error is an infra failure, not a rejection: fall
-    // through and create the assistant mirror best-effort.
-    log.warn({ err: gwErr }, "Gateway DB contact create dual-write failed");
+    // The gateway is the source of truth and the mirror no longer records ACL
+    // state, so a thrown write means NO DB recorded an active verified channel.
+    // Fail closed rather than reply success off a stale best-effort mirror.
+    log.error(
+      { err: gwErr },
+      "Gateway DB contact create failed; failing verification closed",
+    );
+    gatewayRejected = true;
   }
 
   if (gatewayRejected) {
@@ -539,28 +536,19 @@ export async function upsertVerifiedContactChannel(params: {
   // Create the assistant mirror. OR IGNORE for idempotency under retries; if the
   // channel insert fails mid-flight, the orphan contact row is harmless.
   await assistantDbRun(
-    `INSERT OR IGNORE INTO contacts (id, display_name, role, created_at, updated_at)
-     VALUES (?, ?, 'contact', ?, ?)`,
+    `INSERT OR IGNORE INTO contacts (id, display_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?)`,
     [contactId, contactDisplayName, now, now],
   );
 
+  // ACL columns are gateway-owned; the mirror carries identity/info only and
+  // relies on the schema defaults (status='unverified', policy='allow').
   await assistantDbRun(
     `INSERT OR IGNORE INTO contact_channels
        (id, contact_id, type, address, is_primary, external_chat_id,
-        status, policy, verified_at, verified_via, interaction_count,
-        created_at, updated_at)
-     VALUES (?, ?, ?, ?, 0, ?, 'active', 'allow', ?, ?, 0, ?, ?)`,
-    [
-      channelId,
-      contactId,
-      sourceChannel,
-      address,
-      externalChatId,
-      now,
-      verifiedVia,
-      now,
-      now,
-    ],
+        interaction_count, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 0, ?, 0, ?, ?)`,
+    [channelId, contactId, sourceChannel, address, externalChatId, now, now],
   );
 
   return { verified: true };
@@ -576,11 +564,14 @@ export async function upsertVerifiedContactChannel(params: {
  * first seen on a channel.
  *
  * - Existing channel: updates display name, external_chat_id.
- *   Status and policy are left unchanged so blocked/revoked channels stay that way.
- * - New channel: inserts contact + channel with status='unverified', policy='allow'.
+ *   Status and policy live in the gateway DB and are left unchanged so
+ *   blocked/revoked channels stay that way.
+ * - New channel: inserts contact + channel. ACL columns (status, policy) are
+ *   gateway-owned; the gateway DB seeds status='unverified', policy='allow'.
  *
- * Dual-writes to both the assistant DB (source of truth) and the gateway DB.
- * Skips silently when the assistant IPC socket is unavailable (test environments).
+ * Dual-writes to both the assistant DB (identity/info mirror) and the gateway
+ * DB (ACL source of truth). Skips silently when the assistant IPC socket is
+ * unavailable (test environments).
  */
 export async function upsertContactChannel(params: {
   sourceChannel: string;
@@ -661,15 +652,17 @@ export async function upsertContactChannel(params: {
   const channelId = crypto.randomUUID();
 
   await assistantDbRun(
-    `INSERT OR IGNORE INTO contacts (id, display_name, role, created_at, updated_at)
-     VALUES (?, ?, 'contact', ?, ?)`,
+    `INSERT OR IGNORE INTO contacts (id, display_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?)`,
     [contactId, contactDisplayName, now, now],
   );
+  // ACL columns are gateway-owned; the mirror carries identity/info only and
+  // relies on the schema defaults (status='unverified', policy='allow').
   await assistantDbRun(
     `INSERT OR IGNORE INTO contact_channels
        (id, contact_id, type, address, is_primary, external_chat_id,
-        status, policy, interaction_count, created_at, updated_at)
-     VALUES (?, ?, ?, ?, 0, ?, 'unverified', 'allow', 0, ?, ?)`,
+        interaction_count, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 0, ?, 0, ?, ?)`,
     [
       channelId,
       contactId,

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -295,7 +295,7 @@ export function getGatewayChannelByKey(
  *
  * Returns `{ verified: false }` when the authoritative gateway row is
  * blocked/revoked, or when the authoritative gateway write fails, so the caller
- * suppresses the success reply (the mirror no longer records ACL state, so a
+ * suppresses the success reply (the mirror carries identity/info only, so a
  * lost gateway write must fail closed). Returns `{ verified: true }` on the
  * normal activate/insert paths.
  */
@@ -428,9 +428,10 @@ export async function upsertVerifiedContactChannel(params: {
         gatewayRejected = true;
       }
     } catch (gwErr) {
-      // The gateway is the source of truth and the mirror no longer records ACL
-      // state, so a thrown write means NO DB recorded an active verified channel.
-      // Fail closed rather than reply success off a stale best-effort mirror.
+      // The gateway DB is the source of truth and the assistant mirror carries
+      // identity/info only, so a thrown gateway write means no DB recorded an
+      // active verified channel. Fail closed rather than reply success off the
+      // mirror.
       log.error(
         { err: gwErr },
         "Gateway DB contact channel update failed; failing verification closed",
@@ -442,8 +443,8 @@ export async function upsertVerifiedContactChannel(params: {
       return { verified: false };
     }
 
-    // Activate the assistant mirror. ACL columns are gateway-owned and no
-    // longer mirrored; only identity/info columns are written here.
+    // Activate the assistant mirror. ACL columns are gateway-owned; only
+    // identity/info columns are written here.
     await assistantDbRun(
       `UPDATE contact_channels
        SET address = ?,
@@ -517,9 +518,10 @@ export async function upsertVerifiedContactChannel(params: {
       gatewayRejected = true;
     }
   } catch (gwErr) {
-    // The gateway is the source of truth and the mirror no longer records ACL
-    // state, so a thrown write means NO DB recorded an active verified channel.
-    // Fail closed rather than reply success off a stale best-effort mirror.
+    // The gateway DB is the source of truth and the assistant mirror carries
+    // identity/info only, so a thrown gateway write means no DB recorded an
+    // active verified channel. Fail closed rather than reply success off the
+    // mirror.
     log.error(
       { err: gwErr },
       "Gateway DB contact create failed; failing verification closed",
@@ -591,25 +593,19 @@ export async function upsertContactChannel(params: {
   const existing = await assistantDbQuery<{
     channelId: string;
     contactId: string;
-    channelStatus: string;
   }>(
-    `SELECT cc.id AS channelId, cc.contact_id AS contactId, cc.status AS channelStatus
+    `SELECT cc.id AS channelId, cc.contact_id AS contactId
      FROM contact_channels cc
      WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-     ORDER BY
-       CASE cc.status
-         WHEN 'active' THEN 0
-         WHEN 'unverified' THEN 1
-         ELSE 2
-       END,
-       cc.updated_at DESC
+     ORDER BY cc.updated_at DESC
      LIMIT 1`,
     [sourceChannel, address],
   );
 
   if (existing.length > 0) {
     const row = existing[0];
-    if (row.channelStatus === "blocked") return;
+    // Gateway DB is the source of truth for ACL: a blocked channel stays blocked.
+    if (gatewayChannelStatus(sourceChannel, address) === "blocked") return;
 
     // Update identity/display fields; preserve status and policy.
     await assistantDbRun(

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -36,7 +36,6 @@ export interface ContactChannelRow {
   address: string;
   externalChatId: string | null;
   displayName: string | null;
-  status: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -54,8 +53,7 @@ export async function findContactChannelByAddress(
     `SELECT cc.id AS channelId, cc.contact_id AS contactId,
             cc.address,
             cc.external_chat_id AS externalChatId,
-            c.display_name AS displayName,
-            cc.status
+            c.display_name AS displayName
      FROM contact_channels cc
      JOIN contacts c ON c.id = cc.contact_id
      WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -326,8 +326,8 @@ export async function upsertVerifiedContactChannel(params: {
   const contactDisplayName = displayName ?? username ?? address;
 
   // Resolve the existing channel's identity (id, parent contact) only. The
-  // ACL/status decision is owned by the gateway pre-check below; cc.status is
-  // used solely to prefer the most-relevant mirror row, not to gate the upsert.
+  // ACL/status decision is owned by the gateway pre-check below; the most
+  // recently updated mirror row is preferred.
   const existing = await assistantDbQuery<{
     channelId: string;
     contactId: string;
@@ -335,13 +335,7 @@ export async function upsertVerifiedContactChannel(params: {
     `SELECT cc.id AS channelId, cc.contact_id AS contactId
      FROM contact_channels cc
      WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-     ORDER BY
-       CASE cc.status
-         WHEN 'active' THEN 0
-         WHEN 'unverified' THEN 1
-         ELSE 2
-       END,
-       cc.updated_at DESC
+     ORDER BY cc.updated_at DESC
      LIMIT 1`,
     [sourceChannel, address],
   );

--- a/gateway/src/verification/outbound-voice-verification-sync.test.ts
+++ b/gateway/src/verification/outbound-voice-verification-sync.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
+import { and, eq } from "drizzle-orm";
 
 import { initSigningKey } from "../auth/token-service.js";
 import {
@@ -120,8 +121,8 @@ async function setupTestDirs(): Promise<void> {
   await initGatewayDb();
 }
 
-// Seeds both DBs: the assistant mirror (for activeBindingFor reads) and the
-// gateway DB (now the source of truth for guardian-binding lookups).
+// Seeds both DBs: the assistant identity mirror and the gateway DB, which is
+// the source of truth for guardian role and channel ACL state.
 function insertGuardianContact(id: string, principalId: string, now: number) {
   testAssistantDb!
     .prepare(
@@ -192,18 +193,23 @@ function activeBindingFor(phone: string): {
   status: string;
   updatedAt: number | null;
 } | null {
-  const row = testAssistantDb!
-    .prepare(
-      `SELECT cc.address, cc.status, cc.updated_at AS updatedAt
-       FROM contacts c
-       JOIN contact_channels cc ON cc.contact_id = c.id
-       WHERE c.role = 'guardian' AND cc.type = 'phone'
-         AND cc.address = ?
-       LIMIT 1`,
+  const row = getGatewayDb()
+    .select({
+      address: contactChannels.address,
+      status: contactChannels.status,
+      updatedAt: contactChannels.updatedAt,
+    })
+    .from(contacts)
+    .innerJoin(contactChannels, eq(contactChannels.contactId, contacts.id))
+    .where(
+      and(
+        eq(contacts.role, "guardian"),
+        eq(contactChannels.type, "phone"),
+        eq(contactChannels.address, phone),
+      ),
     )
-    .get(phone) as
-    | { address: string; status: string; updatedAt: number | null }
-    | undefined;
+    .limit(1)
+    .get();
   return row ?? null;
 }
 


### PR DESCRIPTION
## Summary
Combo 11, workstream 3: the gateway is the source of truth for the 8 contact-ACL columns, but still mirror-wrote them into the assistant DB (a leftover from when the assistant read ACL). This removes every gateway write of the 8 ACL columns into the assistant DB, and — because removing the writes would otherwise leave several gateway **reads** returning stale/default values — repoints those coupled reads to the gateway DB in the same change. The 3 gateway-owned INFO writes (`last_seen_at`, `interaction_count`, `last_interaction`) and all identity/info writes are kept.

8 ACL columns dropped from assistant-DB writes: `contacts.role`, `contacts.principal_id`; `contact_channels.{status, policy, verified_at, verified_via, revoked_reason, blocked_reason}`.

## What changed (6 PRs, squash-merged here)
- **#36160** guardian-bootstrap: slim the assistant mirror; **invert `createGuardianBinding` to gateway-primary** (authoritative gateway write first, assistant identity mirror best-effort) so a revoke→recreate can't leave the gateway revoked on an assistant-write failure.
- **#36161** binding-helpers: revoke channel guardians in the gateway DB only.
- **#36165** contact-helpers: strip channel ACL writes; reactivation gates on the gateway row; **fail closed** if the authoritative gateway write is lost.
- **#36163** twilio voice verify: revoke + conflict-detection read/write the gateway DB only.
- **#36166** contact-prompt: stop mirroring guardian `role`.
- **#36167** contact-store: remove `dualWriteChannelStatusToAssistantDb` + the contact/channel ACL dual-writes; `upsertContact` read-back and the delete role guard now source ACL from the gateway DB.

Plus a remediation commit: DROP-safe `user_file` sibling lookup, drop a dead `cc.status` read, an `assistant-acl-write-drain` guard test (fails CI if an assistant-DB ACL write is reintroduced), and comment cleanup.

## Notes / decisions
- **m0008 is intentionally left intact** (migrations are append-only). Its retirement belongs to the assistant DROP-COLUMN migration (302), where its assistant ACL reads actually break. The narrow "pending-m0008 retry overwrites a post-change guardian" window is an accepted split-window in the meantime.
- **Residual assistant-DB ACL reads** (m0006/m0008 one-time migrations) are inventoried in the guard test header for the next workstream (reads-drain → DROP 302). The write side is now clean (guard-enforced).

## Self-review
4 passes run (external feedback, plan faithfulness, repo integration, slop). Integration + slop: PASS. Gaps found (DROP-safe lookup, dead read, guard test, stale comments) were remediated in the final commit.

Part of plan: remove-gateway-acl-mirror-writes.md