### PR TITLE
Active overlay: fit-to-available-width + list→detail drill-in

### DIFF
--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -65,7 +65,9 @@ export function ActiveOverlayShell({
   // the viewport. Re-measure on open, on column resize (live detail-panel
   // width + sidebar collapse both reflow it), on pill resize (the live
   // activity count/avatars change the pill width without reflowing the
-  // column), and on window resize.
+  // column), on sibling-pill resize/appearance (the two overlays share a
+  // centered flex row, so the other pill repositions this one without resizing
+  // the column or this shell), and on window resize.
   useEffect(() => {
     const measure = () => {
       const el = containerRef.current;
@@ -95,7 +97,19 @@ export function ActiveOverlayShell({
 
     const el = containerRef.current;
     const parent = el?.offsetParent as HTMLElement | null;
+    const row = el?.parentElement ?? null;
     let observer: ResizeObserver | undefined;
+    // Observe the shell root + every sibling pill in the centered flex row. A
+    // sibling's width change shifts this shell horizontally (changing
+    // containerLeft) without resizing the column or this shell, so neither
+    // observe(parent) nor observe(el) alone would fire (Codex P2). `observe` is
+    // idempotent, so re-observing on later mutations is safe.
+    const observeSiblings = () => {
+      if (!observer || !el) return;
+      for (const sibling of Array.from(row?.children ?? [])) {
+        if (sibling !== el) observer.observe(sibling);
+      }
+    };
     if (parent && el && typeof ResizeObserver !== "undefined") {
       observer = new ResizeObserver(measure);
       observer.observe(parent);
@@ -103,10 +117,24 @@ export function ActiveOverlayShell({
       // re-measure even when the column width is unchanged — keeps the centering
       // clamp anchored instead of drifting off-center until the next resize.
       observer.observe(el);
+      observeSiblings();
+    }
+    // A sibling pill mounting/unmounting (the other overlay activating or going
+    // idle) likewise repositions this shell without firing any ResizeObserver,
+    // so watch the row for child add/remove: re-measure and pick up resizes of
+    // any pill that appeared after setup.
+    let rowObserver: MutationObserver | undefined;
+    if (row && typeof MutationObserver !== "undefined") {
+      rowObserver = new MutationObserver(() => {
+        observeSiblings();
+        measure();
+      });
+      rowObserver.observe(row, { childList: true });
     }
     window.addEventListener("resize", measure);
     return () => {
       observer?.disconnect();
+      rowObserver?.disconnect();
       window.removeEventListener("resize", measure);
     };
   }, [expanded]);

--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -210,8 +210,8 @@ export function ActiveOverlayShell({
 
       <AnimatePresence>
         {expanded && (
-          // Absolute dropdown anchored under the pill so its width no longer
-          // dictates the row's width (Figma 6063:149685). Width is fitted to the
+          // Absolute dropdown anchored under the pill so its width is decoupled
+          // from the row's width (Figma 6063:149685). Width is fitted to the
           // chat column (see `fittedWidth`) rather than the viewport.
           <motion.div
             // Horizontal centering lives in motion's `x: "-50%"` (not a

--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -3,6 +3,21 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Typography } from "@vellumai/design-library";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
+/** Design max width of the dropdown (Figma 6063:149685). */
+const DROPDOWN_MAX_PX = 589;
+/** Min gutter (2rem) kept on each side of the chat column so it never clips. */
+const DROPDOWN_GUTTER_PX = 32;
+
+/** Geometry of the dropdown's positioning context, measured from the DOM. */
+interface ShellMetrics {
+  /** `clientWidth` of the offsetParent (the chat column / positioned ancestor). */
+  available: number;
+  /** Pill (shell root) left edge, relative to the offsetParent's content box. */
+  containerLeft: number;
+  /** Pill (shell root) width — the anchor the dropdown centers on. */
+  containerWidth: number;
+}
+
 export interface ActiveOverlayShellProps {
   /** `data-testid` for the root container (e.g. `"active-workflows-overlay"`). */
   testId: string;
@@ -32,6 +47,81 @@ export function ActiveOverlayShell({
   const [expanded, setExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const reduce = useReducedMotion();
+  // Measured geometry of the bounding chat column. `null` until measured
+  // (happy-dom/SSR have no layout) — see the fitted-width fallback below.
+  const [metrics, setMetrics] = useState<ShellMetrics | null>(null);
+
+  // Measure the chat column (the shell root's offsetParent — the nearest
+  // positioned ancestor) so the dropdown fits the available width instead of
+  // the viewport. Re-measure on open, on column resize (live detail-panel
+  // width + sidebar collapse both reflow it), and on window resize.
+  useEffect(() => {
+    const measure = () => {
+      const el = containerRef.current;
+      const parent = el?.offsetParent as HTMLElement | null;
+      const available = parent?.clientWidth ?? 0;
+      if (!el || !parent || available <= 0) {
+        setMetrics((prev) => (prev === null ? prev : null));
+        return;
+      }
+      const elRect = el.getBoundingClientRect();
+      const parentRect = parent.getBoundingClientRect();
+      const containerLeft = elRect.left - parentRect.left;
+      const containerWidth = elRect.width;
+      // Skip no-op updates: the observer fires on every reflow pixel while a
+      // detail panel is dragged, but downstream only cares when a value changed.
+      setMetrics((prev) =>
+        prev &&
+        prev.available === available &&
+        prev.containerLeft === containerLeft &&
+        prev.containerWidth === containerWidth
+          ? prev
+          : { available, containerLeft, containerWidth },
+      );
+    };
+
+    measure();
+
+    const parent = containerRef.current?.offsetParent as HTMLElement | null;
+    let observer: ResizeObserver | undefined;
+    if (parent && typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(measure);
+      observer.observe(parent);
+    }
+    window.addEventListener("resize", measure);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [expanded]);
+
+  // Fitted width: cap at the design max, shrink to the column minus gutters.
+  // Unmeasured (happy-dom / pre-measure / detached) → keep the requested max,
+  // mirroring `animated-right-drawer`'s "unmeasured container keeps requested
+  // width" fallback. Never produce a width <= 0.
+  const fittedWidth = metrics
+    ? Math.max(1, Math.min(DROPDOWN_MAX_PX, metrics.available - DROPDOWN_GUTTER_PX))
+    : DROPDOWN_MAX_PX;
+
+  // Horizontal placement. The transform keeps `x: "-50%"` (centering on the
+  // pill); we only adjust the `left` anchor so a far-off-center pill (two
+  // pills side by side) can't push the box past either column gutter.
+  // Unmeasured → fall back to the `left-1/2` (50%) anchor.
+  let dropdownLeft: number | string = "50%";
+  if (metrics) {
+    const pillCenter = metrics.containerLeft + metrics.containerWidth / 2;
+    const boxLeftDefault = pillCenter - fittedWidth / 2;
+    const lo = DROPDOWN_GUTTER_PX;
+    const hi = metrics.available - DROPDOWN_GUTTER_PX - fittedWidth;
+    // When the box can't fit both gutters (very narrow column) center it.
+    const boxLeft =
+      hi >= lo
+        ? Math.max(lo, Math.min(boxLeftDefault, hi))
+        : (metrics.available - fittedWidth) / 2;
+    // Convert the parent-relative box-left back to the `left` value that, with
+    // the `x: "-50%"` transform, lands the box there: left = boxLeft - C + w/2.
+    dropdownLeft = boxLeft - metrics.containerLeft + fittedWidth / 2;
+  }
 
   // While open, dismiss on outside pointerdown or Escape.
   useEffect(() => {
@@ -76,15 +166,19 @@ export function ActiveOverlayShell({
 
       <AnimatePresence>
         {expanded && (
-          // Absolute dropdown anchored under the pill so its 589px width no longer
-          // dictates the row's width (Figma 6063:149685).
+          // Absolute dropdown anchored under the pill so its width no longer
+          // dictates the row's width (Figma 6063:149685). Width is fitted to the
+          // chat column (see `fittedWidth`) rather than the viewport.
           <motion.div
             // Horizontal centering lives in motion's `x: "-50%"` (not a
             // `-translate-x-1/2` class) so it composes with the animated
             // `scale`/`y` in the same inline `transform` — version-independent
             // of Tailwind's translate-property model.
-            className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 flex w-[min(589px,calc(100vw-2rem))] flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
-            style={{ transformOrigin: "top center" }}
+            className="pointer-events-auto absolute top-full z-20 mt-2 flex flex-col gap-4 rounded-xl bg-[var(--surface-lift)] px-3 py-4 shadow-lg"
+            // Width fits the chat column (not the viewport) so a detail panel +
+            // sidebar can't clip it; `left` is the clamped anchor that pairs
+            // with the `x: "-50%"` transform below.
+            style={{ width: fittedWidth, left: dropdownLeft, transformOrigin: "top center" }}
             initial={{ opacity: 0, scale: 0.96, y: -4, x: "-50%" }}
             animate={{ opacity: 1, scale: 1, y: 0, x: "-50%" }}
             exit={{ opacity: 0, scale: 0.96, y: -4, x: "-50%" }}

--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -25,8 +25,12 @@ export interface ActiveOverlayShellProps {
   title: string;
   /** Renders the pill; receives the current expand state + a toggle handler. */
   renderPill: (args: { expanded: boolean; onToggle: () => void }) => ReactNode;
-  /** The mapped inline-card rows shown inside the expanded dropdown. */
-  children: ReactNode;
+  /**
+   * Renders the mapped inline-card rows shown inside the expanded dropdown.
+   * Receives `close()` so a row can drill into its detail panel and dismiss the
+   * dropdown in one click (both heavy layers stop competing for column width).
+   */
+  children: (api: { close: () => void }) => ReactNode;
 }
 
 /**
@@ -193,7 +197,7 @@ export function ActiveOverlayShell({
               {title}
             </Typography>
             <div className="flex max-h-[320px] flex-col gap-2 overflow-y-auto">
-              {children}
+              {children({ close: () => setExpanded(false) })}
             </div>
           </motion.div>
         )}

--- a/clients/web/src/domains/chat/components/active-overlay-shell.tsx
+++ b/clients/web/src/domains/chat/components/active-overlay-shell.tsx
@@ -5,7 +5,12 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 /** Design max width of the dropdown (Figma 6063:149685). */
 const DROPDOWN_MAX_PX = 589;
-/** Min gutter (2rem) kept on each side of the chat column so it never clips. */
+/**
+ * Total horizontal gutter (2rem) reserved between the dropdown and the chat
+ * column edges so it never clips. The width shrink subtracts it once, so when
+ * the column bounds the width each side gets ~16px; the `left` clamp can keep a
+ * full gutter on a side when it has room.
+ */
 const DROPDOWN_GUTTER_PX = 32;
 
 /** Geometry of the dropdown's positioning context, measured from the DOM. */
@@ -58,7 +63,9 @@ export function ActiveOverlayShell({
   // Measure the chat column (the shell root's offsetParent — the nearest
   // positioned ancestor) so the dropdown fits the available width instead of
   // the viewport. Re-measure on open, on column resize (live detail-panel
-  // width + sidebar collapse both reflow it), and on window resize.
+  // width + sidebar collapse both reflow it), on pill resize (the live
+  // activity count/avatars change the pill width without reflowing the
+  // column), and on window resize.
   useEffect(() => {
     const measure = () => {
       const el = containerRef.current;
@@ -86,11 +93,16 @@ export function ActiveOverlayShell({
 
     measure();
 
-    const parent = containerRef.current?.offsetParent as HTMLElement | null;
+    const el = containerRef.current;
+    const parent = el?.offsetParent as HTMLElement | null;
     let observer: ResizeObserver | undefined;
-    if (parent && typeof ResizeObserver !== "undefined") {
+    if (parent && el && typeof ResizeObserver !== "undefined") {
       observer = new ResizeObserver(measure);
       observer.observe(parent);
+      // Also observe the shell root so pill-width changes (live count/avatars)
+      // re-measure even when the column width is unchanged — keeps the centering
+      // clamp anchored instead of drifting off-center until the next resize.
+      observer.observe(el);
     }
     window.addEventListener("resize", measure);
     return () => {
@@ -99,7 +111,7 @@ export function ActiveOverlayShell({
     };
   }, [expanded]);
 
-  // Fitted width: cap at the design max, shrink to the column minus gutters.
+  // Fitted width: cap at the design max, shrink to the column minus one gutter.
   // Unmeasured (happy-dom / pre-measure / detached) → keep the requested max,
   // mirroring `animated-right-drawer`'s "unmeasured container keeps requested
   // width" fallback. Never produce a width <= 0.

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -96,6 +96,12 @@ describe("ActiveSubagentsOverlay — expanded", () => {
     const panel = title.parentElement;
     expect(panel?.className).toContain("absolute");
     expect(panel?.className).toContain("pointer-events-auto");
+
+    // Width is driven by the measured-column fallback (happy-dom has no layout),
+    // so it must resolve to a finite, positive px value — not 0 or NaN.
+    const fittedWidth = Number.parseFloat(panel?.style.width ?? "");
+    expect(Number.isFinite(fittedWidth)).toBe(true);
+    expect(fittedWidth).toBeGreaterThan(0);
   });
 
   test("clicking a collapsed avatar expands the panel", () => {

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -149,6 +149,53 @@ describe("ActiveSubagentsOverlay — expanded", () => {
   });
 });
 
+describe("ActiveSubagentsOverlay — drill-in", () => {
+  test("opening a row fires onSubagentClick and closes the dropdown", async () => {
+    const ids = seedMany(2);
+    const opened: string[] = [];
+    const { queryByText } = render(
+      <ActiveSubagentsOverlay
+        subagentIds={ids}
+        onSubagentClick={(id) => opened.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /open subagent/i })[0],
+    );
+
+    // The detail panel still opens (existing behavior).
+    expect(opened).toEqual(["sa-0"]);
+    // ...and the dropdown then closes so the two layers stop competing. It
+    // animates out via AnimatePresence (~1.8s in happy-dom), so wait it out.
+    await waitFor(
+      () => expect(queryByText("2 Active Subagents")).toBeNull(),
+      { timeout: 4000 },
+    );
+  });
+
+  test("stopping a row does NOT close the dropdown", () => {
+    const ids = seedMany(2);
+    const stopped: string[] = [];
+    const { queryByText } = render(
+      <ActiveSubagentsOverlay
+        subagentIds={ids}
+        onStopSubagent={(id) => stopped.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active subagents/i }));
+    fireEvent.click(screen.getAllByTestId("subagent-inline-card-stop")[0]);
+
+    expect(stopped).toEqual(["sa-0"]);
+    // Stopping keeps the list open so you can stop another / keep watching.
+    expect(queryByText("2 Active Subagents")).toBeTruthy();
+  });
+});
+
 describe("ActiveSubagentsOverlay — dismissal", () => {
   test("Escape collapses the open panel", async () => {
     const ids = seedMany(2);

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.test.tsx
@@ -7,7 +7,7 @@
  * callbacks, and Escape / outside-click dismissal.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   cleanup,
   fireEvent,
@@ -15,6 +15,52 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { createElement, type ReactElement, type ReactNode } from "react";
+
+// Mock `motion/react` so the dropdown mounts/unmounts synchronously. The real
+// AnimatePresence exit runs ~1.8s in happy-dom; under full-suite load that
+// overran the per-test timeout and flaked the drill-in/dismissal assertions
+// (which wait for the panel to leave the DOM). This strips motion-only props
+// and forwards className/style/children so the layout assertions still hold.
+mock.module("motion/react", () => {
+  const MOTION_ONLY_PROPS = new Set([
+    "initial",
+    "animate",
+    "exit",
+    "transition",
+    "variants",
+    "whileHover",
+    "whileTap",
+    "whileFocus",
+    "whileInView",
+    "whileDrag",
+    "layout",
+    "layoutId",
+    "drag",
+    "custom",
+    "onAnimationStart",
+    "onAnimationComplete",
+  ]);
+  return {
+    motion: new Proxy(
+      {} as Record<string, (props: Record<string, unknown>) => ReactElement>,
+      {
+        get: (_target, tag) => (props: Record<string, unknown>) => {
+          const domProps: Record<string, unknown> = {};
+          for (const key in props) {
+            if (!MOTION_ONLY_PROPS.has(key)) domProps[key] = props[key];
+          }
+          return createElement(String(tag), domProps);
+        },
+      },
+    ),
+    // Render children immediately and drop them synchronously on unmount (no
+    // exit hold) so close-on-drill-in / Escape / outside-click assertions don't
+    // depend on real animation timing.
+    AnimatePresence: ({ children }: { children?: ReactNode }) => children,
+    useReducedMotion: () => true,
+  };
+});
 
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { useSubagentStore } from "@/domains/chat/subagent-store";

--- a/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-subagents-overlay/active-subagents-overlay.tsx
@@ -29,14 +29,25 @@ export function ActiveSubagentsOverlay({
         />
       )}
     >
-      {subagentIds.map((id) => (
-        <SubagentInlineProgressCard
-          key={id}
-          subagentId={id}
-          onSubagentClick={onSubagentClick}
-          onStopSubagent={onStopSubagent}
-        />
-      ))}
+      {({ close }) =>
+        subagentIds.map((id) => (
+          <SubagentInlineProgressCard
+            key={id}
+            subagentId={id}
+            // Opening drills into the detail panel and dismisses the dropdown
+            // so the two layers stop competing for width; stopping keeps it open.
+            onSubagentClick={
+              onSubagentClick
+                ? (sid) => {
+                    onSubagentClick(sid);
+                    close();
+                  }
+                : undefined
+            }
+            onStopSubagent={onStopSubagent}
+          />
+        ))
+      }
     </ActiveOverlayShell>
   );
 }

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -15,6 +15,52 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { createElement, type ReactElement, type ReactNode } from "react";
+
+// Mock `motion/react` so the dropdown mounts/unmounts synchronously. The real
+// AnimatePresence exit runs ~1.8s in happy-dom; under full-suite load that
+// overran the per-test timeout and flaked the drill-in/dismissal assertions
+// (which wait for the panel to leave the DOM). This strips motion-only props
+// and forwards className/style/children so the layout assertions still hold.
+mock.module("motion/react", () => {
+  const MOTION_ONLY_PROPS = new Set([
+    "initial",
+    "animate",
+    "exit",
+    "transition",
+    "variants",
+    "whileHover",
+    "whileTap",
+    "whileFocus",
+    "whileInView",
+    "whileDrag",
+    "layout",
+    "layoutId",
+    "drag",
+    "custom",
+    "onAnimationStart",
+    "onAnimationComplete",
+  ]);
+  return {
+    motion: new Proxy(
+      {} as Record<string, (props: Record<string, unknown>) => ReactElement>,
+      {
+        get: (_target, tag) => (props: Record<string, unknown>) => {
+          const domProps: Record<string, unknown> = {};
+          for (const key in props) {
+            if (!MOTION_ONLY_PROPS.has(key)) domProps[key] = props[key];
+          }
+          return createElement(String(tag), domProps);
+        },
+      },
+    ),
+    // Render children immediately and drop them synchronously on unmount (no
+    // exit hold) so close-on-drill-in / Escape / outside-click assertions don't
+    // depend on real animation timing.
+    AnimatePresence: ({ children }: { children?: ReactNode }) => children,
+    useReducedMotion: () => true,
+  };
+});
 
 mock.module(
   "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card",

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -94,6 +94,12 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
     const panel = title.parentElement;
     expect(panel?.className).toContain("absolute");
     expect(panel?.className).toContain("pointer-events-auto");
+
+    // Width is driven by the measured-column fallback (happy-dom has no layout),
+    // so it must resolve to a finite, positive px value — not 0 or NaN.
+    const fittedWidth = Number.parseFloat(panel?.style.width ?? "");
+    expect(Number.isFinite(fittedWidth)).toBe(true);
+    expect(fittedWidth).toBeGreaterThan(0);
   });
 
   test("uses the singular noun when exactly one workflow is active", () => {

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.test.tsx
@@ -19,8 +19,34 @@ import {
 mock.module(
   "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card",
   () => ({
-    WorkflowInlineProgressCard: ({ runId }: { runId: string }) => (
-      <div data-testid="wf-card" data-run-id={runId} />
+    // Mirrors the real card's affordances (open present only when clickable,
+    // stop present only when stoppable) so the overlay's drill-in/stop wiring
+    // can be exercised without hydrating the workflow store.
+    WorkflowInlineProgressCard: ({
+      runId,
+      onWorkflowClick,
+      onStopWorkflow,
+    }: {
+      runId: string;
+      onWorkflowClick?: (runId: string) => void;
+      onStopWorkflow?: (runId: string) => void;
+    }) => (
+      <div data-testid="wf-card" data-run-id={runId}>
+        {onWorkflowClick ? (
+          <button
+            type="button"
+            aria-label="Open workflow"
+            onClick={() => onWorkflowClick(runId)}
+          />
+        ) : null}
+        {onStopWorkflow ? (
+          <button
+            type="button"
+            aria-label="Stop workflow"
+            onClick={() => onStopWorkflow(runId)}
+          />
+        ) : null}
+      </div>
     ),
   }),
 );
@@ -110,6 +136,55 @@ describe("ActiveWorkflowsOverlay — expanded", () => {
 
     expect(screen.getByText("1 Active Workflow")).toBeTruthy();
     expect(screen.queryByText("1 Active Workflows")).toBeNull();
+  });
+});
+
+describe("ActiveWorkflowsOverlay — drill-in", () => {
+  test("opening a row fires onWorkflowClick and closes the dropdown", async () => {
+    const ids = makeIds(2);
+    const opened: string[] = [];
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay
+        workflowRunIds={ids}
+        onWorkflowClick={(id) => opened.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /open workflow/i })[0],
+    );
+
+    // The detail panel still opens (existing behavior).
+    expect(opened).toEqual(["wf-0"]);
+    // ...and the dropdown then closes so the two layers stop competing. It
+    // animates out via AnimatePresence (~1.8s in happy-dom), so wait it out.
+    await waitFor(
+      () => expect(queryByText("2 Active Workflows")).toBeNull(),
+      { timeout: 4000 },
+    );
+  });
+
+  test("stopping a row does NOT close the dropdown", () => {
+    const ids = makeIds(2);
+    const stopped: string[] = [];
+    const { queryByText } = render(
+      <ActiveWorkflowsOverlay
+        workflowRunIds={ids}
+        onStopWorkflow={(id) => stopped.push(id)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active workflows/i }));
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /stop workflow/i })[0],
+    );
+
+    expect(stopped).toEqual(["wf-0"]);
+    // Stopping keeps the list open so you can stop another / keep watching.
+    expect(queryByText("2 Active Workflows")).toBeTruthy();
   });
 });
 

--- a/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
+++ b/clients/web/src/domains/chat/components/active-workflows-overlay/active-workflows-overlay.tsx
@@ -29,14 +29,25 @@ export function ActiveWorkflowsOverlay({
         />
       )}
     >
-      {workflowRunIds.map((runId) => (
-        <WorkflowInlineProgressCard
-          key={runId}
-          runId={runId}
-          onWorkflowClick={onWorkflowClick}
-          onStopWorkflow={onStopWorkflow}
-        />
-      ))}
+      {({ close }) =>
+        workflowRunIds.map((runId) => (
+          <WorkflowInlineProgressCard
+            key={runId}
+            runId={runId}
+            // Opening drills into the detail panel and dismisses the dropdown
+            // so the two layers stop competing for width; stopping keeps it open.
+            onWorkflowClick={
+              onWorkflowClick
+                ? (id) => {
+                    onWorkflowClick(id);
+                    close();
+                  }
+                : undefined
+            }
+            onStopWorkflow={onStopWorkflow}
+          />
+        ))
+      }
     </ActiveOverlayShell>
   );
 }


### PR DESCRIPTION
## Summary
Two UX fixes for the shared floating "Active Subagents" / "Active Workflows" overlay (`ActiveOverlayShell`) so it stops clipping when a right-hand detail panel is open and the chat column is narrow:
- **Fit-to-width:** the dropdown now sizes/positions itself to the measured chat-column width (ResizeObserver on the shell's positioning context + the shell root) capped at `min(589, available−32)`, with a horizontal clamp — instead of a viewport-based fixed width. Unchanged at ≥~1280px; shrinks-to-fit (no clipping) below. Existing fade+scale animation, reduced-motion, no-scrim click-through, dismiss, and internal scroll preserved.
- **Drill-in handoff:** selecting a row now opens its detail panel *and* closes the overlay (stop actions keep it open), so the two layers stop competing for horizontal space.

## Self-review result
PASS — 4 fresh-eyes passes (external, faithfulness, integration, slop). 1 gap remediated (#36179: also observe the shell root so pill-width changes re-anchor the clamp; corrected gutter comment). Advisory items deferred (a 2-site drill-in wrapper intentionally left inline).

## PRs merged into this feature branch
- #36176: fix(chat): fit active-overlay dropdown to the available column width
- #36177: feat(chat): close active-overlay dropdown when a subagent/workflow is opened

### Fix PRs
- #36179: fix(chat): re-measure active-overlay on pill resize; correct gutter comment

Part of plan: active-overlay-fit-drill-in.md