### PR TITLE
feat(web): add labeled-tabs progress mode to FormSurface

### DIFF
--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -116,6 +116,8 @@ export interface FormSurfaceData {
   submitLabel?: string;
   pages?: FormPage[];
   pageLabels?: { next?: string; back?: string; submit?: string };
+  /** Progress indicator style for multi-page forms: segment bar or labeled tabs. */
+  progressStyle?: "bar" | "tabs";
 }
 
 export interface ListItem {

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+import { SurfaceRouter } from "./surface-router";
+
+const meta: Meta = {
+  title: "Chat/Surfaces/Form",
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-[640px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+// Multi-page Slack-style setup wizard. Pages-only forms ship `fields: []`
+// after daemon normalization, so the story data mirrors that wire shape.
+const SETUP_PAGES = [
+  {
+    id: "create-app",
+    title: "Create App",
+    description: "Create a Slack app from an app manifest.",
+    fields: [
+      {
+        id: "appName",
+        type: "text",
+        label: "App name",
+        placeholder: "Vellum",
+        required: true,
+      },
+    ],
+  },
+  {
+    id: "app-token",
+    title: "Generate App Token",
+    description: "Generate an app-level token with the `connections:write` scope.",
+    fields: [
+      {
+        id: "appToken",
+        type: "password",
+        label: "App-level token",
+        placeholder: "xapp-...",
+        required: true,
+      },
+    ],
+  },
+  {
+    id: "install",
+    title: "Install App",
+    description: "Install the app to your workspace and paste the bot token.",
+    fields: [
+      {
+        id: "botToken",
+        type: "password",
+        label: "Bot token",
+        placeholder: "xoxb-...",
+        required: true,
+      },
+    ],
+  },
+];
+
+function makeFormSurface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "form-surface",
+    surfaceType: "form",
+    title: "Connect Slack",
+    data: {
+      fields: [],
+      pages: SETUP_PAGES,
+      pageLabels: { next: "Next", back: "Back", submit: "Finish setup" },
+    },
+    ...overrides,
+  };
+}
+
+function FormPreview({ initialSurface }: { initialSurface: Surface }) {
+  const [surface, setSurface] = useState(initialSurface);
+  return (
+    <SurfaceRouter
+      surface={surface}
+      onAction={(_surfaceId, actionId) => {
+        setSurface((current) => ({
+          ...current,
+          completed: true,
+          completionSummary:
+            actionId === "submit" ? "Form submitted" : "Form dismissed",
+        }));
+      }}
+    />
+  );
+}
+
+// Default multi-page progress: the segment bar (no `progressStyle`).
+export const SegmentBar: Story = {
+  render: () => <FormPreview initialSurface={makeFormSurface()} />,
+};
+
+// Multi-page progress rendered as labeled step tabs.
+export const LabeledTabs: Story = {
+  render: () => (
+    <FormPreview
+      initialSurface={makeFormSurface({
+        data: {
+          fields: [],
+          progressStyle: "tabs",
+          pages: SETUP_PAGES,
+          pageLabels: { next: "Next", back: "Back", submit: "Finish setup" },
+        },
+      })}
+    />
+  ),
+};
+
+// Single-page form (top-level fields, no pages) — no progress indicator.
+export const SinglePage: Story = {
+  render: () => (
+    <FormPreview
+      initialSurface={makeFormSurface({
+        title: "Add API key",
+        data: {
+          description: "Paste the API key for this integration.",
+          fields: [
+            {
+              id: "apiKey",
+              type: "password",
+              label: "API key",
+              placeholder: "sk-...",
+              required: true,
+            },
+          ],
+          submitLabel: "Save",
+        },
+      })}
+    />
+  ),
+};
+
+// A one-page `pages` payload that opts into tabs: the tab strip is skipped
+// (a single step), but the page title is still shown.
+export const SinglePageTabs: Story = {
+  render: () => (
+    <FormPreview
+      initialSurface={makeFormSurface({
+        data: {
+          fields: [],
+          progressStyle: "tabs",
+          pages: SETUP_PAGES.slice(0, 1),
+          pageLabels: { submit: "Create app" },
+        },
+      })}
+    />
+  ),
+};
+
+// Completed state rendered by the router.
+export const Completed: Story = {
+  render: () => (
+    <SurfaceRouter
+      surface={makeFormSurface({
+        completed: true,
+        completionSummary: "Slack connected",
+      })}
+      onAction={() => {}}
+    />
+  ),
+};

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -290,7 +290,12 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
 
       {showStepProgress &&
         (showTabs ? (
-          <PageTabs current={currentPage} pages={allPages} onNavigate={handleNavigate} />
+          <PageTabs
+            current={currentPage}
+            pages={allPages}
+            onNavigate={handleNavigate}
+            disabled={isSubmitting}
+          />
         ) : (
           <PageProgress current={currentPage} total={totalPages} />
         ))}

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -42,6 +42,7 @@ interface FormSurfaceData {
     back?: string;
     submit?: string;
   };
+  progressStyle?: "bar" | "tabs";
 }
 
 interface FormSurfaceProps {
@@ -177,6 +178,45 @@ function PageProgress({ current, total }: { current: number; total: number }) {
   );
 }
 
+function PageTabs({
+  current,
+  pages,
+  onNavigate,
+}: {
+  current: number;
+  pages: FormPage[];
+  onNavigate: (index: number) => void;
+}) {
+  return (
+    <div className="mb-4 flex items-center gap-4 overflow-x-auto border-b border-[var(--border-subtle)]">
+      {pages.map((page, i) => {
+        const isActive = i === current;
+        const isCompleted = i < current;
+        const isClickable = isCompleted;
+        const textClass = isActive
+          ? "text-[var(--content-strong)]"
+          : isCompleted
+            ? "text-[var(--content-default)]"
+            : "text-[var(--content-faint)]";
+        return (
+          <button
+            key={page.id}
+            type="button"
+            onClick={isClickable ? () => onNavigate(i) : undefined}
+            disabled={!isClickable}
+            aria-current={isActive ? "step" : undefined}
+            className={`-mb-px whitespace-nowrap border-b-2 pb-2 text-body-medium-default transition-colors ${
+              isActive ? "border-[var(--primary-base)]" : "border-transparent"
+            } ${textClass} ${isClickable ? "cursor-pointer" : "cursor-default"}`}
+          >
+            {i + 1}. {page.title}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -255,6 +295,15 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
     setCurrentPage((prev) => Math.max(prev - 1, 0));
   }, []);
 
+  const handleNavigate = useCallback(
+    (pageIndex: number) => {
+      if (pageIndex >= currentPage) return;
+      setValidationErrors({});
+      setCurrentPage(pageIndex);
+    },
+    [currentPage],
+  );
+
   const handleSubmit = useCallback(
     async (e: FormEvent) => {
       e.preventDefault();
@@ -292,11 +341,14 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
         </div>
       )}
 
-      {isMultiPage && totalPages > 1 && (
-        <PageProgress current={currentPage} total={totalPages} />
-      )}
+      {isMultiPage && totalPages > 1 &&
+        (formData.progressStyle === "tabs" ? (
+          <PageTabs current={currentPage} pages={allPages} onNavigate={handleNavigate} />
+        ) : (
+          <PageProgress current={currentPage} total={totalPages} />
+        ))}
 
-      {currentPageData.title && isMultiPage && (
+      {currentPageData.title && isMultiPage && formData.progressStyle !== "tabs" && (
         <h3 className="mb-1 text-title-small text-[var(--content-strong)]">
           {currentPageData.title}
         </h3>

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -5,6 +5,8 @@ import type { Surface } from "@/domains/chat/types/types";
 import { Button, Toggle } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { PageProgress } from "@/domains/chat/components/surfaces/page-progress";
+import { PageTabs } from "@/domains/chat/components/surfaces/page-tabs";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,7 +27,7 @@ interface FormField {
   options?: FormFieldOption[];
 }
 
-interface FormPage {
+export interface FormPage {
   id: string;
   title: string;
   description?: string;
@@ -157,64 +159,6 @@ function renderField(
         />
       );
   }
-}
-
-// ---------------------------------------------------------------------------
-// Progress indicator for multi-page forms
-// ---------------------------------------------------------------------------
-
-function PageProgress({ current, total }: { current: number; total: number }) {
-  return (
-    <div className="mb-4 flex items-center gap-1.5">
-      {Array.from({ length: total }, (_, i) => (
-        <div
-          key={i}
-          className={`h-1.5 flex-1 rounded-full transition-colors ${
-            i <= current ? "bg-[var(--primary-base)]" : "bg-[var(--border-subtle)]"
-          }`}
-        />
-      ))}
-    </div>
-  );
-}
-
-function PageTabs({
-  current,
-  pages,
-  onNavigate,
-}: {
-  current: number;
-  pages: FormPage[];
-  onNavigate: (index: number) => void;
-}) {
-  return (
-    <div className="mb-4 flex items-center gap-4 overflow-x-auto border-b border-[var(--border-subtle)]">
-      {pages.map((page, i) => {
-        const isActive = i === current;
-        const isCompleted = i < current;
-        const isClickable = isCompleted;
-        const textClass = isActive
-          ? "text-[var(--content-strong)]"
-          : isCompleted
-            ? "text-[var(--content-default)]"
-            : "text-[var(--content-faint)]";
-        return (
-          <button
-            key={page.id}
-            type="button"
-            onClick={isClickable ? () => onNavigate(i) : undefined}
-            disabled={!isClickable}
-            aria-current={isActive ? "step" : undefined}
-            className={`-mb-px whitespace-nowrap border-b-2 pb-2 text-body-medium-default transition-colors ${
-              isActive ? "border-[var(--primary-base)]" : "border-transparent"
-            } ${textClass} ${isClickable ? "cursor-pointer" : "cursor-default"}`}
-          >
-            {i + 1}. {page.title}
-          </button>
-        );
-      })}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -275,6 +275,9 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
     ? (formData.pageLabels?.submit ?? "Submit")
     : (formData.submitLabel ?? "Submit");
 
+  const showStepProgress = isMultiPage && totalPages > 1;
+  const showTabs = showStepProgress && formData.progressStyle === "tabs";
+
   return (
     <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
       {surface.title && (
@@ -285,14 +288,14 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
         </div>
       )}
 
-      {isMultiPage && totalPages > 1 &&
-        (formData.progressStyle === "tabs" ? (
+      {showStepProgress &&
+        (showTabs ? (
           <PageTabs current={currentPage} pages={allPages} onNavigate={handleNavigate} />
         ) : (
           <PageProgress current={currentPage} total={totalPages} />
         ))}
 
-      {currentPageData.title && isMultiPage && formData.progressStyle !== "tabs" && (
+      {currentPageData.title && isMultiPage && !showTabs && (
         <h3 className="mb-1 text-title-small text-[var(--content-strong)]">
           {currentPageData.title}
         </h3>

--- a/clients/web/src/domains/chat/components/surfaces/page-progress.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/page-progress.tsx
@@ -1,0 +1,19 @@
+interface PageProgressProps {
+  current: number;
+  total: number;
+}
+
+export function PageProgress({ current, total }: PageProgressProps) {
+  return (
+    <div className="mb-4 flex items-center gap-1.5">
+      {Array.from({ length: total }, (_, i) => (
+        <div
+          key={i}
+          className={`h-1.5 flex-1 rounded-full transition-colors ${
+            i <= current ? "bg-[var(--primary-base)]" : "bg-[var(--border-subtle)]"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
@@ -1,37 +1,56 @@
-import { Tabs } from "@vellumai/design-library";
-
 import type { FormPage } from "@/domains/chat/components/surfaces/form-surface";
 
 interface PageTabsProps {
   current: number;
   pages: FormPage[];
   onNavigate: (index: number) => void;
+  disabled?: boolean;
 }
 
 /**
- * Labeled step tabs for a multi-page form. The current page is active,
- * completed pages (before the current one) are clickable to navigate
- * back, and future pages are disabled — forward navigation goes through
- * the Next button. Built on the design library `Tabs` primitive for
- * keyboard navigation, focus handling, and consistent styling.
+ * Labeled step navigation for a multi-page form. A gated, ordered wizard is a
+ * step pattern rather than a tabs/tabpanel widget, so the current step is
+ * marked with `aria-current="step"`: completed steps are buttons that navigate
+ * back, future steps are disabled, and forward navigation goes through the Next
+ * button. While the form is submitting, navigation is disabled so the visible
+ * step can't drift from the already-submitted values. The visual style matches
+ * the design system's underline tabs.
  */
-export function PageTabs({ current, pages, onNavigate }: PageTabsProps) {
+export function PageTabs({
+  current,
+  pages,
+  onNavigate,
+  disabled = false,
+}: PageTabsProps) {
   return (
-    <Tabs.Root
-      value={pages[current]?.id}
-      onValueChange={(value) => {
-        const index = pages.findIndex((page) => page.id === value);
-        if (index >= 0) onNavigate(index);
-      }}
-      className="mb-4"
+    <nav
+      aria-label="Form steps"
+      className="mb-4 flex items-center gap-4 overflow-x-auto border-b border-[var(--border-subtle)]"
     >
-      <Tabs.List className="overflow-x-auto">
-        {pages.map((page, i) => (
-          <Tabs.Trigger key={page.id} value={page.id} disabled={i > current}>
+      {pages.map((page, i) => {
+        const isActive = i === current;
+        const isCompleted = i < current;
+        const canNavigate = isCompleted && !disabled;
+        const textClass = isActive
+          ? "text-[var(--content-strong)]"
+          : isCompleted
+            ? "text-[var(--content-default)]"
+            : "text-[var(--content-faint)]";
+        return (
+          <button
+            key={page.id}
+            type="button"
+            onClick={canNavigate ? () => onNavigate(i) : undefined}
+            disabled={!canNavigate}
+            aria-current={isActive ? "step" : undefined}
+            className={`-mb-px whitespace-nowrap border-b-2 pb-2 text-body-medium-default transition-colors ${
+              isActive ? "border-[var(--primary-base)]" : "border-transparent"
+            } ${textClass} ${canNavigate ? "cursor-pointer" : "cursor-default"}`}
+          >
             {i + 1}. {page.title}
-          </Tabs.Trigger>
-        ))}
-      </Tabs.List>
-    </Tabs.Root>
+          </button>
+        );
+      })}
+    </nav>
   );
 }

--- a/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
@@ -1,0 +1,37 @@
+import { Tabs } from "@vellumai/design-library";
+
+import type { FormPage } from "@/domains/chat/components/surfaces/form-surface";
+
+interface PageTabsProps {
+  current: number;
+  pages: FormPage[];
+  onNavigate: (index: number) => void;
+}
+
+/**
+ * Labeled step tabs for a multi-page form. The current page is active,
+ * completed pages (before the current one) are clickable to navigate
+ * back, and future pages are disabled — forward navigation goes through
+ * the Next button. Built on the design library `Tabs` primitive for
+ * keyboard navigation, focus handling, and consistent styling.
+ */
+export function PageTabs({ current, pages, onNavigate }: PageTabsProps) {
+  return (
+    <Tabs.Root
+      value={pages[current]?.id}
+      onValueChange={(value) => {
+        const index = pages.findIndex((page) => page.id === value);
+        if (index >= 0) onNavigate(index);
+      }}
+      className="mb-4"
+    >
+      <Tabs.List className="overflow-x-auto">
+        {pages.map((page, i) => (
+          <Tabs.Trigger key={page.id} value={page.id} disabled={i > current}>
+            {i + 1}. {page.title}
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+    </Tabs.Root>
+  );
+}


### PR DESCRIPTION
## What

Adds a `progressStyle` option to `FormSurface` so multi-page forms can render either the existing segment bar (`"bar"`, default) or labeled **step navigation** (`"tabs"`) — numbered steps with an active underline. Unblocks the deterministic Slack setup UI arc (LUM-2608/2609).

## Changes

- **`assistant/src/daemon/message-types/surfaces.ts`** — add optional `progressStyle?: "bar" | "tabs"` to `FormSurfaceData`. Flows through the daemon's existing `...raw` form-payload spread, no route changes.
- **`clients/web/.../form-surface.tsx`** — add `progressStyle` to the client type; a shared `showTabs = isMultiPage && totalPages > 1 && progressStyle === "tabs"` flag drives both the indicator choice and per-page-title suppression (so a single-page `pages` payload in tabs mode keeps its title); `handleNavigate` clears validation errors and blocks forward jumps; `disabled={isSubmitting}` is passed to the step nav.
- **`clients/web/.../page-tabs.tsx`** (new) — `PageTabs` renders labeled steps as **semantic step navigation**: a `<nav aria-label="Form steps">` of `<button>`s with `aria-current="step"`. A gated, sequential wizard is a stepper, not a tabs/tabpanel widget, so it deliberately does **not** use the Radix `Tabs` primitive (which would emit `role="tab"`/`aria-controls` pointing at non-existent panels). Current step active, completed steps clickable to navigate back, future steps + in-flight submits disabled. Styled with design tokens to match the underline-tab look.
- **`clients/web/.../page-progress.tsx`** (new) — the existing segment-bar `PageProgress`, extracted to its own file.
- **`clients/web/.../form-surface.stories.tsx`** (new) — Storybook stories: segment bar, labeled steps, single-page, single-page-tabs edge case, completed.

## Backward compatibility

`progressStyle` is optional and defaults to `undefined` → the existing segment bar. `PageProgress` behavior is unchanged and all existing `FormSurface` callers are unaffected.

## Testing

- `clients/web` lint + `tsc --noEmit`, `assistant` `tsc --noEmit` — all pass
- Storybook builds; screenshots of all modes posted in a comment

Closes LUM-2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)