### PR TITLE
[codex] fix chat nudge banner overlap

### DIFF
--- a/clients/web/src/components/nudges/nudge-chat-banner.test.tsx
+++ b/clients/web/src/components/nudges/nudge-chat-banner.test.tsx
@@ -81,4 +81,21 @@ describe("NudgeChatBanner", () => {
     expect(html).toContain("background:var(--surface-base)");
     expect(html).not.toContain("background:var(--surface-overlay)");
   });
+
+  test("keeps the leading icon square visually distinct", () => {
+    const html = renderToStaticMarkup(
+      <NudgeChatBanner
+        icon={<span>icon</span>}
+        title="Vellum is open source"
+        subtitle="Star us on GitHub or contribute"
+        ctaLabel="Star us"
+        ctaAriaLabel="Star Vellum on GitHub"
+        ariaLabel="Vellum is open source on GitHub"
+        onAction={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(html).toContain("background:var(--surface-lift)");
+  });
 });

--- a/clients/web/src/components/nudges/nudge-chat-banner.test.tsx
+++ b/clients/web/src/components/nudges/nudge-chat-banner.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, mock, test } from "bun:test";
+import { type ButtonHTMLAttributes, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("@vellumai/design-library", () => ({
+  Button: ({
+    children,
+    iconOnly,
+    leftIcon: _leftIcon,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: {
+    children?: ReactNode;
+    iconOnly?: ReactNode;
+    leftIcon?: ReactNode;
+    variant?: string;
+    size?: string;
+  } & ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{iconOnly ?? children}</button>
+  ),
+  Notice: ({
+    children,
+    actions,
+    tone,
+  }: {
+    children?: ReactNode;
+    actions?: ReactNode;
+    tone?: string;
+  }) => (
+    <div data-testid="notice" data-tone={tone}>
+      {children}
+      {actions ? <div data-testid="notice-actions">{actions}</div> : null}
+    </div>
+  ),
+  Card: {
+    Root: ({
+      children,
+      padding: _padding,
+      bordered: _bordered,
+      elevated: _elevated,
+      ...props
+    }: {
+      children?: ReactNode;
+      padding?: unknown;
+      bordered?: unknown;
+      elevated?: unknown;
+    }) => <div {...props}>{children}</div>,
+    Body: ({
+      children,
+      padding: _padding,
+      ...props
+    }: {
+      children?: ReactNode;
+      padding?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+  ResizablePanel: () => <div data-testid="resizable-panel" />,
+  Typography: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+const { NudgeChatBanner } = await import("@/components/nudges/nudge-chat-banner");
+
+describe("NudgeChatBanner", () => {
+  test("uses an opaque surface so transcript content does not show through", () => {
+    const html = renderToStaticMarkup(
+      <NudgeChatBanner
+        icon={<span>icon</span>}
+        title="Vellum is open source"
+        subtitle="Star us on GitHub or contribute"
+        ctaLabel="Star us"
+        ctaAriaLabel="Star Vellum on GitHub"
+        ariaLabel="Vellum is open source on GitHub"
+        onAction={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(html).toContain("background:var(--surface-base)");
+    expect(html).not.toContain("background:var(--surface-overlay)");
+  });
+});

--- a/clients/web/src/components/nudges/nudge-chat-banner.tsx
+++ b/clients/web/src/components/nudges/nudge-chat-banner.tsx
@@ -11,7 +11,7 @@ import { Button } from "@vellumai/design-library";
  *
  * Width is constrained to `--chat-max-width` so the banner aligns with
  * the composer below it. Surface tokens follow the design-system
- * conventions (overlay surface, base border, subtle shadow).
+ * conventions (base surface, element border, subtle shadow).
  */
 export interface NudgeChatBannerProps {
   /** Decorative leading icon — rendered inside a 32px rounded square. */
@@ -62,7 +62,7 @@ export function NudgeChatBanner({
       <div className="flex flex-1 items-center gap-2 px-4 py-3 md:gap-3">
         <span
           className="flex size-8 shrink-0 items-center justify-center rounded-lg"
-          style={{ background: "var(--surface-base)" }}
+          style={{ background: "var(--surface-lift)" }}
         >
           {icon}
         </span>

--- a/clients/web/src/components/nudges/nudge-chat-banner.tsx
+++ b/clients/web/src/components/nudges/nudge-chat-banner.tsx
@@ -49,7 +49,7 @@ export function NudgeChatBanner({
     <div
       className="mx-auto flex overflow-hidden rounded-xl border"
       style={{
-        background: "var(--surface-overlay)",
+        background: "var(--surface-base)",
         borderColor: "var(--border-element)",
         animation: "fadeInUp 0.25s ease-out both",
         maxWidth: "var(--chat-max-width)",

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { type ButtonHTMLAttributes, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -236,15 +237,61 @@ describe("ChatBody — banner overlay suppression (LUM-1566)", () => {
     expect(html).toContain("BANNER_CONTENT");
   });
 
-  test("reserves transcript space when a bottom banner overlay is present", () => {
-    const html = renderToStaticMarkup(
-      <ChatBody
-        {...baseProps({
-          bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
-        })}
-      />,
-    );
-    expect(html).toContain("padding-bottom:88px");
+  test("reserves the measured bottom banner height", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let measuredHeight = 137;
+    let resizeCallback: ResizeObserverCallback | null = null;
+
+    HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this.querySelector('[data-testid="banner"]')) {
+        return {
+          bottom: measuredHeight,
+          height: measuredHeight,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+
+    try {
+      const { container } = render(
+        <ChatBody
+          {...baseProps({
+            bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
+          })}
+        />,
+      );
+      await waitFor(() => {
+        expect(container.innerHTML).toContain("padding-bottom: 137px");
+      });
+
+      measuredHeight = 164;
+      act(() => {
+        resizeCallback?.([], {} as ResizeObserver);
+      });
+      await waitFor(() => {
+        expect(container.innerHTML).toContain("padding-bottom: 164px");
+      });
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+      globalThis.ResizeObserver = originalResizeObserver;
+      cleanup();
+    }
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -56,10 +56,16 @@ mock.module("@vellumai/design-library", () => ({
   Button: ({
     children,
     iconOnly,
+    leftIcon: _leftIcon,
+    variant: _variant,
+    size: _size,
     ...props
   }: {
     children?: ReactNode;
     iconOnly?: ReactNode;
+    leftIcon?: ReactNode;
+    variant?: string;
+    size?: string;
   } & ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button {...props}>{iconOnly ?? children}</button>
   ),
@@ -228,6 +234,17 @@ describe("ChatBody — banner overlay suppression (LUM-1566)", () => {
       />,
     );
     expect(html).toContain("BANNER_CONTENT");
+  });
+
+  test("reserves transcript space when a bottom banner overlay is present", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
+        })}
+      />,
+    );
+    expect(html).toContain("padding-bottom:88px");
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -1,4 +1,10 @@
-import { type DragEventHandler, type ReactNode } from "react";
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type DragEventHandler,
+  type ReactNode,
+} from "react";
 
 import { Eye, Paperclip, Square, X } from "lucide-react";
 
@@ -11,8 +17,6 @@ import {
     type RefreshFeedback,
 } from "@/domains/chat/refresh-feedback-pill";
 import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
-
-const BOTTOM_BANNER_OVERLAY_RESERVE_PX = 88;
 
 /**
  * Single composition of a chat panel: a scrollable messages/empty-state
@@ -215,6 +219,33 @@ export function ChatBody({
   activeSubagentsSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
+  const bottomBannerOverlayRef = useRef<HTMLDivElement | null>(null);
+  const [bottomBannerOverlayHeight, setBottomBannerOverlayHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    if (isEmptyState || !bannerSlot) {
+      setBottomBannerOverlayHeight(0);
+      return;
+    }
+
+    const el = bottomBannerOverlayRef.current;
+    if (!el) return;
+
+    const updateHeight = () => {
+      const nextHeight = Math.ceil(el.getBoundingClientRect().height);
+      setBottomBannerOverlayHeight((currentHeight) =>
+        currentHeight === nextHeight ? currentHeight : nextHeight,
+      );
+    };
+
+    updateHeight();
+
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [bannerSlot, isEmptyState]);
 
   // When the empty state is visible, center greeting + composer + starters
   // as one group. `safe center` falls back to start-alignment when the
@@ -239,7 +270,9 @@ export function ChatBody({
   const hasOverlay =
     !isEmptyState && (showScrollToLatest || Boolean(bannerSlot));
   const bottomOverlayReservePx =
-    !isEmptyState && bannerSlot ? BOTTOM_BANNER_OVERLAY_RESERVE_PX : undefined;
+    !isEmptyState && bannerSlot && bottomBannerOverlayHeight > 0
+      ? bottomBannerOverlayHeight
+      : undefined;
 
   return (
     <div
@@ -286,7 +319,11 @@ export function ChatBody({
                 />
               </div>
             )}
-            {bannerSlot}
+            {bannerSlot && (
+              <div ref={bottomBannerOverlayRef} className="w-full">
+                {bannerSlot}
+              </div>
+            )}
           </div>
         )}
         <div className="mx-auto max-w-[var(--chat-max-width)]">

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/domains/chat/refresh-feedback-pill";
 import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
 
+const BOTTOM_BANNER_OVERLAY_RESERVE_PX = 88;
+
 /**
  * Single composition of a chat panel: a scrollable messages/empty-state
  * area on top, and a composer stack underneath.
@@ -236,6 +238,8 @@ export function ChatBody({
   // at the call site), so this only affects `bannerSlot`.
   const hasOverlay =
     !isEmptyState && (showScrollToLatest || Boolean(bannerSlot));
+  const bottomOverlayReservePx =
+    !isEmptyState && bannerSlot ? BOTTOM_BANNER_OVERLAY_RESERVE_PX : undefined;
 
   return (
     <div
@@ -245,7 +249,10 @@ export function ChatBody({
       onDragLeave={dragHandlers.onDragLeave}
       onDrop={dragHandlers.onDrop}
     >
-      <ChatScrollArea {...scrollAreaProps} />
+      <ChatScrollArea
+        {...scrollAreaProps}
+        bottomOverlayReservePx={bottomOverlayReservePx}
+      />
 
       {!isEmptyState && showScrollToLatest && activeSubagentsSlot && (
         <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center px-3 pt-2">

--- a/clients/web/src/domains/chat/components/chat-scroll-area.tsx
+++ b/clients/web/src/domains/chat/components/chat-scroll-area.tsx
@@ -57,6 +57,8 @@ export interface ChatScrollAreaProps {
   transcriptRef: ForwardedRef<TranscriptHandle>;
   /** {@link TranscriptProps} forwarded to {@link Transcript}. */
   transcriptProps: TranscriptProps;
+  /** Space reserved below the scrollable transcript for bottom floating UI. */
+  bottomOverlayReservePx?: number;
 }
 
 export function ChatScrollArea({
@@ -67,6 +69,7 @@ export function ChatScrollArea({
   emptyStateProps,
   transcriptRef,
   transcriptProps,
+  bottomOverlayReservePx,
 }: ChatScrollAreaProps) {
   // When the empty state is shown, this wrapper must NOT take `flex-1` so
   // the parent `ChatBody` can center it together with the composer +
@@ -75,9 +78,12 @@ export function ChatScrollArea({
   const wrapperClass = showEmptyState
     ? "relative flex min-h-0 flex-col"
     : "relative flex min-h-0 flex-1 flex-col";
+  const wrapperStyle = bottomOverlayReservePx
+    ? { paddingBottom: bottomOverlayReservePx }
+    : undefined;
 
   return (
-    <div className={wrapperClass}>
+    <div className={wrapperClass} style={wrapperStyle}>
       {isLoadingHistory && messageCount === 0 && <ChatSkeleton />}
       {showMaintenanceRecoveryCard && <MaintenanceRecoveryCard />}
       {showEmptyState && <ChatEmptyState {...emptyStateProps} />}


### PR DESCRIPTION
## Summary
- Make the in-chat nudge banner use an opaque surface so transcript content cannot show through it.
- Reserve bottom space in the chat scroll area whenever a bottom banner overlay is present.
- Add regression coverage for the opaque banner and scroll reserve behavior.

## Root Cause
The nudge banner rendered in an absolute bottom overlay above the composer while the transcript scroll area did not reserve space for that overlay. The banner also used `--surface-overlay`, which can visually allow content behind it to show through.

## Validation
- `cd clients/web && bun test src/domains/chat/components/chat-body.test.tsx src/components/nudges/nudge-chat-banner.test.tsx src/domains/chat/components/chat-scroll-area.test.tsx`
- `cd clients/web && bunx tsc --noEmit`