### PR TITLE
chore(repo): prime agents with package docs at session start; require one component per file

### DIFF
--- a/.claude/hooks/session-docs-primer.sh
+++ b/.claude/hooks/session-docs-primer.sh
@@ -7,7 +7,11 @@
 project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
 cd "$project_dir" 2>/dev/null || exit 0
 
-mapfile -t index < <(
+# Bash 3.2 (macOS /bin/bash) has no mapfile/readarray; collect with a read loop.
+index=()
+while IFS= read -r entry; do
+  [ -n "$entry" ] && index+=("$entry")
+done < <(
   find . \
     \( -path '*/node_modules' -o -path '*/.git' -o -name generated -o -name dist -o -name build \) -prune -o \
     \( -name AGENTS.md -o -name CLAUDE.md \) -print 2>/dev/null |

--- a/.claude/hooks/session-docs-primer.sh
+++ b/.claude/hooks/session-docs-primer.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# At session start, surface the repo's convention index (every AGENTS.md /
+# CLAUDE.md) and direct the agent to read a package's governing docs before
+# editing its code. Runs once per session, not per edit. Skips vendored and
+# generated trees.
+
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$project_dir" 2>/dev/null || exit 0
+
+mapfile -t index < <(
+  find . \
+    \( -path '*/node_modules' -o -path '*/.git' -o -name generated -o -name dist -o -name build \) -prune -o \
+    \( -name AGENTS.md -o -name CLAUDE.md \) -print 2>/dev/null |
+    sed 's|^\./||' | sort
+)
+
+[ "${#index[@]}" -gt 0 ] || exit 0
+
+list=$(printf '  - %s\n' "${index[@]}")
+
+msg=$(
+  cat <<EOF
+Repo conventions live in nested AGENTS.md / CLAUDE.md files and per-package docs/ folders. Before editing code in an area, read its governing docs FIRST and follow the closest, most specific one when rules conflict:
+  1. the repo-root AGENTS.md,
+  2. the nearest AGENTS.md / CLAUDE.md at or above the file you are editing,
+  3. the docs/*.md beside that nearest file (e.g. clients/web/docs/CONVENTIONS.md and clients/web/docs/STYLE_GUIDE.md for web code).
+Convention index for this repo:
+${list}
+EOF
+)
+
+jq -n --arg ctx "$msg" '{
+  "hookSpecificOutput": { "hookEventName": "SessionStart", "additionalContext": $ctx }
+}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/session-docs-primer.sh\""
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,14 @@ When a Vellum [Linear](https://linear.app/) ticket exists for the work, link it 
 
 Never commit worktree directories or worktree artifacts. Git worktrees are local working copies and must remain local. The `.gitignore` already excludes common patterns (`worktrees/`, `.worktrees/`, `.codex-worktrees/`, `*-worktrees/`); if a tool creates worktree directories under a new prefix, add the pattern to `.gitignore` before committing.
 
+## Single Source of Truth
+
+Don't copy-paste logic. Duplicated logic drifts: a bug gets fixed in one copy and left in the others, and the copies diverge silently over time. When the same behavior (a derivation, formatter, guard, validation, fetch/retry sequence, handler) appears in more than one place, extract it into one named function/hook/module that every caller imports — fix it once, it's fixed everywhere.
+
+- Extract on the **second** occurrence, not the fifth — two copies is the signal, not a milestone to pass.
+- Share **behavior**, not just shapes: reusing a type while re-implementing the logic around it still drifts.
+- Put the extracted code at the right layer (see the package's own docs — e.g. `clients/web/docs/CONVENTIONS.md` "Top-level shared directories"): used by one area → inside it; used by two or more → a shared module. Then delete the originals in the same change.
+
 ## Dead Code Removal
 
 Proactively remove unused code during every change. Remove code your change makes unused, clean up adjacent dead code, delete rather than comment out, check for orphaned files. Ask: "After my change, is there any code that nothing calls, imports, or references?" If yes, delete it.

--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -621,6 +621,12 @@ multi-prop wiring, conditional rendering beyond a one-liner) should be
 extracted into a named component. Trivial inline JSX (a single element,
 a static label) stays inline.
 
+An extracted component is a named component, and a named component lives
+in its own file — see [STYLE_GUIDE — One component per file](./STYLE_GUIDE.md#one-component-per-file).
+Don't append a second component as an extra export on its parent;
+co-locating is a deliberate, rare exception for a trivial helper private
+to its sibling.
+
 Reference: [React — Thinking in React: break the UI into a component hierarchy](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy)
 
 ### Stabilize external callbacks with refs

--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -441,6 +441,16 @@ conversations (Slack, email, Telegram) have keys like
    for external channel adapters; web-originated traffic uses
    `conversationId`.
 
+### Don't duplicate logic — one source of truth
+
+When the same logic (a derivation, formatter, guard, fetch sequence, or
+handler) appears in more than one place, extract it into a single named
+function/hook/util that every caller imports. Copy-pasted logic drifts —
+a bug fixed in one copy survives in the others — so extract on the
+**second** occurrence, share behavior rather than just types, and delete
+the originals in the same PR. Where the extracted code lives follows the
+decision rule below.
+
 ### Top-level shared directories
 
 Code used across multiple domains lives in top-level shared

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -329,6 +329,20 @@ interface ChatBodyProps {
 export function ChatBody({ messages, onSubmit }: ChatBodyProps) { /* ... */ }
 ```
 
+### One component per file
+
+Default to **one component per file**, in a kebab-case file named after
+its export (see [Component filenames match the export](#component-filenames-match-the-export)).
+A new component goes in its own new file rather than as a second export
+appended to an existing one.
+
+Co-locating more than one component in a single file is a deliberate
+exception, not the default — reserve it for a trivial presentational
+helper that is private to its sibling and meaningless on its own. The
+moment a sub-component grows its own responsibility (its own props,
+conditional rendering beyond a one-liner, or independent reuse), give it
+its own file. When in doubt, split.
+
 ---
 
 ## Hooks


### PR DESCRIPTION
## What

Two small, related guardrails so agents (and people) follow the repo's existing conventions instead of rediscovering them per change. Split out of the FormSurface PR (#36182) since it's an unrelated concern.

### 1. SessionStart hook — read the docs before editing
`.claude/hooks/session-docs-primer.sh` runs **once at session start** (not per edit) and injects, as `additionalContext`:
- a directive to read a package's governing docs before editing its code — the repo-root `AGENTS.md`, the nearest `AGENTS.md`/`CLAUDE.md` above the file, and that package's `docs/*.md` — following the most specific doc on conflicts;
- an auto-generated index of every `AGENTS.md`/`CLAUDE.md` in the repo.

This flattens the discovery/traversal step (root `AGENTS.md` → `clients/web/AGENTS.md` → `docs/CONVENTIONS.md`/`STYLE_GUIDE.md`) that's easy to skip. SessionStart is the idiomatic hook for loading conventions/context at the start; it mirrors the existing committed `linear-ticket-reminder` `UserPromptSubmit` hook. Registered in `.claude/settings.json`.

### 2. Document "one component per file"
- `clients/web/docs/STYLE_GUIDE.md` — adds a "One component per file" rule: it's the default, with rare deliberate exceptions for a trivial helper private to its sibling. No ESLint rule — a strong default, not a hard gate.
- `clients/web/docs/CONVENTIONS.md` — the existing "Extract sub-components" guidance now cross-links the rule, so the own-file expectation is explicit where extraction is discussed.

## Why

Conventions only help if they're read. The hook makes the index unavoidable at session start; writing the one-per-file default down makes it enforceable by review rather than left to taste.

## Testing

- Hook emits valid JSON and the expected directive + index (`echo '{}' | CLAUDE_PROJECT_DIR=$PWD .claude/hooks/session-docs-primer.sh | jq`).
- Docs-only + config + hook script; no app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wuqoKsrCJ336NLvvNPMvv)_