### PR TITLE
combo11: de-register m0006/m0008 (assistant ACL readers) ahead of the column drop

### DIFF
--- a/gateway/src/db/data-migrations/index.ts
+++ b/gateway/src/db/data-migrations/index.ts
@@ -24,9 +24,7 @@ import * as m0002 from "./m0002-actor-token-tables-to-gateway.js";
 import * as m0003 from "./m0003-recover-backup-key.js";
 import * as m0004 from "./m0004-actor-token-hash-index-unfiltered.js";
 import * as m0005 from "./m0005-normalize-contact-channel-addresses.js";
-import * as m0006 from "./m0006-reconcile-contacts-from-assistant.js";
 import * as m0007 from "./m0007-backfill-ingress-invites.js";
-import * as m0008 from "./m0008-upsert-acl-columns-from-assistant.js";
 
 const log = getLogger("data-migrations");
 
@@ -37,15 +35,15 @@ type MigrationModule = {
   down: () => MigrationResult | Promise<MigrationResult>;
 };
 
+// The assistant-ACL reconcile/backfill migrations (m0006, m0008) are retired:
+// the gateway DB is the ACL source of truth.
 const MIGRATIONS: { key: string; mod: MigrationModule }[] = [
   { key: "m0001-guardian-init-lock", mod: m0001 },
   { key: "m0002-actor-token-tables-to-gateway", mod: m0002 },
   { key: "m0003-recover-backup-key", mod: m0003 },
   { key: "m0004-actor-token-hash-index-unfiltered", mod: m0004 },
   { key: "m0005-normalize-contact-channel-addresses", mod: m0005 },
-  { key: "m0006-reconcile-contacts-from-assistant", mod: m0006 },
   { key: "m0007-backfill-ingress-invites", mod: m0007 },
-  { key: "m0008-upsert-acl-columns-from-assistant", mod: m0008 },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- De-register the m0006 (reconcile) and m0008 (ACL backfill) one-time data-migrations from the gateway registry; the gateway DB is the ACL source of truth and these are the last readers of the soon-to-be-dropped assistant ACL columns
- Migration files and their tests are left untouched on disk (append-only)

Part of plan: drop-assistant-acl-columns.md (PR 1 of 3)