### PR TITLE
Fix BYOK advisor profile default

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1453,7 +1453,58 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles.frontier?.status).toBe("disabled");
   });
 
-  test("off-platform boot repairs a disabled managed advisor to a personal profile", () => {
+  test("off-platform boot repairs a disabled managed advisor to a personal profile when no active managed replacement exists", () => {
+    writeConfig({
+      llm: {
+        advisorProfile: "frontier",
+        profiles: {
+          frontier: {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            model: "claude-opus-4-8",
+            status: "disabled",
+          },
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "open-model",
+            status: "disabled",
+          },
+          "quality-optimized": {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+            status: "disabled",
+          },
+          "cost-optimized": {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/deepseek-v4-flash",
+            status: "disabled",
+          },
+          "custom-quality-optimized": {
+            source: "user",
+            provider: "anthropic",
+            provider_connection: "anthropic-personal",
+            model: "claude-opus-4-8",
+            label: "Quality",
+          },
+        },
+      },
+    });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const config = loadConfig();
+
+    expect(config.llm.advisorProfile).toBe("custom-quality-optimized");
+  });
+
+  test("platform boot repairs a disabled managed advisor to an active managed profile", () => {
+    process.env.IS_PLATFORM = "true";
     writeConfig({
       llm: {
         advisorProfile: "frontier",
@@ -1479,7 +1530,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
 
-    expect(config.llm.advisorProfile).toBe("custom-quality-optimized");
+    expect(config.llm.advisorProfile).toBe("quality-optimized");
   });
 
   test("off-platform boot clears a disabled managed advisor when no active replacement exists", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1482,6 +1482,49 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.advisorProfile).toBe("custom-quality-optimized");
   });
 
+  test("off-platform boot clears a disabled managed advisor when no active replacement exists", () => {
+    writeConfig({
+      llm: {
+        advisorProfile: "frontier",
+        profiles: {
+          frontier: {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            model: "claude-opus-4-8",
+            status: "disabled",
+          },
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "open-model",
+            status: "disabled",
+          },
+          "quality-optimized": {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+            status: "disabled",
+          },
+          "cost-optimized": {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/deepseek-v4-flash",
+            status: "disabled",
+          },
+        },
+      },
+    });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const config = loadConfig();
+
+    expect(config.llm.advisorProfile).toBeUndefined();
+  });
+
   test("off-platform managed-inference hatch keeps selected managed connection active", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1426,7 +1426,60 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 
     expect(config.llm.profiles.balanced?.status).toBe("disabled");
     expect(config.llm.profiles["quality-optimized"]?.status).toBe("disabled");
+    expect(config.llm.profiles.frontier?.status).toBe("disabled");
     expect(config.llm.profiles["cost-optimized"]?.status).toBe("disabled");
+  });
+
+  test("off-platform BYOK hatch defaults advisor to the personal quality profile", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify({ llm: { default: { provider: "anthropic" } } }, null, 2) +
+        "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const config = loadConfig();
+
+    expect(config.llm.activeProfile).toBe("custom-balanced");
+    expect(config.llm.advisorProfile).toBe("custom-quality-optimized");
+    expect(config.llm.profiles["custom-quality-optimized"]?.provider).toBe(
+      "anthropic",
+    );
+    expect(
+      config.llm.profiles["custom-quality-optimized"]?.provider_connection,
+    ).toBe("anthropic-personal");
+    expect(config.llm.profiles.frontier?.status).toBe("disabled");
+  });
+
+  test("off-platform boot repairs a disabled managed advisor to a personal profile", () => {
+    writeConfig({
+      llm: {
+        advisorProfile: "frontier",
+        profiles: {
+          frontier: {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            model: "claude-opus-4-8",
+            status: "disabled",
+          },
+          "custom-quality-optimized": {
+            source: "user",
+            provider: "anthropic",
+            provider_connection: "anthropic-personal",
+            model: "claude-opus-4-8",
+            label: "Quality",
+          },
+        },
+      },
+    });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const config = loadConfig();
+
+    expect(config.llm.advisorProfile).toBe("custom-quality-optimized");
   });
 
   test("off-platform managed-inference hatch keeps selected managed connection active", () => {
@@ -1451,6 +1504,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.advisorProfile).toBe("balanced");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
       "together-managed",
     );

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -426,19 +426,31 @@ export function seedInferenceProfiles(
     }
   }
 
-  // Advisor profile: default to the strongest managed profile when unset, so
-  // the advisor consults `frontier` (Anthropic Opus) out of the box, falling
-  // back to `quality-optimized` if `frontier` is unavailable. The `frontier`
-  // arm requires managed ownership: the seed loop above leaves a user-owned
-  // profile named `frontier` in place, and pointing the advisor at that would
-  // consult an arbitrary user model. Guarded on existence so it never names a
-  // missing profile (superRefine rejects that); off-platform/BYOK installs can
-  // repoint it at one of their own profiles.
-  if (readString(llm.advisorProfile) === undefined) {
-    if (readObject(profiles["frontier"])?.source === "managed") {
-      llm.advisorProfile = "frontier";
-    } else if (readObject(profiles["quality-optimized"]) !== null) {
-      llm.advisorProfile = "quality-optimized";
+  // Advisor profile: BYOK hatches default to the strongest personal profile
+  // backed by the entered provider key. Managed-profile hatches and registered
+  // platform installs default to the strongest active managed profile.
+  const requestedAdvisorProfile = readString(llm.advisorProfile);
+  const requestedAdvisorEntry =
+    requestedAdvisorProfile !== undefined
+      ? readObject(profiles[requestedAdvisorProfile])
+      : null;
+  const requestedAdvisorIsDisabledManaged =
+    requestedAdvisorEntry?.source === "managed" &&
+    requestedAdvisorEntry.status === "disabled";
+  const preferPersonalAdvisor =
+    (userConnectionName !== undefined &&
+      hatchSelectedManagedConnection === undefined) ||
+    requestedAdvisorIsDisabledManaged;
+  if (
+    requestedAdvisorProfile === undefined ||
+    requestedAdvisorIsDisabledManaged
+  ) {
+    const defaultAdvisorProfile = selectDefaultAdvisorProfile(
+      profiles,
+      preferPersonalAdvisor,
+    );
+    if (defaultAdvisorProfile) {
+      llm.advisorProfile = defaultAdvisorProfile;
     }
   }
 
@@ -576,6 +588,48 @@ function pruneRemovedProfileReferences(
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function selectDefaultAdvisorProfile(
+  profiles: Record<string, Record<string, unknown>>,
+  preferPersonalProfile: boolean,
+): string | undefined {
+  const personal = firstActiveProfile(profiles, [
+    "custom-quality-optimized",
+    "custom-balanced",
+    "custom-cost-optimized",
+  ]);
+  const managed = firstActiveManagedProfile(profiles, [
+    "frontier",
+    "quality-optimized",
+    "balanced",
+    "cost-optimized",
+  ]);
+  return preferPersonalProfile ? (personal ?? managed) : (managed ?? personal);
+}
+
+function firstActiveProfile(
+  profiles: Record<string, Record<string, unknown>>,
+  names: string[],
+): string | undefined {
+  for (const name of names) {
+    const profile = readObject(profiles[name]);
+    if (profile && profile.status !== "disabled") return name;
+  }
+  return undefined;
+}
+
+function firstActiveManagedProfile(
+  profiles: Record<string, Record<string, unknown>>,
+  names: string[],
+): string | undefined {
+  for (const name of names) {
+    const profile = readObject(profiles[name]);
+    if (profile?.source === "managed" && profile.status !== "disabled") {
+      return name;
+    }
+  }
+  return undefined;
 }
 
 function getHatchSelectedManagedConnection(

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -451,6 +451,8 @@ export function seedInferenceProfiles(
     );
     if (defaultAdvisorProfile) {
       llm.advisorProfile = defaultAdvisorProfile;
+    } else if (requestedAdvisorIsDisabledManaged) {
+      delete llm.advisorProfile;
     }
   }
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -438,9 +438,8 @@ export function seedInferenceProfiles(
     requestedAdvisorEntry?.source === "managed" &&
     requestedAdvisorEntry.status === "disabled";
   const preferPersonalAdvisor =
-    (userConnectionName !== undefined &&
-      hatchSelectedManagedConnection === undefined) ||
-    requestedAdvisorIsDisabledManaged;
+    userConnectionName !== undefined &&
+    hatchSelectedManagedConnection === undefined;
   if (
     requestedAdvisorProfile === undefined ||
     requestedAdvisorIsDisabledManaged


### PR DESCRIPTION
## Summary
- Default off-platform BYOK advisor profiles to the strongest personal profile created for the entered provider key.
- Repair disabled managed advisor selections, such as `frontier`, to an active personal profile on boot.
- Preserve managed-profile hatches by selecting the strongest active managed advisor profile.

## Root Cause
The inference-profile seeder picked `frontier` whenever a managed `frontier` entry existed, without considering that BYOK hatches disable managed profiles or that a personal quality profile had just been created.

## Checks
- `cd assistant && bun test src/__tests__/config-loader-backfill.test.ts`
- `cd assistant && bun run typecheck:fast`
- Commit hook: Prettier, ESLint, assistant type-check
- Pre-push hook: assistant type-check, changed-file ESLint
