### PR TITLE
[codex] Fix managed assistant credential errors

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2506,6 +2506,41 @@ describe("session-agent-loop", () => {
       expect(lastSync?.[1]).toBe("mock-msg-id");
       expect(lastSync?.[1]).not.toBe("msg-orphaned-reservation");
     });
+
+    test("managed-key provider-error cleanup publishes message invalidation after deleting the reservation", async () => {
+      reserveMessageMock.mockImplementationOnce(async () => ({
+        id: "msg-managed-key-reservation",
+      }));
+      mockConversationErrorClassification = {
+        code: "MANAGED_KEY_INVALID",
+        userMessage: "Couldn't refresh assistant credentials.",
+        retryable: false,
+        errorCategory: "managed_key_invalid",
+      };
+
+      const ctx = makeCtx({
+        loopProvider: {
+          name: "mock-provider",
+          async sendMessage() {
+            throw new Error("API key has expired.");
+          },
+        } as unknown as Provider,
+      });
+      await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+
+      expect(deleteMessageByIdMock).toHaveBeenCalledTimes(1);
+      const deleteCall = deleteMessageByIdMock.mock.calls[0] as unknown as [
+        string,
+      ];
+      expect(deleteCall[0]).toBe("msg-managed-key-reservation");
+      expect(addMessageMock).not.toHaveBeenCalled();
+      expect(syncMessageToDiskMock).not.toHaveBeenCalled();
+
+      const messagePublishes = (
+        publishSyncInvalidationMock.mock.calls as unknown as Array<[string[]]>
+      ).filter((args) => args[0]?.includes("conversation:test-conv:messages"));
+      expect(messagePublishes).toHaveLength(1);
+    });
   });
 
   describe("partial persistence", () => {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -278,6 +278,7 @@ const deleteMessageByIdMock = mock(() => ({
 }));
 const reserveMessageMock = mock(async () => ({ id: "msg-reserve" }));
 const updateMessageContentMock = mock(() => {});
+const addMessageMock = mock(() => ({ id: "mock-msg-id" }));
 mock.module("../memory/conversation-crud.js", () => ({
   setConversationProcessingStartedAt: () => {},
   isConversationProcessing: () => false,
@@ -292,7 +293,7 @@ mock.module("../memory/conversation-crud.js", () => ({
     trustContext: undefined,
   }),
   getConversationOriginInterface: () => null,
-  addMessage: () => ({ id: "mock-msg-id" }),
+  addMessage: addMessageMock,
   deleteMessageById: deleteMessageByIdMock,
   updateConversationContextWindow: () => {},
   updateConversationSlackContextWatermark:
@@ -560,13 +561,16 @@ mock.module("../workspace/git-service.js", () => ({
   }),
 }));
 
+let mockConversationErrorClassification = {
+  code: "CONVERSATION_PROCESSING_FAILED",
+  userMessage: "Something went wrong processing your message.",
+  retryable: false,
+  errorCategory: "processing_failed",
+};
+
 mock.module("../daemon/conversation-error.js", () => ({
-  classifyConversationError: (_err: unknown, _ctx: unknown) => ({
-    code: "CONVERSATION_PROCESSING_FAILED",
-    userMessage: "Something went wrong processing your message.",
-    retryable: false,
-    errorCategory: "processing_failed",
-  }),
+  classifyConversationError: (_err: unknown, _ctx: unknown) =>
+    mockConversationErrorClassification,
   isUserCancellation: (err: unknown, ctx: { aborted?: boolean }) => {
     if (!ctx.aborted) return false;
     if (err instanceof DOMException && err.name === "AbortError") return true;
@@ -872,6 +876,13 @@ beforeEach(() => {
   deleteMessageByIdMock.mockClear();
   reserveMessageMock.mockClear();
   updateMessageContentMock.mockClear();
+  addMessageMock.mockClear();
+  mockConversationErrorClassification = {
+    code: "CONVERSATION_PROCESSING_FAILED",
+    userMessage: "Something went wrong processing your message.",
+    retryable: false,
+    errorCategory: "processing_failed",
+  };
   indexMessageNowMock.mockClear();
   projectAssistantMessageMock.mockClear();
   publishSyncInvalidationMock.mockClear();
@@ -2240,6 +2251,49 @@ describe("session-agent-loop", () => {
         .calls[0] as unknown as [string, string];
       expect(backfillCall[0]).toBe("test-conv");
       expect(backfillCall[1]).toBe("mock-msg-id");
+    });
+
+    test("does not persist managed credential refresh failures as assistant text", async () => {
+      mockConversationErrorClassification = {
+        code: "MANAGED_KEY_INVALID",
+        userMessage: "Couldn't refresh assistant credentials.",
+        retryable: false,
+        errorCategory: "managed_key_invalid",
+      };
+      const events: ServerMessage[] = [];
+
+      const ctx = makeCtx({
+        loopProvider: {
+          name: "mock-provider",
+          async sendMessage() {
+            throw new Error("API key has expired.");
+          },
+        } as unknown as Provider,
+      });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(
+        events.filter((event) => event.type === "assistant_text_delta"),
+      ).toHaveLength(0);
+
+      const conversationError = events.find(
+        (event) => event.type === "conversation_error",
+      );
+      expect(conversationError).toBeDefined();
+      expect(conversationError).toMatchObject({
+        code: "MANAGED_KEY_INVALID",
+        userMessage: "Couldn't refresh assistant credentials.",
+        errorCategory: "managed_key_invalid",
+      });
+
+      expect(addMessageMock).not.toHaveBeenCalled();
+      expect(recordRequestLogMock).not.toHaveBeenCalled();
+      expect(backfillMessageIdOnLogsMock).not.toHaveBeenCalled();
+      expect(deleteMessageByIdMock).toHaveBeenCalledTimes(1);
+      const deleteCall = deleteMessageByIdMock.mock.calls[0] as unknown as [
+        string,
+      ];
+      expect(deleteCall[0]).toBe("msg-reserve");
     });
   });
 

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -623,6 +623,24 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("provider_invalid_key");
     });
 
+    it("classifies managed-proxy auth failures as managed credential refresh failures", () => {
+      providerRoutingSources.anthropic = "managed-proxy";
+      const err = new ProviderError(
+        'Anthropic API error (403): {"detail":"API key has expired."}',
+        "anthropic",
+        403,
+      );
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("MANAGED_KEY_INVALID");
+      expect(result.userMessage).toBe(
+        "Couldn't refresh assistant credentials.",
+      );
+      expect(result.retryable).toBe(false);
+      expect(result.errorCategory).toBe("managed_key_invalid");
+    });
+
     it("classifies ProviderError 401 with 'invalid x-api-key' message as PROVIDER_INVALID_KEY", () => {
       // Regex-match branch — Anthropic's standard 401 wording.
       const err = new ProviderError(

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -102,6 +102,12 @@ import type {
 
 const log = getLogger("agent-loop-handlers");
 
+function shouldPersistProviderErrorAsAssistantMessage(classified: {
+  code: string;
+}): boolean {
+  return classified.code !== "MANAGED_KEY_INVALID";
+}
+
 /**
  * Persist the history-stripped marker after the loop strips runtime injections
  * for compaction / overflow recovery. The marker is a durability hint, not
@@ -161,6 +167,7 @@ export interface EventHandlerState {
   readonly exchangeRawResponses: unknown[];
   model: string;
   providerErrorUserMessage: string | null;
+  persistProviderErrorAsAssistantMessage: boolean;
   lastAssistantMessageId: string | undefined;
   /**
    * True when `handleLlmCallStarted` has reserved an empty assistant row
@@ -339,6 +346,7 @@ export function createEventHandlerState(): EventHandlerState {
     exchangeRawResponses: [],
     model: "",
     providerErrorUserMessage: null,
+    persistProviderErrorAsAssistantMessage: false,
     lastAssistantMessageId: undefined,
     assistantRowAwaitingFinalization: false,
     pendingToolResults: new Map(),
@@ -1616,6 +1624,8 @@ function handleError(
     buildConversationErrorMessage(deps.ctx.conversationId, classified),
   );
   state.providerErrorUserMessage = classified.userMessage;
+  state.persistProviderErrorAsAssistantMessage =
+    shouldPersistProviderErrorAsAssistantMessage(classified);
 }
 
 export function handleMaxTokensReached(
@@ -2129,6 +2139,13 @@ function handleProviderError(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "provider_error" }>,
 ): void {
+  const classified = classifyConversationError(event.error, {
+    phase: "agent_loop",
+  });
+  if (!shouldPersistProviderErrorAsAssistantMessage(classified)) {
+    return;
+  }
+
   try {
     recordRequestLog(
       deps.ctx.conversationId,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1151,23 +1151,21 @@ export async function runAgentLoopImpl(
       !abortController.signal.aborted &&
       !yieldedForHandoff
     ) {
-      // Drop any reservation stranded by the failed LLM call before
-      // inserting the synthetic error message. The B3 pre-allocation
-      // path reserves an empty assistant row at `llm_call_started`;
-      // when the call exits through the provider-error branch (no
-      // `message_complete`), `assistantRowAwaitingFinalization` stays
-      // true. Without this delete the transcript would carry both the
-      // empty reserved row AND the error message — and downstream sync
-      // (`syncLastAssistantMessageToDisk`) would mis-target the empty
-      // row. After delete we set `lastAssistantMessageId` to the new
-      // error row's id so the post-loop emission paths still point at
-      // a real message.
+      // Drop any reservation stranded by the failed LLM call. The B3
+      // pre-allocation path reserves an empty assistant row at
+      // `llm_call_started`; when the call exits through the provider-error
+      // branch (no `message_complete`), `assistantRowAwaitingFinalization`
+      // stays true. Without this delete the transcript would carry an empty
+      // reserved row, and downstream sync (`syncLastAssistantMessageToDisk`)
+      // would target it.
       if (
         state.assistantRowAwaitingFinalization &&
         state.lastAssistantMessageId
       ) {
         try {
           deleteMessageById(state.lastAssistantMessageId);
+          state.lastAssistantMessageId = undefined;
+          state.assistantRowAwaitingFinalization = false;
         } catch (err) {
           rlog.warn(
             { err, messageId: state.lastAssistantMessageId },
@@ -1175,57 +1173,63 @@ export async function runAgentLoopImpl(
           );
         }
       }
-      const errChannelMeta = {
-        ...provenanceFromTrustContext(ctx.trustContext),
-        userMessageChannel: capturedTurnChannelContext.userMessageChannel,
-        assistantMessageChannel:
-          capturedTurnChannelContext.assistantMessageChannel,
-        userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
-        assistantMessageInterface:
-          capturedTurnInterfaceContext.assistantMessageInterface,
-      };
-      const errorAssistantMessage = createAssistantMessage(
-        state.providerErrorUserMessage,
-      );
-      const errorRow = await addMessage(
-        ctx.conversationId,
-        "assistant",
-        JSON.stringify(errorAssistantMessage.content),
-        { metadata: errChannelMeta },
-      );
-      persistedErrorAssistantMessage = true;
-      // Repoint `lastAssistantMessageId` at the synthetic error row so the
-      // post-loop sync, attachment resolution, and `message_complete`/
-      // `generation_handoff` emissions all reference a real, persisted
-      // message id. The previous reservation (if any) was already deleted
-      // above. Mark finalization complete so the next LLM call in this run
-      // (or a downstream handler) doesn't try to clean up an id that
-      // already corresponds to a finalized row.
-      state.lastAssistantMessageId = errorRow.id;
-      state.assistantRowAwaitingFinalization = false;
-      newMessages.push(errorAssistantMessage);
-      // Pipe the just-assigned message id into any orphaned LLM request log
-      // row(s) for this turn. The success path links rows via
-      // `handleMessageComplete` -> `backfillMessageIdOnLogs`, but provider-
-      // failure turns never fire `message_complete` (the synthetic assistant
-      // message is persisted directly above), so without this call the rows
-      // from `handleProviderError` stay with `message_id IS NULL` and a
-      // later turn's backfill sweep would wrong-attach them to that turn's
-      // assistant message. Scope is per-conversation, so concurrent runs on
-      // other conversations cannot collide. Non-fatal — a DB hiccup must
-      // not escalate a provider rejection into a turn-level throw.
-      try {
-        backfillMessageIdOnLogs(ctx.conversationId, errorRow.id);
-      } catch (err) {
-        rlog.warn(
-          { err },
-          "Failed to backfill message_id on provider-error LLM request logs (non-fatal)",
+      if (!state.persistProviderErrorAsAssistantMessage) {
+        state.assistantRowAwaitingFinalization = false;
+        state.lastAssistantMessageId = undefined;
+      } else {
+        const errChannelMeta = {
+          ...provenanceFromTrustContext(ctx.trustContext),
+          userMessageChannel: capturedTurnChannelContext.userMessageChannel,
+          assistantMessageChannel:
+            capturedTurnChannelContext.assistantMessageChannel,
+          userMessageInterface:
+            capturedTurnInterfaceContext.userMessageInterface,
+          assistantMessageInterface:
+            capturedTurnInterfaceContext.assistantMessageInterface,
+        };
+        const errorAssistantMessage = createAssistantMessage(
+          state.providerErrorUserMessage,
         );
+        const errorRow = await addMessage(
+          ctx.conversationId,
+          "assistant",
+          JSON.stringify(errorAssistantMessage.content),
+          { metadata: errChannelMeta },
+        );
+        persistedErrorAssistantMessage = true;
+        // Repoint `lastAssistantMessageId` at the synthetic error row so the
+        // post-loop sync, attachment resolution, and `message_complete`/
+        // `generation_handoff` emissions all reference a real, persisted
+        // message id. The previous reservation (if any) was already deleted
+        // above. Mark finalization complete so the next LLM call in this run
+        // (or a downstream handler) doesn't try to clean up an id that
+        // already corresponds to a finalized row.
+        state.lastAssistantMessageId = errorRow.id;
+        state.assistantRowAwaitingFinalization = false;
+        newMessages.push(errorAssistantMessage);
+        // Pipe the just-assigned message id into any orphaned LLM request log
+        // row(s) for this turn. The success path links rows via
+        // `handleMessageComplete` -> `backfillMessageIdOnLogs`, but provider-
+        // failure turns never fire `message_complete` (the synthetic assistant
+        // message is persisted directly above), so without this call the rows
+        // from `handleProviderError` stay with `message_id IS NULL` and a
+        // later turn's backfill sweep would wrong-attach them to that turn's
+        // assistant message. Scope is per-conversation, so concurrent runs on
+        // other conversations cannot collide. Non-fatal — a DB hiccup must
+        // not escalate a provider rejection into a turn-level throw.
+        try {
+          backfillMessageIdOnLogs(ctx.conversationId, errorRow.id);
+        } catch (err) {
+          rlog.warn(
+            { err },
+            "Failed to backfill message_id on provider-error LLM request logs (non-fatal)",
+          );
+        }
+        // Do NOT send assistant_text_delta here — handleProviderError already
+        // emitted a conversation_error event for this same error text, and the
+        // client renders it as an InlineChatErrorAlert. Sending a text delta
+        // would create a duplicate plain-text bubble below the alert card.
       }
-      // Do NOT send assistant_text_delta here — handleProviderError already
-      // emitted a conversation_error event for this same error text, and the
-      // client renders it as an InlineChatErrorAlert. Sending a text delta
-      // would create a duplicate plain-text bubble below the alert card.
     }
 
     // Base persisted into `ctx.messages` is the loop's own returned history

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -520,12 +520,14 @@ export async function runAgentLoopImpl(
   let turnStarted = false;
   const state = createEventHandlerState();
   let persistedErrorAssistantMessage = false;
+  let deletedReservedAssistantMessage = false;
 
   const publishLoopMessagesChanged = (): void => {
     if (
       state.lastAssistantMessageId ||
       state.persistedToolUseIds.size > 0 ||
-      persistedErrorAssistantMessage
+      persistedErrorAssistantMessage ||
+      deletedReservedAssistantMessage
     ) {
       publishConversationMessagesChanged(ctx.conversationId);
     }
@@ -1164,6 +1166,7 @@ export async function runAgentLoopImpl(
       ) {
         try {
           deleteMessageById(state.lastAssistantMessageId);
+          deletedReservedAssistantMessage = true;
           state.lastAssistantMessageId = undefined;
           state.assistantRowAwaitingFinalization = false;
         } catch (err) {

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -315,20 +315,17 @@ function classifyCore(
     }
     if (error.statusCode === 401 || error.statusCode === 403) {
       // Both managed-proxy and user-key 401/403s reach this branch.
-      // Managed-proxy routes through the assistant API key (stale → re-
-      // provision) and emits `MANAGED_KEY_INVALID`; everything else is a
-      // user-set credential that the upstream provider rejected → emit
-      // `PROVIDER_INVALID_KEY` so the macOS chat banner renders an
-      // "Invalid API key" surface (distinct from "API key required"
-      // which only fires when the key is genuinely missing — see
-      // `providerNotConfiguredClassification`).
+      // Managed-proxy routes through the assistant API key; if that
+      // credential is stale, the user cannot fix it from model settings.
+      // Everything else is a user-set credential that the upstream provider
+      // rejected, so emit `PROVIDER_INVALID_KEY` and let the chat banner point
+      // at Settings.
       const providerName = error.provider;
       if (getProviderRoutingSource(providerName) === "managed-proxy") {
         return {
           code: "MANAGED_KEY_INVALID",
-          userMessage:
-            "The assistant API key is invalid. Attempting to re-provision…",
-          retryable: true,
+          userMessage: "Couldn't refresh assistant credentials.",
+          retryable: false,
           errorCategory: "managed_key_invalid",
         };
       }

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -807,8 +807,7 @@ export function ChatMainPanel({
           }
           diskPressureBanner={diskPressureBannerSlot}
           showMissingApiKeyBanner={
-            error?.code === "PROVIDER_NOT_CONFIGURED" ||
-            error?.code === "MANAGED_KEY_INVALID"
+            error?.code === "PROVIDER_NOT_CONFIGURED"
           }
           onOpenAiSettings={pushToAiSettings}
           onDismissApiKeyError={handleDismissApiKeyError}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -58,7 +58,11 @@ import { useTranscriptScroll } from "@/domains/chat/transcript/use-transcript-sc
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { Button } from "@vellumai/design-library";
 import { Link, useLocation, useNavigate } from "react-router";
-import { getChatBillingBannerDecision, shouldShowGenericChatErrorNotice } from "@/domains/chat/utils/error-classification";
+import {
+  getChatBillingBannerDecision,
+  isManagedCredentialChatError,
+  shouldShowGenericChatErrorNotice,
+} from "@/domains/chat/utils/error-classification";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/types/types";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -475,18 +479,19 @@ export function ChatMainPanel({
 
   const showDoctorAction =
     assistantState.kind === "active" && !assistantState.isLocal;
+  const doctorAction = showDoctorAction ? (
+    <Button asChild variant="outlined" size="compact">
+      <Link to={`${routes.settings.debug}?tab=doctor`}>
+        Go to Doctor
+      </Link>
+    </Button>
+  ) : undefined;
 
   const genericChatError = shouldShowGenericChatErrorNotice(error) && error
     ? {
         message: error.message,
         tone: "error" as const,
-        actions: showDoctorAction ? (
-          <Button asChild variant="outlined" size="compact">
-            <Link to={`${routes.settings.debug}?tab=doctor`}>
-              Go to Doctor
-            </Link>
-          </Button>
-        ) : undefined,
+        actions: doctorAction,
       }
     : null;
   const hasGenericChatError = genericChatError !== null;
@@ -495,6 +500,9 @@ export function ChatMainPanel({
       ? {
           message: notice.message,
           tone: "warning" as const,
+          actions: isManagedCredentialChatError(notice)
+            ? doctorAction
+            : undefined,
         }
       : null;
   const genericChatBanner = genericChatError ?? genericChatNotice;

--- a/clients/web/src/domains/chat/components/composer-notices.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.tsx
@@ -55,7 +55,7 @@ export interface ComposerNoticesProps {
    */
   billingBannerSlot?: ReactNode;
 
-  /** True when the assistant returned `PROVIDER_NOT_CONFIGURED` or `MANAGED_KEY_INVALID`. */
+  /** True when the assistant returned `PROVIDER_NOT_CONFIGURED`. */
   showMissingApiKeyBanner: boolean;
   /** Handler invoked when the user clicks "Open settings" on the missing-API-key banner. */
   onOpenAiSettings: () => void;

--- a/clients/web/src/domains/chat/utils/error-classification.test.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.test.ts
@@ -54,6 +54,16 @@ describe("chat error classification", () => {
     expect(shouldShowGenericChatErrorNotice(error)).toBe(true);
   });
 
+  test("routes managed key failures through the generic Doctor-capable notice", () => {
+    const error = {
+      code: "MANAGED_KEY_INVALID",
+      errorCategory: "managed_key_invalid",
+    };
+
+    expect(shouldSuppressGenericChatErrorNotice(error)).toBe(false);
+    expect(shouldShowGenericChatErrorNotice(error)).toBe(true);
+  });
+
   test("suppresses inline notice when displayAs is modal", () => {
     // secret_blocked from a fresh new-conversation POST is surfaced as a
     // dialog, not an inline banner. The inline Notice must stay hidden so

--- a/clients/web/src/domains/chat/utils/error-classification.test.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getChatBillingBannerDecision,
+  isManagedCredentialChatError,
   shouldShowGenericChatErrorNotice,
   shouldSuppressGenericChatErrorNotice,
 } from "@/domains/chat/utils/error-classification";
@@ -60,6 +61,7 @@ describe("chat error classification", () => {
       errorCategory: "managed_key_invalid",
     };
 
+    expect(isManagedCredentialChatError(error)).toBe(true);
     expect(shouldSuppressGenericChatErrorNotice(error)).toBe(false);
     expect(shouldShowGenericChatErrorNotice(error)).toBe(true);
   });

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -12,7 +12,6 @@ export type ChatBillingBannerDecision = "managed_credits" | "provider_billing";
 
 const PROVIDER_BILLING_CODE = "PROVIDER_BILLING";
 const PROVIDER_NOT_CONFIGURED_CODE = "PROVIDER_NOT_CONFIGURED";
-const MANAGED_KEY_INVALID_CODE = "MANAGED_KEY_INVALID";
 const MANAGED_CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
 const PROVIDER_BILLING_CATEGORY = "provider_billing";
 
@@ -56,7 +55,6 @@ export function shouldSuppressGenericChatErrorNotice(
   return (
     getChatBillingBannerDecision(error) !== null ||
     error?.code === PROVIDER_NOT_CONFIGURED_CODE ||
-    error?.code === MANAGED_KEY_INVALID_CODE ||
     error?.displayAs === "modal"
   );
 }

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -12,6 +12,7 @@ export type ChatBillingBannerDecision = "managed_credits" | "provider_billing";
 
 const PROVIDER_BILLING_CODE = "PROVIDER_BILLING";
 const PROVIDER_NOT_CONFIGURED_CODE = "PROVIDER_NOT_CONFIGURED";
+const MANAGED_KEY_INVALID_CODE = "MANAGED_KEY_INVALID";
 const MANAGED_CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
 const PROVIDER_BILLING_CATEGORY = "provider_billing";
 
@@ -63,4 +64,10 @@ export function shouldShowGenericChatErrorNotice(
   error: ChatErrorLike | null | undefined,
 ): boolean {
   return !!error && !shouldSuppressGenericChatErrorNotice(error);
+}
+
+export function isManagedCredentialChatError(
+  error: ChatErrorLike | null | undefined,
+): boolean {
+  return error?.code === MANAGED_KEY_INVALID_CODE;
 }


### PR DESCRIPTION
## Summary

Fixes the hosted-assistant error path for stale managed assistant credentials.

- classify managed-proxy 401/403 auth failures as `MANAGED_KEY_INVALID` with copy that reflects credential refresh failure
- route `MANAGED_KEY_INVALID` through the generic hosted-assistant error notice so the UI can show the Doctor CTA instead of the missing API key settings banner
- suppress synthetic assistant transcript messages for managed credential refresh failures while preserving the existing synthetic-message/log behavior for ordinary provider failures

## Root Cause

Hosted managed inference routes through the platform using the assistant API key stored in runtime credentials. When that runtime key is stale or expired, users cannot fix the issue by adding a model API key in settings. The previous UI mapped this to missing/invalid API-key surfaces, which pointed users at the wrong recovery action and also left a misleading assistant message in the transcript.

## Impact

For stale managed assistant credentials, users see a single recovery surface that can route them to Doctor/recovery. They no longer see the missing API key banner or a duplicate assistant-auth message. Direct BYOK provider errors still use the existing settings-oriented invalid key behavior.

## Validation

- `cd assistant && PATH="$HOME/.bun/bin:$PATH" bun test src/__tests__/conversation-error.test.ts`
- `cd assistant && PATH="$HOME/.bun/bin:$PATH" bun test src/__tests__/conversation-agent-loop.test.ts`
- `cd assistant && PATH="$HOME/.bun/bin:$PATH" bun run typecheck:fast`
- `cd clients/web && PATH="$HOME/.bun/bin:$PATH" bun test src/domains/chat/utils/error-classification.test.ts`
- `cd clients/web && PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- pre-commit hook: assistant/web lint and typecheck
- pre-push hook: assistant typecheck and lint
