### PR TITLE
feat(web): add acp-chat-view feature flag (scaffold, no consumer)

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -243,6 +243,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "acp-chat-view",
+      "scope": "client",
+      "key": "acp-chat-view",
+      "label": "ACP Chat View",
+      "description": "Render the ACP run detail panel as a chat-style conversation (agent messages, thinking, tool/code, plan, and a clickable file-diff view) instead of the event timeline.",
+      "defaultEnabled": false
+    },
+    {
       "id": "compaction-playground",
       "scope": "assistant",
       "key": "compaction-playground",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -243,6 +243,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "acp-chat-view",
+      "scope": "client",
+      "key": "acp-chat-view",
+      "label": "ACP Chat View",
+      "description": "Render the ACP run detail panel as a chat-style conversation (agent messages, thinking, tool/code, plan, and a clickable file-diff view) instead of the event timeline.",
+      "defaultEnabled": false
+    },
+    {
       "id": "compaction-playground",
       "scope": "assistant",
       "key": "compaction-playground",


### PR DESCRIPTION
## Summary
- Add the `acp-chat-view` client-scoped feature flag (default off) to the canonical registry and sync the bundled copies.
- No consumer yet — gates the upcoming ACP chat-view redesign.

Part of plan: acp-chat-detail-view.md (PR 1 of 11)