### PR TITLE
feat(acp): forward tool-call locations[] in SSE session updates

### DIFF
--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -330,4 +330,72 @@ describe("VellumAcpClientHandler seq + enriched fields", () => {
       seq: 1,
     });
   });
+
+  test("tool_call_update forwards locations[] when present", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-2",
+        status: "completed",
+        locations: [
+          { path: "/repo/src/main.ts", line: 42 },
+          { path: "/repo/src/util.ts" },
+        ],
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      updateType: "tool_call_update",
+      toolCallId: "tc-2",
+      locations: [
+        { path: "/repo/src/main.ts", line: 42 },
+        { path: "/repo/src/util.ts", line: undefined },
+      ],
+    });
+  });
+
+  test("tool_call forwards locations[] when present", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-3",
+        title: "Edit main.ts",
+        kind: "edit",
+        status: "pending",
+        locations: [{ path: "/repo/src/main.ts", line: 7 }],
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      updateType: "tool_call",
+      toolCallId: "tc-3",
+      locations: [{ path: "/repo/src/main.ts", line: 7 }],
+    });
+  });
+
+  test("tool_call_update omits locations key when absent", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-4",
+        status: "in_progress",
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0] as { locations?: unknown };
+    expect(msg.locations).toBeUndefined();
+    expect("locations" in msg && msg.locations !== undefined).toBe(false);
+  });
 });

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -168,6 +168,11 @@ export class VellumAcpClientHandler implements Client {
           toolTitle: update.title,
           toolKind: update.kind,
           toolStatus: update.status,
+          locations:
+            update.locations?.map((l) => ({
+              path: l.path,
+              line: l.line ?? undefined,
+            })) ?? undefined,
         });
         break;
       }
@@ -180,6 +185,11 @@ export class VellumAcpClientHandler implements Client {
           toolKind: update.kind ?? undefined,
           toolStatus: update.status ?? undefined,
           content: update.content ? JSON.stringify(update.content) : undefined,
+          locations:
+            update.locations?.map((l) => ({
+              path: l.path,
+              line: l.line ?? undefined,
+            })) ?? undefined,
         });
         break;
       }

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -28,6 +28,8 @@ export interface AcpSessionUpdate {
   toolTitle?: string;
   toolKind?: string;
   toolStatus?: string;
+  /** Files touched by this tool call (for the file-diff affordance). */
+  locations?: { path: string; line?: number }[];
   /** Stable id for the message this chunk belongs to. */
   messageId?: string;
   /** Monotonic ordering hint within the session. */


### PR DESCRIPTION
## Summary
- Add optional `locations[]` to `AcpSessionUpdate` and forward it for tool_call/tool_call_update.
- Additive/backward-compatible; older clients ignore it. Powers the upcoming file-diff view's files-touched affordance.
- Web treats `locations` as optional, so older daemons that omit the field degrade gracefully.

Part of plan: acp-chat-detail-view.md (PR 2 of 11)