### PR TITLE
feat(web): add acp-run chat-block projection (sibling to step projection)

### DIFF
--- a/clients/web/src/domains/chat/acp-run-message-projection.test.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.test.ts
@@ -211,6 +211,81 @@ describe("tool blocks", () => {
     const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
     expect(tool.locations).toEqual([{ path: "a.ts", line: 12 }, { path: "b.ts" }]);
   });
+
+  it("honors a terminal status on the initial tool_call (no follow-up update)", () => {
+    const blocks = computeAcpRunChatBlocks([
+      event({
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Read",
+        toolStatus: "completed",
+      }),
+      event({
+        updateType: "tool_call",
+        toolCallId: "tc2",
+        toolTitle: "Bash",
+        toolStatus: "failed",
+      }),
+    ]);
+
+    expect((blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>).status).toBe(
+      "completed",
+    );
+    expect((blocks[1] as Extract<AcpChatBlock, { kind: "tool" }>).status).toBe(
+      "error",
+    );
+  });
+
+  it("defaults the initial tool_call status to running when absent", () => {
+    const blocks = computeAcpRunChatBlocks([
+      event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Read" }),
+    ]);
+    expect((blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>).status).toBe(
+      "running",
+    );
+  });
+
+  it("clears stale locations when an update carries an empty array", () => {
+    const blocks = computeAcpRunChatBlocks([
+      {
+        seq: 0,
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Edit",
+        locations: [{ path: "a.ts", line: 12 }],
+      } as AcpRunRawEvent,
+      {
+        seq: 1,
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        // ACP `locations: []` means "replace with empty".
+        locations: [],
+      } as AcpRunRawEvent,
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.locations).toEqual([]);
+  });
+
+  it("preserves locations when an update omits the locations field", () => {
+    const blocks = computeAcpRunChatBlocks([
+      {
+        seq: 0,
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Edit",
+        locations: [{ path: "a.ts", line: 12 }],
+      } as AcpRunRawEvent,
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "completed",
+      }),
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.locations).toEqual([{ path: "a.ts", line: 12 }]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/acp-run-message-projection.test.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "bun:test";
+
+import type { AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+import {
+  computeAcpRunChatBlocks,
+  createAcpRunChatProjection,
+  type AcpChatBlock,
+} from "@/domains/chat/acp-run-message-projection";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let seq = 0;
+
+function event(overrides: Partial<AcpRunRawEvent>): AcpRunRawEvent {
+  return {
+    seq: seq++,
+    updateType: "agent_message_chunk",
+    ...overrides,
+  };
+}
+
+function agentChunk(messageId: string, content: string): AcpRunRawEvent {
+  return event({ updateType: "agent_message_chunk", messageId, content });
+}
+
+function thoughtChunk(messageId: string, content: string): AcpRunRawEvent {
+  return event({ updateType: "agent_thought_chunk", messageId, content });
+}
+
+function userChunk(messageId: string, content: string): AcpRunRawEvent {
+  return event({ updateType: "user_message_chunk", messageId, content });
+}
+
+function steerMarker(n: number, instruction: string): AcpRunRawEvent {
+  return event({
+    updateType: "agent_message_chunk",
+    messageId: `local-marker-${n}`,
+    content: `↻ Steering: ${instruction}`,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// computeAcpRunChatBlocks — chronological ordering
+// ---------------------------------------------------------------------------
+
+describe("computeAcpRunChatBlocks ordering", () => {
+  it("preserves chronological order across block kinds", () => {
+    const blocks = computeAcpRunChatBlocks([
+      userChunk("u1", "hi"),
+      thoughtChunk("t1", "let me think"),
+      agentChunk("a1", "hello"),
+      event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Read" }),
+    ]);
+
+    expect(blocks.map((b) => b.kind)).toEqual([
+      "user",
+      "thinking",
+      "agent",
+      "tool",
+    ]);
+  });
+
+  it("includes user turns (unlike the step projection)", () => {
+    const blocks = computeAcpRunChatBlocks([userChunk("u1", "do the thing")]);
+    expect(blocks).toEqual([{ kind: "user", id: "u1", content: "do the thing" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// messageId coalescing
+// ---------------------------------------------------------------------------
+
+describe("messageId coalescing", () => {
+  it("coalesces two same-id agent chunks into one concatenated block", () => {
+    const blocks = computeAcpRunChatBlocks([
+      agentChunk("a1", "Hello, "),
+      agentChunk("a1", "world"),
+    ]);
+
+    expect(blocks).toEqual([
+      { kind: "agent", messageId: "a1", content: "Hello, world", isComplete: false },
+    ]);
+  });
+
+  it("coalesces same-id thinking chunks", () => {
+    const blocks = computeAcpRunChatBlocks([
+      thoughtChunk("t1", "step "),
+      thoughtChunk("t1", "one"),
+    ]);
+
+    expect(blocks).toEqual([
+      { kind: "thinking", messageId: "t1", content: "step one", isComplete: false },
+    ]);
+  });
+
+  it("starts a new block when the messageId changes and closes the prior", () => {
+    const blocks = computeAcpRunChatBlocks([
+      agentChunk("a1", "first"),
+      agentChunk("a2", "second"),
+    ]);
+
+    expect(blocks).toEqual([
+      { kind: "agent", messageId: "a1", content: "first", isComplete: true },
+      { kind: "agent", messageId: "a2", content: "second", isComplete: false },
+    ]);
+  });
+
+  it("flips isComplete on the prior block when a later block starts", () => {
+    const blocks = computeAcpRunChatBlocks([
+      agentChunk("a1", "answer"),
+      event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Bash" }),
+    ]);
+
+    const agent = blocks[0] as Extract<AcpChatBlock, { kind: "agent" }>;
+    expect(agent.isComplete).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// steer markers / user turns
+// ---------------------------------------------------------------------------
+
+describe("user blocks", () => {
+  it("turns a steer marker into a user block with the prefix stripped", () => {
+    const blocks = computeAcpRunChatBlocks([steerMarker(2, "focus on tests")]);
+    expect(blocks).toEqual([
+      { kind: "user", id: "local-marker-2", content: "focus on tests" },
+    ]);
+  });
+
+  it("treats a steer marker as a user turn even mid-stream", () => {
+    const blocks = computeAcpRunChatBlocks([
+      agentChunk("a1", "working"),
+      steerMarker(1, "actually, stop"),
+      agentChunk("a2", "ok"),
+    ]);
+
+    expect(blocks.map((b) => b.kind)).toEqual(["agent", "user", "agent"]);
+    const user = blocks[1] as Extract<AcpChatBlock, { kind: "user" }>;
+    expect(user.content).toBe("actually, stop");
+    const firstAgent = blocks[0] as Extract<AcpChatBlock, { kind: "agent" }>;
+    expect(firstAgent.isComplete).toBe(true);
+  });
+
+  it("does not strip a prefix from a plain user_message_chunk", () => {
+    const blocks = computeAcpRunChatBlocks([userChunk("u1", "hi there")]);
+    expect((blocks[0] as { content: string }).content).toBe("hi there");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tool blocks
+// ---------------------------------------------------------------------------
+
+describe("tool blocks", () => {
+  it("transitions a tool block running -> completed -> error", () => {
+    const proj = createAcpRunChatProjection();
+
+    let blocks = proj.project([
+      event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Read" }),
+    ]);
+    expect((blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>).status).toBe(
+      "running",
+    );
+
+    blocks = proj.project([
+      event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Read" }),
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "completed",
+        content: "file contents",
+      }),
+    ]);
+    let tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.status).toBe("completed");
+    expect(tool.content).toBe("file contents");
+
+    blocks = proj.project([
+      event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Read" }),
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "completed",
+        content: "file contents",
+      }),
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "failed",
+      }),
+    ]);
+    tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.status).toBe("error");
+  });
+
+  it("carries locations from a tool event when present", () => {
+    const blocks = computeAcpRunChatBlocks([
+      {
+        seq: 0,
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Edit",
+        // Passthrough field not in the store type; read defensively.
+        locations: [{ path: "a.ts", line: 12 }, { path: "b.ts" }],
+      } as AcpRunRawEvent,
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.locations).toEqual([{ path: "a.ts", line: 12 }, { path: "b.ts" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// plan upsert
+// ---------------------------------------------------------------------------
+
+describe("plan upsert", () => {
+  it("upserts a single plan block across multiple plan events", () => {
+    const plan1 = JSON.stringify([{ content: "step 1", status: "pending" }]);
+    const plan2 = JSON.stringify([
+      { content: "step 1", status: "completed" },
+      { content: "step 2", status: "pending" },
+    ]);
+
+    const blocks = computeAcpRunChatBlocks([
+      event({ updateType: "plan", content: plan1 }),
+      agentChunk("a1", "thinking out loud"),
+      event({ updateType: "plan", content: plan2 }),
+    ]);
+
+    const planBlocks = blocks.filter((b) => b.kind === "plan");
+    expect(planBlocks).toHaveLength(1);
+    expect(planBlocks[0]).toEqual({
+      kind: "plan",
+      entries: [
+        { label: "step 1", checked: true },
+        { label: "step 2", checked: false },
+      ],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incremental projector — append fast path
+// ---------------------------------------------------------------------------
+
+describe("incremental projector", () => {
+  it("returns the same reference when events are unchanged", () => {
+    const proj = createAcpRunChatProjection();
+    const events = [agentChunk("a1", "hi")];
+    const first = proj.project(events);
+    const second = proj.project(events);
+    expect(second).toBe(first);
+  });
+
+  it("append fast path returns value-equal output to a full rebuild", () => {
+    const proj = createAcpRunChatProjection();
+
+    const base = [agentChunk("a1", "Hello, "), thoughtChunk("t1", "hmm")];
+    proj.project(base);
+
+    const tail = event({
+      updateType: "tool_call",
+      toolCallId: "tc1",
+      toolTitle: "Bash",
+    });
+    const grown = [...base, tail];
+
+    const incremental = proj.project(grown);
+    const fromScratch = computeAcpRunChatBlocks(grown);
+
+    expect(incremental).toEqual(fromScratch);
+  });
+
+  it("falls back to a full rebuild on a non-append diff (truncation)", () => {
+    const proj = createAcpRunChatProjection();
+    const full = [agentChunk("a1", "one"), agentChunk("a2", "two")];
+    proj.project(full);
+
+    const truncated = full.slice(0, 1);
+    const result = proj.project(truncated);
+    expect(result).toEqual(computeAcpRunChatBlocks(truncated));
+  });
+});

--- a/clients/web/src/domains/chat/acp-run-message-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.ts
@@ -204,7 +204,9 @@ export function applyAcpChatEvent(
         toolCallId,
         title: event.toolTitle ?? "",
         toolKind: event.toolKind,
-        status: "running",
+        // Honor a terminal status on the initial tool_call (hydrated snapshots
+        // may carry one with no follow-up update); default to "running".
+        status: mapToolStatus(event.toolStatus, "running"),
         content: event.content,
         locations: parseLocations(event),
       });
@@ -219,6 +221,10 @@ export function applyAcpChatEvent(
       );
       if (index === -1) return;
       const target = blocks[index] as Extract<AcpChatBlock, { kind: "tool" }>;
+      // A valid `locations` array (including `[]`) REPLACES the snapshot; an
+      // empty array clears stale locations. `undefined` means the field is
+      // absent/malformed — preserve the previous value.
+      const parsedLocations = parseLocations(event);
       blocks[index] = {
         ...target,
         title: event.toolTitle ?? target.title,
@@ -226,7 +232,7 @@ export function applyAcpChatEvent(
         status: mapToolStatus(event.toolStatus, target.status),
         // ACP `ToolCallUpdate.content` REPLACES the snapshot, not a delta.
         content: event.content ?? target.content,
-        locations: parseLocations(event) ?? target.locations,
+        locations: parsedLocations ?? target.locations,
       };
       return;
     }
@@ -250,8 +256,12 @@ export function applyAcpChatEvent(
 /**
  * Best-effort extraction of `locations` from a tool event. The store's raw
  * event carries no typed `locations` field today; this reads an optional
- * passthrough off the event without widening the store type. Returns
- * `undefined` (no change) when absent or malformed.
+ * passthrough off the event without widening the store type.
+ *
+ * Returns `undefined` only when the field is ABSENT or not an array (the caller
+ * treats this as "no change"). A VALID array — including an empty one — returns
+ * a parsed array (possibly `[]`), so an ACP `locations: []` update can clear
+ * stale locations rather than preserving the previous value.
  */
 function parseLocations(
   event: AcpRunRawEvent,
@@ -268,7 +278,7 @@ function parseLocations(
         : { path: obj.path },
     );
   }
-  return out.length ? out : undefined;
+  return out;
 }
 
 /**

--- a/clients/web/src/domains/chat/acp-run-message-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.ts
@@ -1,0 +1,422 @@
+/**
+ * Incremental chat-block projection for an ACP run's detail view.
+ *
+ * Sibling to `acp-run-step-projection.ts`: where the step projection folds the
+ * raw ACP event buffer into a timeline of agent steps (user echoes dropped),
+ * this projection folds the same `AcpRunRawEvent[]` (from `acp-run-store.ts`)
+ * into an ordered `AcpChatBlock[]` for a Devin-style chat transcript — user
+ * turns INCLUDED, rendered as their own bubbles.
+ *
+ * The store appends each event to `entry.events` (see `acp-run-store.ts`
+ * `appendEvent`) without coalescing message/thought chunks, so the live shape
+ * is always a plain **append** — `[...events, ev]`, a new array with every
+ * prior element reference-equal and one new element at the tail. Coalescing
+ * same-`messageId` chunks into a single block happens here, mirroring the step
+ * projection so the two never drift on chunk handling.
+ *
+ * `computeAcpRunChatBlocks(events)` is O(n); running it on every streamed event
+ * is O(n^2) over a run. The incremental projector replays only the diff vs the
+ * previous call through the same `applyAcpChatEvent` reducer the full rebuild
+ * uses, so the two paths can't drift. Any diff that isn't a plain append falls
+ * back to a full O(n) rebuild, which is always correct.
+ *
+ * `isComplete` rule for agent/thinking blocks: a block flips to `isComplete:
+ * true` once any later block is appended after it. The trailing block is left
+ * `isComplete: false` until the run produces a subsequent block or terminates.
+ */
+
+import { useRef } from "react";
+
+import type { AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+import type { AcpToolStatus } from "@/domains/chat/acp-run-step-projection";
+
+// ---------------------------------------------------------------------------
+// Chat block union
+// ---------------------------------------------------------------------------
+
+export type AcpChatBlock =
+  | { kind: "user"; id: string; content: string }
+  | { kind: "agent"; messageId: string; content: string; isComplete: boolean }
+  | { kind: "thinking"; messageId: string; content: string; isComplete: boolean }
+  | {
+      kind: "tool";
+      toolCallId: string;
+      title: string;
+      toolKind?: string;
+      status: AcpToolStatus;
+      content?: string;
+      locations?: { path: string; line?: number }[];
+    }
+  | { kind: "plan"; entries: { label: string; checked: boolean }[] };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+/** Synthetic id for chunks from older daemons that don't emit a messageId. */
+const ANONYMOUS_MESSAGE_ID = "";
+
+/** Prefix `appendLocalMarker` stamps onto optimistic steering notes. */
+const STEER_MARKER_PREFIX = "↻ Steering: ";
+
+/** Synthetic `messageId` prefix `appendLocalMarker` uses for steer markers. */
+const LOCAL_MARKER_ID_PREFIX = "local-marker-";
+
+/** Map a raw daemon `toolStatus` to a block status; keep `fallback` if absent. */
+function mapToolStatus(
+  toolStatus: string | undefined,
+  fallback: AcpToolStatus,
+): AcpToolStatus {
+  switch (toolStatus) {
+    case "complete":
+    case "completed":
+      return "completed";
+    case "failed":
+    case "error":
+      return "error";
+    case undefined:
+      return fallback;
+    default:
+      return "running";
+  }
+}
+
+/**
+ * Is this `agent_message_chunk` actually an optimistic steering marker (a local
+ * user turn), not real agent output? `appendLocalMarker` tags markers with a
+ * `local-marker-*` messageId AND a `↻ Steering: ` content prefix; either signal
+ * is enough so a marker is recognized even if one shape changes.
+ */
+function isSteerMarker(event: AcpRunRawEvent): boolean {
+  return (
+    (event.messageId?.startsWith(LOCAL_MARKER_ID_PREFIX) ?? false) ||
+    (event.content?.startsWith(STEER_MARKER_PREFIX) ?? false)
+  );
+}
+
+/** Strip the steer-marker prefix so the bubble shows the raw instruction. */
+function stripSteerPrefix(content: string | undefined): string {
+  const text = content ?? "";
+  return text.startsWith(STEER_MARKER_PREFIX)
+    ? text.slice(STEER_MARKER_PREFIX.length)
+    : text;
+}
+
+/** Mark the trailing agent/thinking block (if any, still live) as complete. */
+function closeTrailingMessage(blocks: AcpChatBlock[]): void {
+  const last = blocks[blocks.length - 1];
+  if (
+    last &&
+    (last.kind === "agent" || last.kind === "thinking") &&
+    !last.isComplete
+  ) {
+    blocks[blocks.length - 1] = { ...last, isComplete: true };
+  }
+}
+
+/**
+ * Fold a single raw ACP event into `blocks` (mutated in place). Shared by the
+ * full rebuild and the incremental projector so the two paths can't diverge.
+ */
+export function applyAcpChatEvent(
+  blocks: AcpChatBlock[],
+  event: AcpRunRawEvent,
+): void {
+  // A local steer marker rides in on an `agent_message_chunk`; route it to a
+  // user block before the agent-chunk handling below claims it.
+  if (event.updateType === "agent_message_chunk" && isSteerMarker(event)) {
+    closeTrailingMessage(blocks);
+    blocks.push({
+      kind: "user",
+      id: event.messageId ?? `steer-${blocks.length}`,
+      content: stripSteerPrefix(event.content),
+    });
+    return;
+  }
+
+  switch (event.updateType) {
+    case "user_message_chunk": {
+      const messageId = event.messageId ?? ANONYMOUS_MESSAGE_ID;
+      const last = blocks[blocks.length - 1];
+      // Coalesce consecutive same-id user chunks into one bubble.
+      if (last && last.kind === "user" && last.id === messageId) {
+        blocks[blocks.length - 1] = {
+          ...last,
+          content: last.content + stripSteerPrefix(event.content),
+        };
+        return;
+      }
+      closeTrailingMessage(blocks);
+      blocks.push({
+        kind: "user",
+        id: messageId,
+        content: stripSteerPrefix(event.content),
+      });
+      return;
+    }
+
+    case "agent_message_chunk": {
+      const messageId = event.messageId ?? ANONYMOUS_MESSAGE_ID;
+      const last = blocks[blocks.length - 1];
+      if (last && last.kind === "agent" && last.messageId === messageId) {
+        blocks[blocks.length - 1] = {
+          ...last,
+          content: last.content + (event.content ?? ""),
+        };
+        return;
+      }
+      closeTrailingMessage(blocks);
+      blocks.push({
+        kind: "agent",
+        messageId,
+        content: event.content ?? "",
+        isComplete: false,
+      });
+      return;
+    }
+
+    case "agent_thought_chunk": {
+      const messageId = event.messageId ?? ANONYMOUS_MESSAGE_ID;
+      const last = blocks[blocks.length - 1];
+      if (last && last.kind === "thinking" && last.messageId === messageId) {
+        blocks[blocks.length - 1] = {
+          ...last,
+          content: last.content + (event.content ?? ""),
+        };
+        return;
+      }
+      closeTrailingMessage(blocks);
+      blocks.push({
+        kind: "thinking",
+        messageId,
+        content: event.content ?? "",
+        isComplete: false,
+      });
+      return;
+    }
+
+    case "tool_call": {
+      const toolCallId = event.toolCallId;
+      if (toolCallId === undefined) return;
+      closeTrailingMessage(blocks);
+      blocks.push({
+        kind: "tool",
+        toolCallId,
+        title: event.toolTitle ?? "",
+        toolKind: event.toolKind,
+        status: "running",
+        content: event.content,
+        locations: parseLocations(event),
+      });
+      return;
+    }
+
+    case "tool_call_update": {
+      const toolCallId = event.toolCallId;
+      if (toolCallId === undefined) return;
+      const index = blocks.findIndex(
+        (b) => b.kind === "tool" && b.toolCallId === toolCallId,
+      );
+      if (index === -1) return;
+      const target = blocks[index] as Extract<AcpChatBlock, { kind: "tool" }>;
+      blocks[index] = {
+        ...target,
+        title: event.toolTitle ?? target.title,
+        toolKind: event.toolKind ?? target.toolKind,
+        status: mapToolStatus(event.toolStatus, target.status),
+        // ACP `ToolCallUpdate.content` REPLACES the snapshot, not a delta.
+        content: event.content ?? target.content,
+        locations: parseLocations(event) ?? target.locations,
+      };
+      return;
+    }
+
+    case "plan": {
+      const entries = parsePlanEntries(event.content);
+      if (entries === null) return;
+      const index = blocks.findIndex((b) => b.kind === "plan");
+      const planBlock: AcpChatBlock = { kind: "plan", entries };
+      if (index === -1) {
+        closeTrailingMessage(blocks);
+        blocks.push(planBlock);
+      } else {
+        blocks[index] = planBlock;
+      }
+      return;
+    }
+  }
+}
+
+/**
+ * Best-effort extraction of `locations` from a tool event. The store's raw
+ * event carries no typed `locations` field today; this reads an optional
+ * passthrough off the event without widening the store type. Returns
+ * `undefined` (no change) when absent or malformed.
+ */
+function parseLocations(
+  event: AcpRunRawEvent,
+): { path: string; line?: number }[] | undefined {
+  const raw = (event as { locations?: unknown }).locations;
+  if (!Array.isArray(raw)) return undefined;
+  const out: { path: string; line?: number }[] = [];
+  for (const item of raw) {
+    const obj = (item ?? {}) as Record<string, unknown>;
+    if (typeof obj.path !== "string") continue;
+    out.push(
+      typeof obj.line === "number"
+        ? { path: obj.path, line: obj.line }
+        : { path: obj.path },
+    );
+  }
+  return out.length ? out : undefined;
+}
+
+/**
+ * Parse a `plan` event's JSON `content` into entries. Returns `null` (skip the
+ * event) on malformed JSON or an unexpected shape rather than throwing.
+ * Mirrors the step projection's parser so the two stay in lockstep.
+ */
+function parsePlanEntries(
+  content: string | undefined,
+): { label: string; checked: boolean }[] | null {
+  if (!content) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  const raw = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { entries?: unknown })?.entries)
+      ? (parsed as { entries: unknown[] }).entries
+      : null;
+  if (raw === null) return null;
+  return raw.map((item) => {
+    const obj = (item ?? {}) as Record<string, unknown>;
+    const text = obj.content ?? obj.label ?? "";
+    return {
+      label: typeof text === "string" ? text : String(text),
+      checked: obj.checked === true || obj.status === "completed",
+    };
+  });
+}
+
+/**
+ * Build the full `AcpChatBlock[]` for an event buffer by folding
+ * `applyAcpChatEvent` over each event. Single source of truth for the
+ * projection.
+ */
+export function computeAcpRunChatBlocks(
+  events: AcpRunRawEvent[],
+): AcpChatBlock[] {
+  const blocks: AcpChatBlock[] = [];
+  for (const event of events) applyAcpChatEvent(blocks, event);
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Incremental projector
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify how `next` differs from `prev` at the raw-event-array level.
+ *  - `identity` — same array reference.
+ *  - `first` — no previous (cold cache).
+ *  - `append` — `prev` is a strict prefix of `next`; replay from `prev.length`.
+ *  - `mutate-last` — same length, last element changed; full rebuild (a grown
+ *    coalesced block can't be cheaply re-derived).
+ *  - `fallback` — anything else (full-replace, truncation, reorder).
+ */
+function classifyAcpDiff(
+  prev: AcpRunRawEvent[] | null,
+  next: AcpRunRawEvent[],
+):
+  | { kind: "identity" | "first" | "mutate-last" | "fallback" }
+  | { kind: "append"; from: number } {
+  if (prev === next) return { kind: "identity" };
+  if (prev === null) return { kind: "first" };
+  if (next.length < prev.length) return { kind: "fallback" };
+
+  for (let i = 0; i < prev.length; i++) {
+    if (prev[i] !== next[i]) {
+      if (i === prev.length - 1 && next.length === prev.length) {
+        return { kind: "mutate-last" };
+      }
+      return { kind: "fallback" };
+    }
+  }
+
+  if (next.length === prev.length) return { kind: "identity" };
+  return { kind: "append", from: prev.length };
+}
+
+/**
+ * Create a stateful incremental projector. `project(events)` returns the
+ * `AcpChatBlock[]` for `events`, replaying only the diff vs the previous call.
+ * Returns the cached array by reference when the input is unchanged so
+ * `React.memo` consumers can bail.
+ *
+ * One projector instance owns one cache slot — hold it per component instance
+ * (see `useAcpRunChatBlocks`), never module-global.
+ */
+export function createAcpRunChatProjection() {
+  let prevEvents: AcpRunRawEvent[] | null = null;
+  let blocks: AcpChatBlock[] = [];
+
+  function fullBuild(events: AcpRunRawEvent[]): AcpChatBlock[] {
+    blocks = computeAcpRunChatBlocks(events);
+    prevEvents = events;
+    return blocks;
+  }
+
+  function project(events: AcpRunRawEvent[]): AcpChatBlock[] {
+    const diff = classifyAcpDiff(prevEvents, events);
+
+    switch (diff.kind) {
+      case "identity":
+        return blocks;
+
+      case "first":
+        return fullBuild(events);
+
+      case "append": {
+        const clone = blocks.slice();
+        for (let i = diff.from; i < events.length; i++) {
+          applyAcpChatEvent(clone, events[i]!);
+        }
+        prevEvents = events;
+        blocks = clone;
+        return blocks;
+      }
+
+      case "mutate-last":
+      case "fallback":
+        return fullBuild(events);
+    }
+  }
+
+  return { project };
+}
+
+/**
+ * Hook wrapper: holds an incremental projector per component instance (in a
+ * `useRef`, tied to the component lifecycle — never a module-global cache).
+ * Returns a referentially-stable array across renders when the input events
+ * are unchanged.
+ */
+export function useAcpRunChatBlocks(events: AcpRunRawEvent[]): AcpChatBlock[] {
+  const projectorRef = useRef<ReturnType<
+    typeof createAcpRunChatProjection
+  > | null>(null);
+
+  // Intentional render-phase ref usage: the projector is a per-instance
+  // diff-aware cache (like `useMemo`, but it must run every render to fold in
+  // new events). Mirrors `useAcpRunSteps`.
+  /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
+  if (projectorRef.current == null) {
+    projectorRef.current = createAcpRunChatProjection();
+  }
+  return projectorRef.current.project(events);
+  /* eslint-enable react-hooks/refs */
+}


### PR DESCRIPTION
## Summary
- New `acp-run-message-projection.ts` folding the ACP event buffer into ordered chat blocks (agent/thinking/tool/plan + user turns).
- Sibling to the timeline step projection, which is left untouched.

Part of plan: acp-chat-detail-view.md (PR 3 of 11)