### PR TITLE
feat(web): add self-contained file diff view for acp runs

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.test.ts
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeLineDiff, type DiffRow } from "./compute-line-diff";
+
+function types(rows: DiffRow[]): string[] {
+  return rows.map((r) => r.type);
+}
+
+describe("computeLineDiff", () => {
+  test("identical text → all context rows with both line numbers", () => {
+    const rows = computeLineDiff("a\nb\nc", "a\nb\nc");
+    expect(types(rows)).toEqual(["ctx", "ctx", "ctx"]);
+    expect(rows[0]).toEqual({ type: "ctx", text: "a", oldNo: 1, newNo: 1 });
+    expect(rows[2]).toEqual({ type: "ctx", text: "c", oldNo: 3, newNo: 3 });
+  });
+
+  test("new file (empty old) → all additions", () => {
+    const rows = computeLineDiff("", "x\ny");
+    expect(types(rows)).toEqual(["add", "add"]);
+    expect(rows[0]).toEqual({ type: "add", text: "x", newNo: 1 });
+    expect(rows[1]).toEqual({ type: "add", text: "y", newNo: 2 });
+    expect(rows.every((r) => r.oldNo === undefined)).toBe(true);
+  });
+
+  test("deleted file (empty new) → all deletions", () => {
+    const rows = computeLineDiff("x\ny", "");
+    expect(types(rows)).toEqual(["del", "del"]);
+    expect(rows[0]).toEqual({ type: "del", text: "x", oldNo: 1 });
+    expect(rows[1]).toEqual({ type: "del", text: "y", oldNo: 2 });
+    expect(rows.every((r) => r.newNo === undefined)).toBe(true);
+  });
+
+  test("modify in the middle → context preserved, changed line del+add", () => {
+    const rows = computeLineDiff("a\nb\nc", "a\nB\nc");
+    expect(types(rows)).toEqual(["ctx", "del", "add", "ctx"]);
+    expect(rows[1]).toMatchObject({ type: "del", text: "b", oldNo: 2 });
+    expect(rows[2]).toMatchObject({ type: "add", text: "B", newNo: 2 });
+    expect(rows[3]).toMatchObject({ type: "ctx", text: "c", oldNo: 3, newNo: 3 });
+  });
+
+  test("pure insertion keeps surrounding context", () => {
+    const rows = computeLineDiff("a\nc", "a\nb\nc");
+    expect(types(rows)).toEqual(["ctx", "add", "ctx"]);
+    expect(rows[1]).toMatchObject({ type: "add", text: "b", newNo: 2 });
+  });
+
+  test("pure deletion keeps surrounding context", () => {
+    const rows = computeLineDiff("a\nb\nc", "a\nc");
+    expect(types(rows)).toEqual(["ctx", "del", "ctx"]);
+    expect(rows[1]).toMatchObject({ type: "del", text: "b", oldNo: 2 });
+  });
+
+  test("both empty → no rows", () => {
+    expect(computeLineDiff("", "")).toEqual([]);
+  });
+
+  test("oversized input → single too-large sentinel row", () => {
+    const huge = Array.from({ length: 2001 }, (_, i) => `line ${i}`).join("\n");
+    const rows = computeLineDiff(huge, "a");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe("too-large");
+    expect(rows[0].text).toMatch(/too large/i);
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.test.ts
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.test.ts
@@ -54,6 +54,26 @@ describe("computeLineDiff", () => {
     expect(computeLineDiff("", "")).toEqual([]);
   });
 
+  test("identical text with trailing newline → all context, no phantom row", () => {
+    const rows = computeLineDiff("a\nb\n", "a\nb\n");
+    expect(types(rows)).toEqual(["ctx", "ctx"]);
+    expect(rows[0]).toEqual({ type: "ctx", text: "a", oldNo: 1, newNo: 1 });
+    expect(rows[1]).toEqual({ type: "ctx", text: "b", oldNo: 2, newNo: 2 });
+  });
+
+  test("trailing-newline addition → single add, no phantom rows", () => {
+    const rows = computeLineDiff("a\n", "a\nb\n");
+    expect(types(rows)).toEqual(["ctx", "add"]);
+    expect(rows[0]).toEqual({ type: "ctx", text: "a", oldNo: 1, newNo: 1 });
+    expect(rows[1]).toMatchObject({ type: "add", text: "b", newNo: 2 });
+  });
+
+  test("genuine trailing blank line is preserved as a real line", () => {
+    const rows = computeLineDiff("a\n\n", "a\n\n");
+    expect(types(rows)).toEqual(["ctx", "ctx"]);
+    expect(rows[1]).toEqual({ type: "ctx", text: "", oldNo: 2, newNo: 2 });
+  });
+
   test("oversized input → single too-large sentinel row", () => {
     const huge = Array.from({ length: 2001 }, (_, i) => `line ${i}`).join("\n");
     const rows = computeLineDiff(huge, "a");

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.ts
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.ts
@@ -24,7 +24,12 @@ const MAX_DIFF_LINES = 2000;
 
 function splitLines(text: string): string[] {
   if (text === "") return [];
-  return text.split("\n");
+  const lines = text.split("\n");
+  // Drop only the empty segment the trailing newline terminator produces, so a
+  // normal `"a\n"` file is one line, not two. Real blank lines (e.g. `"a\n\n"`)
+  // are preserved because the split yields a non-terminator empty line too.
+  if (text.endsWith("\n")) lines.pop();
+  return lines;
 }
 
 /**

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.ts
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/compute-line-diff.ts
@@ -1,0 +1,96 @@
+/**
+ * Dependency-free line-level diff for the ACP file-diff view.
+ *
+ * Splits both sides on `\n` and runs an LCS to classify each line as added,
+ * removed, or unchanged context. Pure — no third-party deps, no I/O.
+ */
+
+export type DiffRowType = "add" | "del" | "ctx" | "too-large";
+
+export interface DiffRow {
+  type: DiffRowType;
+  text: string;
+  /** 1-based line number in `oldText`, present for `del` and `ctx` rows. */
+  oldNo?: number;
+  /** 1-based line number in `newText`, present for `add` and `ctx` rows. */
+  newNo?: number;
+}
+
+/**
+ * Above this many lines on either side we skip the O(n·m) LCS and emit a
+ * single sentinel row so huge inputs don't lock up the renderer.
+ */
+const MAX_DIFF_LINES = 2000;
+
+function splitLines(text: string): string[] {
+  if (text === "") return [];
+  return text.split("\n");
+}
+
+/**
+ * Longest-common-subsequence backtrace over two line arrays, producing the
+ * classic add/del/ctx row sequence.
+ */
+function lcsDiff(oldLines: string[], newLines: string[]): DiffRow[] {
+  const m = oldLines.length;
+  const n = newLines.length;
+
+  // dp[i][j] = LCS length of oldLines[i:] and newLines[j:].
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0),
+  );
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] =
+        oldLines[i] === newLines[j]
+          ? dp[i + 1][j + 1] + 1
+          : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+
+  const rows: DiffRow[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (oldLines[i] === newLines[j]) {
+      rows.push({ type: "ctx", text: oldLines[i], oldNo: i + 1, newNo: j + 1 });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      rows.push({ type: "del", text: oldLines[i], oldNo: i + 1 });
+      i++;
+    } else {
+      rows.push({ type: "add", text: newLines[j], newNo: j + 1 });
+      j++;
+    }
+  }
+  while (i < m) {
+    rows.push({ type: "del", text: oldLines[i], oldNo: i + 1 });
+    i++;
+  }
+  while (j < n) {
+    rows.push({ type: "add", text: newLines[j], newNo: j + 1 });
+    j++;
+  }
+  return rows;
+}
+
+export function computeLineDiff(oldText: string, newText: string): DiffRow[] {
+  const oldLines = splitLines(oldText);
+  const newLines = splitLines(newText);
+
+  if (oldLines.length > MAX_DIFF_LINES || newLines.length > MAX_DIFF_LINES) {
+    return [{ type: "too-large", text: "Diff too large — showing full content" }];
+  }
+
+  // New file: nothing on the left, every line is an addition.
+  if (oldLines.length === 0) {
+    return newLines.map((text, idx) => ({ type: "add", text, newNo: idx + 1 }));
+  }
+  // Deleted file: nothing on the right, every line is a removal.
+  if (newLines.length === 0) {
+    return oldLines.map((text, idx) => ({ type: "del", text, oldNo: idx + 1 }));
+  }
+
+  return lcsDiff(oldLines, newLines);
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/file-diff-view.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/file-diff-view.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { FileDiffView } from "./file-diff-view";
+
+afterEach(cleanup);
+
+function rowTypes(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll("[data-diff-type]")).map(
+    (el) => el.getAttribute("data-diff-type") ?? "",
+  );
+}
+
+describe("FileDiffView", () => {
+  test("renders the file path", () => {
+    render(
+      <FileDiffView path="src/foo.ts" oldText="a" newText="a" onBack={() => {}} />,
+    );
+    expect(screen.getByText("src/foo.ts")).toBeDefined();
+  });
+
+  test("renders add/del/ctx rows with token-class surfaces", () => {
+    const { container } = render(
+      <FileDiffView
+        path="src/foo.ts"
+        oldText={"a\nb\nc"}
+        newText={"a\nB\nc"}
+        onBack={() => {}}
+      />,
+    );
+
+    expect(rowTypes(container)).toEqual(["ctx", "del", "add", "ctx"]);
+
+    const del = container.querySelector('[data-diff-type="del"]');
+    const add = container.querySelector('[data-diff-type="add"]');
+    expect(del?.className).toContain("var(--system-negative-weak)");
+    expect(del?.className).toContain("var(--system-negative-strong)");
+    expect(add?.className).toContain("var(--system-positive-weak)");
+    expect(add?.className).toContain("var(--system-positive-strong)");
+
+    const ctx = container.querySelector('[data-diff-type="ctx"]');
+    expect(ctx?.className).toContain("var(--content-tertiary)");
+  });
+
+  test("new file renders only additions", () => {
+    const { container } = render(
+      <FileDiffView path="new.ts" newText={"x\ny"} onBack={() => {}} />,
+    );
+    expect(rowTypes(container)).toEqual(["add", "add"]);
+  });
+
+  test("fires onBack when the Back control is activated", () => {
+    const onBack = mock(() => {});
+    render(<FileDiffView path="x.ts" oldText="a" newText="a" onBack={onBack} />);
+
+    fireEvent.click(screen.getByTestId("file-diff-back"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/file-diff-view.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/file-diff-view.tsx
@@ -1,0 +1,112 @@
+import { ArrowLeft } from "lucide-react";
+
+import { Button, Typography } from "@vellumai/design-library";
+
+import { computeLineDiff, type DiffRow } from "./compute-line-diff";
+
+export interface FileDiffViewProps {
+  /** Repo-relative path of the file being diffed. */
+  path: string;
+  /** File contents before the change. Empty/undefined → treated as a new file. */
+  oldText?: string;
+  /** File contents after the change. Empty/undefined → treated as a deletion. */
+  newText?: string;
+  /** Invoked when the Back affordance is activated. */
+  onBack: () => void;
+}
+
+const GUTTER = "—";
+
+function rowSurfaceClass(type: DiffRow["type"]): string {
+  switch (type) {
+    case "add":
+      return "bg-[var(--system-positive-weak)] text-[var(--system-positive-strong)]";
+    case "del":
+      return "bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]";
+    case "too-large":
+      return "text-[var(--content-tertiary)] italic";
+    case "ctx":
+    default:
+      return "text-[var(--content-tertiary)]";
+  }
+}
+
+function rowMarker(type: DiffRow["type"]): string {
+  switch (type) {
+    case "add":
+      return "+";
+    case "del":
+      return "-";
+    default:
+      return " ";
+  }
+}
+
+/**
+ * Presentational unified file-diff renderer. Pure: it derives its rows from
+ * `computeLineDiff` and renders monospace add/del/ctx lines with design
+ * tokens. No syntax highlighting (matches the existing `CodeBlock`).
+ */
+export function FileDiffView({ path, oldText, newText, onBack }: FileDiffViewProps) {
+  const rows = computeLineDiff(oldText ?? "", newText ?? "");
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)]">
+      <div className="flex items-center gap-2 border-b border-[var(--border-base)] px-2 py-1.5">
+        <Button
+          variant="ghost"
+          size="compact"
+          iconOnly={<ArrowLeft />}
+          onClick={onBack}
+          aria-label="Back"
+          tooltip="Back"
+          data-testid="file-diff-back"
+        />
+        <Typography
+          variant="body-small-emphasised"
+          className="truncate font-mono text-[var(--content-default)]"
+          title={path}
+        >
+          {path}
+        </Typography>
+      </div>
+
+      <div className="overflow-x-auto font-mono text-xs">
+        {rows.map((row, idx) => (
+          <DiffLine key={idx} row={row} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DiffLine({ row }: { row: DiffRow }) {
+  // Future: a syntax highlighter for `row.text` could slot in here, keyed off
+  // the file extension — kept plain for now to match `CodeBlock`.
+  if (row.type === "too-large") {
+    return (
+      <div
+        data-diff-type="too-large"
+        className={`px-3 py-2 whitespace-pre-wrap ${rowSurfaceClass(row.type)}`}
+      >
+        {row.text}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-diff-type={row.type}
+      className={`flex items-start whitespace-pre ${rowSurfaceClass(row.type)}`}
+    >
+      <span className="w-10 shrink-0 select-none px-2 text-right text-[var(--content-tertiary)] tabular-nums">
+        {row.oldNo ?? GUTTER}
+      </span>
+      <span className="w-10 shrink-0 select-none px-2 text-right text-[var(--content-tertiary)] tabular-nums">
+        {row.newNo ?? GUTTER}
+      </span>
+      <span className="w-4 shrink-0 select-none text-center">{rowMarker(row.type)}</span>
+      <span className="flex-1 pr-3">{row.text}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `FileDiffView` + a dependency-free `computeLineDiff` (LCS) rendering a unified diff with design tokens.
- No syntax highlighting in v1 (matches existing CodeBlock); no new dependencies.

Part of plan: acp-chat-detail-view.md (PR 5 of 11)