### PR TITLE
feat(chat): derive stable avatar seeds for workflow spawned agents

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
@@ -10,6 +10,8 @@ import { cleanup, renderHook } from "@testing-library/react";
 
 import {
   computeWorkflowCardData,
+  selectWorkflowAgentAvatarSeeds,
+  useWorkflowAgentAvatarSeeds,
   useWorkflowCardData,
 } from "@/domains/chat/hooks/use-workflow-card-data";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
@@ -349,5 +351,77 @@ describe("useWorkflowCardData — hydration wiring", () => {
     expect(spy).not.toHaveBeenCalled();
 
     useWorkflowStore.setState({ hydrateRunIfNeeded: realHydrate });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectWorkflowAgentAvatarSeeds — stable seed derivation
+// ---------------------------------------------------------------------------
+
+describe("selectWorkflowAgentAvatarSeeds", () => {
+  test("returns [] when the run has no leaves and no spawned agents", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(makeEntry({ runId: "wf" }));
+    expect(seeds).toEqual([]);
+  });
+
+  test("seeds a single leaf", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({ runId: "wf", leaves: [{ seq: 0, status: "running" }] }),
+    );
+    expect(seeds).toEqual(["wf:0"]);
+  });
+
+  test("seeds two leaves in ascending seq order", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({
+        runId: "wf",
+        leaves: [
+          { seq: 1, status: "completed" },
+          { seq: 0, status: "running" },
+        ],
+      }),
+    );
+    expect(seeds).toEqual(["wf:0", "wf:1"]);
+  });
+
+  test("caps at three seeds when more than three leaves exist", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({
+        runId: "wf",
+        leaves: [
+          { seq: 0, status: "running" },
+          { seq: 1, status: "running" },
+          { seq: 2, status: "running" },
+          { seq: 3, status: "running" },
+          { seq: 4, status: "running" },
+        ],
+      }),
+    );
+    expect(seeds).toEqual(["wf:0", "wf:1", "wf:2"]);
+  });
+
+  test("synthesizes index seeds when leaves are empty but agentsSpawned > 0", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({ runId: "wf", agentsSpawned: 5 }),
+    );
+    expect(seeds).toEqual(["wf:0", "wf:1", "wf:2"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useWorkflowAgentAvatarSeeds — store wiring
+// ---------------------------------------------------------------------------
+
+describe("useWorkflowAgentAvatarSeeds", () => {
+  afterEach(() => {
+    cleanup();
+    useWorkflowStore.getState().reset();
+  });
+
+  test("returns [] for an unknown runId", () => {
+    const { result } = renderHook(() =>
+      useWorkflowAgentAvatarSeeds("wf-unknown"),
+    );
+    expect(result.current).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
@@ -197,6 +197,51 @@ export function computeWorkflowCardData(
 }
 
 /**
+ * Max avatars rendered in the workflow card's spawned-agent stack. Matches
+ * the Figma 3-avatar sample; the count text carries the total.
+ */
+export const MAX_VISIBLE_WORKFLOW_AGENT_AVATARS = 3;
+
+/** Stable empty seed array so the hook returns a constant ref for unknown runs. */
+const EMPTY_SEEDS: string[] = [];
+
+/**
+ * Derive stable avatar seeds for a run's spawned agents. The count mirrors
+ * the card's agent count (`computeWorkflowCardData`) so avatars and the count
+ * text stay consistent. Live runs seed from the sorted leaves' `seq`; a
+ * hydrated count-only run (no per-leaf events) synthesizes index seeds. Each
+ * seed is a stable `${runId}:${seq}` string.
+ */
+export function selectWorkflowAgentAvatarSeeds(entry: WorkflowEntry): string[] {
+  const count = entry.leaves.size || entry.agentsSpawned;
+  const visible = Math.min(count, MAX_VISIBLE_WORKFLOW_AGENT_AVATARS);
+
+  const seqs =
+    entry.leaves.size > 0
+      ? sortedLeaves(entry)
+          .slice(0, visible)
+          .map((l) => l.seq)
+      : Array.from({ length: visible }, (_, i) => i);
+
+  return seqs.map((seq) => `${entry.runId}:${seq}`);
+}
+
+/**
+ * React hook: subscribe to the workflow store entry for `runId` and derive
+ * its spawned-agent avatar seeds. Selecting the stable `entry` ref then
+ * deriving in `useMemo` avoids returning a fresh array every render (which
+ * would loop a consumer's effects). Returns a constant empty array when no
+ * entry exists yet.
+ */
+export function useWorkflowAgentAvatarSeeds(runId: string): string[] {
+  const entry = useWorkflowStore((state) => state.byId[runId]);
+  return useMemo(
+    () => (entry ? selectWorkflowAgentAvatarSeeds(entry) : EMPTY_SEEDS),
+    [entry],
+  );
+}
+
+/**
  * React hook: subscribe to the workflow store entry for `runId` and
  * project it into `ToolCallCardData`. Returns `null` when no entry exists
  * yet (spawn race, or a history / post-reload card before hydration), so


### PR DESCRIPTION
## Summary
- Add selectWorkflowAgentAvatarSeeds + useWorkflowAgentAvatarSeeds + MAX_VISIBLE_WORKFLOW_AGENT_AVATARS to use-workflow-card-data.ts
- Seeds are stable `runId:seq` strings (live leaves, with index fallback for hydrated count-only runs)

Part of plan: workflow-card-agent-count-chip.md (PR 1 of 3)