### PR TITLE
feat(chat): add WorkflowAgentsChip (avatar stack + count pill)

### DIFF
--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tests for `WorkflowAgentsChip`.
+ *
+ * `SubagentAvatarChip` lazily loads a ~48 kB bundled-avatar payload, so it is
+ * mocked to a testid stub here to keep the test focused on the chip's own
+ * structure: one avatar per seed, the count text, and the count-only path.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+mock.module("@/components/avatar/subagent-avatar-chip", () => ({
+  SubagentAvatarChip: ({ subagentId }: { subagentId: string }) => (
+    <span data-testid="avatar-stub" data-subagent-id={subagentId} />
+  ),
+}));
+
+import { WorkflowAgentsChip } from "@/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip";
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("WorkflowAgentsChip", () => {
+  test("renders the pill, one avatar per seed, and the count text", () => {
+    const { getByTestId, getAllByTestId } = render(
+      <WorkflowAgentsChip countLabel="3 agents" seeds={["a", "b", "c"]} />,
+    );
+
+    expect(getByTestId("workflow-inline-card-agents-chip")).toBeTruthy();
+    expect(getAllByTestId("avatar-stub").length).toBe(3);
+    expect(getByTestId("workflow-inline-card-step-count").textContent).toBe(
+      "3 agents",
+    );
+  });
+
+  test("renders count-only with no avatar stack when seeds is empty", () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <WorkflowAgentsChip countLabel="1 agent" seeds={[]} />,
+    );
+
+    expect(getByTestId("workflow-inline-card-agents-chip")).toBeTruthy();
+    expect(queryAllByTestId("avatar-stub").length).toBe(0);
+    expect(getByTestId("workflow-inline-card-step-count").textContent).toBe(
+      "1 agent",
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.tsx
@@ -23,15 +23,16 @@ export function WorkflowAgentsChip({
   seeds,
 }: WorkflowAgentsChipProps) {
   return (
-    <span
+    <div
       data-testid="workflow-inline-card-agents-chip"
       className="inline-flex items-center gap-1 rounded-full bg-[var(--surface-overlay)] px-1.5 py-1"
     >
       {seeds.length > 0 && (
         // Decorative identicons seeded by `runId:seq` (not real subagent
         // identities), so the stack is aria-hidden and the count text carries
-        // the accessible meaning.
-        <span aria-hidden className="flex items-center">
+        // the accessible meaning. The wrappers are divs because
+        // `SubagentAvatarChip` renders a div, which is invalid inside a span.
+        <div aria-hidden className="flex items-center">
           {seeds.map((seed, index) => (
             <SubagentAvatarChip
               key={seed}
@@ -44,7 +45,7 @@ export function WorkflowAgentsChip({
               }
             />
           ))}
-        </span>
+        </div>
       )}
 
       <Typography
@@ -54,6 +55,6 @@ export function WorkflowAgentsChip({
       >
         {countLabel}
       </Typography>
-    </span>
+    </div>
   );
 }

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.tsx
@@ -1,0 +1,59 @@
+/**
+ * Purely presentational agent-count chip for the workflow inline card.
+ *
+ * Renders a rounded surface-overlay pill with an overlapping stack of
+ * decorative subagent avatars followed by the formatted count. The count
+ * string and avatar seeds are supplied by the caller; the chip holds no
+ * workflow state of its own.
+ */
+
+import { Typography } from "@vellumai/design-library";
+
+import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+
+export interface WorkflowAgentsChipProps {
+  /** Already-formatted count, e.g. "3 agents". */
+  countLabel: string;
+  /** Decorative avatar seeds (`runId:seq`), one avatar per seed. */
+  seeds: string[];
+}
+
+export function WorkflowAgentsChip({
+  countLabel,
+  seeds,
+}: WorkflowAgentsChipProps) {
+  return (
+    <span
+      data-testid="workflow-inline-card-agents-chip"
+      className="inline-flex items-center gap-1 rounded-full bg-[var(--surface-overlay)] px-1.5 py-1"
+    >
+      {seeds.length > 0 && (
+        // Decorative identicons seeded by `runId:seq` (not real subagent
+        // identities), so the stack is aria-hidden and the count text carries
+        // the accessible meaning.
+        <span aria-hidden className="flex items-center">
+          {seeds.map((seed, index) => (
+            <SubagentAvatarChip
+              key={seed}
+              subagentId={seed}
+              size={14}
+              className={
+                index === 0
+                  ? undefined
+                  : "-ml-1 rounded-full ring-2 ring-[var(--surface-overlay)]"
+              }
+            />
+          ))}
+        </span>
+      )}
+
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-secondary)]"
+        data-testid="workflow-inline-card-step-count"
+      >
+        {countLabel}
+      </Typography>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- New presentational WorkflowAgentsChip: rounded-full surface-overlay pill with an overlapping SubagentAvatarChip stack + the 'N agents' count
- aria-hidden decorative avatars; tokens only; count keeps the workflow-inline-card-step-count testid

Part of plan: workflow-card-agent-count-chip.md (PR 2 of 3)