### PR TITLE
feat(chat): show spawned-agent avatar chip on the workflow card

### DIFF
--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
@@ -7,9 +7,25 @@
  * header-click callback.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { act } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
+
+// `SubagentAvatarChip` (rendered inside the agents chip) lazily loads a heavy
+// bundled-avatar payload, so it is stubbed to keep avatar output deterministic.
+mock.module("@/components/avatar/subagent-avatar-chip", () => ({
+  SubagentAvatarChip: ({ subagentId }: { subagentId: string }) => (
+    <span data-testid="avatar-stub" data-subagent-id={subagentId} />
+  ),
+}));
 
 import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
@@ -22,6 +38,10 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 function startRun(runId: string, label = "Research workflow") {
@@ -52,6 +72,7 @@ describe("WorkflowInlineProgressCard — fixture run", () => {
     );
 
     expect(getByTestId("workflow-inline-progress-card")).toBeTruthy();
+    expect(getByTestId("workflow-inline-card-agents-chip")).toBeTruthy();
     expect(getByText("2 agents")).toBeTruthy();
   });
 
@@ -64,12 +85,17 @@ describe("WorkflowInlineProgressCard — fixture run", () => {
       <WorkflowInlineProgressCard runId="wf-order" onStopWorkflow={() => {}} />,
     );
 
+    const chip = getByTestId("workflow-inline-card-agents-chip");
     const stepCount = getByTestId("workflow-inline-card-step-count");
     const stop = getByTestId("workflow-inline-card-stop");
     // The stop button follows the step count in DOM order (step count first).
     expect(
       stepCount.compareDocumentPosition(stop) &
         Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // The agents chip precedes the stop button (stop stays rightmost).
+    expect(
+      chip.compareDocumentPosition(stop) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
@@ -20,11 +20,16 @@
 import { AlertCircle, CheckCircle2, Square, Workflow } from "lucide-react";
 import { useCallback, type KeyboardEvent, type MouseEvent } from "react";
 
-import { Button, Typography } from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library";
 
 import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
-import { useWorkflowCardData } from "@/domains/chat/hooks/use-workflow-card-data";
+import {
+  useWorkflowAgentAvatarSeeds,
+  useWorkflowCardData,
+} from "@/domains/chat/hooks/use-workflow-card-data";
+
+import { WorkflowAgentsChip } from "./workflow-agents-chip";
 
 export interface WorkflowInlineProgressCardProps {
   runId: string;
@@ -40,6 +45,7 @@ export function WorkflowInlineProgressCard({
   onStopWorkflow,
 }: WorkflowInlineProgressCardProps) {
   const data = useWorkflowCardData(runId);
+  const agentSeeds = useWorkflowAgentAvatarSeeds(runId);
   // "loading" = the live window where stopping the run is meaningful
   // (see `deriveCardState`).
   const isRunning = data?.state === "loading";
@@ -139,13 +145,7 @@ export function WorkflowInlineProgressCard({
       </span>
       <span className="flex shrink-0 items-center gap-2">
         {showStepCount ? (
-          <Typography
-            variant="body-small-default"
-            className="text-[var(--content-tertiary)]"
-            data-testid="workflow-inline-card-step-count"
-          >
-            {stepCount}
-          </Typography>
+          <WorkflowAgentsChip countLabel={stepCount} seeds={agentSeeds} />
         ) : null}
         {onStopWorkflow && isRunning ? (
           <Button


### PR DESCRIPTION
## Summary
- Replace the bare 'N agents' text on WorkflowInlineProgressCard with WorkflowAgentsChip (avatar stack + count pill), fed by useWorkflowAgentAvatarSeeds
- Stop button stays the rightmost element; existing count/ordering behavior preserved

Part of plan: workflow-card-agent-count-chip.md (PR 3 of 3)