### PR TITLE
feat(web): parse acp tool content into typed blocks + file changes

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -38,6 +38,8 @@ export interface AcpRunRawEvent {
   toolTitle?: string;
   toolKind?: string;
   toolStatus?: string;
+  /** Files touched by this tool call (for the file-diff affordance). */
+  locations?: { path: string; line?: number }[];
   messageId?: string;
 }
 

--- a/clients/web/src/domains/chat/acp-tool-content.test.ts
+++ b/clients/web/src/domains/chat/acp-tool-content.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  getAcpFileChanges,
+  parseAcpToolContent,
+  type AcpToolContentBlock,
+} from "@/domains/chat/acp-tool-content";
+
+describe("parseAcpToolContent", () => {
+  it("parses an array of diff blocks", () => {
+    const content = JSON.stringify([
+      { type: "diff", path: "a.ts", newText: "new", oldText: "old" },
+      { type: "diff", path: "b.ts", newText: "created" },
+    ]);
+    expect(parseAcpToolContent(content)).toEqual([
+      { type: "diff", path: "a.ts", newText: "new", oldText: "old" },
+      { type: "diff", path: "b.ts", newText: "created" },
+    ]);
+  });
+
+  it("parses an array of content blocks (nested ContentBlock text)", () => {
+    const content = JSON.stringify([
+      { type: "content", content: { type: "text", text: "hello" } },
+    ]);
+    expect(parseAcpToolContent(content)).toEqual([
+      { type: "content", text: "hello" },
+    ]);
+  });
+
+  it("tolerates a single object instead of an array", () => {
+    const content = JSON.stringify({
+      type: "diff",
+      path: "a.ts",
+      newText: "new",
+    });
+    expect(parseAcpToolContent(content)).toEqual([
+      { type: "diff", path: "a.ts", newText: "new" },
+    ]);
+  });
+
+  it("maps terminal blocks", () => {
+    const content = JSON.stringify([{ type: "terminal", terminalId: "t-1" }]);
+    expect(parseAcpToolContent(content)).toEqual([{ type: "terminal" }]);
+  });
+
+  it("ignores unknown variants while keeping known ones", () => {
+    const content = JSON.stringify([
+      { type: "image", data: "..." },
+      { type: "content", content: { type: "text", text: "kept" } },
+    ]);
+    expect(parseAcpToolContent(content)).toEqual([
+      { type: "content", text: "kept" },
+    ]);
+  });
+
+  it("returns [] for malformed JSON wrapped in braces", () => {
+    expect(parseAcpToolContent("{not json")).toEqual([]);
+  });
+
+  it("returns [] for empty and undefined input", () => {
+    expect(parseAcpToolContent("")).toEqual([]);
+    expect(parseAcpToolContent(undefined)).toEqual([]);
+  });
+
+  it("falls back to a single content block for a plain non-JSON string", () => {
+    expect(parseAcpToolContent("just some text")).toEqual([
+      { type: "content", text: "just some text" },
+    ]);
+  });
+
+  it("never throws on a JSON null", () => {
+    expect(parseAcpToolContent("null")).toEqual([]);
+  });
+});
+
+describe("getAcpFileChanges", () => {
+  it("extracts changes from diff blocks alone", () => {
+    const blocks: AcpToolContentBlock[] = [
+      { type: "diff", path: "a.ts", newText: "new", oldText: "old" },
+      { type: "content", text: "noise" },
+      { type: "diff", path: "b.ts", newText: "created" },
+    ];
+    expect(getAcpFileChanges(blocks)).toEqual([
+      { path: "a.ts", newText: "new", oldText: "old" },
+      { path: "b.ts", newText: "created" },
+    ]);
+  });
+
+  it("merges diff paths with extra locations, deduping by path", () => {
+    const blocks: AcpToolContentBlock[] = [
+      { type: "diff", path: "a.ts", newText: "new" },
+    ];
+    const locations = [{ path: "a.ts", line: 1 }, { path: "c.ts" }];
+    expect(getAcpFileChanges(blocks, locations)).toEqual([
+      { path: "a.ts", newText: "new" },
+      { path: "c.ts" },
+    ]);
+  });
+
+  it("returns path-only entries from locations when there are no diffs", () => {
+    expect(getAcpFileChanges([], [{ path: "x.ts" }, { path: "y.ts" }])).toEqual(
+      [{ path: "x.ts" }, { path: "y.ts" }],
+    );
+  });
+
+  it("returns [] when there are no diffs and no locations", () => {
+    expect(getAcpFileChanges([])).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/chat/acp-tool-content.ts
+++ b/clients/web/src/domains/chat/acp-tool-content.ts
@@ -1,0 +1,116 @@
+/**
+ * Parses the stringified ACP tool-call `content` into typed display blocks and
+ * derives the set of file changes a tool call touched.
+ *
+ * The daemon JSON-stringifies the ACP `ToolCallContent[]` into the SSE event's
+ * `content` field (see assistant/src/acp/client-handler.ts). ACP content blocks
+ * come in three variants we render: `content` (text), `diff`
+ * (`{ path, newText, oldText? }`), and `terminal`. Parsing is deliberately
+ * defensive — malformed, empty, or non-JSON input must never throw, since the
+ * content originates off the wire from an external agent.
+ */
+
+export type AcpToolContentBlock =
+  | { type: "content"; text: string }
+  | { type: "diff"; path: string; oldText?: string; newText: string }
+  | { type: "terminal"; text?: string };
+
+/**
+ * Parse the stringified ACP tool content into typed blocks.
+ *
+ * Tolerates a single object or an array, mapping only the known variants. A
+ * plain non-JSON string falls back to a single `content` block carrying the raw
+ * text. Returns `[]` for empty/undefined/malformed input — never throws.
+ */
+export function parseAcpToolContent(content?: string): AcpToolContentBlock[] {
+  if (!content) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    // Input that looks structurally like JSON (object/array) but fails to parse
+    // is malformed wire data → []. Free-form prose is treated as raw text.
+    const trimmed = content.trimStart();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) return [];
+    return [{ type: "content", text: content }];
+  }
+
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  const blocks: AcpToolContentBlock[] = [];
+
+  for (const item of items) {
+    const block = parseBlock(item);
+    if (block) blocks.push(block);
+  }
+
+  return blocks;
+}
+
+function parseBlock(item: unknown): AcpToolContentBlock | null {
+  if (typeof item !== "object" || item === null) return null;
+  const obj = item as Record<string, unknown>;
+
+  switch (obj.type) {
+    case "content":
+      return { type: "content", text: extractContentText(obj.content) };
+    case "diff": {
+      if (typeof obj.path !== "string" || typeof obj.newText !== "string") {
+        return null;
+      }
+      return {
+        type: "diff",
+        path: obj.path,
+        newText: obj.newText,
+        ...(typeof obj.oldText === "string" ? { oldText: obj.oldText } : {}),
+      };
+    }
+    case "terminal":
+      return { type: "terminal" };
+    default:
+      return null;
+  }
+}
+
+/**
+ * The ACP `content` variant nests the text under a `ContentBlock`
+ * (`{ content: { type: "text", text } }`). Read that text when present,
+ * tolerating a bare string for resilience.
+ */
+function extractContentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (typeof content === "object" && content !== null) {
+    const text = (content as Record<string, unknown>).text;
+    if (typeof text === "string") return text;
+  }
+  return "";
+}
+
+/**
+ * Collect file changes from `diff` blocks, then union in any `locations[].path`
+ * not already represented (path-only). Deduped by path; diff entries win over
+ * a path-only `locations` entry for the same file.
+ */
+export function getAcpFileChanges(
+  blocks: AcpToolContentBlock[],
+  locations?: { path: string; line?: number }[],
+): { path: string; oldText?: string; newText?: string }[] {
+  const byPath = new Map<string, { path: string; oldText?: string; newText?: string }>();
+
+  for (const block of blocks) {
+    if (block.type !== "diff") continue;
+    byPath.set(block.path, {
+      path: block.path,
+      newText: block.newText,
+      ...(block.oldText !== undefined ? { oldText: block.oldText } : {}),
+    });
+  }
+
+  for (const location of locations ?? []) {
+    if (!byPath.has(location.path)) {
+      byPath.set(location.path, { path: location.path });
+    }
+  }
+
+  return Array.from(byPath.values());
+}

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -59,6 +59,36 @@ describe("handleAcpSessionUpdate", () => {
     expect(getState().highWaterMark.get("acp-1")).toBe(1);
   });
 
+  it("plumbs locations into the store when present on the event", () => {
+    spawn();
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "tool_call",
+      toolCallId: "tc-1",
+      seq: 1,
+      // `locations` rides the wire (daemon forwards it) but isn't on the web
+      // event type yet — cast to attach it like the daemon does.
+      locations: [{ path: "a.ts", line: 12 }, { path: "b.ts" }],
+    } as Parameters<typeof handleAcpSessionUpdate>[0]);
+    expect(getState().byId["acp-1"]?.events[0]?.locations).toEqual([
+      { path: "a.ts", line: 12 },
+      { path: "b.ts" },
+    ]);
+  });
+
+  it("omits locations when absent on the event", () => {
+    spawn();
+    handleAcpSessionUpdate({
+      type: "acp_session_update",
+      acpSessionId: "acp-1",
+      updateType: "tool_call",
+      toolCallId: "tc-1",
+      seq: 1,
+    });
+    expect(getState().byId["acp-1"]?.events[0]?.locations).toBeUndefined();
+  });
+
   it("drops a replayed event at or below the high-water mark", () => {
     spawn();
     const update = {

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -36,6 +36,11 @@ export function handleAcpSessionUpdate(event: AcpSessionUpdateEvent): void {
       toolTitle: event.toolTitle,
       toolKind: event.toolKind,
       toolStatus: event.toolStatus,
+      // `locations` rides the SSE event since the daemon forwards tool-call
+      // locations[], but the web event type doesn't declare it yet — read it
+      // defensively. Absent on older daemons.
+      locations: (event as { locations?: { path: string; line?: number }[] })
+        .locations,
       messageId: event.messageId,
     },
   });


### PR DESCRIPTION
## Summary
- Add `parseAcpToolContent` (content/diff/terminal, never throws) and `getAcpFileChanges`.
- Plumb optional `locations` through the store event + handler.

Part of plan: acp-chat-detail-view.md (PR 4 of 11)