### PR TITLE
feat(acp): forward & persist cumulative input/output tokens

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -245,6 +245,10 @@ paths:
                           type: number
                         costCurrency:
                           type: string
+                        inputTokens:
+                          type: number
+                        outputTokens:
+                          type: number
                         eventLog:
                           type: array
                           items: {}

--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -28,6 +28,8 @@ export interface HistoryRow {
   context_size: number | null;
   cost_amount: number | null;
   cost_currency: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
 }
 
 export function clearHistory(): void {
@@ -58,6 +60,8 @@ export function insertHistoryRow(row: {
   contextSize?: number | null;
   costAmount?: number | null;
   costCurrency?: string | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
 }): void {
   getSqlite()
     .query(
@@ -65,8 +69,9 @@ export function insertHistoryRow(row: {
          id, agent_id, acp_session_id, parent_conversation_id,
          started_at, completed_at, status, stop_reason, error,
          event_log_json, cwd, task, parent_tool_use_id,
-         used_tokens, context_size, cost_amount, cost_currency
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         used_tokens, context_size, cost_amount, cost_currency,
+         input_tokens, output_tokens
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       row.id,
@@ -86,6 +91,8 @@ export function insertHistoryRow(row: {
       row.contextSize ?? null,
       row.costAmount ?? null,
       row.costCurrency ?? null,
+      row.inputTokens ?? null,
+      row.outputTokens ?? null,
     );
 }
 
@@ -95,7 +102,8 @@ export function readHistoryRow(id: string): HistoryRow | null {
       `SELECT id, agent_id, acp_session_id, parent_conversation_id,
               started_at, completed_at, status, stop_reason, error,
               event_log_json, cwd, task, parent_tool_use_id,
-              used_tokens, context_size, cost_amount, cost_currency
+              used_tokens, context_size, cost_amount, cost_currency,
+              input_tokens, output_tokens
        FROM acp_session_history WHERE id = ?`,
     )
     .get(id) as HistoryRow | null;

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -46,7 +46,10 @@ function buildSessionWithFakeProcess(opts: {
   latestUsage?: AcpUsageSnapshot;
 }): {
   manager: AcpSessionManager;
-  resolvePrompt: (v: { stopReason: string }) => void;
+  resolvePrompt: (v: {
+    stopReason: string;
+    usage?: { inputTokens: number; outputTokens: number };
+  }) => void;
   rejectPrompt: (e: Error) => void;
   emitUpdate: (update: AcpSessionUpdate) => void;
 } {
@@ -54,9 +57,13 @@ function buildSessionWithFakeProcess(opts: {
   const sent: ServerMessage[] = [];
   const sendToVellum = (msg: ServerMessage) => sent.push(msg);
 
-  let resolvePrompt!: (v: { stopReason: string }) => void;
+  type PromptResolution = {
+    stopReason: string;
+    usage?: { inputTokens: number; outputTokens: number };
+  };
+  let resolvePrompt!: (v: PromptResolution) => void;
   let rejectPrompt!: (e: Error) => void;
-  const promptPromise = new Promise<{ stopReason: string }>((res, rej) => {
+  const promptPromise = new Promise<PromptResolution>((res, rej) => {
     resolvePrompt = res;
     rejectPrompt = rej;
   });
@@ -403,6 +410,88 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.context_size).toBeNull();
     expect(row!.cost_amount).toBeNull();
     expect(row!.cost_currency).toBeNull();
+    expect(row!.input_tokens).toBeNull();
+    expect(row!.output_tokens).toBeNull();
+  });
+
+  test("emits acp_session_usage and persists input/output tokens from PromptResponse.usage", async () => {
+    const id = "session-io-usage-1";
+    const sent: ServerMessage[] = [];
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-io",
+      protocolSessionId: "proto-io",
+      parentConversationId: "conv-io",
+      // A prior usage_update established the context-window gauge; the prompt
+      // response only adds cumulative input/output token totals.
+      latestUsage: { usedTokens: 1200, contextSize: 200_000 },
+    });
+
+    // Capture the usage event emitted at turn end.
+    const captureSend = (
+      handles.manager as unknown as { sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }> }
+    ).sessions.get(id);
+    const originalSend = captureSend!.sendToVellum;
+    captureSend!.sendToVellum = (msg: ServerMessage) => {
+      sent.push(msg);
+      originalSend(msg);
+    };
+
+    handles.resolvePrompt({
+      stopReason: "end_turn",
+      usage: { inputTokens: 5000, outputTokens: 800 },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const usageEvent = sent.find((m) => m.type === "acp_session_usage");
+    expect(usageEvent).toMatchObject({
+      type: "acp_session_usage",
+      acpSessionId: id,
+      inputTokens: 5000,
+      outputTokens: 800,
+      usedTokens: 1200,
+      contextSize: 200_000,
+    });
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.input_tokens).toBe(5000);
+    expect(row!.output_tokens).toBe(800);
+    // Context-window gauge from the prior usage_update is preserved.
+    expect(row!.used_tokens).toBe(1200);
+    expect(row!.context_size).toBe(200_000);
+  });
+
+  test("does not emit usage or write token columns when PromptResponse carries no usage", async () => {
+    const id = "session-io-no-usage-1";
+    const sent: ServerMessage[] = [];
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-io-none",
+      protocolSessionId: "proto-io-none",
+      parentConversationId: "conv-io-none",
+    });
+
+    const entry = (
+      handles.manager as unknown as { sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }> }
+    ).sessions.get(id);
+    const originalSend = entry!.sendToVellum;
+    entry!.sendToVellum = (msg: ServerMessage) => {
+      sent.push(msg);
+      originalSend(msg);
+    };
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sent.find((m) => m.type === "acp_session_usage")).toBeUndefined();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.input_tokens).toBeNull();
+    expect(row!.output_tokens).toBeNull();
   });
 
   test("legacy rows without a cwd read back as null", () => {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -299,6 +299,8 @@ export class AcpSessionManager {
             contextSize: msg.contextSize,
             costAmount: msg.costAmount,
             costCurrency: msg.costCurrency,
+            inputTokens: msg.inputTokens ?? state.latestUsage?.inputTokens,
+            outputTokens: msg.outputTokens ?? state.latestUsage?.outputTokens,
           };
         }
       }
@@ -509,6 +511,8 @@ export class AcpSessionManager {
         contextSize: row.contextSize,
         costAmount: row.costAmount ?? undefined,
         costCurrency: row.costCurrency ?? undefined,
+        inputTokens: row.inputTokens ?? undefined,
+        outputTokens: row.outputTokens ?? undefined,
       };
     }
 
@@ -905,6 +909,8 @@ export class AcpSessionManager {
       contextSize: usage?.contextSize ?? null,
       costAmount: usage?.costAmount ?? null,
       costCurrency: usage?.costCurrency ?? null,
+      inputTokens: usage?.inputTokens ?? null,
+      outputTokens: usage?.outputTokens ?? null,
     };
     try {
       getDb()
@@ -971,6 +977,34 @@ export class AcpSessionManager {
             current.state.stopReason = response.stopReason;
           }
           current.currentPrompt = null;
+
+          // `PromptResponse.usage` carries cumulative input/output totals across
+          // all turns. Overwrite (not accumulate) onto the latest usage gauge so
+          // the terminal persist captures them, and emit so clients see the final
+          // counts. Reuse the most recent context-window snapshot for
+          // usedTokens/contextSize, which the prompt response does not report.
+          const usage = response.usage;
+          if (usage) {
+            const prior = current.state.latestUsage;
+            current.state.latestUsage = {
+              usedTokens: prior?.usedTokens ?? 0,
+              contextSize: prior?.contextSize ?? 0,
+              costAmount: prior?.costAmount,
+              costCurrency: prior?.costCurrency,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+            };
+            current.sendToVellum({
+              type: "acp_session_usage",
+              acpSessionId,
+              usedTokens: current.state.latestUsage.usedTokens,
+              contextSize: current.state.latestUsage.contextSize,
+              costAmount: current.state.latestUsage.costAmount,
+              costCurrency: current.state.latestUsage.costCurrency,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+            });
+          }
           log.info(
             { acpSessionId, stopReason: response.stopReason },
             "ACP prompt completed",

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -42,4 +42,8 @@ export interface AcpUsageSnapshot {
   contextSize: number;
   costAmount?: number;
   costCurrency?: string;
+  /** Cumulative input tokens across all turns, from `PromptResponse.usage`. */
+  inputTokens?: number;
+  /** Cumulative output tokens across all turns, from `PromptResponse.usage`. */
+  outputTokens?: number;
 }

--- a/assistant/src/api/events/acp-session-usage.test.ts
+++ b/assistant/src/api/events/acp-session-usage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { AcpSessionUsageEventSchema } from "./acp-session-usage.js";
+
+describe("AcpSessionUsageEventSchema", () => {
+  test("parses an event carrying cumulative input/output tokens", () => {
+    const event = {
+      type: "acp_session_usage" as const,
+      acpSessionId: "acp-session-abc",
+      usedTokens: 1200,
+      contextSize: 200000,
+      inputTokens: 950,
+      outputTokens: 250,
+      costAmount: 0.42,
+      costCurrency: "USD",
+    };
+
+    const result = AcpSessionUsageEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("parses a usage event without the token fields", () => {
+    const event = {
+      type: "acp_session_usage" as const,
+      acpSessionId: "acp-session-abc",
+      usedTokens: 1200,
+      contextSize: 200000,
+    };
+
+    const result = AcpSessionUsageEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("rejects an unrecognized field under .strict()", () => {
+    const result = AcpSessionUsageEventSchema.safeParse({
+      type: "acp_session_usage",
+      acpSessionId: "acp-session-abc",
+      usedTokens: 1200,
+      contextSize: 200000,
+      unexpected: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/assistant/src/api/events/acp-session-usage.ts
+++ b/assistant/src/api/events/acp-session-usage.ts
@@ -4,9 +4,10 @@
  * Server → client gauge of an ACP session's context-window usage,
  * forwarded from the ACP `usage_update` notification. `usedTokens` is
  * the tokens currently in context, `contextSize` the window size; the
- * optional `costAmount`/`costCurrency` mirror the agent's cumulative
- * cost. A side gauge, not part of the ordered update timeline — carries
- * no `seq`.
+ * optional `inputTokens`/`outputTokens` are the session's cumulative
+ * input/output token totals and `costAmount`/`costCurrency` mirror the
+ * agent's cumulative cost. A side gauge, not part of the ordered update
+ * timeline — carries no `seq`.
  *
  * Canonical wire-contract source. Daemon code imports the type
  * directly from this file; external consumers import via
@@ -21,6 +22,8 @@ export const AcpSessionUsageEventSchema = z
     acpSessionId: z.string(),
     usedTokens: z.number(),
     contextSize: z.number(),
+    inputTokens: z.number().optional(),
+    outputTokens: z.number().optional(),
     costAmount: z.number().optional(),
     costCurrency: z.string().optional(),
   })

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -60,6 +60,8 @@ export interface AcpSessionUsage {
   contextSize: number;
   costAmount?: number;
   costCurrency?: string;
+  inputTokens?: number;
+  outputTokens?: number;
 }
 
 // --- Domain-level union alias (consumed by message-protocol.ts) ---

--- a/assistant/src/memory/schema/acp.ts
+++ b/assistant/src/memory/schema/acp.ts
@@ -37,6 +37,10 @@ export const acpSessionHistory = sqliteTable(
     contextSize: integer("context_size"),
     costAmount: real("cost_amount"),
     costCurrency: text("cost_currency"),
+    // Cumulative input/output tokens across all turns. Null for rows written
+    // before migration 305.
+    inputTokens: integer("input_tokens"),
+    outputTokens: integer("output_tokens"),
   },
   (table) => [
     index("idx_acp_session_history_started_at").on(table.startedAt),

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -50,6 +50,14 @@ interface FakeSessionState {
   completedAt?: number;
   error?: string;
   stopReason?: string;
+  latestUsage?: {
+    usedTokens: number;
+    contextSize: number;
+    costAmount?: number;
+    costCurrency?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+  };
 }
 
 let fakeInMemorySessions: FakeSessionState[] = [];
@@ -159,6 +167,10 @@ interface ResponseShape {
     completedAt?: number | null;
     stopReason?: string | null;
     error?: string | null;
+    usedTokens?: number;
+    contextSize?: number;
+    inputTokens?: number;
+    outputTokens?: number;
     eventLog?: unknown[];
   }>;
 }
@@ -250,6 +262,59 @@ describe("GET /v1/acp/sessions — merged in-memory + history", () => {
         content: "hello",
       },
     ]);
+  });
+
+  test("returns input/output tokens for live and history sessions", async () => {
+    fakeInMemorySessions = [
+      {
+        id: "live-tokens",
+        agentId: "agent-live",
+        acpSessionId: "proto-live",
+        parentConversationId: "conv-live",
+        status: "running",
+        startedAt: 9000,
+        latestUsage: {
+          usedTokens: 1200,
+          contextSize: 200_000,
+          inputTokens: 5000,
+          outputTokens: 800,
+        },
+      },
+    ];
+    insertHistoryRow({
+      id: "hist-tokens",
+      agentId: "agent-hist",
+      acpSessionId: "proto-hist",
+      parentConversationId: "conv-hist",
+      startedAt: 1000,
+      status: "completed",
+      usedTokens: 4200,
+      contextSize: 200_000,
+      inputTokens: 3300,
+      outputTokens: 450,
+    });
+
+    const handler = getSessionsHandler();
+    const body = (await handler({})) as ResponseShape;
+    const live = body.sessions.find((s) => s.id === "live-tokens");
+    const hist = body.sessions.find((s) => s.id === "hist-tokens");
+    expect(live).toMatchObject({ inputTokens: 5000, outputTokens: 800 });
+    expect(hist).toMatchObject({ inputTokens: 3300, outputTokens: 450 });
+  });
+
+  test("omits input/output tokens for history rows without them", async () => {
+    insertHistoryRow({
+      id: "hist-no-tokens",
+      status: "completed",
+      startedAt: 1000,
+    });
+
+    const handler = getSessionsHandler();
+    const body = (await handler({})) as ResponseShape;
+    const s = body.sessions.find((row) => row.id === "hist-no-tokens");
+    expect(s).toBeDefined();
+    expect(s!.inputTokens).toBeUndefined();
+    expect(s!.outputTokens).toBeUndefined();
   });
 
   test("dedupes by id with in-memory winning on collision", async () => {

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -56,6 +56,8 @@ const sessionEntrySchema = z.object({
   contextSize: z.number().optional(),
   costAmount: z.number().optional(),
   costCurrency: z.string().optional(),
+  inputTokens: z.number().optional(),
+  outputTokens: z.number().optional(),
   eventLog: z.array(z.unknown()).optional(),
 });
 
@@ -701,6 +703,8 @@ function listMergedSessions(opts: {
       contextSize: s.latestUsage?.contextSize,
       costAmount: s.latestUsage?.costAmount,
       costCurrency: s.latestUsage?.costCurrency,
+      inputTokens: s.latestUsage?.inputTokens,
+      outputTokens: s.latestUsage?.outputTokens,
       eventLog: manager.getBufferedUpdates(s.id),
     });
   }
@@ -753,6 +757,8 @@ function listMergedSessions(opts: {
       contextSize: row.contextSize ?? undefined,
       costAmount: row.costAmount ?? undefined,
       costCurrency: row.costCurrency ?? undefined,
+      inputTokens: row.inputTokens ?? undefined,
+      outputTokens: row.outputTokens ?? undefined,
       eventLog,
     });
   }


### PR DESCRIPTION
## Summary
- Read response.usage at turn end; emit input/output tokens on acp_session_usage; persist to migration-305 columns; rehydrate; return via /acp/sessions.
- Additive/optional; older daemons/clients unaffected.

Part of plan: acp-chat-detail-view.md (PR 10 of 11)