### PR TITLE
fix(acp): accept tool-call locations in the strict acp_session_update wire schema

### DIFF
--- a/assistant/src/api/events/acp-session-update.test.ts
+++ b/assistant/src/api/events/acp-session-update.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import { AssistantEventSchema } from "../index.js";
+import { AcpSessionUpdateEventSchema } from "./acp-session-update.js";
+
+describe("AcpSessionUpdateEventSchema", () => {
+  test("accepts a tool_call event carrying locations and round-trips the field", () => {
+    const event = {
+      type: "acp_session_update" as const,
+      acpSessionId: "acp-1",
+      updateType: "tool_call" as const,
+      toolCallId: "tool-1",
+      toolTitle: "Edit file",
+      toolKind: "edit",
+      toolStatus: "in_progress",
+      locations: [{ path: "src/foo.ts", line: 42 }, { path: "src/bar.ts" }],
+    };
+
+    const result = AcpSessionUpdateEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.locations).toEqual([
+      { path: "src/foo.ts", line: 42 },
+      { path: "src/bar.ts" },
+    ]);
+  });
+
+  test("accepts a locations-bearing event through the AssistantEventSchema union", () => {
+    const event = {
+      type: "acp_session_update" as const,
+      acpSessionId: "acp-1",
+      updateType: "tool_call_update" as const,
+      toolCallId: "tool-1",
+      locations: [{ path: "src/baz.ts", line: 7 }],
+    };
+
+    const result = AssistantEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    expect(
+      result.success &&
+        result.data.type === "acp_session_update" &&
+        result.data.locations,
+    ).toEqual([{ path: "src/baz.ts", line: 7 }]);
+  });
+
+  test("still accepts a normal event without locations", () => {
+    const event = {
+      type: "acp_session_update" as const,
+      acpSessionId: "acp-1",
+      updateType: "agent_message_chunk" as const,
+      content: "hello",
+      messageId: "msg-1",
+    };
+
+    const result = AcpSessionUpdateEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.locations).toBeUndefined();
+  });
+
+  test("still rejects unrecognized keys (schema remains strict)", () => {
+    const event = {
+      type: "acp_session_update" as const,
+      acpSessionId: "acp-1",
+      updateType: "tool_call" as const,
+      bogusField: "nope",
+    };
+
+    const result = AcpSessionUpdateEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
+  });
+});

--- a/assistant/src/api/events/acp-session-update.ts
+++ b/assistant/src/api/events/acp-session-update.ts
@@ -35,6 +35,10 @@ export const AcpSessionUpdateEventSchema = z
     toolTitle: z.string().optional(),
     toolKind: z.string().optional(),
     toolStatus: z.string().optional(),
+    /** Files touched by this tool call (for the file-diff affordance). */
+    locations: z
+      .array(z.object({ path: z.string(), line: z.number().optional() }))
+      .optional(),
     /** Stable id for the message this chunk belongs to. */
     messageId: z.string().optional(),
     /** Monotonic ordering hint within the session. */


### PR DESCRIPTION
## Summary
- Add optional `locations` to the canonical `.strict()` `AcpSessionUpdateEventSchema` so locations-bearing tool events are no longer rejected.
- Completes the earlier daemon-side `locations` forwarding (the field existed only on the daemon-internal type).

Part of plan: acp-chat-detail-view.md (fix for PR 2)