### PR TITLE
Workflow card: spawned-agent count chip (avatars + "N agents")

### DIFF
--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tests for `WorkflowAgentsChip`.
+ *
+ * `SubagentAvatarChip` lazily loads a ~48 kB bundled-avatar payload, so it is
+ * mocked to a testid stub here to keep the test focused on the chip's own
+ * structure: one avatar per seed, the count text, and the count-only path.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+mock.module("@/components/avatar/subagent-avatar-chip", () => ({
+  SubagentAvatarChip: ({ subagentId }: { subagentId: string }) => (
+    <span data-testid="avatar-stub" data-subagent-id={subagentId} />
+  ),
+}));
+
+import { WorkflowAgentsChip } from "@/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip";
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("WorkflowAgentsChip", () => {
+  test("renders the pill, one avatar per seed, and the count text", () => {
+    const { getByTestId, getAllByTestId } = render(
+      <WorkflowAgentsChip countLabel="3 agents" seeds={["a", "b", "c"]} />,
+    );
+
+    expect(getByTestId("workflow-inline-card-agents-chip")).toBeTruthy();
+    expect(getAllByTestId("avatar-stub").length).toBe(3);
+    expect(getByTestId("workflow-inline-card-step-count").textContent).toBe(
+      "3 agents",
+    );
+  });
+
+  test("renders count-only with no avatar stack when seeds is empty", () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <WorkflowAgentsChip countLabel="1 agent" seeds={[]} />,
+    );
+
+    expect(getByTestId("workflow-inline-card-agents-chip")).toBeTruthy();
+    expect(queryAllByTestId("avatar-stub").length).toBe(0);
+    expect(getByTestId("workflow-inline-card-step-count").textContent).toBe(
+      "1 agent",
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-agents-chip.tsx
@@ -1,0 +1,60 @@
+/**
+ * Purely presentational agent-count chip for the workflow inline card.
+ *
+ * Renders a rounded surface-overlay pill with an overlapping stack of
+ * decorative subagent avatars followed by the formatted count. The count
+ * string and avatar seeds are supplied by the caller; the chip holds no
+ * workflow state of its own.
+ */
+
+import { Typography } from "@vellumai/design-library";
+
+import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+
+export interface WorkflowAgentsChipProps {
+  /** Already-formatted count, e.g. "3 agents". */
+  countLabel: string;
+  /** Decorative avatar seeds (`runId:seq`), one avatar per seed. */
+  seeds: string[];
+}
+
+export function WorkflowAgentsChip({
+  countLabel,
+  seeds,
+}: WorkflowAgentsChipProps) {
+  return (
+    <div
+      data-testid="workflow-inline-card-agents-chip"
+      className="inline-flex items-center gap-1 rounded-full bg-[var(--surface-overlay)] px-1.5 py-1"
+    >
+      {seeds.length > 0 && (
+        // Decorative identicons seeded by `runId:seq` (not real subagent
+        // identities), so the stack is aria-hidden and the count text carries
+        // the accessible meaning. The wrappers are divs because
+        // `SubagentAvatarChip` renders a div, which is invalid inside a span.
+        <div aria-hidden className="flex items-center">
+          {seeds.map((seed, index) => (
+            <SubagentAvatarChip
+              key={seed}
+              subagentId={seed}
+              size={14}
+              className={
+                index === 0
+                  ? undefined
+                  : "-ml-1 rounded-full ring-2 ring-[var(--surface-overlay)]"
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-secondary)]"
+        data-testid="workflow-inline-card-step-count"
+      >
+        {countLabel}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
@@ -7,9 +7,25 @@
  * header-click callback.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { act } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
+
+// `SubagentAvatarChip` (rendered inside the agents chip) lazily loads a heavy
+// bundled-avatar payload, so it is stubbed to keep avatar output deterministic.
+mock.module("@/components/avatar/subagent-avatar-chip", () => ({
+  SubagentAvatarChip: ({ subagentId }: { subagentId: string }) => (
+    <span data-testid="avatar-stub" data-subagent-id={subagentId} />
+  ),
+}));
 
 import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
@@ -22,6 +38,10 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 function startRun(runId: string, label = "Research workflow") {
@@ -52,6 +72,7 @@ describe("WorkflowInlineProgressCard — fixture run", () => {
     );
 
     expect(getByTestId("workflow-inline-progress-card")).toBeTruthy();
+    expect(getByTestId("workflow-inline-card-agents-chip")).toBeTruthy();
     expect(getByText("2 agents")).toBeTruthy();
   });
 
@@ -64,12 +85,17 @@ describe("WorkflowInlineProgressCard — fixture run", () => {
       <WorkflowInlineProgressCard runId="wf-order" onStopWorkflow={() => {}} />,
     );
 
+    const chip = getByTestId("workflow-inline-card-agents-chip");
     const stepCount = getByTestId("workflow-inline-card-step-count");
     const stop = getByTestId("workflow-inline-card-stop");
     // The stop button follows the step count in DOM order (step count first).
     expect(
       stepCount.compareDocumentPosition(stop) &
         Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // The agents chip precedes the stop button (stop stays rightmost).
+    expect(
+      chip.compareDocumentPosition(stop) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
@@ -143,7 +143,9 @@ export function WorkflowInlineProgressCard({
           bypassDwell={data.state !== "loading"}
         />
       </span>
-      <span className="flex shrink-0 items-center gap-2">
+      {/* div (not span) so the chip's div root nests validly; the count text
+          and Stop button stay inline via flex. Stop remains rightmost. */}
+      <div className="flex shrink-0 items-center gap-2">
         {showStepCount ? (
           <WorkflowAgentsChip countLabel={stepCount} seeds={agentSeeds} />
         ) : null}
@@ -157,7 +159,7 @@ export function WorkflowInlineProgressCard({
             onClick={handleStop}
           />
         ) : null}
-      </span>
+      </div>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
@@ -20,11 +20,16 @@
 import { AlertCircle, CheckCircle2, Square, Workflow } from "lucide-react";
 import { useCallback, type KeyboardEvent, type MouseEvent } from "react";
 
-import { Button, Typography } from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library";
 
 import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
-import { useWorkflowCardData } from "@/domains/chat/hooks/use-workflow-card-data";
+import {
+  useWorkflowAgentAvatarSeeds,
+  useWorkflowCardData,
+} from "@/domains/chat/hooks/use-workflow-card-data";
+
+import { WorkflowAgentsChip } from "./workflow-agents-chip";
 
 export interface WorkflowInlineProgressCardProps {
   runId: string;
@@ -40,6 +45,7 @@ export function WorkflowInlineProgressCard({
   onStopWorkflow,
 }: WorkflowInlineProgressCardProps) {
   const data = useWorkflowCardData(runId);
+  const agentSeeds = useWorkflowAgentAvatarSeeds(runId);
   // "loading" = the live window where stopping the run is meaningful
   // (see `deriveCardState`).
   const isRunning = data?.state === "loading";
@@ -139,13 +145,7 @@ export function WorkflowInlineProgressCard({
       </span>
       <span className="flex shrink-0 items-center gap-2">
         {showStepCount ? (
-          <Typography
-            variant="body-small-default"
-            className="text-[var(--content-tertiary)]"
-            data-testid="workflow-inline-card-step-count"
-          >
-            {stepCount}
-          </Typography>
+          <WorkflowAgentsChip countLabel={stepCount} seeds={agentSeeds} />
         ) : null}
         {onStopWorkflow && isRunning ? (
           <Button

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
@@ -10,6 +10,8 @@ import { cleanup, renderHook } from "@testing-library/react";
 
 import {
   computeWorkflowCardData,
+  selectWorkflowAgentAvatarSeeds,
+  useWorkflowAgentAvatarSeeds,
   useWorkflowCardData,
 } from "@/domains/chat/hooks/use-workflow-card-data";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
@@ -349,5 +351,77 @@ describe("useWorkflowCardData — hydration wiring", () => {
     expect(spy).not.toHaveBeenCalled();
 
     useWorkflowStore.setState({ hydrateRunIfNeeded: realHydrate });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectWorkflowAgentAvatarSeeds — stable seed derivation
+// ---------------------------------------------------------------------------
+
+describe("selectWorkflowAgentAvatarSeeds", () => {
+  test("returns [] when the run has no leaves and no spawned agents", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(makeEntry({ runId: "wf" }));
+    expect(seeds).toEqual([]);
+  });
+
+  test("seeds a single leaf", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({ runId: "wf", leaves: [{ seq: 0, status: "running" }] }),
+    );
+    expect(seeds).toEqual(["wf:0"]);
+  });
+
+  test("seeds two leaves in ascending seq order", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({
+        runId: "wf",
+        leaves: [
+          { seq: 1, status: "completed" },
+          { seq: 0, status: "running" },
+        ],
+      }),
+    );
+    expect(seeds).toEqual(["wf:0", "wf:1"]);
+  });
+
+  test("caps at three seeds when more than three leaves exist", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({
+        runId: "wf",
+        leaves: [
+          { seq: 0, status: "running" },
+          { seq: 1, status: "running" },
+          { seq: 2, status: "running" },
+          { seq: 3, status: "running" },
+          { seq: 4, status: "running" },
+        ],
+      }),
+    );
+    expect(seeds).toEqual(["wf:0", "wf:1", "wf:2"]);
+  });
+
+  test("synthesizes index seeds when leaves are empty but agentsSpawned > 0", () => {
+    const seeds = selectWorkflowAgentAvatarSeeds(
+      makeEntry({ runId: "wf", agentsSpawned: 5 }),
+    );
+    expect(seeds).toEqual(["wf:0", "wf:1", "wf:2"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useWorkflowAgentAvatarSeeds — store wiring
+// ---------------------------------------------------------------------------
+
+describe("useWorkflowAgentAvatarSeeds", () => {
+  afterEach(() => {
+    cleanup();
+    useWorkflowStore.getState().reset();
+  });
+
+  test("returns [] for an unknown runId", () => {
+    const { result } = renderHook(() =>
+      useWorkflowAgentAvatarSeeds("wf-unknown"),
+    );
+    expect(result.current).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
@@ -424,4 +424,17 @@ describe("useWorkflowAgentAvatarSeeds", () => {
     );
     expect(result.current).toEqual([]);
   });
+
+  test("returns a referentially stable array across renders when the entry is unchanged", () => {
+    useWorkflowStore.getState().startRun({ runId: "wf-stable", timestamp: NOW });
+    useWorkflowStore.getState().leafStarted({ runId: "wf-stable", seq: 0 });
+
+    const { result, rerender } = renderHook(() =>
+      useWorkflowAgentAvatarSeeds("wf-stable"),
+    );
+    const first = result.current;
+    rerender();
+    // Same store entry ref → useMemo returns the same array (no churn).
+    expect(result.current).toBe(first);
+  });
 });

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
@@ -197,6 +197,51 @@ export function computeWorkflowCardData(
 }
 
 /**
+ * Max avatars rendered in the workflow card's spawned-agent stack. Matches
+ * the Figma 3-avatar sample; the count text carries the total.
+ */
+export const MAX_VISIBLE_WORKFLOW_AGENT_AVATARS = 3;
+
+/** Stable empty seed array so the hook returns a constant ref for unknown runs. */
+const EMPTY_SEEDS: string[] = [];
+
+/**
+ * Derive stable avatar seeds for a run's spawned agents. The count mirrors
+ * the card's agent count (`computeWorkflowCardData`) so avatars and the count
+ * text stay consistent. Live runs seed from the sorted leaves' `seq`; a
+ * hydrated count-only run (no per-leaf events) synthesizes index seeds. Each
+ * seed is a stable `${runId}:${seq}` string.
+ */
+export function selectWorkflowAgentAvatarSeeds(entry: WorkflowEntry): string[] {
+  const count = entry.leaves.size || entry.agentsSpawned;
+  const visible = Math.min(count, MAX_VISIBLE_WORKFLOW_AGENT_AVATARS);
+
+  const seqs =
+    entry.leaves.size > 0
+      ? sortedLeaves(entry)
+          .slice(0, visible)
+          .map((l) => l.seq)
+      : Array.from({ length: visible }, (_, i) => i);
+
+  return seqs.map((seq) => `${entry.runId}:${seq}`);
+}
+
+/**
+ * React hook: subscribe to the workflow store entry for `runId` and derive
+ * its spawned-agent avatar seeds. Selecting the stable `entry` ref then
+ * deriving in `useMemo` avoids returning a fresh array every render (which
+ * would loop a consumer's effects). Returns a constant empty array when no
+ * entry exists yet.
+ */
+export function useWorkflowAgentAvatarSeeds(runId: string): string[] {
+  const entry = useWorkflowStore((state) => state.byId[runId]);
+  return useMemo(
+    () => (entry ? selectWorkflowAgentAvatarSeeds(entry) : EMPTY_SEEDS),
+    [entry],
+  );
+}
+
+/**
  * React hook: subscribe to the workflow store entry for `runId` and
  * project it into `ToolCallCardData`. Returns `null` when no entry exists
  * yet (spawn race, or a history / post-reload card before hydration), so

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
@@ -109,6 +109,15 @@ function sortedLeaves(entry: WorkflowEntry): WorkflowLeaf[] {
 }
 
 /**
+ * Spawned-agent count: prefer the live leaf count, fall back to the run's
+ * reported `agentsSpawned`. Shared by the count text and the avatar seeds so
+ * the two stay consistent.
+ */
+function workflowAgentCount(entry: WorkflowEntry): number {
+  return entry.leaves.size || entry.agentsSpawned;
+}
+
+/**
  * Derive the header `(title, info)` tuple.
  *
  * The bold title is the workflow's *name* (`label`) — stable and
@@ -180,9 +189,8 @@ export function computeWorkflowCardData(
     leaves,
   );
 
-  // Step count reflects spawned agents, not generic "steps". Prefer the
-  // live leaf count, falling back to the run's reported `agentsSpawned`.
-  const count = entry.leaves.size || entry.agentsSpawned;
+  // Step count reflects spawned agents, not generic "steps".
+  const count = workflowAgentCount(entry);
   const stepCount = `${count} agent${count === 1 ? "" : "s"}`;
 
   return {
@@ -200,21 +208,24 @@ export function computeWorkflowCardData(
  * Max avatars rendered in the workflow card's spawned-agent stack. Matches
  * the Figma 3-avatar sample; the count text carries the total.
  */
-export const MAX_VISIBLE_WORKFLOW_AGENT_AVATARS = 3;
+const MAX_VISIBLE_WORKFLOW_AGENT_AVATARS = 3;
 
 /** Stable empty seed array so the hook returns a constant ref for unknown runs. */
 const EMPTY_SEEDS: string[] = [];
 
 /**
- * Derive stable avatar seeds for a run's spawned agents. The count mirrors
- * the card's agent count (`computeWorkflowCardData`) so avatars and the count
- * text stay consistent. Live runs seed from the sorted leaves' `seq`; a
+ * Derive stable avatar seeds for a run's spawned agents. The count comes from
+ * the shared `workflowAgentCount` helper (same as the card's count text) so
+ * avatars and the count stay consistent. Live runs seed from the sorted
+ * leaves' `seq`; a
  * hydrated count-only run (no per-leaf events) synthesizes index seeds. Each
  * seed is a stable `${runId}:${seq}` string.
  */
 export function selectWorkflowAgentAvatarSeeds(entry: WorkflowEntry): string[] {
-  const count = entry.leaves.size || entry.agentsSpawned;
-  const visible = Math.min(count, MAX_VISIBLE_WORKFLOW_AGENT_AVATARS);
+  const visible = Math.min(
+    workflowAgentCount(entry),
+    MAX_VISIBLE_WORKFLOW_AGENT_AVATARS,
+  );
 
   const seqs =
     entry.leaves.size > 0


### PR DESCRIPTION
## Summary
Turns the workflow inline card's bare "N agents" text into the Figma chip (node 6063-148802): an overlapping decorative avatar stack of spawned leaves + the count, inside a `rounded-full` `--surface-overlay` pill. The Stop button stays the rightmost element. Data comes from the existing workflow store (`entry.leaves` + `agentsSpawned`) — no store/daemon/IPC changes.

## Self-review result
PASS after 1 remediation round — 4 gaps fixed (shared count helper, un-exported internal const, div-in-span at the card boundary, hook stability test). Declined 1 (shared AvatarStack extraction — rule-of-3 not met; would add regression risk to the subagents pill for a cosmetic change).

## PRs merged into feature branch
- #36195: derive stable avatar seeds for workflow spawned agents
- #36196: add WorkflowAgentsChip (avatar stack + count pill) — Codex P2 (div-in-span) fixed before merge
- #36197: show spawned-agent avatar chip on the workflow card

### Self-review remediation
- a10b6a15a7: shared `workflowAgentCount` helper, module-private cap const, card actions `<span>`→`<div>`, hook referential-stability test

Part of plan: workflow-card-agent-count-chip.md