### PR TITLE
feat(web): acp usage meter (cumulative input/output/total tokens)

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -475,6 +475,21 @@ describe("updateUsage", () => {
     expect(entry.costCurrency).toBe("USD");
   });
 
+  it("sets cumulative input/output tokens", () => {
+    spawn();
+    getState().updateUsage({
+      acpSessionId: "acp-1",
+      usedTokens: 1500,
+      contextSize: 200000,
+      inputTokens: 12000,
+      outputTokens: 3400,
+    });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.inputTokens).toBe(12000);
+    expect(entry.outputTokens).toBe(3400);
+  });
+
   it("ignores an unknown session", () => {
     const before = { ...getState().byId };
     getState().updateUsage({
@@ -671,6 +686,23 @@ describe("seedFromHistory", () => {
     expect(entry.contextSize).toBe(200000);
     expect(entry.costAmount).toBe(0.005);
     expect(entry.costCurrency).toBe("USD");
+  });
+
+  it("folds persisted input/output tokens onto a live entry", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().seedFromHistory([
+      historyEntry({
+        acpSessionId: "acp-1",
+        status: "completed",
+        completedAt: NOW + 5000,
+        inputTokens: 12000,
+        outputTokens: 3400,
+      }),
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.inputTokens).toBe(12000);
+    expect(entry.outputTokens).toBe(3400);
   });
 
   it("backfills a missing task from history", () => {

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -63,6 +63,10 @@ export interface AcpRunEntry {
   usedTokens: number;
   /** Size of the agent's context window. */
   contextSize: number;
+  /** Cumulative input tokens across all turns, when available. */
+  inputTokens?: number;
+  /** Cumulative output tokens across all turns, when available. */
+  outputTokens?: number;
   /** Cumulative cost reported by the agent, when available. */
   costAmount?: number;
   costCurrency?: string;
@@ -138,6 +142,8 @@ export interface AcpRunActions {
     acpSessionId: string;
     usedTokens: number;
     contextSize: number;
+    inputTokens?: number;
+    outputTokens?: number;
     costAmount?: number;
     costCurrency?: string;
   }) => void;
@@ -242,6 +248,8 @@ function mergeHistoryEntry(
     completedAt: incoming.completedAt ?? existing.completedAt,
     usedTokens: incoming.usedTokens || existing.usedTokens,
     contextSize: incoming.contextSize || existing.contextSize,
+    inputTokens: incoming.inputTokens ?? existing.inputTokens,
+    outputTokens: incoming.outputTokens ?? existing.outputTokens,
     costAmount: incoming.costAmount ?? existing.costAmount,
     costCurrency: incoming.costCurrency ?? existing.costCurrency,
     task: existing.task ?? incoming.task,
@@ -431,6 +439,8 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
           ...existing,
           usedTokens: params.usedTokens,
           contextSize: params.contextSize,
+          inputTokens: params.inputTokens,
+          outputTokens: params.outputTokens,
           costAmount: params.costAmount,
           costCurrency: params.costCurrency,
         },

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-usage-meter.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-usage-meter.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { type AcpRunEntry } from "@/domains/chat/acp-run-store";
+
+import { AcpUsageMeter } from "./acp-usage-meter";
+
+afterEach(cleanup);
+
+function entry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
+  return {
+    acpSessionId: "acp-1",
+    agent: "claude",
+    parentConversationId: "conv-1",
+    status: "completed",
+    startedAt: 0,
+    usedTokens: 0,
+    contextSize: 0,
+    events: [],
+    ...overrides,
+  };
+}
+
+function statValue(label: string): string | undefined {
+  return document
+    .querySelector(`[data-usage-stat="${label}"]`)
+    ?.textContent?.replace(/^[A-Za-z]+/, "");
+}
+
+describe("AcpUsageMeter", () => {
+  test("renders input, output, and total with thousands separators", () => {
+    render(<AcpUsageMeter entry={entry({ inputTokens: 12000, outputTokens: 3400 })} />);
+
+    expect(screen.getByTestId("acp-usage-meter")).toBeDefined();
+    expect(statValue("input")).toBe("12,000");
+    expect(statValue("output")).toBe("3,400");
+    // Total = input + output.
+    expect(statValue("total")).toBe("15,400");
+  });
+
+  test("treats a missing side as zero when the other is present", () => {
+    render(<AcpUsageMeter entry={entry({ inputTokens: 5000 })} />);
+
+    expect(statValue("input")).toBe("5,000");
+    expect(statValue("output")).toBe("0");
+    expect(statValue("total")).toBe("5,000");
+  });
+
+  test("renders nothing when both input and output are absent", () => {
+    const { container } = render(<AcpUsageMeter entry={entry()} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-usage-meter.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-usage-meter.tsx
@@ -1,0 +1,51 @@
+import { Typography } from "@vellumai/design-library";
+
+import { type AcpRunEntry } from "@/domains/chat/acp-run-store";
+
+const TOKEN_FORMAT = new Intl.NumberFormat("en-US");
+
+interface MeterStatProps {
+  label: string;
+  value: number;
+}
+
+function MeterStat({ label, value }: MeterStatProps) {
+  return (
+    <div className="flex items-baseline gap-1" data-usage-stat={label.toLowerCase()}>
+      <Typography
+        variant="label-small-default"
+        className="text-[var(--content-tertiary)]"
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-secondary)] tabular-nums"
+      >
+        {TOKEN_FORMAT.format(value)}
+      </Typography>
+    </div>
+  );
+}
+
+/**
+ * Presentational meter for an ACP run's cumulative token usage. Renders the
+ * Input, Output, and Total token counts (thousands-separated) for the chat
+ * view header. Renders nothing when neither input nor output is known (older
+ * daemons / pre-migration rows). No cost, no context-window gauge.
+ */
+export function AcpUsageMeter({ entry }: { entry: AcpRunEntry }) {
+  const { inputTokens, outputTokens } = entry;
+  if (inputTokens === undefined && outputTokens === undefined) return null;
+
+  const input = inputTokens ?? 0;
+  const output = outputTokens ?? 0;
+
+  return (
+    <div className="flex items-center gap-3" data-testid="acp-usage-meter">
+      <MeterStat label="Input" value={input} />
+      <MeterStat label="Output" value={output} />
+      <MeterStat label="Total" value={input + output} />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
@@ -148,6 +148,27 @@ describe("rehydration — terminal session", () => {
     expect(getState().byToolUseId.get("tool-1")).toBe("acp-1");
   });
 
+  test("carries cumulative input/output tokens from the session row", async () => {
+    await seed([
+      {
+        id: "acp-1",
+        acpSessionId: "proto-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "completed",
+        startedAt: 1000,
+        completedAt: 5000,
+        inputTokens: 12000,
+        outputTokens: 3400,
+        eventLog: [],
+      },
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.inputTokens).toBe(12000);
+    expect(entry.outputTokens).toBe(3400);
+  });
+
   test("a pre-migration row without usage hides the meter and degrades gracefully", async () => {
     await seed([
       {
@@ -167,6 +188,8 @@ describe("rehydration — terminal session", () => {
     expect(entry.status).toBe("completed");
     expect(entry.usedTokens).toBe(0);
     expect(entry.contextSize).toBe(0);
+    expect(entry.inputTokens).toBeUndefined();
+    expect(entry.outputTokens).toBeUndefined();
     expect(entry.costAmount).toBeUndefined();
     expect(entry.costCurrency).toBeUndefined();
   });

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -48,6 +48,8 @@ interface AcpSessionRow {
   completedAt?: number | null;
   usedTokens?: number;
   contextSize?: number;
+  inputTokens?: number;
+  outputTokens?: number;
   costAmount?: number;
   costCurrency?: string;
   eventLog?: AcpSessionEventLogItem[];
@@ -113,6 +115,8 @@ function toRunEntry(row: AcpSessionRow): AcpRunEntry {
     parentToolUseId: row.parentToolUseId,
     usedTokens: row.usedTokens ?? 0,
     contextSize: row.contextSize ?? 0,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
     costAmount: row.costAmount,
     costCurrency: row.costCurrency,
     events,

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -122,6 +122,21 @@ describe("handleAcpSessionUsage", () => {
     expect(entry?.costCurrency).toBe("USD");
   });
 
+  it("maps cumulative input/output tokens into the store", () => {
+    spawn();
+    handleAcpSessionUsage({
+      type: "acp_session_usage",
+      acpSessionId: "acp-1",
+      usedTokens: 1500,
+      contextSize: 200000,
+      inputTokens: 12000,
+      outputTokens: 3400,
+    });
+    const entry = getState().byId["acp-1"];
+    expect(entry?.inputTokens).toBe(12000);
+    expect(entry?.outputTokens).toBe(3400);
+  });
+
   it("ignores usage for an unknown session", () => {
     handleAcpSessionUsage({
       type: "acp_session_usage",

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -51,6 +51,8 @@ export function handleAcpSessionUsage(event: AcpSessionUsageEvent): void {
     acpSessionId: event.acpSessionId,
     usedTokens: event.usedTokens,
     contextSize: event.contextSize,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
     costAmount: event.costAmount,
     costCurrency: event.costCurrency,
   });


### PR DESCRIPTION
## Summary
- Plumb cumulative input/output tokens through the store, usage handler, and rehydration.
- Add AcpUsageMeter (input / output / total) for the chat view header. No cost, no context gauge.

Part of plan: acp-chat-detail-view.md (PR 11 of 11)