### PR TITLE
feat(web): add acp chat block components

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-agent-message.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-agent-message.test.tsx
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { AcpChatAgentMessage } from "./acp-chat-agent-message";
+
+afterEach(cleanup);
+
+describe("AcpChatAgentMessage", () => {
+  test("renders the message content", () => {
+    render(<AcpChatAgentMessage content="Hello world" isComplete />);
+    expect(screen.getByText("Hello world")).toBeDefined();
+  });
+
+  test("shows a streaming indicator while incomplete", () => {
+    render(<AcpChatAgentMessage content="partial" isComplete={false} />);
+    expect(screen.getByTestId("acp-chat-agent-streaming")).toBeDefined();
+  });
+
+  test("hides the streaming indicator once complete", () => {
+    render(<AcpChatAgentMessage content="done" isComplete />);
+    expect(screen.queryByTestId("acp-chat-agent-streaming")).toBeNull();
+  });
+
+  test("renders left-aligned, full-width, no bubble", () => {
+    render(<AcpChatAgentMessage content="x" isComplete />);
+    const root = screen.getByTestId("acp-chat-agent-message");
+    expect(root.className).toContain("items-start");
+    expect(root.className).toContain("w-full");
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-agent-message.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-agent-message.tsx
@@ -1,0 +1,35 @@
+/**
+ * A streamed agent response in the ACP chat transcript. Left-aligned and
+ * full-width with no bubble — mirrors the main chat's assistant styling. A
+ * trailing `ThreeDotIndicator` marks the block as still streaming.
+ */
+
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+
+export interface AcpChatAgentMessageProps {
+  /** Markdown body of the agent message. */
+  content: string;
+  /** When false the block is still streaming; shows a trailing indicator. */
+  isComplete: boolean;
+}
+
+export function AcpChatAgentMessage({
+  content,
+  isComplete,
+}: AcpChatAgentMessageProps) {
+  return (
+    <div
+      data-testid="acp-chat-agent-message"
+      className="flex w-full flex-col items-start text-chat text-[var(--content-default)]"
+    >
+      <ChatMarkdownMessage content={content} />
+      {!isComplete && (
+        <ThreeDotIndicator
+          className="mt-1"
+          data-testid="acp-chat-agent-streaming"
+        />
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-plan-block.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-plan-block.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { AcpChatPlanBlock } from "./acp-chat-plan-block";
+
+afterEach(cleanup);
+
+describe("AcpChatPlanBlock", () => {
+  test("renders a row per entry", () => {
+    render(
+      <AcpChatPlanBlock
+        entries={[
+          { label: "Read files", checked: true },
+          { label: "Edit files", checked: false },
+        ]}
+      />,
+    );
+    const rows = screen.getAllByTestId("acp-chat-plan-entry");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("Read files")).toBeDefined();
+    expect(screen.getByText("Edit files")).toBeDefined();
+  });
+
+  test("marks checked vs unchecked entries", () => {
+    render(
+      <AcpChatPlanBlock
+        entries={[
+          { label: "done", checked: true },
+          { label: "todo", checked: false },
+        ]}
+      />,
+    );
+    const rows = screen.getAllByTestId("acp-chat-plan-entry");
+    expect(rows[0]?.getAttribute("data-checked")).toBe("true");
+    expect(rows[1]?.getAttribute("data-checked")).toBe("false");
+  });
+
+  test("renders nothing for an empty plan", () => {
+    render(<AcpChatPlanBlock entries={[]} />);
+    expect(screen.queryByTestId("acp-chat-plan-block")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-plan-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-plan-block.tsx
@@ -1,0 +1,63 @@
+/**
+ * A plan checklist in the ACP chat transcript. Renders one row per entry with a
+ * checked/unchecked glyph; completed rows read as muted with a strikethrough.
+ */
+
+import { Circle, CheckCircle2, ListChecks } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+export interface AcpChatPlanBlockProps {
+  /** Plan entries projected from the run's `plan` event. */
+  entries: { label: string; checked: boolean }[];
+}
+
+export function AcpChatPlanBlock({ entries }: AcpChatPlanBlockProps) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div
+      data-testid="acp-chat-plan-block"
+      className="w-full rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3"
+    >
+      <div className="mb-2 flex items-center gap-1.5 text-[var(--content-tertiary)]">
+        <ListChecks aria-hidden className="h-3.5 w-3.5 shrink-0" />
+        <Typography variant="body-small-emphasised" className="text-inherit">
+          Plan
+        </Typography>
+      </div>
+
+      <ul className="flex flex-col gap-1.5">
+        {entries.map((entry, idx) => (
+          <li
+            key={idx}
+            data-testid="acp-chat-plan-entry"
+            data-checked={entry.checked}
+            className="flex items-start gap-2"
+          >
+            {entry.checked ? (
+              <CheckCircle2
+                aria-hidden
+                className="mt-0.5 h-4 w-4 shrink-0 text-[var(--system-positive-strong)]"
+              />
+            ) : (
+              <Circle
+                aria-hidden
+                className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-disabled)]"
+              />
+            )}
+            <span
+              className={
+                entry.checked
+                  ? "text-body-small-default text-[var(--content-tertiary)] line-through"
+                  : "text-body-small-default text-[var(--content-default)]"
+              }
+            >
+              {entry.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { AcpChatTerminalBlock } from "./acp-chat-terminal-block";
+
+afterEach(cleanup);
+
+describe("AcpChatTerminalBlock", () => {
+  test("renders nothing for active statuses", () => {
+    const { container } = render(
+      <AcpChatTerminalBlock status="running" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("completed + end_turn → Completed", () => {
+    render(<AcpChatTerminalBlock status="completed" stopReason="end_turn" />);
+    expect(screen.getByText("Completed")).toBeDefined();
+    expect(
+      screen.getByTestId("acp-chat-terminal-block").getAttribute("data-terminal-kind"),
+    ).toBe("completed");
+  });
+
+  test("completed with no stopReason → Completed", () => {
+    render(<AcpChatTerminalBlock status="completed" />);
+    expect(screen.getByText("Completed")).toBeDefined();
+  });
+
+  test("completed + max_tokens → Stopped: limit reached", () => {
+    render(<AcpChatTerminalBlock status="completed" stopReason="max_tokens" />);
+    expect(screen.getByText("Stopped: limit reached")).toBeDefined();
+  });
+
+  test("completed + max_turn_requests → Stopped: limit reached", () => {
+    render(
+      <AcpChatTerminalBlock status="completed" stopReason="max_turn_requests" />,
+    );
+    expect(screen.getByText("Stopped: limit reached")).toBeDefined();
+  });
+
+  test("completed + refusal → Refused", () => {
+    render(<AcpChatTerminalBlock status="completed" stopReason="refusal" />);
+    expect(screen.getByText("Refused")).toBeDefined();
+  });
+
+  test("completed + cancelled → Cancelled", () => {
+    render(<AcpChatTerminalBlock status="completed" stopReason="cancelled" />);
+    expect(screen.getByText("Cancelled")).toBeDefined();
+  });
+
+  test("failed → error styling with the error message", () => {
+    render(
+      <AcpChatTerminalBlock status="failed" error="boom: connection lost" />,
+    );
+    const root = screen.getByTestId("acp-chat-terminal-block");
+    expect(root.getAttribute("data-terminal-kind")).toBe("failed");
+    expect(root.className).toContain("var(--system-negative-strong)");
+    expect(screen.getByText("boom: connection lost")).toBeDefined();
+  });
+
+  test("failed with no error → fallback copy", () => {
+    render(<AcpChatTerminalBlock status="failed" />);
+    expect(screen.getByText("Run failed")).toBeDefined();
+  });
+
+  test("cancelled status → Cancelled", () => {
+    render(<AcpChatTerminalBlock status="cancelled" />);
+    const root = screen.getByTestId("acp-chat-terminal-block");
+    expect(root.getAttribute("data-terminal-kind")).toBe("cancelled");
+    expect(screen.getByText("Cancelled")).toBeDefined();
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
@@ -1,0 +1,88 @@
+/**
+ * The final system block in the ACP chat transcript. Summarizes how the run
+ * ended: a completed run differentiates its `stopReason`; a failed run renders
+ * with error styling and surfaces the `error` message.
+ *
+ * Reuses the shared `AcpRunStatus` type from `acp-run-status.ts`. Only terminal
+ * statuses produce a block — active statuses render nothing (the trailing
+ * agent/thinking block already shows the live indicator).
+ */
+
+import { AlertTriangle, CheckCircle2, MinusCircle } from "lucide-react";
+
+import { isActiveAcpStatus, type AcpRunStatus } from "@/utils/acp-run-status";
+
+export interface AcpChatTerminalBlockProps {
+  /** Terminal status of the run. Active statuses render nothing. */
+  status: AcpRunStatus;
+  /** Raw ACP stop reason; differentiates completed-run copy. */
+  stopReason?: string;
+  /** Error message shown when the run failed. */
+  error?: string;
+}
+
+/** Completed-run copy keyed off the ACP stop reason. */
+function completedLabel(stopReason: string | undefined): string {
+  switch (stopReason) {
+    case "max_tokens":
+    case "max_turn_requests":
+      return "Stopped: limit reached";
+    case "refusal":
+      return "Refused";
+    case "cancelled":
+      return "Cancelled";
+    case "end_turn":
+    default:
+      return "Completed";
+  }
+}
+
+export function AcpChatTerminalBlock({
+  status,
+  stopReason,
+  error,
+}: AcpChatTerminalBlockProps) {
+  if (isActiveAcpStatus(status)) return null;
+
+  if (status === "failed") {
+    return (
+      <div
+        data-testid="acp-chat-terminal-block"
+        data-terminal-kind="failed"
+        className="flex items-start gap-2 rounded-lg bg-[var(--system-negative-weak)] px-3 py-2 text-body-small-default text-[var(--system-negative-strong)]"
+      >
+        <AlertTriangle aria-hidden className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>{error ?? "Run failed"}</span>
+      </div>
+    );
+  }
+
+  // `cancelled` status (distinct from a completed-but-cancelled stopReason).
+  if (status === "cancelled") {
+    return (
+      <div
+        data-testid="acp-chat-terminal-block"
+        data-terminal-kind="cancelled"
+        className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)]"
+      >
+        <MinusCircle aria-hidden className="h-4 w-4 shrink-0" />
+        <span>Cancelled</span>
+      </div>
+    );
+  }
+
+  const label = completedLabel(stopReason);
+  return (
+    <div
+      data-testid="acp-chat-terminal-block"
+      data-terminal-kind="completed"
+      className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)]"
+    >
+      <CheckCircle2
+        aria-hidden
+        className="h-4 w-4 shrink-0 text-[var(--system-positive-strong)]"
+      />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.test.tsx
@@ -20,6 +20,32 @@ describe("AcpChatThinkingBlock", () => {
     expect(screen.getByText("Thought process")).toBeDefined();
   });
 
+  test("auto-collapses when streaming completes while mounted", () => {
+    const { rerender } = render(
+      <AcpChatThinkingBlock content="reasoning" isComplete={false} />,
+    );
+    expect(screen.getByTestId("acp-chat-thinking-body")).toBeDefined();
+
+    rerender(<AcpChatThinkingBlock content="reasoning" isComplete />);
+    expect(screen.queryByTestId("acp-chat-thinking-body")).toBeNull();
+    expect(screen.getByText("Thought process")).toBeDefined();
+  });
+
+  test("persists a manual toggle across an isComplete change", () => {
+    const { rerender } = render(
+      <AcpChatThinkingBlock content="reasoning" isComplete={false} />,
+    );
+    const toggle = screen.getByTestId("acp-chat-thinking-toggle");
+
+    // User collapses the block mid-stream.
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId("acp-chat-thinking-body")).toBeNull();
+
+    // Streaming completes — the user's collapsed choice must stick.
+    rerender(<AcpChatThinkingBlock content="reasoning" isComplete />);
+    expect(screen.queryByTestId("acp-chat-thinking-body")).toBeNull();
+  });
+
   test("toggles the body open and closed", () => {
     render(<AcpChatThinkingBlock content="deep thoughts" isComplete />);
     const toggle = screen.getByTestId("acp-chat-thinking-toggle");

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { AcpChatThinkingBlock } from "./acp-chat-thinking-block";
+
+afterEach(cleanup);
+
+describe("AcpChatThinkingBlock", () => {
+  test("auto-expands and shows a streaming indicator while incomplete", () => {
+    render(<AcpChatThinkingBlock content="reasoning" isComplete={false} />);
+    expect(screen.getByTestId("acp-chat-thinking-body")).toBeDefined();
+    expect(screen.getByTestId("acp-chat-thinking-streaming")).toBeDefined();
+    expect(screen.getByText("Thinking…")).toBeDefined();
+  });
+
+  test("collapses by default once complete", () => {
+    render(<AcpChatThinkingBlock content="reasoning" isComplete />);
+    expect(screen.queryByTestId("acp-chat-thinking-body")).toBeNull();
+    expect(screen.queryByTestId("acp-chat-thinking-streaming")).toBeNull();
+    expect(screen.getByText("Thought process")).toBeDefined();
+  });
+
+  test("toggles the body open and closed", () => {
+    render(<AcpChatThinkingBlock content="deep thoughts" isComplete />);
+    const toggle = screen.getByTestId("acp-chat-thinking-toggle");
+
+    expect(screen.queryByTestId("acp-chat-thinking-body")).toBeNull();
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("acp-chat-thinking-body")).toBeDefined();
+    expect(screen.getByText("deep thoughts")).toBeDefined();
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId("acp-chat-thinking-body")).toBeNull();
+  });
+
+  test("reflects expanded state via aria-expanded", () => {
+    render(<AcpChatThinkingBlock content="x" isComplete />);
+    const toggle = screen.getByTestId("acp-chat-thinking-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.tsx
@@ -1,0 +1,66 @@
+/**
+ * A self-contained collapsible "thinking" block for the ACP chat transcript.
+ *
+ * Deliberately does NOT reuse `SingleActivity`, which couples to the global
+ * viewer-store drawer. Collapse state is local: auto-expanded while streaming,
+ * default collapsed once the block completes. The header carries a muted
+ * `Brain` glyph and a streaming indicator while live.
+ */
+
+import { Brain, ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+
+export interface AcpChatThinkingBlockProps {
+  /** Markdown body of the reasoning trace. */
+  content: string;
+  /** When false the block is still streaming; auto-expands and shows an indicator. */
+  isComplete: boolean;
+}
+
+export function AcpChatThinkingBlock({
+  content,
+  isComplete,
+}: AcpChatThinkingBlockProps) {
+  // Auto-expanded while streaming; collapsed once complete. Local only — never
+  // touches the global viewer store.
+  const [expanded, setExpanded] = useState(!isComplete);
+
+  return (
+    <div data-testid="acp-chat-thinking-block" className="w-full">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+        data-testid="acp-chat-thinking-toggle"
+        className="flex w-full items-center gap-1.5 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
+      >
+        {expanded ? (
+          <ChevronDown aria-hidden className="h-3.5 w-3.5 shrink-0" />
+        ) : (
+          <ChevronRight aria-hidden className="h-3.5 w-3.5 shrink-0" />
+        )}
+        <Brain aria-hidden className="h-3.5 w-3.5 shrink-0" />
+        <span>{isComplete ? "Thought process" : "Thinking…"}</span>
+        {!isComplete && (
+          <ThreeDotIndicator
+            className="ml-1"
+            dotSize={5}
+            data-testid="acp-chat-thinking-streaming"
+          />
+        )}
+      </button>
+
+      {expanded && (
+        <div
+          data-testid="acp-chat-thinking-body"
+          className="mt-1.5 border-l-2 border-[var(--border-base)] pl-3 text-body-small-default text-[var(--content-tertiary)]"
+        >
+          <ChatMarkdownMessage content={content} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block.tsx
@@ -24,16 +24,18 @@ export function AcpChatThinkingBlock({
   content,
   isComplete,
 }: AcpChatThinkingBlockProps) {
-  // Auto-expanded while streaming; collapsed once complete. Local only — never
-  // touches the global viewer store.
-  const [expanded, setExpanded] = useState(!isComplete);
+  // Auto-expanded while streaming; collapsed once complete. A user toggle sets
+  // an override that sticks regardless of later `isComplete` changes. Local
+  // only — never touches the global viewer store.
+  const [override, setOverride] = useState<boolean | null>(null);
+  const expanded = override ?? !isComplete;
 
   return (
     <div data-testid="acp-chat-thinking-block" className="w-full">
       <button
         type="button"
         aria-expanded={expanded}
-        onClick={() => setExpanded((prev) => !prev)}
+        onClick={() => setOverride(!expanded)}
         data-testid="acp-chat-thinking-toggle"
         className="flex w-full items-center gap-1.5 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
       >

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { AcpChatBlock } from "@/domains/chat/acp-run-message-projection";
+
+import { AcpChatToolCard } from "./acp-chat-tool-card";
+
+afterEach(cleanup);
+
+type ToolBlock = Extract<AcpChatBlock, { kind: "tool" }>;
+
+function toolBlock(overrides: Partial<ToolBlock> = {}): ToolBlock {
+  return {
+    kind: "tool",
+    toolCallId: "call-1",
+    title: "Read file",
+    status: "completed",
+    ...overrides,
+  };
+}
+
+describe("AcpChatToolCard", () => {
+  test("renders the tool title", () => {
+    render(<AcpChatToolCard block={toolBlock()} onOpenDiff={() => {}} />);
+    expect(screen.getByText("Read file")).toBeDefined();
+  });
+
+  test("renders the status pill per status", () => {
+    const { rerender } = render(
+      <AcpChatToolCard block={toolBlock({ status: "running" })} onOpenDiff={() => {}} />,
+    );
+    expect(screen.getByText("Running")).toBeDefined();
+    expect(screen.getByTestId("acp-chat-tool-running")).toBeDefined();
+
+    rerender(
+      <AcpChatToolCard block={toolBlock({ status: "completed" })} onOpenDiff={() => {}} />,
+    );
+    expect(screen.getByText("Completed")).toBeDefined();
+
+    rerender(
+      <AcpChatToolCard block={toolBlock({ status: "error" })} onOpenDiff={() => {}} />,
+    );
+    expect(screen.getByText("Failed")).toBeDefined();
+  });
+
+  test("hides the running indicator when not running", () => {
+    render(
+      <AcpChatToolCard block={toolBlock({ status: "completed" })} onOpenDiff={() => {}} />,
+    );
+    expect(screen.queryByTestId("acp-chat-tool-running")).toBeNull();
+  });
+
+  test("renders inline content output in a monospace block", () => {
+    const content = JSON.stringify([
+      { type: "content", content: { type: "text", text: "file contents here" } },
+    ]);
+    render(
+      <AcpChatToolCard block={toolBlock({ content })} onOpenDiff={() => {}} />,
+    );
+    const output = screen.getByTestId("acp-chat-tool-output");
+    expect(output.textContent).toContain("file contents here");
+    expect(output.className).toContain("font-mono");
+  });
+
+  test("renders a file chip per diff and fires onOpenDiff with the file change", () => {
+    const content = JSON.stringify([
+      { type: "diff", path: "src/a.ts", oldText: "old", newText: "new" },
+    ]);
+    const onOpenDiff = mock((_: { path: string }) => {});
+    render(
+      <AcpChatToolCard block={toolBlock({ content })} onOpenDiff={onOpenDiff} />,
+    );
+
+    const chip = screen.getByTestId("acp-chat-tool-file-chip");
+    expect(chip.textContent).toContain("src/a.ts");
+    fireEvent.click(chip);
+    expect(onOpenDiff).toHaveBeenCalledTimes(1);
+    expect(onOpenDiff).toHaveBeenCalledWith({
+      path: "src/a.ts",
+      oldText: "old",
+      newText: "new",
+    });
+  });
+
+  test("unions path-only locations into chips", () => {
+    render(
+      <AcpChatToolCard
+        block={toolBlock({ locations: [{ path: "src/touched.ts" }] })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    expect(screen.getByText("src/touched.ts")).toBeDefined();
+  });
+
+  test("renders no chips when there are no file changes", () => {
+    render(<AcpChatToolCard block={toolBlock()} onOpenDiff={() => {}} />);
+    expect(screen.queryByTestId("acp-chat-tool-file-chip")).toBeNull();
+  });
+
+  test("collapses long output behind a toggle", () => {
+    const longText = "x".repeat(800);
+    const content = JSON.stringify([
+      { type: "content", content: { type: "text", text: longText } },
+    ]);
+    render(
+      <AcpChatToolCard block={toolBlock({ content })} onOpenDiff={() => {}} />,
+    );
+
+    expect(screen.queryByTestId("acp-chat-tool-output")).toBeNull();
+    const toggle = screen.getByTestId("acp-chat-tool-output-toggle");
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("acp-chat-tool-output")).toBeDefined();
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
@@ -1,0 +1,168 @@
+/**
+ * A tool call rendered as a distinct card in the ACP chat transcript: a kind
+ * glyph, the tool title, a status pill, and a streaming indicator while
+ * running. Inline output (parsed from the tool content) renders in a monospace
+ * block, collapsed behind a toggle when long. Any file changes the call touched
+ * surface as clickable chips that invoke `onOpenDiff`.
+ */
+
+import { ChevronDown, ChevronRight, Code, FileText } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Tag, Typography, type TagTone } from "@vellumai/design-library";
+
+import {
+  getAcpFileChanges,
+  parseAcpToolContent,
+} from "@/domains/chat/acp-tool-content";
+import type { AcpChatBlock } from "@/domains/chat/acp-run-message-projection";
+import type { AcpToolStatus } from "@/domains/chat/acp-run-step-projection";
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+
+type AcpToolBlock = Extract<AcpChatBlock, { kind: "tool" }>;
+
+/** A single file the tool call touched. */
+export type AcpFileChange = {
+  path: string;
+  oldText?: string;
+  newText?: string;
+};
+
+export interface AcpChatToolCardProps {
+  /** The `kind: "tool"` chat block to render. */
+  block: AcpToolBlock;
+  /** Invoked when a file-change chip is activated. */
+  onOpenDiff: (fileChange: AcpFileChange) => void;
+}
+
+/** Output longer than this (chars) collapses behind a toggle. */
+const COLLAPSE_THRESHOLD = 600;
+
+const STATUS_TONE: Record<AcpToolStatus, TagTone> = {
+  running: "neutral",
+  completed: "positive",
+  error: "negative",
+};
+
+const STATUS_LABEL: Record<AcpToolStatus, string> = {
+  running: "Running",
+  completed: "Completed",
+  error: "Failed",
+};
+
+/** Leading kind glyph — file glyph for read/edit, code brackets otherwise. */
+function KindIcon({ toolKind }: { toolKind?: string }) {
+  const Icon = toolKind === "read" || toolKind === "edit" ? FileText : Code;
+  return (
+    <Icon
+      aria-hidden
+      className="h-4 w-4 shrink-0 text-[var(--content-tertiary)]"
+    />
+  );
+}
+
+export function AcpChatToolCard({ block, onOpenDiff }: AcpChatToolCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const parsed = useMemo(
+    () => parseAcpToolContent(block.content),
+    [block.content],
+  );
+
+  const outputText = useMemo(
+    () =>
+      parsed
+        .filter((b) => b.type === "content" || b.type === "terminal")
+        .map((b) => ("text" in b ? (b.text ?? "") : ""))
+        .filter((text) => text.length > 0)
+        .join("\n"),
+    [parsed],
+  );
+
+  const fileChanges = useMemo(
+    () => getAcpFileChanges(parsed, block.locations),
+    [parsed, block.locations],
+  );
+
+  const isRunning = block.status === "running";
+  const isLong = outputText.length > COLLAPSE_THRESHOLD;
+  const showOutput = outputText.length > 0 && (!isLong || expanded);
+
+  return (
+    <div
+      data-testid="acp-chat-tool-card"
+      data-status={block.status}
+      className="w-full rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3"
+    >
+      <div className="flex items-center gap-2">
+        <KindIcon toolKind={block.toolKind} />
+        <Typography
+          variant="body-small-emphasised"
+          className="min-w-0 flex-1 truncate text-[var(--content-default)]"
+          title={block.title}
+        >
+          {block.title || "Tool call"}
+        </Typography>
+        <Tag
+          tone={STATUS_TONE[block.status]}
+          data-testid="acp-chat-tool-status"
+        >
+          {STATUS_LABEL[block.status]}
+        </Tag>
+        {isRunning && (
+          <ThreeDotIndicator
+            className="shrink-0"
+            data-testid="acp-chat-tool-running"
+          />
+        )}
+      </div>
+
+      {fileChanges.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {fileChanges.map((fileChange) => (
+            <button
+              key={fileChange.path}
+              type="button"
+              data-testid="acp-chat-tool-file-chip"
+              onClick={() => onOpenDiff(fileChange)}
+              title={fileChange.path}
+              className="flex max-w-full items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] px-2 py-1 text-body-small-default text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)]"
+            >
+              <FileText aria-hidden className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate font-mono">{fileChange.path}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {outputText.length > 0 && (
+        <div className="mt-2">
+          {isLong && (
+            <button
+              type="button"
+              data-testid="acp-chat-tool-output-toggle"
+              aria-expanded={expanded}
+              onClick={() => setExpanded((prev) => !prev)}
+              className="mb-1.5 flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-default)]"
+            >
+              {expanded ? (
+                <ChevronDown aria-hidden className="h-3.5 w-3.5 shrink-0" />
+              ) : (
+                <ChevronRight aria-hidden className="h-3.5 w-3.5 shrink-0" />
+              )}
+              <span>{expanded ? "Hide output" : "Show output"}</span>
+            </button>
+          )}
+          {showOutput && (
+            <pre
+              data-testid="acp-chat-tool-output"
+              className="max-h-60 overflow-auto rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] p-2.5 font-mono text-body-small-default whitespace-pre-wrap break-words text-[var(--content-default)]"
+            >
+              {outputText}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-user-turn.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-user-turn.test.tsx
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { AcpChatUserTurn } from "./acp-chat-user-turn";
+
+afterEach(cleanup);
+
+describe("AcpChatUserTurn", () => {
+  test("renders the content", () => {
+    render(<AcpChatUserTurn content="do the thing" />);
+    expect(screen.getByText("do the thing")).toBeDefined();
+  });
+
+  test("renders right-aligned with a bubble surface", () => {
+    render(<AcpChatUserTurn content="hi" />);
+    const root = screen.getByTestId("acp-chat-user-turn");
+    expect(root.className).toContain("justify-end");
+
+    const bubble = root.firstElementChild as HTMLElement;
+    expect(bubble.className).toContain("max-w-[80%]");
+    expect(bubble.className).toContain("rounded-lg");
+    expect(bubble.className).toContain("bg-[var(--surface-lift)]");
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-user-turn.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-user-turn.tsx
@@ -1,0 +1,22 @@
+/**
+ * A user turn in the ACP chat transcript — right-aligned bubble mirroring the
+ * main chat's user message styling.
+ */
+
+export interface AcpChatUserTurnProps {
+  /** Plain-text body of the user's message. */
+  content: string;
+}
+
+export function AcpChatUserTurn({ content }: AcpChatUserTurnProps) {
+  return (
+    <div
+      data-testid="acp-chat-user-turn"
+      className="flex w-full justify-end"
+    >
+      <div className="max-w-[80%] rounded-lg bg-[var(--surface-lift)] px-4 py-3 whitespace-pre-wrap text-chat text-[var(--content-default)]">
+        {content}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Presentational chat blocks for the ACP chat view: agent message, self-contained collapsible thinking, tool card (with clickable file-change chips → onOpenDiff), plan checklist, user turn, terminal state.

Part of plan: acp-chat-detail-view.md (PR 6 of 11)