### PR TITLE
combo11: skip migration 031 guardian lookup when the ACL columns are absent

### DIFF
--- a/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
@@ -68,6 +68,14 @@ function seedGuardian(input: {
   );
 }
 
+/** Drop the legacy ACL columns the guardian read depends on. */
+function dropAclColumns(): void {
+  const sqlite = getSqlite();
+  sqlite.run("ALTER TABLE contacts DROP COLUMN role");
+  sqlite.run("ALTER TABLE contact_channels DROP COLUMN status");
+  sqlite.run("ALTER TABLE contact_channels DROP COLUMN verified_at");
+}
+
 function guardianUserFile(id: string): string | null {
   const row = getSqlite()
     .query<{ user_file: string | null }, [string]>(
@@ -322,5 +330,29 @@ describe("workspace migration 031-drop-user-md", () => {
   test("down() is a no-op (deletion is irreversible)", () => {
     dropUserMdMigration.down(workspaceDir());
     expect(existsSync(userMdPath())).toBe(false);
+  });
+
+  test("ACL columns absent — skips guardian cleanup cleanly and leaves USER.md untouched", () => {
+    // Mirror the later phase that drops the assistant-DB ACL columns. The
+    // migration must skip the guardian-dependent cleanup with no throw.
+    const content = customizedContent();
+    writeFileSync(userMdPath(), content, "utf-8");
+
+    dropAclColumns();
+    try {
+      expect(() => dropUserMdMigration.run(workspaceDir())).not.toThrow();
+    } finally {
+      // Restore schema so later runs (file load order independent) see the
+      // columns; beforeEach only clears rows, not schema.
+      const sqlite = getSqlite();
+      sqlite.run("ALTER TABLE contacts ADD COLUMN role TEXT");
+      sqlite.run("ALTER TABLE contact_channels ADD COLUMN status TEXT");
+      sqlite.run("ALTER TABLE contact_channels ADD COLUMN verified_at INTEGER");
+    }
+
+    // USER.md is left exactly as-is; no users/ scaffold is created.
+    expect(existsSync(userMdPath())).toBe(true);
+    expect(readFileSync(userMdPath(), "utf-8")).toBe(content);
+    expect(existsSync(join(workspaceDir(), "users"))).toBe(false);
   });
 });

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -115,6 +115,31 @@ function isValidSlug(slug: string): boolean {
   return basename(slug) === slug && slug !== "." && slug !== "..";
 }
 
+/** Names of the columns present on a table, via `PRAGMA table_info`. */
+function tableColumns(db: Database, table: string): Set<string> {
+  const rows = db
+    .query<{ name: string }, []>(`PRAGMA table_info(${table})`)
+    .all();
+  return new Set(rows.map((r) => r.name));
+}
+
+/**
+ * The guardian read below depends on the legacy ACL columns
+ * `contacts.role` and `contact_channels.status` / `verified_at`. The gateway
+ * owns guardian ACL, and a later phase drops these columns from the assistant
+ * DB. On schemas without them this one-time cleanup is a no-op: fresh installs
+ * have no legacy USER.md to clean, and existing installs already ran it.
+ */
+function aclColumnsPresent(db: Database): boolean {
+  const contactCols = tableColumns(db, "contacts");
+  const channelCols = tableColumns(db, "contact_channels");
+  return (
+    contactCols.has("role") &&
+    channelCols.has("status") &&
+    channelCols.has("verified_at")
+  );
+}
+
 /**
  * Strip LIKE metacharacters so the prefix match runs literally. SQLite has
  * no default LIKE escape character, so strip rather than escape. Inlined
@@ -201,6 +226,8 @@ export const dropUserMdMigration: WorkspaceMigration = {
     }
 
     try {
+      if (!aclColumnsPresent(db)) return; // ACL columns dropped — cleanup is a no-op.
+
       // Resolve the guardian contact from the local DB. Prefer the
       // vellum-channel binding (the canonical native guardian); fall back to
       // whichever guardian has the most recently verified active channel.


### PR DESCRIPTION
## Summary
- Workspace migration 031 now checks for contacts.role / contact_channels.status / verified_at via PRAGMA and skips the USER.md guardian cleanup cleanly when they are absent
- Behavior unchanged when the columns exist; this makes 031 safe once the ACL columns are dropped

Part of plan: drain-contacts-role.md (PR 3 of 4)