### PR TITLE
combo11: expose the guardian contact id(s) from the gateway over IPC

### DIFF
--- a/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
@@ -27,6 +27,8 @@ const { getGuardianContactIds, invalidateGuardianContactCache } = await import(
   "../guardian-contact-reader.js"
 );
 
+const { emitContactChange } = await import("../contact-events.js");
+
 beforeEach(() => {
   ipcCallPersistentMock.mockClear();
   ipcError = undefined;
@@ -94,6 +96,18 @@ describe("getGuardianContactIds", () => {
     };
     await getGuardianContactIds();
     invalidateGuardianContactCache();
+    await getGuardianContactIds();
+
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a contact-change event clears the cache", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+    await getGuardianContactIds();
+    emitContactChange();
     await getGuardianContactIds();
 
     expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);

--- a/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the daemon guardian-contact reader.
+ *
+ * `getGuardianContactIds` relays to the gateway IPC method
+ * `get_guardian_contact` via `ipcCallPersistent`, caches the result with a
+ * short TTL, and FAIL-SOFTS to an empty set (no throw) on IPC error.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let ipcResult: unknown = { ok: true, guardians: [] };
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(async () => {
+  if (ipcError) throw ipcError;
+  return ipcResult;
+});
+
+const actualGatewayClient = await import("../../ipc/gateway-client.js");
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+const { getGuardianContactIds, invalidateGuardianContactCache } = await import(
+  "../guardian-contact-reader.js"
+);
+
+beforeEach(() => {
+  ipcCallPersistentMock.mockClear();
+  ipcError = undefined;
+  ipcResult = { ok: true, guardians: [] };
+  invalidateGuardianContactCache();
+});
+
+describe("getGuardianContactIds", () => {
+  test("returns the guardian id set from the gateway IPC", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+
+    const ids = await getGuardianContactIds();
+
+    expect([...ids]).toEqual(["g1"]);
+    expect(ipcCallPersistentMock).toHaveBeenCalledWith(
+      "get_guardian_contact",
+      {},
+    );
+  });
+
+  test("caches within the TTL (second call does not re-invoke the IPC)", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+
+    const first = await getGuardianContactIds();
+    const second = await getGuardianContactIds();
+
+    expect([...first]).toEqual(["g1"]);
+    expect([...second]).toEqual(["g1"]);
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fail-softs to an empty set on IPC error (no throw)", async () => {
+    ipcError = new Error("gateway down");
+
+    const ids = await getGuardianContactIds();
+
+    expect([...ids]).toEqual([]);
+  });
+
+  test("does not cache a failed read (retries on the next call)", async () => {
+    ipcError = new Error("gateway down");
+    await getGuardianContactIds();
+
+    ipcError = undefined;
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+    const ids = await getGuardianContactIds();
+
+    expect([...ids]).toEqual(["g1"]);
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("invalidate forces a re-fetch", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+    await getGuardianContactIds();
+    invalidateGuardianContactCache();
+    await getGuardianContactIds();
+
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/contacts/guardian-contact-reader.ts
+++ b/assistant/src/contacts/guardian-contact-reader.ts
@@ -13,6 +13,7 @@ import { GetGuardianContactIpcResponseSchema } from "@vellumai/gateway-client/ga
 
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
 import { getLogger } from "../util/logger.js";
+import { onContactChange } from "./contact-events.js";
 
 const log = getLogger("guardian-contact-reader");
 
@@ -42,7 +43,13 @@ export async function getGuardianContactIds(): Promise<Set<string>> {
   }
 }
 
-/** Drop the cached guardian set (e.g. after a guardian rebind). */
+/**
+ * Drop the cached guardian set. Subscribed to `onContactChange` so contact
+ * mutations (rebind/revoke/upsert) refetch on the next read; also exported for
+ * any caller that wants to invalidate explicitly.
+ */
 export function invalidateGuardianContactCache(): void {
   cache = null;
 }
+
+onContactChange(invalidateGuardianContactCache);

--- a/assistant/src/contacts/guardian-contact-reader.ts
+++ b/assistant/src/contacts/guardian-contact-reader.ts
@@ -1,0 +1,48 @@
+/**
+ * Daemon-side reader for the guardian contact id(s), sourced from the gateway
+ * DB (source of truth) via the `get_guardian_contact` IPC.
+ *
+ * Lets contact-serve paths determine the guardian without reading the local
+ * `contacts.role` column. Result is cached with a short TTL.
+ *
+ * FAIL-SOFT: a cache miss or IPC error returns an empty set and logs a warning;
+ * this never throws (it runs on contact-serve paths).
+ */
+
+import { GetGuardianContactIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import { ipcCallPersistent } from "../ipc/gateway-client.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("guardian-contact-reader");
+
+const CACHE_TTL_MS = 30_000;
+
+let cache: { ids: Set<string>; expiresAt: number } | null = null;
+
+/**
+ * Guardian contact ids from the gateway DB. Cached for {@link CACHE_TTL_MS};
+ * returns an empty set on IPC error (never throws).
+ */
+export async function getGuardianContactIds(): Promise<Set<string>> {
+  if (cache && cache.expiresAt > Date.now()) return cache.ids;
+
+  try {
+    const result = await ipcCallPersistent("get_guardian_contact", {});
+    const { guardians } = GetGuardianContactIpcResponseSchema.parse(result);
+    const ids = new Set(guardians.map((g) => g.id));
+    cache = { ids, expiresAt: Date.now() + CACHE_TTL_MS };
+    return ids;
+  } catch (err) {
+    log.warn(
+      { err },
+      "get_guardian_contact IPC failed; returning empty guardian set",
+    );
+    return new Set();
+  }
+}
+
+/** Drop the cached guardian set (e.g. after a guardian rebind). */
+export function invalidateGuardianContactCache(): void {
+  cache = null;
+}

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -94,6 +94,10 @@ const upsertVerifiedChannelHandler = contactRoutes.find(
   (r) => r.method === "upsert_verified_channel",
 )!.handler;
 
+const getGuardianContactHandler = contactRoutes.find(
+  (r) => r.method === "get_guardian_contact",
+)!.handler;
+
 beforeAll(async () => {
   await initGatewayDb();
 });
@@ -346,6 +350,34 @@ describe("mark_channel_revoked IPC handler", () => {
     await expect(
       markChannelRevokedHandler({ contactChannelId: "nonexistent" }),
     ).rejects.toThrow(/not found/);
+  });
+});
+
+describe("get_guardian_contact IPC handler", () => {
+  test("returns the guardian contact id(s) from the gateway DB", async () => {
+    seedContact("g1", "guardian");
+    seedContact("c1", "contact");
+
+    const res = (await getGuardianContactHandler({})) as {
+      ok: boolean;
+      guardians: { id: string; displayName: string }[];
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.guardians).toEqual([{ id: "g1", displayName: "name-g1" }]);
+  });
+
+  test("excludes non-guardian contacts", async () => {
+    seedContact("c1", "contact");
+    seedContact("c2", "contact");
+
+    const res = (await getGuardianContactHandler({})) as {
+      ok: boolean;
+      guardians: { id: string }[];
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.guardians).toEqual([]);
   });
 });
 

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -62,6 +62,18 @@ export class ContactStore {
       .all();
   }
 
+  /**
+   * Guardian contacts (id + displayName) from the gateway DB (source of truth).
+   * Singular per workspace, but returns a set to be safe.
+   */
+  listGuardianContactIds(): { id: string; displayName: string }[] {
+    return this.db
+      .select({ id: contacts.id, displayName: contacts.displayName })
+      .from(contacts)
+      .where(eq(contacts.role, "guardian"))
+      .all();
+  }
+
   getContactByChannel(
     channelType: string,
     address: string,

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -9,6 +9,8 @@
 
 import {
   GetContactIpcParamsSchema,
+  GetGuardianContactIpcParamsSchema,
+  GetGuardianContactIpcResponseSchema,
   ListContactsIpcParamsSchema,
   MarkChannelRevokedIpcParamsSchema,
   MarkChannelRevokedIpcResponseSchema,
@@ -102,6 +104,17 @@ export const contactRoutes: IpcRoute[] = [
           ? { assistantMetadata: result.assistantMetadata }
           : {}),
       };
+    },
+  },
+  {
+    // Exposes the guardian contact id(s) from the gateway DB (source of truth)
+    // so the daemon can determine the guardian without reading the local
+    // contacts.role column.
+    method: "get_guardian_contact",
+    schema: GetGuardianContactIpcParamsSchema,
+    handler: () => {
+      const guardians = getStore().listGuardianContactIds();
+      return GetGuardianContactIpcResponseSchema.parse({ ok: true, guardians });
     },
   },
   {

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -291,3 +291,28 @@ export const GetContactIpcResponseSchema = z.object({
 export type GetContactIpcResponse = z.infer<
   typeof GetContactIpcResponseSchema
 >;
+
+export const GetGuardianContactIpcParamsSchema = z
+  .object({})
+  .strict()
+  .default({});
+
+export type GetGuardianContactIpcParams = z.infer<
+  typeof GetGuardianContactIpcParamsSchema
+>;
+
+export const GuardianContactSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+});
+
+export type GuardianContact = z.infer<typeof GuardianContactSchema>;
+
+export const GetGuardianContactIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  guardians: z.array(GuardianContactSchema),
+});
+
+export type GetGuardianContactIpcResponse = z.infer<
+  typeof GetGuardianContactIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
- New gateway IPC get_guardian_contact returns the guardian contact id(s) from the gateway DB (source of truth)
- Cached, fail-soft daemon-side client helper so contact-serve paths can determine the guardian without reading the local contacts.role column

Part of plan: drain-contacts-role.md (PR 1 of 4)