### PR TITLE
feat(web): assemble acp run chat view

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.test.tsx
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+
+import type {
+  AcpRunEntry,
+  AcpRunRawEvent,
+} from "@/domains/chat/acp-run-store";
+
+const steerAcpRun = mock(async () => ({ acpSessionId: "acp-1", steered: true }));
+const stopAcpRun = mock(async () => {});
+
+// The real actions module imports the daemon client + resolved-assistants
+// store; mock at that boundary so the view's steer/stop calls stay in-process.
+mock.module("@/domains/chat/utils/acp-run-actions", () => ({
+  steerAcpRun,
+  stopAcpRun,
+}));
+
+// Modules are imported AFTER the mock registers so the real actions module
+// (which pulls in the not-generated daemon client) is never evaluated.
+const { useAcpRunStore } = await import("@/domains/chat/acp-run-store");
+const { AcpRunChatView } = await import("./acp-run-chat-view");
+
+// Reset only the data slices (merge, not replace) so the store's action
+// methods — `appendLocalMarker`, etc. — survive between tests.
+function freshState() {
+  return {
+    byId: {},
+    orderedIds: [],
+    byToolUseId: new Map<string, string>(),
+    highWaterMark: new Map<string, number>(),
+  };
+}
+
+function entry(overrides: Partial<AcpRunEntry> = {}): AcpRunEntry {
+  return {
+    acpSessionId: "acp-1",
+    agent: "claude",
+    parentConversationId: "conv-1",
+    task: "Refactor the parser",
+    status: "running",
+    startedAt: 0,
+    usedTokens: 0,
+    contextSize: 0,
+    events: [],
+    ...overrides,
+  };
+}
+
+/** Seed a run + its raw events into the store so the projection has input. */
+function seed(e: AcpRunEntry, events: AcpRunRawEvent[]) {
+  useAcpRunStore.setState({
+    ...freshState(),
+    byId: { [e.acpSessionId]: { ...e, events } },
+    orderedIds: [e.acpSessionId],
+  });
+}
+
+beforeEach(() => {
+  useAcpRunStore.setState(freshState());
+  steerAcpRun.mockClear();
+  stopAcpRun.mockClear();
+});
+
+afterEach(cleanup);
+
+describe("AcpRunChatView", () => {
+  test("renders chat blocks in order from the seeded store events", () => {
+    const e = entry();
+    seed(e, [
+      { seq: 1, updateType: "user_message_chunk", messageId: "u1", content: "fix it" },
+      { seq: 2, updateType: "agent_thought_chunk", messageId: "t1", content: "pondering" },
+      { seq: 3, updateType: "agent_message_chunk", messageId: "a1", content: "on it" },
+      {
+        seq: 4,
+        updateType: "tool_call",
+        toolCallId: "call-1",
+        toolTitle: "Read file",
+        toolStatus: "completed",
+      },
+    ]);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    expect(screen.getByTestId("acp-chat-user-turn")).toBeDefined();
+    // Thinking block auto-expands while streaming; agent + tool render too.
+    expect(screen.getByTestId("acp-chat-thinking-block")).toBeDefined();
+    expect(screen.getByTestId("acp-chat-agent-message")).toBeDefined();
+    expect(screen.getByTestId("acp-chat-tool-card")).toBeDefined();
+
+    // Order: user before agent before tool in the conversation container.
+    const conversation = screen.getByTestId("acp-chat-conversation");
+    const html = conversation.innerHTML;
+    expect(html.indexOf("acp-chat-user-turn")).toBeLessThan(
+      html.indexOf("acp-chat-agent-message"),
+    );
+    expect(html.indexOf("acp-chat-agent-message")).toBeLessThan(
+      html.indexOf("acp-chat-tool-card"),
+    );
+  });
+
+  test("renders the objective and usage meter in the header", () => {
+    const e = entry({ inputTokens: 1000, outputTokens: 200 });
+    seed(e, []);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    expect(screen.getByTestId("acp-chat-objective").textContent).toContain(
+      "Refactor the parser",
+    );
+    expect(screen.getByTestId("acp-usage-meter")).toBeDefined();
+  });
+
+  test("shows the steer composer only while running and calls steerAcpRun", () => {
+    const e = entry({ status: "running" });
+    seed(e, []);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    const form = screen.getByTestId("acp-chat-steer-form");
+    const input = within(form).getByLabelText("Steering instruction");
+    fireEvent.change(input, { target: { value: "use the new API" } });
+    fireEvent.submit(form);
+
+    expect(steerAcpRun).toHaveBeenCalledTimes(1);
+    expect(steerAcpRun).toHaveBeenCalledWith("acp-1", "use the new API");
+
+    // Optimistic local marker projects as a user turn immediately.
+    expect(screen.getByText("use the new API")).toBeDefined();
+  });
+
+  test("hides the steer composer when the run is terminal", () => {
+    const e = entry({ status: "completed" });
+    seed(e, []);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    expect(screen.queryByTestId("acp-chat-steer-form")).toBeNull();
+  });
+
+  test("opens FileDiffView from a tool-card file chip and Back restores the conversation", () => {
+    const e = entry();
+    const content = JSON.stringify([
+      { type: "diff", path: "src/parser.ts", oldText: "old", newText: "new" },
+    ]);
+    seed(e, [
+      {
+        seq: 1,
+        updateType: "tool_call",
+        toolCallId: "call-1",
+        toolTitle: "Edit file",
+        toolStatus: "completed",
+        content,
+      },
+    ]);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    // Conversation visible; no diff yet.
+    expect(screen.getByTestId("acp-chat-conversation")).toBeDefined();
+    expect(screen.queryByTestId("file-diff-back")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("acp-chat-tool-file-chip"));
+
+    // Diff replaces the conversation.
+    expect(screen.getByTestId("file-diff-back")).toBeDefined();
+    expect(screen.queryByTestId("acp-chat-conversation")).toBeNull();
+    expect(screen.getByText("src/parser.ts")).toBeDefined();
+
+    // Back restores the conversation.
+    fireEvent.click(screen.getByTestId("file-diff-back"));
+    expect(screen.getByTestId("acp-chat-conversation")).toBeDefined();
+    expect(screen.queryByTestId("file-diff-back")).toBeNull();
+  });
+
+  test("renders the terminal block when the run has a terminal status", () => {
+    const e = entry({ status: "completed", stopReason: "end_turn" });
+    seed(e, []);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    const terminal = screen.getByTestId("acp-chat-terminal-block");
+    expect(terminal.getAttribute("data-terminal-kind")).toBe("completed");
+  });
+
+  test("calls stopAcpRun when Stop is pressed while running", () => {
+    const e = entry({ status: "running" });
+    seed(e, []);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByLabelText("Stop run"));
+    expect(stopAcpRun).toHaveBeenCalledWith("acp-1");
+  });
+});

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.test.tsx
@@ -192,4 +192,59 @@ describe("AcpRunChatView", () => {
     fireEvent.click(screen.getByLabelText("Stop run"));
     expect(stopAcpRun).toHaveBeenCalledWith("acp-1");
   });
+
+  test("resets run-specific local state when the session switches", () => {
+    const first = entry({ acpSessionId: "acp-1", status: "running" });
+    seed(first, []);
+
+    const { container, rerender } = render(
+      <AcpRunChatView entry={first} onClose={() => {}} />,
+    );
+    const view = within(container);
+
+    // Dirty the run-specific subcomponent state: type a steer instruction.
+    const input = within(view.getByTestId("acp-chat-steer-form")).getByLabelText(
+      "Steering instruction",
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "leftover instruction" } });
+    expect(input.value).toBe("leftover instruction");
+
+    // Switch the drawer to a different ACP run.
+    const second = entry({ acpSessionId: "acp-2", status: "running" });
+    seed(second, []);
+    rerender(<AcpRunChatView entry={second} onClose={() => {}} />);
+
+    // Composer remounts fresh (keyed on acpSessionId): no stale input.
+    const nextInput = within(
+      view.getByTestId("acp-chat-steer-form"),
+    ).getByLabelText("Steering instruction") as HTMLInputElement;
+    expect(nextInput.value).toBe("");
+
+    // Header remounts fresh: the Stop button is not stuck disabled from the
+    // previous run's `stopping` state.
+    expect((view.getByLabelText("Stop run") as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  test("hides the streaming indicator on a trailing live block when terminal", () => {
+    // A run that ends right after an agent_message_chunk: the projection leaves
+    // the trailing agent block isComplete=false, but the view treats it as
+    // complete because the run status is terminal.
+    const e = entry({ status: "completed", stopReason: "end_turn" });
+    seed(e, [
+      {
+        seq: 1,
+        updateType: "agent_message_chunk",
+        messageId: "a1",
+        content: "all done",
+      },
+    ]);
+
+    render(<AcpRunChatView entry={e} onClose={() => {}} />);
+
+    expect(screen.getByTestId("acp-chat-agent-message")).toBeDefined();
+    // No live caret / ThreeDotIndicator because the run is terminal.
+    expect(screen.queryByTestId("acp-chat-agent-streaming")).toBeNull();
+  });
 });

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
@@ -1,0 +1,367 @@
+/**
+ * Devin-style chat view for an ACP run. Assembles the projected chat blocks
+ * (PR 3) into a streaming conversation, with the usage meter (PR 11) in the
+ * header, a nested file diff (PR 5) opened from tool-card file chips, and a
+ * steer composer that posts follow-up instructions while the run is live.
+ *
+ * Self-contained for reversibility: it copies the detail panel's header /
+ * objective / steer markup + tokens rather than importing them, and owns the
+ * nested-diff selection in LOCAL state (not the viewer store).
+ */
+
+import { ArrowDown, Code, Send, Square, X } from "lucide-react";
+import { useCallback, useState, type FormEvent } from "react";
+
+import { Button, Typography } from "@vellumai/design-library";
+
+import {
+  useAcpRunChatBlocks,
+  type AcpChatBlock,
+} from "@/domains/chat/acp-run-message-projection";
+import {
+  useAcpRunStore,
+  type AcpRunEntry,
+  type AcpRunRawEvent,
+} from "@/domains/chat/acp-run-store";
+import { AcpChatAgentMessage } from "@/domains/chat/components/acp-run-chat-view/acp-chat-agent-message";
+import { AcpChatPlanBlock } from "@/domains/chat/components/acp-run-chat-view/acp-chat-plan-block";
+import { AcpChatTerminalBlock } from "@/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block";
+import { AcpChatThinkingBlock } from "@/domains/chat/components/acp-run-chat-view/acp-chat-thinking-block";
+import {
+  AcpChatToolCard,
+  type AcpFileChange,
+} from "@/domains/chat/components/acp-run-chat-view/acp-chat-tool-card";
+import { AcpChatUserTurn } from "@/domains/chat/components/acp-run-chat-view/acp-chat-user-turn";
+import { AcpUsageMeter } from "@/domains/chat/components/acp-run-chat-view/acp-usage-meter";
+import { FileDiffView } from "@/domains/chat/components/acp-run-chat-view/file-diff-view";
+import { useStickToBottom } from "@/domains/chat/components/acp-run-chat-view/use-stick-to-bottom";
+import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
+import {
+  steerAcpRun,
+  stopAcpRun,
+} from "@/domains/chat/utils/acp-run-actions";
+import {
+  acpRunStatusColor,
+  acpRunStatusLabel,
+  isActiveAcpStatus,
+} from "@/utils/acp-run-status";
+import { captureError } from "@/lib/sentry/capture-error";
+
+/** Stable per-block key so React reconciles blocks across streamed re-renders. */
+function blockKey(block: AcpChatBlock, index: number): string {
+  switch (block.kind) {
+    case "user":
+      return `user-${block.id || index}`;
+    case "agent":
+      return `agent-${block.messageId || index}`;
+    case "thinking":
+      return `thinking-${block.messageId || index}`;
+    case "tool":
+      return `tool-${block.toolCallId}`;
+    case "plan":
+      return "plan";
+  }
+}
+
+const EMPTY_EVENTS: AcpRunRawEvent[] = [];
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface AcpRunChatViewProps {
+  entry: AcpRunEntry;
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function AcpRunChatView({ entry, onClose }: AcpRunChatViewProps) {
+  const isRunning = isActiveAcpStatus(entry.status);
+
+  const events = useAcpRunStore(
+    (s) => s.byId[entry.acpSessionId]?.events ?? EMPTY_EVENTS,
+  );
+  const blocks = useAcpRunChatBlocks(events);
+
+  // Nested file diff in LOCAL state (never the viewer store). When set, the
+  // conversation is replaced by the diff with a Back affordance.
+  const [activeDiff, setActiveDiff] = useState<AcpFileChange | null>(null);
+
+  // Reset nested diff on run switch — render-phase guard tracking the prev id,
+  // mirroring `AcpRunDetailPanel`.
+  const [prevSessionId, setPrevSessionId] = useState(entry.acpSessionId);
+  if (prevSessionId !== entry.acpSessionId) {
+    setPrevSessionId(entry.acpSessionId);
+    setActiveDiff(null);
+  }
+
+  const handleOpenDiff = useCallback(
+    (fileChange: AcpFileChange) => setActiveDiff(fileChange),
+    [],
+  );
+  const handleCloseDiff = useCallback(() => setActiveDiff(null), []);
+
+  // The hook re-pins in a layout effect keyed on `blocks` identity (the
+  // projection returns a fresh array on every streamed append), so no
+  // render-phase content-change call is needed.
+  const { scrollRef, showScrollToLatest, scrollToLatest } =
+    useStickToBottom(blocks);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
+      <ChatViewHeader
+        entry={entry}
+        isRunning={isRunning}
+        onClose={onClose}
+      />
+
+      {activeDiff ? (
+        <div className="flex-1 overflow-y-auto px-5 py-5">
+          <FileDiffView
+            path={activeDiff.path}
+            oldText={activeDiff.oldText}
+            newText={activeDiff.newText}
+            onBack={handleCloseDiff}
+          />
+        </div>
+      ) : (
+        <div className="relative min-h-0 flex-1">
+          <div
+            ref={scrollRef}
+            data-testid="acp-chat-conversation"
+            className="flex h-full flex-col gap-4 overflow-y-auto px-5 py-5"
+          >
+            <ObjectiveSection task={entry.task} />
+
+            {blocks.map((block, index) => (
+              <ChatBlock
+                key={blockKey(block, index)}
+                block={block}
+                onOpenDiff={handleOpenDiff}
+              />
+            ))}
+
+            {!isRunning && (
+              <AcpChatTerminalBlock
+                status={entry.status}
+                stopReason={entry.stopReason}
+                error={entry.error}
+              />
+            )}
+          </div>
+
+          {showScrollToLatest && (
+            <Button
+              variant="outlined"
+              size="compact"
+              iconOnly={<ArrowDown />}
+              onClick={scrollToLatest}
+              aria-label="Go to newest"
+              tooltip="Go to newest"
+              data-testid="acp-chat-scroll-to-latest"
+              className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full shadow-md"
+            />
+          )}
+        </div>
+      )}
+
+      {isRunning && !activeDiff && (
+        <SteerComposer acpSessionId={entry.acpSessionId} />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+function ChatViewHeader({
+  entry,
+  isRunning,
+  onClose,
+}: {
+  entry: AcpRunEntry;
+  isRunning: boolean;
+  onClose: () => void;
+}) {
+  const [stopping, setStopping] = useState(false);
+
+  const handleStop = useCallback(() => {
+    setStopping(true);
+    void stopAcpRun(entry.acpSessionId).catch((err) => {
+      setStopping(false);
+      captureError(err, { context: "AcpRunChatView.stop" });
+    });
+  }, [entry.acpSessionId]);
+
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] px-5 py-4">
+      <Code
+        aria-hidden
+        className="h-5 w-5 shrink-0 text-[var(--content-secondary)]"
+      />
+      <Typography
+        variant="title-medium"
+        title={entry.agent}
+        className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
+      >
+        {entry.agent}
+      </Typography>
+      <StatusBadgePill
+        color={acpRunStatusColor(entry.status)}
+        label={acpRunStatusLabel(entry.status)}
+      />
+      <span className="flex-1" />
+      <AcpUsageMeter entry={entry} />
+      {isRunning && (
+        <button
+          type="button"
+          aria-label="Stop run"
+          onClick={handleStop}
+          disabled={stopping}
+          className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--system-negative-strong)] bg-transparent px-2.5 py-1.5 text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--system-negative-weak)] disabled:cursor-default disabled:opacity-50"
+        >
+          <Square className="h-3 w-3" fill="currentColor" />
+          <Typography variant="label-small-default">Stop</Typography>
+        </button>
+      )}
+      <Button
+        variant="outlined"
+        iconOnly={<X />}
+        onClick={onClose}
+        aria-label="Close run detail"
+        tooltip="Close"
+        className="shrink-0 rounded-lg"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Objective
+// ---------------------------------------------------------------------------
+
+function ObjectiveSection({ task }: { task: string | undefined }) {
+  if (!task) return null;
+  return (
+    <div data-testid="acp-chat-objective">
+      <Typography
+        variant="body-medium-default"
+        as="h3"
+        className="mb-1 text-[var(--content-emphasised)]"
+      >
+        Objective
+      </Typography>
+      <Typography
+        variant="body-medium-lighter"
+        as="p"
+        className="whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)]"
+      >
+        {task}
+      </Typography>
+      <div className="mt-4 h-px w-full bg-[var(--border-hover)]" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Block dispatch
+// ---------------------------------------------------------------------------
+
+function ChatBlock({
+  block,
+  onOpenDiff,
+}: {
+  block: AcpChatBlock;
+  onOpenDiff: (fileChange: AcpFileChange) => void;
+}) {
+  switch (block.kind) {
+    case "user":
+      return <AcpChatUserTurn content={block.content} />;
+    case "agent":
+      return (
+        <AcpChatAgentMessage
+          content={block.content}
+          isComplete={block.isComplete}
+        />
+      );
+    case "thinking":
+      return (
+        <AcpChatThinkingBlock
+          content={block.content}
+          isComplete={block.isComplete}
+        />
+      );
+    case "tool":
+      return <AcpChatToolCard block={block} onOpenDiff={onOpenDiff} />;
+    case "plan":
+      return <AcpChatPlanBlock entries={block.entries} />;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Steer composer
+// ---------------------------------------------------------------------------
+
+function SteerComposer({ acpSessionId }: { acpSessionId: string }) {
+  const [input, setInput] = useState("");
+  const [pending, setPending] = useState(false);
+
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const instruction = input.trim();
+      if (!instruction || pending) return;
+      setPending(true);
+
+      // Optimistic user turn so the steer shows immediately ahead of the
+      // daemon's echoed events. Appended without advancing the dedup
+      // high-water mark so the daemon's first real post-steer event survives.
+      useAcpRunStore.getState().appendLocalMarker({
+        acpSessionId,
+        content: `↻ Steering: ${instruction}`,
+      });
+
+      void steerAcpRun(acpSessionId, instruction)
+        .then(() => setInput(""))
+        .catch((err) => {
+          captureError(err, { context: "AcpRunChatView.steer" });
+        })
+        .finally(() => setPending(false));
+    },
+    [input, pending, acpSessionId],
+  );
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      data-testid="acp-chat-steer-form"
+      className="shrink-0 border-t border-[var(--border-hover)] px-5 py-3"
+    >
+      <div className="flex items-center gap-2 rounded-md bg-[var(--surface-base)] px-3 py-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Steer the run…"
+          disabled={pending}
+          aria-label="Steering instruction"
+          className="text-body-medium-default min-w-0 flex-1 bg-transparent text-[color:var(--content-default)] placeholder:text-[color:var(--content-tertiary)] focus:outline-none disabled:opacity-50"
+        />
+        <Button
+          type="submit"
+          variant="primary"
+          size="compact"
+          iconOnly={<Send />}
+          disabled={pending || input.trim() === ""}
+          aria-label="Send steering instruction"
+          className="shrink-0"
+        />
+      </div>
+    </form>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
@@ -90,8 +90,10 @@ export function AcpRunChatView({ entry, onClose }: AcpRunChatViewProps) {
   // conversation is replaced by the diff with a Back affordance.
   const [activeDiff, setActiveDiff] = useState<AcpFileChange | null>(null);
 
-  // Reset nested diff on run switch — render-phase guard tracking the prev id,
-  // mirroring `AcpRunDetailPanel`.
+  // Reset nested diff (parent-owned state) on run switch — render-phase guard
+  // tracking the prev id, mirroring `AcpRunDetailPanel`. Run-specific state that
+  // lives inside subcomponents (header `stopping`, composer `input`/`pending`)
+  // is reset by keying them on `entry.acpSessionId` below so they remount fresh.
   const [prevSessionId, setPrevSessionId] = useState(entry.acpSessionId);
   if (prevSessionId !== entry.acpSessionId) {
     setPrevSessionId(entry.acpSessionId);
@@ -110,9 +112,16 @@ export function AcpRunChatView({ entry, onClose }: AcpRunChatViewProps) {
   const { scrollRef, showScrollToLatest, scrollToLatest } =
     useStickToBottom(blocks);
 
+  // Whether the run is terminal — used to force any trailing live agent/thinking
+  // block to render as complete (the projection leaves the last block
+  // `isComplete: false` until a later block arrives, which never happens once
+  // the run ends). Terminal = NOT active.
+  const isTerminal = !isRunning;
+
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
       <ChatViewHeader
+        key={`header-${entry.acpSessionId}`}
         entry={entry}
         isRunning={isRunning}
         onClose={onClose}
@@ -140,6 +149,7 @@ export function AcpRunChatView({ entry, onClose }: AcpRunChatViewProps) {
               <ChatBlock
                 key={blockKey(block, index)}
                 block={block}
+                isTerminal={isTerminal}
                 onOpenDiff={handleOpenDiff}
               />
             ))}
@@ -169,7 +179,10 @@ export function AcpRunChatView({ entry, onClose }: AcpRunChatViewProps) {
       )}
 
       {isRunning && !activeDiff && (
-        <SteerComposer acpSessionId={entry.acpSessionId} />
+        <SteerComposer
+          key={`steer-${entry.acpSessionId}`}
+          acpSessionId={entry.acpSessionId}
+        />
       )}
     </div>
   );
@@ -274,9 +287,12 @@ function ObjectiveSection({ task }: { task: string | undefined }) {
 
 function ChatBlock({
   block,
+  isTerminal,
   onOpenDiff,
 }: {
   block: AcpChatBlock;
+  /** When the run is terminal, force trailing live agent/thinking blocks complete. */
+  isTerminal: boolean;
   onOpenDiff: (fileChange: AcpFileChange) => void;
 }) {
   switch (block.kind) {
@@ -286,14 +302,14 @@ function ChatBlock({
       return (
         <AcpChatAgentMessage
           content={block.content}
-          isComplete={block.isComplete}
+          isComplete={block.isComplete || isTerminal}
         />
       );
     case "thinking":
       return (
         <AcpChatThinkingBlock
           content={block.content}
-          isComplete={block.isComplete}
+          isComplete={block.isComplete || isTerminal}
         />
       );
     case "tool":

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/use-stick-to-bottom.ts
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/use-stick-to-bottom.ts
@@ -1,0 +1,81 @@
+/**
+ * Small local stick-to-bottom coordinator for the ACP chat view.
+ *
+ * The shared `useTranscriptScroll` is built around the paginated
+ * `TranscriptHandle` / `TranscriptItem` contract (load-older anchoring,
+ * conversationId reset). The ACP chat view has none of that — no pagination,
+ * no transcript handle — so wiring the full contract would be heavier than the
+ * behavior warrants. This hook covers exactly what the chat view needs:
+ *
+ *   1. Pin the scroll container to the bottom as content streams in, but only
+ *      while the user is already near the bottom (so a user who scrolled up to
+ *      read isn't yanked back down).
+ *   2. Surface a "Go to newest" affordance (`showScrollToLatest`) when the user
+ *      has scrolled away from the bottom.
+ *
+ * happy-dom has no layout, so `scrollHeight`/`clientHeight` are 0 in tests —
+ * the math degrades gracefully (everything reads as "pinned"), which is the
+ * intended default.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+/** Distance (px) from the bottom within which we treat the user as "pinned". */
+const PIN_THRESHOLD = 80;
+
+export interface UseStickToBottomReturn {
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+  showScrollToLatest: boolean;
+  scrollToLatest: () => void;
+}
+
+function isNearBottom(el: HTMLElement): boolean {
+  const distance = el.scrollHeight - el.clientHeight - el.scrollTop;
+  return distance <= PIN_THRESHOLD;
+}
+
+export function useStickToBottom(contentKey: unknown): UseStickToBottomReturn {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // Whether the user is currently pinned to the bottom. Seeded true so a fresh
+  // run lands at the latest block.
+  const pinnedRef = useRef(true);
+  const [showScrollToLatest, setShowScrollToLatest] = useState(false);
+
+  const pinToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, []);
+
+  const reclassify = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const pinned = isNearBottom(el);
+    pinnedRef.current = pinned;
+    setShowScrollToLatest((prev) => (prev === !pinned ? prev : !pinned));
+  }, []);
+
+  const scrollToLatest = useCallback(() => {
+    pinnedRef.current = true;
+    pinToBottom();
+    setShowScrollToLatest(false);
+  }, [pinToBottom]);
+
+  // Re-pin (or surface the affordance) whenever the content identity changes.
+  // useLayoutEffect so the pin lands before paint and there's no visible jump.
+  useLayoutEffect(() => {
+    if (pinnedRef.current) pinToBottom();
+    else reclassify();
+  }, [contentKey, pinToBottom, reclassify]);
+
+  // Track user scroll so a manual scroll-up disengages the pin and shows the
+  // "Go to newest" pill; scrolling back down re-engages it.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", reclassify, { passive: true });
+    return () => el.removeEventListener("scroll", reclassify);
+  }, [reclassify]);
+
+  return { scrollRef, showScrollToLatest, scrollToLatest };
+}


### PR DESCRIPTION
## Summary
- AcpRunChatView: conversation from useAcpRunChatBlocks, header with AcpUsageMeter, steer composer, terminal block, and a local-state nested FileDiffView opened from tool-card file chips.

Part of plan: acp-chat-detail-view.md (PR 7 of 11)