### PR TITLE
fix(acp): preserve tool-call locations through history rehydration

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -180,6 +180,10 @@ describe("AcpSessionManager — terminal persistence", () => {
       toolTitle: "Read file",
       toolKind: "read",
       toolStatus: "running",
+      locations: [
+        { path: "/repo/src/main.ts", line: 7 },
+        { path: "/repo/README.md" },
+      ],
     });
     handles.emitUpdate({
       type: "acp_session_update",
@@ -217,6 +221,12 @@ describe("AcpSessionManager — terminal persistence", () => {
       updateType: "tool_call",
       toolCallId: "tc-1",
     });
+    // locations[] survives persistence so the route round-trips it for
+    // history rehydration (the live SSE path already forwards it).
+    expect(log[1]!.locations).toEqual([
+      { path: "/repo/src/main.ts", line: 7 },
+      { path: "/repo/README.md" },
+    ]);
     expect(log[2]).toMatchObject({
       updateType: "tool_call_update",
       toolCallId: "tc-1",
@@ -429,7 +439,9 @@ describe("AcpSessionManager — terminal persistence", () => {
 
     // Capture the usage event emitted at turn end.
     const captureSend = (
-      handles.manager as unknown as { sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }> }
+      handles.manager as unknown as {
+        sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }>;
+      }
     ).sessions.get(id);
     const originalSend = captureSend!.sendToVellum;
     captureSend!.sendToVellum = (msg: ServerMessage) => {
@@ -474,7 +486,9 @@ describe("AcpSessionManager — terminal persistence", () => {
     });
 
     const entry = (
-      handles.manager as unknown as { sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }> }
+      handles.manager as unknown as {
+        sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }>;
+      }
     ).sessions.get(id);
     const originalSend = entry!.sendToVellum;
     entry!.sendToVellum = (msg: ServerMessage) => {

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
@@ -148,6 +148,36 @@ describe("rehydration — terminal session", () => {
     expect(getState().byToolUseId.get("tool-1")).toBe("acp-1");
   });
 
+  test("carries tool-call locations onto the rehydrated event", async () => {
+    await seed([
+      {
+        id: "acp-1",
+        acpSessionId: "proto-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "completed",
+        startedAt: 1000,
+        completedAt: 5000,
+        eventLog: [
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "t-1",
+            toolTitle: "Edit",
+            locations: [{ path: "/src/a.ts", line: 12 }, { path: "/src/b.ts" }],
+            seq: 4,
+          },
+        ],
+      },
+    ]);
+
+    const event = getState().byId["acp-1"]!.events[0]!;
+    expect(event.locations).toEqual([
+      { path: "/src/a.ts", line: 12 },
+      { path: "/src/b.ts" },
+    ]);
+  });
+
   test("carries cumulative input/output tokens from the session row", async () => {
     await seed([
       {
@@ -204,8 +234,16 @@ describe("rehydration — terminal session", () => {
         status: "completed",
         startedAt: 1000,
         eventLog: [
-          { type: "acp_session_update", updateType: "tool_call", toolCallId: "t-0" },
-          { type: "acp_session_update", updateType: "tool_call", toolCallId: "t-1" },
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "t-0",
+          },
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "t-1",
+          },
         ],
       },
     ]);
@@ -322,9 +360,24 @@ describe("rehydration — active session + live stream dedup", () => {
         status: "running",
         startedAt: 1000,
         eventLog: [
-          { type: "acp_session_update", updateType: "tool_call", toolCallId: "h-1", seq: 1 },
-          { type: "acp_session_update", updateType: "tool_call", toolCallId: "h-2", seq: 2 },
-          { type: "acp_session_update", updateType: "tool_call", toolCallId: "h-3", seq: 3 },
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "h-1",
+            seq: 1,
+          },
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "h-2",
+            seq: 2,
+          },
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "h-3",
+            seq: 3,
+          },
         ],
       },
     ]);
@@ -384,8 +437,20 @@ describe("rehydration — active session + live stream dedup", () => {
         status: "running",
         startedAt: 1000,
         eventLog: [
-          { type: "acp_session_update", updateType: "agent_message_chunk", content: "a", messageId: "m-1", seq: 1 },
-          { type: "acp_session_update", updateType: "agent_message_chunk", content: "b", messageId: "m-1", seq: 2 },
+          {
+            type: "acp_session_update",
+            updateType: "agent_message_chunk",
+            content: "a",
+            messageId: "m-1",
+            seq: 1,
+          },
+          {
+            type: "acp_session_update",
+            updateType: "agent_message_chunk",
+            content: "b",
+            messageId: "m-1",
+            seq: 2,
+          },
         ],
       },
     ]);

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -17,7 +17,11 @@ import { useEffect } from "react";
 
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import { captureError } from "@/lib/sentry/capture-error";
-import { useAcpRunStore, type AcpRunEntry, type AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+import {
+  useAcpRunStore,
+  type AcpRunEntry,
+  type AcpRunRawEvent,
+} from "@/domains/chat/acp-run-store";
 import { type AcpRunStatus } from "@/utils/acp-run-status";
 
 interface AcpSessionEventLogItem {
@@ -27,6 +31,7 @@ interface AcpSessionEventLogItem {
   toolTitle?: string;
   toolKind?: string;
   toolStatus?: string;
+  locations?: { path: string; line?: number }[];
   messageId?: string;
   seq?: number;
 }
@@ -66,11 +71,16 @@ type AcpSessionsResponses = {
   200: AcpSessionsResponse;
 };
 
-const TERMINAL_STATUSES = new Set<AcpRunStatus>(["completed", "failed", "cancelled"]);
+const TERMINAL_STATUSES = new Set<AcpRunStatus>([
+  "completed",
+  "failed",
+  "cancelled",
+]);
 
 /** Map a daemon session status string onto an {@link AcpRunStatus}. */
 function toRunStatus(status: string): AcpRunStatus {
-  if (TERMINAL_STATUSES.has(status as AcpRunStatus)) return status as AcpRunStatus;
+  if (TERMINAL_STATUSES.has(status as AcpRunStatus))
+    return status as AcpRunStatus;
   return status === "initializing" ? "initializing" : "running";
 }
 
@@ -91,6 +101,7 @@ function toRawEvents(eventLog: AcpSessionEventLogItem[]): AcpRunRawEvent[] {
       toolTitle: item.toolTitle,
       toolKind: item.toolKind,
       toolStatus: item.toolStatus,
+      locations: item.locations,
       messageId: item.messageId,
     });
   }
@@ -108,10 +119,10 @@ function toRunEntry(row: AcpSessionRow): AcpRunEntry {
     parentConversationId: row.parentConversationId ?? "",
     task: row.task,
     status,
-    stopReason: isTerminal ? row.stopReason ?? undefined : undefined,
-    error: isTerminal ? row.error ?? undefined : undefined,
+    stopReason: isTerminal ? (row.stopReason ?? undefined) : undefined,
+    error: isTerminal ? (row.error ?? undefined) : undefined,
     startedAt: row.startedAt ?? Date.now(),
-    completedAt: isTerminal ? row.completedAt ?? undefined : undefined,
+    completedAt: isTerminal ? (row.completedAt ?? undefined) : undefined,
     parentToolUseId: row.parentToolUseId,
     usedTokens: row.usedTokens ?? 0,
     contextSize: row.contextSize ?? 0,


### PR DESCRIPTION
## Summary
- Carry tool-call `locations` through /acp/sessions history + web toRawEvents so locations-derived file chips survive a page reload.
- Additive/optional; mirrors the live-path plumbing.

Part of plan: acp-chat-detail-view.md (follow-up: locations rehydration)