### PR TITLE
feat(web): render acp chat view behind acp-chat-view flag

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.test.tsx
@@ -45,6 +45,9 @@ const { AcpRunDetailPanel } = await import(
   "@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel"
 );
 const { useAcpRunStore } = await import("@/domains/chat/acp-run-store");
+const { useAssistantFeatureFlagStore } = await import(
+  "@/stores/assistant-feature-flag-store"
+);
 import type {
   AcpRunEntry,
   AcpRunRawEvent,
@@ -89,6 +92,7 @@ const TOOL_CALL_EVENT: AcpRunRawEvent = {
 afterEach(() => {
   cleanup();
   useAcpRunStore.getState().reset();
+  useAssistantFeatureFlagStore.setState({ acpChatView: false });
   stopCalls.length = 0;
   steerCalls.length = 0;
   nextSteerResponse = { acpSessionId: "acp-1", steered: true };
@@ -506,5 +510,33 @@ describe("AcpRunDetailPanel — stop / steer / error", () => {
       />,
     );
     expect(screen.getByText("agent crashed")).toBeDefined();
+  });
+});
+
+describe("AcpRunDetailPanel — acp-chat-view flag swap", () => {
+  test("flag ON renders the chat view, not the timeline", () => {
+    const entry = makeEntry();
+    seedStore(entry);
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ acpChatView: true });
+    });
+
+    render(<AcpRunDetailPanel entry={entry} onClose={noop} />);
+
+    expect(screen.getByTestId("acp-chat-conversation")).toBeDefined();
+    expect(screen.queryByText("Timeline")).toBeNull();
+  });
+
+  test("flag OFF renders the timeline, not the chat view", () => {
+    const entry = makeEntry();
+    seedStore(entry);
+    act(() => {
+      useAssistantFeatureFlagStore.setState({ acpChatView: false });
+    });
+
+    render(<AcpRunDetailPanel entry={entry} onClose={noop} />);
+
+    expect(screen.getByText("Timeline")).toBeDefined();
+    expect(screen.queryByTestId("acp-chat-conversation")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.tsx
@@ -42,6 +42,7 @@ import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-mes
 import { MetricCard } from "@/domains/chat/components/metric-card";
 import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
 import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
+import { AcpRunChatView } from "@/domains/chat/components/acp-run-chat-view/acp-run-chat-view";
 import { AcpRunPhaseTimeline } from "@/domains/chat/components/acp-run-detail-panel/acp-run-phase-timeline";
 import {
   useAcpRunSteps,
@@ -58,6 +59,7 @@ import {
   isActiveAcpStatus,
 } from "@/utils/acp-run-status";
 import { captureError } from "@/lib/sentry/capture-error";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -223,7 +225,24 @@ export interface AcpRunDetailPanelProps {
 // Main component
 // ---------------------------------------------------------------------------
 
+/**
+ * Flag-gated entry point: with `acp-chat-view` on, the run renders as the
+ * Devin-style chat conversation; off, it renders the event timeline below. A
+ * single top-level branch keeps the swap fully reversible — flip the flag (or
+ * revert this wiring) to restore the timeline UI verbatim.
+ */
 export function AcpRunDetailPanel({
+  entry,
+  onClose,
+}: AcpRunDetailPanelProps) {
+  const chatView = useAssistantFeatureFlagStore.use.acpChatView();
+  if (chatView) {
+    return <AcpRunChatView entry={entry} onClose={onClose} />;
+  }
+  return <AcpRunTimelinePanel entry={entry} onClose={onClose} />;
+}
+
+function AcpRunTimelinePanel({
   entry,
   onClose,
 }: AcpRunDetailPanelProps) {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -244,7 +244,7 @@
     },
     {
       "id": "acp-chat-view",
-      "scope": "client",
+      "scope": "assistant",
       "key": "acp-chat-view",
       "label": "ACP Chat View",
       "description": "Render the ACP run detail panel as a chat-style conversation (agent messages, thinking, tool/code, plan, and a clickable file-diff view) instead of the event timeline.",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -244,7 +244,7 @@
     },
     {
       "id": "acp-chat-view",
-      "scope": "client",
+      "scope": "assistant",
       "key": "acp-chat-view",
       "label": "ACP Chat View",
       "description": "Render the ACP run detail panel as a chat-style conversation (agent messages, thinking, tool/code, plan, and a clickable file-diff view) instead of the event timeline.",


### PR DESCRIPTION
## Summary
- Flag-gate the detail panel: acp-chat-view ON renders AcpRunChatView, OFF renders the untouched timeline.
- Single reversible branch — revert this PR or flip the flag to restore today's UI.

Part of plan: acp-chat-detail-view.md (PR 8 of 11)