### PR TITLE
feat(design-library): add Stepper primitive for FormSurface step navigation

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
@@ -1,3 +1,5 @@
+import { Stepper } from "@vellumai/design-library";
+
 import type { FormPage } from "@/domains/chat/components/surfaces/form-surface";
 
 interface PageTabsProps {
@@ -8,13 +10,10 @@ interface PageTabsProps {
 }
 
 /**
- * Labeled step navigation for a multi-page form. A gated, ordered wizard is a
- * step pattern rather than a tabs/tabpanel widget, so the current step is
- * marked with `aria-current="step"`: completed steps are buttons that navigate
- * back, future steps are disabled, and forward navigation goes through the Next
- * button. While the form is submitting, navigation is disabled so the visible
- * step can't drift from the already-submitted values. The visual style matches
- * the design system's underline tabs.
+ * Labeled step navigation for a multi-page form, built on the design library
+ * `Stepper` primitive. Steps are numbered from their page title; completed
+ * steps navigate back, and future steps (plus any step while the form is
+ * submitting) are disabled.
  */
 export function PageTabs({
   current,
@@ -22,35 +21,19 @@ export function PageTabs({
   onNavigate,
   disabled = false,
 }: PageTabsProps) {
+  const steps = pages.map((page, i) => ({
+    id: page.id,
+    label: `${i + 1}. ${page.title}`,
+    disabled: disabled || i > current,
+  }));
+
   return (
-    <nav
+    <Stepper
       aria-label="Form steps"
-      className="mb-4 flex items-center gap-4 overflow-x-auto border-b border-[var(--border-subtle)]"
-    >
-      {pages.map((page, i) => {
-        const isActive = i === current;
-        const isCompleted = i < current;
-        const canNavigate = isCompleted && !disabled;
-        const textClass = isActive
-          ? "text-[var(--content-strong)]"
-          : isCompleted
-            ? "text-[var(--content-default)]"
-            : "text-[var(--content-faint)]";
-        return (
-          <button
-            key={page.id}
-            type="button"
-            onClick={canNavigate ? () => onNavigate(i) : undefined}
-            disabled={!canNavigate}
-            aria-current={isActive ? "step" : undefined}
-            className={`-mb-px whitespace-nowrap border-b-2 pb-2 text-body-medium-default transition-colors ${
-              isActive ? "border-[var(--primary-base)]" : "border-transparent"
-            } ${textClass} ${canNavigate ? "cursor-pointer" : "cursor-default"}`}
-          >
-            {i + 1}. {page.title}
-          </button>
-        );
-      })}
-    </nav>
+      steps={steps}
+      current={current}
+      onStepSelect={onNavigate}
+      className="mb-4"
+    />
   );
 }

--- a/packages/design-library/src/components/stepper.stories.tsx
+++ b/packages/design-library/src/components/stepper.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { Stepper } from "./stepper";
+
+const meta: Meta<typeof Stepper> = {
+  title: "Components/Stepper",
+  component: Stepper,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Stepper>;
+
+const STEPS = [
+  { id: "create", label: "1. Create App" },
+  { id: "token", label: "2. Generate App Token" },
+  { id: "install", label: "3. Install App" },
+];
+
+// Gated wizard: the active step is underlined, completed steps navigate back,
+// and future steps are disabled.
+function GatedStepper() {
+  const [current, setCurrent] = useState(1);
+  return (
+    <Stepper
+      aria-label="Setup steps"
+      steps={STEPS.map((step, i) => ({ ...step, disabled: i > current }))}
+      current={current}
+      onStepSelect={setCurrent}
+    />
+  );
+}
+
+export const Gated: Story = {
+  render: () => <GatedStepper />,
+};
+
+export const FirstStep: Story = {
+  args: {
+    "aria-label": "Setup steps",
+    steps: STEPS.map((step, i) => ({ ...step, disabled: i > 0 })),
+    current: 0,
+    onStepSelect: () => {},
+  },
+};

--- a/packages/design-library/src/components/stepper.tsx
+++ b/packages/design-library/src/components/stepper.tsx
@@ -1,0 +1,75 @@
+import { type ComponentProps } from "react";
+
+import { cn } from "../utils/cn";
+
+export interface StepperStep {
+  id: string;
+  label: string;
+  /** Mark the step as not navigable (e.g. a future step in a gated wizard). */
+  disabled?: boolean;
+}
+
+export type StepperProps = ComponentProps<"nav"> & {
+  steps: StepperStep[];
+  /** Index of the active step. */
+  current: number;
+  /**
+   * Called with the step index when a navigable step (not active, not
+   * disabled) is selected. Omit to render the steps as non-interactive.
+   */
+  onStepSelect?: (index: number) => void;
+};
+
+/**
+ * Labeled step navigation for a sequential, gated flow such as a multi-page
+ * form wizard. The active step is marked with `aria-current="step"`, navigable
+ * steps are buttons that call `onStepSelect`, and disabled steps are inert.
+ * This is the step pattern — distinct from `Tabs`, which models parallel,
+ * independently selectable panels.
+ */
+export function Stepper({
+  steps,
+  current,
+  onStepSelect,
+  className,
+  ...rest
+}: StepperProps) {
+  return (
+    <nav
+      data-slot="stepper"
+      className={cn(
+        "flex items-center gap-4 overflow-x-auto border-b border-[var(--border-base)]",
+        className,
+      )}
+      {...rest}
+    >
+      {steps.map((step, index) => {
+        const isActive = index === current;
+        const navigable = !isActive && !step.disabled && !!onStepSelect;
+        return (
+          <button
+            key={step.id}
+            type="button"
+            data-slot="stepper-step"
+            disabled={!navigable}
+            aria-current={isActive ? "step" : undefined}
+            onClick={navigable ? () => onStepSelect?.(index) : undefined}
+            className={cn(
+              "-mb-px inline-flex items-center whitespace-nowrap border-b-2 border-transparent pb-2 text-body-medium-default outline-none transition-colors",
+              "keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
+              isActive &&
+                "border-[var(--primary-base)] text-[var(--content-strong)]",
+              navigable &&
+                "cursor-pointer text-[var(--content-default)] hover:text-[var(--content-strong)]",
+              !isActive &&
+                !navigable &&
+                "cursor-default text-[var(--content-disabled)]",
+            )}
+          >
+            {step.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -88,6 +88,11 @@ export {
   type SegmentControlProps,
 } from "./components/segment-control";
 export {
+  Stepper,
+  type StepperStep,
+  type StepperProps,
+} from "./components/stepper";
+export {
   Slider,
   isRangeValue,
   toValueArray,


### PR DESCRIPTION
## What

Follow-up to #36182 (LUM-2608) addressing review feedback on the FormSurface step control.

Adds a **`Stepper` primitive** to `@vellumai/design-library` and rebuilds `FormSurface`'s `PageTabs` on top of it, replacing the hand-rolled native-`button` step strip that #36182 merged.

## Why

Codex flagged (P2) that the step strip hand-rolled native buttons instead of using a design-library primitive — duplicating the shared focus/disabled styling and missing the common keyboard-focus treatment (`clients/web/AGENTS.md`: start UI controls from the design library). A gated, sequential wizard isn't a `Tabs`/tabpanel widget, so the right fix is a dedicated step primitive in the library.

## Changes

- **`packages/design-library/src/components/stepper.tsx`** (new) — `Stepper`: a `nav` of `aria-current="step"` step buttons with three states — **active** (underline + `--content-strong`), **navigable** (`--content-default`, `cursor-pointer`, `hover:--content-strong`, keyboard-focus ring), and **disabled** (`--content-disabled`). Generic API (`steps`, `current`, `onStepSelect`); the consumer marks future/locked steps `disabled`.
- **`packages/design-library/src/index.ts`** — export `Stepper` + types.
- **`packages/design-library/src/components/stepper.stories.tsx`** (new) — story covering the gated-wizard states.
- **`clients/web/.../page-tabs.tsx`** — now a thin adapter that maps form pages → `Stepper` steps (numbered labels; future steps and in-flight submits disabled).

This resolves the review feedback in one place: the hover + keyboard-focus gap and the `--content-faint` → `--content-disabled` token question are both handled by the primitive's baked-in styling.

## Testing

- `packages/design-library` `tsc --noEmit` + `build-storybook` (new Stepper story) — pass
- `clients/web` `tsc --noEmit` + lint + `build-storybook` — pass

Part of LUM-2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wuqoKsrCJ336NLvvNPMvv)_