### PR TITLE
combo11: derive guardian role/name from the gateway, stop reading contacts.role locally

### DIFF
--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -211,11 +211,16 @@ describe("handleListContacts relay", () => {
     expect(ch.externalUserId).toBe(ch.address);
   });
 
-  test("applies guardian display-name override to relayed contacts in the gateway guardian id set", async () => {
-    guardianIds = new Set(["gw-1"]);
+  test("trusts the gateway-relayed guardian role + applies the name override regardless of the id-set cache", async () => {
+    // Relayed read carries role "guardian" from the gateway. The guardian id
+    // set is empty/stale (rebind race) but must NOT downgrade the role; the
+    // name override keys off the relayed role.
+    guardianIds = new Set();
     ipcStub = () => ({
       ok: true,
-      contacts: [gatewayContact({ displayName: "Real Name" })],
+      contacts: [
+        gatewayContact({ role: "guardian", displayName: "Real Name" }),
+      ],
     });
 
     const result = await handleListContacts({});
@@ -353,11 +358,12 @@ describe("handleGetContact relay", () => {
     expect(contact.updatedAt).toBe(1700000000);
   });
 
-  test("applies guardian display-name override when the contact is in the gateway guardian id set", async () => {
-    guardianIds = new Set(["gw-1"]);
+  test("trusts the gateway-relayed guardian role + applies the name override regardless of the id-set cache", async () => {
+    // Empty/stale guardian id set must not downgrade a relayed guardian.
+    guardianIds = new Set();
     ipcStub = () => ({
       ok: true,
-      contact: gatewayContact({ displayName: "Real Name" }),
+      contact: gatewayContact({ role: "guardian", displayName: "Real Name" }),
     });
 
     const result = await handleGetContact("gw-1");

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -37,6 +37,13 @@ mock.module("../prompts/user-reference.js", () => ({
   resolveGuardianName: () => "Your Guardian",
 }));
 
+// Role + the guardian name override derive from the gateway guardian id set.
+// Drive it deterministically per test.
+let guardianIds = new Set<string>();
+mock.module("../contacts/guardian-contact-reader.js", () => ({
+  getGuardianContactIds: async () => guardianIds,
+}));
+
 // IPC relay stub — each test sets the response/behavior.
 type IpcStub = (method: string, params?: Record<string, unknown>) => unknown;
 let ipcStub: IpcStub = () => undefined;
@@ -179,6 +186,7 @@ beforeEach(() => {
   localCalls.length = 0;
   debugLogs.length = 0;
   listContactsArgs.length = 0;
+  guardianIds = new Set();
 });
 
 describe("handleListContacts relay", () => {
@@ -203,13 +211,15 @@ describe("handleListContacts relay", () => {
     expect(ch.externalUserId).toBe(ch.address);
   });
 
-  test("applies guardian display-name override to relayed contacts", async () => {
+  test("applies guardian display-name override to relayed contacts in the gateway guardian id set", async () => {
+    guardianIds = new Set(["gw-1"]);
     ipcStub = () => ({
       ok: true,
-      contacts: [gatewayContact({ role: "guardian", displayName: "Real Name" })],
+      contacts: [gatewayContact({ displayName: "Real Name" })],
     });
 
     const result = await handleListContacts({});
+    expect(result.contacts[0].role).toBe("guardian");
     expect(result.contacts[0].displayName).toBe("Your Guardian");
   });
 
@@ -343,13 +353,15 @@ describe("handleGetContact relay", () => {
     expect(contact.updatedAt).toBe(1700000000);
   });
 
-  test("applies guardian display-name override", async () => {
+  test("applies guardian display-name override when the contact is in the gateway guardian id set", async () => {
+    guardianIds = new Set(["gw-1"]);
     ipcStub = () => ({
       ok: true,
-      contact: gatewayContact({ role: "guardian", displayName: "Real Name" }),
+      contact: gatewayContact({ displayName: "Real Name" }),
     });
 
     const result = await handleGetContact("gw-1");
+    expect(result.contact.role).toBe("guardian");
     expect(result.contact.displayName).toBe("Your Guardian");
   });
 

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -96,7 +96,9 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     id: row.id,
     displayName: row.displayName,
     notes: row.notes,
-    role: row.role,
+    // Role is gateway-owned: the serve layer stamps the real role from the
+    // gateway guardian id set. This neutral default is never authoritative.
+    role: "contact",
     lastInteraction: null,
     interactionCount: 0,
     createdAt: row.createdAt,

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -4,11 +4,13 @@
  * `handleListContacts`, `handleGetContact`, and the `search_contacts`
  * no-filter case relay to the gateway rich read (`contacts_list_rich` /
  * `contacts_get_rich`), which is the source of truth for the ACL fields
- * (`role`/`status`/`policy`/`verifiedAt`/`interactionCount`/`lastInteraction`).
- * These tests assert the serialized response shape is gateway-sourced and
- * unchanged for the web client, that no read path falls back to the assistant
- * DB, and that a relay failure fails closed (surfaces an error) instead of
- * reading local ACL.
+ * (`status`/`policy`/`verifiedAt`/`interactionCount`/`lastInteraction`).
+ * Contact-level `role` is derived at the serve layer from the gateway guardian
+ * id set (never the local `contacts.role` column). These tests assert the
+ * serialized response shape is gateway-sourced and unchanged for the web
+ * client, that no read path falls back to the assistant DB, that role + the
+ * guardian name override derive from the gateway guardian id set, and that a
+ * relay failure fails closed (surfaces an error) instead of reading local ACL.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -58,12 +60,29 @@ mock.module("../../../contacts/contact-store.js", () => ({
   searchContacts: searchContactsMock,
 }));
 
+// Role + the guardian name override derive from the gateway guardian id set,
+// never the local `contacts.role` column. Drive the set deterministically.
+let guardianIds = new Set<string>();
+const getGuardianContactIdsMock = mock(async () => guardianIds);
+
+mock.module("../../../contacts/guardian-contact-reader.js", () => ({
+  getGuardianContactIds: getGuardianContactIdsMock,
+}));
+
+// Make the guardian display-name override observable without a persona file.
+const actualUserReference = await import("../../../prompts/user-reference.js");
+mock.module("../../../prompts/user-reference.js", () => ({
+  ...actualUserReference,
+  resolveGuardianName: (name?: string | null) => `guardian:${name}`,
+}));
+
 const { handleListContacts, handleGetContact, ROUTES } =
   await import("../contact-routes.js");
 
 // Daemon-native contact: INFO is hydrated locally; channel-level ACL fields
 // (status/policy/verification) are gateway-owned and absent on native reads.
-// Contact-level `role` is stored locally (NOT NULL) and always returned.
+// The fixture's `role` is ignored — the serve layer derives role from the
+// gateway guardian id set.
 const nativeContact = {
   id: "ct_2",
   displayName: "Bob",
@@ -133,9 +152,11 @@ describe("contacts read API relays from the gateway", () => {
     contactStoreReadGuard.mockClear();
     searchContactsResult = [];
     searchContactsMock.mockClear();
+    guardianIds = new Set(["ct_1"]);
+    getGuardianContactIdsMock.mockClear();
   });
 
-  test("list relays to contacts_list_rich and serializes the gateway ACL fields", async () => {
+  test("list relays to contacts_list_rich and derives the guardian role from the gateway id set", async () => {
     ipcResult = { ok: true, contacts: [gatewayContact] };
 
     const result = await handleListContacts({ limit: "50" });
@@ -147,8 +168,10 @@ describe("contacts read API relays from the gateway", () => {
     expect(result.contacts).toHaveLength(1);
 
     const [contact] = result.contacts;
-    // ACL fields are gateway-sourced and reach the web client unchanged.
+    // Role + name override derive from the gateway guardian id set.
     expect((contact as { role?: string }).role).toBe("guardian");
+    expect(contact.displayName).toBe("guardian:Alice");
+    expect(getGuardianContactIdsMock).toHaveBeenCalled();
     expect(contact.interactionCount).toBe(7);
     expect(contact.lastInteraction).toBe(1900);
     const channel = contact.channels[0] as Record<string, unknown>;
@@ -200,6 +223,7 @@ describe("contacts read API relays from the gateway", () => {
     ]);
     expect(result.ok).toBe(true);
     expect(result.contact.role).toBe("guardian");
+    expect(result.contact.displayName).toBe("guardian:Alice");
     expect(result.contact.interactionCount).toBe(7);
     const channel = result.contact.channels[0] as Record<string, unknown>;
     expect(channel.status).toBe("active");
@@ -265,6 +289,8 @@ describe("filtered/native contact reads stay daemon-native", () => {
     contactStoreReadGuard.mockClear();
     searchContactsResult = [];
     searchContactsMock.mockClear();
+    guardianIds = new Set();
+    getGuardianContactIdsMock.mockClear();
   });
 
   test("query-filtered list serves daemon-native INFO and validates against the response schema", async () => {
@@ -284,11 +310,36 @@ describe("filtered/native contact reads stay daemon-native", () => {
     expect(channel.interactionCount).toBe(4);
     expect(channel.lastSeenAt).toBe(4100);
     expect(channel.externalUserId).toBe("+15550200");
-    // Contact-level `role` is locally stored (NOT NULL) and always present.
+    // Non-guardian id derives role "contact" (no name override).
     expect((contact as { role: string }).role).toBe("contact");
+    expect(contact.displayName).toBe("Bob");
     // Channel-level ACL fields (status/policy) are gateway-owned and absent.
     expect("status" in channel).toBe(false);
     expect(() => listResponseSchema.parse(result)).not.toThrow();
+  });
+
+  test("daemon-native search stamps role guardian + the name override from the gateway id set", async () => {
+    searchContactsResult = [nativeContact];
+    guardianIds = new Set(["ct_2"]);
+
+    const result = await handleListContacts({ query: "Bob", limit: "10" });
+
+    expect(searchContactsMock).toHaveBeenCalled();
+    const [contact] = result.contacts;
+    expect((contact as { role: string }).role).toBe("guardian");
+    expect(contact.displayName).toBe("guardian:Bob");
+    expect(getGuardianContactIdsMock).toHaveBeenCalled();
+  });
+
+  test("fail-soft: an empty guardian id set yields role contact with no override", async () => {
+    searchContactsResult = [nativeContact];
+    guardianIds = new Set();
+
+    const result = await handleListContacts({ query: "Bob", limit: "10" });
+
+    const [contact] = result.contacts;
+    expect((contact as { role: string }).role).toBe("contact");
+    expect(contact.displayName).toBe("Bob");
   });
 
   test("POST search with a filter validates against the response schema", async () => {

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -156,7 +156,7 @@ describe("contacts read API relays from the gateway", () => {
     getGuardianContactIdsMock.mockClear();
   });
 
-  test("list relays to contacts_list_rich and derives the guardian role from the gateway id set", async () => {
+  test("list relays to contacts_list_rich and trusts the gateway-sourced role", async () => {
     ipcResult = { ok: true, contacts: [gatewayContact] };
 
     const result = await handleListContacts({ limit: "50" });
@@ -168,10 +168,11 @@ describe("contacts read API relays from the gateway", () => {
     expect(result.contacts).toHaveLength(1);
 
     const [contact] = result.contacts;
-    // Role + name override derive from the gateway guardian id set.
+    // Role comes straight from the relayed payload; the name override keys off
+    // that role. The guardian id set is NOT consulted on relayed reads.
     expect((contact as { role?: string }).role).toBe("guardian");
     expect(contact.displayName).toBe("guardian:Alice");
-    expect(getGuardianContactIdsMock).toHaveBeenCalled();
+    expect(getGuardianContactIdsMock).not.toHaveBeenCalled();
     expect(contact.interactionCount).toBe(7);
     expect(contact.lastInteraction).toBe(1900);
     const channel = contact.channels[0] as Record<string, unknown>;
@@ -183,6 +184,35 @@ describe("contacts read API relays from the gateway", () => {
     // Channel compat echoes address into externalUserId for older clients.
     expect(channel.externalUserId).toBe("+15550100");
 
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed list trusts the gateway role even when the guardian id set is empty/stale", async () => {
+    // Reproduces the rebind race: the gateway already returned role "guardian",
+    // but the 30s guardian-id cache is empty (or fail-softed). The relayed role
+    // must NOT be downgraded to "contact", and the name override must still run.
+    ipcResult = { ok: true, contacts: [gatewayContact] };
+    guardianIds = new Set();
+
+    const result = await handleListContacts({ limit: "50" });
+
+    const [contact] = result.contacts;
+    expect((contact as { role?: string }).role).toBe("guardian");
+    expect(contact.displayName).toBe("guardian:Alice");
+    // Relayed reads don't consult the guardian id set (they trust the role).
+    expect(getGuardianContactIdsMock).not.toHaveBeenCalled();
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed get trusts the gateway role even when the guardian id set is empty/stale", async () => {
+    ipcResult = { ok: true, contact: gatewayContact };
+    guardianIds = new Set();
+
+    const result = await handleGetContact("ct_1");
+
+    expect(result.contact.role).toBe("guardian");
+    expect(result.contact.displayName).toBe("guardian:Alice");
+    expect(getGuardianContactIdsMock).not.toHaveBeenCalled();
     expect(contactStoreReadGuard).not.toHaveBeenCalled();
   });
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -37,6 +37,9 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("contact-routes");
 
+/** Sentinel for relayed-read calls that trust the gateway role (no derivation). */
+const EMPTY_GUARDIAN_IDS: ReadonlySet<string> = new Set<string>();
+
 /**
  * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
  * adapters honor its statusCode/errorCode (4xx surfaces as 4xx, not a generic
@@ -67,13 +70,18 @@ function withGuardianNameOverride<
 }
 
 /**
- * Stamp `role` from the gateway guardian id set (source of truth). Every
- * serve path derives the role here rather than from the local `contacts.role`
- * column; fail-soft (empty set → everyone is `"contact"`).
+ * Stamp `role` from the gateway guardian id set on DAEMON-NATIVE reads, whose
+ * `role` is the neutral `"contact"` default (search / contactType-filtered).
+ * Fail-soft: empty set → everyone is `"contact"`.
+ *
+ * NOT applied to gateway-relayed reads (`contacts_list_rich`/`_get_rich`),
+ * which already carry a gateway-sourced `role`. Re-deriving there would let a
+ * stale/empty 30s id-set cache DOWNGRADE a freshly-rebound guardian to
+ * `"contact"` during a rebind.
  */
 function withGatewayRole<T extends { id: string; role: string }>(
   contact: T,
-  guardianIds: Set<string>,
+  guardianIds: ReadonlySet<string>,
 ): T {
   return {
     ...contact,
@@ -94,12 +102,18 @@ function withChannelCompat<T extends { channels: { address: string }[] }>(
   };
 }
 
-/** Compose the response transforms: derive role from the gateway guardian id
- * set, apply the guardian display-name override from that derived role, and add
- * the channel compat field. Also coerces nullable gateway-sourced fields to
- * their DB defaults so the response satisfies the strict enum schema even in
- * degraded mode (assistant DB unreachable → gateway soft-fail join produces
- * nulls).
+/** Compose the response transforms, then apply the guardian display-name
+ * override (keyed off the role that's correct for this path) and the channel
+ * compat field. Also coerces nullable gateway-sourced fields to their DB
+ * defaults so the response satisfies the strict enum schema even in degraded
+ * mode (assistant DB unreachable → gateway soft-fail join produces nulls).
+ *
+ * `deriveRole` controls where `role` comes from:
+ *   - `true`  (daemon-native reads): role is the neutral `"contact"` default,
+ *     so derive it from the gateway guardian id set.
+ *   - `false` (gateway-relayed reads): TRUST the gateway-sourced `role` already
+ *     on the `ContactRead`. Never re-derive — a stale/empty id-set cache must
+ *     not downgrade a relayed guardian to `"contact"`.
  */
 function prepareContactResponse<
   T extends {
@@ -109,12 +123,14 @@ function prepareContactResponse<
     contactType?: string | null;
     channels: { address: string }[];
   },
->(contact: T, guardianIds: Set<string>): T {
+>(contact: T, guardianIds: ReadonlySet<string>, deriveRole: boolean): T {
   const coerced =
     contact.contactType == null
       ? { ...contact, contactType: "human" as T["contactType"] }
       : contact;
-  const withRole = withGatewayRole(coerced, guardianIds);
+  const withRole = deriveRole
+    ? withGatewayRole(coerced, guardianIds)
+    : coerced;
   return withChannelCompat(withGuardianNameOverride(withRole));
 }
 
@@ -132,8 +148,9 @@ function isContactType(value: string): value is ContactType {
 // blockedReason) are gateway-owned and present ONLY on gateway-relayed reads
 // (`contacts_list_rich`/`contacts_get_rich`). Daemon-native filtered reads
 // (search / contactType) omit them, so they are `.optional()`. Contact-level
-// `role` is derived from the gateway guardian id set at the serve layer (see
-// prepareContactResponse) and returned on all paths. INFO telemetry
+// `role` is gateway-sourced: relayed reads trust the role on the `ContactRead`,
+// while daemon-native reads derive it from the gateway guardian id set at the
+// serve layer (see prepareContactResponse). INFO telemetry
 // (lastSeenAt/interactionCount/lastInteraction) is locally hydrated on every
 // read path and stays required.
 const contactChannelSchema = z.object({
@@ -186,10 +203,13 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
       ...(role ? { role } : {}),
     });
     const { contacts } = ListContactsIpcResponseSchema.parse(result);
-    const guardianIds = await getGuardianContactIds();
+    // Relayed reads carry a gateway-sourced role — trust it (deriveRole=false),
+    // so the guardian id set is not consulted here.
     return {
       ok: true,
-      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
+      contacts: contacts.map((c) =>
+        prepareContactResponse(c, EMPTY_GUARDIAN_IDS, false),
+      ),
     };
   } catch (err) {
     rethrowGatewayError(err);
@@ -226,10 +246,13 @@ export async function handleListContacts(queryParams: Record<string, string>) {
       contactType,
       limit,
     });
+    // Daemon-native read: role is the neutral default, so derive it.
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
+      contacts: contacts.map((c) =>
+        prepareContactResponse(c, guardianIds, true),
+      ),
     };
   }
 
@@ -242,10 +265,13 @@ export async function handleListContacts(queryParams: Record<string, string>) {
       "handleListContacts: contactType-filtered read served daemon-native (gateway-native contactType filtering is design-blocked, pending ACL classification)",
     );
     const contacts = listContacts(limit, contactType);
+    // Daemon-native read: role is the neutral default, so derive it.
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
+      contacts: contacts.map((c) =>
+        prepareContactResponse(c, guardianIds, true),
+      ),
     };
   }
 
@@ -261,10 +287,10 @@ export async function handleGetContact(contactId: string) {
     }
     const { contact, assistantMetadata } =
       GetContactIpcResponseSchema.parse(result);
-    const guardianIds = await getGuardianContactIds();
+    // Relayed read: trust the gateway-sourced role (deriveRole=false).
     return {
       ok: true,
-      contact: prepareContactResponse(contact, guardianIds),
+      contact: prepareContactResponse(contact, EMPTY_GUARDIAN_IDS, false),
       assistantMetadata: assistantMetadata ?? undefined,
     };
   } catch (err) {
@@ -689,9 +715,10 @@ export const ROUTES: RouteDefinition[] = [
       log.debug(
         "search_contacts: search served daemon-native (gateway-native search is design-blocked)",
       );
+      // Daemon-native read: role is the neutral default, so derive it.
       const guardianIds = await getGuardianContactIds();
       return searchContacts(parsed).map((c) =>
-        prepareContactResponse(c, guardianIds),
+        prepareContactResponse(c, guardianIds, true),
       );
     },
   },
@@ -788,8 +815,12 @@ async function handleMergeContactsRoute(args: RouteHandlerArgs) {
 
   try {
     const contact = mergeContacts(keepId, mergeId);
+    // Daemon-native read (assistant DB): role is the neutral default, derive it.
     const guardianIds = await getGuardianContactIds();
-    return { ok: true, contact: prepareContactResponse(contact, guardianIds) };
+    return {
+      ok: true,
+      contact: prepareContactResponse(contact, guardianIds, true),
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new BadRequestError(message);

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -21,6 +21,7 @@ import {
   mergeContacts,
   searchContacts,
 } from "../../contacts/contact-store.js";
+import { getGuardianContactIds } from "../../contacts/guardian-contact-reader.js";
 import type { ContactRole, ContactType } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
@@ -65,6 +66,21 @@ function withGuardianNameOverride<
   return contact;
 }
 
+/**
+ * Stamp `role` from the gateway guardian id set (source of truth). Every
+ * serve path derives the role here rather than from the local `contacts.role`
+ * column; fail-soft (empty set → everyone is `"contact"`).
+ */
+function withGatewayRole<T extends { id: string; role: string }>(
+  contact: T,
+  guardianIds: Set<string>,
+): T {
+  return {
+    ...contact,
+    role: guardianIds.has(contact.id) ? "guardian" : "contact",
+  };
+}
+
 /** Adds `externalUserId` (= `address`) to each channel for older macOS clients. */
 function withChannelCompat<T extends { channels: { address: string }[] }>(
   contact: T,
@@ -78,24 +94,28 @@ function withChannelCompat<T extends { channels: { address: string }[] }>(
   };
 }
 
-/** Compose both response transforms (guardian display name + channel compat).
- * Also coerces nullable gateway-sourced fields to their DB defaults so the
- * response satisfies the strict enum schema even in degraded mode (assistant
- * DB unreachable → gateway soft-fail join produces nulls).
+/** Compose the response transforms: derive role from the gateway guardian id
+ * set, apply the guardian display-name override from that derived role, and add
+ * the channel compat field. Also coerces nullable gateway-sourced fields to
+ * their DB defaults so the response satisfies the strict enum schema even in
+ * degraded mode (assistant DB unreachable → gateway soft-fail join produces
+ * nulls).
  */
 function prepareContactResponse<
   T extends {
+    id: string;
     role: string;
     displayName: string;
     contactType?: string | null;
     channels: { address: string }[];
   },
->(contact: T): T {
+>(contact: T, guardianIds: Set<string>): T {
   const coerced =
     contact.contactType == null
       ? { ...contact, contactType: "human" as T["contactType"] }
       : contact;
-  return withChannelCompat(withGuardianNameOverride(coerced));
+  const withRole = withGatewayRole(coerced, guardianIds);
+  return withChannelCompat(withGuardianNameOverride(withRole));
 }
 
 const VALID_CONTACT_TYPES: readonly ContactType[] = ["human", "assistant"];
@@ -112,9 +132,10 @@ function isContactType(value: string): value is ContactType {
 // blockedReason) are gateway-owned and present ONLY on gateway-relayed reads
 // (`contacts_list_rich`/`contacts_get_rich`). Daemon-native filtered reads
 // (search / contactType) omit them, so they are `.optional()`. Contact-level
-// `role` is stored locally (NOT NULL, default "contact") and returned on all
-// paths. INFO telemetry (lastSeenAt/interactionCount/lastInteraction) is
-// locally hydrated on every read path and stays required.
+// `role` is derived from the gateway guardian id set at the serve layer (see
+// prepareContactResponse) and returned on all paths. INFO telemetry
+// (lastSeenAt/interactionCount/lastInteraction) is locally hydrated on every
+// read path and stays required.
 const contactChannelSchema = z.object({
   id: z.string(),
   contactId: z.string(),
@@ -165,9 +186,10 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
       ...(role ? { role } : {}),
     });
     const { contacts } = ListContactsIpcResponseSchema.parse(result);
+    const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map(prepareContactResponse),
+      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
     };
   } catch (err) {
     rethrowGatewayError(err);
@@ -204,9 +226,10 @@ export async function handleListContacts(queryParams: Record<string, string>) {
       contactType,
       limit,
     });
+    const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map(prepareContactResponse),
+      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
     };
   }
 
@@ -219,9 +242,10 @@ export async function handleListContacts(queryParams: Record<string, string>) {
       "handleListContacts: contactType-filtered read served daemon-native (gateway-native contactType filtering is design-blocked, pending ACL classification)",
     );
     const contacts = listContacts(limit, contactType);
+    const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map(prepareContactResponse),
+      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
     };
   }
 
@@ -237,9 +261,10 @@ export async function handleGetContact(contactId: string) {
     }
     const { contact, assistantMetadata } =
       GetContactIpcResponseSchema.parse(result);
+    const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contact: prepareContactResponse(contact),
+      contact: prepareContactResponse(contact, guardianIds),
       assistantMetadata: assistantMetadata ?? undefined,
     };
   } catch (err) {
@@ -664,7 +689,10 @@ export const ROUTES: RouteDefinition[] = [
       log.debug(
         "search_contacts: search served daemon-native (gateway-native search is design-blocked)",
       );
-      return searchContacts(parsed).map(prepareContactResponse);
+      const guardianIds = await getGuardianContactIds();
+      return searchContacts(parsed).map((c) =>
+        prepareContactResponse(c, guardianIds),
+      );
     },
   },
 
@@ -749,7 +777,7 @@ export const ROUTES: RouteDefinition[] = [
 // Transport-agnostic handlers (moved from HTTP-only)
 // ---------------------------------------------------------------------------
 
-function handleMergeContactsRoute(args: RouteHandlerArgs) {
+async function handleMergeContactsRoute(args: RouteHandlerArgs) {
   const { body } = args;
   const keepId = body?.keepId as string | undefined;
   const mergeId = body?.mergeId as string | undefined;
@@ -760,7 +788,8 @@ function handleMergeContactsRoute(args: RouteHandlerArgs) {
 
   try {
     const contact = mergeContacts(keepId, mergeId);
-    return { ok: true, contact: prepareContactResponse(contact) };
+    const guardianIds = await getGuardianContactIds();
+    return { ok: true, contact: prepareContactResponse(contact, guardianIds) };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new BadRequestError(message);


### PR DESCRIPTION
## Summary
- parseContact no longer reads the local contacts.role column; every contact-serve path (incl. daemon-native search) derives role + the guardian name override from the gateway guardian id set (get_guardian_contact IPC), fail-soft
- Wire role field unchanged, so contacts skills + CLI need no changes

Part of plan: drain-contacts-role.md (PR 2 of 4)