### PR TITLE
chore(acp): self-review cleanup (steer constants, locations casts, terminal text, scroll test)

### DIFF
--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -168,11 +168,7 @@ export class VellumAcpClientHandler implements Client {
           toolTitle: update.title,
           toolKind: update.kind,
           toolStatus: update.status,
-          locations:
-            update.locations?.map((l) => ({
-              path: l.path,
-              line: l.line ?? undefined,
-            })) ?? undefined,
+          locations: mapLocations(update.locations),
         });
         break;
       }
@@ -185,11 +181,7 @@ export class VellumAcpClientHandler implements Client {
           toolKind: update.kind ?? undefined,
           toolStatus: update.status ?? undefined,
           content: update.content ? JSON.stringify(update.content) : undefined,
-          locations:
-            update.locations?.map((l) => ({
-              path: l.path,
-              line: l.line ?? undefined,
-            })) ?? undefined,
+          locations: mapLocations(update.locations),
         });
         break;
       }
@@ -403,6 +395,19 @@ export class VellumAcpClientHandler implements Client {
     }
     return {};
   }
+}
+
+/** Normalize ACP tool-call locations into the SSE update's `locations` shape. */
+function mapLocations(
+  locations:
+    | ReadonlyArray<{ path: string; line?: number | null }>
+    | null
+    | undefined,
+): Array<{ path: string; line?: number }> | undefined {
+  return (
+    locations?.map((l) => ({ path: l.path, line: l.line ?? undefined })) ??
+    undefined
+  );
 }
 
 function findAllowOptionId(

--- a/clients/web/src/domains/chat/acp-run-message-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.ts
@@ -27,7 +27,11 @@
 
 import { useRef } from "react";
 
-import type { AcpRunRawEvent } from "@/domains/chat/acp-run-store";
+import {
+  LOCAL_MARKER_ID_PREFIX,
+  STEER_MARKER_PREFIX,
+  type AcpRunRawEvent,
+} from "@/domains/chat/acp-run-store";
 import type { AcpToolStatus } from "@/domains/chat/acp-run-step-projection";
 
 // ---------------------------------------------------------------------------
@@ -55,12 +59,6 @@ export type AcpChatBlock =
 
 /** Synthetic id for chunks from older daemons that don't emit a messageId. */
 const ANONYMOUS_MESSAGE_ID = "";
-
-/** Prefix `appendLocalMarker` stamps onto optimistic steering notes. */
-const STEER_MARKER_PREFIX = "↻ Steering: ";
-
-/** Synthetic `messageId` prefix `appendLocalMarker` uses for steer markers. */
-const LOCAL_MARKER_ID_PREFIX = "local-marker-";
 
 /** Map a raw daemon `toolStatus` to a block status; keep `fallback` if absent. */
 function mapToolStatus(
@@ -254,19 +252,18 @@ export function applyAcpChatEvent(
 }
 
 /**
- * Best-effort extraction of `locations` from a tool event. The store's raw
- * event carries no typed `locations` field today; this reads an optional
- * passthrough off the event without widening the store type.
+ * Normalize a tool event's typed `locations` field for a chat block.
  *
- * Returns `undefined` only when the field is ABSENT or not an array (the caller
+ * Returns `undefined` when the field is ABSENT or not an array (the caller
  * treats this as "no change"). A VALID array — including an empty one — returns
  * a parsed array (possibly `[]`), so an ACP `locations: []` update can clear
- * stale locations rather than preserving the previous value.
+ * stale locations rather than preserving the previous value. The runtime guard
+ * tolerates off-wire shapes that don't match the declared type.
  */
 function parseLocations(
   event: AcpRunRawEvent,
 ): { path: string; line?: number }[] | undefined {
-  const raw = (event as { locations?: unknown }).locations;
+  const raw = event.locations;
   if (!Array.isArray(raw)) return undefined;
   const out: { path: string; line?: number }[] = [];
   for (const item of raw) {

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -16,6 +16,16 @@ import { createSelectors } from "@/utils/create-selectors";
 import { isActiveAcpStatus, type AcpRunStatus } from "@/utils/acp-run-status";
 
 // ---------------------------------------------------------------------------
+// Optimistic-steer marker contract
+// ---------------------------------------------------------------------------
+
+/** Content prefix `appendLocalMarker` stamps onto an optimistic steering note. */
+export const STEER_MARKER_PREFIX = "↻ Steering: ";
+
+/** Synthetic `messageId` prefix `appendLocalMarker` gives a steer marker. */
+export const LOCAL_MARKER_ID_PREFIX = "local-marker-";
+
+// ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
 
@@ -376,7 +386,7 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
     const marker: AcpRunRawEvent = {
       seq: maxSeq + 0.5,
       updateType: "agent_message_chunk",
-      messageId: `local-marker-${existing.events.length}`,
+      messageId: `${LOCAL_MARKER_ID_PREFIX}${existing.events.length}`,
       content: params.content,
     };
 

--- a/clients/web/src/domains/chat/acp-tool-content.test.ts
+++ b/clients/web/src/domains/chat/acp-tool-content.test.ts
@@ -38,9 +38,18 @@ describe("parseAcpToolContent", () => {
     ]);
   });
 
-  it("maps terminal blocks", () => {
+  it("maps terminal blocks without text", () => {
     const content = JSON.stringify([{ type: "terminal", terminalId: "t-1" }]);
     expect(parseAcpToolContent(content)).toEqual([{ type: "terminal" }]);
+  });
+
+  it("carries terminal text through when present", () => {
+    const content = JSON.stringify([
+      { type: "terminal", terminalId: "t-1", text: "$ ls\nfile.txt" },
+    ]);
+    expect(parseAcpToolContent(content)).toEqual([
+      { type: "terminal", text: "$ ls\nfile.txt" },
+    ]);
   });
 
   it("ignores unknown variants while keeping known ones", () => {

--- a/clients/web/src/domains/chat/acp-tool-content.ts
+++ b/clients/web/src/domains/chat/acp-tool-content.ts
@@ -65,8 +65,13 @@ function parseBlock(item: unknown): AcpToolContentBlock | null {
         ...(typeof obj.oldText === "string" ? { oldText: obj.oldText } : {}),
       };
     }
-    case "terminal":
-      return { type: "terminal" };
+    case "terminal": {
+      // The ACP terminal block references a terminal by id and carries no text
+      // of its own; surface a `text` field only on the best-effort chance the
+      // wire shape includes one rather than discarding it.
+      const text = extractTerminalText(obj);
+      return text !== undefined ? { type: "terminal", text } : { type: "terminal" };
+    }
     default:
       return null;
   }
@@ -84,6 +89,23 @@ function extractContentText(content: unknown): string {
     if (typeof text === "string") return text;
   }
   return "";
+}
+
+/**
+ * Best-effort terminal text. The wire shape references a terminal by id and has
+ * no text of its own, so this reads a direct `text` field (or a nested
+ * `output`/`content` text) when one is present and returns `undefined`
+ * otherwise — never fabricating an empty string.
+ */
+function extractTerminalText(obj: Record<string, unknown>): string | undefined {
+  if (typeof obj.text === "string") return obj.text;
+  if (typeof obj.output === "string") return obj.output;
+  if (typeof obj.content === "string") return obj.content;
+  if (typeof obj.content === "object" && obj.content !== null) {
+    const text = (obj.content as Record<string, unknown>).text;
+    if (typeof text === "string") return text;
+  }
+  return undefined;
 }
 
 /**

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
@@ -19,6 +19,7 @@ import {
   type AcpChatBlock,
 } from "@/domains/chat/acp-run-message-projection";
 import {
+  STEER_MARKER_PREFIX,
   useAcpRunStore,
   type AcpRunEntry,
   type AcpRunRawEvent,
@@ -339,7 +340,7 @@ function SteerComposer({ acpSessionId }: { acpSessionId: string }) {
       // high-water mark so the daemon's first real post-steer event survives.
       useAcpRunStore.getState().appendLocalMarker({
         acpSessionId,
-        content: `↻ Steering: ${instruction}`,
+        content: `${STEER_MARKER_PREFIX}${instruction}`,
       });
 
       void steerAcpRun(acpSessionId, instruction)

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/use-stick-to-bottom.test.ts
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/use-stick-to-bottom.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for `useStickToBottom`, the ACP chat view's local
+ * stick-to-bottom coordinator.
+ *
+ * happy-dom has no layout, so `scrollHeight`/`clientHeight`/`scrollTop` are
+ * always 0 and the component test can't exercise the scroll math. These tests
+ * mount the hook in a tiny harness that attaches its `scrollRef` to a real div,
+ * stub that div's layout properties, and dispatch real DOM scroll events so the
+ * hook's `addEventListener("scroll", ...)` listener fires exactly as it would
+ * on a real gesture.
+ *
+ * Layout invariant: `distance = scrollHeight - clientHeight - scrollTop`. With
+ * `scrollHeight: 5000`, `clientHeight: 800`, the bottom is `scrollTop: 4200`,
+ * and the PIN_THRESHOLD is 80px.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+
+import {
+  useStickToBottom,
+  type UseStickToBottomReturn,
+} from "./use-stick-to-bottom";
+
+/**
+ * Stub a div's `scrollTop`/`scrollHeight`/`clientHeight` (happy-dom reports 0).
+ * Assigning `scrollTop` records the value so `scrollToLatest`'s
+ * `el.scrollTop = el.scrollHeight` is observable.
+ */
+function stubLayout(
+  el: HTMLElement,
+  opts: { scrollTop?: number; scrollHeight?: number; clientHeight?: number },
+): void {
+  let scrollTop = opts.scrollTop ?? 0;
+  let scrollHeight = opts.scrollHeight ?? 5000;
+  let clientHeight = opts.clientHeight ?? 800;
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+    },
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => scrollHeight,
+    set: (v: number) => {
+      scrollHeight = v;
+    },
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => clientHeight,
+    set: (v: number) => {
+      clientHeight = v;
+    },
+  });
+}
+
+/**
+ * Mount the hook with its `scrollRef` attached to a real div so the scroll
+ * listener binds to that node. Returns the live div plus a getter for the
+ * latest hook return (captured each render).
+ */
+function mountHook(contentKey: unknown): {
+  el: HTMLDivElement;
+  latest: () => UseStickToBottomReturn;
+} {
+  let latest: UseStickToBottomReturn | null = null;
+
+  function Harness() {
+    const api = useStickToBottom(contentKey);
+    latest = api;
+    return createElement("div", { ref: api.scrollRef, "data-testid": "scroll" });
+  }
+
+  const { container } = render(createElement(Harness));
+  const el = container.querySelector(
+    "[data-testid=scroll]",
+  ) as HTMLDivElement;
+
+  return { el, latest: () => latest as UseStickToBottomReturn };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useStickToBottom", () => {
+  test("surfaces the scroll-to-latest affordance once the user scrolls up", () => {
+    // GIVEN a scroll container pinned to the bottom (distance 0)
+    const { el, latest } = mountHook("content-1");
+    stubLayout(el, { scrollTop: 4200, scrollHeight: 5000, clientHeight: 800 });
+
+    // WHILE pinned, no affordance is shown
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+    });
+    expect(latest().showScrollToLatest).toBe(false);
+
+    // WHEN the user scrolls well away from the bottom (distance 4200 > 80)
+    act(() => {
+      el.scrollTop = 0;
+      el.dispatchEvent(new Event("scroll"));
+    });
+
+    // THEN the "Go to newest" affordance surfaces
+    expect(latest().showScrollToLatest).toBe(true);
+  });
+
+  test("scrollToLatest pins to the bottom and clears the affordance", () => {
+    // GIVEN a container the user has scrolled up in, with the affordance shown
+    const { el, latest } = mountHook("content-1");
+    stubLayout(el, { scrollTop: 0, scrollHeight: 5000, clientHeight: 800 });
+
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+    });
+    expect(latest().showScrollToLatest).toBe(true);
+
+    // WHEN the user invokes scrollToLatest
+    act(() => {
+      latest().scrollToLatest();
+    });
+
+    // THEN the container is scrolled to the bottom and the flag clears
+    expect(el.scrollTop).toBe(5000);
+    expect(latest().showScrollToLatest).toBe(false);
+  });
+
+  test("re-engages the pin when the user scrolls back to the bottom", () => {
+    const { el, latest } = mountHook("content-1");
+    stubLayout(el, { scrollTop: 0, scrollHeight: 5000, clientHeight: 800 });
+
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+    });
+    expect(latest().showScrollToLatest).toBe(true);
+
+    // WHEN the user scrolls back within the pin threshold (distance 60 <= 80)
+    act(() => {
+      el.scrollTop = 4140;
+      el.dispatchEvent(new Event("scroll"));
+    });
+
+    // THEN the affordance hides again
+    expect(latest().showScrollToLatest).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -67,10 +67,8 @@ describe("handleAcpSessionUpdate", () => {
       updateType: "tool_call",
       toolCallId: "tc-1",
       seq: 1,
-      // `locations` rides the wire (daemon forwards it) but isn't on the web
-      // event type yet — cast to attach it like the daemon does.
       locations: [{ path: "a.ts", line: 12 }, { path: "b.ts" }],
-    } as Parameters<typeof handleAcpSessionUpdate>[0]);
+    });
     expect(getState().byId["acp-1"]?.events[0]?.locations).toEqual([
       { path: "a.ts", line: 12 },
       { path: "b.ts" },

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -36,11 +36,8 @@ export function handleAcpSessionUpdate(event: AcpSessionUpdateEvent): void {
       toolTitle: event.toolTitle,
       toolKind: event.toolKind,
       toolStatus: event.toolStatus,
-      // `locations` rides the SSE event since the daemon forwards tool-call
-      // locations[], but the web event type doesn't declare it yet — read it
-      // defensively. Absent on older daemons.
-      locations: (event as { locations?: { path: string; line?: number }[] })
-        .locations,
+      // Tool-call locations[]; absent on older daemons.
+      locations: event.locations,
       messageId: event.messageId,
     },
   });


### PR DESCRIPTION
## Summary
- Single source of truth for steer-marker constants (store) consumed by composer + projection.
- Drop now-stale locations casts/comments (typed field exists since PR 4).
- parseAcpToolContent carries terminal text; add useStickToBottom unit test; dedupe client-handler locations map.
- No behavior change except terminal-text passthrough. Timeline files untouched.

Part of plan: acp-chat-detail-view.md (self-review remediation)