### PR TITLE
feat(design-library): style Stepper steps by position so completed steps stay distinct

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/page-tabs.tsx
@@ -12,8 +12,7 @@ interface PageTabsProps {
 /**
  * Labeled step navigation for a multi-page form, built on the design library
  * `Stepper` primitive. Steps are numbered from their page title; completed
- * steps navigate back, and future steps (plus any step while the form is
- * submitting) are disabled.
+ * steps navigate back, and navigation is disabled while the form is submitting.
  */
 export function PageTabs({
   current,
@@ -24,7 +23,6 @@ export function PageTabs({
   const steps = pages.map((page, i) => ({
     id: page.id,
     label: `${i + 1}. ${page.title}`,
-    disabled: disabled || i > current,
   }));
 
   return (
@@ -33,6 +31,7 @@ export function PageTabs({
       steps={steps}
       current={current}
       onStepSelect={onNavigate}
+      disabled={disabled}
       className="mb-4"
     />
   );

--- a/packages/design-library/src/components/stepper.stories.tsx
+++ b/packages/design-library/src/components/stepper.stories.tsx
@@ -18,14 +18,14 @@ const STEPS = [
   { id: "install", label: "3. Install App" },
 ];
 
-// Gated wizard: the active step is underlined, completed steps navigate back,
-// and future steps are disabled.
+// Gated wizard: completed steps navigate back, the active step is underlined,
+// and upcoming steps are muted and locked.
 function GatedStepper() {
   const [current, setCurrent] = useState(1);
   return (
     <Stepper
       aria-label="Setup steps"
-      steps={STEPS.map((step, i) => ({ ...step, disabled: i > current }))}
+      steps={STEPS}
       current={current}
       onStepSelect={setCurrent}
     />
@@ -39,8 +39,20 @@ export const Gated: Story = {
 export const FirstStep: Story = {
   args: {
     "aria-label": "Setup steps",
-    steps: STEPS.map((step, i) => ({ ...step, disabled: i > 0 })),
+    steps: STEPS,
     current: 0,
     onStepSelect: () => {},
+  },
+};
+
+// While submitting, navigation is disabled — but completed steps keep their
+// visited styling, staying visually distinct from the muted upcoming steps.
+export const Submitting: Story = {
+  args: {
+    "aria-label": "Setup steps",
+    steps: STEPS,
+    current: 1,
+    onStepSelect: () => {},
+    disabled: true,
   },
 };

--- a/packages/design-library/src/components/stepper.tsx
+++ b/packages/design-library/src/components/stepper.tsx
@@ -5,32 +5,39 @@ import { cn } from "../utils/cn";
 export interface StepperStep {
   id: string;
   label: string;
-  /** Mark the step as not navigable (e.g. a future step in a gated wizard). */
-  disabled?: boolean;
 }
 
 export type StepperProps = ComponentProps<"nav"> & {
   steps: StepperStep[];
-  /** Index of the active step. */
+  /** Index of the active step; earlier steps are completed, later are upcoming. */
   current: number;
   /**
-   * Called with the step index when a navigable step (not active, not
-   * disabled) is selected. Omit to render the steps as non-interactive.
+   * Called with the step index when a completed step is selected. Omit to
+   * render a non-interactive display stepper.
    */
   onStepSelect?: (index: number) => void;
+  /**
+   * Disable all step navigation (e.g. while a form is submitting) without
+   * changing the completed / active / upcoming styling.
+   */
+  disabled?: boolean;
 };
 
 /**
  * Labeled step navigation for a sequential, gated flow such as a multi-page
- * form wizard. The active step is marked with `aria-current="step"`, navigable
- * steps are buttons that call `onStepSelect`, and disabled steps are inert.
- * This is the step pattern — distinct from `Tabs`, which models parallel,
- * independently selectable panels.
+ * form wizard. Steps are styled by position relative to `current`: completed
+ * steps (before it) read as visited and can navigate back, the active step is
+ * marked with `aria-current="step"`, and upcoming steps (after it) are muted
+ * and locked. A completed step keeps its visited styling even when navigation
+ * is disabled, so it never looks like an upcoming step. This is the step
+ * pattern — distinct from `Tabs`, which models parallel, independently
+ * selectable panels.
  */
 export function Stepper({
   steps,
   current,
   onStepSelect,
+  disabled = false,
   className,
   ...rest
 }: StepperProps) {
@@ -45,7 +52,8 @@ export function Stepper({
     >
       {steps.map((step, index) => {
         const isActive = index === current;
-        const navigable = !isActive && !step.disabled && !!onStepSelect;
+        const isCompleted = index < current;
+        const navigable = isCompleted && !disabled && !!onStepSelect;
         return (
           <button
             key={step.id}
@@ -59,11 +67,11 @@ export function Stepper({
               "keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
               isActive &&
                 "border-[var(--primary-base)] text-[var(--content-strong)]",
-              navigable &&
-                "cursor-pointer text-[var(--content-default)] hover:text-[var(--content-strong)]",
-              !isActive &&
-                !navigable &&
-                "cursor-default text-[var(--content-disabled)]",
+              isCompleted && "text-[var(--content-default)]",
+              !isActive && !isCompleted && "text-[var(--content-disabled)]",
+              navigable
+                ? "cursor-pointer hover:text-[var(--content-strong)]"
+                : "cursor-default",
             )}
           >
             {step.label}

--- a/packages/design-library/src/components/stepper.tsx
+++ b/packages/design-library/src/components/stepper.tsx
@@ -1,3 +1,4 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import { type ComponentProps } from "react";
 
 import { cn } from "../utils/cn";
@@ -22,6 +23,31 @@ export type StepperProps = ComponentProps<"nav"> & {
    */
   disabled?: boolean;
 };
+
+// Color is keyed on the step's position (`status`); interactivity is keyed on
+// the native `:enabled` / `:disabled` state, so a completed step keeps its
+// visited color even when navigation is locked (e.g. while submitting).
+export const stepVariants = cva(
+  [
+    "-mb-px inline-flex items-center whitespace-nowrap border-b-2 border-transparent pb-2",
+    "text-body-medium-default outline-none transition-colors",
+    "keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
+    "enabled:cursor-pointer enabled:hover:text-[var(--content-strong)]",
+    "disabled:cursor-default",
+  ].join(" "),
+  {
+    variants: {
+      status: {
+        active: "border-[var(--primary-base)] text-[var(--content-strong)]",
+        completed: "text-[var(--content-default)]",
+        upcoming: "text-[var(--content-disabled)]",
+      },
+    },
+    defaultVariants: { status: "upcoming" },
+  },
+);
+
+export type StepStatus = NonNullable<VariantProps<typeof stepVariants>["status"]>;
 
 /**
  * Labeled step navigation for a sequential, gated flow such as a multi-page
@@ -51,28 +77,23 @@ export function Stepper({
       {...rest}
     >
       {steps.map((step, index) => {
-        const isActive = index === current;
-        const isCompleted = index < current;
-        const navigable = isCompleted && !disabled && !!onStepSelect;
+        const status: StepStatus =
+          index === current
+            ? "active"
+            : index < current
+              ? "completed"
+              : "upcoming";
+        const navigable =
+          status === "completed" && !disabled && !!onStepSelect;
         return (
           <button
             key={step.id}
             type="button"
             data-slot="stepper-step"
             disabled={!navigable}
-            aria-current={isActive ? "step" : undefined}
+            aria-current={status === "active" ? "step" : undefined}
             onClick={navigable ? () => onStepSelect?.(index) : undefined}
-            className={cn(
-              "-mb-px inline-flex items-center whitespace-nowrap border-b-2 border-transparent pb-2 text-body-medium-default outline-none transition-colors",
-              "keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
-              isActive &&
-                "border-[var(--primary-base)] text-[var(--content-strong)]",
-              isCompleted && "text-[var(--content-default)]",
-              !isActive && !isCompleted && "text-[var(--content-disabled)]",
-              navigable
-                ? "cursor-pointer hover:text-[var(--content-strong)]"
-                : "cursor-default",
-            )}
+            className={stepVariants({ status })}
           >
             {step.label}
           </button>

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -89,8 +89,10 @@ export {
 } from "./components/segment-control";
 export {
   Stepper,
+  stepVariants,
   type StepperStep,
   type StepperProps,
+  type StepStatus,
 } from "./components/stepper";
 export {
   Slider,


### PR DESCRIPTION
## What

Follow-up to #36209 (LUM-2608) addressing design feedback: in the merged `Stepper`, a **completed** step that isn't currently clickable (e.g. while the form is submitting) collapsed to the same `--content-disabled` styling as an **upcoming** step — so a finished step looked identical to one not yet reached.

## Why

Across step/wizard components, completed, current, and upcoming are three *visually distinct* states — a completed step reads as "done," not "not started":

- **Ant Design Steps** — `finish` / `process` / `wait` each get their own color.
- **Material / MUI Stepper** — distinct `.Mui-completed` (done) vs `.Mui-active` vs upcoming treatments.
- **Carbon / PatternFly / eBay** — complete vs current vs incomplete are separate states.

Our Stepper is an icon-less text+underline control, so the equivalent is a color hierarchy: **active** `--content-strong` + underline › **completed** `--content-default` › **upcoming** `--content-disabled`. The bug was tying the completed color to *clickability* rather than *position*.

## Fix

Style each step by its position relative to `current` (completed / active / upcoming), independent of whether it is currently navigable. A completed step keeps its visited `--content-default` styling even when navigation is locked, so it stays distinct from upcoming steps.

**During submit — before vs. after:**

[Stepper submit before/after](```''https://raw.githubusercontent.com/vellum-ai/vellum-assistant/refs/heads/ashlee-claude/lum-2608-screenshots/pr-screenshots/lum-2608/08-stepper-submit-before-after.png)''```

The normal (interactive) three-state hierarchy is unchanged:

[Stepper gated](```''https://raw.githubusercontent.com/vellum-ai/vellum-assistant/refs/heads/ashlee-claude/lum-2608-screenshots/pr-screenshots/lum-2608/06-stepper-gated.png''```)

## Changes

- **`stepper.tsx`** — derive completed / active / upcoming from `current`; completed renders `--content-default` regardless of navigability, upcoming renders `--content-disabled`. Replace the per-step `disabled` flag with a single `disabled` prop on the Stepper that locks navigation without changing the state styling.
- **`page-tabs.tsx`** — maps form pages to `{ id, label }` steps and passes the submitting state through `disabled`; no longer conflates the submit lock with future-step gating.
- **`stepper.stories.tsx`** — drop per-step `disabled`; add a `Submitting` story showing completed steps stay distinct while locked.

## Testing

- `packages/design-library`: `tsc --noEmit` + `build-storybook` — pass
- `clients/web`: `tsc --noEmit` (pre-commit) — pass

Part of LUM-2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wuqoKsrCJ336NLvvNPMvv)_