### PR TITLE
combo11: resolve guardian state in tests from the gateway, not local ACL columns

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -90,6 +90,7 @@ import {
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 initAuthSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
@@ -131,6 +132,7 @@ function resetTables(): void {
     "contact_channels",
     "contacts",
   );
+  resetGatewayAclStore();
   deliveryChannels.resetAllRunDeliveryClaims();
   pendingInteractions.clear();
 }

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -169,6 +169,7 @@ import {
 } from "../runtime/verification-templates.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 import { revokeChannelsByType } from "./helpers/seed-contact-channel.js";
 
 initializeDb();
@@ -184,6 +185,7 @@ function resetTables(): void {
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
   db.run("DELETE FROM external_conversation_bindings");
+  resetGatewayAclStore();
   telegramDeliverCalls.length = 0;
   voiceCallInitCalls.length = 0;
   mockBotUsername = "test_bot";

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -74,17 +74,11 @@ mock.module("../ipc/gateway-client.js", () => ({
     params?: Record<string, unknown>,
   ) => {
     if (method === "mark_channel_revoked") {
-      const { getDb } = await import("../memory/db-connection.js");
-      const { contactChannels } = await import("../memory/schema.js");
-      const { eq } = await import("drizzle-orm");
+      const { revokeChannelById } = await import(
+        "./helpers/seed-contact-channel.js"
+      );
       const channelId = params?.contactChannelId as string | undefined;
-      if (channelId) {
-        getDb()
-          .update(contactChannels)
-          .set({ status: "revoked" })
-          .where(eq(contactChannels.id, channelId))
-          .run();
-      }
+      if (channelId) revokeChannelById(channelId);
     }
     return {
       ok: true,
@@ -105,40 +99,10 @@ mock.module("../ipc/gateway-client.js", () => ({
 // existence from the gateway. Derive the list from the local binding state so
 // the gateway-backed presence guard mirrors the DB the rest of the test sets up.
 const resolveGuardianList = async (input?: { channelTypes?: string[] }) => {
-  const { getDb } = await import("../memory/db-connection.js");
-  const { contacts, contactChannels } = await import("../memory/schema.js");
-  const { and, eq } = await import("drizzle-orm");
-  const channels = input?.channelTypes ?? [];
-  return channels
-    .map((channelType) => {
-      const row = getDb()
-        .select({ contact: contacts, channel: contactChannels })
-        .from(contacts)
-        .innerJoin(
-          contactChannels,
-          eq(contacts.id, contactChannels.contactId),
-        )
-        .where(
-          and(
-            eq(contacts.role, "guardian"),
-            eq(contactChannels.type, channelType),
-            eq(contactChannels.status, "active"),
-          ),
-        )
-        .get();
-      if (!row) return null;
-      return {
-        channelType,
-        contactId: row.contact.id,
-        principalId: row.contact.principalId ?? null,
-        displayName: row.contact.displayName ?? null,
-        address: row.channel.address,
-        externalChatId: row.channel.externalChatId ?? null,
-        status: "active",
-        verifiedAt: row.channel.verifiedAt ?? null,
-      };
-    })
-    .filter((g) => g !== null);
+  const { deriveGuardianDeliveries } = await import(
+    "./helpers/derive-guardian-delivery.js"
+  );
+  return deriveGuardianDeliveries({ channelTypes: input?.channelTypes ?? [] });
 };
 
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
@@ -179,7 +143,6 @@ import {
 } from "../memory/guardian-rate-limits.js";
 import {
   channelVerificationSessions,
-  contactChannels,
   conversations,
 } from "../memory/schema.js";
 import {
@@ -206,6 +169,7 @@ import {
 } from "../runtime/verification-templates.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { revokeChannelsByType } from "./helpers/seed-contact-channel.js";
 
 initializeDb();
 
@@ -226,16 +190,11 @@ function resetTables(): void {
 }
 
 /**
- * Revoke a guardian channel's local ACL state directly. The production revoke
- * is gateway-owned (relayed via mark_channel_revoked); this stamps the local
- * mirror so the guardian-resolution reads still under test see the downgrade.
+ * Stamp the local mirror of a gateway-owned guardian-channel revoke so the
+ * guardian-resolution reads still running locally observe the downgrade.
  */
 function revokeGuardianChannelLocally(channelType: string): void {
-  getDb()
-    .update(contactChannels)
-    .set({ status: "revoked" })
-    .where(eq(contactChannels.type, channelType))
-    .run();
+  revokeChannelsByType(channelType);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -87,6 +87,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { conversations } from "../memory/schema.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -115,6 +116,7 @@ function resetTables(): void {
   db.run("DELETE FROM conversations");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 
   // Seed the vellum guardian binding (gateway does this at startup in production)
   createGuardianBinding({
@@ -210,6 +212,7 @@ describe("guardian-dispatch", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "local-actor-principal",
@@ -253,6 +256,7 @@ describe("guardian-dispatch", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
 
     const convId = "conv-dispatch-no-principal";
     ensureConversation(convId);

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -32,40 +32,10 @@ mock.module("../config/loader.js", () => ({
 // by reseeding or clearing the local binding directly.
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async (input?: { channelTypes?: string[] }) => {
-    const { getDb } = await import("../memory/db-connection.js");
-    const { contacts, contactChannels } = await import("../memory/schema.js");
-    const { and, eq } = await import("drizzle-orm");
-    const channels = input?.channelTypes ?? [];
-    return channels
-      .map((channelType) => {
-        const row = getDb()
-          .select({ contact: contacts, channel: contactChannels })
-          .from(contacts)
-          .innerJoin(
-            contactChannels,
-            eq(contacts.id, contactChannels.contactId),
-          )
-          .where(
-            and(
-              eq(contacts.role, "guardian"),
-              eq(contactChannels.type, channelType),
-              eq(contactChannels.status, "active"),
-            ),
-          )
-          .get();
-        if (!row) return null;
-        return {
-          channelType,
-          contactId: row.contact.id,
-          principalId: row.contact.principalId ?? null,
-          displayName: row.contact.displayName ?? null,
-          address: row.channel.address,
-          externalChatId: row.channel.externalChatId ?? null,
-          status: "active",
-          verifiedAt: row.channel.verifiedAt ?? null,
-        };
-      })
-      .filter((g) => g !== null);
+    const { deriveGuardianDeliveries } = await import(
+      "./helpers/derive-guardian-delivery.js"
+    );
+    return deriveGuardianDeliveries({ channelTypes: input?.channelTypes ?? [] });
   },
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -30,6 +30,7 @@ import {
   setAdapterProcessMessage,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -43,6 +44,7 @@ function resetTables(): void {
   db.run("DELETE FROM external_conversation_bindings");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -62,11 +62,11 @@ mock.module("../../daemon/approval-generators.js", () => ({
 }));
 
 import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
-import { and, desc, eq } from "drizzle-orm";
 
+import { isChannelId } from "../../channels/types.js";
 import { findContactChannel } from "../../contacts/contact-store.js";
-import { getDb } from "../../memory/db-connection.js";
-import { contactChannels, contacts } from "../../memory/schema.js";
+import { getCachedMemberAcl } from "../../runtime/member-verdict-cache.js";
+import { deriveGuardianForChannel } from "./derive-guardian-delivery.js";
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
@@ -147,27 +147,6 @@ function stampTrustVerdict(body: Record<string, unknown>): void {
   body.sourceMetadata = { ...(meta ?? {}), trustVerdict: verdict };
 }
 
-/**
- * Local mirror of the gateway's active-guardian-channel resolution, querying
- * the contact store directly (the production query now lives in the gateway).
- */
-function localGuardianForChannel(channelType: string) {
-  const row = getDb()
-    .select({ contact: contacts, channel: contactChannels })
-    .from(contacts)
-    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(
-        eq(contacts.role, "guardian"),
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.status, "active"),
-      ),
-    )
-    .orderBy(desc(contactChannels.verifiedAt))
-    .get();
-  return row ? { contact: row.contact, channel: row.channel } : null;
-}
-
 /** Local mirror of the gateway resolver, reading the daemon contact store. */
 export function resolveLocalTrustVerdict(input: {
   channelType: string;
@@ -182,28 +161,25 @@ export function resolveLocalTrustVerdict(input: {
         address: input.actorExternalId,
       })
     : null;
-  const guardian = localGuardianForChannel(input.channelType);
+  const guardian = deriveGuardianForChannel(input.channelType);
 
   const isGuardian =
     !!guardian &&
     !!canonicalSenderId &&
-    guardian.channel.address.toLowerCase() === canonicalSenderId.toLowerCase();
+    guardian.address.toLowerCase() === canonicalSenderId.toLowerCase();
 
-  // ACL columns are no longer on the slimmed ContactChannel type; read the raw
-  // row (columns still exist) so this local mirror sees status/policy/verified.
-  const memberRow = member
-    ? (getDb()
-        .select()
-        .from(contactChannels)
-        .where(eq(contactChannels.id, member.channel.id))
-        .get() ?? null)
-    : null;
+  // Mirror the gateway: read the member ACL from the warmed verdict cache (the
+  // source production resolves from) rather than the local ACL columns.
+  const memberAcl =
+    member && input.actorExternalId && isChannelId(input.channelType)
+      ? getCachedMemberAcl(input.channelType, input.actorExternalId)
+      : undefined;
 
   let trustClass: TrustClass;
   if (isGuardian) {
     trustClass = "guardian";
-  } else if (memberRow) {
-    const status = memberRow.status;
+  } else if (memberAcl) {
+    const status = memberAcl.status;
     if (status === "active") trustClass = "trusted_contact";
     else if (status === "unverified" || status === "pending")
       trustClass = "unverified_contact";
@@ -215,23 +191,21 @@ export function resolveLocalTrustVerdict(input: {
   const verdict: TrustVerdict = { trustClass, canonicalSenderId };
 
   if (guardian) {
-    verdict.guardianExternalUserId = guardian.channel.address;
-    verdict.guardianDeliveryChatId = guardian.channel.externalChatId;
-    if (guardian.contact.principalId)
-      verdict.guardianPrincipalId = guardian.contact.principalId;
-    verdict.guardianDisplayName = guardian.contact.displayName;
+    verdict.guardianExternalUserId = guardian.address;
+    verdict.guardianDeliveryChatId = guardian.externalChatId ?? null;
+    if (guardian.principalId)
+      verdict.guardianPrincipalId = guardian.principalId;
+    verdict.guardianDisplayName = guardian.displayName ?? undefined;
   }
 
-  if (member && memberRow) {
+  if (member && memberAcl) {
     verdict.contactId = member.channel.contactId;
     verdict.channelId = member.channel.id;
     verdict.type = member.channel.type;
     verdict.address = member.channel.address;
     verdict.externalChatId = member.channel.externalChatId;
-    verdict.status = memberRow.status;
-    verdict.policy = memberRow.policy;
-    verdict.verifiedAt = memberRow.verifiedAt;
-    verdict.verifiedVia = memberRow.verifiedVia;
+    verdict.status = memberAcl.status;
+    verdict.policy = memberAcl.policy;
     verdict.memberDisplayName = member.contact.displayName;
   }
 

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -65,13 +65,12 @@ import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
 
 import { isChannelId } from "../../channels/types.js";
 import { findContactChannel } from "../../contacts/contact-store.js";
-import { getCachedMemberAcl } from "../../runtime/member-verdict-cache.js";
-import { deriveGuardianForChannel } from "./derive-guardian-delivery.js";
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
   MessageProcessor,
 } from "../../runtime/http-types.js";
+import { getCachedMemberAcl } from "../../runtime/member-verdict-cache.js";
 import {
   handleChannelDeliveryAck as _handleChannelDeliveryAck,
   handleListDeadLetters as _handleListDeadLetters,
@@ -82,6 +81,7 @@ import {
   handleDeleteConversation as _handleDeleteConversation,
 } from "../../runtime/routes/channel-inbound-routes.js";
 import { RouteError } from "../../runtime/routes/errors.js";
+import { deriveGuardianForChannel } from "./derive-guardian-delivery.js";
 
 /**
  * Wrap a transport-agnostic handler call, converting RouteError throws

--- a/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
+++ b/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
@@ -2,40 +2,33 @@
  * Test-only resolver that mirrors the gateway's active-guardian-channel query.
  *
  * Production resolves the guardian binding + per-channel delivery endpoints from
- * the gateway (the `resolve_guardian_delivery` IPC route). Tests seed the
- * guardian state via {@link seedContactChannel} / `createGuardianBinding` and
- * back the gateway reader with this resolver so the gateway-derived delivery
- * list reflects the seeded binding. The ACL-column reads are confined here so
- * the trust/guardian test files don't reference the assistant ACL columns
- * directly.
+ * the gateway (`gateway/src/risk/guardian-delivery-resolver.ts`, reached via the
+ * `resolve_guardian_delivery` IPC route) — `role = 'guardian'` joined to active
+ * gateway contact channels, ordered by verification recency. Tests seed that
+ * gateway state via {@link seedContactChannel} / `createGuardianBinding` into the
+ * in-process gateway ACL store ({@link liveGatewayAclRows}); this resolver reads
+ * the SAME store so the gateway-derived delivery list reflects the seeded
+ * binding. No assistant ACL columns are read here — those are Phase-B-dropped.
  */
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";
-import { and, desc, eq } from "drizzle-orm";
 
-import { getDb } from "../../memory/db-connection.js";
-import { contactChannels, contacts } from "../../memory/schema.js";
+import { liveGatewayAclRows } from "./gateway-acl-store.js";
 
 /**
- * Resolve active guardian deliveries from the local contacts DB, optionally
+ * Resolve active guardian deliveries from the gateway ACL store, optionally
  * filtered to a single channel (when `channelType` is given) or to a set of
  * channel types (when `channelTypes` is given). Mirrors the gateway resolution:
- * `contacts.role = 'guardian'` joined to active contact channels, ordered by
- * verification recency.
+ * `role = 'guardian'` joined to active channels, ordered by verification
+ * recency.
  */
 export function deriveGuardianDeliveries(filter?: {
   channelType?: string;
   channelTypes?: string[];
 }): GuardianDelivery[] {
-  const rows = getDb()
-    .select({ contact: contacts, channel: contactChannels })
-    .from(contacts)
-    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(eq(contacts.role, "guardian"), eq(contactChannels.status, "active")),
-    )
-    .orderBy(desc(contactChannels.verifiedAt))
-    .all();
+  const rows = liveGatewayAclRows()
+    .filter((r) => r.role === "guardian" && r.status === "active")
+    .sort((a, b) => (b.verifiedAt ?? 0) - (a.verifiedAt ?? 0));
 
   if (rows.length === 0) return [];
 
@@ -43,16 +36,16 @@ export function deriveGuardianDeliveries(filter?: {
   // rows are ordered by verifiedAt desc), matching the gateway resolution.
   const byChannel = new Map<string, GuardianDelivery>();
   for (const r of rows) {
-    if (byChannel.has(r.channel.type)) continue;
-    byChannel.set(r.channel.type, {
-      channelType: r.channel.type,
-      contactId: r.contact.id,
-      principalId: r.contact.principalId ?? null,
-      displayName: r.contact.displayName ?? null,
-      address: r.channel.address,
-      externalChatId: r.channel.externalChatId ?? null,
+    if (byChannel.has(r.channelType)) continue;
+    byChannel.set(r.channelType, {
+      channelType: r.channelType,
+      contactId: r.contactId,
+      principalId: r.principalId ?? null,
+      displayName: r.displayName ?? null,
+      address: r.address,
+      externalChatId: r.externalChatId ?? null,
       status: "active",
-      verifiedAt: r.channel.verifiedAt ?? null,
+      verifiedAt: r.verifiedAt ?? null,
     });
   }
   const list = [...byChannel.values()];

--- a/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
+++ b/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
@@ -4,40 +4,46 @@
  * Production resolves the guardian binding + per-channel delivery endpoints from
  * the gateway (`gateway/src/risk/guardian-delivery-resolver.ts`, reached via the
  * `resolve_guardian_delivery` IPC route) — `role = 'guardian'` joined to active
- * gateway contact channels, ordered by verification recency. Tests seed that
- * gateway state via {@link seedContactChannel} / `createGuardianBinding` into the
- * in-process gateway ACL store ({@link liveGatewayAclRows}); this resolver reads
- * the SAME store so the gateway-derived delivery list reflects the seeded
+ * gateway contact channels, returning EVERY active row ordered by `verifiedAt`
+ * desc, optionally narrowed to `channelTypes` (empty array = unfiltered). Tests
+ * seed that gateway state via {@link seedContactChannel} / `createGuardianBinding`
+ * into the in-process gateway ACL store ({@link gatewayAclRows}); this resolver
+ * reads the SAME store so the gateway-derived delivery list reflects the seeded
  * binding. No assistant ACL columns are read here — those are Phase-B-dropped.
  */
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";
 
-import { liveGatewayAclRows } from "./gateway-acl-store.js";
+import { gatewayAclRows } from "./gateway-acl-store.js";
 
 /**
  * Resolve active guardian deliveries from the gateway ACL store, optionally
  * filtered to a single channel (when `channelType` is given) or to a set of
  * channel types (when `channelTypes` is given). Mirrors the gateway resolution:
- * `role = 'guardian'` joined to active channels, ordered by verification
- * recency.
+ * `role = 'guardian'` joined to active channels, returning ALL active rows
+ * ordered by verification recency. An empty `channelTypes` array means
+ * unfiltered (all types), matching the production resolver.
  */
 export function deriveGuardianDeliveries(filter?: {
   channelType?: string;
   channelTypes?: string[];
 }): GuardianDelivery[] {
-  const rows = liveGatewayAclRows()
-    .filter((r) => r.role === "guardian" && r.status === "active")
-    .sort((a, b) => (b.verifiedAt ?? 0) - (a.verifiedAt ?? 0));
+  const channelTypes =
+    filter?.channelTypes ??
+    (filter?.channelType !== undefined ? [filter.channelType] : undefined);
 
-  if (rows.length === 0) return [];
-
-  // One active guardian per channel type (most-recently-verified wins, since
-  // rows are ordered by verifiedAt desc), matching the gateway resolution.
-  const byChannel = new Map<string, GuardianDelivery>();
-  for (const r of rows) {
-    if (byChannel.has(r.channelType)) continue;
-    byChannel.set(r.channelType, {
+  return gatewayAclRows()
+    .filter((r) => {
+      if (r.role !== "guardian" || r.status !== "active") return false;
+      // Empty array => no filter (all types), matching production's
+      // `channelTypes.length > 0` predicate guard.
+      if (channelTypes && channelTypes.length > 0) {
+        return channelTypes.includes(r.channelType);
+      }
+      return true;
+    })
+    .sort((a, b) => (b.verifiedAt ?? 0) - (a.verifiedAt ?? 0))
+    .map((r) => ({
       channelType: r.channelType,
       contactId: r.contactId,
       principalId: r.principalId ?? null,
@@ -46,21 +52,12 @@ export function deriveGuardianDeliveries(filter?: {
       externalChatId: r.externalChatId ?? null,
       status: "active",
       verifiedAt: r.verifiedAt ?? null,
-    });
-  }
-  const list = [...byChannel.values()];
-
-  const channelTypes =
-    filter?.channelTypes ??
-    (filter?.channelType ? [filter.channelType] : undefined);
-  return channelTypes
-    ? list.filter((g) => channelTypes.includes(g.channelType))
-    : list;
+    }));
 }
 
 /**
  * The single active guardian delivery for a channel type, mirroring the
- * gateway's per-channel resolution.
+ * gateway's per-channel resolution (most-recently-verified wins).
  */
 export function deriveGuardianForChannel(
   channelType: string,

--- a/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
+++ b/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
@@ -1,0 +1,76 @@
+/**
+ * Test-only resolver that mirrors the gateway's active-guardian-channel query.
+ *
+ * Production resolves the guardian binding + per-channel delivery endpoints from
+ * the gateway (the `resolve_guardian_delivery` IPC route). Tests seed the
+ * guardian state via {@link seedContactChannel} / `createGuardianBinding` and
+ * back the gateway reader with this resolver so the gateway-derived delivery
+ * list reflects the seeded binding. The ACL-column reads are confined here so
+ * the trust/guardian test files don't reference the assistant ACL columns
+ * directly.
+ */
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+import { and, desc, eq } from "drizzle-orm";
+
+import { getDb } from "../../memory/db-connection.js";
+import { contactChannels, contacts } from "../../memory/schema.js";
+
+/**
+ * Resolve active guardian deliveries from the local contacts DB, optionally
+ * filtered to a single channel (when `channelType` is given) or to a set of
+ * channel types (when `channelTypes` is given). Mirrors the gateway resolution:
+ * `contacts.role = 'guardian'` joined to active contact channels, ordered by
+ * verification recency.
+ */
+export function deriveGuardianDeliveries(filter?: {
+  channelType?: string;
+  channelTypes?: string[];
+}): GuardianDelivery[] {
+  const rows = getDb()
+    .select({ contact: contacts, channel: contactChannels })
+    .from(contacts)
+    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
+    .where(
+      and(eq(contacts.role, "guardian"), eq(contactChannels.status, "active")),
+    )
+    .orderBy(desc(contactChannels.verifiedAt))
+    .all();
+
+  if (rows.length === 0) return [];
+
+  // One active guardian per channel type (most-recently-verified wins, since
+  // rows are ordered by verifiedAt desc), matching the gateway resolution.
+  const byChannel = new Map<string, GuardianDelivery>();
+  for (const r of rows) {
+    if (byChannel.has(r.channel.type)) continue;
+    byChannel.set(r.channel.type, {
+      channelType: r.channel.type,
+      contactId: r.contact.id,
+      principalId: r.contact.principalId ?? null,
+      displayName: r.contact.displayName ?? null,
+      address: r.channel.address,
+      externalChatId: r.channel.externalChatId ?? null,
+      status: "active",
+      verifiedAt: r.channel.verifiedAt ?? null,
+    });
+  }
+  const list = [...byChannel.values()];
+
+  const channelTypes =
+    filter?.channelTypes ??
+    (filter?.channelType ? [filter.channelType] : undefined);
+  return channelTypes
+    ? list.filter((g) => channelTypes.includes(g.channelType))
+    : list;
+}
+
+/**
+ * The single active guardian delivery for a channel type, mirroring the
+ * gateway's per-channel resolution.
+ */
+export function deriveGuardianForChannel(
+  channelType: string,
+): GuardianDelivery | null {
+  return deriveGuardianDeliveries({ channelType })[0] ?? null;
+}

--- a/assistant/src/__tests__/helpers/gateway-acl-store.ts
+++ b/assistant/src/__tests__/helpers/gateway-acl-store.ts
@@ -27,6 +27,8 @@ export interface GatewayAclRow {
   role: string;
   /** Mirrors gwContactChannels.status. */
   status: string;
+  /** Mirrors gwContactChannels.policy (allow/deny). */
+  policy: string;
   verifiedAt: number | null;
 }
 
@@ -59,6 +61,13 @@ export function setGatewayAclStatusByType(
 /** All gateway ACL rows currently in the store. */
 export function gatewayAclRows(): GatewayAclRow[] {
   return [...rows.values()];
+}
+
+/** The gateway ACL row for a channel id, or `undefined` when absent. */
+export function gatewayAclByChannelId(
+  channelId: string,
+): GatewayAclRow | undefined {
+  return rows.get(channelId);
 }
 
 /**

--- a/assistant/src/__tests__/helpers/gateway-acl-store.ts
+++ b/assistant/src/__tests__/helpers/gateway-acl-store.ts
@@ -1,0 +1,89 @@
+/**
+ * In-process stand-in for the gateway ACL DB (`gwContacts`/`gwContactChannels`),
+ * used by the trust/guardian test helpers.
+ *
+ * Production resolves the guardian binding + per-channel trust from the GATEWAY
+ * DB (see `gateway/src/risk/guardian-delivery-resolver.ts`). The gateway package
+ * is not a dependency of the assistant, so its `getGatewayDb()` can't be imported
+ * here; instead this module mirrors the gateway ACL rows the resolver reads
+ * (`role`, `status`, `verifiedAt`, delivery endpoints). The test seed helpers
+ * write here and the test guardian-delivery resolver reads here, so NO test code
+ * touches the assistant DB's ACL columns (which Phase B drops).
+ *
+ * Isolation: rows are keyed by the assistant channel id (which the identity
+ * upsert regenerates per test). Reads drop any row whose backing assistant
+ * identity channel no longer exists, so a `DELETE FROM contact_channels` /
+ * `resetDbForTesting()` in a test's `beforeEach` automatically evicts stale
+ * gateway rows without each test having to reset this store.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { getDb } from "../../memory/db-connection.js";
+import { contactChannels } from "../../memory/schema.js";
+
+export interface GatewayAclRow {
+  contactId: string;
+  channelId: string;
+  channelType: string;
+  address: string;
+  externalChatId: string | null;
+  principalId: string | null;
+  displayName: string | null;
+  /** Guardian iff role === "guardian"; mirrors gwContacts.role. */
+  role: string;
+  /** Mirrors gwContactChannels.status. */
+  status: string;
+  verifiedAt: number | null;
+}
+
+const rows = new Map<string, GatewayAclRow>();
+
+/** Upsert a gateway ACL row for a channel (keyed by assistant channel id). */
+export function upsertGatewayAcl(row: GatewayAclRow): void {
+  rows.set(row.channelId, row);
+}
+
+/** Patch the status of an existing gateway ACL row, if present. */
+export function setGatewayAclStatusByChannelId(
+  channelId: string,
+  status: string,
+): void {
+  const existing = rows.get(channelId);
+  if (existing) existing.status = status;
+}
+
+/** Patch the status of every gateway ACL row of a channel type. */
+export function setGatewayAclStatusByType(
+  channelType: string,
+  status: string,
+): void {
+  for (const row of rows.values()) {
+    if (row.channelType === channelType) row.status = status;
+  }
+}
+
+/**
+ * Live gateway ACL rows: those whose backing assistant identity channel still
+ * exists. Stale rows (left over from a prior test whose tables were reset) are
+ * dropped, giving automatic per-test isolation.
+ */
+export function liveGatewayAclRows(): GatewayAclRow[] {
+  const db = getDb();
+  const live: GatewayAclRow[] = [];
+  for (const row of rows.values()) {
+    const exists = db
+      .select({ id: contactChannels.id })
+      .from(contactChannels)
+      .where(eq(contactChannels.id, row.channelId))
+      .get();
+    if (exists) live.push(row);
+    else rows.delete(row.channelId);
+  }
+  return live;
+}
+
+/** Test-only: clear the entire gateway ACL store. */
+export function __resetGatewayAclStoreForTest(): void {
+  rows.clear();
+}

--- a/assistant/src/__tests__/helpers/gateway-acl-store.ts
+++ b/assistant/src/__tests__/helpers/gateway-acl-store.ts
@@ -10,17 +10,10 @@
  * write here and the test guardian-delivery resolver reads here, so NO test code
  * touches the assistant DB's ACL columns (which Phase B drops).
  *
- * Isolation: rows are keyed by the assistant channel id (which the identity
- * upsert regenerates per test). Reads drop any row whose backing assistant
- * identity channel no longer exists, so a `DELETE FROM contact_channels` /
- * `resetDbForTesting()` in a test's `beforeEach` automatically evicts stale
- * gateway rows without each test having to reset this store.
+ * Purely in-memory: no assistant DB / `src/` reach. Isolation is explicit — a
+ * test's `beforeEach` calls {@link resetGatewayAclStore} to clear the store,
+ * mirroring how sibling in-memory test stores reset themselves.
  */
-
-import { eq } from "drizzle-orm";
-
-import { getDb } from "../../memory/db-connection.js";
-import { contactChannels } from "../../memory/schema.js";
 
 export interface GatewayAclRow {
   contactId: string;
@@ -63,27 +56,16 @@ export function setGatewayAclStatusByType(
   }
 }
 
-/**
- * Live gateway ACL rows: those whose backing assistant identity channel still
- * exists. Stale rows (left over from a prior test whose tables were reset) are
- * dropped, giving automatic per-test isolation.
- */
-export function liveGatewayAclRows(): GatewayAclRow[] {
-  const db = getDb();
-  const live: GatewayAclRow[] = [];
-  for (const row of rows.values()) {
-    const exists = db
-      .select({ id: contactChannels.id })
-      .from(contactChannels)
-      .where(eq(contactChannels.id, row.channelId))
-      .get();
-    if (exists) live.push(row);
-    else rows.delete(row.channelId);
-  }
-  return live;
+/** All gateway ACL rows currently in the store. */
+export function gatewayAclRows(): GatewayAclRow[] {
+  return [...rows.values()];
 }
 
-/** Test-only: clear the entire gateway ACL store. */
-export function __resetGatewayAclStoreForTest(): void {
+/**
+ * Clear the gateway ACL store. Tests call this in `beforeEach` (alongside the
+ * assistant DB reset) for per-test isolation, the same way sibling in-memory
+ * test stores reset themselves.
+ */
+export function resetGatewayAclStore(): void {
   rows.clear();
 }

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -23,6 +23,7 @@ import { getDb } from "../../memory/db-connection.js";
 import { contacts } from "../../memory/schema.js";
 import { setMemberVerdict } from "../../runtime/member-verdict-cache.js";
 import {
+  gatewayAclByChannelId,
   setGatewayAclStatusByChannelId,
   setGatewayAclStatusByType,
   upsertGatewayAcl,
@@ -78,19 +79,24 @@ export function seedContactChannel(params: {
 
   // Stamp the gateway-owned ACL row (role/status/verifiedAt + delivery
   // endpoints) into the gateway ACL store — the source the guardian-delivery
-  // resolver reads, mirroring production.
+  // resolver reads, mirroring production. Re-seeding a channel's member ACL
+  // (e.g. a guardian's own active member row) without an explicit role keeps
+  // the existing gateway role, mirroring the gateway: an identity/member upsert
+  // never downgrades a guardian to a plain contact.
   const status = params.status ?? "active";
+  const existing = gatewayAclByChannelId(channel.id);
   upsertGatewayAcl({
     contactId: contact.id,
     channelId: channel.id,
     channelType: channel.type,
     address: channel.address,
     externalChatId: channel.externalChatId ?? null,
-    principalId: params.principalId ?? null,
+    principalId: params.principalId ?? existing?.principalId ?? null,
     displayName: contact.displayName ?? null,
-    role: params.role ?? "contact",
+    role: params.role ?? existing?.role ?? "contact",
     status,
-    verifiedAt: params.verifiedAt ?? null,
+    policy: params.policy ?? "allow",
+    verifiedAt: params.verifiedAt ?? existing?.verifiedAt ?? null,
   });
 
   // Warm the verdict cache so the sync trust fallback resolves this member, as

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -7,7 +7,7 @@
  * fallback resolve the intended trust.
  */
 
-import { eq } from "drizzle-orm";
+import { eq, type SQL } from "drizzle-orm";
 
 import { isChannelId } from "../../channels/types.js";
 import { upsertContact } from "../../contacts/contact-store.js";
@@ -93,4 +93,28 @@ export function seedContactChannel(params: {
   }
 
   return { contactId: contact.id, channelId: channel.id };
+}
+
+/**
+ * Stamp the local mirror of a gateway-owned channel ACL downgrade. Production
+ * revoke is gateway-owned (relayed via `mark_channel_revoked`); tests whose
+ * guardian-resolution reads run locally call these to mark channels `revoked`
+ * so those reads observe the downgrade. The ACL-column write is confined here
+ * so the trust/guardian test files don't reference the columns.
+ */
+export function revokeChannelsByType(channelType: string): void {
+  revokeChannelsWhere(eq(contactChannels.type, channelType));
+}
+
+/** Stamp a gateway-owned channel revoke for a single channel id. */
+export function revokeChannelById(channelId: string): void {
+  revokeChannelsWhere(eq(contactChannels.id, channelId));
+}
+
+function revokeChannelsWhere(predicate: SQL): void {
+  getDb()
+    .update(contactChannels)
+    .set({ status: "revoked", updatedAt: Date.now() })
+    .where(predicate)
+    .run();
 }

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -2,12 +2,15 @@
  * Test-only member seeding.
  *
  * Production identity upserts no longer write ACL columns (gateway-owned).
- * Tests that simulate gateway-resolved members stamp the ACL columns directly
- * and warm the member-verdict cache so verdict synthesis and the sync trust
- * fallback resolve the intended trust.
+ * Tests that simulate gateway-resolved members seed the ACL state into the
+ * in-process gateway ACL store ({@link upsertGatewayAcl}, the stand-in for
+ * `gwContacts`/`gwContactChannels`) and warm the member-verdict cache so verdict
+ * synthesis and the sync trust fallback resolve the intended trust. The assistant
+ * row carries only identity/info columns (id, displayName, channel address/chat
+ * id, principalId) — never the Phase-B-dropped ACL columns.
  */
 
-import { eq, type SQL } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import { isChannelId } from "../../channels/types.js";
 import { upsertContact } from "../../contacts/contact-store.js";
@@ -17,8 +20,13 @@ import type {
   ContactRole,
 } from "../../contacts/types.js";
 import { getDb } from "../../memory/db-connection.js";
-import { contactChannels, contacts } from "../../memory/schema.js";
+import { contacts } from "../../memory/schema.js";
 import { setMemberVerdict } from "../../runtime/member-verdict-cache.js";
+import {
+  setGatewayAclStatusByChannelId,
+  setGatewayAclStatusByType,
+  upsertGatewayAcl,
+} from "./gateway-acl-store.js";
 
 export function seedContactChannel(params: {
   sourceChannel: string;
@@ -54,30 +62,36 @@ export function seedContactChannel(params: {
     reassignConflictingChannels: !!params.contactId,
   });
 
+  // principalId is an identity column that survives Phase B — keep stamping it
+  // on the assistant row so identity-keyed reads resolve it.
   const db = getDb();
-  if (params.role !== undefined || params.principalId !== undefined) {
-    const set: Record<string, unknown> = {};
-    if (params.role !== undefined) set.role = params.role;
-    if (params.principalId !== undefined) set.principalId = params.principalId;
-    db.update(contacts).set(set).where(eq(contacts.id, contact.id)).run();
+  if (params.principalId !== undefined) {
+    db.update(contacts)
+      .set({ principalId: params.principalId })
+      .where(eq(contacts.id, contact.id))
+      .run();
   }
 
   const channel = contact.channels.find(
     (ch) => ch.type === params.sourceChannel,
   )!;
-  const aclSet: Record<string, unknown> = { updatedAt: Date.now() };
-  if (params.status !== undefined) aclSet.status = params.status;
-  if (params.policy !== undefined) aclSet.policy = params.policy;
-  if (params.verifiedAt !== undefined) aclSet.verifiedAt = params.verifiedAt;
-  if (params.verifiedVia !== undefined) aclSet.verifiedVia = params.verifiedVia;
-  if (params.revokedReason !== undefined)
-    aclSet.revokedReason = params.revokedReason;
-  if (params.blockedReason !== undefined)
-    aclSet.blockedReason = params.blockedReason;
-  db.update(contactChannels)
-    .set(aclSet)
-    .where(eq(contactChannels.id, channel.id))
-    .run();
+
+  // Stamp the gateway-owned ACL row (role/status/verifiedAt + delivery
+  // endpoints) into the gateway ACL store — the source the guardian-delivery
+  // resolver reads, mirroring production.
+  const status = params.status ?? "active";
+  upsertGatewayAcl({
+    contactId: contact.id,
+    channelId: channel.id,
+    channelType: channel.type,
+    address: channel.address,
+    externalChatId: channel.externalChatId ?? null,
+    principalId: params.principalId ?? null,
+    displayName: contact.displayName ?? null,
+    role: params.role ?? "contact",
+    status,
+    verifiedAt: params.verifiedAt ?? null,
+  });
 
   // Warm the verdict cache so the sync trust fallback resolves this member, as
   // a gateway verdict fetch would in production.
@@ -87,7 +101,7 @@ export function seedContactChannel(params: {
       canonicalSenderId: address,
       contactId: contact.id,
       channelId: channel.id,
-      status: (params.status ?? "active") as ChannelStatus,
+      status: status as ChannelStatus,
       policy: (params.policy ?? "allow") as ChannelPolicy,
     });
   }
@@ -96,25 +110,16 @@ export function seedContactChannel(params: {
 }
 
 /**
- * Stamp the local mirror of a gateway-owned channel ACL downgrade. Production
- * revoke is gateway-owned (relayed via `mark_channel_revoked`); tests whose
- * guardian-resolution reads run locally call these to mark channels `revoked`
- * so those reads observe the downgrade. The ACL-column write is confined here
- * so the trust/guardian test files don't reference the columns.
+ * Stamp the gateway-owned channel ACL downgrade. Production revoke is
+ * gateway-owned (relayed via `mark_channel_revoked`); tests whose
+ * guardian-resolution reads run against the gateway ACL store call these to
+ * mark channels `revoked` so those reads observe the downgrade.
  */
 export function revokeChannelsByType(channelType: string): void {
-  revokeChannelsWhere(eq(contactChannels.type, channelType));
+  setGatewayAclStatusByType(channelType, "revoked");
 }
 
 /** Stamp a gateway-owned channel revoke for a single channel id. */
 export function revokeChannelById(channelId: string): void {
-  revokeChannelsWhere(eq(contactChannels.id, channelId));
-}
-
-function revokeChannelsWhere(predicate: SQL): void {
-  getDb()
-    .update(contactChannels)
-    .set({ status: "revoked", updatedAt: Date.now() })
-    .where(predicate)
-    .run();
+  setGatewayAclStatusByChannelId(channelId, "revoked");
 }

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -96,24 +96,20 @@ function richContactForId(contactId: string | undefined) {
   if (!contactId) return undefined;
   const contact = getContact(contactId);
   if (!contact) return undefined;
-  // ACL columns live on the still-present DB rows, not the slimmed interfaces;
-  // read them raw to build the gateway-rich response the production read parses.
-  const contactRole = (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contact.id) as { role: string } | undefined
-  )?.role;
+  // The gateway owns the ACL; tests seed it into the gateway ACL store. Source
+  // role/status/policy from there to build the gateway-rich response the
+  // production read parses (never the Phase-B-dropped assistant ACL columns).
   return {
     ok: true,
     contact: {
       id: contact.id,
       displayName: contact.displayName,
-      role: contactRole ?? "contact",
+      role: gatewayContactRole(contact.id) ?? "contact",
       interactionCount: contact.interactionCount,
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
       channels: contact.channels.map((c) => {
-        const acl = rawChannelAcl(c.id);
+        const acl = gatewayChannelAcl(c.id);
         return {
           id: c.id,
           contactId: c.contactId,
@@ -124,39 +120,35 @@ function richContactForId(contactId: string | undefined) {
           status: acl.status,
           policy: acl.policy,
           verifiedAt: acl.verifiedAt,
-          verifiedVia: acl.verifiedVia,
-          lastSeenAt: acl.lastSeenAt,
-          interactionCount: acl.interactionCount,
-          lastInteraction: acl.lastInteraction,
-          revokedReason: acl.revokedReason,
-          blockedReason: acl.blockedReason,
+          verifiedVia: null,
+          lastSeenAt: null,
+          interactionCount: 0,
+          lastInteraction: null,
+          revokedReason: null,
+          blockedReason: null,
         };
       }),
     },
   };
 }
 
-/** Read a channel's ACL columns straight off the still-present DB row. */
-function rawChannelAcl(channelId: string) {
-  return getSqlite()
-    .query(
-      `SELECT status, policy, verified_at AS verifiedAt, verified_via AS verifiedVia,
-              last_seen_at AS lastSeenAt, interaction_count AS interactionCount,
-              last_interaction AS lastInteraction, revoked_reason AS revokedReason,
-              blocked_reason AS blockedReason
-         FROM contact_channels WHERE id = ?`,
-    )
-    .get(channelId) as {
-    status: string;
-    policy: string;
-    verifiedAt: number | null;
-    verifiedVia: string | null;
-    lastSeenAt: number | null;
-    interactionCount: number;
-    lastInteraction: number | null;
-    revokedReason: string | null;
-    blockedReason: string | null;
+/** Read a channel's seeded ACL view from the gateway ACL store. */
+function gatewayChannelAcl(channelId: string): {
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+} {
+  const row = gatewayAclByChannelId(channelId);
+  return {
+    status: row?.status ?? "unverified",
+    policy: row?.policy ?? "allow",
+    verifiedAt: row?.verifiedAt ?? null,
   };
+}
+
+/** The seeded gateway role for any of a contact's channels. */
+function gatewayContactRole(contactId: string): string | undefined {
+  return gatewayAclRows().find((r) => r.contactId === contactId)?.role;
 }
 
 import {
@@ -164,13 +156,18 @@ import {
   getContact,
   upsertContact,
 } from "../contacts/contact-store.js";
-import { getDb, getSqlite } from "../memory/db-connection.js";
+import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import {
   handleChannelInbound,
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
+import {
+  gatewayAclByChannelId,
+  gatewayAclRows,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -194,6 +191,7 @@ function resetState(): void {
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
   gatewayIpcCalls.length = 0;

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -101,24 +101,20 @@ function richContactForId(contactId: string | undefined) {
   if (!contactId) return undefined;
   const contact = getContact(contactId);
   if (!contact) return undefined;
-  // ACL columns live on the still-present DB rows, not the slimmed interfaces;
-  // read them raw to build the gateway-rich response the production read parses.
-  const contactRole = (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contact.id) as { role: string } | undefined
-  )?.role;
+  // The gateway owns the ACL; tests seed it into the gateway ACL store. Source
+  // role/status/policy from there to build the gateway-rich response the
+  // production read parses (never the Phase-B-dropped assistant ACL columns).
   return {
     ok: true,
     contact: {
       id: contact.id,
       displayName: contact.displayName,
-      role: contactRole ?? "contact",
+      role: gatewayContactRole(contact.id) ?? "contact",
       interactionCount: contact.interactionCount,
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
       channels: contact.channels.map((c) => {
-        const acl = rawChannelAcl(c.id);
+        const acl = gatewayChannelAcl(c.id);
         return {
           id: c.id,
           contactId: c.contactId,
@@ -129,39 +125,35 @@ function richContactForId(contactId: string | undefined) {
           status: acl.status,
           policy: acl.policy,
           verifiedAt: acl.verifiedAt,
-          verifiedVia: acl.verifiedVia,
-          lastSeenAt: acl.lastSeenAt,
-          interactionCount: acl.interactionCount,
-          lastInteraction: acl.lastInteraction,
-          revokedReason: acl.revokedReason,
-          blockedReason: acl.blockedReason,
+          verifiedVia: null,
+          lastSeenAt: null,
+          interactionCount: 0,
+          lastInteraction: null,
+          revokedReason: null,
+          blockedReason: null,
         };
       }),
     },
   };
 }
 
-/** Read a channel's ACL columns straight off the still-present DB row. */
-function rawChannelAcl(channelId: string) {
-  return getSqlite()
-    .query(
-      `SELECT status, policy, verified_at AS verifiedAt, verified_via AS verifiedVia,
-              last_seen_at AS lastSeenAt, interaction_count AS interactionCount,
-              last_interaction AS lastInteraction, revoked_reason AS revokedReason,
-              blocked_reason AS blockedReason
-         FROM contact_channels WHERE id = ?`,
-    )
-    .get(channelId) as {
-    status: string;
-    policy: string;
-    verifiedAt: number | null;
-    verifiedVia: string | null;
-    lastSeenAt: number | null;
-    interactionCount: number;
-    lastInteraction: number | null;
-    revokedReason: string | null;
-    blockedReason: string | null;
+/** Read a channel's seeded ACL view from the gateway ACL store. */
+function gatewayChannelAcl(channelId: string): {
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+} {
+  const row = gatewayAclByChannelId(channelId);
+  return {
+    status: row?.status ?? "unverified",
+    policy: row?.policy ?? "allow",
+    verifiedAt: row?.verifiedAt ?? null,
   };
+}
+
+/** The seeded gateway role for any of a contact's channels. */
+function gatewayContactRole(contactId: string): string | undefined {
+  return gatewayAclRows().find((r) => r.contactId === contactId)?.role;
 }
 
 // Lets a test inject a side-effect into the gateway claim — runs after the
@@ -200,6 +192,11 @@ import {
   resolveMemberGateStatus,
 } from "../runtime/invite-redemption-service.js";
 import { hashVoiceCode } from "../util/voice-code.js";
+import {
+  gatewayAclByChannelId,
+  gatewayAclRows,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
@@ -208,6 +205,7 @@ function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");
   getSqlite().run("DELETE FROM contact_channels");
   getSqlite().run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 /** Create a throwaway contact and return its ID, for use as the invite's contactId. */
@@ -215,13 +213,9 @@ function createTargetContact(displayName = "Target Contact"): string {
   return upsertContact({ displayName, role: "contact" }).id;
 }
 
-/** Read a contact's local role column (dropped from the Contact interface). */
+/** Read a contact's seeded gateway role (gateway-owned, not a local column). */
 function localContactRole(contactId: string): string | undefined {
-  return (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contactId) as { role: string } | undefined
-  )?.role;
+  return gatewayContactRole(contactId);
 }
 
 describe("invite-redemption-service", () => {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -434,6 +434,7 @@ import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 import { deriveGuardianDeliveries } from "./helpers/derive-guardian-delivery.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
@@ -516,6 +517,7 @@ function resetTables() {
     "contact_channels",
     "contacts",
   );
+  resetGatewayAclStore();
   ensuredConvIds = new Set();
 }
 
@@ -2952,6 +2954,7 @@ describe("relay-server", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
     try {
       ensureConversation("conv-invite-no-name");
       const session = createCallSession({
@@ -2996,6 +2999,7 @@ describe("relay-server", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
     try {
       ensureConversation("conv-invite-uuid-name");
       const session = createCallSession({

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -26,8 +26,6 @@ import {
   test,
 } from "bun:test";
 
-import { and, desc, eq } from "drizzle-orm";
-
 // ── Platform + logger mocks (must come before any source imports) ────
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -254,7 +252,7 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
 // setup keeps driving guardian resolution without per-test changes. Both the
 // async read and the sync cache peek (read by resolveActorTrust) share the same
 // DB-derived snapshot mirroring the gateway's active-guardian-channel query.
-function deriveGuardianDeliveries(
+function resolveGuardianDeliveries(
   channelTypes?: string[],
 ): Array<Record<string, unknown>> {
   if (mockGuardianDeliveryList) {
@@ -264,41 +262,14 @@ function deriveGuardianDeliveries(
         )
       : mockGuardianDeliveryList;
   }
-  const rows = getDb()
-    .select({ contact: contacts, channel: contactChannels })
-    .from(contacts)
-    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(eq(contacts.role, "guardian"), eq(contactChannels.status, "active")),
-    )
-    .orderBy(desc(contactChannels.verifiedAt))
-    .all();
-  if (rows.length === 0) return [];
-  const guardianId = rows[0].contact.id;
-  const list = rows
-    .filter((r) => r.contact.id === guardianId)
-    .map((r) => ({
-      channelType: r.channel.type,
-      contactId: r.contact.id,
-      principalId: r.contact.principalId ?? null,
-      displayName: r.contact.displayName ?? null,
-      address: r.channel.address,
-      externalChatId: r.channel.externalChatId ?? null,
-      status: r.channel.status,
-      verifiedAt: r.channel.verifiedAt ?? null,
-    }));
-  return channelTypes
-    ? list.filter((g) =>
-        channelTypes.includes(g.channelType),
-      )
-    : list;
+  return deriveGuardianDeliveries({ channelTypes });
 }
 
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async (input?: { channelTypes?: string[] }) =>
-    deriveGuardianDeliveries(input?.channelTypes),
+    resolveGuardianDeliveries(input?.channelTypes),
   peekCachedGuardianDelivery: (input?: { channelTypes?: string[] }) =>
-    deriveGuardianDeliveries(input?.channelTypes),
+    resolveGuardianDeliveries(input?.channelTypes),
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,
@@ -454,11 +425,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { createInvite } from "../memory/invite-store.js";
 import { resetTestTables } from "../memory/raw-query.js";
-import {
-  contactChannels,
-  contacts,
-  conversations,
-} from "../memory/schema.js";
+import { conversations } from "../memory/schema.js";
 import {
   createOutboundSession,
   getGuardianBinding,
@@ -466,6 +433,7 @@ import {
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { deriveGuardianDeliveries } from "./helpers/derive-guardian-delivery.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -73,6 +73,7 @@ import {
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -94,6 +95,7 @@ function resetState(): void {
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
 }
@@ -394,9 +396,13 @@ describe("trusted contact lifecycle notification signals", () => {
     // Clear the guardian contact's displayName to empty string so the
     // display name resolution returns a falsy value. createGuardianBinding
     // defaults displayName to the externalUserId, which would be a non-empty
-    // string and defeat the purpose of this test.
+    // string and defeat the purpose of this test. The role column is
+    // gateway-owned now, so target the guardian contact by its seeded
+    // (externalUserId-derived) display name instead.
     const db = getDb();
-    db.run("UPDATE contacts SET display_name = '' WHERE role = 'guardian'");
+    db.run(
+      "UPDATE contacts SET display_name = '' WHERE display_name = 'guardian-noname-111'",
+    );
 
     // Do NOT create a requester contact — display name should resolve to null
 

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -73,7 +73,7 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 }));
 
 import { findContactChannel } from "../contacts/contact-store.js";
-import { getDb, getSqlite } from "../memory/db-connection.js";
+import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   createOutboundSession,
@@ -84,6 +84,10 @@ import {
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import {
+  gatewayAclByChannelId,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -102,6 +106,7 @@ function resetState(): void {
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
   emitSignalCalls.length = 0;
   notifyGuardianCalls.length = 0;
   deliverReplyCalls.length = 0;
@@ -271,13 +276,8 @@ for (const config of CHANNEL_CONFIGS) {
       });
 
       expect(contactResult).not.toBeNull();
-      // Assert the gateway dual-write landed in the local ACL columns.
-      const acl = getSqlite()
-        .query("SELECT status, policy FROM contact_channels WHERE id = ?")
-        .get(contactResult!.channel.id) as {
-        status: string;
-        policy: string;
-      } | null;
+      // Assert the gateway-resolved ACL landed in the gateway ACL store.
+      const acl = gatewayAclByChannelId(contactResult!.channel.id);
       expect(acl!.status).toBe("active");
       expect(acl!.policy).toBe("allow");
       expect(contactResult!.channel.type).toBe(config.channel);

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -42,6 +42,7 @@ import {
 } from "../runtime/member-verdict-cache.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 import { deriveGuardianForChannel } from "./helpers/derive-guardian-delivery.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -55,6 +56,7 @@ function resetTables(): void {
   db.run("DELETE FROM channel_guardian_rate_limits");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 // Mirror a warmed gateway verdict so the sync resolveActorTrust fallback

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -22,8 +22,6 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { and, desc, eq } from "drizzle-orm";
-
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel } from "../contacts/contact-store.js";
 import {
@@ -33,7 +31,6 @@ import {
 import type { ChannelStatus } from "../contacts/types.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { contactChannels, contacts } from "../memory/schema.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
 import {
   createOutboundSession,
@@ -44,6 +41,7 @@ import {
   setMemberVerdict,
 } from "../runtime/member-verdict-cache.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { deriveGuardianForChannel } from "./helpers/derive-guardian-delivery.js";
 
 await initializeDb();
 
@@ -77,28 +75,6 @@ function warmMemberVerdict(
     status,
     policy: "allow",
   });
-}
-
-/**
- * Read the local active guardian channel for a channel type, mirroring the
- * gateway's role/status resolution. Used by assertions that confirm the local
- * guardian binding state after verification flows.
- */
-function localGuardianForChannel(channelType: string) {
-  const row = getDb()
-    .select({ contact: contacts, channel: contactChannels })
-    .from(contacts)
-    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(
-        eq(contacts.role, "guardian"),
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.status, "active"),
-      ),
-    )
-    .orderBy(desc(contactChannels.verifiedAt))
-    .get();
-  return row ? { contact: row.contact, channel: row.channel } : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -413,9 +389,9 @@ describe("trusted contact verification → member activation", () => {
     }
 
     // The original guardian binding should remain intact
-    const guardianResult = localGuardianForChannel("telegram");
+    const guardianResult = deriveGuardianForChannel("telegram");
     expect(guardianResult).not.toBeNull();
-    expect(guardianResult!.channel.address).toBe("guardian-user-original");
+    expect(guardianResult!.address).toBe("guardian-user-original");
   });
 
   test("guardian inbound verification succeeds but does not create binding", async () => {
@@ -437,7 +413,7 @@ describe("trusted contact verification → member activation", () => {
       expect(result.verificationType).toBe("guardian");
     }
 
-    const guardianResult = localGuardianForChannel("telegram");
+    const guardianResult = deriveGuardianForChannel("telegram");
     expect(guardianResult).toBeNull();
   });
 });

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -59,24 +59,20 @@ function richContactForId(contactId: string | undefined) {
   if (!contactId) return undefined;
   const contact = getContact(contactId);
   if (!contact) return undefined;
-  // ACL columns live on the still-present DB rows, not the slimmed interfaces;
-  // read them raw to build the gateway-rich response the production read parses.
-  const contactRole = (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contact.id) as { role: string } | undefined
-  )?.role;
+  // The gateway owns the ACL; tests seed it into the gateway ACL store. Source
+  // role/status/policy from there to build the gateway-rich response the
+  // production read parses (never the Phase-B-dropped assistant ACL columns).
   return {
     ok: true,
     contact: {
       id: contact.id,
       displayName: contact.displayName,
-      role: contactRole ?? "contact",
+      role: gatewayContactRole(contact.id) ?? "contact",
       interactionCount: contact.interactionCount,
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
       channels: contact.channels.map((c) => {
-        const acl = rawChannelAcl(c.id);
+        const acl = gatewayChannelAcl(c.id);
         return {
           id: c.id,
           contactId: c.contactId,
@@ -87,48 +83,40 @@ function richContactForId(contactId: string | undefined) {
           status: acl.status,
           policy: acl.policy,
           verifiedAt: acl.verifiedAt,
-          verifiedVia: acl.verifiedVia,
-          lastSeenAt: acl.lastSeenAt,
-          interactionCount: acl.interactionCount,
-          lastInteraction: acl.lastInteraction,
-          revokedReason: acl.revokedReason,
-          blockedReason: acl.blockedReason,
+          verifiedVia: null,
+          lastSeenAt: null,
+          interactionCount: 0,
+          lastInteraction: null,
+          revokedReason: null,
+          blockedReason: null,
         };
       }),
     },
   };
 }
 
-/** Read a channel's ACL columns straight off the still-present DB row. */
-function rawChannelAcl(channelId: string) {
-  return getSqlite()
-    .query(
-      `SELECT status, policy, verified_at AS verifiedAt, verified_via AS verifiedVia,
-              last_seen_at AS lastSeenAt, interaction_count AS interactionCount,
-              last_interaction AS lastInteraction, revoked_reason AS revokedReason,
-              blocked_reason AS blockedReason
-         FROM contact_channels WHERE id = ?`,
-    )
-    .get(channelId) as {
-    status: string;
-    policy: string;
-    verifiedAt: number | null;
-    verifiedVia: string | null;
-    lastSeenAt: number | null;
-    interactionCount: number;
-    lastInteraction: number | null;
-    revokedReason: string | null;
-    blockedReason: string | null;
+/** Read a channel's seeded ACL view from the gateway ACL store. */
+function gatewayChannelAcl(channelId: string): {
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+} {
+  const row = gatewayAclByChannelId(channelId);
+  return {
+    status: row?.status ?? "unverified",
+    policy: row?.policy ?? "allow",
+    verifiedAt: row?.verifiedAt ?? null,
   };
 }
 
-/** Read a contact's local role column (dropped from the Contact interface). */
+/** The seeded gateway role for any of a contact's channels. */
+function gatewayContactRole(contactId: string): string | undefined {
+  return gatewayAclRows().find((r) => r.contactId === contactId)?.role;
+}
+
+/** Read a contact's seeded gateway role (gateway-owned, not a local column). */
 function localContactRole(contactId: string): string | undefined {
-  return (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contactId) as { role: string } | undefined
-  )?.role;
+  return gatewayContactRole(contactId);
 }
 
 function resetGatewayIpc() {
@@ -150,6 +138,11 @@ import { initializeDb } from "../memory/db-init.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
+import {
+  gatewayAclByChannelId,
+  gatewayAclRows,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
@@ -158,6 +151,7 @@ function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");
   getSqlite().run("DELETE FROM contact_channels");
   getSqlite().run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 /** Create a throwaway contact and return its ID, for use as the invite's contactId. */

--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -42,6 +42,10 @@ mock.module("../../util/logger.js", () => ({
 // the a2a.enabled flag. We use the real config system backed by initializeDb's
 // workspace directory.
 
+import {
+  gatewayAclByChannelId,
+  resetGatewayAclStore,
+} from "../../__tests__/helpers/gateway-acl-store.js";
 import { seedContactChannel } from "../../__tests__/helpers/seed-contact-channel.js";
 import {
   invalidateConfigCache,
@@ -81,13 +85,12 @@ const originalFetch = globalThis.fetch;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Read a channel's local ACL columns directly to assert the gateway dual-write. */
+/** Read a channel's gateway ACL row to assert the gateway-resolved trust. */
 function aclColumns(
   channelId: string,
 ): { status: string; policy: string } | null {
-  return getSqlite()
-    .query("SELECT status, policy FROM contact_channels WHERE id = ?")
-    .get(channelId) as { status: string; policy: string } | null;
+  const row = gatewayAclByChannelId(channelId);
+  return row ? { status: row.status, policy: row.policy } : null;
 }
 
 function resetTables(): void {
@@ -96,6 +99,7 @@ function resetTables(): void {
   sqlite.run("DELETE FROM assistant_contact_metadata");
   sqlite.run("DELETE FROM contact_channels");
   sqlite.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 function setConfigEnabled(enabled: boolean): void {


### PR DESCRIPTION
## Summary
- Rework 5 trust/guardian test files + helper to seed/resolve guardian + channel trust state from the gateway test DB instead of the assistant contacts.role / contact_channels.status/verifiedAt columns
- Keeps assertions on gateway-owned ACL against the gateway DB; makes these tests safe once the assistant ACL columns are dropped

Part of plan: drain-contacts-role.md (PR 4 of 4)