### PR TITLE
Render Slack Block Kit in the Slack adapter, not the delivery path

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -81,8 +81,8 @@ mock.module("../runtime/gateway-client.js", () => ({
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
-    setConversationProcessingStartedAt: () => {},
-    isConversationProcessing: () => false,
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
@@ -240,6 +240,7 @@ describe("channel-reply-delivery", () => {
       payload: {
         chatId: "chat-1",
         text: "Before tool.",
+        useBlocks: true,
         attachments: undefined,
         assistantId: "assistant-1",
       },
@@ -249,6 +250,7 @@ describe("channel-reply-delivery", () => {
       payload: {
         chatId: "chat-1",
         text: "After tool.",
+        useBlocks: true,
         attachments,
         assistantId: "assistant-1",
       },
@@ -307,12 +309,14 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].payload).toEqual({
       chatId: "chat-3",
       text: "Before tool.",
+      useBlocks: true,
       attachments: undefined,
       assistantId: "assistant-2",
     });
     expect(deliveryCalls[1].payload).toEqual({
       chatId: "chat-3",
       text: "After tool.",
+      useBlocks: true,
       attachments: [
         {
           id: "att-2",

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -7,13 +7,11 @@ import {
   getMessages,
   updateMessageMetadata,
 } from "../memory/conversation-crud.js";
-import { channelForCallback } from "../messaging/providers/callback-routing.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
 import { deliverChannelReply } from "./gateway-client.js";
 import type { RuntimeAttachmentMetadata } from "./http-types.js";
-import { textToSlackBlocks } from "./slack-block-formatting.js";
 
 const log = getLogger("channel-reply-delivery");
 
@@ -165,8 +163,6 @@ export async function deliverRenderedReplyViaCallback(
     return;
   }
 
-  const isSlack = channelForCallback(callbackUrl) === "slack";
-
   // Only the first segment uses messageTs for in-place update;
   // subsequent segments are posted as new messages.
   let currentMessageTs = messageTs;
@@ -175,13 +171,14 @@ export async function deliverRenderedReplyViaCallback(
     const isLastSegment = i === deliverableSegments.length - 1;
     const isFirstSegment = i === startFromSegment;
     const segmentText = deliverableSegments[i];
-    const blocks = isSlack ? textToSlackBlocks(segmentText) : undefined;
     const result: ChannelDeliveryResult = await deliverChannelReply(
       callbackUrl,
       {
         chatId,
         text: segmentText,
-        blocks,
+        // Ask the channel to render richly; each channel's adapter decides how
+        // (Slack → Block Kit). Channels without rich rendering send plain text.
+        useBlocks: true,
         attachments: isLastSegment ? replyAttachments : undefined,
         assistantId,
         ephemeral,


### PR DESCRIPTION
## What

`channel-reply-delivery.ts` — the channel-agnostic outbound delivery path — decided Slack Block Kit formatting itself (`channelForCallback(callbackUrl) === "slack"` → `textToSlackBlocks`), leaking a Slack-specific presentation decision into the generic path.

This moves that decision into the Slack adapter, which already knows how to render text → Block Kit. The delivery path now sets the existing `useBlocks` "render richly" hint; Slack's `resolveBlocks` honors it (`textToSlackBlocks(text)`), and every other channel ignores it and sends plain text.

## Why this shape (not a registry)

The first instinct was a per-channel formatter registry — but with only one channel that formats richly, that generalizes from a single example and mostly *relocates* the hardcode. This adds **no new abstraction**: it removes the `=== "slack"` check, the `textToSlackBlocks` import, and the per-segment block computation from the generic path, and lets the channel own its own presentation (the channels-as-adapters direction).

## Behavior-preserving

- Slack replies render the same blocks — `textToSlackBlocks` per segment, now via the `useBlocks` flag in the Slack send layer (`resolveBlocks`).
- Non-Slack channels ignore `useBlocks` → plain text (unchanged).
- Guardian / other direct Slack sends don't set `useBlocks` → stay plain text (unchanged).

Verified: typecheck, lint, `channel-reply-delivery` (29) + `outbound-slack-persistence` (7) green.

## Follow-up (separate)

Slack exposes a real `plan` block (a task list with per-task status/details/output) — a natural richer rendering for the assistant's task-progress surfaces. That's its own feature (plan data at delivery + when-to-render logic + schema mapping); this cleanup makes the Slack adapter the right home for it. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_