### PR TITLE
refactor(web): compose PageProgress classes with cn()

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/page-progress.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/page-progress.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/utils/misc";
+
 interface PageProgressProps {
   current: number;
   total: number;
@@ -7,11 +9,17 @@ export function PageProgress({ current, total }: PageProgressProps) {
   return (
     <div className="mb-4 flex items-center gap-1.5">
       {Array.from({ length: total }, (_, i) => (
+        // The unfilled track uses --border-subtle (not a surface token): it's
+        // the lightest token that still reads against the white --surface-lift
+        // form card; surface tokens are too pale to show here.
         <div
           key={i}
-          className={`h-1.5 flex-1 rounded-full transition-colors ${
-            i <= current ? "bg-[var(--primary-base)]" : "bg-[var(--border-subtle)]"
-          }`}
+          className={cn(
+            "h-1.5 flex-1 rounded-full transition-colors",
+            i <= current
+              ? "bg-[var(--primary-base)]"
+              : "bg-[var(--border-subtle)]",
+          )}
         />
       ))}
     </div>


### PR DESCRIPTION
## What

Follow-up to the LUM-2608 styling review. `PageProgress` (the FormSurface segment-bar indicator, added in #36182) composed its conditional segment classes with a raw template literal; this switches it to the `cn()` helper, matching the design library's class composition.

## Why

`cn()` (clsx + tailwind-merge) is the project's class-composition helper and what the design-library components use. The template-literal form worked (it interpolates complete literal class strings, which Tailwind detects) but bypasses tailwind-merge and diverges from convention.

I deliberately **kept** the unfilled track's `--border-subtle` token rather than swapping it to a surface token. On the white FormSurface card (`--surface-lift` = `#FFFFFF`), the surface tokens (`--surface-sunken` / `--surface-base` = `#F6F5F4`) are too pale to read, while `--border-subtle` (`#E9E6E2`) is the lightest token that stays visible. Added a code comment so it isn't "corrected" into invisibility later.

## Scope

This covers only `PageProgress` (a file we added in #36182). The broader pattern — the rest of `clients/web/.../surfaces/` composing conditional classes with template literals / string concatenation — is pre-existing and tracked in LUM-2616.

## Testing

- `clients/web`: `tsc --noEmit` (pre-commit) — pass. No visual change (tokens unchanged).

Part of LUM-2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wuqoKsrCJ336NLvvNPMvv)_