### PR TITLE
feat(web): virtualize chat transcript with VirtualList

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -190,7 +190,6 @@ const INITIAL_PAGINATION: Omit<TranscriptPaginationState, "items"> = {
   hasMore: false,
   oldestTimestamp: null,
   isLoadingOlder: false,
-  isPinnedToLatest: true,
 };
 
 function initialState(): ChatSessionState {

--- a/clients/web/src/domains/chat/components/chat-scroll-area.tsx
+++ b/clients/web/src/domains/chat/components/chat-scroll-area.tsx
@@ -1,4 +1,4 @@
-import { type ForwardedRef } from "react";
+import { type Ref } from "react";
 
 import {
   Transcript,
@@ -54,7 +54,7 @@ export interface ChatScrollAreaProps {
   /** {@link ChatEmptyStateProps} forwarded to {@link ChatEmptyState}. */
   emptyStateProps: ChatEmptyStateProps;
   /** Ref forwarded to the underlying {@link Transcript}. */
-  transcriptRef: ForwardedRef<TranscriptHandle>;
+  transcriptRef: Ref<TranscriptHandle>;
   /** {@link TranscriptProps} forwarded to {@link Transcript}. */
   transcriptProps: TranscriptProps;
 }

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -182,7 +182,6 @@ export function useConversationHistory({
       hasMore: pagination.hasMore,
       oldestTimestamp: pagination.oldestLoadedTimestamp,
       isLoadingOlder: pagination.isFetchingOlderPages,
-      isPinnedToLatest: true,
     });
 
     recordDiagnostic("history_tq_data_apply", {

--- a/clients/web/src/domains/chat/transcript/transcript-scroll-utils.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-scroll-utils.ts
@@ -104,63 +104,29 @@ export function findLatestUserAnchorKey(
 }
 
 // ---------------------------------------------------------------------------
-// Items-change decision helper
+// Prepend detection (firstItemIndex anchoring)
 // ---------------------------------------------------------------------------
 
-export interface AnchorSnapshot {
-  key: string;
-  scrollTop: number;
-  /** scrollHeight captured at the moment the anchor was saved. The
-   *  hook restores `scrollTop + (newScrollHeight − savedScrollHeight)`
-   *  after the older-page prepend lands, so the user's view stays on
-   *  the same row regardless of how many pixels of older content were
-   *  inserted above it. */
-  scrollHeight: number;
-}
-
-export type ItemsChangeAction =
-  | { kind: "none" }
-  | {
-      kind: "anchor-correct";
-      newIndex: number;
-      savedScrollTop: number;
-      savedScrollHeight: number;
-    };
-
-export interface ItemsChangeContext {
-  items: readonly TranscriptItem[];
-  previousItems: readonly TranscriptItem[];
-  conversationId: string | null;
-  savedAnchor: AnchorSnapshot | null;
-}
-
-/** Decide what the scroll coordinator should do in response to an
- *  `items` change. The caller is responsible for executing the action
- *  (calling into the TranscriptHandle) and for updating the
- *  `savedAnchor` bookkeeping state.
+/** How many history items were prepended at the front since the previous
+ *  render — the amount to decrement virtuoso's `firstItemIndex` by so the
+ *  viewport stays visually stable after an older-page load (virtuoso anchors
+ *  the scroll position itself; no manual scrollTop math needed).
  *
- *  Notes:
- *  - "open-to-latest" on conversation switch is handled by the
- *    conversation-reset effect, not here.
- *  - Streaming growth deliberately returns `none` here. The viewport
- *    stays put so the reader is in control; the "Go to Newest" pill
- *    appears once distance-from-bottom crosses its threshold. */
-export function decideItemsChangeAction(
-  ctx: ItemsChangeContext,
-): ItemsChangeAction {
-  if (ctx.conversationId === null) return { kind: "none" };
-
-  if (ctx.savedAnchor && ctx.items.length > 0) {
-    const newIndex = findAnchorIndex(ctx.items, ctx.savedAnchor.key);
-    if (newIndex >= 0) {
-      return {
-        kind: "anchor-correct",
-        newIndex,
-        savedScrollTop: ctx.savedAnchor.scrollTop,
-        savedScrollHeight: ctx.savedAnchor.scrollHeight,
-      };
-    }
-  }
-
-  return { kind: "none" };
+ *  Returns the prepended count only for a *pure* front-prepend: the list grew
+ *  and the previously-first item now sits exactly that many slots down.
+ *  Anything else — append, in-place streaming growth, replace, shrink, or the
+ *  first render with no baseline — returns 0 and leaves `firstItemIndex`
+ *  untouched (stable `computeItemKey` handles reconciliation there). */
+export function computePrependDelta(
+  historyItems: readonly TranscriptItem[],
+  prevFirstKey: string | null,
+  prevLen: number,
+): number {
+  if (prevFirstKey === null) return 0;
+  const newLen = historyItems.length;
+  if (newLen <= prevLen) return 0;
+  const delta = newLen - prevLen;
+  // For a pure prepend the old first item must now sit exactly `delta` slots
+  // down; otherwise it's a prepend+append mix or a reorder — don't shift.
+  return findAnchorIndex(historyItems, prevFirstKey) === delta ? delta : 0;
 }

--- a/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
@@ -74,13 +74,64 @@ mock.module(
 
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 
-import { Transcript } from "@/domains/chat/transcript/transcript";
+import { partitionLatestTurn } from "@/domains/chat/transcript/partition-latest-turn";
+import { LatestEdgeRow } from "@/domains/chat/transcript/transcript";
+import { TranscriptRow } from "@/domains/chat/transcript/transcript-row";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 const noop = () => {};
+
+/**
+ * Renders the transcript's row content WITHOUT the `VirtualList` wrapper.
+ * `react-virtuoso` doesn't paint items under jsdom in this workspace (see the
+ * header in `transcript.test.tsx`), and these tests assert on the spawn-group
+ * markup *inside* a message body — a per-row concern. `Turn` mirrors
+ * `Transcript`'s `itemContent` exactly: history items as `TranscriptRow`s,
+ * then the composite latest-edge row (anchor user message + streaming
+ * response), so the assistant turn under test paints as it does in production.
+ * Accepts the same prop subset these tests pass to `Transcript`, so call sites
+ * are unchanged apart from the element name.
+ */
+function Turn({
+  items,
+  conversationId = null,
+  onSurfaceAction = noop,
+  onSubagentClick,
+  onStopSubagent,
+}: {
+  items: TranscriptItem[];
+  conversationId?: string | null;
+  onSurfaceAction?: (surfaceId: string, action: string, input?: unknown) => void;
+  onSubagentClick?: (subagentId: string) => void;
+  onStopSubagent?: (subagentId: string) => void;
+}) {
+  const partition = partitionLatestTurn(items);
+  const rowProps = {
+    conversationId,
+    onSurfaceAction,
+    onSubagentClick,
+    onStopSubagent,
+  };
+  return (
+    <>
+      {partition.historyItems.map((item) => (
+        <TranscriptRow key={item.key} item={item} {...rowProps} />
+      ))}
+      {partition.anchorMessage && (
+        <LatestEdgeRow
+          anchorMessage={partition.anchorMessage}
+          responseItems={partition.responseItems}
+          hasAvatar={false}
+          viewportMinHeight={undefined}
+          rowProps={rowProps}
+        />
+      )}
+    </>
+  );
+}
 
 /**
  * Expand every collapsed `SubagentSpawnGroup` in the tree so its per-subagent
@@ -258,7 +309,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     ];
 
     const { getAllByTestId, queryAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -278,7 +329,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     ];
 
     const { container, getAllByTestId, queryAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -307,7 +358,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     ];
 
     const { container, getByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -336,7 +387,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     ];
 
     const { queryAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -355,7 +406,7 @@ describe("Transcript — collapsible subagent spawn group", () => {
     ];
 
     const { container, getByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -392,7 +443,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
     ];
 
     const { container, getAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -427,7 +478,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
     ];
 
     const { container, getAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -476,7 +527,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
     ];
 
     const { container, getAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -497,7 +548,7 @@ describe("Transcript — running-spawn inline cards (PR 8 fix)", () => {
     ];
 
     const { queryAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -551,7 +602,7 @@ describe("Transcript — toolUseId anchor (PR 3)", () => {
     ];
 
     const { getAllByTestId, container } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -626,7 +677,7 @@ describe("Transcript — cross-group claimed-set (fix-r1-c)", () => {
     ];
 
     const { container, getAllByTestId } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -679,7 +730,7 @@ describe("Transcript — live → reconcile card lifecycle (PR 6)", () => {
 
   function transcript(items: TranscriptItem[]) {
     return (
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}
@@ -813,7 +864,7 @@ describe("Transcript — legacy SubagentProgressCard mount is gone (PR 8)", () =
     ];
 
     const { container } = render(
-      <Transcript
+      <Turn
         items={items}
         conversationId={null}
         onSurfaceAction={noop}

--- a/clients/web/src/domains/chat/transcript/transcript.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.stories.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useTurnStore } from "@/domains/chat/turn-store";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+import { Transcript } from "./transcript";
+import type { MessageItem, TranscriptItem } from "./types";
+
+// ---------------------------------------------------------------------------
+// Fixtures — mocked transcript data (the shape the ingest boundary produces:
+// `textSegments` + `contentOrder` + `contentBlocks` in lockstep).
+// ---------------------------------------------------------------------------
+
+function message(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+): MessageItem {
+  const msg: DisplayMessage = {
+    id,
+    role,
+    textSegments: [text],
+    contentOrder: [{ type: "text", id: "0" }],
+    contentBlocks: [{ type: "text", text }],
+  };
+  return { kind: "message", key: id, message: msg };
+}
+const user = (id: string, text: string) => message(id, "user", text);
+const assistant = (id: string, text: string) => message(id, "assistant", text);
+
+const CONVERSATION: TranscriptItem[] = [
+  user("u1", "How do I set up the project locally?"),
+  assistant(
+    "a1",
+    "Clone the repo, run `bun install`, then `bun run dev`. The web client lives in `clients/web` and proxies API calls to the local gateway.",
+  ),
+  user("u2", "What runs in CI on a pull request?"),
+  assistant(
+    "a2",
+    "Three required checks: **Lint**, **Type Check**, and the isolated **Test** runner. Each test file runs in its own subprocess so `mock.module` can't leak between files.",
+  ),
+  user("u3", "How do feature flags work here?"),
+  assistant(
+    "a3",
+    "Flags live in `meta/feature-flags/feature-flag-registry.json` with a matching kebab-case `id` and `key`. A gate function delegates to the resolver; undeclared flags fail closed.",
+  ),
+];
+
+// A longer history so the virtualization (windowing + scroll) is exercised.
+const LONG_HISTORY: TranscriptItem[] = Array.from({ length: 24 }, (_, i) => [
+  user(`lu${i}`, `Question ${i + 1}: can you explain part ${i + 1}?`),
+  assistant(
+    `la${i}`,
+    `Answer ${i + 1}. ${"Here is a paragraph that wraps over a couple of lines to give the row some height. ".repeat(2)}`,
+  ),
+]).flat();
+
+// A simple gradient avatar via the real ChatAvatar (production mounts one at
+// the bottom of the latest turn through `renderAvatar`).
+const AVATAR_URL =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='56' height='56'><defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%237c5cff'/><stop offset='1' stop-color='%23e83f5b'/></linearGradient></defs><rect width='56' height='56' rx='28' fill='url(%23g)'/></svg>`,
+  );
+const renderAvatar = () => (
+  <ChatAvatar
+    components={null}
+    traits={null}
+    customImageUrl={AVATAR_URL}
+    size={48}
+  />
+);
+
+/** A sized chat surface; `Transcript` fills its `h-full` parent. */
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 720,
+        width: 780,
+        overflow: "hidden",
+        borderRadius: 12,
+        border: "1px solid var(--border-base)",
+        background: "var(--surface-base)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const meta: Meta<typeof Transcript> = {
+  title: "Chat/Transcript",
+  component: Transcript,
+  parameters: { layout: "centered" },
+  args: {
+    conversationId: "demo",
+    onSurfaceAction: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <Frame>
+        <Story />
+      </Frame>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof Transcript>;
+
+/** A settled conversation, opened at the latest message. */
+export const Conversation: Story = {
+  args: { items: CONVERSATION, renderAvatar },
+};
+
+/** No messages yet — the transcript renders nothing. */
+export const Empty: Story = {
+  args: { items: [] },
+};
+
+/** Enough turns to overflow the viewport; only the visible window is in the
+ *  DOM. Scroll up to page through history. */
+export const LongHistory: Story = {
+  args: { items: LONG_HISTORY, renderAvatar },
+};
+
+/**
+ * The latest answer streams in over time while the turn store reports a
+ * streaming phase. The user's question pins to the top of the viewport and the
+ * response fills the reserved space below it (self-contained — the story drives
+ * its own interval, like a real turn). Open it and watch the answer build.
+ */
+export const Streaming: Story = {
+  render: function StreamingStory(args) {
+    const [items, setItems] = useState<TranscriptItem[]>(() => [
+      ...CONVERSATION,
+      user("uq", "Walk me through the whole release flow, in detail."),
+    ]);
+
+    useEffect(() => {
+      useTurnStore.setState({ phase: "streaming" });
+      const chunks = [
+        "Sure — here's the end-to-end flow.",
+        "On every PR, CI runs lint, type-check, and the isolated test runner.",
+        "Merging to `main` triggers the release workflow via GitHub Actions.",
+        "The workflow builds the web client and the desktop app artifacts.",
+        "Artifacts are uploaded and the version is tagged.",
+        "Feature-flagged work stays dark until the flag is flipped on the platform.",
+        "Finally, the rollout is monitored and can be reverted by toggling the flag.",
+      ];
+      let i = 0;
+      const id = setInterval(() => {
+        if (i >= chunks.length) {
+          clearInterval(id);
+          useTurnStore.setState({ phase: "idle" });
+          return;
+        }
+        setItems((prev) => [...prev, assistant(`s${i}`, chunks[i] ?? "")]);
+        i += 1;
+      }, 1300);
+      return () => {
+        clearInterval(id);
+        useTurnStore.setState({ phase: "idle" });
+      };
+    }, []);
+
+    return <Transcript {...args} items={items} renderAvatar={renderAvatar} />;
+  },
+};

--- a/clients/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.test.tsx
@@ -1,15 +1,14 @@
 /**
  * Tests for the `Transcript` component.
  *
- * Since LUM-2605 the transcript renders through the `VirtualList`
- * (`react-virtuoso`) primitive, which paints nothing under
- * `renderToStaticMarkup` (its item rendering is driven by layout effects).
- * So the suite is split:
+ * The transcript renders through the `VirtualList` (`react-virtuoso`)
+ * primitive, which paints nothing under `renderToStaticMarkup` (its item
+ * rendering is driven by layout effects). So the suite is split:
  *
  *  - The composite trailing row's layout invariants (markers, min-height,
- *    child ordering, avatar DOM identity) are unit-tested against the
- *    extracted {@link LatestEdgeRow} via `renderToStaticMarkup` / jsdom —
- *    those assertions don't need virtuoso at all.
+ *    child ordering, avatar DOM identity) are unit-tested against
+ *    {@link LatestEdgeRow} via `renderToStaticMarkup` / jsdom — those
+ *    assertions don't need virtuoso at all.
  *  - The wiring Transcript owns — that it mounts the list scroller and that
  *    its row-index map resolves message ids (`scrollToMessage`) — is checked
  *    with a jsdom render. NOTE: `react-virtuoso` only paints items when the

--- a/clients/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.test.tsx
@@ -1,23 +1,31 @@
 /**
- * Smoke tests for the `Transcript` component.
+ * Tests for the `Transcript` component.
  *
- * The repo doesn't run DOM-based tests (no `@testing-library/react`). We
- * verify behavior via `renderToStaticMarkup` plus `mock.module` shims that
- * replace leaf rendering dependencies with deterministic stubs.
+ * Since LUM-2605 the transcript renders through the `VirtualList`
+ * (`react-virtuoso`) primitive, which paints nothing under
+ * `renderToStaticMarkup` (its item rendering is driven by layout effects).
+ * So the suite is split:
  *
- * The component uses plain `flex-col` to render items: history items
- * appear first in DOM order (visual top, oldest first) and the
- * LatestTurnRow follows at the end of the DOM (visual bottom).
+ *  - The composite trailing row's layout invariants (markers, min-height,
+ *    child ordering, avatar DOM identity) are unit-tested against the
+ *    extracted {@link LatestEdgeRow} via `renderToStaticMarkup` / jsdom —
+ *    those assertions don't need virtuoso at all.
+ *  - The wiring Transcript owns — that it mounts the list scroller and that
+ *    its row-index map resolves message ids (`scrollToMessage`) — is checked
+ *    with a jsdom render. NOTE: `react-virtuoso` only paints items when the
+ *    test's `VirtuosoMockContext` is the SAME module instance the list renders
+ *    with; in this workspace the design-library bundles its own react-virtuoso
+ *    copy (distinct from clients/web's), so items don't paint under jsdom
+ *    here. The "items flow through virtuoso" path is covered by the
+ *    design-library's own VirtualList tests.
+ *
+ * The transcript uses plain `flex-col`: history items appear first in DOM
+ * order (visual top, oldest first) and the latest-edge composite follows
+ * at the end (visual bottom).
  */
 
-import {
-  afterEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
-import { act, useEffect } from "react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, createRef, useEffect } from "react";
 import { cleanup, render } from "@testing-library/react";
 
 // `ChatMarkdownMessage` pulls in `react-markdown` + `remark-gfm`. They render
@@ -58,12 +66,17 @@ mock.module("@/domains/chat/components/chat-attachments/message-attachments", ()
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
-import type { TranscriptItem } from "@/domains/chat/transcript/types";
+import type { MessageItem } from "@/domains/chat/transcript/types";
 
-import { Transcript } from "@/domains/chat/transcript/transcript";
+import {
+  LatestEdgeRow,
+  Transcript,
+  type TranscriptHandle,
+} from "@/domains/chat/transcript/transcript";
 
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
-function userMessage(id: string, content: string): TranscriptItem {
+
+function userMessage(id: string, content: string): MessageItem {
   const msg: DisplayMessage = {
     id,
     role: "user",
@@ -72,7 +85,7 @@ function userMessage(id: string, content: string): TranscriptItem {
   return { kind: "message", key: id, message: msg };
 }
 
-function assistantMessage(id: string, content: string): TranscriptItem {
+function assistantMessage(id: string, content: string): MessageItem {
   const msg: DisplayMessage = {
     id,
     role: "assistant",
@@ -83,128 +96,90 @@ function assistantMessage(id: string, content: string): TranscriptItem {
 
 const noop = () => {};
 
-describe("Transcript", () => {
-  test("with empty items, renders zero rows", () => {
+/** Minimal shared row props for `LatestEdgeRow` — only `onSurfaceAction` is
+ *  required; the rest are optional callbacks the row renderers tolerate. */
+const rowProps = { onSurfaceAction: noop };
+
+// ---------------------------------------------------------------------------
+// LatestEdgeRow — composite trailing row layout invariants (static markup).
+// ---------------------------------------------------------------------------
+
+describe("LatestEdgeRow", () => {
+  test("with an anchor, renders the latest-turn cluster and the edge sentinel", () => {
     const html = renderToStaticMarkup(
-      <Transcript
-        items={[]}
-        conversationId={null}
-        onSurfaceAction={noop}
-
-      />,
-    );
-    // No message content → no rendered rows.
-    expect(html).not.toContain('data-latest-turn="true"');
-    expect(html).not.toContain('data-testid="markdown"');
-  });
-
-  test("scroll container has flex-col class (chronological order)", () => {
-    const html = renderToStaticMarkup(
-      <Transcript
-        items={[]}
-        conversationId={null}
-        onSurfaceAction={noop}
-
-      />,
-    );
-    expect(html).toContain("flex-col");
-    expect(html).not.toContain("flex-col-reverse");
-  });
-
-  test("with trailing user message, renders history rows and a latest-turn row", () => {
-    const items: TranscriptItem[] = [
-      assistantMessage("a1", "hello"),
-      userMessage("u1", "first question"),
-      assistantMessage("a2", "some reply"),
-      userMessage("u2", "latest question"),
-      assistantMessage("a3", "streaming reply"),
-    ];
-    // partitionLatestTurn -> historyItems: [a1, u1, a2] (3), anchor: u2,
-    //                       responseItems: [a3].
-    const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId={null}
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={userMessage("u1", "latest question")}
+        responseItems={[assistantMessage("a1", "streaming reply")]}
+        hasAvatar={false}
+        viewportMinHeight={undefined}
+        rowProps={rowProps}
       />,
     );
 
-    // All history message content appears in the rendered output.
-    expect(html).toContain("hello");
-    expect(html).toContain("first question");
-    expect(html).toContain("some reply");
-
-    // LatestTurnRow renders the anchor message + response items inline.
     expect(html).toContain("latest question");
     expect(html).toContain("streaming reply");
-
-    // Marker attributes emitted by LatestTurnRow.
     expect(html).toContain('data-latest-turn="true"');
     expect(html).toContain('data-latest-edge="true"');
   });
 
-  test("with no user messages at all, no latest-turn row is rendered", () => {
-    const items: TranscriptItem[] = [
-      assistantMessage("a1", "only assistant"),
-      assistantMessage("a2", "also assistant"),
-    ];
+  test("with no anchor, renders no latest-turn cluster but still the edge sentinel", () => {
     const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId={null}
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={null}
+        responseItems={[]}
+        hasAvatar={false}
+        viewportMinHeight={undefined}
+        rowProps={rowProps}
       />,
     );
 
     expect(html).not.toContain('data-latest-turn="true"');
-    // History items still render.
-    expect(html).toContain("only assistant");
-    expect(html).toContain("also assistant");
+    expect(html).toContain('data-latest-edge="true"');
   });
 
-  test("items render in correct visual order (flex-col: history first in DOM, latest-turn last)", () => {
-    const items: TranscriptItem[] = [
-      assistantMessage("a1", "FIRST_MSG"),
-      userMessage("u1", "SECOND_MSG"),
-      assistantMessage("a2", "THIRD_MSG"),
-    ];
-    // partition: history=[a1], anchor=u1, response=[a2]
+  test("with an anchor, applies the viewport min-height (anchor pins to top)", () => {
     const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId={null}
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={userMessage("u1", "ANCHOR_MARKER")}
+        responseItems={[]}
+        hasAvatar={false}
+        viewportMinHeight={640}
+        rowProps={rowProps}
       />,
     );
+    expect(html).toContain("min-height");
+  });
 
-    // In flex-col DOM order: history items come first (visual top),
-    // LatestTurnRow (u1 + a2) is rendered last (visual bottom).
-    const latestTurnIdx = html.indexOf('data-latest-turn="true"');
-    const firstMsgIdx = html.indexOf("FIRST_MSG");
-    expect(latestTurnIdx).toBeGreaterThanOrEqual(0);
-    expect(firstMsgIdx).toBeGreaterThanOrEqual(0);
-    // History appears first in DOM (before LatestTurnRow).
-    expect(firstMsgIdx).toBeLessThan(latestTurnIdx);
+  test("with no anchor, omits the min-height entirely", () => {
+    // Codex P2 #1 regression. With assistant-only history the wrapper must
+    // not occupy a full viewport-height region after the last history item,
+    // or the bottom-pin would land on blank space instead of the latest
+    // assistant message.
+    const html = renderToStaticMarkup(
+      <LatestEdgeRow
+        anchorMessage={null}
+        responseItems={[]}
+        hasAvatar
+        renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
+        viewportMinHeight={640}
+        rowProps={rowProps}
+      />,
+    );
+    expect(html).toContain('data-latest-assistant-avatar="true"');
+    expect(html).not.toContain("min-height");
   });
 });
 
-describe("Transcript avatar slot", () => {
-  test("renderAvatar with no anchor (assistant-only history) still mounts the avatar at the bottom", () => {
-    // No user message → no anchor. Avatar must still appear so the
-    // bottom-of-conversation slot is conversation-agnostic.
-    const items: TranscriptItem[] = [
-      assistantMessage("a1", "only assistant"),
-    ];
+describe("LatestEdgeRow avatar slot", () => {
+  test("no anchor (assistant-only history) still mounts the avatar", () => {
     const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId={null}
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={null}
+        responseItems={[]}
+        hasAvatar
         renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
+        viewportMinHeight={undefined}
+        rowProps={rowProps}
       />,
     );
 
@@ -214,19 +189,15 @@ describe("Transcript avatar slot", () => {
     expect(html).toContain('data-latest-edge="true"');
   });
 
-  test("renderAvatar with anchor: avatar appears AFTER the latest-turn cluster but BEFORE the latest-edge sentinel", () => {
-    const items: TranscriptItem[] = [
-      assistantMessage("a1", "history"),
-      userMessage("u1", "ANCHOR_MARKER"),
-      assistantMessage("a2", "RESPONSE_MARKER"),
-    ];
+  test("with anchor: avatar appears AFTER the cluster but BEFORE the edge sentinel", () => {
     const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId={null}
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={userMessage("u1", "ANCHOR_MARKER")}
+        responseItems={[assistantMessage("a1", "RESPONSE_MARKER")]}
+        hasAvatar
         renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
+        viewportMinHeight={640}
+        rowProps={rowProps}
       />,
     );
 
@@ -246,106 +217,18 @@ describe("Transcript avatar slot", () => {
     expect(avatarIdx).toBeLessThan(edgeIdx);
   });
 
-  test("renderAvatar omitted → no avatar slot rendered", () => {
-    const items: TranscriptItem[] = [
-      userMessage("u1", "question"),
-      assistantMessage("a1", "reply"),
-    ];
+  test("with anchor: avatar appears BEFORE the flex-1 spacer (stays attached to content)", () => {
+    // The spacer pushes the latest-edge sentinel to the viewport bottom — but
+    // the avatar must stay attached to the assistant's content, not get
+    // pushed away with the sentinel.
     const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId={null}
-        onSurfaceAction={noop}
-
-      />,
-    );
-
-    expect(html).not.toContain('data-latest-assistant-avatar="true"');
-    // Latest-edge sentinel still renders because the anchor exists.
-    expect(html).toContain('data-latest-edge="true"');
-  });
-
-  test("renderAvatar with neither anchor nor history → avatar still renders (empty conversation w/ avatar)", () => {
-    const html = renderToStaticMarkup(
-      <Transcript
-        items={[]}
-        conversationId={null}
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={userMessage("u1", "ANCHOR_MARKER")}
+        responseItems={[assistantMessage("a1", "RESPONSE_MARKER")]}
+        hasAvatar
         renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
-      />,
-    );
-    expect(html).toContain('data-latest-assistant-avatar="true"');
-    expect(html).toContain("AVATAR_SLOT_MARKER");
-  });
-
-  // Codex P2 #1 regression. When `renderAvatar` is provided but there is
-  // NO anchor message (assistant-only history — e.g. a recovered conversation
-  // whose user message was lost, or the onboarding-only state), the latest-
-  // edge wrapper must not apply `minHeight: viewportMinHeight`. If it did,
-  // the wrapper would occupy a full viewport-height region after the last
-  // history item, and the bottom-pin scroll on conversation switch (see
-  // `595071cbb1 — scroll to bottom on transcript container DOM attach`)
-  // would land on blank space + the avatar instead of on the actual latest
-  // assistant message.
-  test("renderAvatar with no anchor: latest-edge wrapper does NOT apply viewport-height min-height", () => {
-    const items: TranscriptItem[] = [
-      assistantMessage("a1", "LATEST_ASSISTANT_MSG"),
-    ];
-    const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId="conv-1"
-        onSurfaceAction={noop}
-
-        renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
-      />,
-    );
-
-    // Sanity: avatar + edge sentinel both render.
-    expect(html).toContain('data-latest-assistant-avatar="true"');
-    expect(html).toContain('data-latest-edge="true"');
-    // The only place the component sets `min-height` is the latest-edge
-    // wrapper. With no anchor, that style must be omitted entirely.
-    expect(html).not.toContain("min-height");
-  });
-
-  test("renderAvatar with anchor: latest-edge wrapper applies min-height (viewport pinning preserved)", () => {
-    const items: TranscriptItem[] = [
-      userMessage("u1", "ANCHOR_MARKER"),
-    ];
-    const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId="conv-1"
-        onSurfaceAction={noop}
-
-        renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
-      />,
-    );
-
-    // Min-height attribute must be present so the anchor pins to the top
-    // and the flex-1 spacer pushes the avatar to the bottom.
-    expect(html).toContain("min-height");
-  });
-
-  // Layout invariant: the avatar must sit directly below the response
-  // items, NOT below the `flex-1` spacer. With anchor + avatar, the spacer
-  // pushes the latest-edge sentinel to the bottom of the viewport — but
-  // the avatar must stay attached to the assistant's content, not get
-  // pushed away with the sentinel.
-  test("renderAvatar with anchor: avatar appears BEFORE the flex-1 spacer", () => {
-    const items: TranscriptItem[] = [
-      userMessage("u1", "ANCHOR_MARKER"),
-      assistantMessage("a1", "RESPONSE_MARKER"),
-    ];
-    const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId="conv-1"
-        onSurfaceAction={noop}
-
-        renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
+        viewportMinHeight={640}
+        rowProps={rowProps}
       />,
     );
 
@@ -354,11 +237,6 @@ describe("Transcript avatar slot", () => {
     const spacerIdx = html.indexOf('data-latest-edge-spacer="true"');
     const edgeIdx = html.indexOf('data-latest-edge="true"');
 
-    expect(responseIdx).toBeGreaterThanOrEqual(0);
-    expect(avatarIdx).toBeGreaterThanOrEqual(0);
-    expect(spacerIdx).toBeGreaterThanOrEqual(0);
-    expect(edgeIdx).toBeGreaterThanOrEqual(0);
-
     // response → avatar → spacer → edge sentinel
     expect(responseIdx).toBeLessThan(avatarIdx);
     expect(avatarIdx).toBeLessThan(spacerIdx);
@@ -366,35 +244,29 @@ describe("Transcript avatar slot", () => {
   });
 
   test("no anchor: no flex-1 spacer rendered (avatar sits inline under history)", () => {
-    const items: TranscriptItem[] = [
-      assistantMessage("a1", "history one"),
-    ];
     const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId="conv-1"
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={null}
+        responseItems={[]}
+        hasAvatar
         renderAvatar={() => <span>AVATAR_SLOT_MARKER</span>}
+        viewportMinHeight={undefined}
+        rowProps={rowProps}
       />,
     );
 
     expect(html).toContain('data-latest-assistant-avatar="true"');
-    // No spacer in the no-anchor case — avatar sits inline.
     expect(html).not.toContain('data-latest-edge-spacer="true"');
   });
 
-  test("anchor without renderAvatar: still applies min-height (viewport pinning is for the anchor, not the avatar)", () => {
-    const items: TranscriptItem[] = [
-      userMessage("u1", "ANCHOR_MARKER"),
-      assistantMessage("a1", "RESPONSE_MARKER"),
-    ];
+  test("anchor without avatar: still applies min-height (pinning is for the anchor)", () => {
     const html = renderToStaticMarkup(
-      <Transcript
-        items={items}
-        conversationId="conv-1"
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={userMessage("u1", "ANCHOR_MARKER")}
+        responseItems={[assistantMessage("a1", "RESPONSE_MARKER")]}
+        hasAvatar={false}
+        viewportMinHeight={640}
+        rowProps={rowProps}
       />,
     );
 
@@ -406,23 +278,18 @@ describe("Transcript avatar slot", () => {
 // ---------------------------------------------------------------------------
 // Codex P2 #2 regression — DOM identity across no-anchor → anchor transition.
 //
-// The latest-edge wrapper has unkeyed conditional children. Codex's review
-// claimed that inserting `<LatestTurnRow>` at slot 0 (was `false`) would
-// cause React to "reconcile the following <div>s by index", reusing the
-// current avatar wrapper as the spacer and remounting `ChatAvatar`, replaying
-// the entrance-spring animation. Empirically that does NOT happen — React's
-// reconciler tracks `fiber.index` (the OLD render's position), so the
-// existing avatar fiber at fiber.index=2 still matches newIdx=2 even after
-// the conditional slot 0 lights up. This test locks in the correct behavior
-// so a future refactor (e.g. reordering siblings, changing the conditional
-// shape) doesn't silently regress.
+// When the anchor lights up, `<LatestTurnRow>` is inserted at slot 0 (was
+// `false`). React's reconciler tracks `fiber.index` (the OLD render's
+// position), so the existing avatar fiber still matches its new position and
+// `ChatAvatar` is NOT remounted — its entrance-spring state is preserved.
+// Re-targeted at `LatestEdgeRow` (the unit that owns the conditional shape).
 // ---------------------------------------------------------------------------
-describe("Transcript no-anchor → anchor transition preserves avatar DOM identity", () => {
+describe("LatestEdgeRow no-anchor → anchor transition preserves avatar DOM identity", () => {
   afterEach(() => {
     cleanup();
   });
 
-  test("ChatAvatar instance is NOT remounted when first user anchor appears", async () => {
+  test("avatar instance is NOT remounted when the first anchor appears", async () => {
     let avatarMountCount = 0;
     let avatarUnmountCount = 0;
     function MountTracker() {
@@ -434,64 +301,101 @@ describe("Transcript no-anchor → anchor transition preserves avatar DOM identi
       }, []);
       return <span data-testid="mount-tracker">avatar</span>;
     }
-
-    // Start with assistant-only history + renderAvatar. No anchor.
-    const historyOnly: TranscriptItem[] = [
-      assistantMessage("a1", "history one"),
-    ];
-
     const renderAvatar = () => <MountTracker />;
 
     const { rerender } = render(
-      <Transcript
-        items={historyOnly}
-        conversationId="conv-1"
-        onSurfaceAction={noop}
-
+      <LatestEdgeRow
+        anchorMessage={null}
+        responseItems={[]}
+        hasAvatar
         renderAvatar={renderAvatar}
+        viewportMinHeight={undefined}
+        rowProps={rowProps}
       />,
     );
     expect(avatarMountCount).toBe(1);
     expect(avatarUnmountCount).toBe(0);
 
-    // Now insert the first user message → anchor lights up. This is the
-    // exact transition Codex flagged.
-    const withAnchor: TranscriptItem[] = [
-      assistantMessage("a1", "history one"),
-      userMessage("u1", "first user message"),
+    // First user message lands → anchor lights up.
+    await act(async () => {
+      rerender(
+        <LatestEdgeRow
+          anchorMessage={userMessage("u1", "first user message")}
+          responseItems={[]}
+          hasAvatar
+          renderAvatar={renderAvatar}
+          viewportMinHeight={640}
+          rowProps={rowProps}
+        />,
+      );
+    });
+    expect(avatarMountCount).toBe(1);
+    expect(avatarUnmountCount).toBe(0);
+
+    // Reverse direction: drop the anchor again. Avatar identity preserved.
+    await act(async () => {
+      rerender(
+        <LatestEdgeRow
+          anchorMessage={null}
+          responseItems={[]}
+          hasAvatar
+          renderAvatar={renderAvatar}
+          viewportMinHeight={undefined}
+          rowProps={rowProps}
+        />,
+      );
+    });
+    expect(avatarMountCount).toBe(1);
+    expect(avatarUnmountCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transcript — row model wired into VirtualList (jsdom; see file header on why
+// items don't paint here).
+// ---------------------------------------------------------------------------
+
+describe("Transcript (virtualized)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("mounts the VirtualList scroller for a non-empty transcript", () => {
+    const items: MessageItem[] = [
+      assistantMessage("a1", "reply"),
+      userMessage("u1", "question"),
     ];
-    await act(async () => {
-      rerender(
-        <Transcript
-          items={withAnchor}
-          conversationId="conv-1"
-          onSurfaceAction={noop}
-  
-          renderAvatar={renderAvatar}
-        />,
-      );
-    });
+    const { container } = render(
+      <Transcript items={items} conversationId="c1" onSurfaceAction={noop} />,
+    );
+    // VirtualList tags its scroll root with this slot; its presence proves the
+    // row model is wired into the primitive even though items don't paint.
+    expect(container.querySelector('[data-slot="virtual-list"]')).not.toBeNull();
+  });
 
-    // CRITICAL: ChatAvatar must NOT have been unmounted + remounted.
-    // If it had, entrance-spring state would replay on every first-turn
-    // landing — exactly the flicker this PR is preventing.
-    expect(avatarMountCount).toBe(1);
-    expect(avatarUnmountCount).toBe(0);
+  test("scrollToMessage resolves loaded ids and rejects unknown ones", () => {
+    const ref = createRef<TranscriptHandle>();
+    const items: MessageItem[] = [
+      assistantMessage("a1", "reply one"),
+      userMessage("u1", "question one"),
+      assistantMessage("a2", "reply two"),
+      userMessage("u2", "latest question"),
+    ];
+    // partition: history [a1, u1, a2] (all registered in indexById) + anchor u2.
+    render(
+      <Transcript
+        ref={ref}
+        items={items}
+        conversationId="c1"
+        onSurfaceAction={noop}
+      />,
+    );
 
-    // Reverse direction: drop the anchor (e.g. message deletion or
-    // conversation restore). Avatar identity must still be preserved.
-    await act(async () => {
-      rerender(
-        <Transcript
-          items={historyOnly}
-          conversationId="conv-1"
-          onSurfaceAction={noop}
-  
-          renderAvatar={renderAvatar}
-        />,
-      );
-    });
-    expect(avatarMountCount).toBe(1);
-    expect(avatarUnmountCount).toBe(0);
+    // A loaded history message and the anchor resolve to a row index → true.
+    expect(ref.current?.scrollToMessage("a1")).toBe(true);
+    expect(ref.current?.scrollToMessage("u2")).toBe(true);
+    // An id not present in the loaded window → false (the caller retries once
+    // the older page loads).
+    expect(ref.current?.scrollToMessage("not-loaded")).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.test.tsx
@@ -398,4 +398,29 @@ describe("Transcript (virtualized)", () => {
     // the older page loads).
     expect(ref.current?.scrollToMessage("not-loaded")).toBe(false);
   });
+
+  test("scrollToMessage resolves a latest-turn response message (deep link to latest reply)", () => {
+    // Regression: the composite latest-edge row renders the anchor user message
+    // AND the streaming response inside LatestTurnRow. A deep link to the
+    // latest assistant reply (a response item, not yet folded into history)
+    // must resolve to the composite row rather than returning false and having
+    // the caller give up + clear the URL.
+    const ref = createRef<TranscriptHandle>();
+    const items: MessageItem[] = [
+      userMessage("u1", "latest question"),
+      assistantMessage("a1", "latest reply"),
+    ];
+    // partition: history [], anchor u1, response [a1] (rendered in the composite).
+    render(
+      <Transcript
+        ref={ref}
+        items={items}
+        conversationId="c1"
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(ref.current?.scrollToMessage("u1")).toBe(true);
+    expect(ref.current?.scrollToMessage("a1")).toBe(true);
+  });
 });

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -1,19 +1,36 @@
 
 import {
-  Fragment,
-  forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
+  useState,
   type ReactNode,
+  type Ref,
 } from "react";
 
-import { partitionLatestTurn } from "@/domains/chat/transcript/partition-latest-turn";
-import type { TranscriptItem } from "@/domains/chat/transcript/types";
+import {
+  VirtualList,
+  type VirtualListHandle,
+} from "@vellumai/design-library/components/virtual-list";
 
-import { LatestTurnRow } from "@/domains/chat/transcript/latest-turn-row";
+import { partitionLatestTurn } from "@/domains/chat/transcript/partition-latest-turn";
+import {
+  computePrependDelta,
+  findLatestUserAnchorKey,
+  PINNED_THRESHOLD_PX,
+  type ScrollClassification,
+} from "@/domains/chat/transcript/transcript-scroll-utils";
+import type {
+  MessageItem,
+  TranscriptItem,
+} from "@/domains/chat/transcript/types";
+
+import {
+  LatestTurnRow,
+  type LatestTurnRowProps,
+} from "@/domains/chat/transcript/latest-turn-row";
 import { PullRefreshSpinner } from "@/domains/chat/transcript/pull-refresh-spinner";
 import { TranscriptRow } from "@/domains/chat/transcript/transcript-row";
 import { PULL_THRESHOLD_PX } from "@/domains/chat/transcript/pull-to-refresh-utils";
@@ -22,15 +39,20 @@ import { useViewportMinHeight } from "@/domains/chat/transcript/use-viewport-min
 import type { ConfirmationDecision } from "@/types/event-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 
-/** Distance from the bottom (in px) at or below which the transcript is
- *  considered pinned to the latest message. Surfaced through
- *  `TranscriptHandle.getScrollState()` for the debug API. Kept in sync
- *  with the same threshold inside `useTranscriptScroll`. */
-const PINNED_THRESHOLD_PX = 64;
+/** Virtuoso addresses items by an absolute index that survives prepends. We
+ *  start high and decrement by the prepended count (see `computePrependDelta`)
+ *  so older pages insert at the front without the viewport jumping. */
+const FIRST_ITEM_INDEX_BASE = 1_000_000;
 
-/** Outcome of a pull-to-refresh, returned by the consumer's
- *  `onPullRefresh` handler so the page can render the right feedback
- *  pill. */
+/** Constant key for the composite latest-edge row. A stable key preserves the
+ *  `LatestTurnRow` memo and the assistant avatar's entrance-spring state across
+ *  streaming growth and the no-anchor → anchor transition. */
+const LATEST_EDGE_KEY = "latest-edge";
+
+/**
+ * Outcome of a pull-to-refresh, returned by the consumer's `onPullRefresh`
+ * handler so the page can render the right feedback pill.
+ */
 export type RefreshOutcome =
   | { kind: "no-change" }
   | { kind: "new-messages"; count: number }
@@ -117,238 +139,402 @@ export interface TranscriptProps {
    *  when omitted, getScrollState() falls back to defaults. `isPinned`
    *  is derived from scroll geometry inside `getScrollState()` rather
    *  than passed in. */
-  scrollCoordinatorState?: {
-    showScrollToLatest: boolean;
-    shouldLoadOlder: boolean;
-  };
+  scrollCoordinatorState?: Pick<
+    ScrollClassification,
+    "showScrollToLatest" | "shouldLoadOlder"
+  >;
+  ref?: Ref<TranscriptHandle>;
 }
 
 export interface TranscriptHandle {
   scrollToLatest(opts?: { behavior?: "auto" | "smooth" }): void;
   /** Scroll a message into view by id and briefly highlight it. Returns
-   *  `false` when no element with that message id is currently rendered (e.g.
-   *  the message lives in an older history page not yet loaded). */
+   *  `false` when the message is not currently loaded (e.g. it lives in an
+   *  older history page that hasn't been fetched). The caller may retry once
+   *  the page loads. */
   scrollToMessage(messageId: string): boolean;
-  getScrollElement(): HTMLDivElement | null;
-  /** Inner wrapper that surrounds all rendered children. Sized to the
-   *  scroll content; observable via `ResizeObserver` to detect when
-   *  scroll content height changes (e.g. async min-height settling,
-   *  late image loads, streaming growth). */
-  getContentElement(): HTMLDivElement | null;
+  getScrollElement(): HTMLElement | null;
   getViewportHeight(): number;
   /** Debug API: snapshot of the current scroll state (distance from bottom,
-   *  pinned-to-latest flag, button visibility, older-page load flag). */
-  getScrollState(): {
-    distanceFromBottom: number;
-    isPinned: boolean;
-    showScrollToLatest: boolean;
-    shouldLoadOlder: boolean;
-  };
+   *  pinned-to-latest flag, button visibility, older-page load flag). Reuses
+   *  the coordinator's {@link ScrollClassification} shape rather than
+   *  re-declaring it. */
+  getScrollState(): ScrollClassification;
 }
 
-export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
-  function Transcript(props, ref) {
-    const { items, conversationId, onPullRefresh, pullRefreshEnabled, ...rest } =
-      props;
-    const scrollRef = useRef<HTMLDivElement | null>(null);
-    const contentRef = useRef<HTMLDivElement | null>(null);
-    // Pending removal of the transient deep-link highlight class.
-    const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const viewportMinHeight = useViewportMinHeight(scrollRef);
-
-    useEffect(() => {
-      return () => {
-        if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
-      };
-    }, []);
-
-    const pullEnabled = !!pullRefreshEnabled && !!onPullRefresh;
-    const handlePullRefresh = useCallback(async () => {
-      if (!onPullRefresh) return;
-      await onPullRefresh();
-    }, [onPullRefresh]);
-    const pull = usePullToRefresh({
-      scrollRef,
-      onRefresh: handlePullRefresh,
-      enabled: pullEnabled,
-    });
-
-
-    const partition = useMemo(() => partitionLatestTurn(items), [items]);
-
-    useImperativeHandle(
-      ref,
-      (): TranscriptHandle => ({
-        scrollToLatest(opts) {
-          const el = scrollRef.current;
-          if (!el) return;
-          el.scrollTo({
-            top: el.scrollHeight - el.clientHeight,
-            behavior: opts?.behavior ?? "auto",
-          });
-        },
-        scrollToMessage(messageId) {
-          const target = document.getElementById(`msg-${messageId}`);
-          if (!target) return false;
-          target.scrollIntoView({ block: "center", behavior: "smooth" });
-          target.classList.add("message-highlighted");
-          if (highlightTimerRef.current) {
-            clearTimeout(highlightTimerRef.current);
-          }
-          highlightTimerRef.current = setTimeout(() => {
-            target.classList.remove("message-highlighted");
-            highlightTimerRef.current = null;
-          }, 2000);
-          return true;
-        },
-        getScrollElement() {
-          return scrollRef.current;
-        },
-        getContentElement() {
-          return contentRef.current;
-        },
-        getViewportHeight() {
-          return scrollRef.current?.clientHeight ?? 0;
-        },
-        getScrollState() {
-          const el = scrollRef.current;
-          if (!el) {
-            return {
-              distanceFromBottom: 0,
-              isPinned: true,
-              showScrollToLatest: false,
-              shouldLoadOlder: false,
-            };
-          }
-          const distanceFromBottom = Math.max(
-            0,
-            el.scrollHeight - el.clientHeight - el.scrollTop,
-          );
-          return {
-            distanceFromBottom,
-            isPinned: distanceFromBottom <= PINNED_THRESHOLD_PX,
-            showScrollToLatest: rest.scrollCoordinatorState?.showScrollToLatest ?? false,
-            shouldLoadOlder: rest.scrollCoordinatorState?.shouldLoadOlder ?? false,
-          };
-        },
-      }),
-      [rest.scrollCoordinatorState],
-    );
-
-    const rowProps = {
-      conversationId,
-      onSurfaceAction: rest.onSurfaceAction,
-      onForkConversation: rest.onForkConversation,
-      onInspectMessage: rest.onInspectMessage,
-      renderOnboardingChoice: rest.renderOnboardingChoice,
-      assistantDisplayName: rest.assistantDisplayName,
-      onOpenRuleEditor: rest.onOpenRuleEditor,
-      unknownNudgeToolCallIds: rest.unknownNudgeToolCallIds,
-      onDismissUnknownNudge: rest.onDismissUnknownNudge,
-      onConfirmationSubmit: rest.onConfirmationSubmit,
-      onAllowAndCreateRule: rest.onAllowAndCreateRule,
-      onOpenApp: rest.onOpenApp,
-      onOpenDocument: rest.onOpenDocument,
-      assistantId: rest.assistantId,
-      onSubagentClick: rest.onSubagentClick,
-      onStopSubagent: rest.onStopSubagent,
-      onWorkflowClick: rest.onWorkflowClick,
-      onStopWorkflow: rest.onStopWorkflow,
+/** A row in the virtual list: either a stable history item, or the single
+ *  composite "latest-edge" row (latest user message + its streaming response +
+ *  the avatar), which is always last when present. */
+type VirtualRow =
+  | { type: "history"; item: TranscriptItem }
+  | {
+      type: "latest-edge";
+      anchorMessage: MessageItem | null;
+      responseItems: TranscriptItem[];
+      hasAvatar: boolean;
     };
 
-    return (
-      <div
-        key={conversationId}
-        ref={scrollRef}
-        data-testid="transcript-scroll-container"
-        className="flex h-full w-full flex-col overflow-y-auto overscroll-none [overflow-anchor:none]"
-      >
-        {/* Inner content wrapper — observed by the scroll coordinator's
-         *  ResizeObserver so we can re-pin to bottom when scroll content
-         *  height changes (async min-height settle, late image loads,
-         *  streaming growth). Wrapping all rows in a single observed
-         *  element is cheaper than observing each row individually. */}
-        <div ref={contentRef} className="flex w-full flex-col">
-          {/* History items in chronological order — oldest at top. */}
-          {partition.historyItems.map((item) => (
-            <Fragment key={item.key}>
-              <div className="mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6">
-                <TranscriptRow item={item} {...rowProps} />
-              </div>
-            </Fragment>
-          ))}
-          {/* Latest-edge region: contains the latest-turn cluster and the
-           *  assistant avatar. Two layout modes:
-           *
-           *  1. Anchor present — `minHeight: viewportMinHeight` pins the
-           *     anchor user message to the viewport top. The avatar
-           *     renders directly below the response items so it follows
-           *     the conversation flow visually. The `flex-1` spacer then
-           *     fills the remaining vertical space so the latest-edge
-           *     sentinel sits at the bottom of the viewport (preserving
-           *     the bottom-pin scroll target).
-           *  2. No anchor (assistant-only history, e.g. recovered
-           *     conversation or first paint before a submit) — neither
-           *     the viewport-height min-height NOR the flex-1 spacer
-           *     render. The avatar appears inline directly below the
-           *     last history item.
-           *
-           *  Key invariant: the avatar always sits directly below the
-           *  most recent assistant content. No giant empty gap between
-           *  the response and the avatar. The spacer is purely a layout
-           *  device to keep the latest-edge sentinel at the viewport
-           *  bottom for the anchor-pinning UX — it must NOT push the
-           *  avatar away from its content.
-           *
-           *  The avatar is intentionally decoupled from `partition.anchorMessage`
-           *  so it persists across the user-send → response gap AND across the
-           *  "no user message yet" case. The wrapper renders whenever either
-           *  the anchor or avatar slot is active; DOM identity (and ChatAvatar
-           *  entrance-spring state) is preserved across the no-anchor → anchor
-           *  transition because React's reconciler tracks `fiber.index` (see
-           *  the `transcript.test.tsx` regression test). */}
-          {(partition.anchorMessage || rest.renderAvatar) && (
-            <div
-              className="mx-auto flex w-full max-w-[var(--chat-max-width)] flex-col contain-content px-4 sm:px-6"
-              style={
-                partition.anchorMessage
-                  ? { minHeight: viewportMinHeight }
-                  : undefined
-              }
-            >
-              {partition.anchorMessage && (
-                <LatestTurnRow
-                  anchorMessage={partition.anchorMessage}
-                  responseItems={partition.responseItems}
-                  {...rowProps}
-                />
-              )}
-              {rest.renderAvatar && (
-                <div
-                  data-latest-assistant-avatar="true"
-                  className="flex justify-start pl-1 pt-3 pb-2"
-                >
-                  {rest.renderAvatar()}
-                </div>
-              )}
-              {partition.anchorMessage && (
-                <div data-latest-edge-spacer="true" className="flex-1" />
-              )}
-              <div aria-hidden data-latest-edge="true" />
-            </div>
-          )}
-          {/* Spinner last = visual bottom in flex-col. Only rendered when
-           *  the gesture is feature-flag-enabled so the flag-off path has
-           *  zero DOM impact. */}
-          {pullEnabled && (
-            <PullRefreshSpinner
-              height={pull.pullDistance}
-              progress={pull.pullDistance / PULL_THRESHOLD_PX}
-              phase={pull.phase}
-            />
-          )}
+/** The shared per-row props forwarded to every `TranscriptRow` /
+ *  `LatestTurnRow` — everything the row renderers need except the item
+ *  payload itself. */
+type RowSharedProps = Omit<
+  LatestTurnRowProps,
+  "anchorMessage" | "responseItems"
+>;
+
+export interface LatestEdgeRowProps {
+  /** The latest user message, or `null` for assistant-only history (the
+   *  avatar still mounts, but no anchor / min-height / spacer). */
+  anchorMessage: MessageItem | null;
+  responseItems: TranscriptItem[];
+  /** Whether to mount the bottom-pinned assistant avatar slot. */
+  hasAvatar: boolean;
+  /** Produces the avatar element; only invoked when `hasAvatar`. */
+  renderAvatar?: () => ReactNode;
+  /** Reserved min-height that pins the anchor to the viewport top while the
+   *  response streams into the space below. Applied only when an anchor is
+   *  present. */
+  viewportMinHeight: number | undefined;
+  /** Shared row props forwarded to the inner `LatestTurnRow`. */
+  rowProps: RowSharedProps;
+}
+
+/**
+ * The composite trailing row of the transcript: the latest user message
+ * (anchor) + its streaming response + the bottom-pinned assistant avatar,
+ * all inside a min-height wrapper. Two layout modes:
+ *
+ *  1. **Anchor present** — `minHeight: viewportMinHeight` pins the anchor to
+ *     the viewport top; the avatar renders below the response; the `flex-1`
+ *     spacer fills the remaining space so the latest-edge sentinel sits at
+ *     the viewport bottom.
+ *  2. **No anchor** (assistant-only history, or first paint before a submit) —
+ *     no min-height, no spacer; the avatar appears inline below the last
+ *     history item.
+ *
+ * The avatar is decoupled from the anchor so it persists across the
+ * user-send → response gap; the composite's constant row key preserves its
+ * `ChatAvatar` entrance-spring state across the no-anchor → anchor flip.
+ *
+ * Extracted from `Transcript` so its layout invariants (markers, min-height,
+ * child ordering) stay unit-testable with `renderToStaticMarkup` —
+ * `Transcript` itself renders through virtuoso, which paints nothing
+ * server-side.
+ */
+export function LatestEdgeRow({
+  anchorMessage,
+  responseItems,
+  hasAvatar,
+  renderAvatar,
+  viewportMinHeight,
+  rowProps,
+}: LatestEdgeRowProps) {
+  return (
+    <div
+      className="mx-auto flex w-full max-w-[var(--chat-max-width)] flex-col contain-content px-4 sm:px-6"
+      style={anchorMessage ? { minHeight: viewportMinHeight } : undefined}
+    >
+      {anchorMessage && (
+        <LatestTurnRow
+          anchorMessage={anchorMessage}
+          responseItems={responseItems}
+          {...rowProps}
+        />
+      )}
+      {hasAvatar && renderAvatar && (
+        <div
+          data-latest-assistant-avatar="true"
+          className="flex justify-start pl-1 pt-3 pb-2"
+        >
+          {renderAvatar()}
         </div>
-      </div>
+      )}
+      {anchorMessage && (
+        <div data-latest-edge-spacer="true" className="flex-1" />
+      )}
+      <div aria-hidden data-latest-edge="true" />
+    </div>
+  );
+}
+
+export function Transcript({
+  items,
+  conversationId,
+  onPullRefresh,
+  pullRefreshEnabled,
+  ref,
+  ...rest
+}: TranscriptProps) {
+  const virtualListRef = useRef<VirtualListHandle>(null);
+  // Virtuoso owns the scroll element. Capture it after mount into state so the
+  // viewport-min-height + pull-to-refresh hooks (which expect a ref) re-run
+  // once it exists, and again when the list remounts on conversation switch.
+  const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null);
+  const scrollElRef = useMemo(() => ({ current: scrollEl }), [scrollEl]);
+  // Pending removal of the transient deep-link highlight class.
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const hasItems = items.length > 0;
+  useLayoutEffect(() => {
+    setScrollEl(virtualListRef.current?.getScrollElement() ?? null);
+  }, [conversationId, hasItems]);
+
+  useLayoutEffect(() => {
+    return () => {
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+    };
+  }, []);
+
+  const viewportMinHeight = useViewportMinHeight(scrollElRef);
+
+  const pullEnabled = !!pullRefreshEnabled && !!onPullRefresh;
+  const handlePullRefresh = useCallback(async () => {
+    if (!onPullRefresh) return;
+    await onPullRefresh();
+  }, [onPullRefresh]);
+  const pull = usePullToRefresh({
+    scrollRef: scrollElRef,
+    onRefresh: handlePullRefresh,
+    enabled: pullEnabled,
+  });
+
+  const partition = useMemo(() => partitionLatestTurn(items), [items]);
+
+  // History rows + a single trailing composite when there's an anchor or an
+  // avatar to mount (mirrors the old latest-edge guard).
+  const rows = useMemo<VirtualRow[]>(() => {
+    const out: VirtualRow[] = partition.historyItems.map((item) => ({
+      type: "history",
+      item,
+    }));
+    if (partition.anchorMessage || rest.renderAvatar) {
+      out.push({
+        type: "latest-edge",
+        anchorMessage: partition.anchorMessage,
+        responseItems: partition.responseItems,
+        hasAvatar: !!rest.renderAvatar,
+      });
+    }
+    return out;
+  }, [partition, rest.renderAvatar]);
+
+  // firstItemIndex: decrement by the prepended history count so older pages
+  // insert at the front without the viewport jumping (virtuoso anchors the
+  // scroll itself). Derived during render — it must be correct on the prepend
+  // frame — and guarded on `items` identity so StrictMode's double-invoke
+  // can't double-apply the decrement.
+  const firstItemIndexRef = useRef(FIRST_ITEM_INDEX_BASE);
+  const prevFirstKeyRef = useRef<string | null>(null);
+  const prevHistoryLenRef = useRef(0);
+  const prevConversationIdRef = useRef(conversationId);
+  const processedItemsRef = useRef<TranscriptItem[] | null>(null);
+  if (processedItemsRef.current !== items) {
+    if (prevConversationIdRef.current !== conversationId) {
+      prevConversationIdRef.current = conversationId;
+      firstItemIndexRef.current = FIRST_ITEM_INDEX_BASE;
+      prevFirstKeyRef.current = null;
+      prevHistoryLenRef.current = 0;
+    }
+    firstItemIndexRef.current -= computePrependDelta(
+      partition.historyItems,
+      prevFirstKeyRef.current,
+      prevHistoryLenRef.current,
     );
-  },
-);
+    prevFirstKeyRef.current = partition.historyItems[0]?.key ?? null;
+    prevHistoryLenRef.current = partition.historyItems.length;
+    processedItemsRef.current = items;
+  }
+  const firstItemIndex = firstItemIndexRef.current;
+
+  // Map both the server `message.id` (the deep-link + DOM id) and the optimistic
+  // `clientMessageId` to a row index, for `scrollToMessage`.
+  const indexById = useMemo(() => {
+    const map = new Map<string, number>();
+    const register = (msg: MessageItem | null, index: number) => {
+      if (!msg) return;
+      map.set(msg.message.id, index);
+      if (msg.message.clientMessageId) {
+        map.set(msg.message.clientMessageId, index);
+      }
+    };
+    rows.forEach((row, index) => {
+      if (row.type === "history") {
+        if (row.item.kind === "message") register(row.item, index);
+      } else {
+        register(row.anchorMessage, index);
+      }
+    });
+    return map;
+  }, [rows]);
+
+  useImperativeHandle(
+    ref,
+    (): TranscriptHandle => ({
+      scrollToLatest(opts) {
+        virtualListRef.current?.scrollToBottom({
+          behavior: opts?.behavior ?? "auto",
+        });
+      },
+      scrollToMessage(messageId) {
+        const index = indexById.get(messageId);
+        if (index === undefined) return false;
+        virtualListRef.current?.scrollToIndex({
+          index,
+          behavior: "smooth",
+          align: "center",
+        });
+        // The row may not be painted yet (virtuoso scrolls, then mounts it),
+        // so poll briefly for the DOM node before applying the highlight.
+        let frames = 0;
+        const tryHighlight = () => {
+          const target = document.getElementById(`msg-${messageId}`);
+          if (target) {
+            target.classList.add("message-highlighted");
+            if (highlightTimerRef.current) {
+              clearTimeout(highlightTimerRef.current);
+            }
+            highlightTimerRef.current = setTimeout(() => {
+              target.classList.remove("message-highlighted");
+              highlightTimerRef.current = null;
+            }, 2000);
+            return;
+          }
+          if (frames++ < 10) requestAnimationFrame(tryHighlight);
+        };
+        requestAnimationFrame(tryHighlight);
+        return true;
+      },
+      getScrollElement() {
+        return virtualListRef.current?.getScrollElement() ?? null;
+      },
+      getViewportHeight() {
+        return virtualListRef.current?.getScrollElement()?.clientHeight ?? 0;
+      },
+      getScrollState() {
+        const el = virtualListRef.current?.getScrollElement() ?? null;
+        if (!el) {
+          return {
+            distanceFromBottom: 0,
+            isPinned: true,
+            showScrollToLatest: false,
+            shouldLoadOlder: false,
+          };
+        }
+        const distanceFromBottom = Math.max(
+          0,
+          el.scrollHeight - el.clientHeight - el.scrollTop,
+        );
+        return {
+          distanceFromBottom,
+          isPinned: distanceFromBottom <= PINNED_THRESHOLD_PX,
+          showScrollToLatest:
+            rest.scrollCoordinatorState?.showScrollToLatest ?? false,
+          shouldLoadOlder: rest.scrollCoordinatorState?.shouldLoadOlder ?? false,
+        };
+      },
+    }),
+    [indexById, rest.scrollCoordinatorState],
+  );
+
+  // Submit pin: when a new user message becomes the anchor, align the composite
+  // (last row) to the viewport top — the min-height wrapper reserves a viewport
+  // of space below it for the streaming response. Skipped on conversation
+  // switch, where the remount + initialTopMostItemIndex="LAST" handle position.
+  const prevAnchorKeyRef = useRef<string | null>(
+    findLatestUserAnchorKey(items),
+  );
+  const prevConvForPinRef = useRef(conversationId);
+  useLayoutEffect(() => {
+    const anchorKey = findLatestUserAnchorKey(items);
+    if (prevConvForPinRef.current !== conversationId) {
+      prevConvForPinRef.current = conversationId;
+      prevAnchorKeyRef.current = anchorKey;
+      return;
+    }
+    if (
+      anchorKey !== null &&
+      anchorKey !== prevAnchorKeyRef.current &&
+      rows.length > 0
+    ) {
+      virtualListRef.current?.scrollToIndex({
+        index: rows.length - 1,
+        align: "start",
+        behavior: "auto",
+      });
+    }
+    prevAnchorKeyRef.current = anchorKey;
+  }, [items, conversationId, rows.length]);
+
+  const rowProps = {
+    conversationId,
+    onSurfaceAction: rest.onSurfaceAction,
+    onForkConversation: rest.onForkConversation,
+    onInspectMessage: rest.onInspectMessage,
+    renderOnboardingChoice: rest.renderOnboardingChoice,
+    assistantDisplayName: rest.assistantDisplayName,
+    onOpenRuleEditor: rest.onOpenRuleEditor,
+    unknownNudgeToolCallIds: rest.unknownNudgeToolCallIds,
+    onDismissUnknownNudge: rest.onDismissUnknownNudge,
+    onConfirmationSubmit: rest.onConfirmationSubmit,
+    onAllowAndCreateRule: rest.onAllowAndCreateRule,
+    onOpenApp: rest.onOpenApp,
+    onOpenDocument: rest.onOpenDocument,
+    assistantId: rest.assistantId,
+    onSubagentClick: rest.onSubagentClick,
+    onStopSubagent: rest.onStopSubagent,
+    onWorkflowClick: rest.onWorkflowClick,
+    onStopWorkflow: rest.onStopWorkflow,
+  };
+
+  const renderAvatar = rest.renderAvatar;
+
+  const itemContent = (_index: number, row: VirtualRow): ReactNode => {
+    if (row.type === "history") {
+      return (
+        <div className="mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6">
+          <TranscriptRow item={row.item} {...rowProps} />
+        </div>
+      );
+    }
+    // Latest-edge region — see {@link LatestEdgeRow} for the two layout modes.
+    return (
+      <LatestEdgeRow
+        anchorMessage={row.anchorMessage}
+        responseItems={row.responseItems}
+        hasAvatar={row.hasAvatar}
+        renderAvatar={renderAvatar}
+        viewportMinHeight={viewportMinHeight}
+        rowProps={rowProps}
+      />
+    );
+  };
+
+  const computeItemKey = useCallback(
+    (_index: number, row: VirtualRow): string =>
+      row.type === "history" ? row.item.key : LATEST_EDGE_KEY,
+    [],
+  );
+
+  return (
+    <VirtualList<VirtualRow>
+      key={conversationId}
+      ref={virtualListRef}
+      items={rows}
+      itemContent={itemContent}
+      computeItemKey={computeItemKey}
+      firstItemIndex={firstItemIndex}
+      initialTopMostItemIndex="LAST"
+      increaseViewportBy={{ top: 200, bottom: 0 }}
+      className="h-full w-full overscroll-none [overflow-anchor:none]"
+      footer={
+        pullEnabled ? (
+          <PullRefreshSpinner
+            height={pull.pullDistance}
+            progress={pull.pullDistance / PULL_THRESHOLD_PX}
+            phase={pull.phase}
+          />
+        ) : undefined
+      }
+    />
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -216,10 +216,10 @@ export interface LatestEdgeRowProps {
  * user-send → response gap; the composite's constant row key preserves its
  * `ChatAvatar` entrance-spring state across the no-anchor → anchor flip.
  *
- * Extracted from `Transcript` so its layout invariants (markers, min-height,
- * child ordering) stay unit-testable with `renderToStaticMarkup` —
- * `Transcript` itself renders through virtuoso, which paints nothing
- * server-side.
+ * A standalone component (rather than inline JSX) so its layout invariants
+ * (markers, min-height, child ordering) are unit-testable with
+ * `renderToStaticMarkup` — `Transcript` renders through virtuoso, which paints
+ * nothing server-side.
  */
 export function LatestEdgeRow({
   anchorMessage,
@@ -320,7 +320,7 @@ export function Transcript({
   const partition = useMemo(() => partitionLatestTurn(items), [items]);
 
   // History rows + a single trailing composite when there's an anchor or an
-  // avatar to mount (mirrors the old latest-edge guard).
+  // avatar to mount.
   const rows = useMemo<VirtualRow[]>(() => {
     const out: VirtualRow[] = partition.historyItems.map((item) => ({
       type: "history",

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -275,8 +275,27 @@ export function Transcript({
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hasItems = items.length > 0;
+  // Virtuoso exposes its scroller asynchronously (after the initial commit, via
+  // its internal scrollerRef), so a single synchronous read here can miss it —
+  // leaving `useViewportMinHeight` sized to 0, which collapses the latest-edge
+  // pin-to-top reserve. Read synchronously for the fast path, then poll on
+  // rAF until the scroller exists. Re-runs on first mount + conversation switch
+  // (the list remounts on `key={conversationId}`, yielding a new scroller).
   useLayoutEffect(() => {
-    setScrollEl(virtualListRef.current?.getScrollElement() ?? null);
+    let raf = 0;
+    let tries = 0;
+    const capture = () => {
+      const el = virtualListRef.current?.getScrollElement() ?? null;
+      if (el) {
+        setScrollEl(el);
+      } else if (tries++ < 30) {
+        raf = requestAnimationFrame(capture);
+      }
+    };
+    capture();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
   }, [conversationId, hasItems]);
 
   useLayoutEffect(() => {
@@ -361,7 +380,15 @@ export function Transcript({
       if (row.type === "history") {
         if (row.item.kind === "message") register(row.item, index);
       } else {
+        // The composite renders the anchor user message AND the latest turn's
+        // response messages (inside LatestTurnRow), so a deep link to the
+        // latest assistant reply must resolve to this row too — not just the
+        // anchor. All of them map to the single latest-edge row index; the
+        // post-scroll `#msg-<id>` highlight then targets the exact node.
         register(row.anchorMessage, index);
+        for (const resp of row.responseItems) {
+          if (resp.kind === "message") register(resp, index);
+        }
       }
     });
     return map;
@@ -383,9 +410,12 @@ export function Transcript({
           behavior: "smooth",
           align: "center",
         });
-        // The row may not be painted yet (virtuoso scrolls, then mounts it),
-        // so poll briefly for the DOM node before applying the highlight.
-        let frames = 0;
+        // Virtuoso scrolls (smoothly), then mounts the target row only once the
+        // scroll reaches it — for a far target that can take several hundred ms.
+        // Poll on a time budget (not a fixed frame count) so the highlight still
+        // lands: the render-everything predecessor highlighted reliably because
+        // every row was always in the DOM, and we preserve that.
+        const highlightStart = performance.now();
         const tryHighlight = () => {
           const target = document.getElementById(`msg-${messageId}`);
           if (target) {
@@ -399,7 +429,9 @@ export function Transcript({
             }, 2000);
             return;
           }
-          if (frames++ < 10) requestAnimationFrame(tryHighlight);
+          if (performance.now() - highlightStart < 2500) {
+            requestAnimationFrame(tryHighlight);
+          }
         };
         requestAnimationFrame(tryHighlight);
         return true;

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -117,5 +117,4 @@ export interface TranscriptPaginationState {
   hasMore: boolean;
   oldestTimestamp: number | null;
   isLoadingOlder: boolean;
-  isPinnedToLatest: boolean;
 }

--- a/clients/web/src/domains/chat/transcript/use-pull-to-refresh.ts
+++ b/clients/web/src/domains/chat/transcript/use-pull-to-refresh.ts
@@ -46,7 +46,13 @@ function visualPullHeight(dragDistance: number): number {
 }
 
 export interface UsePullToRefreshArgs {
-  scrollRef: RefObject<HTMLDivElement | null>;
+  /** The scroll container. Widened from `HTMLDivElement` to `HTMLElement`
+   *  because the virtualized transcript hands us virtuoso's scroller element
+   *  (captured via `VirtualList.getScrollElement()`) rather than a div the
+   *  component owns directly. The hook only reads
+   *  `scrollTop`/`scrollHeight`/`clientHeight` and `style.overscrollBehavior`,
+   *  all of which live on `HTMLElement`. */
+  scrollRef: RefObject<HTMLElement | null>;
   onRefresh: () => Promise<void>;
   enabled: boolean;
 }

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -1,13 +1,12 @@
 /**
  * Tests for the transcript scroll coordinator.
  *
- * This project's test runner (bun:test) has no DOM environment and no
- * @testing-library/react, so we cannot render the hook directly. Instead
- * we split the coordinator into pure helpers (`classifyScrollPosition`,
- * `findAnchorIndex`, `decideItemsChangeAction`) that own every
- * load-bearing decision. The hook itself is a thin wiring layer on top of
- * those helpers — each test below maps directly to one of the
- * acceptance-criteria behaviors in the PR plan.
+ * The coordinator's load-bearing decisions live in pure helpers
+ * (`classifyScrollPosition`, `findAnchorIndex`, `findLatestUserAnchorKey`,
+ * `computePrependDelta`) so they can be unit-tested without a render cycle.
+ * The hook itself is a thin wiring layer on top of those helpers; its
+ * scroll-event / load-older timing is covered separately in
+ * `use-transcript-scroll.burst.test.tsx`.
  *
  * The transcript uses plain `flex-col` (chronological order):
  *   - distanceFromTop    = scrollTop
@@ -21,7 +20,7 @@ import { describe, expect, mock, test } from "bun:test";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   classifyScrollPosition,
-  decideItemsChangeAction,
+  computePrependDelta,
   findAnchorIndex,
   findLatestUserAnchorKey,
   PINNED_THRESHOLD_PX,
@@ -77,14 +76,12 @@ function makeHandle(): TranscriptHandle & {
   calls: {
     scrollToLatest: Array<[{ behavior?: "auto" | "smooth" }?]>;
     getScrollElement: number;
-    getContentElement: number;
     getViewportHeight: number;
   };
 } {
   const calls = {
     scrollToLatest: [] as Array<[{ behavior?: "auto" | "smooth" }?]>,
     getScrollElement: 0,
-    getContentElement: 0,
     getViewportHeight: 0,
   };
   const scrollToLatest = mock((opts?: { behavior?: "auto" | "smooth" }) => {
@@ -92,10 +89,6 @@ function makeHandle(): TranscriptHandle & {
   });
   const getScrollElement = mock((): HTMLDivElement | null => {
     calls.getScrollElement += 1;
-    return null;
-  });
-  const getContentElement = mock((): HTMLDivElement | null => {
-    calls.getContentElement += 1;
     return null;
   });
   const getViewportHeight = mock((): number => {
@@ -112,7 +105,6 @@ function makeHandle(): TranscriptHandle & {
     scrollToLatest,
     scrollToMessage: mock((): boolean => false),
     getScrollElement,
-    getContentElement,
     getViewportHeight,
     getScrollState,
     calls,
@@ -267,12 +259,10 @@ describe("findAnchorIndex", () => {
 // ---------------------------------------------------------------------------
 // findLatestUserAnchorKey
 //
-// Backs the items-effect's submit-detection branch. The hook compares
-// the latest call's key to the previous render's key — when they differ
-// (typically because the user just sent a new message), the hook
-// re-engages the auto-pin window so the new anchor lands at the top of
-// the viewport even if the upstream `scrollToLatest()` call fired
-// before the optimistic add landed.
+// Backs the submit-detection branch in `Transcript`. The component compares
+// this render's key to the previous render's key — when they differ
+// (typically because the user just sent a new message), it pins the new
+// anchor to the viewport top so the response streams into the space below.
 // ---------------------------------------------------------------------------
 
 describe("findLatestUserAnchorKey", () => {
@@ -359,104 +349,49 @@ describe("findLatestUserAnchorKey", () => {
 });
 
 // ---------------------------------------------------------------------------
-// decideItemsChangeAction
+// computePrependDelta
+//
+// Drives virtuoso's `firstItemIndex` decrement so an older-page prepend keeps
+// the viewport visually stable. Returns the prepended count ONLY for a pure
+// front-prepend; every other shape (append, in-place growth, mixed
+// prepend+append, replace, shrink, first render) returns 0 so the index is
+// left untouched and stable `computeItemKey` handles reconciliation.
 // ---------------------------------------------------------------------------
 
-describe("decideItemsChangeAction — no-conversation returns none", () => {
-  test("does not act when conversationId is null", () => {
-    const action = decideItemsChangeAction({
-      items: items(["m1"]),
-      previousItems: [],
-      conversationId: null,
-      savedAnchor: null,
-    });
-    expect(action.kind).toBe("none");
-  });
-});
-
-describe("decideItemsChangeAction — streaming growth", () => {
-  // The coordinator deliberately does NOT auto-follow as a response
-  // streams in. The user keeps control of the viewport; the "Go to
-  // Newest" pill surfaces once they drift past the threshold.
-
-  test("items grow during streaming -> none", () => {
-    const prev = items(["m1", "m2"]);
-    const next = items(["m1", "m2", "m3"]);
-    const action = decideItemsChangeAction({
-      items: next,
-      previousItems: prev,
-      conversationId: "conv-1",
-      savedAnchor: null,
-    });
-    expect(action.kind).toBe("none");
+describe("computePrependDelta", () => {
+  test("first render (no baseline key) returns 0", () => {
+    expect(computePrependDelta(items(["m1", "m2"]), null, 0)).toBe(0);
   });
 
-  test("content swap at same length -> none", () => {
-    const prev = items(["m1", "m2"]);
-    const next = items(["m1", "m2-edited"]);
-    const action = decideItemsChangeAction({
-      items: next,
-      previousItems: prev,
-      conversationId: "conv-1",
-      savedAnchor: null,
-    });
-    expect(action.kind).toBe("none");
+  test("pure front-prepend returns the prepended count", () => {
+    // prev first key "m1" (len 3) now sits at index 2 after 2 older items.
+    const after = items(["o1", "o2", "m1", "m2", "m3"]);
+    expect(computePrependDelta(after, "m1", 3)).toBe(2);
   });
 
-  test("no change -> none", () => {
-    const list = items(["m1", "m2"]);
-    const action = decideItemsChangeAction({
-      items: list,
-      previousItems: list,
-      conversationId: "conv-1",
-      savedAnchor: null,
-    });
-    expect(action.kind).toBe("none");
-  });
-});
-
-describe("decideItemsChangeAction — anchor-preserving prepend", () => {
-  test("saved anchor present and found -> anchor-correct with saved metrics", () => {
-    const before = items(["m1", "m2", "m3"]);
-    const afterPrepend = items(["o1", "o2", "m1", "m2", "m3"]);
-    const action = decideItemsChangeAction({
-      items: afterPrepend,
-      previousItems: before,
-      conversationId: "conv-1",
-      savedAnchor: { key: "m1", scrollTop: 42, scrollHeight: 1800 },
-    });
-    expect(action).toEqual({
-      kind: "anchor-correct",
-      newIndex: 2,
-      savedScrollTop: 42,
-      savedScrollHeight: 1800,
-    });
+  test("append-only returns 0 (old first item stays at the front)", () => {
+    const after = items(["m1", "m2", "m3"]);
+    expect(computePrependDelta(after, "m1", 2)).toBe(0);
   });
 
-  test("anchor correction wins over the otherwise-noop streaming-growth path", () => {
-    const before = items(["m1"]);
-    const afterPrepend = items(["o1", "m1", "m2"]);
-    const action = decideItemsChangeAction({
-      items: afterPrepend,
-      previousItems: before,
-      conversationId: "conv-1",
-      savedAnchor: { key: "m1", scrollTop: 123, scrollHeight: 1800 },
-    });
-    expect(action.kind).toBe("anchor-correct");
+  test("mixed prepend+append returns 0 (don't mis-shift)", () => {
+    // Grew by 2, but the old first key moved only 1 slot → not a pure prepend.
+    const after = items(["o1", "m1", "m2", "m3"]);
+    expect(computePrependDelta(after, "m1", 2)).toBe(0);
   });
 
-  test("saved anchor but key missing -> falls through to none", () => {
-    const action = decideItemsChangeAction({
-      items: items(["n1", "n2"]),
-      previousItems: items(["m1"]),
-      conversationId: "conv-1",
-      savedAnchor: {
-        key: "m1-no-longer-present",
-        scrollTop: 10,
-        scrollHeight: 1800,
-      },
-    });
-    expect(action.kind).toBe("none");
+  test("same length (content swap / streaming in-place) returns 0", () => {
+    const after = items(["m1", "m2-edited"]);
+    expect(computePrependDelta(after, "m1", 2)).toBe(0);
+  });
+
+  test("shrink returns 0", () => {
+    expect(computePrependDelta(items(["m2", "m3"]), "m1", 3)).toBe(0);
+  });
+
+  test("old first key absent after a replace returns 0", () => {
+    const after = items(["n1", "n2", "n3"]);
+    expect(computePrependDelta(after, "m1", 2)).toBe(0);
   });
 });
 
@@ -529,39 +464,19 @@ describe("integration — handleScroll-style dispatch via pure helpers", () => {
     expect(show).toBe(false);
   });
 
-  test("anchor-preserving prepend: saved anchor -> anchor-correct on next items change", () => {
-    const before = items(["m1", "m2", "m3"]);
-    // Saved anchor captured during a load-older scroll event.
-    const saved = { key: "m1", scrollTop: 150, scrollHeight: 1800 };
-    // New items arrive with two older messages prepended.
+  test("anchor-preserving prepend: pure front-prepend yields a non-zero delta", () => {
+    // The prepend correction now rides virtuoso's `firstItemIndex` via
+    // `computePrependDelta` rather than a saved-anchor scrollTop fix-up.
     const after = items(["o1", "o2", "m1", "m2", "m3"]);
-    const action = decideItemsChangeAction({
-      items: after,
-      previousItems: before,
-      conversationId: "conv-1",
-      savedAnchor: saved,
-    });
-    expect(action).toEqual({
-      kind: "anchor-correct",
-      newIndex: 2,
-      savedScrollTop: 150,
-      savedScrollHeight: 1800,
-    });
+    expect(computePrependDelta(after, "m1", 3)).toBe(2);
   });
 
   test("streaming growth never triggers an auto-scroll", () => {
     const handle = makeHandle();
-    const prev = items(["m1"]);
+    // In-place growth at the tail (a streaming response) is not a prepend, so
+    // `firstItemIndex` is left untouched and no scroll command is issued.
     const grown = items(["m1", "m2"]);
-    const action = decideItemsChangeAction({
-      items: grown,
-      previousItems: prev,
-      conversationId: "conv-1",
-      savedAnchor: null,
-    });
-    // Decision helper no longer emits stick-to-latest under any pinned
-    // state — the viewport stays put while the user reads.
-    expect(action.kind).toBe("none");
+    expect(computePrependDelta(grown, "m1", 1)).toBe(0);
     expect(handle.calls.scrollToLatest.length).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -1,8 +1,7 @@
-// Thin scroll coordinator for the virtualized chat transcript. Since
-// LUM-2605 the transcript renders through the `VirtualList` primitive,
-// which owns windowing, prepend anchoring (`firstItemIndex`), and the
-// initial bottom-pin. This hook is what remains of the old hand-rolled
-// coordinator — two responsibilities that live above the primitive:
+// Thin scroll coordinator for the virtualized chat transcript. The transcript
+// renders through the `VirtualList` primitive, which owns windowing, prepend
+// anchoring (`firstItemIndex`), and the initial bottom-pin. This hook owns the
+// two responsibilities that live above the primitive:
 //
 //   1. "Go to Newest" pill visibility — surfaced once the user drifts
 //      more than `SHOW_SCROLL_BUTTON_THRESHOLD_PX` from the bottom.
@@ -10,13 +9,11 @@
 //      within `LOAD_OLDER_THRESHOLD_PX` of the top, de-duplicated by a
 //      synchronous in-flight lock.
 //
-// Everything the previous implementation did with manual scrollTop math —
-// the auto-pin window, anchor-preserving prepend correction, container /
-// content ResizeObservers, wheel/touch/keydown disengage — is now handled
-// inside `VirtualList` (and the composite "latest-edge" row's min-height
-// spacer in `transcript.tsx`). The coordinator only reads scroll geometry
-// off the virtuoso scroller and classifies it; it never moves the viewport
-// except through the `TranscriptHandle.scrollToLatest` command.
+// `VirtualList` (and the composite "latest-edge" row's min-height spacer in
+// `transcript.tsx`) own everything else — the auto-pin on open, prepend
+// position preservation, and resize re-pin. The coordinator only reads scroll
+// geometry off the virtuoso scroller and classifies it; it never moves the
+// viewport except through the `TranscriptHandle.scrollToLatest` command.
 //
 // The transcript is plain `flex-col` (oldest first, latest at the bottom):
 //   - distanceFromTop    = scrollTop

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -1,25 +1,26 @@
-// Scroll coordinator hook for the chronological-order transcript. Owns:
+// Thin scroll coordinator for the virtualized chat transcript. Since
+// LUM-2605 the transcript renders through the `VirtualList` primitive,
+// which owns windowing, prepend anchoring (`firstItemIndex`), and the
+// initial bottom-pin. This hook is what remains of the old hand-rolled
+// coordinator — two responsibilities that live above the primitive:
 //
-//   1. Pinned-to-latest detection + "Go to Newest" affordance visibility.
-//   2. Anchor-preserving older-page prepends.
-//   3. Conversation-switch reset: scroll the reused container back to the
-//      latest message so the new conversation does not inherit the
-//      previous conversation's scrollTop.
+//   1. "Go to Newest" pill visibility — surfaced once the user drifts
+//      more than `SHOW_SCROLL_BUTTON_THRESHOLD_PX` from the bottom.
+//   2. Older-page paging — fire `onLoadOlder()` when the user scrolls
+//      within `LOAD_OLDER_THRESHOLD_PX` of the top, de-duplicated by a
+//      synchronous in-flight lock.
 //
-// The coordinator deliberately does NOT auto-follow streaming growth.
-// As a response streams in, the viewport stays put and the "Go to Newest"
-// pill surfaces so the user can catch up on their own — see the
-// `LatestTurnRow` min-height spacer for the layout half of this pattern.
+// Everything the previous implementation did with manual scrollTop math —
+// the auto-pin window, anchor-preserving prepend correction, container /
+// content ResizeObservers, wheel/touch/keydown disengage — is now handled
+// inside `VirtualList` (and the composite "latest-edge" row's min-height
+// spacer in `transcript.tsx`). The coordinator only reads scroll geometry
+// off the virtuoso scroller and classifies it; it never moves the viewport
+// except through the `TranscriptHandle.scrollToLatest` command.
 //
-// The transcript uses plain `flex-col` (NOT column-reverse): oldest items
-// first, latest at the bottom. scrollTop = 0 is the visual top (oldest);
-// scrollTop = scrollHeight − clientHeight is the visual bottom (latest).
-// Switching off column-reverse is what makes the "stay put while streaming"
-// behavior possible — column-reverse's intrinsic bottom-anchoring fights
-// every attempt to keep the viewport still.
-//
-// The hook only issues scroll commands through the `TranscriptHandle`
-// interface — it never touches `scrollIntoView` directly.
+// The transcript is plain `flex-col` (oldest first, latest at the bottom):
+//   - distanceFromTop    = scrollTop
+//   - distanceFromBottom = scrollHeight − clientHeight − scrollTop
 
 import type { RefObject } from "react";
 import {
@@ -32,13 +33,7 @@ import {
 } from "react";
 
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
-import {
-  type AnchorSnapshot,
-  classifyScrollPosition,
-  decideItemsChangeAction,
-  findLatestUserAnchorKey,
-  type ScrollMetrics,
-} from "@/domains/chat/transcript/transcript-scroll-utils";
+import { classifyScrollPosition } from "@/domains/chat/transcript/transcript-scroll-utils";
 
 import type { TranscriptHandle } from "@/domains/chat/transcript/transcript";
 
@@ -76,91 +71,52 @@ export function useTranscriptScroll(
     onLoadOlder,
   } = args;
 
-  // Coerced to boolean so the dep arrays below re-fire exactly once on
-  // the 0→N transition (Transcript mounts) without re-firing on every
-  // TanStack Query background refetch that produces a new `items` array.
+  // Coerced to boolean so the listener-attach effects below re-fire exactly
+  // once on the 0→N transition (Transcript mounts, virtuoso scroller exists)
+  // without re-firing on every TanStack Query background refetch.
   const hasItems = items.length > 0;
 
-  const [isPinnedToLatest, setIsPinnedToLatest] = useState(true);
   const [showScrollToLatest, setShowScrollToLatest] = useState(false);
 
   // ---------- Latest-props ref (ref-backed fresh-closure pattern) ---------
-  // Synced in useLayoutEffect (declared BEFORE the items-effect below)
-  // so the items-effect — whose deps are intentionally narrow
-  // (`items` + `conversationId` + transcriptRef + engageAutoPin) —
-  // reads fresh values for everything else via latestRef without
-  // forcing those values into its dep array. Putting them in the
-  // items-effect deps would cause it to re-run on transitions that
-  // shouldn't trigger items-change work, with two real consequences:
-  // (1) the `decideItemsChangeAction` branch consumes `savedAnchorRef`
-  // on a heightDelta=0 no-op, and (2) the chain-load branch re-fires
-  // `onLoadOlder()` on a just-released lock while items haven't yet
-  // prepended. See the dedicated lock-release effect below.
+  // Synced in useLayoutEffect (declared BEFORE the items-effect below) so the
+  // narrow-dep items-effect and the stable scroll handler read fresh mutable
+  // values without listing them in their dep arrays — listing `isLoadingOlder`
+  // there is exactly what caused the older-page double-load regression the
+  // burst tests lock in.
   // TODO: migrate to useEffectEvent once it's stable in React.
   const latestRef = useRef({
-    items,
     hasMore,
     isLoadingOlder,
     conversationId,
     onLoadOlder,
-    isPinnedToLatest,
     showScrollToLatest,
   });
   useLayoutEffect(() => {
     latestRef.current = {
-      items,
       hasMore,
       isLoadingOlder,
       conversationId,
       onLoadOlder,
-      isPinnedToLatest,
       showScrollToLatest,
     };
-  }, [
-    items,
-    hasMore,
-    isLoadingOlder,
-    conversationId,
-    onLoadOlder,
-    isPinnedToLatest,
-    showScrollToLatest,
-  ]);
-
-  // ---------- Saved anchor for prepend preservation ---------------------
-  const savedAnchorRef = useRef<AnchorSnapshot | null>(null);
+  }, [hasMore, isLoadingOlder, conversationId, onLoadOlder, showScrollToLatest]);
 
   // ---------- Synchronous load-older in-flight lock ---------------------
   //
   // The `isLoadingOlder` prop is the source of truth, but it propagates
-  // through React state: parent calls `setIsLoadingOlder(true)` inside
-  // `onLoadOlder`, React commits, then a `useLayoutEffect` mirrors the
-  // new value into `latestRef`. Between the firing scroll event and the
-  // latestRef refresh, ~5–20 more scroll events can fire — every one
-  // sees the stale `isLoadingOlder=false` and re-fires `onLoadOlder`.
-  // Even though React Query dedupes the underlying fetch, the rapid
-  // re-fires overwrite `savedAnchorRef` with progressively different
-  // scrollTop values mid-gesture, producing jittery scroll restoration
-  // after the prepend.
-  //
-  // The fix: a ref that flips to `true` SYNCHRONOUSLY at the moment we
-  // call `onLoadOlder`. Subsequent scroll events within the same burst
-  // see `true` and skip. The lock is released by the dedicated
-  // `isLoadingOlder` transition effect below — declared BEFORE the
-  // items-effect so it fires first in the commit phase when both
-  // change together (the underfilled-viewport chain-load case).
+  // through React state, so between a firing scroll event and the latestRef
+  // refresh many more scroll events can fire — every one would see the stale
+  // `isLoadingOlder=false` and re-fire `onLoadOlder`. This ref flips to `true`
+  // SYNCHRONOUSLY the moment we fire; subsequent events within the same burst
+  // see `true` and skip. Released by the transition effect just below.
   const loadOlderInFlightRef = useRef(false);
   const prevIsLoadingOlderRef = useRef(isLoadingOlder);
 
   // ---------- Lock release on isLoadingOlder true→false transition ------
-  //
-  // Declared as its own effect (not co-located with the items-effect)
-  // so transitions of `isLoadingOlder` that do NOT coincide with an
-  // items change cannot accidentally trigger the items-effect's
-  // anchor-correct + chain-load work. Declared BEFORE the items-effect
-  // so in commits where BOTH `isLoadingOlder` and `items` change
-  // (underfilled-viewport prepend), this effect runs first within the
-  // commit phase and the items-effect's chain-load branch sees the
-  // released lock immediately.
+  // Declared BEFORE the items-effect so in commits where BOTH `isLoadingOlder`
+  // and `items` change (underfilled-viewport chain-load), this runs first and
+  // the items-effect's kick sees the released lock immediately.
   useLayoutEffect(() => {
     if (prevIsLoadingOlderRef.current && !isLoadingOlder) {
       loadOlderInFlightRef.current = false;
@@ -168,406 +124,74 @@ export function useTranscriptScroll(
     prevIsLoadingOlderRef.current = isLoadingOlder;
   }, [isLoadingOlder]);
 
-  // ---------- Previous items ref (for change detection) -----------------
-  const previousItemsRef = useRef<TranscriptItem[]>(items);
-
-  // ---------- Previous latest-user-anchor key (submit detection) --------
-  // Seeded from the initial items so the items-effect's first run on
-  // mount does not register a spurious "new anchor" event.
-  const previousAnchorKeyRef = useRef<string | null>(
-    findLatestUserAnchorKey(items),
-  );
-
-  // ---------- Auto-pin window --------------------------------------------
-  // While `shouldAutoPinRef` is true, every layout change of the scroll
-  // content re-pins the viewport to the bottom. This is what makes the
-  // initial render of a new conversation land at the latest message
-  // even when content height keeps growing across multiple frames —
-  // `useViewportMinHeight`'s deferred `setHeight`, late image/font
-  // loads, etc. The flag is engaged briefly on intentful events
-  // (conversation switch, "Go to Newest", user submit) and auto-
-  // disengages on a 500 ms timer or on the first user-input scroll —
-  // whichever comes first. The window is intentionally short so a
-  // streaming response (which takes the HTTP round-trip plus first
-  // token to *start*) does not trigger auto-follow.
-  const shouldAutoPinRef = useRef(false);
-  const autoPinTimeoutRef = useRef<number | null>(null);
-
-  const disengageAutoPin = useCallback(() => {
-    shouldAutoPinRef.current = false;
-    if (autoPinTimeoutRef.current !== null) {
-      clearTimeout(autoPinTimeoutRef.current);
-      autoPinTimeoutRef.current = null;
-    }
-  }, []);
-
-  const engageAutoPin = useCallback(() => {
-    shouldAutoPinRef.current = true;
-    if (autoPinTimeoutRef.current !== null) {
-      clearTimeout(autoPinTimeoutRef.current);
-    }
-    autoPinTimeoutRef.current = window.setTimeout(() => {
-      shouldAutoPinRef.current = false;
-      autoPinTimeoutRef.current = null;
-    }, 500);
-  }, []);
-
-  // Always clear the timer on unmount.
-  useEffect(
-    () => () => {
-      if (autoPinTimeoutRef.current !== null) {
-        clearTimeout(autoPinTimeoutRef.current);
-      }
-    },
-    [],
-  );
-
-  // -----------------------------------------------------------------------
-  // Conversation switch: reset pinned state and engage the auto-pin
-  // window. The items effect + content ResizeObserver will land the
-  // viewport on the latest message once the new content is in the DOM,
-  // and keep re-pinning across the async layout-settling phase
-  // (useViewportMinHeight, late image loads). The window auto-expires
-  // before any streaming response could start.
-  // -----------------------------------------------------------------------
-  useLayoutEffect(() => {
-    startTransition(() => {
-      setIsPinnedToLatest(true);
-      setShowScrollToLatest(false);
-    });
-    savedAnchorRef.current = null;
-    previousItemsRef.current = [];
-    // Force the items-effect's submit-detection block to treat the next
-    // run as a "new anchor" event so a fresh conversation lands at the
-    // latest message even if it happens to share an anchor key with the
-    // outgoing one (e.g. seeded fixtures, restored drafts).
-    previousAnchorKeyRef.current = null;
-    engageAutoPin();
-  }, [conversationId, engageAutoPin]);
-
-  // -----------------------------------------------------------------------
-  // Items change handler — runs in useLayoutEffect so the anchor correction
-  // happens before the browser paints.
-  //
-  // Deps are intentionally narrow: `items` + `conversationId` (the two
-  // values that determine WHEN this work should run) plus the two
-  // stable refs (`transcriptRef`, `engageAutoPin`). Everything else
-  // that the body reads — `hasMore`, `isLoadingOlder`, `onLoadOlder`,
-  // `isPinnedToLatest`, `showScrollToLatest` — comes from `latestRef`,
-  // which is synced in the useLayoutEffect declared above this one.
-  // Listing those values directly in this effect's deps would cause it
-  // to re-run for transitions that didn't change items, and the
-  // anchor-correct + chain-load branches would fire against stale
-  // assumptions (e.g. the `isLoadingOlder` true→false → premature
-  // chain-load bug).
-  // -----------------------------------------------------------------------
-  useLayoutEffect(() => {
-    const prev = previousItemsRef.current;
-    previousItemsRef.current = items;
+  // ---------- Shared classify + apply ------------------------------------
+  // Reads scroll geometry off the virtuoso scroller, classifies it against
+  // the load-bearing thresholds, drives the pill state, and fires the gated
+  // load-older path. Stable (closes over refs + a stable setter only) so the
+  // items-effect's deps stay narrow.
+  const classifyAndApply = useCallback((el: HTMLElement) => {
     const latest = latestRef.current;
+    const classification = classifyScrollPosition(
+      {
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      },
+      {
+        hasMore: latest.hasMore,
+        isLoadingOlder: latest.isLoadingOlder,
+        hasConversation: latest.conversationId !== null,
+      },
+    );
 
-    const action = decideItemsChangeAction({
-      items,
-      previousItems: prev,
-      conversationId,
-      savedAnchor: savedAnchorRef.current,
-    });
-
-    switch (action.kind) {
-      case "anchor-correct": {
-        const scrollElement = transcriptRef.current?.getScrollElement();
-        if (scrollElement) {
-          const heightDelta =
-            scrollElement.scrollHeight - action.savedScrollHeight;
-          scrollElement.scrollTop = action.savedScrollTop + heightDelta;
-        }
-        savedAnchorRef.current = null;
-        break;
-      }
-      case "none":
-      default:
-        break;
-    }
-
-    // New-submit detection. When the latest user-message anchor changes
-    // (typically because the user just submitted a new message and the
-    // optimistic add landed in `messages`), the new `LatestTurnRow`
-    // expands to viewport min-height. We need to re-pin to the bottom so
-    // the new anchor sits at the top of the viewport.
-    //
-    // Why this is a separate code path from the existing `shouldAutoPinRef`
-    // block below: the upstream `scrollToLatest()` call in
-    // `handleSubmit` engages the auto-pin window BEFORE the optimistic
-    // user message is added. By the time the items-effect runs, layout
-    // can still be in flux (composer textarea resetting to one-line
-    // height changes scroll-container clientHeight; new LatestTurnRow's
-    // `viewportMinHeight` state may lag behind the underlying
-    // ResizeObserver tick). Re-engaging the auto-pin window from
-    // here — gated specifically on "anchor changed" — extends the
-    // content-ResizeObserver re-pin window so it covers the post-submit
-    // layout-settling phase, and the unconditional `scrollToLatest`
-    // below guarantees we hit the latest bottom even if the upstream
-    // window already lapsed.
-    const newAnchorKey = findLatestUserAnchorKey(items);
-    const prevAnchorKey = previousAnchorKeyRef.current;
-    previousAnchorKeyRef.current = newAnchorKey;
-    const isNewAnchor =
-      newAnchorKey !== null && newAnchorKey !== prevAnchorKey;
-    if (isNewAnchor) {
-      engageAutoPin();
-      transcriptRef.current?.scrollToLatest({ behavior: "auto" });
-    } else if (
-      shouldAutoPinRef.current &&
-      items.length > 0 &&
-      transcriptRef.current
-    ) {
-      // First-pass pin during the auto-pin window. The content
-      // ResizeObserver will catch any subsequent height changes (async
-      // min-height settle, late image loads) and re-pin until the
-      // window expires.
-      transcriptRef.current.scrollToLatest({ behavior: "auto" });
-    }
-
-    // After every items change re-classify the scroll position. The
-    // browser does NOT fire a scroll event when scrollHeight grows under
-    // a stationary scrollTop (the streaming case), so without this the
-    // "Go to Newest" pill would only surface once the user touched the
-    // scroll wheel. Read mutable flags from `latest` (synced by the
-    // useLayoutEffect declared above this one, so values are fresh for
-    // the current commit).
-    const el = transcriptRef.current?.getScrollElement();
-    if (el) {
-      const classification = classifyScrollPosition(
-        {
-          scrollTop: el.scrollTop,
-          scrollHeight: el.scrollHeight,
-          clientHeight: el.clientHeight,
-        },
-        {
-          hasMore: latest.hasMore,
-          isLoadingOlder: latest.isLoadingOlder,
-          hasConversation: conversationId !== null,
-        },
-      );
-      if (classification.isPinned !== latest.isPinnedToLatest) {
-        setIsPinnedToLatest(classification.isPinned);
-      }
-      if (classification.showScrollToLatest !== latest.showScrollToLatest) {
-        setShowScrollToLatest(classification.showScrollToLatest);
-      }
-
-      // Underfilled viewport: no scroll event can fire, so kick load-older
-      // from here. Skip the anchor save during auto-pin (resize observer re-pins).
-      // Gate on the synchronous in-flight lock so a chain-load sequence
-      // (response prepends → items change → effect re-runs near top) cannot
-      // double-fire on a single render cycle.
-      if (
-        classification.shouldLoadOlder &&
-        !loadOlderInFlightRef.current
-      ) {
-        if (!shouldAutoPinRef.current) {
-          const firstItem = items[0];
-          if (firstItem) {
-            savedAnchorRef.current = {
-              key: firstItem.key,
-              scrollTop: el.scrollTop,
-              scrollHeight: el.scrollHeight,
-            };
-          }
-        }
-        loadOlderInFlightRef.current = true;
-        latest.onLoadOlder();
-      }
-    }
-  }, [items, conversationId, transcriptRef, engageAutoPin]);
-
-  // -----------------------------------------------------------------------
-  // Container resize re-pin. When the scroll container resizes (e.g. the
-  // document panel opens and squeezes the chat pane), `scrollHeight −
-  // clientHeight` shifts and the max scrollTop changes. Re-pin to the
-  // bottom when the user was already pinned so the "Go to Newest" pill
-  // doesn't appear spuriously after a layout change the user didn't
-  // initiate.
-  //
-  // The observer lifecycle is managed via refs so that we only
-  // disconnect/reconnect when the underlying DOM node actually changes
-  // (e.g. Transcript remounts inside ResizablePanel). `conversationId`
-  // is the dep-array signal for remounts — it corresponds directly to
-  // the `key={conversationId}` prop on the scroll container.
-  //
-  // `hasItems` covers the deferred-mount case: `Transcript` only
-  // renders when `messageCount > 0`, so on initial conversation load
-  // `conversationId` fires before the element exists. The boolean
-  // flips once on the 0→N transition, re-running the effect after
-  // the element mounts, without re-running on every TQ refetch.
-  // -----------------------------------------------------------------------
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const observedElRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (typeof ResizeObserver === "undefined") return;
-
-    const el = transcriptRef.current?.getScrollElement() ?? null;
-    if (el === observedElRef.current) return;
-
-    resizeObserverRef.current?.disconnect();
-    observedElRef.current = el;
-
-    if (!el) {
-      resizeObserverRef.current = null;
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      if (latestRef.current.isPinnedToLatest) {
-        transcriptRef.current?.scrollToLatest({ behavior: "auto" });
-      }
-    });
-    observer.observe(el);
-    resizeObserverRef.current = observer;
-  }, [conversationId, transcriptRef, hasItems]);
-
-  // Disconnect observer on hook unmount.
-  useEffect(() => () => {
-    resizeObserverRef.current?.disconnect();
-  }, []);
-
-  // -----------------------------------------------------------------------
-  // Content resize re-pin. The *content* element (inner wrapper around
-  // all rendered rows) changes size whenever scroll content grows:
-  //   - `useViewportMinHeight` setting min-height after first paint
-  //   - Late image / web-font loads
-  //   - Streaming response items appended
-  //   - User-submitted messages adding a new turn
-  // While `shouldAutoPinRef` is true, every fire snaps scrollTop back
-  // to the visual bottom so the viewport stays at the latest message
-  // through all of those async height changes. The 500 ms window
-  // ensures streaming alone (which starts after first token / HTTP
-  // round-trip) never auto-follows.
-  // -----------------------------------------------------------------------
-  const contentObserverRef = useRef<ResizeObserver | null>(null);
-  const observedContentElRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (typeof ResizeObserver === "undefined") return;
-
-    const el = transcriptRef.current?.getContentElement?.() ?? null;
-    if (el === observedContentElRef.current) return;
-
-    contentObserverRef.current?.disconnect();
-    observedContentElRef.current = el;
-
-    if (!el) {
-      contentObserverRef.current = null;
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      if (shouldAutoPinRef.current) {
-        transcriptRef.current?.scrollToLatest({ behavior: "auto" });
-      }
-    });
-    observer.observe(el);
-    contentObserverRef.current = observer;
-  }, [conversationId, transcriptRef, hasItems]);
-
-  useEffect(() => () => {
-    contentObserverRef.current?.disconnect();
-  }, []);
-
-  // -----------------------------------------------------------------------
-  // User-input scroll cancels the auto-pin window. Any of these gestures
-  // means the user has taken control of the viewport — we stop fighting
-  // them. We listen on the scroll element rather than the scroll event
-  // because the scroll event also fires from our own programmatic pins,
-  // which would otherwise disengage their own window mid-pin.
-  // -----------------------------------------------------------------------
-  useEffect(() => {
-    const el = transcriptRef.current?.getScrollElement() ?? null;
-    if (!el) return;
-    el.addEventListener("wheel", disengageAutoPin, { passive: true });
-    el.addEventListener("touchmove", disengageAutoPin, { passive: true });
-    el.addEventListener("keydown", disengageAutoPin, { passive: true });
-    return () => {
-      el.removeEventListener("wheel", disengageAutoPin);
-      el.removeEventListener("touchmove", disengageAutoPin);
-      el.removeEventListener("keydown", disengageAutoPin);
-    };
-  }, [conversationId, transcriptRef, disengageAutoPin, hasItems]);
-
-  // -----------------------------------------------------------------------
-  // Stable scroll handler. Reads latest props via the ref pattern.
-  // -----------------------------------------------------------------------
-  const handleScroll = useCallback((event: Event) => {
-    const target = event.currentTarget as HTMLElement | null;
-    if (!target) return;
-    const metrics: ScrollMetrics = {
-      scrollTop: target.scrollTop,
-      scrollHeight: target.scrollHeight,
-      clientHeight: target.clientHeight,
-    };
-    const latest = latestRef.current;
-    const classification = classifyScrollPosition(metrics, {
-      hasMore: latest.hasMore,
-      isLoadingOlder: latest.isLoadingOlder,
-      hasConversation: latest.conversationId !== null,
-    });
-
-    if (classification.isPinned !== latest.isPinnedToLatest) {
-      setIsPinnedToLatest(classification.isPinned);
-    }
     if (classification.showScrollToLatest !== latest.showScrollToLatest) {
       setShowScrollToLatest(classification.showScrollToLatest);
     }
 
+    // Gate on the synchronous in-flight lock so a burst of scroll events — or
+    // a chain-load sequence near the top — fires `onLoadOlder` only once per
+    // settled load.
     if (classification.shouldLoadOlder && !loadOlderInFlightRef.current) {
-      // Capture the top-most visible item AND the current scrollHeight so
-      // the items-effect can restore the reader's viewport after the
-      // older-page prepend lands. The restore is
-      // `savedScrollTop + (newScrollHeight − savedScrollHeight)`.
-      const firstItem = latest.items[0];
-      if (firstItem) {
-        savedAnchorRef.current = {
-          key: firstItem.key,
-          scrollTop: metrics.scrollTop,
-          scrollHeight: metrics.scrollHeight,
-        };
-      }
-      // Flip the synchronous lock BEFORE firing so re-entrant scroll
-      // events within the same gesture see the in-flight state
-      // immediately, without waiting for React to commit the parent's
-      // `setIsLoadingOlder(true)` and the mirror useEffect to refresh
-      // `latestRef`.
       loadOlderInFlightRef.current = true;
       latest.onLoadOlder();
     }
   }, []);
 
-  // -----------------------------------------------------------------------
-  // Exposed scrollToLatest — engages the auto-pin window so any async
-  // layout settling after the scroll (image loads, etc.) stays anchored
-  // at the bottom too.
-  // -----------------------------------------------------------------------
-  const scrollToLatest = useCallback(
-    (opts?: { behavior?: "auto" | "smooth" }) => {
-      savedAnchorRef.current = null;
-      engageAutoPin();
-      transcriptRef.current?.scrollToLatest({
-        behavior: opts?.behavior ?? "smooth",
-      });
+  // ---------- Conversation switch: reset the pill ------------------------
+  // VirtualList remounts (key=conversationId) and lands at the bottom, so the
+  // pill must not linger from the outgoing conversation. The items-effect
+  // re-classifies against the fresh scroller right after.
+  useLayoutEffect(() => {
+    startTransition(() => {
+      setShowScrollToLatest(false);
+    });
+  }, [conversationId]);
+
+  // ---------- Items-change re-classify -----------------------------------
+  // The browser fires no scroll event when scrollHeight grows under a
+  // stationary scrollTop (the streaming case) or when a conversation opens
+  // underfilled. Re-classify on every items change so the pill surfaces and
+  // the underfilled-viewport load-older kick still fires. Deps are
+  // intentionally narrow — `items` + `conversationId` (the values that decide
+  // WHEN to re-classify) plus the stable ref/callback; every mutable flag is
+  // read from `latestRef`.
+  useLayoutEffect(() => {
+    const el = transcriptRef.current?.getScrollElement();
+    if (el) classifyAndApply(el);
+  }, [items, conversationId, transcriptRef, classifyAndApply]);
+
+  // ---------- Scroll listener --------------------------------------------
+  const handleScroll = useCallback(
+    (event: Event) => {
+      const target = event.currentTarget as HTMLElement | null;
+      if (target) classifyAndApply(target);
     },
-    [transcriptRef, engageAutoPin],
+    [classifyAndApply],
   );
 
-  // -----------------------------------------------------------------------
-  // Attach the scroll-event listener. The hook owns its own listener
-  // so the orchestrator does not have to wire one externally.
-  //
-  // Re-runs on `conversationId` so a transcript remount (inside
-  // ResizablePanel) re-binds to the newly mounted scroll element.
-  // `handleScroll` is stable across renders so it does not contribute
-  // to re-binding.
-  // -----------------------------------------------------------------------
+  // Attach to the virtuoso scroller. Re-runs on `conversationId` / `hasItems`
+  // so a transcript remount (conversation switch, deferred first mount)
+  // re-binds to the newly mounted scroll element. `handleScroll` is stable.
   useEffect(() => {
     const el = transcriptRef.current?.getScrollElement();
     if (!el) return;
@@ -576,6 +200,16 @@ export function useTranscriptScroll(
       el.removeEventListener("scroll", handleScroll);
     };
   }, [handleScroll, transcriptRef, conversationId, hasItems]);
+
+  // ---------- Exposed scrollToLatest -------------------------------------
+  const scrollToLatest = useCallback(
+    (opts?: { behavior?: "auto" | "smooth" }) => {
+      transcriptRef.current?.scrollToLatest({
+        behavior: opts?.behavior ?? "smooth",
+      });
+    },
+    [transcriptRef],
+  );
 
   return {
     showScrollToLatest,

--- a/clients/web/src/domains/chat/utils/debug-api.test.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.test.ts
@@ -947,7 +947,6 @@ function makeTranscriptHandle(
     scrollToLatest: () => {},
     scrollToMessage: () => false,
     getScrollElement: () => scrollEl,
-    getContentElement: () => null,
     getViewportHeight: () => scrollEl?.clientHeight ?? 0,
     getScrollState: () => ({
       distanceFromBottom: 0,

--- a/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
@@ -95,4 +95,16 @@ describe("VirtualList rendering", () => {
     });
     expect(html).toContain('data-slot="virtual-list"');
   });
+
+  test("renders a provided footer node in the scroll content", () => {
+    const html = render({
+      footer: createElement("div", { "data-testid": "list-footer" }, "footer"),
+    });
+    expect(html).toContain('data-testid="list-footer"');
+    expect(html).toContain("footer");
+  });
+
+  test("mounts no footer when none is provided", () => {
+    expect(render()).not.toContain('data-testid="list-footer"');
+  });
 });

--- a/packages/design-library/src/components/virtual-list/virtual-list.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 import {
   Virtuoso,
+  type Components,
+  type ContextProp,
   type FollowOutput,
   type IndexLocationWithAlign,
   type VirtuosoHandle,
@@ -66,6 +68,12 @@ export interface VirtualListProps<T> {
   overscan?: number;
   increaseViewportBy?: number | { top: number; bottom: number };
   className?: string;
+  /** Node rendered after the last item, inside the scroll content (virtuoso's
+   *  non-sticky `components.Footer`). Use for a load-more spinner or
+   *  pull-to-refresh affordance that must grow the scroll height at the bottom.
+   *  Delivered through virtuoso's `context`, so it updates live without
+   *  remounting (e.g. a spinner whose height changes every frame). */
+  footer?: ReactNode;
   ref?: Ref<VirtualListHandle>;
 }
 
@@ -111,6 +119,17 @@ export function resolveInitialTopMostItemIndex(
   return initialTopMostItemIndex;
 }
 
+/**
+ * Stable footer component for virtuoso. The consumer's `footer` node is
+ * delivered through virtuoso's `context`, so this component keeps a constant
+ * identity and re-renders (rather than remounting) when the footer changes —
+ * essential for a footer that updates every frame, like a pull-to-refresh
+ * spinner.
+ */
+function FooterSlot({ context }: ContextProp<ReactNode>) {
+  return <>{context}</>;
+}
+
 export function VirtualList<T>({
   items,
   itemContent,
@@ -125,10 +144,18 @@ export function VirtualList<T>({
   overscan,
   increaseViewportBy,
   className,
+  footer,
   ref,
 }: VirtualListProps<T>) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const scrollElementRef = useRef<HTMLElement | null>(null);
+
+  // Stable components object so virtuoso never remounts the footer; the live
+  // footer node flows in through `context` below.
+  const components = useMemo<Components<T, ReactNode>>(
+    () => ({ Footer: FooterSlot }),
+    [],
+  );
 
   useImperativeHandle(
     ref,
@@ -189,6 +216,9 @@ export function VirtualList<T>({
         : {})}
       {...(overscan !== undefined ? { overscan } : {})}
       {...(increaseViewportBy !== undefined ? { increaseViewportBy } : {})}
+      // Only mount a Footer when the consumer supplies one; pass the node via
+      // `context` so the stable FooterSlot re-renders it live.
+      {...(footer != null ? { components, context: footer } : {})}
     />
   );
 }


### PR DESCRIPTION
## What

Migrates the chat transcript (`clients/web/src/domains/chat/transcript/`) onto the `VirtualList` design-library primitive from LUM-2604, replacing the manual `overflow-y-auto` container and the 584-line `use-transcript-scroll.ts` hook that rendered **every** message in the DOM. The transcript now windows the DOM while **preserving its current UX** — most importantly the pin-to-top streaming behavior.

This is the first consuming migration of the LUM-2600 virtualization effort (primitives landed in #36186 / LUM-2604).

The design-library `footer` slot is bundled into this PR rather than split out: the session is pinned to one branch, and the slot is small and only meaningful with its first consumer (the pull-to-refresh spinner). Happy to split if preferred.

## Design decisions (locked with the issue author)

- **Pin-to-top streaming, not `followOutput`.** The latest user message pins to the viewport top and the answer streams into reserved space below (read top-down, like Claude.ai). Reproduced via a composite **"latest-edge"** last row carrying a `minHeight` wrapper — *not* virtuoso's `followOutput`. This is the highest-risk visual behavior and wants interactive sign-off.
- **`footer` slot added to `VirtualList`** (generally useful) and **pull-to-refresh kept**, wired through it.

## Changes

**design-library**
- Add an optional `footer?: ReactNode` to `VirtualList`, delivered through virtuoso's `context` via a stable `Footer` component so it re-renders **live** (e.g. the pull-refresh spinner whose height changes each frame) without remounting. Forwarded only when set (same conditional-spread guard as the other optional virtuoso props).

**web**
- Rewrite `transcript.tsx` onto `VirtualList` with a discriminated row model: history items + a single composite **latest-edge** row (latest user message + streaming response + bottom-pinned avatar), keyed by a **constant** so the `ChatAvatar` spring and `LatestTurnRow` memo survive streaming and the no-anchor → anchor flip.
- Anchor older-page prepends via virtuoso's `firstItemIndex`, decremented by a new pure `computePrependDelta` (StrictMode-safe; pure front-prepends only). Replaces the manual `scrollTop` anchor fix-up.
- Slim `use-transcript-scroll.ts` (584 → ~230 lines) to a thin coordinator: Go-to-Newest pill visibility + load-older paging (keeping the synchronous in-flight lock and the underfilled-viewport kick). `VirtualList` owns the rest — dropped the auto-pin window, anchor-correct, and container/content `ResizeObserver` re-pins.
- Widen `use-pull-to-refresh` to `HTMLElement` (virtuoso's scroller); both it and `useViewportMinHeight` consume a shared captured-scroll-element ref.
- Drop `forwardRef` (React 19 ref-as-prop) and `getContentElement()` from `TranscriptHandle` (its only consumer — the deleted content `ResizeObserver` — is gone). Reuse the coordinator's `ScrollClassification` type for the debug handle instead of re-declaring the shape.
- Extract `LatestEdgeRow` so the composite's layout invariants (markers, min-height, child ordering, avatar DOM identity) stay unit-testable under `renderToStaticMarkup` — `Transcript` itself renders through virtuoso, which paints nothing server-side.

## Testing

- `cd packages/design-library && bunx tsc --noEmit` → clean; `bun test …/virtual-list.test.tsx` → **12 pass** (2 new footer tests).
- `cd clients/web && bunx tsc --noEmit` → clean; `bun run lint` (changed files) → 0 errors.
- `bun scripts/run-tests.ts` (the isolated, per-file CI runner) over the chat domain → **131 test files pass**, including the re-targeted `transcript.test.tsx` and `transcript-subagent-inline.test.tsx`.
- New/updated tests: `computePrependDelta` unit tests; `LatestEdgeRow` static-markup tests (markers / min-height / ordering / avatar identity); a `scrollToMessage` row-index handle test; dropped the deleted `decideItemsChangeAction`/`getContentElement` references.

### Interactive sign-off (requested)

react-virtuoso doesn't paint items under jsdom in this workspace, and the pin-to-top behavior isn't unit-testable, so please verify in-browser against a hatched assistant: open-at-bottom; scroll-up paging near the top; prepend-without-jump; **streaming pins the anchor to the top (no auto-follow)**; pill appears >240px / hides under it; pill → bottom; 64px pinned state; conversation-switch resets to bottom; `scrollToMessage` scrolls + highlights (false when unloaded); pull-to-refresh on touch.

Closes LUM-2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HrngnXzqnk4rUSuyKBVvg

---
_Generated by [Claude Code](https://claude.ai/code/session_011HrngnXzqnk4rUSuyKBVvg)_