### PR TITLE
fix(design-library): render non-navigable Stepper steps as spans, not disabled buttons

### DIFF
--- a/packages/design-library/src/components/stepper.tsx
+++ b/packages/design-library/src/components/stepper.tsx
@@ -24,17 +24,13 @@ export type StepperProps = ComponentProps<"nav"> & {
   disabled?: boolean;
 };
 
-// Color is keyed on the step's position (`status`); interactivity is keyed on
-// the native `:enabled` / `:disabled` state, so a completed step keeps its
-// visited color even when navigation is locked (e.g. while submitting).
+// Color is keyed on the step's position (`status`); the `navigable` variant adds
+// the interactive affordances (cursor, hover, focus ring) for the completed
+// steps that render as buttons. A completed step keeps its visited color even
+// when navigation is locked (e.g. while submitting), since color is independent
+// of interactivity.
 export const stepVariants = cva(
-  [
-    "-mb-px inline-flex items-center whitespace-nowrap border-b-2 border-transparent pb-2",
-    "text-body-medium-default outline-none transition-colors",
-    "keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
-    "enabled:cursor-pointer enabled:hover:text-[var(--content-strong)]",
-    "disabled:cursor-default",
-  ].join(" "),
+  "-mb-px inline-flex items-center whitespace-nowrap border-b-2 border-transparent pb-2 text-body-medium-default transition-colors",
   {
     variants: {
       status: {
@@ -42,8 +38,12 @@ export const stepVariants = cva(
         completed: "text-[var(--content-default)]",
         upcoming: "text-[var(--content-disabled)]",
       },
+      navigable: {
+        true: "cursor-pointer outline-none hover:text-[var(--content-strong)] keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
+        false: "cursor-default",
+      },
     },
-    defaultVariants: { status: "upcoming" },
+    defaultVariants: { status: "upcoming", navigable: false },
   },
 );
 
@@ -55,9 +55,13 @@ export type StepStatus = NonNullable<VariantProps<typeof stepVariants>["status"]
  * steps (before it) read as visited and can navigate back, the active step is
  * marked with `aria-current="step"`, and upcoming steps (after it) are muted
  * and locked. A completed step keeps its visited styling even when navigation
- * is disabled, so it never looks like an upcoming step. This is the step
- * pattern — distinct from `Tabs`, which models parallel, independently
- * selectable panels.
+ * is disabled, so it never looks like an upcoming step.
+ *
+ * Only navigable (completed) steps render as `<button>`s; the active and
+ * upcoming steps render as non-interactive `<span>`s, so a screen reader
+ * announces the current step via `aria-current` rather than as a disabled
+ * button. This is the step pattern — distinct from `Tabs`, which models
+ * parallel, independently selectable panels.
  */
 export function Stepper({
   steps,
@@ -85,18 +89,30 @@ export function Stepper({
               : "upcoming";
         const navigable =
           status === "completed" && !disabled && !!onStepSelect;
+
+        if (navigable) {
+          return (
+            <button
+              key={step.id}
+              type="button"
+              data-slot="stepper-step"
+              onClick={() => onStepSelect?.(index)}
+              className={stepVariants({ status, navigable: true })}
+            >
+              {step.label}
+            </button>
+          );
+        }
+
         return (
-          <button
+          <span
             key={step.id}
-            type="button"
             data-slot="stepper-step"
-            disabled={!navigable}
             aria-current={status === "active" ? "step" : undefined}
-            onClick={navigable ? () => onStepSelect?.(index) : undefined}
             className={stepVariants({ status })}
           >
             {step.label}
-          </button>
+          </span>
         );
       })}
     </nav>


### PR DESCRIPTION
## What

Fixes the a11y issue in LUM-2617 (flagged by Devin + Vex on #36213): the `Stepper`'s active and upcoming steps rendered as disabled `button`s, so screen readers announced the **current** step as a "disabled button."

## Fix

Render only navigable (completed) steps as `button`s. The active and upcoming steps render as non-interactive `span`s, with `aria-current="step"` on the active one — so a screen reader announces the current step correctly instead of as a disabled button.

Interactivity (cursor, hover, focus ring) moves into a `navigable` `cva` variant applied to the button. **No visual change and no focus-order change** — only navigable steps were ever focusable, and the classes are identical.

Rendered element per step:

| step | before | after |
| -- | -- | -- |
| completed (navigable) | `button` | `button` |
| active | disabled `button` + `aria-current` | `span` + `aria-current="step"` |
| upcoming | disabled `button` | `span` |
| any step while submitting | disabled `button` | `span` |

## Testing

- `packages/design-library`: `tsc --noEmit` + `build-storybook` — pass
- Verified the rendered DOM: the active step is `span[aria-current=step]` with no `disabled` attribute anywhere; the Gated screenshot is byte-identical to before (no visual change).

Fixes LUM-2617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wuqoKsrCJ336NLvvNPMvv)_