### PR TITLE
Render markdown tables as Slack table blocks

### DIFF
--- a/assistant/src/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/__tests__/slack-block-formatting.test.ts
@@ -221,6 +221,25 @@ describe("textToSlackBlocks", () => {
     ).toBe(true);
   });
 
+  test("falls back to text sections when table cell content exceeds Slack's character cap", () => {
+    // Slack caps total cell characters per table at 10,000. A table within the
+    // row/column limits but with an oversize cell must degrade to structured
+    // text rather than emit a table block Slack would reject as invalid_blocks.
+    const huge = "x".repeat(10_001);
+    const table = [
+      "| Name | Notes |",
+      "| --- | --- |",
+      `| Alpha | ${huge} |`,
+    ].join("\n");
+
+    const blocks = textToSlackBlocks(table);
+    expect(blocks).toBeDefined();
+    expect(blocks!.some((b) => b.type === "table")).toBe(false);
+    expect(
+      blocks!.every((b) => b.type === "section" || b.type === "divider"),
+    ).toBe(true);
+  });
+
   test("requires header + separator + data row for table detection", () => {
     // Only header and separator, no data rows
     const input = "| A | B |\n| --- | --- |";

--- a/assistant/src/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/__tests__/slack-block-formatting.test.ts
@@ -240,6 +240,25 @@ describe("textToSlackBlocks", () => {
     ).toBe(true);
   });
 
+  test("falls back to text once the per-message table-cell budget (10k) is exceeded", () => {
+    // Slack caps aggregate table-cell characters per message at 10,000. Two
+    // tables that each pass the per-table check but together exceed 10k must not
+    // both emit `table` blocks — the later one degrades to text.
+    const bigCell = "x".repeat(6000);
+    const tableA = ["| H | V |", "| --- | --- |", `| a | ${bigCell} |`].join(
+      "\n",
+    );
+    const tableB = ["| H | V |", "| --- | --- |", `| b | ${bigCell} |`].join(
+      "\n",
+    );
+    const blocks = textToSlackBlocks(`${tableA}\n\n${tableB}`);
+    expect(blocks).toBeDefined();
+    // First table fits the budget; the second pushes the aggregate over 10k and
+    // falls back to section blocks.
+    expect(blocks!.filter((b) => b.type === "table").length).toBe(1);
+    expect(blocks!.some((b) => b.type === "section")).toBe(true);
+  });
+
   test("requires header + separator + data row for table detection", () => {
     // Only header and separator, no data rows
     const input = "| A | B |\n| --- | --- |";

--- a/assistant/src/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/__tests__/slack-block-formatting.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { TableBlock } from "@slack/types";
+
 import { textToSlackBlocks } from "../runtime/slack-block-formatting.js";
 
 describe("textToSlackBlocks", () => {
@@ -61,7 +63,7 @@ describe("textToSlackBlocks", () => {
     expect(types).toContain("divider");
   });
 
-  test("converts markdown table to structured bullet points", () => {
+  test("renders a markdown table as a Slack table block", () => {
     const table = [
       "| Tool | Price | License |",
       "| --- | --- | --- |",
@@ -72,20 +74,32 @@ describe("textToSlackBlocks", () => {
     const blocks = textToSlackBlocks(table);
     expect(blocks).toBeDefined();
     expect(blocks!.length).toBe(1);
-    const section = blocks![0] as {
-      type: "section";
-      text: { type: string; text: string };
-    };
-    expect(section.type).toBe("section");
-    expect(section.text.text).toContain("*Alpha*");
-    expect(section.text.text).toContain("Price: $10/mo");
-    expect(section.text.text).toContain("*Beta*");
-    expect(section.text.text).toContain("License: Apache");
-    // Should NOT contain pipe characters from the original table
-    expect(section.text.text).not.toContain("|");
+    // The header is emitted as the first row, then one row per data row.
+    // Cells are `raw_text` elements; markdown inside a cell is not
+    // re-rendered (rich-text cells would be a future enhancement).
+    expect(blocks![0]).toEqual({
+      type: "table",
+      rows: [
+        [
+          { type: "raw_text", text: "Tool" },
+          { type: "raw_text", text: "Price" },
+          { type: "raw_text", text: "License" },
+        ],
+        [
+          { type: "raw_text", text: "Alpha" },
+          { type: "raw_text", text: "$10/mo" },
+          { type: "raw_text", text: "MIT" },
+        ],
+        [
+          { type: "raw_text", text: "Beta" },
+          { type: "raw_text", text: "$20/mo" },
+          { type: "raw_text", text: "Apache" },
+        ],
+      ],
+    });
   });
 
-  test("converts table with surrounding text", () => {
+  test("renders a table with surrounding text", () => {
     const input = [
       "Here are the results:",
       "",
@@ -100,11 +114,11 @@ describe("textToSlackBlocks", () => {
     const blocks = textToSlackBlocks(input);
     expect(blocks).toBeDefined();
     const types = blocks!.map((b) => b.type);
-    // Should have: text section, divider, table section, divider, text section
+    // Should have: text section, divider, table, divider, text section
     expect(types).toEqual([
       "section",
       "divider",
-      "section",
+      "table",
       "divider",
       "section",
     ]);
@@ -128,13 +142,13 @@ describe("textToSlackBlocks", () => {
     const blocks = textToSlackBlocks(table);
     expect(blocks).toBeDefined();
     expect(blocks!.length).toBe(1);
-    const section = blocks![0] as {
-      type: "section";
-      text: { type: string; text: string };
-    };
-    // The escaped pipe should appear as a literal pipe in the cell value
-    expect(section.text.text).toContain("cmd | grep");
-    expect(section.text.text).toContain("Description: filters output");
+    const tableBlock = blocks![0] as TableBlock;
+    expect(tableBlock.type).toBe("table");
+    // The escaped pipe should appear as a literal pipe in the cell value.
+    expect(tableBlock.rows[1]).toEqual([
+      { type: "raw_text", text: "cmd | grep" },
+      { type: "raw_text", text: "filters output" },
+    ]);
   });
 
   test("treats pipe after even backslashes as a real column separator", () => {
@@ -149,13 +163,62 @@ describe("textToSlackBlocks", () => {
     const blocks = textToSlackBlocks(table);
     expect(blocks).toBeDefined();
     expect(blocks!.length).toBe(1);
-    const section = blocks![0] as {
-      type: "section";
-      text: { type: string; text: string };
-    };
-    // C:\\ should be its own cell, "a windows path" in the Description column
-    expect(section.text.text).toContain("C:\\\\");
-    expect(section.text.text).toContain("Description: a windows path");
+    const tableBlock = blocks![0] as TableBlock;
+    expect(tableBlock.type).toBe("table");
+    // C:\\ should be its own cell, "a windows path" in the Description column.
+    expect(tableBlock.rows[1]).toEqual([
+      { type: "raw_text", text: "C:\\\\" },
+      { type: "raw_text", text: "a windows path" },
+    ]);
+  });
+
+  test("pads short rows and substitutes a space for empty cells", () => {
+    // The second data row is missing its third cell, and the third row has an
+    // empty leading cell. Every row must still emit a cell for each column,
+    // and empty cells become a single space because Slack's `raw_text`
+    // element requires at least one character.
+    const table = [
+      "| A | B | C |",
+      "| --- | --- | --- |",
+      "| 1 | 2 | 3 |",
+      "| 4 | 5 |",
+      "|  | 8 | 9 |",
+    ].join("\n");
+
+    const blocks = textToSlackBlocks(table);
+    expect(blocks).toBeDefined();
+    expect(blocks!.length).toBe(1);
+    const tableBlock = blocks![0] as TableBlock;
+    expect(tableBlock.type).toBe("table");
+    // Short row padded to 3 cells, trailing cell filled with a space.
+    expect(tableBlock.rows[2]).toEqual([
+      { type: "raw_text", text: "4" },
+      { type: "raw_text", text: "5" },
+      { type: "raw_text", text: " " },
+    ]);
+    // Empty leading cell also becomes a space.
+    expect(tableBlock.rows[3][0]).toEqual({ type: "raw_text", text: " " });
+  });
+
+  test("falls back to text sections when a table exceeds Slack's column limit", () => {
+    // Slack table blocks allow at most 20 columns. A 21-column table must
+    // degrade to the structured-text rendering rather than emit an invalid
+    // table block.
+    const columns = 21;
+    const headerCells = Array.from({ length: columns }, (_, i) => `H${i}`);
+    const dataCells = Array.from({ length: columns }, (_, i) => `v${i}`);
+    const table = [
+      `| ${headerCells.join(" | ")} |`,
+      `| ${headerCells.map(() => "---").join(" | ")} |`,
+      `| ${dataCells.join(" | ")} |`,
+    ].join("\n");
+
+    const blocks = textToSlackBlocks(table);
+    expect(blocks).toBeDefined();
+    expect(blocks!.some((b) => b.type === "table")).toBe(false);
+    expect(
+      blocks!.every((b) => b.type === "section" || b.type === "divider"),
+    ).toBe(true);
   });
 
   test("requires header + separator + data row for table detection", () => {

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -60,9 +60,10 @@ export function textToSlackBlocks(text: string): KnownBlock[] | undefined {
       if (tableBlock) {
         blocks.push(tableBlock);
       } else {
-        // Table exceeds Slack's table-block limits (≤100 rows / ≤20 columns);
-        // fall back to structured bullet text split across section blocks so an
-        // oversize table degrades on its own rather than failing the payload.
+        // Table exceeds Slack's table-block limits (≤100 rows / ≤20 columns /
+        // ≤10,000 chars across cells); fall back to structured bullet text
+        // split across section blocks so an oversize table degrades on its own
+        // rather than failing the payload.
         const structured = convertTableToStructuredText(
           segment.headers,
           segment.rows,
@@ -290,13 +291,19 @@ function tryParseTable(
 /** Slack `table` blocks allow at most 100 rows (incl. the header) and 20 columns. */
 const SLACK_TABLE_MAX_ROWS = 100;
 const SLACK_TABLE_MAX_COLUMNS = 20;
+/** Slack rejects a `table` block whose cell text totals more than 10,000 characters. */
+const SLACK_TABLE_MAX_TOTAL_CHARS = 10_000;
 
 /**
  * Build a Slack `table` block from a parsed markdown table, or `null` when the
- * table exceeds Slack's table-block limits so the caller can fall back to a text
- * rendering. The header row is emitted first. Cells are `raw_text`; markdown
- * inside a cell is not re-rendered (rich-text cells would be a future
- * enhancement). Short rows are padded so every row has the same cell count.
+ * table exceeds Slack's table-block limits — ≤100 rows (incl. the header), ≤20
+ * columns, and ≤10,000 characters across all cells — so the caller can fall
+ * back to a text rendering. (An over-limit table is rejected as
+ * `invalid_blocks`, which drops every block in the message, so gating here lets
+ * an oversize table degrade to text on its own.) The header row is emitted
+ * first. Cells are `raw_text`; markdown inside a cell is not re-rendered
+ * (rich-text cells would be a future enhancement). Short rows are padded so
+ * every row has the same cell count.
  */
 function tryBuildTableBlock(
   headers: string[],
@@ -316,9 +323,19 @@ function tryBuildTableBlock(
       return { type: "raw_text", text: text.length > 0 ? text : " " };
     });
 
+  const tableRows = [toCells(headers), ...rows.map(toCells)];
+
+  // Slack caps the total character count across all cells in a table at 10,000
+  // (empty cells count as their single padding space); over that, Slack rejects
+  // the block, so fall back to the text rendering instead.
+  const totalCellChars = tableRows
+    .flat()
+    .reduce((sum, cell) => sum + cell.text.length, 0);
+  if (totalCellChars > SLACK_TABLE_MAX_TOTAL_CHARS) return null;
+
   return {
     type: "table",
-    rows: [toCells(headers), ...rows.map(toCells)],
+    rows: tableRows,
   };
 }
 

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -7,7 +7,7 @@
  * oversize-section splitting.
  */
 
-import type { KnownBlock } from "@slack/types";
+import type { KnownBlock, RawTextElement, TableBlock } from "@slack/types";
 
 /** Slack rejects messages with more than 50 Block Kit blocks. */
 const SLACK_BLOCK_LIMIT = 50;
@@ -56,20 +56,28 @@ export function textToSlackBlocks(text: string): KnownBlock[] | undefined {
         text: { type: "plain_text", text: segment.content },
       });
     } else if (segment.type === "table") {
-      const structured = convertTableToStructuredText(
-        segment.headers,
-        segment.rows,
-      );
-      const mrkdwn = markdownToMrkdwn(structured);
-      const chunks = splitLongTextSegment(mrkdwn);
-      for (let c = 0; c < chunks.length; c++) {
-        if (c > 0) {
-          blocks.push({ type: "divider" });
+      const tableBlock = tryBuildTableBlock(segment.headers, segment.rows);
+      if (tableBlock) {
+        blocks.push(tableBlock);
+      } else {
+        // Table exceeds Slack's table-block limits (≤100 rows / ≤20 columns);
+        // fall back to structured bullet text split across section blocks so an
+        // oversize table degrades on its own rather than failing the payload.
+        const structured = convertTableToStructuredText(
+          segment.headers,
+          segment.rows,
+        );
+        const mrkdwn = markdownToMrkdwn(structured);
+        const chunks = splitLongTextSegment(mrkdwn);
+        for (let c = 0; c < chunks.length; c++) {
+          if (c > 0) {
+            blocks.push({ type: "divider" });
+          }
+          blocks.push({
+            type: "section",
+            text: { type: "mrkdwn", text: chunks[c] },
+          });
         }
-        blocks.push({
-          type: "section",
-          text: { type: "mrkdwn", text: chunks[c] },
-        });
       }
     } else {
       // Transform to Slack mrkdwn FIRST, then split. Splitting raw markdown
@@ -276,6 +284,41 @@ function tryParseTable(
   return {
     segment: { type: "table", headers, rows },
     nextIndex: i,
+  };
+}
+
+/** Slack `table` blocks allow at most 100 rows (incl. the header) and 20 columns. */
+const SLACK_TABLE_MAX_ROWS = 100;
+const SLACK_TABLE_MAX_COLUMNS = 20;
+
+/**
+ * Build a Slack `table` block from a parsed markdown table, or `null` when the
+ * table exceeds Slack's table-block limits so the caller can fall back to a text
+ * rendering. The header row is emitted first. Cells are `raw_text`; markdown
+ * inside a cell is not re-rendered (rich-text cells would be a future
+ * enhancement). Short rows are padded so every row has the same cell count.
+ */
+function tryBuildTableBlock(
+  headers: string[],
+  rows: string[][],
+): TableBlock | null {
+  const columnCount = Math.max(
+    headers.length,
+    ...rows.map((row) => row.length),
+  );
+  if (columnCount === 0 || columnCount > SLACK_TABLE_MAX_COLUMNS) return null;
+  if (rows.length + 1 > SLACK_TABLE_MAX_ROWS) return null;
+
+  const toCells = (cells: string[]): RawTextElement[] =>
+    Array.from({ length: columnCount }, (_, c) => {
+      const text = cells[c] ?? "";
+      // `raw_text` requires at least one character.
+      return { type: "raw_text", text: text.length > 0 ? text : " " };
+    });
+
+  return {
+    type: "table",
+    rows: [toCells(headers), ...rows.map(toCells)],
   };
 }
 

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -27,6 +27,9 @@ export function textToSlackBlocks(text: string): KnownBlock[] | undefined {
 
   const segments = splitIntoSegments(text);
   const blocks: KnownBlock[] = [];
+  // Slack caps aggregate table-cell characters across one message at 10,000, so
+  // track usage and fall later tables back to text once the budget is spent.
+  let tableCellCharsUsed = 0;
 
   for (let i = 0; i < segments.length; i++) {
     if (i > 0) {
@@ -57,13 +60,19 @@ export function textToSlackBlocks(text: string): KnownBlock[] | undefined {
       });
     } else if (segment.type === "table") {
       const tableBlock = tryBuildTableBlock(segment.headers, segment.rows);
-      if (tableBlock) {
+      const tableChars = tableBlock ? countTableCellChars(tableBlock) : 0;
+      if (
+        tableBlock &&
+        tableCellCharsUsed + tableChars <= SLACK_TABLE_MAX_TOTAL_CHARS
+      ) {
         blocks.push(tableBlock);
+        tableCellCharsUsed += tableChars;
       } else {
-        // Table exceeds Slack's table-block limits (≤100 rows / ≤20 columns /
-        // ≤10,000 chars across cells); fall back to structured bullet text
-        // split across section blocks so an oversize table degrades on its own
-        // rather than failing the payload.
+        // Table can't render as a `table` block — it either exceeds Slack's
+        // per-table limits (≤100 rows / ≤20 columns / ≤10,000 chars) or it would
+        // push the message past Slack's 10,000-char aggregate table-cell cap.
+        // Fall back to structured bullet text split across section blocks so it
+        // degrades on its own rather than failing the whole payload.
         const structured = convertTableToStructuredText(
           segment.headers,
           segment.rows,
@@ -291,8 +300,23 @@ function tryParseTable(
 /** Slack `table` blocks allow at most 100 rows (incl. the header) and 20 columns. */
 const SLACK_TABLE_MAX_ROWS = 100;
 const SLACK_TABLE_MAX_COLUMNS = 20;
-/** Slack rejects a `table` block whose cell text totals more than 10,000 characters. */
+/**
+ * Slack caps table cell text at 10,000 characters — both within one table block
+ * and in aggregate across every table block in a single message. Either
+ * overflow is rejected as `invalid_blocks`.
+ */
 const SLACK_TABLE_MAX_TOTAL_CHARS = 10_000;
+
+/** Total characters across a table block's `raw_text` cells. */
+function countTableCellChars(block: TableBlock): number {
+  let total = 0;
+  for (const row of block.rows) {
+    for (const cell of row) {
+      if ("text" in cell) total += cell.text.length;
+    }
+  }
+  return total;
+}
 
 /**
  * Build a Slack `table` block from a parsed markdown table, or `null` when the


### PR DESCRIPTION
## What

`textToSlackBlocks` (the Slack adapter's markdown → Block Kit converter) previously flattened markdown tables into structured bullet text inside a `section` block. Slack's Block Kit `table` block — already available in the installed `@slack/types@2.21.1` — renders real tabular data, so this emits one directly:

- The header row is emitted first, then one row per data row.
- Cells are `raw_text` elements.
- Short rows are padded and empty cells become a single space (Slack's `raw_text` requires ≥1 character).

Tables that exceed Slack's table-block limits (**>100 rows** or **>20 columns**) fall back to the existing structured-text rendering, so an oversize table degrades on its own instead of failing the whole Block Kit payload with `invalid_blocks`.

## Why this is safe / scoped

- Change is confined to the Slack adapter's formatting helper (`assistant/src/runtime/slack-block-formatting.ts`) — the daemon delivery path stays channel-agnostic (it just sets `useBlocks`, per LUM-2614).
- Behavior-preserving for the oversize case (same structured-text fallback as before).
- No wire-contract change, no new dependency.

## Known limitation

Cells render as `raw_text`, so **markdown inside a cell (links, bold) is shown literally** rather than re-rendered. Rich-text cells (`rich_text` elements) are a deliberate future enhancement — called out in the helper's doc comment.

## Tests

`assistant/src/__tests__/slack-block-formatting.test.ts` — updated the table tests to assert the `table` block shape and added focused cases for: header-as-first-row, escaped-pipe cell values, short-row padding / empty-cell → space, and the oversize-table (>20 col) fallback to text sections. Full file: 39 pass, plus `tsc` + `eslint` clean.

## Scope

First slice of **LUM-2615** (adopt Slack's agent Block Kit suite for assistant output). This does **not** close LUM-2615 — the `plan` / `card` / `alert` blocks and the streaming "Thinking Steps" (plan/timeline) work remain follow-ups tracked there.

Related: LUM-2598 (channel-adapter generalization epic), LUM-2614 (Block Kit rendering moved into the Slack adapter), LUM-2435 (holistic channel adapter strategy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_