### PR TITLE
refactor(web): compose chat surface classes with cn()

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -7,6 +7,7 @@ import type { Surface } from "@/domains/chat/types/types";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
+import { cn } from "@/utils/misc";
 
 // Weather card has its own data-shape parsing and forecast UI that is only
 // rendered when a card surface advertises a weather template. Defer loading
@@ -90,7 +91,10 @@ function StatusBadge({ status }: { status: string | undefined }) {
   const { label, colorClass } = getStatusConfig(status);
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-body-small-default ${colorClass}`}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-body-small-default",
+        colorClass,
+      )}
       style={{
         backgroundColor: "color-mix(in srgb, currentColor 15%, transparent)",
       }}
@@ -102,13 +106,13 @@ function StatusBadge({ status }: { status: string | undefined }) {
 
 function StepIcon({ status }: { status: string | undefined }) {
   const { colorClass } = getStatusConfig(status);
-  const iconClass = `h-4 w-4 shrink-0 ${colorClass}`;
+  const iconClass = cn("h-4 w-4 shrink-0", colorClass);
 
   switch (status) {
     case "completed":
       return <CircleCheck className={iconClass} />;
     case "in_progress":
-      return <Loader2 className={`${iconClass} animate-spin`} />;
+      return <Loader2 className={cn(iconClass, "animate-spin")} />;
     case "waiting":
       return <Clock className={iconClass} />;
     case "failed":

--- a/clients/web/src/domains/chat/components/surfaces/confirmation-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/confirmation-surface.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from "react";
 import type { Surface } from "@/domains/chat/types/types";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { cn } from "@/utils/misc";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,11 +64,12 @@ export function ConfirmationSurface({ surface, onAction }: ConfirmationSurfacePr
 
   return (
     <div
-      className={`rounded-lg border p-4 ${
+      className={cn(
+        "rounded-lg border p-4",
         data.destructive
           ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)]"
-          : "border-[var(--border-element)] bg-[var(--surface-overlay)]"
-      }`}
+          : "border-[var(--border-element)] bg-[var(--surface-overlay)]",
+      )}
     >
       {surface.title && (
         <div className="mb-3 flex items-center gap-2">
@@ -82,11 +84,12 @@ export function ConfirmationSurface({ surface, onAction }: ConfirmationSurfacePr
 
       <ChatMarkdownMessage
         content={data.message}
-        className={`text-body-medium-default ${
+        className={cn(
+          "text-body-medium-default",
           data.destructive
             ? "text-[var(--system-negative-strong)]"
-            : "text-[var(--content-default)]"
-        }`}
+            : "text-[var(--content-default)]",
+        )}
       />
 
       {data.detail && (
@@ -101,11 +104,12 @@ export function ConfirmationSurface({ surface, onAction }: ConfirmationSurfacePr
           type="button"
           disabled={isSubmitting}
           onClick={handleConfirm}
-          className={`flex items-center gap-2 rounded-lg px-4 py-2 text-body-medium-default transition-colors disabled:opacity-50 ${
+          className={cn(
+            "flex items-center gap-2 rounded-lg px-4 py-2 text-body-medium-default transition-colors disabled:opacity-50",
             data.destructive
               ? "bg-[var(--system-negative-strong)] text-white hover:opacity-90"
-              : "bg-[var(--primary-base)] text-[var(--content-inset)] hover:opacity-90"
-          }`}
+              : "bg-[var(--primary-base)] text-[var(--content-inset)] hover:opacity-90",
+          )}
         >
           {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
           {confirmLabel}

--- a/clients/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
@@ -6,6 +6,7 @@ import { FileUploadSurfaceDataSchema } from "@vellumai/assistant-api";
 import type { Surface } from "@/domains/chat/types/types";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { cn } from "@/utils/misc";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -275,18 +276,20 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         onClick={() => fileInputRef.current?.click()}
-        className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-6 transition-colors ${
+        className={cn(
+          "flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-6 transition-colors",
           isDragOver
             ? "border-[var(--system-positive-strong)] bg-[var(--system-positive-weak)]"
-            : "border-[var(--border-element)] bg-[var(--surface-sunken)] hover:border-[var(--content-faint)]"
-        }`}
+            : "border-[var(--border-element)] bg-[var(--surface-sunken)] hover:border-[var(--content-faint)]",
+        )}
       >
         <Upload
-          className={`h-8 w-8 ${
+          className={cn(
+            "h-8 w-8",
             isDragOver
               ? "text-[var(--system-positive-strong)]"
-              : "text-[var(--content-faint)]"
-          }`}
+              : "text-[var(--content-faint)]",
+          )}
         />
         <p className="text-body-medium-lighter text-[var(--content-quiet)]">
           Drag and drop files here, or click to browse

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -7,6 +7,7 @@ import { Button, Toggle } from "@vellumai/design-library";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { PageProgress } from "@/domains/chat/components/surfaces/page-progress";
 import { PageTabs } from "@/domains/chat/components/surfaces/page-tabs";
+import { cn } from "@/utils/misc";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -77,7 +78,7 @@ function renderField(
           value={typeof value === "string" ? value : ""}
           onChange={(e) => onChange(field.id, e.target.value)}
           placeholder={field.placeholder}
-          className={inputClasses + errorClasses}
+          className={cn(inputClasses, errorClasses)}
         />
       );
 
@@ -89,7 +90,7 @@ function renderField(
             value={typeof value === "string" ? value : ""}
             onChange={(e) => onChange(field.id, e.target.value)}
             placeholder={field.placeholder}
-            className={inputClasses + errorClasses}
+            className={cn(inputClasses, errorClasses)}
           />
           <p className="mt-1 flex items-center gap-1 text-body-small-default text-[var(--content-faint)]">
             <Lock className="h-3 w-3" />
@@ -105,7 +106,7 @@ function renderField(
           onChange={(e) => onChange(field.id, e.target.value)}
           placeholder={field.placeholder}
           rows={3}
-          className={inputClasses + errorClasses + " resize-none"}
+          className={cn(inputClasses, errorClasses, "resize-none")}
         />
       );
 
@@ -114,7 +115,7 @@ function renderField(
         <select
           value={typeof value === "string" ? value : ""}
           onChange={(e) => onChange(field.id, e.target.value)}
-          className={inputClasses + errorClasses}
+          className={cn(inputClasses, errorClasses)}
         >
           <option value="">{field.placeholder || "Select..."}</option>
           {(field.options ?? []).map((opt) => (
@@ -144,7 +145,7 @@ function renderField(
             onChange(field.id, num);
           }}
           placeholder={field.placeholder}
-          className={inputClasses + errorClasses}
+          className={cn(inputClasses, errorClasses)}
         />
       );
 
@@ -155,7 +156,7 @@ function renderField(
           value={typeof value === "string" ? value : String(value)}
           onChange={(e) => onChange(field.id, e.target.value)}
           placeholder={field.placeholder}
-          className={inputClasses + errorClasses}
+          className={cn(inputClasses, errorClasses)}
         />
       );
   }

--- a/clients/web/src/domains/chat/components/surfaces/list-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/list-surface.tsx
@@ -4,6 +4,7 @@ import { sfSymbolToLucideIcon } from "@/domains/chat/components/surfaces/sf-symb
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import { useSelectionState } from "@/domains/chat/components/surfaces/use-selection-state";
 import type { Surface } from "@/domains/chat/types/types";
+import { cn } from "@/utils/misc";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,24 +56,26 @@ export function ListSurface({ surface, onAction }: ListSurfaceProps) {
                 type="button"
                 disabled={!isSelectable}
                 onClick={() => handleToggle(item.id)}
-                className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                className={cn(
+                  "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors",
                   isSelectable
                     ? "cursor-pointer hover:bg-[var(--surface-hover)]"
-                    : "cursor-default"
-                } ${
+                    : "cursor-default",
                   isSelected
                     ? "bg-[var(--system-positive-weak)]"
-                    : ""
-                }`}
+                    : "",
+                )}
               >
                 {/* Selection indicator */}
                 {isSelectable && (
                   <span
-                    className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors ${
+                    className={cn(
+                      "flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors",
                       isSelected
                         ? "border-[var(--primary-base)] bg-[var(--primary-base)] text-[var(--content-inset)]"
-                        : "border-[var(--border-element)]"
-                    } ${selectionMode === "single" ? "rounded-full" : "rounded"}`}
+                        : "border-[var(--border-element)]",
+                      selectionMode === "single" ? "rounded-full" : "rounded",
+                    )}
                   >
                     {isSelected && <Check className="h-3 w-3" />}
                   </span>

--- a/clients/web/src/domains/chat/components/surfaces/table-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/table-surface.tsx
@@ -5,6 +5,7 @@ import { sfSymbolToLucideIcon } from "@/domains/chat/components/surfaces/sf-symb
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import { useSelectionState } from "@/domains/chat/components/surfaces/use-selection-state";
 import type { Surface } from "@/domains/chat/types/types";
+import { cn } from "@/utils/misc";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -174,25 +175,27 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
                 <tr
                   key={row.id}
                   onClick={() => rowSelectable && handleToggle(row.id)}
-                  className={`transition-colors ${
+                  className={cn(
+                    "transition-colors",
                     rowSelectable
                       ? "cursor-pointer hover:bg-[var(--surface-hover)]"
-                      : ""
-                  } ${
+                      : "",
                     isSelected
                       ? "bg-[var(--system-positive-weak)]"
-                      : ""
-                  }`}
+                      : "",
+                  )}
                 >
                   {isSelectable && (
                     <td className="px-3 py-2">
                       {rowSelectable && (
                         <span
-                          className={`flex h-5 w-5 items-center justify-center rounded border transition-colors ${
+                          className={cn(
+                            "flex h-5 w-5 items-center justify-center rounded border transition-colors",
                             isSelected
                               ? "border-[var(--primary-base)] bg-[var(--primary-base)] text-[var(--content-inset)]"
-                              : "border-[var(--border-element)]"
-                          } ${selectionMode === "single" ? "rounded-full" : "rounded"}`}
+                              : "border-[var(--border-element)]",
+                            selectionMode === "single" ? "rounded-full" : "rounded",
+                          )}
                         >
                           {isSelected && <Check className="h-3 w-3" />}
                         </span>
@@ -212,7 +215,7 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
                             {cell.icon && (() => {
                               const LucideIcon = sfSymbolToLucideIcon(cell.icon);
                               return LucideIcon ? (
-                                <LucideIcon className={`h-4 w-4 ${iconColorClass(cell.iconColor)}`} aria-hidden />
+                                <LucideIcon className={cn("h-4 w-4", iconColorClass(cell.iconColor))} aria-hidden />
                               ) : (
                                 <span className={iconColorClass(cell.iconColor)} aria-hidden>
                                   {cell.icon}

--- a/clients/web/src/domains/chat/components/surfaces/weather-forecast-display.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/weather-forecast-display.tsx
@@ -14,6 +14,7 @@ import {
   getWeatherIcon,
   parseWeatherData,
 } from "@/domains/chat/components/surfaces/weather-utils";
+import { cn } from "@/utils/misc";
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -36,22 +37,24 @@ function UnitToggle({
       <button
         type="button"
         onClick={() => onToggle(true)}
-        className={`px-2 py-0.5 text-body-small-default transition-colors ${
+        className={cn(
+          "px-2 py-0.5 text-body-small-default transition-colors",
           useFahrenheit
             ? "bg-[var(--primary-base)] text-[var(--content-inset)]"
-            : "bg-transparent text-[var(--content-quiet)]"
-        }`}
+            : "bg-transparent text-[var(--content-quiet)]",
+        )}
       >
         &deg;F
       </button>
       <button
         type="button"
         onClick={() => onToggle(false)}
-        className={`px-2 py-0.5 text-body-small-default transition-colors ${
+        className={cn(
+          "px-2 py-0.5 text-body-small-default transition-colors",
           !useFahrenheit
             ? "bg-[var(--primary-base)] text-[var(--content-inset)]"
-            : "bg-transparent text-[var(--content-quiet)]"
-        }`}
+            : "bg-transparent text-[var(--content-quiet)]",
+        )}
       >
         &deg;C
       </button>
@@ -241,11 +244,12 @@ function DailySection({
           return (
             <div key={item.id ?? i} className="flex items-center gap-2">
               <span
-                className={`w-12 shrink-0 truncate text-body-small-default ${
+                className={cn(
+                  "w-12 shrink-0 truncate text-body-small-default",
                   isToday
                     ? "text-[var(--content-default)]"
-                    : "text-[var(--content-quiet)]"
-                }`}
+                    : "text-[var(--content-quiet)]",
+                )}
               >
                 {dayName}
               </span>

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
@@ -14,6 +14,7 @@ import type { Surface } from "@/domains/chat/types/types";
 
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import { filterRecords, rec, strOrNum } from "@/domains/chat/components/surfaces/surface-parse-helpers";
+import { cn } from "@/utils/misc";
 
 type WorkResultStatus = "completed" | "partial" | "failed" | "in_progress";
 type WorkResultTone = "neutral" | "positive" | "warning" | "negative";
@@ -257,7 +258,7 @@ function ResultStatusBadge({ status }: { status?: WorkResultStatus }) {
 
   return (
     <span
-      className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-label-small-default ${tone.bg} ${tone.text}`}
+      className={cn("inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-label-small-default", tone.bg, tone.text)}
     >
       <Icon className="h-3.5 w-3.5" />
       {config.label}
@@ -276,7 +277,7 @@ function MetricGrid({ metrics }: { metrics: WorkResultMetric[] }) {
             key={`${metric.label}-${metric.value}`}
             className="min-w-0 bg-[var(--surface-base)] px-3 py-2.5"
           >
-            <div className={`text-title-small tabular-nums ${tone.text}`}>
+            <div className={cn("text-title-small tabular-nums", tone.text)}>
               {metric.value}
             </div>
             <div className="mt-0.5 truncate text-body-small-default text-[var(--content-secondary)]">
@@ -324,7 +325,7 @@ function ItemList({ items }: { items: WorkResultItem[] }) {
         >
           <span
             aria-hidden
-            className={`w-[3px] shrink-0 self-stretch rounded-full ${tone.rail}`}
+            className={cn("w-[3px] shrink-0 self-stretch rounded-full", tone.rail)}
           />
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-start gap-2">
@@ -410,7 +411,7 @@ function SectionIcon({ type }: { type: WorkResultSectionType }) {
     type === "warnings"
       ? "text-[var(--system-mid-strong)]"
       : "text-[var(--content-tertiary)]";
-  return <Icon className={`h-4 w-4 shrink-0 ${color}`} aria-hidden />;
+  return <Icon className={cn("h-4 w-4 shrink-0", color)} aria-hidden />;
 }
 
 function ResultSection({ section }: { section: WorkResultSection }) {


### PR DESCRIPTION
## What

Part of LUM-2616. Replaces raw template-literal interpolation and string concatenation for conditional Tailwind classes with the `cn()` helper across the chat surface components, matching the design-library convention.

## Files (8)

`card-surface`, `confirmation-surface`, `file-upload-surface`, `form-surface`, `list-surface`, `table-surface`, `weather-forecast-display`, `work-result-surface`.

## Pure refactor — class strings unchanged

Every conversion moves the exact class strings into `cn()` args verbatim (e.g. `` `base ${cond ? "a" : "b"}` `` → `cn("base", cond ? "a" : "b")`; `inputClasses + errorClasses` → `cn(inputClasses, errorClasses)`).

`cn()` routes through tailwind-merge, so I checked every spot where a static base and a conditional set the same property and verified the resolved output:

- **FormSurface error border** — `inputClasses` (`--border-subtle`) and `errorClasses` (`--system-negative-strong`) are both border-color. tailwind-merge keeps the error color (it's last), so an invalid field deterministically shows the red border instead of depending on CSS source order between two border-color utilities. Intended behavior; the only resolved-vs-emitted difference in the PR.
- **Selection indicator** (`list`/`table`) — base `rounded` + `rounded-full`/`rounded` resolves to `rounded-full` for single-select (radio) and `rounded` for multi (checkbox). Correct.
- **Typography + arbitrary color** (`confirmation`, `weather`, `card`, `work-result`) — `text-body-*` survives next to `text-[var(--color)]` because `@/utils/misc`'s `cn` registers the 12 typography utilities under the `font-size` merge group. Verified preserved.

## Testing

- `clients/web`: eslint (changed files) + `tsc --noEmit` — pass
- Ran the real `cn()` over the conflict cases above and confirmed the resolved class strings.

## Out of scope (cva candidates, flagged for a possible follow-up)

Review surfaced a few genuinely variant-like spots that could move to `cva` / a shared component later: the duplicated selection-indicator in `list`/`table` (extract a shared component), the `destructive` two-state in `confirmation`, the `tone` map in `work-result`, and the `status` map in `card`. Left as `cn()` here to keep this a behavior-preserving consistency pass.

Part of LUM-2616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wuqoKsrCJ336NLvvNPMvv)_