### PR TITLE
feat(schedule): expose the firing's run id to script-mode subprocesses

### DIFF
--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -32,7 +32,7 @@ export interface ScriptResult {
  */
 export async function runScript(
   command: string,
-  options?: { timeoutMs?: number; cwd?: string },
+  options?: { timeoutMs?: number; cwd?: string; scheduleRunId?: string },
 ): Promise<ScriptResult> {
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const cwd = options?.cwd ?? getWorkspaceDir();
@@ -43,7 +43,12 @@ export async function runScript(
     cwd,
     stdout: "pipe",
     stderr: "pipe",
-    env: buildSanitizedEnv(),
+    env: {
+      ...buildSanitizedEnv(),
+      ...(options?.scheduleRunId
+        ? { __SCHEDULE_RUN_ID: options.scheduleRunId }
+        : {}),
+    },
   });
 
   // Start consuming streams immediately so buffered output is available even on timeout.

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -304,6 +304,7 @@ export async function runScheduleDueWorkOnce(
         );
         const result: ScriptResult = await runScript(job.script, {
           timeoutMs: job.timeoutMs ?? undefined,
+          scheduleRunId: runId,
         });
         completeScheduleRun(runId, {
           status: result.exitCode === 0 ? "ok" : "error",


### PR DESCRIPTION
## Summary
- Inject `__SCHEDULE_RUN_ID` (the firing's cron_runs.id) into the script-mode subprocess env, directly (not via SAFE_ENV_VARS).

Part of plan: script-schedule-cost-attribution.md (PR 2 of 7)