### PR TITLE
feat(usage): add nullable cron_run_id column to llm_usage_events

### DIFF
--- a/assistant/src/memory/migrations/304-add-llm-usage-cron-run-id.ts
+++ b/assistant/src/memory/migrations/304-add-llm-usage-cron-run-id.ts
@@ -1,0 +1,29 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMN_NAME = "cron_run_id";
+const COLUMN_DEFINITION = "cron_run_id TEXT";
+
+/**
+ * Add `cron_run_id` column to the `llm_usage_events` table.
+ *
+ * The column is a nullable, free-form identifier of the cron firing (run) that
+ * incurred this LLM usage, enabling per-firing cost attribution for script-mode
+ * schedules. It is intentionally NOT a foreign key to `cron_runs`: usage events
+ * outlive run rows and must survive run pruning without cascade churn.
+ *
+ * No backfill is needed — all existing rows default to NULL (not attributable
+ * to a cron firing), which is correct for any pre-migration usage.
+ *
+ * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
+ * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
+ * the next boot. The index uses `IF NOT EXISTS` for the same reason.
+ */
+export function migrateAddLlmUsageCronRunId(database: DrizzleDb): void {
+  if (!tableHasColumn(database, "llm_usage_events", COLUMN_NAME)) {
+    database.run(`ALTER TABLE llm_usage_events ADD COLUMN ${COLUMN_DEFINITION}`);
+  }
+  database.run(
+    `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_cron_run_id ON llm_usage_events(cron_run_id)`,
+  );
+}

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -223,6 +223,7 @@ export const llmUsageEvents = sqliteTable(
     createdAt: integer("created_at").notNull(),
     conversationId: text("conversation_id"),
     runId: text("run_id"),
+    cronRunId: text("cron_run_id"),
     requestId: text("request_id"),
     actor: text("actor").notNull(),
     callSite: text("call_site"),

--- a/assistant/src/memory/steps.ts
+++ b/assistant/src/memory/steps.ts
@@ -411,6 +411,7 @@ import { migrateAddProcessingStartedAt } from "./migrations/300-add-processing-s
 import { createWatchdogEventsTable } from "./migrations/301-create-watchdog-events.js";
 import { migrateCreateCompactionEvents } from "./migrations/302-create-compaction-events.js";
 import { migrateAddConversationCreationSeq } from "./migrations/303-add-conversation-creation-seq.js";
+import { migrateAddLlmUsageCronRunId } from "./migrations/304-add-llm-usage-cron-run-id.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1293,4 +1294,5 @@ export const migrationSteps: MigrationStep[] = [
   createWatchdogEventsTable,
   migrateCreateCompactionEvents,
   migrateAddConversationCreationSeq,
+  migrateAddLlmUsageCronRunId,
 ];


### PR DESCRIPTION
## Summary
- Add nullable, indexed, non-FK `cron_run_id` to `llm_usage_events` (migration 304 + drizzle schema).

Part of plan: script-schedule-cost-attribution.md (PR 1 of 7)