### PR TITLE
feat(usage): list a firing's conversations from the usage ledger

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -14,6 +14,7 @@ import {
   getUsageGroupedSeries,
   getUsageHourBuckets,
   getUsageTotals,
+  listRunConversationIds,
   listUsageEvents,
   queryUnreportedUsageEvents,
   recordUsageEvent,
@@ -344,6 +345,49 @@ describe("listUsageEvents", () => {
     expect(typeof event.cacheReadInputTokens).toBe("number");
     expect(typeof event.estimatedCostUsd).toBe("number");
     expect(typeof event.pricingStatus).toBe("string");
+  });
+});
+
+describe("listRunConversationIds", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  /** Record an event for a conversation, stamped with the given cron run id. */
+  function insertRunEvent(
+    cronRunId: string,
+    conversationId: string | null,
+  ): void {
+    const event = recordUsageEvent(makeInput({ conversationId }), pricedResult);
+    const db = getDb();
+    db.run(
+      `UPDATE llm_usage_events SET cron_run_id = '${cronRunId}' WHERE id = '${event.id}'`,
+    );
+  }
+
+  test("returns the distinct conversation ids a firing touched (deduped)", () => {
+    insertRunEvent("run-1", "conv-a");
+    insertRunEvent("run-1", "conv-a"); // same conversation, second LLM call
+    insertRunEvent("run-1", "conv-b");
+
+    expect(listRunConversationIds("run-1").sort()).toEqual([
+      "conv-a",
+      "conv-b",
+    ]);
+  });
+
+  test("returns an empty array for an unknown run", () => {
+    insertRunEvent("run-1", "conv-a");
+    expect(listRunConversationIds("run-unknown")).toEqual([]);
+  });
+
+  test("ignores rows with no conversation id and other runs", () => {
+    insertRunEvent("run-1", "conv-a");
+    insertRunEvent("run-1", null); // memory consolidation etc.
+    insertRunEvent("run-2", "conv-b");
+
+    expect(listRunConversationIds("run-1")).toEqual(["conv-a"]);
   });
 });
 

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -489,6 +489,25 @@ export function getUsageCostForConversationWindow({
 }
 
 /**
+ * Return the distinct conversation ids touched by a single cron firing,
+ * identified by its `cron_run_id` stamp on the usage ledger. Rows with a null
+ * `conversation_id` are excluded, and the result is deduped. Returns an empty
+ * array for an unknown or un-stamped run.
+ */
+export function listRunConversationIds(cronRunId: string): string[] {
+  const rows = rawAll<{ conversation_id: string }>(
+    /*sql*/ `
+    SELECT DISTINCT conversation_id
+    FROM llm_usage_events
+    WHERE cron_run_id = ?1
+      AND conversation_id IS NOT NULL
+    `,
+    cronRunId,
+  );
+  return rows.map((row) => row.conversation_id);
+}
+
+/**
  * Return aggregate totals for all usage events within the given time range.
  */
 export function getUsageTotals(


### PR DESCRIPTION
## Summary
- Add listRunConversationIds(cronRunId): derive a run's conversations from llm_usage_events (DISTINCT conversation_id).

Part of plan: script-schedule-cost-attribution.md (PR 7 of 7)