### PR TITLE
feat(schedule): attribute a script's escalation turn to its firing

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8991,6 +8991,9 @@ paths:
                 source:
                   default: cli
                   type: string
+                cronRunId:
+                  type: string
+                  minLength: 1
               required:
                 - conversationId
                 - hint

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -617,6 +617,10 @@ Examples:
             conversationId: string,
             opts: { hint: string; source: string; json?: boolean },
           ) => {
+            // A script-mode schedule injects __SCHEDULE_RUN_ID into its env
+            // (see schedule/run-script.ts). When set, thread it through so the
+            // woken turn's usage is attributed to the firing.
+            const cronRunId = process.env.__SCHEDULE_RUN_ID;
             const result = await cliIpcCall<{
               invoked: boolean;
               producedToolCalls: boolean;
@@ -626,6 +630,7 @@ Examples:
                 conversationId,
                 hint: opts.hint,
                 source: opts.source,
+                ...(cronRunId ? { cronRunId } : {}),
               },
             });
 

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -317,6 +317,12 @@ export interface WakeOptions {
    * framing outside the fence.
    */
   untrustedOutput?: WakeUntrustedOutput;
+  /**
+   * Schedule-run id to stamp on the usage rows this wake records. Set when the
+   * wake is triggered by a script-mode schedule (the firing's run id), so the
+   * woken turn's cost is attributed to that firing.
+   */
+  cronRunId?: string;
 }
 
 /**
@@ -929,6 +935,7 @@ export async function wakeAgentForOpportunity(
               forceOverrideProfile,
               selectionSeed: conversationId,
             },
+            opts.cronRunId ?? null,
           );
         } catch (err) {
           log.warn(

--- a/assistant/src/runtime/routes/wake-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wake-conversation-routes.ts
@@ -16,6 +16,7 @@ const WakeConversationBody = z.object({
   conversationId: z.string().min(1),
   hint: z.string().min(1),
   source: z.string().default("cli"),
+  cronRunId: z.string().min(1).optional(),
 });
 
 export const ROUTES: RouteDefinition[] = [
@@ -38,17 +39,20 @@ export const ROUTES: RouteDefinition[] = [
       reason: z.string().optional(),
     }),
     handler: async ({ body }) => {
-      const { conversationId, hint, source } =
+      const { conversationId, hint, source, cronRunId } =
         WakeConversationBody.parse(body);
 
       const conversation = getConversation(conversationId);
       if (!conversation) {
-        throw new NotFoundError(
-          `Conversation not found: ${conversationId}`,
-        );
+        throw new NotFoundError(`Conversation not found: ${conversationId}`);
       }
 
-      return wakeAgentForOpportunity({ conversationId, hint, source });
+      return wakeAgentForOpportunity({
+        conversationId,
+        hint,
+        source,
+        cronRunId,
+      });
     },
   },
 ];


### PR DESCRIPTION
## Summary
- conversations wake reads __SCHEDULE_RUN_ID from env and threads it through the wake to recordUsage, stamping cron_run_id on the woken turn's usage.

Part of plan: script-schedule-cost-attribution.md (PR 4 of 7)