### PR TITLE
feat(schedule): converge execute mode onto cron_run_id attribution

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -285,6 +285,11 @@ export async function runAgentLoopImpl(
      * sites. Used when a caller explicitly pins a background run to a profile.
      */
     forceOverrideProfile?: boolean;
+    /**
+     * Firing's `cron_runs.id` stamped onto this turn's usage rows so a
+     * scheduled execute turn attributes its LLM spend to that firing.
+     */
+    cronRunId?: string | null;
   },
 ): Promise<void> {
   if (!ctx.abortController) {
@@ -338,6 +343,11 @@ export async function runAgentLoopImpl(
   // Expose the turn's call site on the live conversation so the runtime
   // injection assembly self-resolves it for the turn's plugin contexts.
   ctx.currentCallSite = turnCallSite;
+
+  // Firing's run id for this turn's usage attribution. Kept local (not on the
+  // conversation) so a reused conversation attributes each turn to its own
+  // firing.
+  const turnCronRunId = options?.cronRunId ?? null;
 
   // Optional per-turn inference-profile override. Plumbed through to every
   // LLM call the loop emits and inherited by any subagents spawned during
@@ -718,6 +728,7 @@ export async function runAgentLoopImpl(
       );
       await applyCompactionResult(ctx, result, onEvent, reqId, {
         slackContextCompactionWatermarkTs: slackWatermarkTs,
+        cronRunId: turnCronRunId,
       });
       slackChronologicalContext = projectSlackProvenanceAfterCompaction(
         provenanceContext,
@@ -1300,6 +1311,7 @@ export async function runAgentLoopImpl(
         callSite: turnCallSite,
         overrideProfile: resolveCurrentOverrideProfile() ?? null,
       },
+      turnCronRunId,
     );
 
     const syncLastAssistantMessageToDisk = (): void => {
@@ -1591,6 +1603,7 @@ function emitUsage(
     callSite: LLMCallSite | null;
     overrideProfile?: string | null;
   },
+  cronRunId: string | null = null,
 ): void {
   recordUsage(
     {
@@ -1610,6 +1623,7 @@ function emitUsage(
     llmCallCount,
     contextWindow,
     attribution,
+    cronRunId,
   );
 }
 
@@ -1669,6 +1683,8 @@ export async function applyCompactionResult(
   reqId: string | null,
   options: {
     slackContextCompactionWatermarkTs?: string | null;
+    /** Firing's `cron_runs.id` stamped onto the compaction usage row. */
+    cronRunId?: string | null;
   } = {},
 ): Promise<void> {
   ctx.messages = result.messages;
@@ -1747,6 +1763,7 @@ export async function applyCompactionResult(
       callSite: result.summaryCallSite ?? null,
       overrideProfile: result.summaryOverrideProfile ?? null,
     },
+    options.cronRunId ?? null,
   );
 }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2013,6 +2013,11 @@ export class Conversation {
       overrideProfile?: string;
       /** Float `overrideProfile` above call-site layers for this run. */
       forceOverrideProfile?: boolean;
+      /**
+       * Firing's `cron_runs.id` stamped onto this turn's usage rows. Per-turn:
+       * forwarded into {@link runAgentLoopImpl} and threaded to `recordUsage`.
+       */
+      cronRunId?: string | null;
     },
   ): Promise<void> {
     const { onEvent, ...rest } = options ?? {};

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1059,6 +1059,7 @@ export async function runDaemon(): Promise<void> {
                 ...(options.overrideProfile
                   ? { overrideProfile: options.overrideProfile }
                   : {}),
+                ...(options.cronRunId ? { cronRunId: options.cronRunId } : {}),
               }
             : undefined,
         );

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -71,6 +71,12 @@ type ProcessMessageOptions = ConversationCreateOptions & {
   sourceChannel?: string;
   /** Originating interface (e.g. "cli", "web"). Defaults to "web". */
   sourceInterface?: string;
+  /**
+   * Firing's `cron_runs.id`, threaded through to the turn's usage rows so a
+   * scheduled execute turn attributes its LLM spend to that firing. Per-turn:
+   * not stored on the long-lived conversation.
+   */
+  cronRunId?: string | null;
 };
 
 function buildEventEmitter(
@@ -146,6 +152,7 @@ async function prepareConversationForMessage(
     sourceChannel,
     sourceInterface,
     onEvent: _onEvent,
+    cronRunId: _cronRunId,
     ...conversationOptions
   } = options ?? {};
   const conversation = await getOrCreateActiveConversation(
@@ -537,6 +544,7 @@ export async function processMessage(
       ...(options?.overrideProfile
         ? { overrideProfile: options.overrideProfile }
         : {}),
+      ...(options?.cronRunId ? { cronRunId: options.cronRunId } : {}),
     });
   } finally {
     if (
@@ -597,6 +605,7 @@ export async function processMessageInBackground(
       ...(options?.overrideProfile
         ? { overrideProfile: options.overrideProfile }
         : {}),
+      ...(options?.cronRunId ? { cronRunId: options.cronRunId } : {}),
     })
     .finally(() => {
       if (

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -73,6 +73,12 @@ export interface RunBackgroundJobOptions {
    * profile; omitted = the call site's default resolution.
    */
   overrideProfile?: string;
+  /**
+   * Firing's `cron_runs.id`, threaded into the turn's usage rows so a scheduled
+   * execute job attributes its LLM spend to that firing. Omitted for
+   * non-scheduled background jobs.
+   */
+  cronRunId?: string | null;
   /** Hard timeout for `processMessage` in milliseconds. */
   timeoutMs: number;
   /**
@@ -276,6 +282,7 @@ export async function runBackgroundJob(
       ...(opts.overrideProfile
         ? { overrideProfile: opts.overrideProfile }
         : {}),
+      ...(opts.cronRunId ? { cronRunId: opts.cronRunId } : {}),
     });
     // Absorb late rejections: if the timeout wins the race, `work` keeps
     // running and may eventually reject — swallow so it doesn't surface as

--- a/assistant/src/schedule/scheduler-types.ts
+++ b/assistant/src/schedule/scheduler-types.ts
@@ -26,6 +26,12 @@ export interface ScheduleMessageOptions {
    * = the call site's default resolution (main-agent model selection).
    */
   overrideProfile?: string;
+  /**
+   * Firing's `cron_runs.id`, stamped onto the turn's usage rows so a scheduled
+   * execute turn attributes its LLM spend to that firing. Per-turn: a reused
+   * conversation attributes each turn to its own firing.
+   */
+  cronRunId?: string | null;
 }
 
 export type ScheduleMessageProcessor = (

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -552,6 +552,7 @@ export async function runScheduleDueWorkOnce(
             await processMessage(conversationId, message, {
               trustClass: "guardian",
               taskRunId,
+              cronRunId: runId,
               ...(job.inferenceProfile
                 ? { overrideProfile: job.inferenceProfile }
                 : {}),
@@ -687,6 +688,7 @@ export async function runScheduleDueWorkOnce(
       try {
         await processMessage(conversationId, job.message, {
           trustClass: "guardian",
+          cronRunId: runId,
           ...(job.inferenceProfile
             ? { overrideProfile: job.inferenceProfile }
             : {}),
@@ -710,6 +712,7 @@ export async function runScheduleDueWorkOnce(
         systemHint: `Schedule: ${job.name}`,
         trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
         callSite: "mainAgent",
+        cronRunId: runId,
         ...(job.inferenceProfile
           ? { overrideProfile: job.inferenceProfile }
           : {}),


### PR DESCRIPTION
## Summary
- Thread the firing's runId through execute-mode turns (runTask + runBackgroundJob) so their usage rows carry cron_run_id.

Part of plan: script-schedule-cost-attribution.md (PR 6 of 7)