### PR TITLE
fix: manual run-now script firings now pass scheduleRunId

### DIFF
--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -903,6 +903,7 @@ async function handleRunScheduleNow(id: string) {
       );
       const result = await runScript(schedule.script, {
         timeoutMs: schedule.timeoutMs ?? undefined,
+        scheduleRunId: runId,
       });
       completeScheduleRun(runId, {
         status: result.exitCode === 0 ? "ok" : "error",


### PR DESCRIPTION
## Summary
Fixes a gap found in plan review for script-schedule-cost-attribution.md: handleRunScheduleNow fired script runs without scheduleRunId, leaving manual script-run LLM spend unattributed. Mirrors the automatic scheduler path.