### PR TITLE
fix: read cron_run_id back in rowToUsageEvent + unreported select

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -269,6 +269,10 @@ describe("recordUsageEvent", () => {
       .query("SELECT cron_run_id FROM llm_usage_events WHERE id = ?")
       .get(event.id) as { cron_run_id: string | null } | null;
     expect(row?.cron_run_id).toBe("cron-run-1");
+
+    // listUsageEvents routes through rowToUsageEvent; cronRunId must survive it.
+    const [typed] = listUsageEvents();
+    expect(typed?.cronRunId).toBe("cron-run-1");
   });
 
   test("cronRunId defaults to null when omitted", () => {

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -94,6 +94,7 @@ function rowToUsageEvent(row: {
   createdAt: number;
   conversationId: string | null;
   runId: string | null;
+  cronRunId: string | null;
   requestId: string | null;
   actor: string;
   callSite: string | null;
@@ -116,6 +117,7 @@ function rowToUsageEvent(row: {
     createdAt: row.createdAt,
     conversationId: row.conversationId,
     runId: row.runId,
+    cronRunId: row.cronRunId,
     requestId: row.requestId,
     actor: row.actor as UsageEvent["actor"],
     callSite: row.callSite as UsageEvent["callSite"],
@@ -220,6 +222,7 @@ export function queryUnreportedUsageEvents(
       createdAt: llmUsageEvents.createdAt,
       conversationId: llmUsageEvents.conversationId,
       runId: llmUsageEvents.runId,
+      cronRunId: llmUsageEvents.cronRunId,
       requestId: llmUsageEvents.requestId,
       actor: llmUsageEvents.actor,
       callSite: llmUsageEvents.callSite,


### PR DESCRIPTION
## Summary
Fixes a gap found in plan review for script-schedule-cost-attribution.md: cron_run_id was written but never read back into the typed UsageEvent, so typed/telemetry consumers silently dropped it.