### PR TITLE
fix(web): thinking drawer no longer truncates when the assistant finishes

### DIFF
--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -6,7 +6,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render as rtlRender } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  type InfiniteData,
+} from "@tanstack/react-query";
+import type { ReactNode } from "react";
 
 // `ToolDetailPanel`'s thinking variant subscribes to the chat-session store,
 // which transitively pulls in the generated daemon SDK. Stub every endpoint it
@@ -30,10 +36,41 @@ const { ToolDetailPanel } = await import(
 const { useChatSessionStore } = await import(
   "@/domains/chat/chat-session-store"
 );
+const { conversationHistoryQueryKey } = await import(
+  "@/domains/chat/transcript/use-history-pagination"
+);
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 
 const noop = () => {};
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const render = (ui: Parameters<typeof rtlRender>[0]) =>
+  rtlRender(ui, { wrapper });
+
+/**
+ * Seed persisted server history into the query cache under the active
+ * conversation key (read as the `("","")` key with nothing selected), so the
+ * drawer's transcript union resolves a committed message that has left the live
+ * turn.
+ */
+function seedHistory(messages: DisplayMessage[]) {
+  const data: InfiniteData<PaginatedHistoryResult> = {
+    pages: [
+      { messages, hasMore: false, oldestTimestamp: null, oldestMessageId: null },
+    ],
+    pageParams: [null],
+  };
+  queryClient.setQueryData(conversationHistoryQueryKey(null, null), data);
+}
 
 function makeDetail(overrides: Partial<ToolDetailPayload> = {}): ToolDetailPayload {
   return {
@@ -52,6 +89,9 @@ function makeDetail(overrides: Partial<ToolDetailPayload> = {}): ToolDetailPaylo
 let writeText: ReturnType<typeof mock>;
 
 beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   writeText = mock(() => Promise.resolve());
   Object.defineProperty(navigator, "clipboard", {
     value: { writeText },
@@ -64,6 +104,7 @@ afterEach(() => {
   act(() => {
     useChatSessionStore.setState({ liveTurn: [] });
   });
+  queryClient.clear();
 });
 
 describe("ToolDetailPanel", () => {
@@ -231,6 +272,33 @@ describe("ToolDetailPanel", () => {
       <ToolDetailPanel detail={detail} onClose={noop} />,
     );
     expect(getByText("snapshot fallback")).toBeDefined();
+  });
+
+  test("thinking variant keeps the full reasoning after the live→history handoff", () => {
+    // When a turn finishes, the committed row leaves the live turn for history.
+    // The drawer must keep rendering the full reasoning resolved from history,
+    // not snap back to the truncated open-time snapshot.
+    seedHistory([
+      {
+        id: "m1",
+        role: "assistant",
+        contentBlocks: [
+          { type: "thinking", thinking: "the full committed reasoning" },
+        ],
+      } as DisplayMessage,
+    ]);
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thought process",
+      messageId: "m1",
+      thinkingGroupIndex: 0,
+      thinkingText: "stale partial snapshot",
+    });
+    const { getByText, queryByText } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+    expect(getByText("the full committed reasoning")).toBeDefined();
+    expect(queryByText("stale partial snapshot")).toBeNull();
   });
 
   test("thinking variant selects a single reasoning segment by item index", () => {

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.test.tsx
@@ -1,15 +1,23 @@
 /**
  * Tests for `useLiveThinkingText` — the selector that re-derives a thinking
- * drawer's reasoning text from the live chat-session store so an open drawer
- * streams instead of freezing its open-time snapshot.
+ * drawer's reasoning text from the rendered transcript (server history ⊕ the
+ * in-flight turn) so an open drawer streams while the assistant thinks and
+ * stays whole after the turn commits, instead of freezing its open-time
+ * snapshot.
  *
  * The chat-session store transitively pulls in the generated daemon SDK. Stub
  * every endpoint it exports so the module loads; nothing here invokes them.
  * Mirrors the comprehensive mock in `multi-activity-group.test.tsx`.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  type InfiniteData,
+} from "@tanstack/react-query";
+import type { ReactNode } from "react";
 
 const sdkStub = async () => ({ data: undefined });
 const realSdkPath = new URL(
@@ -29,35 +37,77 @@ const { useLiveThinkingText } = await import(
 const { useChatSessionStore } = await import(
   "@/domains/chat/chat-session-store"
 );
+const { conversationHistoryQueryKey } = await import(
+  "@/domains/chat/transcript/use-history-pagination"
+);
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const render = <T,>(hook: () => T) => renderHook(hook, { wrapper });
+
+/** Seed the in-flight turn (the live overlay). */
 function seed(messages: DisplayMessage[]) {
   act(() => {
     useChatSessionStore.setState({ liveTurn: messages });
   });
 }
 
+/**
+ * Seed persisted server history into the query cache under the active
+ * conversation key. With no assistant/conversation selected the transcript
+ * reads the `("","")` key, so reading and writing line up.
+ */
+function seedHistory(messages: DisplayMessage[]) {
+  const data: InfiniteData<PaginatedHistoryResult> = {
+    pages: [
+      {
+        messages,
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+      },
+    ],
+    pageParams: [null],
+  };
+  queryClient.setQueryData(conversationHistoryQueryKey(null, null), data);
+}
+
 function msg(overrides: Partial<DisplayMessage>): DisplayMessage {
   return { id: "m1", role: "assistant", ...overrides } as DisplayMessage;
 }
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+});
 
 afterEach(() => {
   cleanup();
   act(() => {
     useChatSessionStore.setState({ liveTurn: [] });
   });
+  queryClient.clear();
 });
 
 describe("useLiveThinkingText", () => {
   test("returns null without a message id or group index", () => {
     seed([msg({ contentBlocks: [{ type: "thinking", thinking: "a" }] })]);
-    expect(renderHook(() => useLiveThinkingText(undefined, 0)).result.current).toBeNull();
-    expect(renderHook(() => useLiveThinkingText("m1", undefined)).result.current).toBeNull();
+    expect(render(() => useLiveThinkingText(undefined, 0)).result.current).toBeNull();
+    expect(render(() => useLiveThinkingText("m1", undefined)).result.current).toBeNull();
   });
 
   test("returns null when the message is absent", () => {
     seed([]);
-    const { result } = renderHook(() => useLiveThinkingText("missing", 0));
+    const { result } = render(() => useLiveThinkingText("missing", 0));
     expect(result.current).toBeNull();
   });
 
@@ -73,7 +123,7 @@ describe("useLiveThinkingText", () => {
         ],
       }),
     ]);
-    const { result } = renderHook(() => useLiveThinkingText("m1", 0));
+    const { result } = render(() => useLiveThinkingText("m1", 0));
     expect(result.current).toBe("first\nsecond");
   });
 
@@ -87,17 +137,17 @@ describe("useLiveThinkingText", () => {
         ],
       }),
     ]);
-    expect(renderHook(() => useLiveThinkingText("m1", 0, 0)).result.current).toBe(
+    expect(render(() => useLiveThinkingText("m1", 0, 0)).result.current).toBe(
       "first",
     );
-    expect(renderHook(() => useLiveThinkingText("m1", 0, 1)).result.current).toBe(
+    expect(render(() => useLiveThinkingText("m1", 0, 1)).result.current).toBe(
       "second",
     );
   });
 
   test("returns null for an out-of-range item index", () => {
     seed([msg({ contentBlocks: [{ type: "thinking", thinking: "only" }] })]);
-    const { result } = renderHook(() => useLiveThinkingText("m1", 0, 5));
+    const { result } = render(() => useLiveThinkingText("m1", 0, 5));
     expect(result.current).toBeNull();
   });
 
@@ -113,17 +163,17 @@ describe("useLiveThinkingText", () => {
         ],
       }),
     ]);
-    expect(renderHook(() => useLiveThinkingText("m1", 0)).result.current).toBe(
+    expect(render(() => useLiveThinkingText("m1", 0)).result.current).toBe(
       "run-A",
     );
-    expect(renderHook(() => useLiveThinkingText("m1", 2)).result.current).toBe(
+    expect(render(() => useLiveThinkingText("m1", 2)).result.current).toBe(
       "run-B",
     );
   });
 
   test("updates live as the store's thinking grows", () => {
     seed([msg({ contentBlocks: [{ type: "thinking", thinking: "partial" }] })]);
-    const { result } = renderHook(() => useLiveThinkingText("m1", 0));
+    const { result } = render(() => useLiveThinkingText("m1", 0));
     expect(result.current).toBe("partial");
 
     seed([
@@ -140,9 +190,39 @@ describe("useLiveThinkingText", () => {
         contentBlocks: [{ type: "thinking", thinking: "aliased" }],
       }),
     ]);
-    const { result } = renderHook(() =>
-      useLiveThinkingText("optimistic-id", 0),
-    );
+    const { result } = render(() => useLiveThinkingText("optimistic-id", 0));
     expect(result.current).toBe("aliased");
+  });
+
+  test("resolves a committed message from history after the live→history handoff", () => {
+    // Regression: when a turn finishes, the live-turn→history handoff drops the
+    // committed row from the live turn. A live-turn-only lookup would miss it
+    // and the drawer would fall back to the stale open-time snapshot. The full
+    // reasoning lives on the history row, so the union must still resolve it.
+    seed([]);
+    seedHistory([
+      msg({
+        contentBlocks: [
+          { type: "thinking", thinking: "the whole reasoning chain" },
+        ],
+      }),
+    ]);
+    const { result } = render(() => useLiveThinkingText("m1", 0));
+    expect(result.current).toBe("the whole reasoning chain");
+  });
+
+  test("the live turn overlays a history twin while streaming", () => {
+    // Mid-stream the same message id exists in both history (a stale reconcile
+    // snapshot) and the live turn (the growing text). The live copy wins.
+    seedHistory([
+      msg({ contentBlocks: [{ type: "thinking", thinking: "stale snapshot" }] }),
+    ]);
+    seed([
+      msg({
+        contentBlocks: [{ type: "thinking", thinking: "live, still growing" }],
+      }),
+    ]);
+    const { result } = render(() => useLiveThinkingText("m1", 0));
+    expect(result.current).toBe("live, still growing");
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
@@ -1,11 +1,24 @@
-import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useMemo } from "react";
+
 import { groupContentBlocks } from "@/domains/chat/transcript/message-content";
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
- * Live reasoning text for a thinking detail drawer, re-derived from the
- * chat-session store on every render so an OPEN drawer streams as
- * `assistant_thinking_delta` events land — instead of freezing the snapshot
- * captured when the drawer was opened.
+ * Reasoning text for a thinking detail drawer, re-derived from the rendered
+ * transcript (server history ⊕ the in-flight turn) on every render so an OPEN
+ * drawer streams as `assistant_thinking_delta` events land AND stays whole after
+ * the turn commits — instead of freezing the snapshot captured when the drawer
+ * was opened.
+ *
+ * Resolving against the transcript union rather than the live turn alone is
+ * load-bearing: when a turn finishes, the live-turn→history handoff drops the
+ * committed row from the live turn, so a live-turn-only lookup would miss it the
+ * moment the assistant stops and the drawer would fall back to the stale
+ * open-time snapshot. The committed reasoning lives on the history row, which the
+ * union carries.
  *
  * The drawer target is identified by `(messageId, groupIndex)` plus an optional
  * `thinkingItemIndex`. With no item index the combined reasoning of the whole
@@ -15,20 +28,21 @@ import { groupContentBlocks } from "@/domains/chat/transcript/message-content";
  * run). Reuses {@link groupContentBlocks} so the panel text cannot drift from
  * the inline activity view it mirrors.
  *
- * Returns a primitive string so Zustand's `Object.is` comparison re-renders the
- * caller only when the text actually grows. Returns `null` when the message or
- * group can't be found (e.g. paged out of the transcript) so callers fall back
- * to the open-time snapshot.
+ * Returns `null` when the message or group can't be found (e.g. paged out of the
+ * loaded transcript) so callers fall back to the open-time snapshot.
  */
 export function useLiveThinkingText(
   messageId: string | undefined,
   groupIndex: number | undefined,
   thinkingItemIndex?: number,
 ): string | null {
-  return useChatSessionStore((s) => {
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const conversationId = useConversationStore.use.activeConversationId();
+  const messages = useTranscriptMessages(assistantId, conversationId);
+  return useMemo(() => {
     if (!messageId || groupIndex == null) return null;
-    const message = s.liveTurn.find(
-      (m) => m.id === messageId || m.mergedMessageIds?.includes(messageId),
+    const message = messages.find((m) =>
+      messageMatchKeys(m).includes(messageId),
     );
     if (!message) return null;
     const groups = groupContentBlocks(message.contentBlocks ?? [], {
@@ -41,5 +55,5 @@ export function useLiveThinkingText(
     );
     if (thinkingItemIndex == null) return segments.join("\n");
     return segments[thinkingItemIndex] ?? null;
-  });
+  }, [messages, messageId, groupIndex, thinkingItemIndex]);
 }

--- a/clients/web/src/domains/chat/hooks/use-live-tool-call.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-tool-call.ts
@@ -1,29 +1,39 @@
-import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useMemo } from "react";
+
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
- * Live tool call looked up by id from the chat-session store, so an OPEN
- * tool-detail drawer reflects streamed `tool_output_chunk` output (and the
- * eventual final `result`) as events land — instead of freezing the snapshot
- * captured when the drawer was opened. The streaming sibling of
+ * Tool call looked up by id from the rendered transcript (server history ⊕ the
+ * in-flight turn), so an OPEN tool-detail drawer reflects streamed
+ * `tool_output_chunk` output (and the eventual final `result`) as events land
+ * AND keeps the final result after the turn commits — instead of freezing the
+ * snapshot captured when the drawer was opened. The sibling of
  * {@link useLiveThinkingText}.
  *
- * Returns the stored tool-call object, whose reference is stable until that
- * specific call changes (the stream updaters clone only the touched call), so
- * Zustand's `Object.is` comparison re-renders the caller only on a real update
- * to this call — not on unrelated transcript churn. Returns `null` when the
- * call can't be found (e.g. its message paged out of the transcript) so callers
- * fall back to the open-time snapshot.
+ * Resolving against the transcript union rather than the live turn alone is
+ * load-bearing: the live-turn→history handoff drops the committed row from the
+ * live turn the moment the turn finishes, so a live-turn-only lookup would lose
+ * the call and the drawer would fall back to the stale open-time snapshot. The
+ * committed call lives on the history row, which the union carries.
+ *
+ * Returns `null` when the call can't be found (e.g. its message paged out of the
+ * loaded transcript) so callers fall back to the open-time snapshot.
  */
 export function useLiveToolCall(
   toolCallId: string | undefined,
 ): ChatMessageToolCall | null {
-  return useChatSessionStore((s) => {
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const conversationId = useConversationStore.use.activeConversationId();
+  const messages = useTranscriptMessages(assistantId, conversationId);
+  return useMemo(() => {
     if (!toolCallId) return null;
-    for (const m of s.liveTurn) {
+    for (const m of messages) {
       const tc = m.toolCalls?.find((t) => t.id === toolCallId);
       if (tc) return tc;
     }
     return null;
-  });
+  }, [messages, toolCallId]);
 }


### PR DESCRIPTION
## Summary
- The "Thought process" (and tool-output) side drawer truncated to its open-time snapshot the moment a turn finished: `useLiveThinkingText`/`useLiveToolCall` read only `liveTurn`, but the live-turn→history handoff drops the committed row from `liveTurn` once it lands in history, so the hook returned `null` and the drawer fell back to the stale snapshot captured when it was opened.
- Resolve both drawer hooks from the rendered transcript union (`useTranscriptMessages`, history + in-flight turn) — the same single source the inline activity view uses — so the drawer streams while the assistant thinks and keeps the full text after commit.
- Add regression tests covering post-handoff (history-only) resolution for both the hook and the panel.

## Original prompt
In the desktop app, the assistant's reasoning streamed correctly in the "Thought process" panel but truncated mid-sentence the instant the turn finished; closing and reopening the panel showed the full text. This was traced to the drawer reading only the in-flight live turn, which is emptied of the committed row at turn end (the full reasoning lives in history). The fix covers both the thinking drawer and the sibling tool-output drawer, which share the root cause.