### PR TITLE
fix(web): wrap subagent-detail-panel tests in a QueryClientProvider

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -9,7 +9,14 @@
  */
 
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render as rtlRender,
+  screen,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 
 mock.module("@/components/avatar-renderer", () => ({
   AvatarRenderer: () => <div data-testid="avatar" />,
@@ -76,6 +83,25 @@ mock.module("@/domains/chat/components/subagent-phase-timeline", () => ({
 
 import { SubagentDetailPanel } from "@/domains/chat/components/subagent-detail-panel";
 import type { SubagentEntry } from "@/domains/chat/subagent-store";
+
+// The nested tool-detail body (`ToolDetailBody`) resolves the live tool call
+// from the transcript union, which is backed by a TanStack Query cache. Render
+// every case under a provider so drilling into a tool step doesn't throw "No
+// QueryClient set". No history is seeded: with no active conversation the
+// history query stays disabled, so the body falls back to the step's open-time
+// snapshot — exactly the values these tests assert.
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const render = (ui: Parameters<typeof rtlRender>[0]) =>
+  rtlRender(ui, { wrapper });
 
 const noop = () => {};
 


### PR DESCRIPTION
## Summary
- After #36232, the nested tool-detail body (`ToolDetailBody`) resolves the live tool call from the transcript union (`useLiveToolCall` → `useTranscriptMessages` → `useInfiniteQuery`), so rendering it requires a TanStack Query provider. `subagent-detail-panel.test.tsx` rendered the panel without one, so the 7 "nested tool detail" tests that drill into a generic tool step threw `No QueryClient set` and broke Main Web CI. (The thinking and web_fetch step paths render inline, which is why only the generic-tool tests failed.)
- Wrap the panel's renders in a `QueryClientProvider`, mirroring the sibling `tool-detail-panel.test.tsx` fix shipped in the same commit. No history is seeded — with no active conversation the history query stays disabled, so the body falls back to the step's open-time snapshot, exactly the values these tests assert. All 21 tests in the file pass.

## Original prompt
Fix only the specific failing CI job in the Main Web run (28217853609 / job 83592587448): `subagent-detail-panel.test.tsx` was failing 7 "nested tool detail" tests with `No QueryClient set`. The fix was scoped to that one job — the sibling test was already fixed in the breaking commit, so this completes the missed-test cleanup.