### PR TITLE
perf(memory): content-hash cache for v3 section embeddings

### DIFF
--- a/assistant/src/memory/__tests__/embedding-cache.test.ts
+++ b/assistant/src/memory/__tests__/embedding-cache.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for `assistant/src/memory/embedding-cache.ts` — the shared dense-vector
+ * cache over the `memory_embeddings` table. Exercises the real SQL against a
+ * temp workspace DB (round-trip, dim-mismatch miss, key isolation, upsert).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "embedding-cache-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+// Deferred so internal `getWorkspaceDir()` resolves to the tmpdir set above.
+const { getDb } = await import("../db-connection.js");
+const { resetDbForTesting } =
+  await import("../../__tests__/db-test-helpers.js");
+const { initializeDb } = await import("../db-init.js");
+const { memoryEmbeddings } = await import("../schema.js");
+const { readEmbeddingCache, writeEmbeddingCache } =
+  await import("../embedding-cache.js");
+
+beforeEach(async () => {
+  resetDbForTesting();
+  // The first run pays the full cold-start migration chain; bump the hook
+  // timeout above bun's 5s default so the leading test doesn't flake in CI.
+  await initializeDb();
+}, 30_000);
+
+const KEY = {
+  targetType: "v3_section",
+  targetId: "people/alice#0",
+  provider: "local",
+  model: "test-model",
+  expectedDim: 4,
+} as const;
+
+function seed(
+  overrides: Partial<{
+    dense: number[];
+    contentHash: string;
+    now: number;
+  }> = {},
+): void {
+  writeEmbeddingCache(getDb(), {
+    targetType: KEY.targetType,
+    targetId: KEY.targetId,
+    provider: KEY.provider,
+    model: KEY.model,
+    dense: overrides.dense ?? [1, 2, 3, 4],
+    contentHash: overrides.contentHash ?? "hash-a",
+    now: overrides.now ?? 1000,
+  });
+}
+
+describe("embedding-cache", () => {
+  test("read returns null when nothing is cached", () => {
+    expect(readEmbeddingCache(getDb(), KEY)).toBeNull();
+  });
+
+  test("write then read round-trips the vector and content hash", () => {
+    seed({ dense: [1, 2, 3, 4], contentHash: "hash-a" });
+
+    const got = readEmbeddingCache(getDb(), KEY);
+    expect(got).not.toBeNull();
+    expect(got!.dense).toEqual([1, 2, 3, 4]);
+    expect(got!.contentHash).toBe("hash-a");
+  });
+
+  test("read misses when the configured dimension differs from the stored row", () => {
+    seed();
+    expect(readEmbeddingCache(getDb(), { ...KEY, expectedDim: 8 })).toBeNull();
+  });
+
+  test("read is isolated by targetType / targetId / provider / model", () => {
+    seed();
+    const db = getDb();
+    expect(
+      readEmbeddingCache(db, { ...KEY, targetType: "concept_page" }),
+    ).toBeNull();
+    expect(
+      readEmbeddingCache(db, { ...KEY, targetId: "people/bob#0" }),
+    ).toBeNull();
+    expect(readEmbeddingCache(db, { ...KEY, provider: "openai" })).toBeNull();
+    expect(readEmbeddingCache(db, { ...KEY, model: "other-model" })).toBeNull();
+  });
+
+  test("re-writing the same key upserts in place (one row, latest content)", () => {
+    const db = getDb();
+    seed({ dense: [1, 2, 3, 4], contentHash: "hash-a", now: 1000 });
+    seed({ dense: [5, 6, 7, 8], contentHash: "hash-b", now: 2000 });
+
+    const got = readEmbeddingCache(db, KEY);
+    expect(got!.dense).toEqual([5, 6, 7, 8]);
+    expect(got!.contentHash).toBe("hash-b");
+
+    // The unique key collapses both writes onto a single row.
+    const rows = db
+      .select()
+      .from(memoryEmbeddings)
+      .all()
+      .filter(
+        (r) => r.targetType === KEY.targetType && r.targetId === KEY.targetId,
+      );
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/embedding-cache.ts
+++ b/assistant/src/memory/embedding-cache.ts
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------------
+// Shared dense-embedding cache over the `memory_embeddings` SQLite table
+// ---------------------------------------------------------------------------
+//
+// A read/write pair that caches one dense vector keyed on
+// `(targetType, targetId, provider, model)` alongside the content hash it was
+// embedded from, so callers can skip the embedding-backend round-trip when an
+// input's text is unchanged. The `embed_concept_page` job pioneered this
+// pattern for whole-page bodies; this module factors out the generic mechanics
+// — dim-match gating, legacy-null-hash handling, blob encode/decode, and the
+// upsert on the unique key — so other embedders (e.g. the v3 section dense
+// store) reuse one implementation instead of duplicating it.
+
+import { randomUUID } from "node:crypto";
+
+import { and, eq } from "drizzle-orm";
+
+import { getLogger } from "../util/logger.js";
+import type { getDb } from "./db-connection.js";
+import { blobToVector, vectorToBlob } from "./job-utils.js";
+import { memoryEmbeddings } from "./schema.js";
+
+const log = getLogger("memory-embedding-cache");
+
+type MemoryDb = ReturnType<typeof getDb>;
+
+/** Lookup key for {@link readEmbeddingCache}. */
+export interface EmbeddingCacheKey {
+  targetType: string;
+  targetId: string;
+  provider: string;
+  model: string;
+  /** Configured embedding dimension; a row at a different size is a miss. */
+  expectedDim: number;
+}
+
+/** A cached dense vector plus the content hash it was embedded from. */
+export interface EmbeddingCacheEntry {
+  dense: number[];
+  contentHash: string;
+}
+
+/**
+ * Look up a cached dense vector keyed on `(targetType, targetId, provider,
+ * model)`. Returns the row only when the persisted dimensions match
+ * `expectedDim` — a stale row from a previous `vectorSize` is treated as a miss
+ * so the caller re-embeds. A row with a null `contentHash` (legacy/corrupt) is
+ * likewise a miss rather than a key the caller could misalign against.
+ */
+export function readEmbeddingCache(
+  db: MemoryDb,
+  key: EmbeddingCacheKey,
+): EmbeddingCacheEntry | null {
+  const row = db
+    .select({
+      vectorBlob: memoryEmbeddings.vectorBlob,
+      vectorJson: memoryEmbeddings.vectorJson,
+      dimensions: memoryEmbeddings.dimensions,
+      contentHash: memoryEmbeddings.contentHash,
+    })
+    .from(memoryEmbeddings)
+    .where(
+      and(
+        eq(memoryEmbeddings.targetType, key.targetType),
+        eq(memoryEmbeddings.targetId, key.targetId),
+        eq(memoryEmbeddings.provider, key.provider),
+        eq(memoryEmbeddings.model, key.model),
+      ),
+    )
+    .get();
+  if (!row || row.dimensions !== key.expectedDim) return null;
+  if (row.contentHash === null) return null;
+  const dense = row.vectorBlob
+    ? blobToVector(row.vectorBlob as Buffer)
+    : (JSON.parse(row.vectorJson!) as number[]);
+  return { dense, contentHash: row.contentHash };
+}
+
+/** Parameters for {@link writeEmbeddingCache}. */
+export interface EmbeddingCacheWrite {
+  targetType: string;
+  targetId: string;
+  dense: number[];
+  contentHash: string;
+  provider: string;
+  model: string;
+  now: number;
+}
+
+/**
+ * Persist a freshly embedded dense vector, upserting on the
+ * `(targetType, targetId, provider, model)` unique key. Best-effort: a write
+ * failure is logged and swallowed so the caller's downstream write still runs.
+ */
+export function writeEmbeddingCache(
+  db: MemoryDb,
+  params: EmbeddingCacheWrite,
+): void {
+  const { targetType, targetId, dense, contentHash, provider, model, now } =
+    params;
+  try {
+    const blobValue = vectorToBlob(dense);
+    db.insert(memoryEmbeddings)
+      .values({
+        id: randomUUID(),
+        targetType,
+        targetId,
+        provider,
+        model,
+        dimensions: dense.length,
+        vectorBlob: blobValue,
+        vectorJson: null,
+        contentHash,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          memoryEmbeddings.targetType,
+          memoryEmbeddings.targetId,
+          memoryEmbeddings.provider,
+          memoryEmbeddings.model,
+        ],
+        set: {
+          vectorBlob: blobValue,
+          vectorJson: null,
+          dimensions: dense.length,
+          contentHash,
+          updatedAt: now,
+        },
+      })
+      .run();
+  } catch (err) {
+    log.warn(
+      { err, targetType, targetId },
+      "Failed to write embedding cache row",
+    );
+  }
+}

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
@@ -14,21 +14,93 @@ mock.module("../../../../memory/qdrant-client.js", () => ({
 
 // Stub the shared embedding backend. Records inputs and returns one
 // deterministic vector per input so `upsertSections` can map vectors → points.
+// `statusProvider/Model` is what `getMemoryBackendStatus` reports (the cache-read
+// identity); `embedProvider/Model` is what `embedWithBackend` returns — kept
+// separate so a test can simulate a provider rotation between the two.
 const embedState = {
   calls: [] as string[][],
   dim: 4,
+  statusProvider: "local" as string | null,
+  statusModel: "test-model" as string | null,
+  embedProvider: "local",
+  embedModel: "test-model",
 };
 mock.module("../../../../memory/embedding-backend.js", () => ({
+  getMemoryBackendStatus: async () => ({
+    enabled: true,
+    degraded: false,
+    provider: embedState.statusProvider,
+    model: embedState.statusModel,
+    reason: null,
+  }),
   embedWithBackend: async (_config: unknown, inputs: string[]) => {
     embedState.calls.push(inputs);
     return {
-      provider: "local",
-      model: "test-model",
+      provider: embedState.embedProvider,
+      model: embedState.embedModel,
       vectors: inputs.map((_input, i) =>
         Array.from({ length: embedState.dim }, (_v, j) => (i + 1) * (j + 1)),
       ),
     };
   },
+}));
+
+// In-memory stand-in for the `memory_embeddings` dense cache. Lets each test
+// program hits/misses without a real DB; keyed exactly as the production helper
+// (`targetType|targetId|provider|model`) with a stored dimension for the
+// dim-match gate. `getDb` is stubbed to a sentinel since the mock ignores it.
+const cacheState = {
+  store: new Map<
+    string,
+    { dense: number[]; contentHash: string; dimensions: number }
+  >(),
+  reads: [] as string[],
+};
+function cacheKey(k: {
+  targetType: string;
+  targetId: string;
+  provider: string;
+  model: string;
+}): string {
+  return `${k.targetType}|${k.targetId}|${k.provider}|${k.model}`;
+}
+mock.module("../../../../memory/embedding-cache.js", () => ({
+  readEmbeddingCache: (
+    _db: unknown,
+    key: {
+      targetType: string;
+      targetId: string;
+      provider: string;
+      model: string;
+      expectedDim: number;
+    },
+  ) => {
+    cacheState.reads.push(cacheKey(key));
+    const row = cacheState.store.get(cacheKey(key));
+    if (!row || row.dimensions !== key.expectedDim) return null;
+    return { dense: row.dense, contentHash: row.contentHash };
+  },
+  writeEmbeddingCache: (
+    _db: unknown,
+    params: {
+      targetType: string;
+      targetId: string;
+      provider: string;
+      model: string;
+      dense: number[];
+      contentHash: string;
+    },
+  ) => {
+    cacheState.store.set(cacheKey(params), {
+      dense: params.dense,
+      contentHash: params.contentHash,
+      dimensions: params.dense.length,
+    });
+  },
+}));
+
+mock.module("../../../../memory/db-connection.js", () => ({
+  getDb: () => ({}),
 }));
 
 // Mock the underlying @qdrant/js-client-rest package. The mock client records
@@ -159,6 +231,12 @@ function resetState(): void {
   state.scrollCalls.length = 0;
   embedState.calls.length = 0;
   embedState.dim = 4;
+  embedState.statusProvider = "local";
+  embedState.statusModel = "test-model";
+  embedState.embedProvider = "local";
+  embedState.embedModel = "test-model";
+  cacheState.store.clear();
+  cacheState.reads.length = 0;
   _resetSectionDenseStoreForTests();
 }
 
@@ -373,6 +451,103 @@ describe("memory v3 section-dense-store — upsert", () => {
 
     expect(state.createCollectionCalls).toBe(1);
     expect(state.upsertCalls).toHaveLength(1);
+  });
+});
+
+describe("memory v3 section-dense-store — embedding cache", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("re-upserting unchanged sections serves from cache (no second embed)", async () => {
+    state.collectionExists = true;
+    const sections = [
+      section("people/alice", 0, "alice lead text"),
+      section("people/alice", 1, "alice section one"),
+    ];
+
+    await upsertSections(CONFIG, sections);
+    expect(embedState.calls).toHaveLength(1); // cold cache → embedded once
+
+    await upsertSections(CONFIG, sections);
+    // No new backend call — the second pass reused both cached vectors.
+    expect(embedState.calls).toHaveLength(1);
+    // But the points were still upserted (rebuilt from cache), with identical
+    // vectors to the first pass.
+    expect(state.upsertCalls).toHaveLength(2);
+    expect(state.upsertCalls[1]!.points.map((p) => p.vector)).toEqual(
+      state.upsertCalls[0]!.points.map((p) => p.vector),
+    );
+  });
+
+  test("a changed section text re-embeds (content hash differs)", async () => {
+    state.collectionExists = true;
+
+    await upsertSections(CONFIG, [section("people/alice", 0, "text A")]);
+    await upsertSections(CONFIG, [section("people/alice", 0, "text B")]);
+
+    expect(embedState.calls).toEqual([["text A"], ["text B"]]);
+  });
+
+  test("partial hit embeds only the changed section, upserts both", async () => {
+    state.collectionExists = true;
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "lead"),
+      section("people/alice", 1, "one"),
+    ]);
+    embedState.calls.length = 0;
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "lead"), // unchanged → cache hit
+      section("people/alice", 1, "one changed"), // changed → miss
+    ]);
+
+    // Only the changed section's text reached the backend.
+    expect(embedState.calls).toEqual([["one changed"]]);
+    // Both points (cached + freshly embedded) were upserted.
+    expect(state.upsertCalls.at(-1)!.points).toHaveLength(2);
+  });
+
+  test("no resolved provider skips the cache and embeds every section", async () => {
+    state.collectionExists = true;
+    embedState.statusProvider = null;
+    embedState.statusModel = null;
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "x"),
+      section("people/alice", 1, "y"),
+    ]);
+
+    // Without an embedding identity the cache cannot be keyed, so it is never
+    // read and every section is embedded — matching the pre-cache behavior.
+    expect(cacheState.reads).toEqual([]);
+    expect(embedState.calls).toEqual([["x", "y"]]);
+  });
+
+  test("a provider rotation re-embeds the whole batch under the new identity", async () => {
+    state.collectionExists = true;
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "lead"),
+      section("people/alice", 1, "one"),
+    ]);
+    embedState.calls.length = 0;
+
+    // The cache-read identity still resolves to local/test-model (so section 0
+    // is a hit), but the backend now answers as a different provider.
+    embedState.embedProvider = "openai";
+    embedState.embedModel = "text-embedding-3";
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "lead"), // hit under the old identity
+      section("people/alice", 1, "one changed"), // miss
+    ]);
+
+    // First the misses are embedded; the rotated provider on that response
+    // forces a full re-embed of every section so the collection stays in one
+    // embedding space.
+    expect(embedState.calls).toEqual([
+      ["one changed"],
+      ["lead", "one changed"],
+    ]);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
@@ -23,7 +23,16 @@ import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
 import { v5 as uuidv5 } from "uuid";
 
 import type { AssistantConfig } from "../../../config/types.js";
-import { embedWithBackend } from "../../../memory/embedding-backend.js";
+import { getDb } from "../../../memory/db-connection.js";
+import {
+  embedWithBackend,
+  getMemoryBackendStatus,
+} from "../../../memory/embedding-backend.js";
+import {
+  readEmbeddingCache,
+  writeEmbeddingCache,
+} from "../../../memory/embedding-cache.js";
+import { embeddingInputContentHash } from "../../../memory/embedding-types.js";
 import { resolveQdrantUrl } from "../../../memory/qdrant-client.js";
 import { getLogger } from "../../../util/logger.js";
 import type { Section } from "./types.js";
@@ -167,11 +176,27 @@ export async function ensureSectionCollection(
 }
 
 /**
+ * `target_type` marker on `memory_embeddings` rows that cache section vectors.
+ * Distinct from the v2 `concept_page` rows so the two caches never collide on a
+ * shared `(targetType, targetId, provider, model)` key.
+ */
+const V3_SECTION_TARGET_TYPE = "v3_section";
+
+/** Human-readable cache id for a section: `<article>#<ordinal>`. */
+function sectionCacheId(article: string, ordinal: number): string {
+  return `${article}#${ordinal}`;
+}
+
+/**
  * Embed each section's `text` and upsert one point per section, keyed by a
  * deterministic `(article, ordinal)`-derived ID. Stable IDs mean re-upserting
  * the same sections overwrites in place rather than accumulating duplicates,
  * so the operation is idempotent. Payload carries `{ article, ordinal, title }`
  * for downstream filtering and rendering.
+ *
+ * Unchanged sections are served from the `memory_embeddings` cache rather than
+ * re-embedded — see {@link embedSectionsCached} — so a maintain pass that
+ * re-selects an already-embedded page makes no backend round-trip for it.
  *
  * An empty `sections` array is a no-op (no embedding round-trip).
  */
@@ -183,25 +208,131 @@ export async function upsertSections(
 
   await ensureSectionCollection(config);
 
-  const { vectors } = await embedWithBackend(
-    config,
-    sections.map((s) => s.text),
-  );
+  const vectors = await embedSectionsCached(config, sections);
 
-  const points = sections.map((section, i) => ({
-    id: pointIdForSection(section.article, section.ordinal),
-    vector: vectors[i]!,
-    payload: {
-      article: section.article,
-      ordinal: section.ordinal,
-      title: section.title,
-    },
-  }));
+  const points = sections.flatMap((section, i) => {
+    const vector = vectors[i];
+    if (!vector) return [];
+    return [
+      {
+        id: pointIdForSection(section.article, section.ordinal),
+        vector,
+        payload: {
+          article: section.article,
+          ordinal: section.ordinal,
+          title: section.title,
+        },
+      },
+    ];
+  });
+
+  if (points.length === 0) return;
 
   await getSectionDenseClient(config).upsert(SECTION_COLLECTION, {
     wait: true,
     points,
   });
+}
+
+/**
+ * Resolve a dense vector per section, reusing cached vectors for sections whose
+ * `text` is unchanged and embedding only the misses in a single batched backend
+ * call. Returns one entry per input section, index-aligned; a position is left
+ * `undefined` only when a fresh embed produced no vector for it.
+ *
+ * The cache lives in the shared `memory_embeddings` table keyed on
+ * `(targetType="v3_section", targetId="<article>#<ordinal>", provider, model)`.
+ * It survives the `deleteSectionsForArticle` callers run before upserting (that
+ * delete clears only Qdrant points), so an unchanged section rebuilds its point
+ * from the cache without a backend round-trip. Vectors are stored and upserted
+ * raw — the section dense lane applies no anisotropy correction, so the cached
+ * vector equals the upserted one.
+ */
+async function embedSectionsCached(
+  config: AssistantConfig,
+  sections: Section[],
+): Promise<Array<number[] | undefined>> {
+  const expectedDim = config.memory.qdrant.vectorSize;
+  const hashes = sections.map((s) =>
+    embeddingInputContentHash({ type: "text", text: s.text }),
+  );
+
+  // Cache identity: read rows under the currently-selected provider/model. When
+  // no provider resolves (backend down/disabled) skip the cache and let the
+  // batched embed below surface the failure exactly as the uncached path did.
+  const status = await getMemoryBackendStatus(config);
+  const db = getDb();
+
+  const result: Array<number[] | undefined> = new Array(sections.length);
+  const missIndices: number[] = [];
+  if (status.provider && status.model) {
+    for (let i = 0; i < sections.length; i++) {
+      const section = sections[i]!;
+      const cached = readEmbeddingCache(db, {
+        targetType: V3_SECTION_TARGET_TYPE,
+        targetId: sectionCacheId(section.article, section.ordinal),
+        provider: status.provider,
+        model: status.model,
+        expectedDim,
+      });
+      if (cached && cached.contentHash === hashes[i]) {
+        result[i] = cached.dense;
+      } else {
+        missIndices.push(i);
+      }
+    }
+  } else {
+    for (let i = 0; i < sections.length; i++) missIndices.push(i);
+  }
+
+  if (missIndices.length === 0) return result;
+
+  // Embed the misses in one batched call (the dominant cost).
+  let embedded = await embedWithBackend(
+    config,
+    missIndices.map((i) => sections[i]!.text),
+  );
+  let writeProvider = embedded.provider;
+  let writeModel = embedded.model;
+  let effectiveIndices = missIndices;
+
+  // A provider/model rotation between the cache read and the embed would mix two
+  // embedding spaces in one collection: cached hits carry the old identity, the
+  // fresh misses the new. Re-embed every section under the new identity so the
+  // whole batch (and the cache rows it writes) shares one space.
+  const hadHits = missIndices.length < sections.length;
+  const rotated =
+    hadHits &&
+    (embedded.provider !== status.provider || embedded.model !== status.model);
+  if (rotated) {
+    effectiveIndices = sections.map((_, i) => i);
+    embedded = await embedWithBackend(
+      config,
+      sections.map((s) => s.text),
+    );
+    writeProvider = embedded.provider;
+    writeModel = embedded.model;
+  }
+
+  const now = Date.now();
+  for (let j = 0; j < effectiveIndices.length; j++) {
+    const i = effectiveIndices[j]!;
+    const vector = embedded.vectors[j];
+    if (!vector) continue;
+    result[i] = vector;
+    const section = sections[i]!;
+    writeEmbeddingCache(db, {
+      targetType: V3_SECTION_TARGET_TYPE,
+      targetId: sectionCacheId(section.article, section.ordinal),
+      dense: vector,
+      contentHash: hashes[i]!,
+      provider: writeProvider,
+      model: writeModel,
+      now,
+    });
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

- The v3 section dense store (`upsertSections` in `memory-v3-shadow/section-dense-store.ts`) re-embedded **every** section it was handed, with no dedup — unlike the v2 `embed_concept_page` path, which content-hash-caches in `memory_embeddings`. Any maintain pass that re-selected an already-embedded page (mtime churn, a stuck high-water mark, a full backfill, capability reconcile) paid the full embedding cost again, driving a Gemini embedding-call spike.
- Add a per-section cache keyed on `(targetType="v3_section", targetId="<article>#<ordinal>", provider, model)` in the existing `memory_embeddings` table. `upsertSections` now embeds only sections whose `text` changed and rebuilds the rest from cache. The cache lives in SQLite, so it survives the `deleteSectionsForArticle` callers run before upserting (that delete clears only Qdrant points).
- Factor the generic cache read/write into `memory/embedding-cache.ts` for reuse. (The v2 job keeps its own copy for now; migrating it onto the shared helper is a follow-up.)
- Edge cases handled: a provider/model rotation between the cache read and the embed re-embeds the whole batch under one identity (no mixed embedding spaces in the collection); a backend-down / no-provider state falls back to the prior uncached behavior. Vectors are stored and upserted raw (the section lane applies no anisotropy correction), so the cached vector equals the upserted one. No DB migration — new rows simply start appearing; the first post-deploy maintain pass seeds the cache.

## Original prompt

Investigating a spike in Gemini embedding calls attributed to memory v3, asking when v3 re-embeds skills, CLI pages, and concept pages, and whether we're re-embedding things we shouldn't. We traced it to the v3 section dense store having no content-hash guard (the v2 concept-page path already has one), so it re-embeds on mtime-delta / missing-row rather than on actual content change. This PR adds the same per-section content-hash cache the v2 path has, so v3 only re-embeds genuinely-changed sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)