### PR TITLE
fix(assistant): stop weak title models from leaking reasoning into conversation titles

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -1,15 +1,45 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const mockRunBtwSidechain = mock(async (_params: Record<string, unknown>) => ({
-  text: "Project kickoff",
-  hadTextDeltas: true,
-  response: {
-    content: [{ type: "text", text: "Project kickoff" }],
+const TITLE_TOOL_NAME = "record_conversation_title";
+
+/** A forced-tool response: the model called `record_conversation_title`. */
+function toolResponse(title: string) {
+  return {
+    content: [
+      {
+        type: "tool_use",
+        id: "toolu_title",
+        name: TITLE_TOOL_NAME,
+        input: { title },
+      },
+    ],
+    model: "test-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "tool_use",
+  };
+}
+
+/** A plain-text response: the model ignored the forced tool and emitted text. */
+function textResponse(text: string) {
+  return {
+    content: [{ type: "text", text }],
     model: "test-model",
     usage: { inputTokens: 10, outputTokens: 5 },
     stopReason: "end_turn",
-  },
-}));
+  };
+}
+
+function makeProvider(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock returns
+  // partial ProviderResponse shapes; `any` keeps the stub assignable to Provider.
+  impl: (messages: any, options: any) => any = async () =>
+    toolResponse("Project kickoff"),
+) {
+  return {
+    name: "test-provider",
+    sendMessage: mock(impl),
+  };
+}
 
 const mockGetConversation = mock(
   (_conversationId: string) =>
@@ -29,21 +59,36 @@ const mockGetMessages = mock(() => [
 const mockUpdateConversationTitle = mock(() => {});
 const mockGetConfiguredProvider = mock(async () => null);
 
-mock.module("../runtime/btw-sidechain.js", () => ({
-  runBtwSidechain: mockRunBtwSidechain,
-}));
-
 mock.module("../memory/conversation-crud.js", () => ({
-    setConversationProcessingStartedAt: () => {},
-    isConversationProcessing: () => false,
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
   getConversation: mockGetConversation,
   getMessages: mockGetMessages,
   updateConversationTitle: mockUpdateConversationTitle,
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 
+// The title service imports `getConfiguredProvider` plus the pure response
+// helpers (`createTimeout`, `userMessage`, `extractToolUse`, `extractAllText`)
+// from this module. Replacing the module means we must re-provide working
+// implementations of those helpers — they are stubbed here to mirror the real
+// behavior the service depends on.
 mock.module("../providers/provider-send-message.js", () => ({
   getConfiguredProvider: mockGetConfiguredProvider,
+  createTimeout: () => ({
+    signal: new AbortController().signal,
+    cleanup: () => {},
+  }),
+  userMessage: (text: string) => ({ role: "user", content: text }),
+  extractToolUse: (response: { content?: Array<{ type: string }> }) =>
+    response?.content?.find((b) => b.type === "tool_use"),
+  extractAllText: (response: {
+    content?: Array<{ type: string; text?: string }>;
+  }) =>
+    (response?.content ?? [])
+      .filter((b) => b.type === "text")
+      .map((b) => b.text ?? "")
+      .join(" "),
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -62,6 +107,7 @@ mock.module("../runtime/sync/resource-sync-events.js", () => ({
 
 import {
   AUTO_TITLE_DETERMINISTIC,
+  AUTO_TITLE_LLM,
   generateAndPersistConversationTitle,
   queueGenerateConversationTitle,
   regenerateConversationTitle,
@@ -70,19 +116,6 @@ import {
 
 describe("conversation-title-service", () => {
   beforeEach(() => {
-    mockRunBtwSidechain.mockClear();
-    mockRunBtwSidechain.mockImplementation(
-      async (_params: Record<string, unknown>) => ({
-        text: "Project kickoff",
-        hadTextDeltas: true,
-        response: {
-          content: [{ type: "text", text: "Project kickoff" }],
-          model: "test-model",
-          usage: { inputTokens: 10, outputTokens: 5 },
-          stopReason: "end_turn",
-        },
-      }),
-    );
     mockGetConversation.mockClear();
     mockGetConversation.mockImplementation(
       (_conversationId: string) =>
@@ -106,13 +139,8 @@ describe("conversation-title-service", () => {
     mockPublishConversationTitleChanged.mockClear();
   });
 
-  test("uses the BTW side-chain helper for initial title generation", async () => {
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("provider.sendMessage should not be called directly");
-      }),
-    };
+  test("forces the title tool and persists the extracted title", async () => {
+    const provider = makeProvider();
 
     const result = await generateAndPersistConversationTitle({
       conversationId: "conv-1",
@@ -121,20 +149,29 @@ describe("conversation-title-service", () => {
     });
 
     expect(result).toEqual({ title: "Project kickoff", updated: true });
-    expect(mockRunBtwSidechain).toHaveBeenCalledTimes(1);
-    expect(mockRunBtwSidechain).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider,
-        systemPrompt: expect.stringContaining("conversation titles"),
-        tools: [],
-        callSite: "conversationTitle",
-        timeoutMs: 15_000,
-      }),
-    );
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, options] = provider.sendMessage.mock.calls[0] as [
+      unknown,
+      {
+        tools: Array<{ name: string }>;
+        systemPrompt: string;
+        config: { callSite: string; tool_choice: unknown };
+      },
+    ];
+    expect(options.config.callSite).toBe("conversationTitle");
+    expect(options.config.tool_choice).toEqual({
+      type: "tool",
+      name: TITLE_TOOL_NAME,
+    });
+    expect(options.tools).toHaveLength(1);
+    expect(options.tools[0].name).toBe(TITLE_TOOL_NAME);
+    expect(options.systemPrompt).toContain("conversation titles");
+
     expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
       "conv-1",
       "Project kickoff",
-      1,
+      AUTO_TITLE_LLM,
     );
     // Emit is service-native: persisting a title broadcasts the update so
     // every title origin (agent loop, bootstrap, voice) updates clients live.
@@ -165,21 +202,15 @@ describe("conversation-title-service", () => {
       },
     ]);
 
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
+    const provider = makeProvider();
 
     await regenerateConversationTitle({ conversationId: "conv-1", provider });
 
-    // The prompt sent to the sidechain should contain plain text, not raw JSON
-    const prompt = (mockRunBtwSidechain.mock.calls[0] as any)?.[0]
+    // The prompt sent to the model should contain plain text, not raw JSON.
+    const prompt = (provider.sendMessage.mock.calls[0] as any)?.[0]?.[0]
       ?.content as string;
     expect(prompt).not.toContain('"type":"text"');
     expect(prompt).not.toContain('"type":"tool_use"');
-    // Tool metadata should NOT appear in the title prompt
     expect(prompt).not.toContain("Tool use");
     expect(prompt).not.toContain("web_search");
     expect(prompt).toContain("Help me plan the kickoff");
@@ -213,31 +244,20 @@ describe("conversation-title-service", () => {
       },
     ]);
 
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
+    const provider = makeProvider();
 
     await regenerateConversationTitle({ conversationId: "conv-1", provider });
 
-    const prompt = (mockRunBtwSidechain.mock.calls[0] as any)?.[0]
+    const prompt = (provider.sendMessage.mock.calls[0] as any)?.[0]?.[0]
       ?.content as string;
     expect(prompt).not.toContain('"type":"tool_result"');
-    // Tool-only assistant message should be skipped entirely
     expect(prompt).not.toContain("Tool use");
     expect(prompt).toContain("Search for restaurants");
     expect(prompt).toContain("Found 3 restaurants nearby");
   });
 
-  test("uses the BTW side-chain helper for title regeneration", async () => {
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("provider.sendMessage should not be called directly");
-      }),
-    };
+  test("forces the title tool for regeneration", async () => {
+    const provider = makeProvider();
 
     const result = await regenerateConversationTitle({
       conversationId: "conv-1",
@@ -245,20 +265,20 @@ describe("conversation-title-service", () => {
     });
 
     expect(result).toEqual({ title: "Project kickoff", updated: true });
-    expect(mockRunBtwSidechain).toHaveBeenCalledTimes(1);
-    expect(mockRunBtwSidechain).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider,
-        systemPrompt: expect.stringContaining("conversation titles"),
-        tools: [],
-        callSite: "conversationTitle",
-        timeoutMs: 15_000,
-      }),
-    );
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    const [, options] = provider.sendMessage.mock.calls[0] as [
+      unknown,
+      { config: { callSite: string; tool_choice: unknown } },
+    ];
+    expect(options.config.callSite).toBe("conversationTitle");
+    expect(options.config.tool_choice).toEqual({
+      type: "tool",
+      name: TITLE_TOOL_NAME,
+    });
     expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
       "conv-1",
       "Project kickoff",
-      1,
+      AUTO_TITLE_LLM,
     );
   });
 
@@ -268,12 +288,7 @@ describe("conversation-title-service", () => {
       isAutoTitle: 1,
     });
 
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
+    const provider = makeProvider();
 
     const result = await regenerateConversationTitle({
       conversationId: "conv-1",
@@ -282,28 +297,12 @@ describe("conversation-title-service", () => {
     });
 
     expect(result).toEqual({ title: "Project kickoff", updated: false });
-    expect(mockRunBtwSidechain).not.toHaveBeenCalled();
+    expect(provider.sendMessage).not.toHaveBeenCalled();
     expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
   });
 
   test("rejects meta-failure outputs like 'Missing Context' and uses fallback", async () => {
-    mockRunBtwSidechain.mockImplementationOnce(async () => ({
-      text: "Missing Context",
-      hadTextDeltas: true,
-      response: {
-        content: [{ type: "text", text: "Missing Context" }],
-        model: "test-model",
-        usage: { inputTokens: 10, outputTokens: 5 },
-        stopReason: "end_turn",
-      },
-    }));
-
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
+    const provider = makeProvider(async () => toolResponse("Missing Context"));
 
     const result = await generateAndPersistConversationTitle({
       conversationId: "conv-1",
@@ -327,28 +326,92 @@ describe("conversation-title-service", () => {
     "No Topic",
     "Empty Conversation",
   ])("rejects meta-failure variant: %s", async (bad) => {
-    mockRunBtwSidechain.mockImplementationOnce(async () => ({
-      text: bad,
-      hadTextDeltas: true,
-      response: {
-        content: [{ type: "text", text: bad }],
-        model: "test-model",
-        usage: { inputTokens: 10, outputTokens: 5 },
-        stopReason: "end_turn",
-      },
-    }));
-
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
+    const provider = makeProvider(async () => toolResponse(bad));
 
     const result = await generateAndPersistConversationTitle({
       conversationId: "conv-1",
       provider,
       userMessage: "something",
+    });
+
+    expect(result.title).toBe("Untitled Conversation");
+  });
+
+  // The core bug this PR fixes: weak title models emit their reasoning or
+  // continue the conversation, and that prose used to get persisted verbatim.
+  // These are real leaked titles observed in production.
+  test.each([
+    "I need to generate a",
+    "I'll work through these 22 files systematically.",
+    "The user wants a title",
+    "Let me look at the new results",
+    "Based on the conversation, this is about cooking.",
+    "Here is a title for the conversation",
+    "Sure, here's a good title",
+    "User: hey baby Assistant: hi",
+    "Knowledge base updated.\n\nGenerate a 2-6 word title",
+  ])("rejects leaked-prose title from the forced tool: %s", async (prose) => {
+    const provider = makeProvider(async () => toolResponse(prose));
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "hey baby",
+    });
+
+    expect(result.title).toBe("Untitled Conversation");
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "Untitled Conversation",
+      AUTO_TITLE_DETERMINISTIC,
+    );
+  });
+
+  test.each([
+    "Auth Middleware Rewrite",
+    "Docker Volume Mounts",
+    "Onboarding Flow",
+    "Morning Check-In",
+    "T-Shirt Discussion",
+  ])("accepts a clean noun-phrase title: %s", async (good) => {
+    const provider = makeProvider(async () => toolResponse(good));
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "x",
+    });
+
+    expect(result).toEqual({ title: good, updated: true });
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      good,
+      AUTO_TITLE_LLM,
+    );
+  });
+
+  test("falls back to response text when the model skips the forced tool", async () => {
+    // Provider returned plain text (forced tool ignored) with a compliant title.
+    const provider = makeProvider(async () => textResponse("Kickoff Planning"));
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "x",
+    });
+
+    expect(result).toEqual({ title: "Kickoff Planning", updated: true });
+  });
+
+  test("rejects prose in the text-fallback path", async () => {
+    const provider = makeProvider(async () =>
+      textResponse("I need to generate a title for this conversation"),
+    );
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "x",
     });
 
     expect(result.title).toBe("Untitled Conversation");
@@ -385,30 +448,20 @@ describe("conversation-title-service", () => {
       isAutoTitle: 1,
     });
 
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
+    const provider = makeProvider();
 
     const result = await regenerateConversationTitle({
       conversationId: "conv-1",
       provider,
     });
 
-    expect(mockRunBtwSidechain).not.toHaveBeenCalled();
+    expect(provider.sendMessage).not.toHaveBeenCalled();
     expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
     expect(result).toEqual({ title: "Existing Title", updated: false });
   });
 
   test("title prompt content does not contain generation instructions", async () => {
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("provider.sendMessage should not be called directly");
-      }),
-    };
+    const provider = makeProvider();
 
     await generateAndPersistConversationTitle({
       conversationId: "conv-1",
@@ -416,14 +469,15 @@ describe("conversation-title-service", () => {
       userMessage: "Help me plan the kickoff",
     });
 
-    const call = mockRunBtwSidechain.mock.calls[0]![0] as {
-      content: string;
-      systemPrompt: string;
-    };
-    // Instructions should be in systemPrompt, not in content
-    expect(call.content).not.toContain("Generate a very short title");
-    expect(call.content).not.toContain("do NOT respond");
-    expect(call.systemPrompt).toContain("Do NOT respond");
+    const [messages, options] = provider.sendMessage.mock.calls[0] as [
+      Array<{ content: string }>,
+      { systemPrompt: string },
+    ];
+    const content = messages[0].content;
+    // Instructions should be in systemPrompt, not in the user content.
+    expect(content).not.toContain("Generate a very short title");
+    expect(content).not.toContain("do NOT respond");
+    expect(options.systemPrompt).toContain("Do NOT respond");
   });
 
   test("queueGenerateConversationTitle serializes concurrent calls", async () => {
@@ -433,46 +487,20 @@ describe("conversation-title-service", () => {
       resolveFirst = r;
     });
 
-    // First call: blocks until we release it
-    mockRunBtwSidechain.mockImplementationOnce(async () => {
+    const provider = makeProvider();
+    // First call: blocks until released.
+    provider.sendMessage.mockImplementationOnce(async () => {
       callOrder.push("first:start");
       await firstBlocked;
       callOrder.push("first:end");
-      return {
-        text: "Title One",
-        hadTextDeltas: true,
-        response: {
-          content: [{ type: "text", text: "Title One" }],
-          model: "test-model",
-          usage: { inputTokens: 10, outputTokens: 5 },
-          stopReason: "end_turn",
-        },
-      };
+      return toolResponse("Title One");
     });
-
-    // Second call: resolves immediately
-    mockRunBtwSidechain.mockImplementationOnce(async () => {
+    // Second call: resolves immediately.
+    provider.sendMessage.mockImplementationOnce(async () => {
       callOrder.push("second:start");
-      return {
-        text: "Title Two",
-        hadTextDeltas: true,
-        response: {
-          content: [{ type: "text", text: "Title Two" }],
-          model: "test-model",
-          usage: { inputTokens: 10, outputTokens: 5 },
-          stopReason: "end_turn",
-        },
-      };
+      return toolResponse("Title Two");
     });
 
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
-
-    // Fire both calls — without serialization both would start immediately
     queueGenerateConversationTitle({
       conversationId: "conv-1",
       provider,
@@ -484,42 +512,26 @@ describe("conversation-title-service", () => {
       userMessage: "second message",
     });
 
-    // Let microtasks settle — only the first call should have started
+    // Let microtasks settle — only the first call should have started.
     await new Promise((r) => setTimeout(r, 10));
     expect(callOrder).toEqual(["first:start"]);
 
-    // Release the first call
     resolveFirst();
     await titleMutex.withLock(async () => {});
 
-    // Second should have started only after first finished
     expect(callOrder).toEqual(["first:start", "first:end", "second:start"]);
   });
 
   test("queue continues processing after a failed call", async () => {
-    // First call: throws
-    mockRunBtwSidechain.mockImplementationOnce(async () => {
+    const provider = makeProvider();
+    // First call: throws.
+    provider.sendMessage.mockImplementationOnce(async () => {
       throw new Error("provider timeout");
     });
-
-    // Second call: succeeds
-    mockRunBtwSidechain.mockImplementationOnce(async () => ({
-      text: "Recovery Title",
-      hadTextDeltas: true,
-      response: {
-        content: [{ type: "text", text: "Recovery Title" }],
-        model: "test-model",
-        usage: { inputTokens: 10, outputTokens: 5 },
-        stopReason: "end_turn",
-      },
-    }));
-
-    const provider = {
-      name: "test-provider",
-      sendMessage: mock(async () => {
-        throw new Error("should not call directly");
-      }),
-    };
+    // Second call: succeeds.
+    provider.sendMessage.mockImplementationOnce(async () =>
+      toolResponse("Recovery Title"),
+    );
 
     queueGenerateConversationTitle({
       conversationId: "conv-1",
@@ -534,8 +546,8 @@ describe("conversation-title-service", () => {
 
     await titleMutex.withLock(async () => {});
 
-    // Both calls went through — failure didn't break the chain
-    expect(mockRunBtwSidechain).toHaveBeenCalledTimes(2);
+    // Both calls went through — failure didn't break the chain.
+    expect(provider.sendMessage).toHaveBeenCalledTimes(2);
     const firstUpdate = (
       mockUpdateConversationTitle.mock.calls as unknown as Array<
         [string, string, number?]
@@ -546,7 +558,6 @@ describe("conversation-title-service", () => {
       "Untitled Conversation",
       AUTO_TITLE_DETERMINISTIC,
     ]);
-    // Second conversation got a proper title
     const secondUpdate = (
       mockUpdateConversationTitle.mock.calls as unknown as string[][]
     ).find((c) => c[0] === "conv-2" && c[1] === "Recovery Title");

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -7,9 +7,14 @@
  * overwritten, never user-provided custom titles.
  */
 
-import { getConfiguredProvider } from "../providers/provider-send-message.js";
-import type { Provider } from "../providers/types.js";
-import { runBtwSidechain } from "../runtime/btw-sidechain.js";
+import {
+  createTimeout,
+  extractAllText,
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage as buildUserMessage,
+} from "../providers/provider-send-message.js";
+import type { Provider, ToolDefinition } from "../providers/types.js";
 import { publishConversationTitleChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import { Mutex } from "../util/mutex.js";
@@ -171,16 +176,7 @@ export async function generateAndPersistConversationTitle(
   }
 
   const prompt = buildTitlePrompt(context, userMessage, assistantResponse);
-  const result = await runBtwSidechain({
-    content: prompt,
-    provider,
-    systemPrompt: buildTitleSystemPrompt(),
-    tools: [],
-    callSite: "conversationTitle",
-    signal,
-    timeoutMs: 15_000,
-  });
-  const title = normalizeTitle(result.text);
+  const title = await generateTitleViaLLM(provider, prompt, signal);
   if (title) {
     // Re-check replaceability before persisting (race guard)
     const current = getConversation(conversationId);
@@ -318,16 +314,7 @@ export async function regenerateConversationTitle(
   if (!/\n(?:User|Assistant): /.test(prompt)) {
     return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
   }
-  const result = await runBtwSidechain({
-    content: prompt,
-    provider,
-    systemPrompt: buildTitleSystemPrompt(),
-    tools: [],
-    callSite: "conversationTitle",
-    signal,
-    timeoutMs: 15_000,
-  });
-  const title = normalizeTitle(result.text);
+  const title = await generateTitleViaLLM(provider, prompt, signal);
   if (title) {
     // Re-check isAutoTitle before persisting (race guard against manual rename)
     const current = getConversation(conversationId);
@@ -394,6 +381,81 @@ function buildTitleSystemPrompt(): string {
     "- Do NOT assess feasibility or comment on capabilities",
     "- If input is sparse or references external context, extract a topic from the words that ARE present (e.g. 'so about that t-shirt...' → 'T-Shirt Discussion'). Never describe the absence, emptiness, or insufficiency of context — titles like 'Missing Context', 'Unclear Request', 'No Topic' are forbidden",
   ].join("\n");
+}
+
+const TITLE_TOOL_NAME = "record_conversation_title";
+
+/**
+ * Tool the title model is forced to call. Constraining the output to a single
+ * `title` argument keeps weak/fast models (e.g. Haiku-class title models) from
+ * "thinking aloud" or continuing the conversation in the response text —
+ * failure modes that otherwise get captured verbatim as the title
+ * (e.g. "I need to generate a…", "I'll work through these files…").
+ */
+function buildTitleTool(): ToolDefinition {
+  return {
+    name: TITLE_TOOL_NAME,
+    description:
+      "Record the conversation's title. Call this exactly once with a short noun phrase naming the TOPIC — never a sentence, a reply, or any preamble.",
+    input_schema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description:
+            "2–5 words, 40 characters max. A scannable sidebar label naming the topic (e.g. 'Auth Middleware Rewrite', 'Docker Volume Mounts'). No quotes, markdown, or trailing punctuation.",
+        },
+      },
+      required: ["title"],
+    },
+  };
+}
+
+/**
+ * Run the title LLM call with a forced tool so the model returns a structured
+ * `{ title }` rather than free text. Returns a normalized title, or "" when the
+ * model declines or misbehaves — callers fall back to a deterministic title.
+ *
+ * Forcing the tool is the primary guard against prose leakage; `normalizeTitle`
+ * is the backstop for the text-fallback path and for any provider that ignores
+ * forced `tool_choice`.
+ */
+async function generateTitleViaLLM(
+  provider: Provider,
+  prompt: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const { signal: timeoutSignal, cleanup } = createTimeout(15_000);
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
+  try {
+    const response = await provider.sendMessage([buildUserMessage(prompt)], {
+      tools: [buildTitleTool()],
+      systemPrompt: buildTitleSystemPrompt(),
+      config: {
+        max_tokens: 256,
+        callSite: "conversationTitle",
+        tool_choice: { type: "tool", name: TITLE_TOOL_NAME },
+        disableCache: true,
+      },
+      signal: combinedSignal,
+    });
+    const toolBlock = extractToolUse(response);
+    const titleInput = toolBlock?.input as { title?: unknown } | undefined;
+    if (
+      toolBlock?.name === TITLE_TOOL_NAME &&
+      typeof titleInput?.title === "string"
+    ) {
+      return normalizeTitle(titleInput.title);
+    }
+    // Provider ignored the forced tool (or the model emitted prose instead of
+    // calling it). Fall back to the response text — `normalizeTitle`'s prose
+    // guard rejects a ramble while keeping a compliant plain-text title.
+    return normalizeTitle(extractAllText(response));
+  } finally {
+    cleanup();
+  }
 }
 
 function buildTitlePrompt(
@@ -503,11 +565,76 @@ function truncateTitle(title: string): string {
 function normalizeTitle(raw: string): string {
   let title = raw.trim().replace(/^["']|["']$/g, "");
   title = stripMarkdown(title);
-  title = stripThinkingTags(title);
+  title = stripThinkingTags(title).trim();
+  if (!title) return "";
+  // Reject outputs that are the model reasoning aloud or continuing the
+  // conversation instead of naming it (e.g. "I need to generate a…", "I'll
+  // work through these files…"). Callers fall back to a deterministic title.
+  if (looksLikeLeakedProse(title)) {
+    return "";
+  }
   if (META_FAILURE_TITLES.has(title.toLowerCase())) {
     return "";
   }
   return truncateTitle(title);
+}
+
+/** Reasoning/sentence openers that never start a legitimate topic title. */
+const LEAKED_PROSE_PREFIXES = [
+  "i need to",
+  "i needed to",
+  "i should",
+  "i will",
+  "i'll",
+  "i can ",
+  "i can't",
+  "i cannot",
+  "i'm ",
+  "i am ",
+  "i've ",
+  "i have ",
+  "i'd ",
+  "i would",
+  "let me",
+  "looking at",
+  "based on",
+  "given the",
+  "to generate",
+  "to summarize",
+  "to title",
+  "the user",
+  "the conversation",
+  "this conversation",
+  "the assistant",
+  "the title",
+  "here's ",
+  "here is ",
+  "here are ",
+  "sure,",
+  "okay,",
+  "ok,",
+];
+
+/**
+ * Heuristic guard for title outputs that are clearly prose — the model
+ * reasoning aloud or replying to the conversation rather than naming it. A real
+ * title is a single-line short noun phrase, so we reject multi-line output,
+ * embedded transcript markers, leading reasoning openers, and sentence-shaped
+ * clauses. Deliberately tight: a false reject only costs a deterministic
+ * fallback title, while a false accept persists a broken one.
+ */
+function looksLikeLeakedProse(title: string): boolean {
+  if (/\n/.test(title)) return true;
+  if (/\b(?:user|assistant)\s*:/i.test(title)) return true;
+  const lower = title.toLowerCase();
+  if (LEAKED_PROSE_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return true;
+  }
+  // Sentence-shaped: terminal punctuation on a multi-word clause.
+  if (/[.?!]$/.test(title) && title.split(/\s+/).length > 5) {
+    return true;
+  }
+  return false;
 }
 
 /** Strip thinking tags so they don't bleed into generated titles. */


### PR DESCRIPTION
## Summary
- Conversation titles were sometimes the title model's own prose — "I need to generate a", "I'll work through these 22 files systematically", "The user wants a title" — captured verbatim (76 such titles in one live DB). The title path generated free text, and weak/fast title models (e.g. claude-haiku-4.5 via OpenRouter, thinking disabled) ignored the "output only the title" system prompt, reasoning aloud or continuing the conversation instead.
- `generateTitleViaLLM` now calls the provider with a forced `record_conversation_title` tool — the same forced-tool structured-output pattern used by `memory/v2/router.ts` and `notifications/decision-engine.ts` — so the model fills a `title` argument instead of free-texting. Replaces the `runBtwSidechain(..., tools: [])` free-text call in both the initial-generation and regeneration paths.
- Added a `looksLikeLeakedProse` backstop in `normalizeTitle` that rejects reasoning/continuation output (leading "I need to…/I'll…/The user…", transcript markers, multi-line, sentence-shaped clauses) and falls back to a clean deterministic title. Covers the text-fallback path and any provider that ignores forced `tool_choice`.

## Original prompt
The app showed a conversation titled "I need to generate a", and the title generator frequently produces these broken titles. Investigation found the title call resolves to a weak model (claude-haiku-4.5 via OpenRouter, thinking off) whose reasoning/continuation prose was persisted verbatim by the free-text title pipeline (76 occurrences in the live DB). The ask was to make title generation robust against weak models — chosen approach: forced-tool structured output plus a prose-rejection backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)