### PR TITLE
fix(memory): keep real module exports in v3 dense-lane test mocks

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/dense.test.ts
@@ -7,17 +7,28 @@ mock.module("../../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
+// Keep the real exports (e.g. getQdrantClient) so this partial mock is harmless
+// when section-dense-store's transitive imports pull them in; only
+// resolveQdrantUrl is pinned to a fixed URL.
+const realQdrantClient = await import("../../../../memory/qdrant-client.js");
 mock.module("../../../../memory/qdrant-client.js", () => ({
+  ...realQdrantClient,
   resolveQdrantUrl: () => "http://127.0.0.1:6333",
 }));
 
 // Stub the shared embedding backend. Records the queries it was asked to embed
 // and returns one deterministic vector so `denseLane` can issue the search.
+// Keep the real exports (e.g. generateSparseEmbedding) so this partial mock is
+// harmless when section-dense-store's transitive imports pull them in; only
+// embedWithBackend is replaced.
+const realEmbeddingBackend =
+  await import("../../../../memory/embedding-backend.js");
 const embedState = {
   calls: [] as string[][],
   throws: null as Error | null,
 };
 mock.module("../../../../memory/embedding-backend.js", () => ({
+  ...realEmbeddingBackend,
   embedWithBackend: async (_config: unknown, inputs: string[]) => {
     embedState.calls.push(inputs);
     if (embedState.throws) throw embedState.throws;


### PR DESCRIPTION
## Summary
- `dense.test.ts` replaced `embedding-backend.js` and `qdrant-client.js` wholesale, exporting only the one symbol each direct caller used (`embedWithBackend` / `resolveQdrantUrl`). #36235 added a `db-connection` + `embedding-cache` import chain to `section-dense-store.ts`, so loading the dense lane now transitively imports `generateSparseEmbedding` (via `job-utils`) and `getQdrantClient` — symbols the partial mocks omit — producing `SyntaxError: Export named 'generateSparseEmbedding' not found` and a red **Test** job on `main`.
- Fix: snapshot each real module with `await import()` and spread it into the mock factory, overriding only the stubbed symbol. This is the leak-safe pattern already used in `broadcaster.test.ts` / `conversation-surfaces-launch.test.ts`.
- Verified: reproduced the exact CI error running the file in isolation; all 7 dense-lane tests pass after the fix; `typecheck:fast` clean.

## Original prompt
Fix only the specific CI failure in the "Test" job of the "CI Main Assistant Checks" run on `main` (commit 97864fb) — `dense.test.ts` throwing `SyntaxError: Export named 'generateSparseEmbedding' not found in module embedding-backend.ts` — without changing anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)