### PR TITLE
feat(macos): title app with the assistant name; fix dev dock "Electron" label

### DIFF
--- a/clients/macos/scripts/prepare-electron-dev-app.ts
+++ b/clients/macos/scripts/prepare-electron-dev-app.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 const ROOT_DIR = path.resolve(import.meta.dir, "..");
@@ -15,6 +15,18 @@ const ELECTRON_INFO_PLIST = path.join(
   ELECTRON_APP,
   "Contents",
   "Info.plist",
+);
+
+// Sentinel marking that we've restarted the Dock for this patched bundle.
+// Lives in `dist/` but OUTSIDE `Electron.app/` so it doesn't disturb the
+// bundle's code signature. Wiped when `electron` is reinstalled (which resets
+// the plist to stock "Electron"), so the next prepare re-busts the Dock.
+const DOCK_BUST_MARKER = path.join(
+  ROOT_DIR,
+  "node_modules",
+  "electron",
+  "dist",
+  ".vellum-dock-busted",
 );
 
 // macOS keys notification authorization to the bundle identifier. The stock
@@ -105,6 +117,24 @@ if (changed || !isValidSignature()) {
       "[prepare-electron-dev-app] lsregister failed (continuing):",
       error instanceof Error ? error.message : error,
     );
+  }
+}
+
+// The Dock and Cmd-Tab read a bundle's label from `CFBundleName`, cached by
+// macOS keyed to the bundle path. The `lsregister -f` above re-registers the
+// bundle but does NOT evict the running Dock's in-memory label, so a bundle
+// first seen as the stock "Electron" keeps showing "Electron" even after its
+// plist is stamped to "Vellum Electron". Restarting the Dock forces it to
+// re-read the name. Done once per patched bundle (tracked by the marker, and
+// again whenever the plist actually changes) so routine `bun run dev` restarts
+// don't blink the Dock on every launch. Best-effort — never block the dev flow.
+if (changed || !existsSync(DOCK_BUST_MARKER)) {
+  try {
+    execFileSync("killall", ["Dock"], { stdio: "ignore" });
+    writeFileSync(DOCK_BUST_MARKER, "");
+  } catch {
+    // Dock not running, or `killall` unavailable — leave the marker absent so
+    // a later run retries.
   }
 }
 

--- a/clients/macos/src/main/about.ts
+++ b/clients/macos/src/main/about.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { AppVersionInfo } from "@vellumai/ipc-contract";
 
 import { RENDERER_BASE_PROD, getDevRendererBase } from "./app-config";
+import { getName, onNameChange } from "./identity";
 import { handle } from "./ipc";
 import { createWindow } from "./windows";
 
@@ -119,13 +120,13 @@ export const openAboutWindow = (): void => {
   void aboutWindow.loadURL(aboutWindowUrl());
 };
 
-let installed = false;
-export const installAbout = (): void => {
-  if (installed) return;
-  installed = true;
-
+// Seed the native About panel — which AppleScript and other tooling can
+// invoke independently of our menu. `applicationName` carries the active
+// assistant's name (e.g. "Aria") when the renderer has published one,
+// falling back to the brand name; everything else is build metadata.
+const applyAboutPanelOptions = (): void => {
   app.setAboutPanelOptions({
-    applicationName: APP_NAME,
+    applicationName: getName() ?? APP_NAME,
     applicationVersion: app.getVersion(),
     // The native panel renders `version` after an em-dash; the commit SHA
     // identifies the exact build.
@@ -133,6 +134,17 @@ export const installAbout = (): void => {
     copyright: COPYRIGHT(),
     website: WEBSITE,
   });
+};
+
+let installed = false;
+export const installAbout = (): void => {
+  if (installed) return;
+  installed = true;
+
+  applyAboutPanelOptions();
+  // Re-seed when the assistant name changes so the native panel tracks the
+  // live identity.
+  onNameChange(applyAboutPanelOptions);
 
   handle("vellum:app:versionInfo", z.tuple([]), () => getVersionInfo());
 

--- a/clients/macos/src/main/identity.ts
+++ b/clients/macos/src/main/identity.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+import { on } from "./ipc";
+
+/**
+ * Active assistant display name (e.g. "Aria"), published by the renderer
+ * over the `vellum:identity:name` channel.
+ *
+ * The renderer holds the identity — fetched from the daemon `/identity`
+ * endpoint into `useAssistantIdentityStore` — and is the source of truth;
+ * main owns only presentation. Subscribers apply the name to the surfaces a
+ * per-assistant identity can drive at runtime: the main window's title (which
+ * feeds the Window menu, the Cmd-` switcher, and Mission Control), the
+ * menu-bar (Tray) tooltip / header line, and the native About panel's
+ * application name. The Dock tile / Cmd-Tab label is deliberately NOT one of
+ * them — that comes from the bundle's `CFBundleName`, read once at launch.
+ *
+ * A blank name resets to `null` so those surfaces fall back to their defaults
+ * before the renderer has published an identity (or after it clears on
+ * sign-out / assistant switch).
+ */
+
+type NameListener = (name: string | null) => void;
+
+let currentName: string | null = null;
+const listeners = new Set<NameListener>();
+
+export const getName = (): string | null => currentName;
+
+/**
+ * Subscribe to name changes. Returns an unsubscribe function. The listener
+ * fires only on an actual change (the setter de-dupes), so a renderer that
+ * republishes the same name on every render doesn't thrash the title / tray.
+ */
+export const onNameChange = (listener: NameListener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+/**
+ * Update the published name and notify subscribers. Blank / whitespace-only
+ * values normalize to `null` (fall back to defaults). No-op when unchanged.
+ */
+export const setName = (name: string | null): void => {
+  const next = name?.trim() ? name.trim() : null;
+  if (next === currentName) return;
+  currentName = next;
+  for (const listener of listeners) listener(next);
+};
+
+const namePayloadSchema = z.tuple([z.string()]);
+
+/**
+ * Register the `vellum:identity:name` renderer→main channel. Fire-and-forget
+ * (`ipcRenderer.send`): a name republish has no return value, and a malformed
+ * payload should drop silently rather than surface in the renderer. Call once
+ * from `whenReady`, before the tray / main window / About install so their
+ * initial render can read any name already published during bootstrap.
+ */
+let installed = false;
+export const installIdentityIpc = (): void => {
+  if (installed) return;
+  installed = true;
+
+  on("vellum:identity:name", namePayloadSchema, ([name]) => {
+    setName(name);
+  });
+};
+
+// Test seam — exported only for unit-test setup so each test starts from a
+// known state. Production code never calls this.
+export const __resetForTesting = (): void => {
+  installed = false;
+  currentName = null;
+  listeners.clear();
+};

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -69,6 +69,7 @@ import { installNotifications } from "./notifications";
 import { installPermissionHandler } from "./permissions";
 import { installPermissionsService } from "./permissions-service";
 import { installPowerEvents } from "./power-events";
+import { installIdentityIpc } from "./identity";
 import { installConnectivityIpc, installStatusIpc } from "./status";
 import { installTextInsertionIpc } from "./textInsertion";
 import { installTray } from "./tray";
@@ -81,14 +82,19 @@ import { hardenedWebPreferences } from "./windows";
 // from the Swift `Vellum.app` / `Vellum Local.app` / `Vellum Dev.app`
 // installs the developer may also be running.
 //
-// Caveat: `app.setName()` does NOT change the Dock / Cmd-Tab label.
-// Those come from the running binary's `CFBundleName` — in dev the
-// binary is `node_modules/electron/dist/Electron.app`, so the Dock
-// says "Electron". That's cosmetic and acceptable for dev runs; the
-// userData split is what actually prevents collision with Swift
-// installs. Packaged builds get a real `productName` from
-// electron-builder, which writes `CFBundleName`, at which point
-// Dock / Cmd-Tab pick up the real name too.
+// Caveat: `app.setName()` does NOT change the Dock / Cmd-Tab label —
+// those come from the running binary's `CFBundleName`. In dev the binary
+// is `node_modules/electron/dist/Electron.app`, whose `CFBundleName` is
+// stamped to "Vellum Electron" by `scripts/prepare-electron-dev-app.ts`
+// (which also busts the macOS Dock display-name cache so the relabel
+// actually surfaces instead of the stale stock "Electron"). The userData
+// split is what prevents collision with Swift installs. Packaged builds
+// get a real `productName` from electron-builder, which writes
+// `CFBundleName`, so Dock / Cmd-Tab pick up the real name there too. The
+// per-assistant name (e.g. "Aria") can't ride the Dock tile — it isn't
+// known at launch and `CFBundleName` is read once — so it drives the
+// window title, the menu-bar tray, and the About panel instead (see
+// `./identity`).
 //
 // Gated on `!app.isPackaged` so a packaged build keeps its
 // electron-builder-derived `CFBundleName` instead of being overridden
@@ -397,6 +403,10 @@ app
     installLoginItemIpc();
     installHotkeyHelper();
     installPermissionsService();
+    // Register the identity (assistant name) channel before About, the Tray,
+    // and the main window install so their initial render reflects any name
+    // the renderer publishes during bootstrap.
+    installIdentityIpc();
     installAbout();
     installAutoUpdate();
     installFeedbackIpc();

--- a/clients/macos/src/main/main-window.ts
+++ b/clients/macos/src/main/main-window.ts
@@ -5,6 +5,7 @@ import { getRendererRootUrl } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin";
 import { decideNavigation } from "./auth-nav";
 import { type VellumCommand } from "./commands";
+import { getName, onNameChange } from "./identity";
 import { handle } from "./ipc";
 import { createWindow } from "./windows";
 import {
@@ -36,6 +37,14 @@ const MAIN_DEFAULT_STATE = "maximized";
 // be dragged below this — unlike the compact onboarding floor, this is the
 // roomy desktop floor the chat layout (sidebar rail + content) needs.
 const MAIN_MIN_SIZE = { width: 800, height: 600 } as const;
+
+// Fallback main-window title before the renderer publishes the assistant's
+// name (and after it clears on sign-out / assistant switch). The live name —
+// e.g. "Aria" — replaces this and drives the Window menu, the Cmd-`
+// switcher, and Mission Control. `titleBarStyle: "hidden"` means it isn't
+// painted in a title bar, but the OS-level NSWindow title still feeds those
+// surfaces.
+const DEFAULT_WINDOW_TITLE = "Vellum";
 
 // macOS traffic-light (window controls) position for the main-app layout.
 //
@@ -230,6 +239,15 @@ const createMainWindow = (): BrowserWindow => {
     browserWindow: { ...sizing, titleBarStyle: "hidden", show: false },
     navigation: { installGuard: installSameOriginNavigationGuard },
   });
+
+  // Main owns the window title (the active assistant's name). Block the
+  // renderer's static `<title>` ("Vellum Assistant") from overriding it via
+  // page-title updates, then seed the current name — `installMainWindow`'s
+  // `onNameChange` subscription keeps it live as identity loads or changes.
+  win.webContents.on("page-title-updated", (event) => {
+    event.preventDefault();
+  });
+  win.setTitle(getName() ?? DEFAULT_WINDOW_TITLE);
 
   // Line the macOS traffic lights up with the renderer's inline title bar for
   // the main app; the compact onboarding / auth window keeps the system
@@ -470,6 +488,17 @@ export const installMainWindow = (): void => {
       setOnboarding(active);
     },
   );
+
+  // Keep the (recreatable) main window's title in sync with the assistant
+  // name. `createMainWindow` seeds the title on creation; this updates the
+  // live window when the renderer publishes a new identity. Reads the
+  // module-scope `mainWindow` at call time so it always targets the current
+  // instance after a recreate.
+  onNameChange((name) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.setTitle(name ?? DEFAULT_WINDOW_TITLE);
+    }
+  });
 
   void ensureVisible();
 };

--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -13,6 +13,7 @@ import {
 } from "./assets/menu-icons";
 import { onAvatarChange } from "./avatar";
 import { acceleratorOption } from "./commands";
+import { getName, onNameChange } from "./identity";
 import { getWatchedLockfile } from "./lockfile-watcher";
 import { dispatchToMain } from "./main-window";
 import { menuIcon } from "./menu-icon";
@@ -120,7 +121,7 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
     {
       // Status line, matching the Swift status menu's header. Disabled so
       // it reads as a label, not an action.
-      label: statusMenuTitle(status),
+      label: statusMenuTitle(status, getName() ?? undefined),
       enabled: false,
     },
   ];
@@ -357,7 +358,7 @@ const applyStatus = (status: AssistantStatus): void => {
   if (!tray) return;
 
   stopPulse();
-  tray.setToolTip(statusMenuTitle(status));
+  tray.setToolTip(statusMenuTitle(status, getName() ?? undefined));
 
   const frames = statusFrames(status);
   tray.setImage(frames[0]!);
@@ -419,6 +420,11 @@ export const installTray = (handlers: TrayHandlers): void => {
   applyStatus(initialStatus);
   const unsubscribeStatus = onStatusChange(applyStatus);
   const unsubscribeAvatar = onAvatarChange(refreshIcon);
+  // Refresh the tooltip when the assistant name changes so a name arriving
+  // after the last status change (e.g. on first identity load) updates the
+  // menu-bar hover text. The right-click menu reads the name lazily at pop
+  // time (see below), so it needs no subscription.
+  const unsubscribeName = onNameChange(() => applyStatus(getStatus()));
   nativeTheme.on("updated", refreshIcon);
 
   // Explicit destroy on quit. In production the OS releases the
@@ -430,6 +436,7 @@ export const installTray = (handlers: TrayHandlers): void => {
     stopPulse();
     unsubscribeStatus();
     unsubscribeAvatar();
+    unsubscribeName();
     nativeTheme.removeListener("updated", refreshIcon);
     trayInstance?.destroy();
     trayInstance = null;

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -266,6 +266,11 @@ const bridge: VellumBridge = {
       ipcRenderer.send("vellum:status:connection", status);
     },
   },
+  identity: {
+    setName: (name: string): void => {
+      ipcRenderer.send("vellum:identity:name", name);
+    },
+  },
   icon: {
     setAvatar: (png: Uint8Array | null): void => {
       ipcRenderer.send("vellum:icon:setAvatar", png);

--- a/clients/web/src/hooks/use-electron-identity-sync.ts
+++ b/clients/web/src/hooks/use-electron-identity-sync.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+
+import { setAssistantName } from "@/runtime/identity";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+/**
+ * Publish the active assistant's display name to the Electron host so the main
+ * process can title the window (Window menu, Cmd-` switcher, Mission Control),
+ * the menu-bar (Tray) tooltip / header, and the native About panel with the
+ * assistant's name (e.g. "Aria"). `setAssistantName` no-ops on non-Electron
+ * hosts (see `@/runtime/identity`), so this hook is safe to mount
+ * unconditionally.
+ *
+ * The renderer's `useAssistantIdentityStore` is the source of truth — hydrated
+ * by `useAssistantIdentityInit` from the daemon `/identity` endpoint, SSE
+ * `identity_changed`, and the optimistic onboarding seed; main owns only the
+ * presentation and de-dupes republished values. Publishing `""` when the name
+ * clears lets main fall back to its defaults.
+ *
+ * Mounted in `RootLayout` (alongside the favicon / icon / status sync) rather
+ * than the chat layout so the name tracks every authenticated route, not only
+ * while chat is on screen.
+ */
+export function useElectronIdentitySync(): void {
+  const name = useAssistantIdentityStore.use.name();
+
+  useEffect(() => {
+    setAssistantName(name ?? "");
+  }, [name]);
+}

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -41,6 +41,7 @@ import { useViewerStore } from "@/stores/viewer-store";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
+import { useElectronIdentitySync } from "@/hooks/use-electron-identity-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { isElectron } from "@/runtime/is-electron";
@@ -138,6 +139,7 @@ export function RootLayout() {
   // the live connection status to the menu-bar dot. Both no-op off Electron.
   useElectronIconSync(avatar.customImageUrl, avatar.components, avatar.traits);
   useElectronStatusSync();
+  useElectronIdentitySync();
   useElectronFeatureFlagBridge();
 
   // Size the Electron main window to the onboarding layout (440×630

--- a/clients/web/src/runtime/identity.ts
+++ b/clients/web/src/runtime/identity.ts
@@ -1,0 +1,21 @@
+import { isElectron } from "@/runtime/is-electron";
+
+/**
+ * Per-capability wrapper for publishing the active assistant's display name
+ * (e.g. "Aria") to the Electron host. Matches the `runtime/status.ts`
+ * pattern: the renderer never touches `window.vellum.*` directly — feature
+ * code calls this named function and the cross-platform branch lives here.
+ *
+ * The renderer holds the identity (`useAssistantIdentityStore`, fed by the
+ * daemon `/identity` fetch + SSE `identity_changed`) and is the source of
+ * truth; main owns only the presentation — the window title, the menu-bar
+ * (Tray) tooltip / header, and the native About panel. Publish a blank string
+ * to clear, at which point main falls back to the brand name. Fire-and-forget
+ * — no acknowledgement.
+ *
+ * Safe to call from any host — no-op off Electron.
+ */
+export function setAssistantName(name: string): void {
+  if (!isElectron()) return;
+  window.vellum?.identity?.setName(name);
+}

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -168,6 +168,9 @@ declare global {
       status?: {
         setConnection(status: AssistantStatus): void;
       };
+      identity?: {
+        setName(name: string): void;
+      };
       icon?: {
         setAvatar(png: Uint8Array | null): void;
       };

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -146,6 +146,9 @@ export interface VellumBridge {
   status: {
     setConnection(status: AssistantStatus): void;
   };
+  identity: {
+    setName(name: string): void;
+  };
   icon: {
     setAvatar(png: Uint8Array | null): void;
   };

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -51,6 +51,9 @@ export const COMMAND_EVENT = "vellum:command";
 // Status
 export const STATUS_CONNECTION = "vellum:status:connection";
 
+// Identity
+export const IDENTITY_NAME = "vellum:identity:name";
+
 // Icon / avatar
 export const ICON_SET_AVATAR = "vellum:icon:setAvatar";
 


### PR DESCRIPTION
## Summary

- Plumb the active assistant display name (e.g. "Aria") from the renderer identity store to the Electron main process over a new vellum:identity:name IPC channel (mirrors the existing STATUS_CONNECTION pattern), and apply it to the window title (Window menu, window switcher, Mission Control), the menu-bar tray tooltip and header, and the native About panel. Dynamic in dev and prod; the renderer wrapper no-ops off Electron and a blank name falls back to brand defaults.
- Fix the dev dock / app-switcher showing the stock "Electron": the prepare script already stamps CFBundleName to "Vellum Electron", but macOS caches the old display name, so restart the Dock once per patched bundle to surface the relabel.
- The dock tile cannot carry the per-assistant name (CFBundleName is read once at launch and is notarization-locked in packaged builds), so the assistant name drives the window title, tray, and About panel instead. Reuses the renderer identity store as the source of truth; no new server message.

## Original prompt

The dev macOS app showed up as "Electron" in the dock and should carry the assistant name. We established the dock tile itself cannot hold the per-assistant name — it comes from the bundle CFBundleName, which macOS reads once at launch and which is notarization-locked in packaged builds — so the assistant name is applied to the surfaces that can be dynamic (window switcher, menu-bar tray, About panel), and the dev dock is fixed to show the branded "Vellum Electron" instead of the stock "Electron" by busting the stale macOS Dock name cache.