### PR TITLE
fix(macos): restore tray and main-window tests after the identity import

### DIFF
--- a/clients/macos/src/main/main-window.test.ts
+++ b/clients/macos/src/main/main-window.test.ts
@@ -12,6 +12,7 @@ type StubWindow = {
   focus: ReturnType<typeof mock>;
   restore: ReturnType<typeof mock>;
   loadURL: ReturnType<typeof mock>;
+  setTitle: ReturnType<typeof mock>;
   isDestroyed: () => boolean;
   isMinimized: () => boolean;
   isVisible: () => boolean;
@@ -105,6 +106,7 @@ const makeWindow = (opts: Record<string, unknown> = {}): StubWindow => {
       state.minimized = false;
     }),
     loadURL: mock(() => Promise.resolve()),
+    setTitle: mock(() => undefined),
     isDestroyed: () => state.destroyed,
     isMinimized: () => state.minimized,
     isVisible: () => state.visible,

--- a/clients/macos/src/main/tray.test.ts
+++ b/clients/macos/src/main/tray.test.ts
@@ -167,6 +167,15 @@ mock.module("./status", () => ({
   PULSE_FRAME_INTERVAL_MS: 80,
 }));
 
+// Mock the identity module so `tray.ts`'s import of it doesn't pull in the
+// real `./ipc` → `electron` chain (the electron mock above omits `ipcMain`).
+// Mirrors the `./status` mock: the tray reads the name for its tooltip/header
+// and subscribes for live updates.
+mock.module("./identity", () => ({
+  getName: () => null,
+  onNameChange: () => () => undefined,
+}));
+
 const { installTray, __resetForTesting } = await import("./tray");
 
 const handlers = {


### PR DESCRIPTION
## Summary

- PR #36238 added an import of ./identity to tray.ts and main-window.ts, which transitively loads ./ipc and electron. Two unit tests broke because their mock setup did not account for the new dependency.
- tray.test.ts: its electron mock omits ipcMain (it mocks ./status to avoid the ipc chain), so the unmocked ./identity import loaded real electron and threw. Add a ./identity mock mirroring the existing ./status mock.
- main-window.test.ts: its BrowserWindow stub lacked setTitle, which createMainWindow now calls to title the window with the assistant name. Add setTitle to the stub.
- Test-only change. All five macos main-process test files pass individually (about, main-window, status, status-icon, tray).

## Original prompt

Fix-forward for the test regression introduced by #36238 (titling the app with the assistant name): the new ./identity import broke tray.test.ts and main-window.test.ts, which were green before. Restore them by updating the test mocks/stubs to account for the new dependency, without changing production behavior.