### PR TITLE
fix(web): publish assistant name on all routes; clear it on logout

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -11,7 +11,6 @@ import { Outlet, useLocation, useNavigate, useNavigationType } from "react-route
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useAssistantIdentityInit } from "@/hooks/use-assistant-identity-init";
 import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, getLocalNumber, setLocalBool, setLocalNumber } from "@/utils/local-settings";
 import { routes } from "@/utils/routes";
@@ -171,16 +170,6 @@ export function ChatLayout() {
       assistantId,
       conversationGroups,
     });
-
-  // Hydrate the sidebar assistant name at the layout level so the
-  // sidebar header shows the correct name on every chat-layout child
-  // route — not only inside a conversation where ChatPage owns the
-  // fetch.
-  useAssistantIdentityInit({
-    assistantId,
-    assistantStateKind,
-  });
-
 
   // Home page unread indicator — drives the red dot on the Home button in
   // the layout header.

--- a/clients/web/src/hooks/use-assistant-identity-init.ts
+++ b/clients/web/src/hooks/use-assistant-identity-init.ts
@@ -1,17 +1,17 @@
 /**
- * Initial assistant-identity hydration for the chat-layout sidebar.
+ * Hydrates the active assistant's identity (name + version) into the
+ * Zustand `useAssistantIdentityStore` for the whole authenticated app.
  *
- * The sidebar header (rendered by `ChatLayout`) shows the assistant's
- * name on every route under `/assistant/*` — chat, home, library,
- * contacts, identity. Its data lives in the Zustand
- * `useAssistantIdentityStore`.
+ * Mounted in `RootLayout` so identity is populated on every route under
+ * `/assistant/*` — chat, settings, logs — not only while a chat route is
+ * on screen. Consumers include the chat sidebar header, the
+ * intelligence/identity tab, and `useElectronIdentitySync` (which titles
+ * the Electron window, tray, and About panel from the store name).
  *
- * Without this hook, the store is hydrated only by `ChatPage`'s
- * identity fetch, so direct navigation to any non-chat route (or
- * navigating away from a conversation) leaves the sidebar header
- * showing the "Your Assistant" fallback. This hook fixes that by
- * fetching identity at the layout level so every sibling route
- * inherits a populated sidebar.
+ * Hydration sources, in order: the optimistic onboarding seed
+ * (`consumePendingAssistantName`), then the daemon `/identity` fetch via
+ * TanStack Query. SSE `identity_changed` refreshes are written to the
+ * store directly by `ChatPage` — idempotent with this hook.
  *
  * Lives in top-level `hooks/` (not under `domains/`) because the
  * assistant identity is consumed by multiple domains — chat sidebar,

--- a/clients/web/src/lib/auth/handle-logout.ts
+++ b/clients/web/src/lib/auth/handle-logout.ts
@@ -7,6 +7,7 @@ import {
   isLocalAssistant,
   isLocalMode,
 } from "@/lib/local-mode";
+import { setAssistantName } from "@/runtime/identity";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -25,6 +26,11 @@ export async function handleLogout(navigate: NavigateFunction): Promise<void> {
     navigate(getOnboardingEntrypoint());
   } else {
     await useAuthStore.getState().logout();
+    // Clear the published assistant name before the hard navigation. The hard
+    // nav replaces the page synchronously, so no React unmount cleanup runs;
+    // without this, Electron main keeps titling the signed-out window, tray,
+    // and About panel with the previous assistant's name. No-op off Electron.
+    setAssistantName("");
     hardNavigate(routes.account.login);
   }
 }

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -22,6 +22,7 @@ import { useVellumCommands } from "@/runtime/vellum-commands";
 
 import { routes } from "@/utils/routes";
 import { shouldSuppressRootStatusBanner } from "@/utils/status-banner-visibility";
+import { useAssistantIdentityInit } from "@/hooks/use-assistant-identity-init";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useBookmarksSync } from "@/hooks/use-bookmarks-sync";
@@ -119,6 +120,12 @@ export function RootLayout() {
     (s) => s.assistantState.kind,
   );
   const isAssistantActive = assistantStateKind === "active";
+  // Hydrate the assistant identity store (name + version) at the app root so
+  // the name is ready on every authenticated route — chat, settings, logs —
+  // and the Electron window title / tray / About panel (published below by
+  // useElectronIdentitySync) track it everywhere, not only on chat routes.
+  // No-ops until an assistant id resolves in a fetchable lifecycle state.
+  useAssistantIdentityInit({ assistantId, assistantStateKind });
   useAssistantFeatureFlagSync(assistantId);
   useAssistantResourceSync(assistantId, isAssistantActive);
   useConversationSync(assistantId, isAssistantActive);

--- a/clients/web/src/stores/assistant-identity-store.ts
+++ b/clients/web/src/stores/assistant-identity-store.ts
@@ -1,10 +1,10 @@
 /**
  * Zustand store for the active assistant's identity (name, version).
  *
- * `ChatLayout` writes via `useAssistantIdentityInit` (first load and
- * assistant-context changes) and reads name/version for the sidebar
- * header and `PreferencesMenu`. `ChatPage` also writes from its own
- * local state when the assistant pushes a fresher identity (SSE
+ * `RootLayout` writes via `useAssistantIdentityInit` (first load and
+ * assistant-context changes); `ChatLayout` reads name/version for the
+ * sidebar header and `PreferencesMenu`. `ChatPage` also writes from its
+ * own local state when the assistant pushes a fresher identity (SSE
  * `identity_changed`) — idempotent with the layout write.
  *
  * A Zustand store avoids prop drilling through the React Router


### PR DESCRIPTION
Addresses Codex feedback on #36238.

**Item 1 — hydrate identity before publishing the name.** `useElectronIdentitySync` (mounted in RootLayout) publishes `useAssistantIdentityStore.name` to the Electron host, but the store was hydrated only by `useAssistantIdentityInit` in ChatLayout. Settings/logs render outside ChatLayout, so a restore or deep-link to `/assistant/settings` or `/assistant/logs` left the store empty and published `""` (window title / tray / About stuck on the "Vellum" fallback until the user visited a chat route). Hoisted `useAssistantIdentityInit` into RootLayout (alongside `useElectronIdentitySync`) and removed the redundant ChatLayout call. The hook gates its query on an active/self_hosted assistant with a resolved id, so onboarding/login/select-assistant routes fire no spurious fetches; mounting once at the app root also removes the unmount/remount churn when navigating between chat and settings/logs.

**Item 2 — clear the Electron name on logout.** Platform logout calls `hardNavigate` (`location.replace`), which destroys the renderer synchronously before any React unmount cleanup runs, so Electron main kept the previous assistant's name on the signed-out window / tray / About. Added `setAssistantName("")` immediately before the hard navigation in `handleLogout` (no-op off Electron). The local-mode branches keep relying on the reactive store→sync path (their renderer survives), and the local-assistant-retained branch intentionally keeps the name since that assistant stays active.

Hook/store doc comments updated to reflect the RootLayout hydration location.