### PR TITLE
fix(memory): key v3 section embedding cache by gemini task/dimensions

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -262,7 +262,14 @@ function getCached(
   return backendCache.get(cacheKey(provider, model, extras));
 }
 
-function geminiCacheExtras(config: AssistantConfig): string[] {
+/**
+ * The Gemini embedding options that change the output vector for identical
+ * input — task type and output dimensionality — rendered as stable cache-key
+ * fragments. Empty for a default Gemini config and for every non-Gemini
+ * provider. Part of the in-memory vector-cache identity here, and reused by the
+ * v3 section dense store so its persistent cache shares the same identity.
+ */
+export function geminiCacheExtras(config: AssistantConfig): string[] {
   const extras: string[] = [];
   if (config.memory.embeddings.geminiTaskType) {
     extras.push(`task=${config.memory.embeddings.geminiTaskType}`);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
@@ -24,6 +24,12 @@ const embedState = {
   statusModel: "test-model" as string | null,
   embedProvider: "local",
   embedModel: "test-model",
+  // Gemini embedding options that change the vector for identical text. The
+  // mocked `geminiCacheExtras` renders these into cache-key fragments exactly
+  // as the production helper does, so a test can flip the task type and assert
+  // the section cache treats it as a miss.
+  geminiTaskType: undefined as string | undefined,
+  geminiDimensions: undefined as number | undefined,
 };
 mock.module("../../../../memory/embedding-backend.js", () => ({
   getMemoryBackendStatus: async () => ({
@@ -42,6 +48,16 @@ mock.module("../../../../memory/embedding-backend.js", () => ({
         Array.from({ length: embedState.dim }, (_v, j) => (i + 1) * (j + 1)),
       ),
     };
+  },
+  geminiCacheExtras: () => {
+    const extras: string[] = [];
+    if (embedState.geminiTaskType) {
+      extras.push(`task=${embedState.geminiTaskType}`);
+    }
+    if (embedState.geminiDimensions != null) {
+      extras.push(`dim=${embedState.geminiDimensions}`);
+    }
+    return extras;
   },
 }));
 
@@ -235,6 +251,8 @@ function resetState(): void {
   embedState.statusModel = "test-model";
   embedState.embedProvider = "local";
   embedState.embedModel = "test-model";
+  embedState.geminiTaskType = undefined;
+  embedState.geminiDimensions = undefined;
   cacheState.store.clear();
   cacheState.reads.length = 0;
   _resetSectionDenseStoreForTests();
@@ -548,6 +566,54 @@ describe("memory v3 section-dense-store — embedding cache", () => {
       ["one changed"],
       ["lead", "one changed"],
     ]);
+  });
+
+  test("a Gemini task-type change re-embeds unchanged text (cache miss)", async () => {
+    state.collectionExists = true;
+    embedState.statusProvider = "gemini";
+    embedState.statusModel = "gemini-embedding-2";
+    embedState.embedProvider = "gemini";
+    embedState.embedModel = "gemini-embedding-2";
+    embedState.geminiTaskType = "RETRIEVAL_DOCUMENT";
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "alice lead text"),
+    ]);
+    expect(embedState.calls).toHaveLength(1); // cold cache → embedded once
+
+    // Same text, same provider/model — but a different Gemini task type yields a
+    // different vector, so the row cached under the old task type must not be
+    // served. The extras are folded into the content hash, so the comparison
+    // misses and the section re-embeds under the new task type.
+    embedState.geminiTaskType = "SEMANTIC_SIMILARITY";
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "alice lead text"),
+    ]);
+
+    expect(embedState.calls).toEqual([
+      ["alice lead text"],
+      ["alice lead text"],
+    ]);
+  });
+
+  test("an unchanged Gemini task type still serves from cache (no spurious miss)", async () => {
+    state.collectionExists = true;
+    embedState.statusProvider = "gemini";
+    embedState.statusModel = "gemini-embedding-2";
+    embedState.embedProvider = "gemini";
+    embedState.embedModel = "gemini-embedding-2";
+    embedState.geminiTaskType = "RETRIEVAL_DOCUMENT";
+
+    const sections = [section("people/alice", 0, "alice lead text")];
+
+    await upsertSections(CONFIG, sections);
+    await upsertSections(CONFIG, sections);
+
+    // Folding the extras into the hash must not break ordinary hits: with the
+    // task type unchanged the second pass reuses the cached vector.
+    expect(embedState.calls).toHaveLength(1);
+    expect(state.upsertCalls).toHaveLength(2);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
@@ -19,6 +19,8 @@
 // shared Qdrant client; the read side (`dense.ts`) reuses that client to query
 // this collection.
 
+import { createHash } from "node:crypto";
+
 import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
 import { v5 as uuidv5 } from "uuid";
 
@@ -26,6 +28,7 @@ import type { AssistantConfig } from "../../../config/types.js";
 import { getDb } from "../../../memory/db-connection.js";
 import {
   embedWithBackend,
+  geminiCacheExtras,
   getMemoryBackendStatus,
 } from "../../../memory/embedding-backend.js";
 import {
@@ -188,6 +191,22 @@ function sectionCacheId(article: string, ordinal: number): string {
 }
 
 /**
+ * Content hash a section's cached vector is keyed by. Folds the provider's
+ * embedding-option extras (Gemini task type / output dimensions) into the base
+ * text hash, so changing an option that alters the vector for identical text is
+ * a cache miss that re-embeds. With no extras the bare text hash is returned
+ * unchanged, keeping existing rows valid for non-Gemini and default-Gemini
+ * configs.
+ */
+function sectionContentHash(text: string, extras: string[]): string {
+  const base = embeddingInputContentHash({ type: "text", text });
+  if (extras.length === 0) return base;
+  return createHash("sha256")
+    .update(`${base}\0${extras.join("\0")}`)
+    .digest("hex");
+}
+
+/**
  * Embed each section's `text` and upsert one point per section, keyed by a
  * deterministic `(article, ordinal)`-derived ID. Stable IDs mean re-upserting
  * the same sections overwrites in place rather than accumulating duplicates,
@@ -253,15 +272,18 @@ async function embedSectionsCached(
   sections: Section[],
 ): Promise<Array<number[] | undefined>> {
   const expectedDim = config.memory.qdrant.vectorSize;
-  const hashes = sections.map((s) =>
-    embeddingInputContentHash({ type: "text", text: s.text }),
-  );
 
   // Cache identity: read rows under the currently-selected provider/model. When
   // no provider resolves (backend down/disabled) skip the cache and let the
   // batched embed below surface the failure exactly as the uncached path did.
   const status = await getMemoryBackendStatus(config);
   const db = getDb();
+
+  // Only Gemini's options change the vector for identical text, so fold the
+  // extras into the cache identity only when Gemini is the resolved provider;
+  // other backends keep the bare text hash. See {@link sectionContentHash}.
+  const extras = status.provider === "gemini" ? geminiCacheExtras(config) : [];
+  const hashes = sections.map((s) => sectionContentHash(s.text, extras));
 
   const result: Array<number[] | undefined> = new Array(sections.length);
   const missIndices: number[] = [];


### PR DESCRIPTION
## Summary

The v3 section embedding cache (`embedSectionsCached` in `section-dense-store.ts`) keyed cached vectors on `(targetType, targetId, provider, model)` plus a **text-only** content hash, omitting the Gemini embedding options (`geminiTaskType` / `geminiDimensions`) that change the vector for identical text. The backend's own in-memory vector cache already folds these into its cache identity via `geminiCacheExtras`. The persistent section cache did not — so a task-type/dimension change while provider/model/vectorSize stayed the same would serve a **stale** vector (key matches, text unchanged → content hash matches), mixing embeddings generated under different Gemini settings in one Qdrant collection after a maintain/backfill pass.

## Fix

Fold the Gemini cache extras into the section cache identity so a task-type/dimensions change becomes a cache miss:

- Export `geminiCacheExtras` from `embedding-backend.ts` (single source of truth) and reuse it in `section-dense-store.ts` — no reimplementation.
- New `sectionContentHash(text, extras)` folds the extras into the base text hash and is applied **identically** on the read comparison and the write. Gated on the resolved provider being Gemini, so non-Gemini providers keep the bare `embeddingInputContentHash` output — the derived hash is byte-identical to today, no churn for local/OpenAI users.
- Backward compatible: existing Gemini rows under the bare key simply become misses after this change and re-embed correctly under the new identity.

## Tests

Extended `section-dense-store.test.ts`:
- A Gemini task-type change (text unchanged) forces a cache **miss** and re-embed.
- An unchanged Gemini task type still serves from cache (no spurious miss).

The `embedding-backend` mock now exports `geminiCacheExtras` driven by `embedState.geminiTaskType` / `geminiDimensions`.

Scoped tests + `typecheck:fast` green.

Addresses Codex feedback on #36235.