### PR TITLE
fix(memory): stub geminiCacheExtras in secret-boundary embedding mock

### DIFF
--- a/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
+++ b/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
@@ -123,6 +123,7 @@ mock.module("../memory/embedding-backend.js", () => ({
     model: "test",
     vectors: [],
   }),
+  geminiCacheExtras: () => [],
   generateSparseEmbedding: () => ({ indices: [], values: [] }),
   getMemoryBackendStatus: async () => ({
     enabled: false,


### PR DESCRIPTION
## Summary

- The `Test` job on `main` (CI Main Assistant Checks, run 28223678026 — the post-merge run for #36242) failed: `mcp-config-secret-boundary.test.ts` threw `SyntaxError: Export named 'geminiCacheExtras' not found in module 'embedding-backend.ts'` at link time.
- Root cause: #36242 added a `geminiCacheExtras` import to `section-dense-store.ts`. The test top-level `import`s `conversation-query-routes.js`, which transitively links `section-dense-store` against the test's hand-rolled partial `embedding-backend` mock — which did not export `geminiCacheExtras`.
- Fix: add a `geminiCacheExtras: () => []` stub to the mock (correct `string[]` return type; never invoked here since the mocked status reports `provider: null`).

## Original prompt

Fix only the specific CI failure in the `Test` job of CI Main Assistant Checks run 28223678026 (the post-merge `main` run for #36242). That job failed because `mcp-config-secret-boundary.test.ts` could not link `section-dense-store.ts`'s newly added `geminiCacheExtras` import against the test's partial `embedding-backend` mock.