### PR TITLE
feat(usage): cost a schedule run by cron_run_id, window as fallback

### DIFF
--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -11,6 +11,7 @@ import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   getUsageCostForConversationWindow,
+  getUsageCostForRun,
   recordUsageEvent,
 } from "../memory/llm-usage-store.js";
 import { BadRequestError } from "../runtime/routes/errors.js";
@@ -128,11 +129,13 @@ function recordCostAt(
   requestId: string,
   createdAt: number,
   estimatedCostUsd: number,
+  cronRunId?: string,
 ) {
   recordUsageEvent(
     {
       conversationId,
       runId: null,
+      cronRunId: cronRunId ?? null,
       requestId,
       actor: "main_agent",
       callSite: "mainAgent",
@@ -247,6 +250,45 @@ describe("usage routes", () => {
       });
 
       expect(total).toBeCloseTo(0.06);
+    });
+  });
+
+  describe("getUsageCostForRun", () => {
+    test("sums rows stamped with the run's cron_run_id even with a sentinel conversation_id", () => {
+      // Script-mode usage: stamped with cron_run_id; conversation_id is a real
+      // conversation distinct from the sentinel the run record carries.
+      recordCostAt("conv-real", "run-stamped-1", 5_000, 0.12, "run-1");
+      recordCostAt("conv-real", "run-stamped-2", 6_000, 0.08, "run-1");
+      // A different run's usage must not leak in.
+      recordCostAt("conv-real", "run-other", 5_500, 0.99, "run-2");
+
+      // The sentinel conversationId matches no real rows, so attribution is
+      // driven purely by cron_run_id.
+      const total = getUsageCostForRun({
+        cronRunId: "run-1",
+        conversationId: "script:job-1",
+        from: 5_000,
+        to: 6_000,
+      });
+
+      expect(total).toBeCloseTo(0.2);
+    });
+
+    test("falls back to the conversation + time-window for un-stamped legacy rows", () => {
+      // Legacy usage: null cron_run_id, attributed by conversation + window.
+      recordCostAt("conv-legacy", "legacy-before", 999, 0.5);
+      recordCostAt("conv-legacy", "legacy-start", 1_000, 0.01);
+      recordCostAt("conv-legacy", "legacy-end", 2_000, 0.03);
+      recordCostAt("conv-legacy", "legacy-after", 2_001, 0.75);
+
+      const total = getUsageCostForRun({
+        cronRunId: "run-legacy",
+        conversationId: "conv-legacy",
+        from: 1_000,
+        to: 2_000,
+      });
+
+      expect(total).toBeCloseTo(0.04);
     });
   });
 

--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -290,6 +290,22 @@ describe("usage routes", () => {
 
       expect(total).toBeCloseTo(0.04);
     });
+
+    test("excludes rows stamped for a different run that overlap this run's window", () => {
+      // A different firing's stamped row shares the conversation + window; it
+      // must not count here — only the unstamped legacy row does.
+      recordCostAt("conv-shared", "legacy-in-window", 1_500, 0.04);
+      recordCostAt("conv-shared", "other-run-in-window", 1_600, 0.5, "run-x");
+
+      const total = getUsageCostForRun({
+        cronRunId: "run-shared",
+        conversationId: "conv-shared",
+        from: 1_000,
+        to: 2_000,
+      });
+
+      expect(total).toBeCloseTo(0.04);
+    });
   });
 
   // -- query parsing / validation --

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -514,8 +514,9 @@ export function getUsageCostForRun({
   let predicate = "cron_run_id = ?1";
   const params: UsageQueryParam[] = [cronRunId];
   if (conversationId) {
+    // Fallback for unstamped legacy rows only; the stamp takes precedence.
     predicate +=
-      " OR (conversation_id = ?2 AND created_at >= ?3 AND created_at <= ?4)";
+      " OR (cron_run_id IS NULL AND conversation_id = ?2 AND created_at >= ?3 AND created_at <= ?4)";
     params.push(conversationId, from, to);
   }
   const rows = rawAll<{ total_cost: number | null }>(

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -494,6 +494,42 @@ export function getUsageCostForConversationWindow({
 }
 
 /**
+ * Cost a single schedule run, attributing usage by EITHER its exact
+ * `cron_run_id` stamp OR the legacy conversation + time-window fallback (for
+ * un-stamped rows). Script-mode runs carry a sentinel `conversationId` that
+ * matches no real rows, so they are costed purely by `cronRunId`; the window
+ * branch is included only when a real `conversationId` is supplied.
+ */
+export function getUsageCostForRun({
+  cronRunId,
+  conversationId,
+  from,
+  to,
+}: {
+  cronRunId: string;
+  conversationId?: string;
+  from: number;
+  to: number;
+}): number {
+  let predicate = "cron_run_id = ?1";
+  const params: UsageQueryParam[] = [cronRunId];
+  if (conversationId) {
+    predicate +=
+      " OR (conversation_id = ?2 AND created_at >= ?3 AND created_at <= ?4)";
+    params.push(conversationId, from, to);
+  }
+  const rows = rawAll<{ total_cost: number | null }>(
+    /*sql*/ `
+    SELECT COALESCE(SUM(estimated_cost_usd), 0) AS total_cost
+    FROM llm_usage_events
+    WHERE ${predicate}
+    `,
+    ...params,
+  );
+  return rows[0]?.total_cost ?? 0;
+}
+
+/**
  * Return the distinct conversation ids touched by a single cron firing,
  * identified by its `cron_run_id` stamp on the usage ledger. Rows with a null
  * `conversation_id` are excluded, and the result is deduped. Returns an empty

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -11,7 +11,7 @@ import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { bootstrapConversation } from "../../memory/conversation-bootstrap.js";
 import { getConversation } from "../../memory/conversation-crud.js";
-import { getUsageCostForConversationWindow } from "../../memory/llm-usage-store.js";
+import { getUsageCostForRun } from "../../memory/llm-usage-store.js";
 import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
 import {
   describeRRuleExpression,
@@ -565,13 +565,12 @@ function handleListScheduleRuns(
         conversationId: r.conversationId,
         conversationExists: conversation != null,
         conversationArchivedAt: conversation?.archivedAt ?? null,
-        estimatedCostUsd: r.conversationId
-          ? getUsageCostForConversationWindow({
-              conversationId: r.conversationId,
-              from: r.startedAt,
-              to: r.finishedAt ?? now,
-            })
-          : 0,
+        estimatedCostUsd: getUsageCostForRun({
+          cronRunId: r.id,
+          conversationId: r.conversationId ?? undefined,
+          from: r.startedAt,
+          to: r.finishedAt ?? now,
+        }),
         createdAt: r.createdAt,
       };
     }),


### PR DESCRIPTION
## Summary
- New `getUsageCostForRun({cronRunId, conversationId, from, to})` sums usage by exact `cron_run_id`, falling back to the legacy conversation+time-window for un-stamped rows.
- Runs list now costs each run via `getUsageCostForRun` — script-mode runs (sentinel conversationId) show real cost instead of $0.

Part of plan: script-schedule-cost-attribution.md (follow-on PR 9)