### PR TITLE
feat(schedule): hide script-created conversations from the main sidebar

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7492,6 +7492,12 @@ paths:
                     required:
                       - role
                       - content
+                conversationType:
+                  type: string
+                  enum:
+                    - standard
+                    - background
+                    - scheduled
       responses:
         "200":
           description: Successful response

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -100,6 +100,12 @@ async function createConversationCli(
   const messages = readSeedMessages(opts?.contentFile);
   if (process.exitCode) return;
 
+  // A script-mode schedule injects __SCHEDULE_RUN_ID into its env (see
+  // schedule/run-script.ts). When set, create the conversation as `scheduled`
+  // so script-mode runs are routed to the Scheduled section instead of
+  // cluttering the main sidebar.
+  const scheduleRunId = process.env.__SCHEDULE_RUN_ID;
+
   const result = await cliIpcCall<{
     id: string;
     title: string;
@@ -109,6 +115,7 @@ async function createConversationCli(
     body: {
       title,
       messages,
+      ...(scheduleRunId ? { conversationType: "scheduled" } : {}),
     },
   });
 

--- a/assistant/src/runtime/routes/conversation-cli-routes.ts
+++ b/assistant/src/runtime/routes/conversation-cli-routes.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { clearAllConversations as clearAllActive } from "../../daemon/handlers/conversations.js";
 import { formatJson, formatMarkdown } from "../../export/formatter.js";
 import { ipcCall as ipcCallGateway } from "../../ipc/gateway-client.js";
+import type { ConversationCreateType } from "../../memory/conversation-crud.js";
 import { isConversationProcessing } from "../../memory/conversation-crud.js";
 import {
   addMessage,
@@ -73,6 +74,12 @@ type SeededConversationMessage = z.infer<
   typeof seededConversationMessageSchema
 >;
 
+const conversationCreateTypeSchema = z.enum([
+  "standard",
+  "background",
+  "scheduled",
+]);
+
 function textContentJson(text: string): string {
   return JSON.stringify([{ type: "text", text }]);
 }
@@ -82,7 +89,20 @@ async function handleCreateCli({ body = {} }: RouteHandlerArgs) {
   const messages =
     (body.messages as SeededConversationMessage[] | undefined) ?? [];
 
-  const conversation = createConversation(title);
+  let conversationType: ConversationCreateType | undefined;
+  if (body.conversationType !== undefined) {
+    const parsed = conversationCreateTypeSchema.safeParse(
+      body.conversationType,
+    );
+    if (!parsed.success) {
+      throw new BadRequestError(
+        `Invalid conversationType: must be one of ${conversationCreateTypeSchema.options.join(", ")}`,
+      );
+    }
+    conversationType = parsed.data;
+  }
+
+  const conversation = createConversation({ title, conversationType });
   const conversationKey = uuid();
   setConversationKey(conversationKey, conversation.id);
 

--- a/assistant/src/runtime/routes/conversation-cli-routes.ts
+++ b/assistant/src/runtime/routes/conversation-cli-routes.ts
@@ -376,6 +376,7 @@ export const ROUTES: RouteDefinition[] = [
     requestBody: z.object({
       title: z.string().optional(),
       messages: z.array(seededConversationMessageSchema).optional(),
+      conversationType: conversationCreateTypeSchema.optional(),
     }),
     responseBody: z.object({
       id: z.string(),


### PR DESCRIPTION
## Summary
- `conversations new` creates the conversation as `scheduled` when `__SCHEDULE_RUN_ID` is set (env-read, no new flag), so script-mode runs don't clutter the main sidebar.
- `conversation_create_cli` handler now accepts + validates an optional `conversationType` and threads it to `createConversation`.

Part of plan: script-schedule-cost-attribution.md (follow-on PR 8)