### PR TITLE
feat(web): add new-thread-suggestions client feature flag (default off)

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -417,6 +417,14 @@
       "label": "OS Beta",
       "description": "Enable the OS Beta model profile (MiniMax M3 / Together) in the assistant's model profile selection.",
       "defaultEnabled": false
+    },
+    {
+      "id": "new-thread-suggestions",
+      "scope": "client",
+      "key": "new-thread-suggestions",
+      "label": "New-thread suggestions library",
+      "description": "Replace the empty-state conversation-starter chips with the scrollable, categorized suggestions library and detail drawer (currently mocked data).",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -417,6 +417,14 @@
       "label": "OS Beta",
       "description": "Enable the OS Beta model profile (MiniMax M3 / Together) in the assistant's model profile selection.",
       "defaultEnabled": false
+    },
+    {
+      "id": "new-thread-suggestions",
+      "scope": "client",
+      "key": "new-thread-suggestions",
+      "label": "New-thread suggestions library",
+      "description": "Replace the empty-state conversation-starter chips with the scrollable, categorized suggestions library and detail drawer (currently mocked data).",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `new-thread-suggestions` client-scope feature flag (default off) to the canonical registry and sync to the three bundled copies.

Part of plan: thread-suggestions-library.md (PR 1 of 10)