### PR TITLE
feat(web): add SuggestionCard (icon + title)

### DIFF
--- a/clients/web/src/domains/chat/components/suggestion-card.test.tsx
+++ b/clients/web/src/domains/chat/components/suggestion-card.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for `SuggestionCard`.
+ *
+ * Covers: rendering the suggestion title + its resolved icon (an svg), and
+ * invoking `onSelect` with the suggestion object on click. Real-DOM via
+ * happy-dom — the card is a plain button with no Radix portals.
+ */
+
+import { afterEach, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SuggestionCard } from "@/domains/chat/components/suggestion-card";
+import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+const suggestion: ThreadSuggestion = {
+  id: "email-helper",
+  title: "Email Helper",
+  iconKey: "gmail",
+  prompt: "Help me with my email.",
+  detail: {
+    heading: "Email Helper",
+    description: "Triage and draft replies.",
+    requirements: [],
+    capabilities: [],
+  },
+};
+
+test("renders the suggestion title and an icon", () => {
+  const { getByRole, container } = render(
+    <SuggestionCard suggestion={suggestion} onSelect={() => {}} />,
+  );
+
+  expect(getByRole("button").textContent).toContain("Email Helper");
+  expect(container.querySelector("svg")).not.toBeNull();
+});
+
+test("exposes an accessible label", () => {
+  const { getByRole } = render(
+    <SuggestionCard suggestion={suggestion} onSelect={() => {}} />,
+  );
+
+  expect(getByRole("button").getAttribute("aria-label")).toBe(
+    "Open suggestion: Email Helper",
+  );
+});
+
+test("invokes onSelect with the suggestion on click", () => {
+  const onSelect = mock((_: ThreadSuggestion) => {});
+  const { getByRole } = render(
+    <SuggestionCard suggestion={suggestion} onSelect={onSelect} />,
+  );
+
+  fireEvent.click(getByRole("button"));
+
+  expect(onSelect).toHaveBeenCalledTimes(1);
+  expect(onSelect).toHaveBeenCalledWith(suggestion);
+});

--- a/clients/web/src/domains/chat/components/suggestion-card.tsx
+++ b/clients/web/src/domains/chat/components/suggestion-card.tsx
@@ -1,0 +1,35 @@
+import { SuggestionIcon } from "@/domains/chat/suggestions/suggestion-icon";
+import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
+import { cn } from "@/utils/misc";
+
+/**
+ * A clickable card for the new-thread suggestions library: the suggestion's
+ * resolved icon centered above its title, on an elevated rounded surface.
+ * Selecting the card (click or keyboard) opens its detail drawer via
+ * `onSelect`.
+ */
+export interface SuggestionCardProps {
+  suggestion: ThreadSuggestion;
+  onSelect: (suggestion: ThreadSuggestion) => void;
+}
+
+export function SuggestionCard({ suggestion, onSelect }: SuggestionCardProps) {
+  return (
+    <button
+      type="button"
+      data-slot="suggestion-card"
+      aria-label={`Open suggestion: ${suggestion.title}`}
+      onClick={() => onSelect(suggestion)}
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 text-center",
+        "rounded-xl px-6 py-5",
+        "bg-[var(--surface-lift)] text-[color:var(--content-default)]",
+        "shadow-sm transition hover:-translate-y-0.5 hover:shadow-md",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary-base)] focus-visible:ring-offset-2",
+      )}
+    >
+      <SuggestionIcon iconKey={suggestion.iconKey} />
+      <span className="text-body-medium-default">{suggestion.title}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add SuggestionCard: a clickable icon+title card for the new-thread suggestions library.

Part of plan: thread-suggestions-library.md (PR 5 of 10)