### PR TITLE
feat(web): add useThreadSuggestions hook (mock-backed)

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-thread-suggestions.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-thread-suggestions.test.ts
@@ -1,0 +1,28 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { MOCK_SUGGESTION_GROUPS } from "@/domains/chat/suggestions/mock-suggestions";
+import { useThreadSuggestions } from "@/domains/chat/hooks/use-thread-suggestions";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useThreadSuggestions", () => {
+  test("returns 3 featured suggestions and the mock groups", () => {
+    const { result } = renderHook(() => useThreadSuggestions());
+
+    expect(result.current.featured).toHaveLength(3);
+    expect(result.current.groups.length).toBe(MOCK_SUGGESTION_GROUPS.length);
+    expect(result.current.groups).toBe(MOCK_SUGGESTION_GROUPS);
+  });
+
+  test("returns a stable reference across re-renders", () => {
+    const { result, rerender } = renderHook(() => useThreadSuggestions());
+
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-thread-suggestions.ts
+++ b/clients/web/src/domains/chat/hooks/use-thread-suggestions.ts
@@ -1,0 +1,34 @@
+/**
+ * Provides the new-thread suggestions library data behind a stable shape.
+ *
+ * The data is currently mocked: `featured` and `groups` come from
+ * {@link MOCK_SUGGESTION_GROUPS}. The result shape is intentionally stable so
+ * the source can later swap to a real query — installed plugins/skills plus a
+ * Vellum-curated source — without touching consumers.
+ */
+
+import { useMemo } from "react";
+
+import type {
+  SuggestionGroup,
+  ThreadSuggestion,
+} from "@/domains/chat/suggestions/types";
+import {
+  MOCK_SUGGESTION_GROUPS,
+  getFeaturedSuggestions,
+} from "@/domains/chat/suggestions/mock-suggestions";
+
+export interface UseThreadSuggestionsResult {
+  featured: ThreadSuggestion[];
+  groups: SuggestionGroup[];
+}
+
+export function useThreadSuggestions(): UseThreadSuggestionsResult {
+  return useMemo(
+    () => ({
+      featured: getFeaturedSuggestions(3),
+      groups: MOCK_SUGGESTION_GROUPS,
+    }),
+    [],
+  );
+}


### PR DESCRIPTION
## Summary
- Add useThreadSuggestions hook returning featured suggestions + groups from mock data behind a stable shape.

Part of plan: thread-suggestions-library.md (PR 8 of 10)