### PR TITLE
feat(web): add SuggestionLibrary (featured row, scroll affordance, groups)

### DIFF
--- a/clients/web/src/domains/chat/components/suggestion-library.test.tsx
+++ b/clients/web/src/domains/chat/components/suggestion-library.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for `SuggestionLibrary`.
+ *
+ * Covers: rendering the featured row cards, the "Scroll down to see more"
+ * affordance, each group's title heading and its cards, and that selecting a
+ * card forwards the suggestion to the library's `onSelect`. Fixtures use
+ * distinct titles so title assertions stay unambiguous.
+ */
+
+import { afterEach, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SuggestionLibrary } from "@/domains/chat/components/suggestion-library";
+import type {
+  SuggestionGroup,
+  ThreadSuggestion,
+} from "@/domains/chat/suggestions/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSuggestion(id: string, title: string): ThreadSuggestion {
+  return {
+    id,
+    title,
+    iconKey: "generic",
+    prompt: `Do ${title}.`,
+    detail: {
+      heading: title,
+      description: `About ${title}.`,
+      requirements: [],
+      capabilities: [],
+    },
+  };
+}
+
+const featured: ThreadSuggestion[] = [
+  makeSuggestion("featured-1", "Featured One"),
+  makeSuggestion("featured-2", "Featured Two"),
+];
+
+const groups: SuggestionGroup[] = [
+  {
+    id: "your-plugins",
+    title: "Your plugins",
+    source: "plugin",
+    suggestions: [
+      makeSuggestion("group-1", "Group One"),
+      makeSuggestion("group-2", "Group Two"),
+      makeSuggestion("group-3", "Group Three"),
+    ],
+  },
+];
+
+test("renders the featured cards", () => {
+  const { getByText } = render(
+    <SuggestionLibrary
+      featured={featured}
+      groups={groups}
+      onSelect={() => {}}
+    />,
+  );
+
+  expect(getByText("Featured One")).not.toBeNull();
+  expect(getByText("Featured Two")).not.toBeNull();
+});
+
+test("renders the scroll affordance", () => {
+  const { getByText } = render(
+    <SuggestionLibrary
+      featured={featured}
+      groups={groups}
+      onSelect={() => {}}
+    />,
+  );
+
+  expect(getByText("Scroll down to see more")).not.toBeNull();
+});
+
+test("renders each group title and its cards", () => {
+  const { getByText } = render(
+    <SuggestionLibrary
+      featured={featured}
+      groups={groups}
+      onSelect={() => {}}
+    />,
+  );
+
+  expect(getByText("Your plugins")).not.toBeNull();
+  expect(getByText("Group One")).not.toBeNull();
+  expect(getByText("Group Two")).not.toBeNull();
+  expect(getByText("Group Three")).not.toBeNull();
+});
+
+test("forwards onSelect with the suggestion when a card is clicked", () => {
+  const onSelect = mock((_: ThreadSuggestion) => {});
+  const { getByText } = render(
+    <SuggestionLibrary featured={featured} groups={groups} onSelect={onSelect} />,
+  );
+
+  fireEvent.click(getByText("Group Two"));
+
+  expect(onSelect).toHaveBeenCalledTimes(1);
+  expect(onSelect).toHaveBeenCalledWith(groups[0].suggestions[1]);
+});

--- a/clients/web/src/domains/chat/components/suggestion-library.tsx
+++ b/clients/web/src/domains/chat/components/suggestion-library.tsx
@@ -1,0 +1,65 @@
+import { ChevronDown } from "lucide-react";
+
+import { SuggestionCard } from "@/domains/chat/components/suggestion-card";
+import type {
+  SuggestionGroup,
+  ThreadSuggestion,
+} from "@/domains/chat/suggestions/types";
+
+/**
+ * The new-thread suggestions library: an always-visible featured row, a
+ * "scroll down to see more" affordance, and the full set of categorized
+ * groups below the fold. Layout-only — it does not own the outer scroll
+ * container; the empty-state scroll area provides that.
+ */
+export interface SuggestionLibraryProps {
+  /** The always-visible featured row (typically 3 cards). */
+  featured: ThreadSuggestion[];
+  /** Full categorized library shown below the featured row. */
+  groups: SuggestionGroup[];
+  onSelect: (suggestion: ThreadSuggestion) => void;
+}
+
+export function SuggestionLibrary({
+  featured,
+  groups,
+  onSelect,
+}: SuggestionLibraryProps) {
+  return (
+    <div data-slot="suggestion-library" className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {featured.map((suggestion) => (
+          <SuggestionCard
+            key={suggestion.id}
+            suggestion={suggestion}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-col items-center gap-1 text-[var(--content-tertiary)]">
+        <span className="text-label-small-default">
+          Scroll down to see more
+        </span>
+        <ChevronDown aria-hidden className="h-4 w-4" />
+      </div>
+
+      {groups.map((group) => (
+        <section key={group.id} className="flex flex-col gap-3">
+          <h3 className="text-title-small text-[var(--content-default)]">
+            {group.title}
+          </h3>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {group.suggestions.map((suggestion) => (
+              <SuggestionCard
+                key={suggestion.id}
+                suggestion={suggestion}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add SuggestionLibrary: featured 3-card row, 'Scroll down to see more' affordance, and category-grouped card sections for the new-thread empty state.

Part of plan: thread-suggestions-library.md (PR 7 of 10)