### PR TITLE
feat(web): show suggestions library on new-thread screen behind flag

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for `useChatEmptyState`'s `startersSlot` selection.
+ *
+ * The hook composes several other hooks (greeting, conversation-starters,
+ * thread-suggestions) and the client feature-flag store. We stub each of those
+ * via `mock.module` so the test stays focused on the slot-selection logic:
+ *
+ * - Flag OFF → the existing conversation-starter chips render (no regression).
+ * - Flag ON (empty conversation, no app-editing) → the new SuggestionLibrary
+ *   renders instead, and selecting a card maps the suggestion onto the
+ *   existing `onSelectStarter` path.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, renderHook } from "@testing-library/react";
+
+import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters";
+import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
+
+// --- Mocks ----------------------------------------------------------------
+
+const flagRef = { value: false };
+
+mock.module("@/stores/client-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    newThreadSuggestions: () => flagRef.value,
+  };
+  return { useClientFeatureFlagStore: store };
+});
+
+mock.module("@/domains/chat/hooks/use-empty-state-greeting", () => ({
+  useEmptyStateGreeting: () => ({ greeting: "Hi there", isGenerating: false }),
+}));
+
+const STARTER: ConversationStarter = {
+  id: "starter-1",
+  label: "Draft a plan",
+  prompt: "Draft a plan for me",
+  category: null,
+  batch: 0,
+};
+
+mock.module("@/domains/chat/hooks/use-conversation-starters", () => ({
+  useConversationStarters: () => ({ starters: [STARTER] }),
+}));
+
+const FEATURED: ThreadSuggestion = {
+  id: "sugg-1",
+  title: "Email Helper",
+  iconKey: "gmail",
+  prompt: "Help me triage my inbox",
+  detail: {
+    heading: "Email Helper",
+    description: "Triage your inbox.",
+    requirements: [],
+    capabilities: [],
+  },
+};
+
+mock.module("@/domains/chat/hooks/use-thread-suggestions", () => ({
+  useThreadSuggestions: () => ({ featured: [FEATURED], groups: [] }),
+}));
+
+import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
+import type { UseChatEmptyStateParams } from "@/domains/chat/hooks/use-chat-empty-state";
+
+function baseParams(
+  overrides: Partial<UseChatEmptyStateParams> = {},
+): UseChatEmptyStateParams {
+  return {
+    assistantId: "a1",
+    conversationId: "c1",
+    isEmptyConversation: true,
+    avatar: { components: null, traits: null, customImageUrl: null } as never,
+    mainView: "chat",
+    openedAppState: null,
+    isAssistantStreaming: false,
+    activeConversationIsProcessing: false,
+    onSelectStarter: () => {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  flagRef.value = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useChatEmptyState startersSlot", () => {
+  test("flag OFF renders the conversation-starter chips, not the library", () => {
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="suggestion-library"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
+    ).not.toBeNull();
+  });
+
+  test("flag ON renders the suggestion library on a fresh thread", () => {
+    flagRef.value = true;
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    const { container, getByText } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="suggestion-library"]'),
+    ).not.toBeNull();
+    expect(getByText(FEATURED.title)).toBeTruthy();
+  });
+
+  test("flag ON: selecting a card submits the suggestion's prompt via onSelectStarter", () => {
+    flagRef.value = true;
+    const selected: ConversationStarter[] = [];
+    const { result } = renderHook(() =>
+      useChatEmptyState(
+        baseParams({ onSelectStarter: (s) => selected.push(s) }),
+      ),
+    );
+
+    const { getByText } = render(<>{result.current.startersSlot}</>);
+    fireEvent.click(getByText(FEATURED.title));
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]).toEqual({
+      id: FEATURED.id,
+      label: FEATURED.title,
+      prompt: FEATURED.prompt,
+      category: null,
+      batch: 0,
+    });
+  });
+
+  test("flag ON but app-editing keeps the conversation-starter grid", () => {
+    flagRef.value = true;
+    const { result } = renderHook(() =>
+      useChatEmptyState(
+        baseParams({
+          mainView: "app-editing",
+          openedAppState: { name: "My App" },
+        }),
+      ),
+    );
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="suggestion-library"]'),
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -13,12 +13,15 @@ import { type ReactNode, useMemo } from "react";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { ChatEmptyStateProps } from "@/domains/chat/components/chat-empty-state";
 import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid";
+import { SuggestionLibrary } from "@/domains/chat/components/suggestion-library";
 import { useConversationStarters } from "@/domains/chat/hooks/use-conversation-starters";
 import { useEmptyStateGreeting } from "@/domains/chat/hooks/use-empty-state-greeting";
+import { useThreadSuggestions } from "@/domains/chat/hooks/use-thread-suggestions";
 import { buildEditAppGreeting, buildEditAppStarters } from "@/domains/chat/utils/edit-app-empty-state";
 import { pickRandomPlaceholder } from "@/domains/chat/utils/empty-state-constants";
 import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters";
 import type { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 // ---------------------------------------------------------------------------
 // Params & return type
@@ -63,6 +66,12 @@ export function useChatEmptyState({
 }: UseChatEmptyStateParams): ChatEmptyStateResult {
   const { components: avatarComponents, traits: avatarTraits, customImageUrl: avatarImageUrl } = avatar;
 
+  const newThreadSuggestionsEnabled =
+    useClientFeatureFlagStore.use.newThreadSuggestions();
+  // Cheap memoized hook — safe to call unconditionally; the result is only
+  // rendered on the flag-on path below.
+  const { featured, groups } = useThreadSuggestions();
+
   const emptyStatePlaceholder = useMemo(() => pickRandomPlaceholder(), []);
   const { greeting: emptyStateGreeting, isGenerating: greetingIsGenerating } =
     useEmptyStateGreeting({
@@ -102,15 +111,41 @@ export function useChatEmptyState({
     ? buildEditAppStarters(editingApp)
     : conversationStarters;
 
-  const startersSlot =
-    isEmptyConversation && emptyStateStarters.length > 0 ? (
+  // Behind the flag, the new suggestions library replaces the starter chips
+  // on a fresh thread. The app-editing override keeps its bespoke chips
+  // regardless of the flag, so it stays on the grid path.
+  const showSuggestionLibrary =
+    newThreadSuggestionsEnabled && isEmptyConversation && !editingApp;
+
+  let startersSlot: ReactNode | undefined;
+  if (showSuggestionLibrary) {
+    startersSlot = (
+      <div className="mt-4">
+        <SuggestionLibrary
+          featured={featured}
+          groups={groups}
+          onSelect={(s) =>
+            onSelectStarter({
+              id: s.id,
+              label: s.title,
+              prompt: s.prompt,
+              category: null,
+              batch: 0,
+            })
+          }
+        />
+      </div>
+    );
+  } else if (isEmptyConversation && emptyStateStarters.length > 0) {
+    startersSlot = (
       <div className="mt-4">
         <ConversationStarterGrid
           starters={emptyStateStarters}
           onSelect={onSelectStarter}
         />
       </div>
-    ) : undefined;
+    );
+  }
 
   // Stable callback so the latest-turn avatar slot isn't rebuilt on every
   // transcript render. Paired with `memo(ChatAvatar)`, the avatar


### PR DESCRIPTION
## Summary
- Behind the new-thread-suggestions flag, render the SuggestionLibrary in the chat empty state instead of the conversation-starter chips. Flag-off behavior is unchanged. Selecting a card submits its prompt via the existing path (detail drawer arrives in a follow-up).

Part of plan: thread-suggestions-library.md (PR 9 of 10)