### PR TITLE
feat(web): open suggestion detail drawer on card click

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.test.tsx
@@ -123,6 +123,7 @@ mock.module("motion/react", () => ({
 
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
 import { SuggestionDetailPanel } from "@/domains/chat/components/suggestion-detail-panel";
+import { useComposerStore } from "@/domains/chat/composer-store";
 import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
 
 // Harness mirroring ChatMainPanel's drawer wiring with the real components.
@@ -145,6 +146,9 @@ function Harness({ onSubmit }: { onSubmit: (prompt: string) => void }) {
   const handleClose = useCallback(() => setSelected(null), []);
   const handleConfirm = useCallback(
     (s: ThreadSuggestion) => {
+      // Mirror the production wiring: seed the composer before submitting so a
+      // blocked send leaves the prompt available to retry.
+      useComposerStore.getState().setInput(s.prompt);
       setSelected(null);
       onSubmit(s.prompt);
     },
@@ -208,6 +212,8 @@ describe("ChatMainPanel suggestion drawer wiring", () => {
     fireEvent.click(getByText("Let's do it!"));
 
     expect(submitted).toEqual([FEATURED.prompt]);
+    // The prompt is seeded into the composer so a blocked send is recoverable.
+    expect(useComposerStore.getState().input).toBe(FEATURED.prompt);
     expect(
       container.querySelector('[data-slot="suggestion-detail-panel"]'),
     ).toBeNull();

--- a/clients/web/src/domains/chat/components/chat-route-content.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.test.tsx
@@ -10,7 +10,9 @@
  *
  * - clicking a featured card opens the drawer with that suggestion's detail;
  * - "Let's do it!" submits the suggestion's prompt and closes the drawer;
- * - close / Save for Later dismiss the drawer without submitting.
+ * - close / Save for Later dismiss the drawer without submitting;
+ * - on mobile the detail opens in a `BottomSheet` (not the desktop drawer) and
+ *   still opens/confirms correctly.
  *
  * `motion/react` is mocked so the drawer mounts/unmounts synchronously instead
  * of depending on real animation timing (see active-subagents-overlay.test).
@@ -121,13 +123,23 @@ mock.module("motion/react", () => ({
   useReducedMotion: () => true,
 }));
 
+import { BottomSheet } from "@vellumai/design-library";
+
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
 import { SuggestionDetailPanel } from "@/domains/chat/components/suggestion-detail-panel";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
 
 // Harness mirroring ChatMainPanel's drawer wiring with the real components.
-function Harness({ onSubmit }: { onSubmit: (prompt: string) => void }) {
+// `isMobile` selects the same desktop-drawer vs mobile-sheet branch the
+// production component picks via `useIsMobile()`.
+function Harness({
+  onSubmit,
+  isMobile = false,
+}: {
+  onSubmit: (prompt: string) => void;
+  isMobile?: boolean;
+}) {
   const [selected, setSelected] = useState<ThreadSuggestion | null>(null);
 
   const { startersSlot } = useChatEmptyState({
@@ -156,20 +168,43 @@ function Harness({ onSubmit }: { onSubmit: (prompt: string) => void }) {
   );
   const handleSaveForLater = useCallback(() => setSelected(null), []);
 
+  const detailPanel = selected ? (
+    <SuggestionDetailPanel
+      suggestion={selected}
+      onClose={handleClose}
+      onConfirm={handleConfirm}
+      onSaveForLater={handleSaveForLater}
+    />
+  ) : null;
+
+  if (isMobile) {
+    return (
+      <>
+        <div>{startersSlot}</div>
+        <BottomSheet.Root
+          open={Boolean(selected)}
+          onOpenChange={(next) => {
+            if (!next) handleClose();
+          }}
+        >
+          <BottomSheet.Content aria-describedby={undefined}>
+            <BottomSheet.Header className="sr-only">
+              <BottomSheet.Title>
+                {selected?.detail.heading ?? "Suggestion"}
+              </BottomSheet.Title>
+            </BottomSheet.Header>
+            {detailPanel}
+          </BottomSheet.Content>
+        </BottomSheet.Root>
+      </>
+    );
+  }
+
   return (
     <AnimatedRightDrawer
       open={Boolean(selected)}
       left={<div>{startersSlot}</div>}
-      right={
-        selected ? (
-          <SuggestionDetailPanel
-            suggestion={selected}
-            onClose={handleClose}
-            onConfirm={handleConfirm}
-            onSaveForLater={handleSaveForLater}
-          />
-        ) : null
-      }
+      right={detailPanel}
     />
   );
 }
@@ -246,6 +281,48 @@ describe("ChatMainPanel suggestion drawer wiring", () => {
     expect(submitted).toHaveLength(0);
     expect(
       container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).toBeNull();
+  });
+
+  test("mobile: card click opens the detail in a bottom sheet and confirms", () => {
+    const submitted: string[] = [];
+    // The sheet portals outside `container`, so query the whole document
+    // (`baseElement`, default document.body) instead.
+    const { getByText, baseElement } = render(
+      <Harness isMobile onSubmit={(p) => submitted.push(p)} />,
+    );
+
+    // Closed: no detail panel and no desktop split.
+    expect(
+      baseElement.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).toBeNull();
+    expect(
+      baseElement.querySelector('[data-slot="animated-right-drawer"]'),
+    ).toBeNull();
+
+    fireEvent.click(getByText(FEATURED.title));
+
+    // Opens in the bottom sheet (still no desktop drawer). The panel's heading
+    // lives inside its own `data-slot`; an sr-only Dialog.Title duplicates the
+    // text for accessibility, so scope the heading assertion to the panel.
+    const sheet = baseElement.querySelector(
+      '[data-slot="bottom-sheet-content"]',
+    );
+    expect(sheet).not.toBeNull();
+    expect(
+      baseElement.querySelector('[data-slot="animated-right-drawer"]'),
+    ).toBeNull();
+    expect(
+      sheet?.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).not.toBeNull();
+    expect(submitted).toHaveLength(0);
+
+    fireEvent.click(getByText("Let's do it!"));
+
+    expect(submitted).toEqual([FEATURED.prompt]);
+    expect(useComposerStore.getState().input).toBe(FEATURED.prompt);
+    expect(
+      baseElement.querySelector('[data-slot="suggestion-detail-panel"]'),
     ).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/chat-route-content.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Focused test for the new-thread suggestion drawer wiring used by
+ * `ChatMainPanel`.
+ *
+ * `ChatMainPanel` itself pulls in dozens of stores/hooks, so rather than
+ * rendering the whole orchestrator we exercise the exact seam it composes: the
+ * `useChatEmptyState` library slot drives `onSelectSuggestion`, which opens an
+ * `AnimatedRightDrawer` holding a real `SuggestionDetailPanel`. All three are
+ * the real components, so this asserts the actual behaviour:
+ *
+ * - clicking a featured card opens the drawer with that suggestion's detail;
+ * - "Let's do it!" submits the suggestion's prompt and closes the drawer;
+ * - close / Save for Later dismiss the drawer without submitting.
+ *
+ * `motion/react` is mocked so the drawer mounts/unmounts synchronously instead
+ * of depending on real animation timing (see active-subagents-overlay.test).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+
+import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
+
+// --- Mocks ----------------------------------------------------------------
+
+const flagRef = { value: true };
+
+mock.module("@/stores/client-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    newThreadSuggestions: () => flagRef.value,
+  };
+  return { useClientFeatureFlagStore: store };
+});
+
+mock.module("@/domains/chat/hooks/use-empty-state-greeting", () => ({
+  useEmptyStateGreeting: () => ({ greeting: "Hi there", isGenerating: false }),
+}));
+
+mock.module("@/domains/chat/hooks/use-conversation-starters", () => ({
+  useConversationStarters: () => ({ starters: [] }),
+}));
+
+const FEATURED: ThreadSuggestion = {
+  id: "sugg-1",
+  title: "Email Helper",
+  iconKey: "gmail",
+  prompt: "Help me triage my inbox",
+  detail: {
+    heading: "Email Helper Detail",
+    description: "Triage your inbox.",
+    requirements: [],
+    capabilities: ["Summarize threads"],
+  },
+};
+
+mock.module("@/domains/chat/hooks/use-thread-suggestions", () => ({
+  useThreadSuggestions: () => ({ featured: [FEATURED], groups: [] }),
+}));
+
+// Render motion elements synchronously and fire `onAnimationComplete` after
+// each render so the drawer mounts on open and its close path (which unmounts
+// content onAnimationComplete) resolves without real animation timing.
+const MOTION_ONLY_PROPS = new Set([
+  "initial",
+  "animate",
+  "exit",
+  "transition",
+  "variants",
+  "whileHover",
+  "whileTap",
+  "layout",
+  "layoutId",
+  "custom",
+  "onAnimationStart",
+  "onAnimationComplete",
+]);
+
+function MotionStub({
+  tag,
+  onAnimationComplete,
+  ...rest
+}: Record<string, unknown> & {
+  tag: string;
+  onAnimationComplete?: () => void;
+}) {
+  useEffect(() => {
+    onAnimationComplete?.();
+  });
+  return createElement(tag, rest);
+}
+
+mock.module("motion/react", () => ({
+  motion: new Proxy(
+    {} as Record<string, (props: Record<string, unknown>) => ReactElement>,
+    {
+      get: (_target, tag) => (props: Record<string, unknown>) => {
+        const domProps: Record<string, unknown> = {};
+        for (const key in props) {
+          if (!MOTION_ONLY_PROPS.has(key)) domProps[key] = props[key];
+        }
+        return createElement(MotionStub, {
+          ...domProps,
+          tag: String(tag),
+          onAnimationComplete: props.onAnimationComplete as
+            | (() => void)
+            | undefined,
+        });
+      },
+    },
+  ),
+  AnimatePresence: ({ children }: { children?: ReactNode }) => children,
+  useReducedMotion: () => true,
+}));
+
+import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
+import { SuggestionDetailPanel } from "@/domains/chat/components/suggestion-detail-panel";
+import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
+
+// Harness mirroring ChatMainPanel's drawer wiring with the real components.
+function Harness({ onSubmit }: { onSubmit: (prompt: string) => void }) {
+  const [selected, setSelected] = useState<ThreadSuggestion | null>(null);
+
+  const { startersSlot } = useChatEmptyState({
+    assistantId: "a1",
+    conversationId: "c1",
+    isEmptyConversation: true,
+    avatar: { components: null, traits: null, customImageUrl: null } as never,
+    mainView: "chat",
+    openedAppState: null,
+    isAssistantStreaming: false,
+    activeConversationIsProcessing: false,
+    onSelectStarter: () => {},
+    onSelectSuggestion: setSelected,
+  });
+
+  const handleClose = useCallback(() => setSelected(null), []);
+  const handleConfirm = useCallback(
+    (s: ThreadSuggestion) => {
+      setSelected(null);
+      onSubmit(s.prompt);
+    },
+    [onSubmit],
+  );
+  const handleSaveForLater = useCallback(() => setSelected(null), []);
+
+  return (
+    <AnimatedRightDrawer
+      open={Boolean(selected)}
+      left={<div>{startersSlot}</div>}
+      right={
+        selected ? (
+          <SuggestionDetailPanel
+            suggestion={selected}
+            onClose={handleClose}
+            onConfirm={handleConfirm}
+            onSaveForLater={handleSaveForLater}
+          />
+        ) : null
+      }
+    />
+  );
+}
+
+beforeEach(() => {
+  flagRef.value = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ChatMainPanel suggestion drawer wiring", () => {
+  test("clicking a featured card opens the drawer with its detail", () => {
+    const submitted: string[] = [];
+    const { getByText, container } = render(
+      <Harness onSubmit={(p) => submitted.push(p)} />,
+    );
+
+    expect(
+      container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).toBeNull();
+
+    fireEvent.click(getByText(FEATURED.title));
+
+    expect(
+      container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).not.toBeNull();
+    expect(getByText(FEATURED.detail.heading)).toBeTruthy();
+    expect(submitted).toHaveLength(0);
+  });
+
+  test("'Let's do it!' submits the prompt and closes the drawer", () => {
+    const submitted: string[] = [];
+    const { getByText, container } = render(
+      <Harness onSubmit={(p) => submitted.push(p)} />,
+    );
+
+    fireEvent.click(getByText(FEATURED.title));
+    fireEvent.click(getByText("Let's do it!"));
+
+    expect(submitted).toEqual([FEATURED.prompt]);
+    expect(
+      container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).toBeNull();
+  });
+
+  test("close dismisses the drawer without submitting", () => {
+    const submitted: string[] = [];
+    const { getByText, getByLabelText, container } = render(
+      <Harness onSubmit={(p) => submitted.push(p)} />,
+    );
+
+    fireEvent.click(getByText(FEATURED.title));
+    fireEvent.click(getByLabelText("Close"));
+
+    expect(submitted).toHaveLength(0);
+    expect(
+      container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).toBeNull();
+  });
+
+  test("Save for Later dismisses the drawer without submitting", () => {
+    const submitted: string[] = [];
+    const { getByText, container } = render(
+      <Harness onSubmit={(p) => submitted.push(p)} />,
+    );
+
+    fireEvent.click(getByText(FEATURED.title));
+    fireEvent.click(getByText("Save for Later"));
+
+    expect(submitted).toHaveLength(0);
+    expect(
+      container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-route-content.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.test.tsx
@@ -136,16 +136,26 @@ import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
 function Harness({
   onSubmit,
   isMobile = false,
+  conversationId = "c1",
+  isEmptyConversation = true,
 }: {
   onSubmit: (prompt: string) => void;
   isMobile?: boolean;
+  conversationId?: string;
+  isEmptyConversation?: boolean;
 }) {
   const [selected, setSelected] = useState<ThreadSuggestion | null>(null);
 
+  // Mirror ChatMainPanel's reset effect: clear any open detail when the active
+  // conversation changes or the thread leaves the empty state.
+  useEffect(() => {
+    setSelected(null);
+  }, [conversationId, isEmptyConversation]);
+
   const { startersSlot } = useChatEmptyState({
     assistantId: "a1",
-    conversationId: "c1",
-    isEmptyConversation: true,
+    conversationId,
+    isEmptyConversation,
     avatar: { components: null, traits: null, customImageUrl: null } as never,
     mainView: "chat",
     openedAppState: null,
@@ -282,6 +292,30 @@ describe("ChatMainPanel suggestion drawer wiring", () => {
     expect(
       container.querySelector('[data-slot="suggestion-detail-panel"]'),
     ).toBeNull();
+  });
+
+  test("switching to another empty thread clears the open detail", () => {
+    const submitted: string[] = [];
+    const { getByText, container, rerender } = render(
+      <Harness conversationId="c1" onSubmit={(p) => submitted.push(p)} />,
+    );
+
+    fireEvent.click(getByText(FEATURED.title));
+    expect(
+      container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).not.toBeNull();
+
+    // New empty thread: id changes while `isEmptyConversation` stays true. The
+    // reset effect must still close the stale drawer so nothing leaks into the
+    // newly active thread.
+    rerender(
+      <Harness conversationId="c2" onSubmit={(p) => submitted.push(p)} />,
+    );
+
+    expect(
+      container.querySelector('[data-slot="suggestion-detail-panel"]'),
+    ).toBeNull();
+    expect(submitted).toHaveLength(0);
   });
 
   test("mobile: card click opens the detail in a bottom sheet and confirms", () => {

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -671,15 +671,16 @@ export function ChatMainPanel({
   const [selectedSuggestion, setSelectedSuggestion] =
     useState<ThreadSuggestion | null>(null);
 
-  // Suggestion cards only render in the empty state, so a picked suggestion is
-  // never meaningful once a conversation goes active. Clearing it here is
-  // defensive: the desktop drawer stays mounted across the empty→active
-  // transition (see below), and this guarantees it's closed there regardless.
+  // Clear any open suggestion detail when the active conversation changes or the
+  // thread leaves the empty state. Keying on `activeConversationId` covers the
+  // empty→empty switch (id changes while `isEmptyConversation` stays true), which
+  // the non-empty transition alone would miss — otherwise the stale drawer/sheet
+  // could submit the previous selection into the newly active thread, since
+  // ChatMainPanel is not keyed by conversation. Setting null on a fresh empty
+  // conversation is harmless because no card is selected yet.
   useEffect(() => {
-    if (!isEmptyConversation && selectedSuggestion) {
-      setSelectedSuggestion(null);
-    }
-  }, [isEmptyConversation, selectedSuggestion]);
+    setSelectedSuggestion(null);
+  }, [activeConversationId, isEmptyConversation]);
 
   // Close, and Save-for-later, both just dismiss the drawer: persisting saved
   // suggestions is not implemented yet.

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -672,10 +672,13 @@ export function ChatMainPanel({
 
   const handleConfirmSuggestion = useCallback(
     (s: ThreadSuggestion) => {
+      // Seed the composer before submitting (mirrors handleSelectStarter) so a
+      // blocked send leaves the prompt in the composer to retry, rather than
+      // silently dropping it when the drawer closes.
+      handleSelectStarter({ prompt: s.prompt });
       setSelectedSuggestion(null);
-      void submitMessage(s.prompt);
     },
-    [submitMessage],
+    [handleSelectStarter],
   );
 
   // -------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -17,7 +17,7 @@
  * - `useChatBannerSlots` — nudge/queued/slack banner assembly
  */
 
-import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
 import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
@@ -39,6 +39,7 @@ import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachmen
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
 import { ActiveWorkflowsOverlay } from "@/domains/chat/components/active-workflows-overlay/active-workflows-overlay";
+import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
 import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
@@ -50,6 +51,8 @@ import { MicPermissionPrimer } from "@/domains/chat/components/mic-permission-pr
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
 import { SendErrorModal } from "@/domains/chat/components/send-error-modal";
+import { SuggestionDetailPanel } from "@/domains/chat/components/suggestion-detail-panel";
+import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
 import { useEditMessage } from "@/domains/chat/hooks/use-edit-message";
 import { useOnboardingChoice } from "@/domains/chat/hooks/use-onboarding-choice";
 import { usePullRefresh } from "@/domains/chat/hooks/use-pull-refresh";
@@ -656,6 +659,26 @@ export function ChatMainPanel({
   }, [submitMessage]);
 
   // -------------------------------------------------------------------------
+  // New-thread suggestion drawer (behind the flag, empty-state only)
+  // -------------------------------------------------------------------------
+  const newThreadSuggestionsEnabled =
+    useClientFeatureFlagStore.use.newThreadSuggestions();
+  const [selectedSuggestion, setSelectedSuggestion] =
+    useState<ThreadSuggestion | null>(null);
+
+  // Close, and Save-for-later, both just dismiss the drawer: persisting saved
+  // suggestions is not implemented yet.
+  const handleCloseSuggestion = useCallback(() => setSelectedSuggestion(null), []);
+
+  const handleConfirmSuggestion = useCallback(
+    (s: ThreadSuggestion) => {
+      setSelectedSuggestion(null);
+      void submitMessage(s.prompt);
+    },
+    [submitMessage],
+  );
+
+  // -------------------------------------------------------------------------
   // Rule editor bridge (viewer-store seq → rule editor open)
   // -------------------------------------------------------------------------
   useRuleEditorBridge(messages, handleOpenRuleEditorForToolCall);
@@ -689,6 +712,9 @@ export function ChatMainPanel({
     isAssistantStreaming,
     activeConversationIsProcessing,
     onSelectStarter: handleSelectStarter,
+    onSelectSuggestion: newThreadSuggestionsEnabled
+      ? setSelectedSuggestion
+      : undefined,
   });
 
   // -------------------------------------------------------------------------
@@ -867,37 +893,65 @@ export function ChatMainPanel({
   const isSidePanel = mainView === "app-editing" && !!openedAppState && !!editingConversationId;
   const variant = isSidePanel ? "side-panel" : "main";
 
+  const chatBody = (
+    <ChatBody
+      variant={variant}
+      scrollAreaProps={{
+        ...chatBodyScrollAreaPropsBase,
+        showMaintenanceRecoveryCard: isSidePanel ? false : isInMaintenanceWithNoMessages,
+      }}
+      composerSlot={composerNode}
+      onStopGenerating={handleStopGenerating}
+      dragHandlers={attachmentDropHandlers}
+      isAttachmentDragOver={isAttachmentDragOver}
+      showScrollToLatest={
+        scrollCoordinator.showScrollToLatest && messages.length > 0
+      }
+      onScrollToLatest={handleScrollToLatest}
+      isStreaming={isAssistantStreaming}
+      refreshFeedback={refreshFeedback}
+      onDismissRefreshFeedback={handleDismissRefreshFeedback}
+      onRetryRefresh={handleRetryRefreshFromPill}
+      genericChatError={genericChatBanner}
+      onDismissChatError={handleDismissChatError}
+      isChannelReadonly={isChannelReadonly}
+      canStopGenerating={canStopGenerating}
+      bannerSlot={isSidePanel ? undefined : mainBannerSlot}
+      queuedDrawerSlot={isSidePanel ? undefined : mainQueuedDrawerSlot}
+      readonlyBannerSlot={channelReadonlyBannerSlot}
+      startersSlot={startersSlot}
+      activeSubagentsSlot={activeSubagentsSlot}
+      activeWorkflowsSlot={activeWorkflowsSlot}
+    />
+  );
+
+  // Behind the flag, the empty-state chat shares the pane with an animated
+  // right-hand drawer that holds the picked suggestion's detail. Outside the
+  // flag-on empty-state path the chat renders exactly as before — no wrapper.
+  const mainContent =
+    newThreadSuggestionsEnabled && isEmptyConversation ? (
+      <AnimatedRightDrawer
+        open={Boolean(selectedSuggestion)}
+        storageKey="vellum:suggestion-drawer-width"
+        left={chatBody}
+        right={
+          selectedSuggestion ? (
+            <SuggestionDetailPanel
+              suggestion={selectedSuggestion}
+              onClose={handleCloseSuggestion}
+              onConfirm={handleConfirmSuggestion}
+              onSaveForLater={handleCloseSuggestion}
+            />
+          ) : null
+        }
+      />
+    ) : (
+      chatBody
+    );
+
   return (
     <>
-      <ChatBody
-        variant={variant}
-        scrollAreaProps={{
-          ...chatBodyScrollAreaPropsBase,
-          showMaintenanceRecoveryCard: isSidePanel ? false : isInMaintenanceWithNoMessages,
-        }}
-        composerSlot={composerNode}
-        onStopGenerating={handleStopGenerating}
-        dragHandlers={attachmentDropHandlers}
-        isAttachmentDragOver={isAttachmentDragOver}
-        showScrollToLatest={
-          scrollCoordinator.showScrollToLatest && messages.length > 0
-        }
-        onScrollToLatest={handleScrollToLatest}
-        isStreaming={isAssistantStreaming}
-        refreshFeedback={refreshFeedback}
-        onDismissRefreshFeedback={handleDismissRefreshFeedback}
-        onRetryRefresh={handleRetryRefreshFromPill}
-        genericChatError={genericChatBanner}
-        onDismissChatError={handleDismissChatError}
-        isChannelReadonly={isChannelReadonly}
-        canStopGenerating={canStopGenerating}
-        bannerSlot={isSidePanel ? undefined : mainBannerSlot}
-        queuedDrawerSlot={isSidePanel ? undefined : mainQueuedDrawerSlot}
-        readonlyBannerSlot={channelReadonlyBannerSlot}
-        startersSlot={startersSlot}
-        activeSubagentsSlot={activeSubagentsSlot}
-        activeWorkflowsSlot={activeWorkflowsSlot}
-      />
+      {mainContent}
       <MicPermissionPrimer
         open={showPrimer}
         onContinue={handlePrimerContinue}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -17,7 +17,7 @@
  * - `useChatBannerSlots` — nudge/queued/slack banner assembly
  */
 
-import { type Dispatch, type MutableRefObject, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { type Dispatch, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
 import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
@@ -53,6 +53,8 @@ import { ProviderBillingBanner } from "@/domains/chat/components/provider-billin
 import { SendErrorModal } from "@/domains/chat/components/send-error-modal";
 import { SuggestionDetailPanel } from "@/domains/chat/components/suggestion-detail-panel";
 import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { BottomSheet } from "@vellumai/design-library";
 import { useEditMessage } from "@/domains/chat/hooks/use-edit-message";
 import { useOnboardingChoice } from "@/domains/chat/hooks/use-onboarding-choice";
 import { usePullRefresh } from "@/domains/chat/hooks/use-pull-refresh";
@@ -663,8 +665,21 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   const newThreadSuggestionsEnabled =
     useClientFeatureFlagStore.use.newThreadSuggestions();
+  // Called unconditionally — the desktop drawer vs mobile sheet choice below
+  // branches on this, but the hook must run on every render.
+  const isMobile = useIsMobile();
   const [selectedSuggestion, setSelectedSuggestion] =
     useState<ThreadSuggestion | null>(null);
+
+  // Suggestion cards only render in the empty state, so a picked suggestion is
+  // never meaningful once a conversation goes active. Clearing it here is
+  // defensive: the desktop drawer stays mounted across the empty→active
+  // transition (see below), and this guarantees it's closed there regardless.
+  useEffect(() => {
+    if (!isEmptyConversation && selectedSuggestion) {
+      setSelectedSuggestion(null);
+    }
+  }, [isEmptyConversation, selectedSuggestion]);
 
   // Close, and Save-for-later, both just dismiss the drawer: persisting saved
   // suggestions is not implemented yet.
@@ -928,29 +943,71 @@ export function ChatMainPanel({
     />
   );
 
-  // Behind the flag, the empty-state chat shares the pane with an animated
-  // right-hand drawer that holds the picked suggestion's detail. Outside the
-  // flag-on empty-state path the chat renders exactly as before — no wrapper.
-  const mainContent =
-    newThreadSuggestionsEnabled && isEmptyConversation ? (
+  const suggestionDetailPanel = selectedSuggestion ? (
+    <SuggestionDetailPanel
+      suggestion={selectedSuggestion}
+      onClose={handleCloseSuggestion}
+      onConfirm={handleConfirmSuggestion}
+      onSaveForLater={handleCloseSuggestion}
+    />
+  ) : null;
+
+  // Behind the flag the picked suggestion's detail rides alongside the chat.
+  //
+  // Desktop: an animated right-hand drawer. The wrapper is gated on the flag
+  // (and desktop), NOT on `isEmptyConversation`, so the `chatBody` subtree keeps
+  // the same tree position across the empty→active transition and never
+  // remounts — preserving composer focus/textarea state through the first send.
+  // Suggestion cards only render in the empty state, so `selectedSuggestion` is
+  // null in active conversations and the drawer simply sits closed there.
+  //
+  // Mobile: `AnimatedRightDrawer` is a desktop split that overflows narrow
+  // viewports, so the chat renders normally and the detail floats above it in a
+  // `BottomSheet` instead.
+  //
+  // Flag off (either viewport): the chat renders exactly as before — no wrapper.
+  let mainContent: ReactNode = chatBody;
+  if (newThreadSuggestionsEnabled && !isMobile) {
+    mainContent = (
       <AnimatedRightDrawer
         open={Boolean(selectedSuggestion)}
         storageKey="vellum:suggestion-drawer-width"
         left={chatBody}
-        right={
-          selectedSuggestion ? (
-            <SuggestionDetailPanel
-              suggestion={selectedSuggestion}
-              onClose={handleCloseSuggestion}
-              onConfirm={handleConfirmSuggestion}
-              onSaveForLater={handleCloseSuggestion}
-            />
-          ) : null
-        }
+        right={suggestionDetailPanel}
       />
-    ) : (
-      chatBody
     );
+  } else if (newThreadSuggestionsEnabled && isMobile) {
+    mainContent = (
+      <>
+        {chatBody}
+        <BottomSheet.Root
+          open={Boolean(selectedSuggestion)}
+          onOpenChange={(next) => {
+            if (!next) handleCloseSuggestion();
+          }}
+        >
+          {/* `SuggestionDetailPanel` brings its own visible heading + scroll-
+              body + footer, so it sits directly inside `Content` (no
+              BottomSheet.Body). The taller cap plus the panel's `h-full` give it
+              a bounded height inside the sheet's flex column so its body scrolls.
+              Radix Dialog still needs a Title for screen readers; the panel's
+              heading isn't a Dialog.Title, so a visually-hidden one mirrors it
+              (matches composer-settings-menu's pattern). */}
+          <BottomSheet.Content
+            aria-describedby={undefined}
+            className="h-[80dvh] max-h-[80dvh]"
+          >
+            <BottomSheet.Header className="sr-only">
+              <BottomSheet.Title>
+                {selectedSuggestion?.detail.heading ?? "Suggestion"}
+              </BottomSheet.Title>
+            </BottomSheet.Header>
+            {suggestionDetailPanel}
+          </BottomSheet.Content>
+        </BottomSheet.Root>
+      </>
+    );
+  }
 
   return (
     <>

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -136,6 +136,26 @@ describe("useChatEmptyState startersSlot", () => {
     });
   });
 
+  test("flag ON: onSelectSuggestion (when provided) wins over onSelectStarter", () => {
+    flagRef.value = true;
+    const submitted: ConversationStarter[] = [];
+    const opened: ThreadSuggestion[] = [];
+    const { result } = renderHook(() =>
+      useChatEmptyState(
+        baseParams({
+          onSelectStarter: (s) => submitted.push(s),
+          onSelectSuggestion: (s) => opened.push(s),
+        }),
+      ),
+    );
+
+    const { getByText } = render(<>{result.current.startersSlot}</>);
+    fireEvent.click(getByText(FEATURED.title));
+
+    expect(opened).toEqual([FEATURED]);
+    expect(submitted).toHaveLength(0);
+  });
+
   test("flag ON but app-editing keeps the conversation-starter grid", () => {
     flagRef.value = true;
     const { result } = renderHook(() =>

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -20,6 +20,7 @@ import { useThreadSuggestions } from "@/domains/chat/hooks/use-thread-suggestion
 import { buildEditAppGreeting, buildEditAppStarters } from "@/domains/chat/utils/edit-app-empty-state";
 import { pickRandomPlaceholder } from "@/domains/chat/utils/empty-state-constants";
 import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters";
+import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
 import type { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
@@ -40,6 +41,12 @@ export interface UseChatEmptyStateParams {
   isAssistantStreaming: boolean;
   activeConversationIsProcessing: boolean;
   onSelectStarter: (starter: ConversationStarter) => void;
+  /**
+   * Behind the new-thread-suggestions flag, clicking a library card invokes
+   * this instead of submitting via {@link onSelectStarter} — the caller opens
+   * the detail drawer. When omitted, the library falls back to submitting.
+   */
+  onSelectSuggestion?: (suggestion: ThreadSuggestion) => void;
 }
 
 export interface ChatEmptyStateResult {
@@ -63,6 +70,7 @@ export function useChatEmptyState({
   isAssistantStreaming,
   activeConversationIsProcessing,
   onSelectStarter,
+  onSelectSuggestion,
 }: UseChatEmptyStateParams): ChatEmptyStateResult {
   const { components: avatarComponents, traits: avatarTraits, customImageUrl: avatarImageUrl } = avatar;
 
@@ -124,15 +132,19 @@ export function useChatEmptyState({
         <SuggestionLibrary
           featured={featured}
           groups={groups}
-          onSelect={(s) =>
+          onSelect={(s) => {
+            if (onSelectSuggestion) {
+              onSelectSuggestion(s);
+              return;
+            }
             onSelectStarter({
               id: s.id,
               label: s.title,
               prompt: s.prompt,
               category: null,
               batch: 0,
-            })
-          }
+            });
+          }}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
- Behind the new-thread-suggestions flag, clicking a suggestion card now opens a right-hand AnimatedRightDrawer with the SuggestionDetailPanel; 'Let's do it!' submits the prompt and closes, close/save dismiss without submitting. Flag-off and non-empty layouts are unchanged.

Part of plan: thread-suggestions-library.md (PR 10 of 10)