### PR TITLE
chore(web): tidy useThreadSuggestions doc and featured-count call

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-thread-suggestions.ts
+++ b/clients/web/src/domains/chat/hooks/use-thread-suggestions.ts
@@ -1,10 +1,7 @@
 /**
- * Provides the new-thread suggestions library data behind a stable shape.
- *
- * The data is currently mocked: `featured` and `groups` come from
- * {@link MOCK_SUGGESTION_GROUPS}. The result shape is intentionally stable so
- * the source can later swap to a real query — installed plugins/skills plus a
- * Vellum-curated source — without touching consumers.
+ * Returns the featured suggestions and grouped suggestions for the new-thread
+ * empty state. The data comes from the bundled mock suggestion set
+ * ({@link MOCK_SUGGESTION_GROUPS}).
  */
 
 import { useMemo } from "react";
@@ -26,7 +23,7 @@ export interface UseThreadSuggestionsResult {
 export function useThreadSuggestions(): UseThreadSuggestionsResult {
   return useMemo(
     () => ({
-      featured: getFeaturedSuggestions(3),
+      featured: getFeaturedSuggestions(),
       groups: MOCK_SUGGESTION_GROUPS,
     }),
     [],


### PR DESCRIPTION
## Summary
Minor cleanups from plan review for thread-suggestions-library.md.
- Rewrite useThreadSuggestions JSDoc to present-tense per AGENTS.md (no roadmap phrasing).
- Drop the redundant explicit count argument at the getFeaturedSuggestions call site (default is 3).