### PR TITLE
fix(web): skip starter generation + remove dead fallback for suggestions library

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -6,9 +6,9 @@
  * via `mock.module` so the test stays focused on the slot-selection logic:
  *
  * - Flag OFF → the existing conversation-starter chips render (no regression).
- * - Flag ON (empty conversation, no app-editing) → the new SuggestionLibrary
- *   renders instead, and selecting a card maps the suggestion onto the
- *   existing `onSelectStarter` path.
+ * - Flag ON (empty conversation, no app-editing) with `onSelectSuggestion`
+ *   provided → the new SuggestionLibrary renders instead, and selecting a card
+ *   calls `onSelectSuggestion` to open the detail drawer.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -103,9 +103,11 @@ describe("useChatEmptyState startersSlot", () => {
     ).not.toBeNull();
   });
 
-  test("flag ON renders the suggestion library on a fresh thread", () => {
+  test("flag ON with onSelectSuggestion renders the suggestion library on a fresh thread", () => {
     flagRef.value = true;
-    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+    const { result } = renderHook(() =>
+      useChatEmptyState(baseParams({ onSelectSuggestion: () => {} })),
+    );
 
     const { container, getByText } = render(<>{result.current.startersSlot}</>);
     expect(
@@ -114,29 +116,20 @@ describe("useChatEmptyState startersSlot", () => {
     expect(getByText(FEATURED.title)).toBeTruthy();
   });
 
-  test("flag ON: selecting a card submits the suggestion's prompt via onSelectStarter", () => {
+  test("flag ON without onSelectSuggestion falls back to the conversation-starter chips", () => {
     flagRef.value = true;
-    const selected: ConversationStarter[] = [];
-    const { result } = renderHook(() =>
-      useChatEmptyState(
-        baseParams({ onSelectStarter: (s) => selected.push(s) }),
-      ),
-    );
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
 
-    const { getByText } = render(<>{result.current.startersSlot}</>);
-    fireEvent.click(getByText(FEATURED.title));
-
-    expect(selected).toHaveLength(1);
-    expect(selected[0]).toEqual({
-      id: FEATURED.id,
-      label: FEATURED.title,
-      prompt: FEATURED.prompt,
-      category: null,
-      batch: 0,
-    });
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="suggestion-library"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
+    ).not.toBeNull();
   });
 
-  test("flag ON: onSelectSuggestion (when provided) wins over onSelectStarter", () => {
+  test("flag ON: selecting a card opens the suggestion via onSelectSuggestion", () => {
     flagRef.value = true;
     const submitted: ConversationStarter[] = [];
     const opened: ThreadSuggestion[] = [];

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -43,8 +43,8 @@ export interface UseChatEmptyStateParams {
   onSelectStarter: (starter: ConversationStarter) => void;
   /**
    * Behind the new-thread-suggestions flag, clicking a library card invokes
-   * this instead of submitting via {@link onSelectStarter} — the caller opens
-   * the detail drawer. When omitted, the library falls back to submitting.
+   * this to open the detail drawer. The library only renders when this is
+   * provided; otherwise the empty state falls back to the starter chips.
    */
   onSelectSuggestion?: (suggestion: ThreadSuggestion) => void;
 }
@@ -88,16 +88,29 @@ export function useChatEmptyState({
       enabled: isEmptyConversation,
     });
 
-  // Gate the daemon fetch by `isEmptyConversation` so non-empty chats
-  // stop polling for data that's never rendered.
-  const { starters: conversationStarters } = useConversationStarters(
-    isEmptyConversation ? assistantId : null,
-  );
-
   const editingApp =
     mainView === "app-editing" && openedAppState
       ? { name: openedAppState.name, dirName: openedAppState.dirName }
       : null;
+
+  // Behind the flag, the new suggestions library replaces the starter chips
+  // on a fresh thread. The app-editing override keeps its bespoke chips
+  // regardless of the flag, so it stays on the grid path. The library also
+  // needs `onSelectSuggestion` to open its detail drawer; without it we fall
+  // back to the chip grid.
+  const showSuggestionLibrary =
+    newThreadSuggestionsEnabled &&
+    isEmptyConversation &&
+    !editingApp &&
+    onSelectSuggestion != null;
+
+  // Gate the daemon fetch by `isEmptyConversation` so non-empty chats stop
+  // polling for data that's never rendered. Also skip it whenever the
+  // suggestions library is shown — the daemon GET enqueues starter generation
+  // and polls every few seconds for chips the library path never renders.
+  const { starters: conversationStarters } = useConversationStarters(
+    isEmptyConversation && !showSuggestionLibrary ? assistantId : null,
+  );
 
   const emptyStateProps: ChatEmptyStateProps = {
     avatarSlot:
@@ -119,12 +132,6 @@ export function useChatEmptyState({
     ? buildEditAppStarters(editingApp)
     : conversationStarters;
 
-  // Behind the flag, the new suggestions library replaces the starter chips
-  // on a fresh thread. The app-editing override keeps its bespoke chips
-  // regardless of the flag, so it stays on the grid path.
-  const showSuggestionLibrary =
-    newThreadSuggestionsEnabled && isEmptyConversation && !editingApp;
-
   let startersSlot: ReactNode | undefined;
   if (showSuggestionLibrary) {
     startersSlot = (
@@ -132,19 +139,7 @@ export function useChatEmptyState({
         <SuggestionLibrary
           featured={featured}
           groups={groups}
-          onSelect={(s) => {
-            if (onSelectSuggestion) {
-              onSelectSuggestion(s);
-              return;
-            }
-            onSelectStarter({
-              id: s.id,
-              label: s.title,
-              prompt: s.prompt,
-              category: null,
-              batch: 0,
-            });
-          }}
+          onSelect={onSelectSuggestion}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
Fixes gaps from plan review for thread-suggestions-library.md.
- Do not call the starter-generating daemon hook when the new-thread suggestions library is shown (avoids background LLM generation + polling for hidden chips).
- Remove the unreachable onSelectStarter submit fallback in the library onSelect (superseded by the detail-drawer path).