### PR TITLE
refactor(web): extract shared SelectionIndicator for list and table surfaces

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/list-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/list-surface.tsx
@@ -1,5 +1,4 @@
-import { Check } from "lucide-react";
-
+import { SelectionIndicator } from "@/domains/chat/components/surfaces/selection-indicator";
 import { sfSymbolToLucideIcon } from "@/domains/chat/components/surfaces/sf-symbol-map";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import { useSelectionState } from "@/domains/chat/components/surfaces/use-selection-state";
@@ -68,17 +67,10 @@ export function ListSurface({ surface, onAction }: ListSurfaceProps) {
               >
                 {/* Selection indicator */}
                 {isSelectable && (
-                  <span
-                    className={cn(
-                      "flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors",
-                      isSelected
-                        ? "border-[var(--primary-base)] bg-[var(--primary-base)] text-[var(--content-inset)]"
-                        : "border-[var(--border-element)]",
-                      selectionMode === "single" ? "rounded-full" : "rounded",
-                    )}
-                  >
-                    {isSelected && <Check className="h-3 w-3" />}
-                  </span>
+                  <SelectionIndicator
+                    selected={isSelected}
+                    single={selectionMode === "single"}
+                  />
                 )}
 
                 {/* Icon */}

--- a/clients/web/src/domains/chat/components/surfaces/selection-indicator.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/selection-indicator.tsx
@@ -1,0 +1,30 @@
+import { Check } from "lucide-react";
+
+import { cn } from "@/utils/misc";
+
+interface SelectionIndicatorProps {
+  selected: boolean;
+  /** Single-select renders a circle (radio); multi-select renders a square. */
+  single: boolean;
+}
+
+/**
+ * Checkbox/radio-style selection indicator for selectable list and table rows:
+ * a rounded square (multi-select) or circle (single-select) that fills with the
+ * primary color and shows a check when selected.
+ */
+export function SelectionIndicator({ selected, single }: SelectionIndicatorProps) {
+  return (
+    <span
+      className={cn(
+        "flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors",
+        selected
+          ? "border-[var(--primary-base)] bg-[var(--primary-base)] text-[var(--content-inset)]"
+          : "border-[var(--border-element)]",
+        single ? "rounded-full" : "rounded",
+      )}
+    >
+      {selected && <Check className="h-3 w-3" />}
+    </span>
+  );
+}

--- a/clients/web/src/domains/chat/components/surfaces/table-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/table-surface.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { SelectionIndicator } from "@/domains/chat/components/surfaces/selection-indicator";
 import { sfSymbolToLucideIcon } from "@/domains/chat/components/surfaces/sf-symbol-map";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import { useSelectionState } from "@/domains/chat/components/surfaces/use-selection-state";
@@ -188,17 +189,10 @@ export function TableSurface({ surface, onAction }: TableSurfaceProps) {
                   {isSelectable && (
                     <td className="px-3 py-2">
                       {rowSelectable && (
-                        <span
-                          className={cn(
-                            "flex h-5 w-5 items-center justify-center rounded border transition-colors",
-                            isSelected
-                              ? "border-[var(--primary-base)] bg-[var(--primary-base)] text-[var(--content-inset)]"
-                              : "border-[var(--border-element)]",
-                            selectionMode === "single" ? "rounded-full" : "rounded",
-                          )}
-                        >
-                          {isSelected && <Check className="h-3 w-3" />}
-                        </span>
+                        <SelectionIndicator
+                          selected={isSelected}
+                          single={selectionMode === "single"}
+                        />
                       )}
                     </td>
                   )}


### PR DESCRIPTION
## What

Follow-up to #36221 (the chat-surfaces `cn()` migration) and the last piece of LUM-2616. Extracts the selection indicator — duplicated near-verbatim in `ListSurface` and `TableSurface` — into one shared `SelectionIndicator` component.

## Why

Both surfaces hand-rendered the same checkbox/radio square (fills with the primary color + shows a check when selected; circle for single-select, square for multi). They now share `surfaces/selection-indicator.tsx`.

## Behavior

Unchanged. The two copies were identical except `list` had `shrink-0`; the shared component keeps it, which is inert inside a table cell (so the table copy is visually unchanged). Class output is otherwise the same.

## Scope note

This is the one dedup from LUM-2616's `cva`/shared-component candidates that's clearly worth it. The others were evaluated and intentionally left as `cn()`:
- `confirmation`'s `destructive` is a simple two-state toggle, not a variant set.
- `work-result`'s `tone` and `card`'s `status` are already centralized lookup maps — `cva` would add indirection without removing duplication.

## Testing

- `clients/web`: eslint (changed files) + `tsc --noEmit` — pass

Fixes LUM-2616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wuqoKsrCJ336NLvvNPMvv)_