### PR TITLE
Filter disabled-plugin tools from `assistant tools list`

### DIFF
--- a/assistant/src/__tests__/tools-get-route.test.ts
+++ b/assistant/src/__tests__/tools-get-route.test.ts
@@ -8,7 +8,9 @@
  * the tool object.
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { Conversation } from "../daemon/conversation.js";
 import {
@@ -25,6 +27,7 @@ import {
   registerTool,
 } from "../tools/registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
 
 interface ToolListEntry {
   name: string;
@@ -78,10 +81,26 @@ function registerFakeConversation(id: string, toolNames: string[]): void {
   } as unknown as Conversation);
 }
 
+/** Drop a `.disabled` sentinel into a plugin's workspace directory. */
+function disablePluginSentinel(name: string): void {
+  const dir = join(getWorkspacePluginsDir(), name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".disabled"), "");
+}
+
 describe("GET /tools", () => {
   beforeEach(() => {
     __resetRegistryForTesting();
     clearConversations();
+  });
+
+  afterEach(() => {
+    // Remove any `.disabled` sentinels written during a test so plugin
+    // disabled-state never leaks across cases.
+    rmSync(join(getWorkspacePluginsDir(), "git-workflow"), {
+      recursive: true,
+      force: true,
+    });
   });
 
   test("returns each registered tool's metadata, sorted by name, with core source", async () => {
@@ -138,6 +157,30 @@ describe("GET /tools", () => {
     expect(sourceOf("p_tool")).toBe("plugin:echo");
     expect(sourceOf("m_tool")).toBe("mcp:linear");
     expect(sourceOf("s_tool")).toBe("skill:my-skill");
+  });
+
+  test("excludes tools contributed by a disabled plugin", async () => {
+    // GIVEN a core tool and a plugin tool, both initially registered
+    registerTool(makeFakeTool("a_core_tool"));
+    registerPluginTools("git-workflow", [makeFakeTool("gw_tool")]);
+
+    // THEN the plugin tool is visible before disabling
+    const before = (await handler({})) as ToolsGetResponse;
+    expect(before.names).toContain("gw_tool");
+    expect(before.tools.some((t) => t.name === "gw_tool")).toBe(true);
+    expect(before.schemas.gw_tool).toBeDefined();
+
+    // WHEN the plugin is disabled via its `.disabled` sentinel
+    disablePluginSentinel("git-workflow");
+
+    // THEN the plugin's tool drops from names, schemas, and the metadata
+    // array on the next call — no daemon restart required — while the core
+    // tool stays put.
+    const after = (await handler({})) as ToolsGetResponse;
+    expect(after.names).not.toContain("gw_tool");
+    expect(after.tools.some((t) => t.name === "gw_tool")).toBe(false);
+    expect(after.schemas.gw_tool).toBeUndefined();
+    expect(after.names).toContain("a_core_tool");
   });
 
   test("with conversationId, scopes to the conversation's tool snapshot and resolves metadata from the registry", async () => {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -43,7 +43,12 @@ import {
   type ManifestOverride,
   resolveExecutionTarget,
 } from "../../tools/execution-target.js";
-import { getAllTools, getTool, getToolOwner } from "../../tools/registry.js";
+import {
+  getAllTools,
+  getEnabledTools,
+  getTool,
+  getToolOwner,
+} from "../../tools/registry.js";
 import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
@@ -397,17 +402,19 @@ interface ToolNamesListResponse {
 
 /**
  * Tool inventory. With no `conversationId`, reports every tool in the
- * global registry (plus skill-manifest tools not yet loaded, for the
- * permission-simulator catalog). With a `conversationId`, scopes the
- * inventory to the tools available to that conversation as of its most
- * recent turn — see {@link handleConversationToolList}.
+ * global registry that is currently active — tools contributed by a
+ * disabled plugin are filtered out at read time, so the listing matches
+ * what conversations can actually call (plus skill-manifest tools not yet
+ * loaded, for the permission-simulator catalog). With a `conversationId`,
+ * scopes the inventory to the tools available to that conversation as of
+ * its most recent turn — see {@link handleConversationToolList}.
  */
 function handleToolNamesList(conversationId?: string): ToolNamesListResponse {
   if (conversationId) {
     return handleConversationToolList(conversationId);
   }
 
-  const tools = getAllTools();
+  const tools = getEnabledTools();
   const nameSet = new Set(tools.map((t) => t.name));
   const schemas: Record<string, SchemaShape> = {};
 
@@ -516,11 +523,13 @@ function toolEntryForName(name: string): ToolListEntry {
  * Build the registered-tool inventory with the metadata a catalog view
  * needs: description, author-asserted risk band, category, and the
  * extension that contributed the tool. Sorted by name for stable output.
- * Covers only tools loaded into the registry; skill tools whose manifests
- * are present but not yet loaded appear in `names`/`schemas` but not here.
+ * Covers only tools loaded into the registry and currently active; tools
+ * from a disabled plugin are excluded (see {@link getEnabledTools}), and
+ * skill tools whose manifests are present but not yet loaded appear in
+ * `names`/`schemas` but not here.
  */
 function buildRegisteredToolEntries(): ToolListEntry[] {
-  return getAllTools()
+  return getEnabledTools()
     .map((tool) => toolEntryForName(tool.name))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -216,6 +216,26 @@ export function getAllTools(): Tool[] {
 }
 
 /**
+ * Return every registered tool except those contributed by a currently
+ * disabled plugin. The `.disabled` sentinel is checked at read time so
+ * `assistant plugins disable <name>` drops the plugin's tools from the
+ * listing on the next call without a daemon restart — mirroring the
+ * filtering in {@link getPluginToolDefinitions} and `getHooksFor`.
+ *
+ * Plugin tools stay in the underlying `tools` map while disabled (they are
+ * only torn out when the plugin's refcount drops to zero), so callers that
+ * report the *available* tool surface — e.g. the `tools_get` route behind
+ * `assistant tools list` — must filter here rather than read `getAllTools()`
+ * directly, which would keep showing a disabled plugin's tools.
+ */
+export function getEnabledTools(): Tool[] {
+  return getAllTools().filter((t) => {
+    const owner = ownersByName.get(t.name);
+    return !(owner?.kind === "plugin" && isPluginDisabled(owner.id));
+  });
+}
+
+/**
  * Return the recorded owner for a tool, or `undefined` if the tool is
  * core-origin (no owner) or unknown. Consumers that need to gate behavior on
  * which extension contributed a tool (permissions checker, approval-handler


### PR DESCRIPTION
## Problem

Running `assistant plugins disable <name>` followed by `assistant tools list` still showed the disabled plugin's tools — the count never dropped. The `disable` command even advertises "Takes effect immediately in a running assistant," but the listing contradicted it.

## Root cause

Disabling a plugin writes a `.disabled` sentinel that each plugin surface checks **at read time**, so the change takes effect on the next turn without a daemon restart. Hooks (`getHooksFor`) and the conversation tool resolver (`getPluginToolDefinitions`) already honored it.

But the `tools_get` route — which backs `assistant tools list` and the macOS permission-simulator catalog — read `getAllTools()` directly. Plugin tools remain in the underlying registry map while disabled (they're only torn out when the plugin's refcount hits zero), so the global listing kept reporting them until a full restart.

## Fix

- Add `getEnabledTools()` to the tool registry: every registered tool minus those owned by a currently-disabled plugin, mirroring the existing read-time `.disabled` filter in `getPluginToolDefinitions` / `getHooksFor`.
- Use it in the global listing path (`handleToolNamesList` and `buildRegisteredToolEntries`) so names, schemas, and the metadata table all reflect the active surface.
- The conversation-scoped path (`--conversation`) is left unchanged — it's already bounded by the conversation's own turn snapshot.

Now disabling a plugin drops its tools from `assistant tools list` on the next invocation, matching what conversations can actually call.

## Testing

- New regression test in `tools-get-route.test.ts`: a plugin tool is visible, then disappears from `names`/`schemas`/`tools` after its `.disabled` sentinel is written, while a core tool stays.
- `registry.test.ts`, `plugin-tool-contribution.test.ts`, `plugin-disabled-state.test.ts`, and `tools-get-route.test.ts` all pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKN52KCEhDW22eHXwEfFqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKN52KCEhDW22eHXwEfFqy)_