### PR TITLE
docs(web): document the backwards-compat version-gating system

### DIFF
--- a/clients/web/AGENTS.md
+++ b/clients/web/AGENTS.md
@@ -13,6 +13,7 @@ Read these before making changes:
 - **[`docs/CONVENTIONS.md` — Platform gating](./docs/CONVENTIONS.md#platform-gating)** — The `usePlatformGate()` hook, the five user states (platform-hosted vs self-hosted × logged-in vs not), and when to gate/disable/hide platform-dependent UI surfaces.
 - **[`docs/CAPACITOR.md`](./docs/CAPACITOR.md)** — Capacitor / iOS patterns: lazy plugin imports, native auth, deep links, autogrowing textareas, streaming watchdogs, OS permission UI, capability detection, keyboard-only affordances. Mandatory reading if any code path you're touching might run inside the iOS WKWebView shell.
 - **[`docs/ELECTRON.md`](./docs/ELECTRON.md)** — Electron renderer patterns: `runtime/` wrapper modules for `window.vellum.*`, domain-owned bridge hooks, the three-file dance for new bridge surfaces. Read this if your change touches anything under `src/runtime/` that uses `window.vellum`.
+- **[`docs/BACKWARDS_COMPAT.md`](./docs/BACKWARDS_COMPAT.md)** — How the web app version-gates features against the locally-installed assistant/daemon. The `src/lib/backwards-compat/` registry, `useAssistantSupports()` / `assistantSupports()`, read-vs-write fallback rules, and how to add or test a gate. Read this before adding a feature that depends on a new daemon endpoint, wire field, or event shape.
 
 ## Common pitfalls
 

--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -1,0 +1,173 @@
+# Web App — Backwards Compatibility
+
+How the web client copes with talking to an assistant (the local daemon)
+that may be running an older — or newer — version than the bundle the
+browser just loaded.
+
+See also [`clients/web/AGENTS.md`](../AGENTS.md), the umbrella
+[`CONVENTIONS.md`](./CONVENTIONS.md), and
+[`STATE_MANAGEMENT.md`](./STATE_MANAGEMENT.md).
+
+---
+
+## The problem
+
+The web app **always serves the latest bundle** from Vellum's
+infrastructure. The assistant side, however, runs locally and can be at
+**any version the user happens to have installed**. New web features ship
+continuously, well before every assistant in the wild has upgraded. So on
+any given page load the browser may be newer than the daemon it's
+connected to — and a feature that assumes a new endpoint, wire field, or
+event shape will break against an older daemon.
+
+The fix is **version gating**: the web app detects the connected
+assistant's version and either lights up the new code path or falls back
+to whatever the assistant understood before.
+
+This is explicitly a **temporary** layer. Every gate is delete-on-sight
+the day we solve serving a matching web bundle per assistant version. To
+keep that future deletion tractable, all the "if assistant < X.Y.Z, do
+the old thing" logic lives in one place.
+
+## Where it lives
+
+| Module | Role |
+|---|---|
+| `src/lib/backwards-compat/` | The centralized registry. One file per gated feature, each declaring its own `MIN_VERSION`. `grep` this path to find everything that can eventually be deleted. |
+| `src/lib/backwards-compat/utils.ts` | The shared gate primitives: `useAssistantSupports`, `assistantSupports`, `whenAssistantVersionKnown`. Every gate uses these so semver parsing and pre-release handling are uniform. |
+| `src/utils/semver.ts` | Low-level `parseSemver` / `compareParsed` / `comparePreRelease`. No app knowledge — just version-string math. |
+| `src/stores/assistant-identity-store.ts` | Zustand store holding the active assistant's `{ name, version }`. The source of truth every gate reads. |
+| `src/assistant/identity.ts` | Fetches identity from the daemon's `/identity` endpoint and refreshes it on the SSE `identity_changed` event. |
+| `src/lib/backwards-compat/impersonate-version-flag.ts` | Debug flag for overriding the reported version locally, so a single dev can exercise old and new code paths without juggling installs. |
+
+## How a gate is detected
+
+`utils.ts` exposes three variants, all reading the active assistant
+version off the identity store. Pick by call site:
+
+- **`useAssistantSupports(minVersion): boolean`** — the hook. Subscribes
+  to the identity store via the `use.version()` selector, so a component
+  (or a query whose `enabled`/key depends on it) **re-renders when the
+  version flips**. Use this on render paths.
+- **`assistantSupports(minVersion): boolean`** — the snapshot. Reads
+  `getState().version` once. Safe outside React: event handlers, async
+  ops, request builders.
+- **`whenAssistantVersionKnown(timeoutMs?): Promise<void>`** — resolves
+  once the version is non-null (or after a 5 s timeout). Used by write
+  paths before reading a snapshot gate; see [Read vs. write
+  paths](#read-vs-write-paths).
+
+### Version semantics
+
+The comparison in `supportsVersion()` has a few deliberate quirks worth
+knowing before you add a gate:
+
+- **Unknown version returns `false`.** The version starts `null` and
+  hydrates asynchronously after identity fetches. Until then, every gate
+  reports "not supported" and the app falls back to the legacy path. That
+  fallback must be something *any* assistant understands.
+- **Pre-release suffixes on the patch are ignored.** `0.8.5-rc.1` counts
+  as `0.8.5`, so RC/beta/alpha testers get the new path the moment the
+  patch version bumps.
+- **`dev` builds are treated as AHEAD of the stable release with the same
+  base** — the opposite of strict semver. A build like
+  `0.10.0-dev.202606211252.5cf8576` contains unreleased commits on top of
+  `0.10.0`, so it's considered *newer* than `0.10.0` stable. Two dev
+  builds with the same base compare by their pre-release string, which
+  encodes a `dev.YYYYMMDDHHMM.sha` timestamp. This lets a gate target a
+  specific dev build by passing the exact dev version string as
+  `minVersion` (the [vision attachment gate](#the-gates) does this).
+- **Unparseable versions (either side) return `false`.**
+
+## Read vs. write paths
+
+The snapshot `assistantSupports()` collapses "version unknown" and
+"version known-but-old" into the same `false`. That's **safe for reads**:
+a read that falls back to a universally-understood legacy route is
+harmless even if it briefly runs before the version hydrates.
+
+It is **not safe for writes** whose legacy fallback mutates state in a way
+a newer assistant would ignore — you could send the old-shaped write to a
+new daemon just because the version hadn't loaded yet. Those paths
+`await whenAssistantVersionKnown()` first, then read the gate against a
+resolved version instead of the conservative `false`-on-unknown default.
+The avatar upload path is the canonical example (`assistant/avatar-api.ts`
+awaits `resolveSupportsAvatarStateManifest()` before branching).
+
+## Adding a gate
+
+1. Create `src/lib/backwards-compat/<feature>.ts`.
+2. Declare a module-level `MIN_VERSION` and a doc comment describing the
+   **old vs. new** behavior — this is what someone deleting the gate later
+   reads to confirm the old path is dead.
+3. Export a small, named helper (`supportsX` / `useSupportsX`) that wraps
+   `assistantSupports(MIN_VERSION)` or `useAssistantSupports(MIN_VERSION)`.
+   Don't call the gate primitives inline at the use site — the named
+   wrapper keeps the gate greppable and gives the boolean a meaning.
+4. For a write path, expose an async `resolveSupportsX()` that awaits
+   `whenAssistantVersionKnown()` first.
+5. Add a colocated `<feature>.test.ts`.
+
+Keep the old code path until the gate is removed — the gate *is* the
+contract that says it still has callers.
+
+## The gates
+
+Each module owns one feature's old/new split. Current registry:
+
+| Gate (`src/lib/backwards-compat/…`) | `MIN_VERSION` | Old behavior (< version) | New behavior (≥ version) |
+|---|---|---|---|
+| `flag-query-freshness.ts` | `0.8.5` | 5 s poll interval on feature-flag queries | Push-based invalidation via `sync_changed` + SSE reconnect (60 s stale, no poll) |
+| `conversation-id-wire-field.ts` | `0.8.6` | Send `conversationKey` (create-or-lookup) on `POST /v1/messages` | Send strict `conversationId` (direct internal-id lookup) |
+| `server-minted-conversation.ts` | `0.8.6` | Mint a draft UUID locally, send as `conversationKey` | Omit both id fields; daemon mints the id and echoes it back on first send |
+| `avatar-state-manifest.ts` | `0.8.7` | Infer render mode from workspace sidecar files; write via generic `workspace/write` + `workspace/delete` | Authoritative `GET /avatar/state` + atomic `POST /avatar/image` |
+| `conversation-processing-state.ts` | `0.8.8` | Client-side optimistic mirror (`processingConversationIds`), cleared manually on terminal events | Trust the server `isProcessing` flag on the conversation row |
+| `llm-context-summary-view.ts` | `0.8.12` | Inline context sections from the list response | `view=summary` light list + lazy per-log detail via `GET /v1/llm-request-logs/:id/context` |
+| `vision-attachment-gate.ts` | `0.10.0-dev.202606211252.5cf8576` | Client filters images out for non-vision models | Allow any file type; the image-fallback plugin filters/captions server-side |
+
+When you delete a row here, also delete its module, its test, and the now-dead
+legacy branch at the call site.
+
+## Related compatibility seams (outside the registry)
+
+A few backwards-compat concerns don't fit the version-gate shape and live
+with the code they protect:
+
+- **SSE event parsing** — `src/lib/streaming/event-parser.ts` accepts both
+  the enveloped event shape (`{ id, conversationId, seq, emittedAt,
+  message }`, 0.8.5+) and the flat legacy shape (`{ type, … }`), wrapping
+  the legacy form in a synthetic envelope so downstream callers never see
+  the difference.
+- **Message normalization** — `src/domains/chat/api/messages.ts`
+  reconstructs the unified `contentBlocks` discriminated union from the
+  pre-0.8.8 positional arrays (`textSegments`, `thinkingSegments`,
+  `toolCalls`, `surfaces`, `attachments`, `contentOrder`) when a daemon
+  omits `contentBlocks`, so the renderer only ever deals with one shape.
+- **Electron / Capacitor bridge** — `src/runtime/is-electron.ts` declares
+  `window.vellum` with **optional capability groups** (`helper?`,
+  `featureFlags?`, `diagnostics?`, …). Consumers guard on presence
+  (`window.vellum?.helper?.hotkey?.fnPushToTalk()`), so a newer renderer
+  running against an older native shell no-ops instead of crashing. This
+  is capability detection rather than version comparison.
+- **localStorage migrations** — `src/utils/storage-migration.ts` performs
+  one-time, idempotent key renames (legacy keys → the `vellum:` / `device:`
+  namespaces). Run at startup before any store reads localStorage. This is
+  client-internal versioning, not daemon compatibility.
+
+## Testing against an old (or new) daemon
+
+You don't need multiple assistant installs. The impersonation flag
+overrides the version every gate sees:
+
+```js
+// In the browser console (debug builds expose window._vellumDebug.flags):
+impersonateVersion("0.8.6"); // pretend the daemon is 0.8.6, then reload
+impersonateVersion(null);    // clear the override, then reload
+impersonateVersion();        // log the current override, no reload
+```
+
+It persists to `localStorage` (`vellum:debug:impersonateAssistantVersion`)
+and reloads the page so the whole app — version-derived constants, SSE
+handlers, every gate — sees one consistent version. The identity store's
+`setIdentity` consults the override and substitutes it, so individual gates
+never need to know the flag exists.

--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -1,8 +1,7 @@
 # Web App — Backwards Compatibility
 
-How the web client copes with talking to an assistant (the local daemon)
-that may be running an older — or newer — version than the bundle the
-browser just loaded.
+How the web client copes with talking to an assistant that may be running an older version 
+than the bundle the browser just loaded.
 
 See also [`clients/web/AGENTS.md`](../AGENTS.md), the umbrella
 [`CONVENTIONS.md`](./CONVENTIONS.md), and
@@ -13,12 +12,12 @@ See also [`clients/web/AGENTS.md`](../AGENTS.md), the umbrella
 ## The problem
 
 The web app **always serves the latest bundle** from Vellum's
-infrastructure. The assistant side, however, runs locally and can be at
+infrastructure. The assistant side, however, runs separately and can be at
 **any version the user happens to have installed**. New web features ship
 continuously, well before every assistant in the wild has upgraded. So on
-any given page load the browser may be newer than the daemon it's
+any given page load the browser may be newer than the assistant it's
 connected to — and a feature that assumes a new endpoint, wire field, or
-event shape will break against an older daemon.
+event shape will break against an older assistant.
 
 The fix is **version gating**: the web app detects the connected
 assistant's version and either lights up the new code path or falls back
@@ -27,7 +26,8 @@ to whatever the assistant understood before.
 This is explicitly a **temporary** layer. Every gate is delete-on-sight
 the day we solve serving a matching web bundle per assistant version. To
 keep that future deletion tractable, all the "if assistant < X.Y.Z, do
-the old thing" logic lives in one place.
+the old thing" logic lives in one place. We will soon also have telemetry
+informing us of live clients in use so we can delete old cold paths incrementally.
 
 ## Where it lives
 
@@ -37,7 +37,7 @@ the old thing" logic lives in one place.
 | `src/lib/backwards-compat/utils.ts` | The shared gate primitives: `useAssistantSupports`, `assistantSupports`, `whenAssistantVersionKnown`. Every gate uses these so semver parsing and pre-release handling are uniform. |
 | `src/utils/semver.ts` | Low-level `parseSemver` / `compareParsed` / `comparePreRelease`. No app knowledge — just version-string math. |
 | `src/stores/assistant-identity-store.ts` | Zustand store holding the active assistant's `{ name, version }`. The source of truth every gate reads. |
-| `src/assistant/identity.ts` | Fetches identity from the daemon's `/identity` endpoint and refreshes it on the SSE `identity_changed` event. |
+| `src/assistant/identity.ts` | Fetches identity from the assistant's `/identity` endpoint and refreshes it on the SSE `identity_changed` event. |
 | `src/lib/backwards-compat/impersonate-version-flag.ts` | Debug flag for overriding the reported version locally, so a single dev can exercise old and new code paths without juggling installs. |
 
 ## How a gate is detected
@@ -88,7 +88,7 @@ harmless even if it briefly runs before the version hydrates.
 
 It is **not safe for writes** whose legacy fallback mutates state in a way
 a newer assistant would ignore — you could send the old-shaped write to a
-new daemon just because the version hadn't loaded yet. Those paths
+new assistant just because the version hadn't loaded yet. Those paths
 `await whenAssistantVersionKnown()` first, then read the gate against a
 resolved version instead of the conservative `false`-on-unknown default.
 The avatar upload path is the canonical example (`assistant/avatar-api.ts`
@@ -119,7 +119,7 @@ Each module owns one feature's old/new split. Current registry:
 |---|---|---|---|
 | `flag-query-freshness.ts` | `0.8.5` | 5 s poll interval on feature-flag queries | Push-based invalidation via `sync_changed` + SSE reconnect (60 s stale, no poll) |
 | `conversation-id-wire-field.ts` | `0.8.6` | Send `conversationKey` (create-or-lookup) on `POST /v1/messages` | Send strict `conversationId` (direct internal-id lookup) |
-| `server-minted-conversation.ts` | `0.8.6` | Mint a draft UUID locally, send as `conversationKey` | Omit both id fields; daemon mints the id and echoes it back on first send |
+| `server-minted-conversation.ts` | `0.8.6` | Mint a draft UUID locally, send as `conversationKey` | Omit both id fields; assistant mints the id and echoes it back on first send |
 | `avatar-state-manifest.ts` | `0.8.7` | Infer render mode from workspace sidecar files; write via generic `workspace/write` + `workspace/delete` | Authoritative `GET /avatar/state` + atomic `POST /avatar/image` |
 | `conversation-processing-state.ts` | `0.8.8` | Client-side optimistic mirror (`processingConversationIds`), cleared manually on terminal events | Trust the server `isProcessing` flag on the conversation row |
 | `llm-context-summary-view.ts` | `0.8.12` | Inline context sections from the list response | `view=summary` light list + lazy per-log detail via `GET /v1/llm-request-logs/:id/context` |
@@ -141,7 +141,7 @@ with the code they protect:
 - **Message normalization** — `src/domains/chat/api/messages.ts`
   reconstructs the unified `contentBlocks` discriminated union from the
   pre-0.8.8 positional arrays (`textSegments`, `thinkingSegments`,
-  `toolCalls`, `surfaces`, `attachments`, `contentOrder`) when a daemon
+  `toolCalls`, `surfaces`, `attachments`, `contentOrder`) when an assistant
   omits `contentBlocks`, so the renderer only ever deals with one shape.
 - **Electron / Capacitor bridge** — `src/runtime/is-electron.ts` declares
   `window.vellum` with **optional capability groups** (`helper?`,
@@ -152,16 +152,16 @@ with the code they protect:
 - **localStorage migrations** — `src/utils/storage-migration.ts` performs
   one-time, idempotent key renames (legacy keys → the `vellum:` / `device:`
   namespaces). Run at startup before any store reads localStorage. This is
-  client-internal versioning, not daemon compatibility.
+  client-internal versioning, not assistant compatibility.
 
-## Testing against an old (or new) daemon
+## Testing against an old (or new) assistant
 
 You don't need multiple assistant installs. The impersonation flag
 overrides the version every gate sees:
 
 ```js
 // In the browser console (debug builds expose window._vellumDebug.flags):
-impersonateVersion("0.8.6"); // pretend the daemon is 0.8.6, then reload
+impersonateVersion("0.8.6"); // pretend the assistant is 0.8.6, then reload
 impersonateVersion(null);    // clear the override, then reload
 impersonateVersion();        // log the current override, no reload
 ```


### PR DESCRIPTION
## Why

The web client always serves the latest bundle, but the assistant/daemon it talks to runs locally and can be at any installed version. The codebase already handles this asymmetry through a centralized version-gating layer in `clients/web/src/lib/backwards-compat/`, but there was no doc explaining how it works. New features that depend on a daemon endpoint, wire field, or event shape need to gate correctly or they break against older daemons — so this seam deserves the same documented treatment as the event bus, state management, and platform gating.

## What

Adds `clients/web/docs/BACKWARDS_COMPAT.md` covering:

- **The problem** — newer web bundle vs. arbitrarily-old local daemon, and why the gates are explicitly a temporary layer.
- **Where it lives** — the `src/lib/backwards-compat/` registry, `utils.ts` primitives, `semver.ts`, and the identity store.
- **Gate detection** — `useAssistantSupports` (hook/render) vs. `assistantSupports` (snapshot) vs. `whenAssistantVersionKnown` (write paths), plus the version semantics (unknown ⇒ `false`, pre-release stripping, `dev` builds treated as ahead of stable).
- **Read vs. write paths** — why writes must await a resolved version before reading a snapshot gate.
- **Adding a gate** — the file-per-feature + `MIN_VERSION` convention.
- **The current gate table** — every module with its `MIN_VERSION` and old/new behavior.
- **Related seams outside the registry** — SSE event-envelope parsing, pre-0.8.8 message normalization, the optional-capability Electron/Capacitor bridge, and localStorage migrations.
- **Testing** — the `impersonateVersion()` debug flag.

Also links the new doc from `clients/web/AGENTS.md` so it's discoverable alongside the other web docs.

Docs-only change — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019i2AX6ih735dZfJSDHWtEu)_