### PR TITLE
Exclude disabled-plugin tools from the executable tool surface

### DIFF
--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../plugins/registry.js";
 import { type HookFunction, type Plugin } from "../plugins/types.js";
 import {
+  getAllToolDefinitions,
   getPluginToolDefinitions,
   registerPluginTools,
 } from "../tools/registry.js";
@@ -146,6 +147,37 @@ describe("per-surface disabled-state filtering", () => {
     await removeSentinel("default-test-tools");
     defs = getPluginToolDefinitions();
     expect(defs.some((d) => d.name === "test_tool")).toBe(true);
+  });
+
+  test("getAllToolDefinitions excludes tools from a disabled plugin", async () => {
+    // getAllToolDefinitions is the base tool snapshot the conversation tool
+    // resolver captures at creation. A plugin disabled BEFORE a new
+    // conversation starts must not leak its tools here — otherwise the
+    // resolver's core/plugin split (which reads the filtered
+    // getPluginToolDefinitions) misclassifies them as core and keeps them on
+    // the wire to the LLM, executable despite being hidden from the catalog.
+    const plugin: Plugin = {
+      manifest: { name: "default-test-base-snapshot", version: "1.0.0" },
+      tools: [makeFakeTool("base_snapshot_tool")],
+    };
+    registerPlugin(plugin);
+    registerPluginTools("default-test-base-snapshot", plugin.tools!);
+
+    // Before disabling: tool is part of the base snapshot.
+    let defs = getAllToolDefinitions();
+    expect(defs.some((d) => d.name === "base_snapshot_tool")).toBe(true);
+
+    // Disable via sentinel.
+    await createSentinel("default-test-base-snapshot");
+
+    // After disabling: tool drops from the base snapshot at read time.
+    defs = getAllToolDefinitions();
+    expect(defs.some((d) => d.name === "base_snapshot_tool")).toBe(false);
+
+    // Re-enable.
+    await removeSentinel("default-test-base-snapshot");
+    defs = getAllToolDefinitions();
+    expect(defs.some((d) => d.name === "base_snapshot_tool")).toBe(true);
   });
 
   test("disabling one plugin does not affect others", async () => {

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -918,7 +918,17 @@ export function getAllToolDefinitions(): Tool[] {
   // the base tool list, which is shared across sessions via the global
   // registry.  Including them here causes "Tool names must be unique"
   // errors when the projection appends the same tools a second time.
-  return getAllTools().filter(
+  //
+  // Build on `getEnabledTools()` so tools from a disabled plugin are also
+  // excluded. This is the base snapshot the conversation tool resolver
+  // captures at creation: a plugin disabled BEFORE a new conversation is
+  // created would otherwise leak its tools here, and because the resolver's
+  // core/plugin split reads the (filtered) `getPluginToolDefinitions()`, the
+  // disabled plugin's tools would be misclassified as core and stay on the
+  // wire to the LLM — executable even though `assistant tools list` reports
+  // them gone. Filtering here keeps the executable surface and the listing
+  // in lockstep.
+  return getEnabledTools().filter(
     (t) => ownersByName.get(t.name)?.kind !== "skill",
   );
 }


### PR DESCRIPTION
## Context

Follow-up to #36262, addressing a [Codex review comment](https://github.com/vellum-ai/vellum-assistant/pull/36262#discussion_r3481519942) (P1) on that PR.

#36262 made `assistant tools list` filter out tools from disabled plugins. But it only fixed the **listing** — the **executable** surface still included them in a common scenario, so the catalog and what the LLM can actually call drifted apart.

## The remaining bug

A conversation captures its base tool snapshot at creation from `getAllToolDefinitions()`, which excluded skill-origin tools but **not** disabled-plugin tools. The resolver (`createResolveToolsCallback`) then splits that snapshot into core vs dynamic categories, identifying plugin tools via `getPluginToolDefinitions()` — which **does** filter disabled plugins.

So when a plugin is disabled **before a new conversation is created**:

1. `getAllToolDefinitions()` snapshot still contains the disabled plugin's tools.
2. `getPluginToolDefinitions()` returns nothing for it, so its tool names aren't in the "plugin" set.
3. The resolver's `coreToolDefs` filter (which strips MCP/workspace/plugin names) therefore keeps those tools, **misclassifying them as core**.
4. They stay on the wire to the LLM every turn → **still executable**, even though `assistant tools list` reports them gone.

## Fix

Build `getAllToolDefinitions()` on `getEnabledTools()` (introduced in #36262), so disabled-plugin tools are excluded from the base snapshot too — alongside the existing skill-origin exclusion.

`getAllToolDefinitions()` is the single source for the agent base snapshot (`conversation.ts`), prompt-cache warming, and the btw sidechain, so all LLM-facing tool sets now match the catalog. Re-enabling a plugin restores its tools on the next turn via the resolver's existing per-turn re-read of `getPluginToolDefinitions()`.

## Testing

- New regression test in `plugin-disabled-state.test.ts`: `getAllToolDefinitions()` includes a plugin's tool, drops it once the `.disabled` sentinel is written, and restores it when re-enabled.
- `plugin-disabled-state`, `tools-get-route`, `registry`, and `conversation-tool-setup-exclude` suites pass; typecheck and lint clean.
- The 3 count-based failures seen when several tool suites share one Bun process are pre-existing cross-file registry contamination (reproduced on `main` without this change); each suite passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKN52KCEhDW22eHXwEfFqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKN52KCEhDW22eHXwEfFqy)_