### PR TITLE
combo11: simplify guardian-id IPC + serve role derivation

### DIFF
--- a/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
@@ -8,7 +8,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-let ipcResult: unknown = { ok: true, guardians: [] };
+let ipcResult: unknown = { ok: true, guardianIds: [] };
 let ipcError: Error | undefined;
 
 const ipcCallPersistentMock = mock(async () => {
@@ -23,7 +23,7 @@ mock.module("../../ipc/gateway-client.js", () => ({
   ipcCallPersistent: ipcCallPersistentMock,
 }));
 
-const { getGuardianContactIds, invalidateGuardianContactCache } = await import(
+const { getGuardianContactIds } = await import(
   "../guardian-contact-reader.js"
 );
 
@@ -32,16 +32,15 @@ const { emitContactChange } = await import("../contact-events.js");
 beforeEach(() => {
   ipcCallPersistentMock.mockClear();
   ipcError = undefined;
-  ipcResult = { ok: true, guardians: [] };
-  invalidateGuardianContactCache();
+  ipcResult = { ok: true, guardianIds: [] };
+  // Clear any cache carried over from a prior test by emitting a contact change
+  // (the in-file onContactChange subscription drops the cache).
+  emitContactChange();
 });
 
 describe("getGuardianContactIds", () => {
   test("returns the guardian id set from the gateway IPC", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+    ipcResult = { ok: true, guardianIds: ["g1"] };
 
     const ids = await getGuardianContactIds();
 
@@ -53,10 +52,7 @@ describe("getGuardianContactIds", () => {
   });
 
   test("caches within the TTL (second call does not re-invoke the IPC)", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+    ipcResult = { ok: true, guardianIds: ["g1"] };
 
     const first = await getGuardianContactIds();
     const second = await getGuardianContactIds();
@@ -79,33 +75,15 @@ describe("getGuardianContactIds", () => {
     await getGuardianContactIds();
 
     ipcError = undefined;
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+    ipcResult = { ok: true, guardianIds: ["g1"] };
     const ids = await getGuardianContactIds();
 
     expect([...ids]).toEqual(["g1"]);
     expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
   });
 
-  test("invalidate forces a re-fetch", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
-    await getGuardianContactIds();
-    invalidateGuardianContactCache();
-    await getGuardianContactIds();
-
-    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
-  });
-
-  test("a contact-change event clears the cache", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+  test("a contact-change event clears the cache (forces a re-fetch)", async () => {
+    ipcResult = { ok: true, guardianIds: ["g1"] };
     await getGuardianContactIds();
     emitContactChange();
     await getGuardianContactIds();

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -96,8 +96,8 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     id: row.id,
     displayName: row.displayName,
     notes: row.notes,
-    // Role is gateway-owned: the serve layer stamps the real role from the
-    // gateway guardian id set. This neutral default is never authoritative.
+    // gateway-owned; the serve layer stamps the real role from the gateway
+    // guardian id set.
     role: "contact",
     lastInteraction: null,
     interactionCount: 0,

--- a/assistant/src/contacts/guardian-contact-reader.ts
+++ b/assistant/src/contacts/guardian-contact-reader.ts
@@ -30,8 +30,8 @@ export async function getGuardianContactIds(): Promise<Set<string>> {
 
   try {
     const result = await ipcCallPersistent("get_guardian_contact", {});
-    const { guardians } = GetGuardianContactIpcResponseSchema.parse(result);
-    const ids = new Set(guardians.map((g) => g.id));
+    const { guardianIds } = GetGuardianContactIpcResponseSchema.parse(result);
+    const ids = new Set(guardianIds);
     cache = { ids, expiresAt: Date.now() + CACHE_TTL_MS };
     return ids;
   } catch (err) {
@@ -45,10 +45,9 @@ export async function getGuardianContactIds(): Promise<Set<string>> {
 
 /**
  * Drop the cached guardian set. Subscribed to `onContactChange` so contact
- * mutations (rebind/revoke/upsert) refetch on the next read; also exported for
- * any caller that wants to invalidate explicitly.
+ * mutations (rebind/revoke/upsert) refetch on the next read.
  */
-export function invalidateGuardianContactCache(): void {
+function invalidateGuardianContactCache(): void {
   cache = null;
 }
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -37,9 +37,6 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("contact-routes");
 
-/** Sentinel for relayed-read calls that trust the gateway role (no derivation). */
-const EMPTY_GUARDIAN_IDS: ReadonlySet<string> = new Set<string>();
-
 /**
  * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
  * adapters honor its statusCode/errorCode (4xx surfaces as 4xx, not a generic
@@ -108,12 +105,12 @@ function withChannelCompat<T extends { channels: { address: string }[] }>(
  * defaults so the response satisfies the strict enum schema even in degraded
  * mode (assistant DB unreachable → gateway soft-fail join produces nulls).
  *
- * `deriveRole` controls where `role` comes from:
- *   - `true`  (daemon-native reads): role is the neutral `"contact"` default,
- *     so derive it from the gateway guardian id set.
- *   - `false` (gateway-relayed reads): TRUST the gateway-sourced `role` already
+ * `guardianIds` controls where `role` comes from:
+ *   - omitted (gateway-relayed reads): TRUST the gateway-sourced `role` already
  *     on the `ContactRead`. Never re-derive — a stale/empty id-set cache must
  *     not downgrade a relayed guardian to `"contact"`.
+ *   - provided (daemon-native reads): role is the neutral `"contact"` default,
+ *     so derive it from the gateway guardian id set.
  */
 function prepareContactResponse<
   T extends {
@@ -123,12 +120,12 @@ function prepareContactResponse<
     contactType?: string | null;
     channels: { address: string }[];
   },
->(contact: T, guardianIds: ReadonlySet<string>, deriveRole: boolean): T {
+>(contact: T, guardianIds?: ReadonlySet<string>): T {
   const coerced =
     contact.contactType == null
       ? { ...contact, contactType: "human" as T["contactType"] }
       : contact;
-  const withRole = deriveRole
+  const withRole = guardianIds
     ? withGatewayRole(coerced, guardianIds)
     : coerced;
   return withChannelCompat(withGuardianNameOverride(withRole));
@@ -203,13 +200,11 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
       ...(role ? { role } : {}),
     });
     const { contacts } = ListContactsIpcResponseSchema.parse(result);
-    // Relayed reads carry a gateway-sourced role — trust it (deriveRole=false),
+    // Relayed reads carry a gateway-sourced role — trust it (omit guardianIds),
     // so the guardian id set is not consulted here.
     return {
       ok: true,
-      contacts: contacts.map((c) =>
-        prepareContactResponse(c, EMPTY_GUARDIAN_IDS, false),
-      ),
+      contacts: contacts.map((c) => prepareContactResponse(c)),
     };
   } catch (err) {
     rethrowGatewayError(err);
@@ -250,9 +245,7 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map((c) =>
-        prepareContactResponse(c, guardianIds, true),
-      ),
+      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
     };
   }
 
@@ -269,9 +262,7 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map((c) =>
-        prepareContactResponse(c, guardianIds, true),
-      ),
+      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
     };
   }
 
@@ -287,10 +278,10 @@ export async function handleGetContact(contactId: string) {
     }
     const { contact, assistantMetadata } =
       GetContactIpcResponseSchema.parse(result);
-    // Relayed read: trust the gateway-sourced role (deriveRole=false).
+    // Relayed read: trust the gateway-sourced role (omit guardianIds).
     return {
       ok: true,
-      contact: prepareContactResponse(contact, EMPTY_GUARDIAN_IDS, false),
+      contact: prepareContactResponse(contact),
       assistantMetadata: assistantMetadata ?? undefined,
     };
   } catch (err) {
@@ -718,7 +709,7 @@ export const ROUTES: RouteDefinition[] = [
       // Daemon-native read: role is the neutral default, so derive it.
       const guardianIds = await getGuardianContactIds();
       return searchContacts(parsed).map((c) =>
-        prepareContactResponse(c, guardianIds, true),
+        prepareContactResponse(c, guardianIds),
       );
     },
   },
@@ -819,7 +810,7 @@ async function handleMergeContactsRoute(args: RouteHandlerArgs) {
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contact: prepareContactResponse(contact, guardianIds, true),
+      contact: prepareContactResponse(contact, guardianIds),
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -125,10 +125,9 @@ function tableColumns(db: Database, table: string): Set<string> {
 
 /**
  * The guardian read below depends on the legacy ACL columns
- * `contacts.role` and `contact_channels.status` / `verified_at`. The gateway
- * owns guardian ACL, and a later phase drops these columns from the assistant
- * DB. On schemas without them this one-time cleanup is a no-op: fresh installs
- * have no legacy USER.md to clean, and existing installs already ran it.
+ * `contacts.role` and `contact_channels.status` / `verified_at`. Guardian ACL
+ * is gateway-owned, so these columns may be absent from the assistant DB; this
+ * one-time cleanup is skipped when they are.
  */
 function aclColumnsPresent(db: Database): boolean {
   const contactCols = tableColumns(db, "contacts");

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -360,11 +360,11 @@ describe("get_guardian_contact IPC handler", () => {
 
     const res = (await getGuardianContactHandler({})) as {
       ok: boolean;
-      guardians: { id: string; displayName: string }[];
+      guardianIds: string[];
     };
 
     expect(res.ok).toBe(true);
-    expect(res.guardians).toEqual([{ id: "g1", displayName: "name-g1" }]);
+    expect(res.guardianIds).toEqual(["g1"]);
   });
 
   test("excludes non-guardian contacts", async () => {
@@ -373,11 +373,11 @@ describe("get_guardian_contact IPC handler", () => {
 
     const res = (await getGuardianContactHandler({})) as {
       ok: boolean;
-      guardians: { id: string }[];
+      guardianIds: string[];
     };
 
     expect(res.ok).toBe(true);
-    expect(res.guardians).toEqual([]);
+    expect(res.guardianIds).toEqual([]);
   });
 });
 

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -63,15 +63,16 @@ export class ContactStore {
   }
 
   /**
-   * Guardian contacts (id + displayName) from the gateway DB (source of truth).
-   * Singular per workspace, but returns a set to be safe.
+   * Guardian contact ids from the gateway DB (source of truth). Singular per
+   * workspace, but returns a list to be safe.
    */
-  listGuardianContactIds(): { id: string; displayName: string }[] {
+  listGuardianContactIds(): string[] {
     return this.db
-      .select({ id: contacts.id, displayName: contacts.displayName })
+      .select({ id: contacts.id })
       .from(contacts)
       .where(eq(contacts.role, "guardian"))
-      .all();
+      .all()
+      .map((r) => r.id);
   }
 
   getContactByChannel(

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -113,8 +113,11 @@ export const contactRoutes: IpcRoute[] = [
     method: "get_guardian_contact",
     schema: GetGuardianContactIpcParamsSchema,
     handler: () => {
-      const guardians = getStore().listGuardianContactIds();
-      return GetGuardianContactIpcResponseSchema.parse({ ok: true, guardians });
+      const guardianIds = getStore().listGuardianContactIds();
+      return GetGuardianContactIpcResponseSchema.parse({
+        ok: true,
+        guardianIds,
+      });
     },
   },
   {

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -301,16 +301,9 @@ export type GetGuardianContactIpcParams = z.infer<
   typeof GetGuardianContactIpcParamsSchema
 >;
 
-export const GuardianContactSchema = z.object({
-  id: z.string(),
-  displayName: z.string(),
-});
-
-export type GuardianContact = z.infer<typeof GuardianContactSchema>;
-
 export const GetGuardianContactIpcResponseSchema = z.object({
   ok: z.boolean(),
-  guardians: z.array(GuardianContactSchema),
+  guardianIds: z.array(z.string()),
 });
 
 export type GetGuardianContactIpcResponse = z.infer<


### PR DESCRIPTION
## Summary
- get_guardian_contact IPC returns guardian ids only (drop unused displayName/GuardianContactSchema)
- un-export invalidateGuardianContactCache; collapse prepareContactResponse to a single optional guardianIds param
- trim migration-phase comments to live invariants

Self-review remediation for plan: drain-contacts-role.md