### PR TITLE
combo11: reset gateway-ACL test stand-in in the shared DB reset

### DIFF
--- a/assistant/src/__tests__/db-test-helpers.ts
+++ b/assistant/src/__tests__/db-test-helpers.ts
@@ -20,6 +20,8 @@
  * from `src/memory/db-connection.ts` instead.
  */
 
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
+
 // Mirrors `src/memory/db-singleton.ts`. Duplicated by design — see the
 // "No source-module imports" section above.
 type DbSlotKey = "main" | "logs" | "memory" | "telemetry";
@@ -58,8 +60,13 @@ function dbSlots(): DbSlots {
  * reset, subsequent `getDb()`/`getLogsDb()`/`getMemoryDb()` calls return a
  * handle to the now-gone file. Idempotent: safe to call when no connection
  * has been opened.
+ *
+ * Also clears the in-process gateway-ACL test stand-in (a module-level Map),
+ * so tests that seed guardian/contact ACL rows get per-test isolation from the
+ * same reset that drops the DB singletons.
  */
 export function resetDbForTesting(): void {
+  resetGatewayAclStore();
   const slots = dbSlots();
   for (const key of ["main", "logs", "memory", "telemetry"] as const) {
     const s = slots[key];

--- a/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
+++ b/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
@@ -9,7 +9,7 @@
  * seed that gateway state via {@link seedContactChannel} / `createGuardianBinding`
  * into the in-process gateway ACL store ({@link gatewayAclRows}); this resolver
  * reads the SAME store so the gateway-derived delivery list reflects the seeded
- * binding. No assistant ACL columns are read here — those are Phase-B-dropped.
+ * binding. No assistant ACL columns are read here — the ACL is gateway-owned.
  */
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";

--- a/assistant/src/__tests__/helpers/gateway-acl-store.ts
+++ b/assistant/src/__tests__/helpers/gateway-acl-store.ts
@@ -8,11 +8,12 @@
  * here; instead this module mirrors the gateway ACL rows the resolver reads
  * (`role`, `status`, `verifiedAt`, delivery endpoints). The test seed helpers
  * write here and the test guardian-delivery resolver reads here, so NO test code
- * touches the assistant DB's ACL columns (which Phase B drops).
+ * touches the assistant DB's ACL columns — those columns are gateway-owned.
  *
- * Purely in-memory: no assistant DB / `src/` reach. Isolation is explicit — a
- * test's `beforeEach` calls {@link resetGatewayAclStore} to clear the store,
- * mirroring how sibling in-memory test stores reset themselves.
+ * Purely in-memory: no assistant DB / `src/` reach. Per-test isolation comes
+ * from the shared DB reset: `resetDbForTesting()` (db-test-helpers.ts) calls
+ * {@link resetGatewayAclStore}, so every test that resets the DB also clears
+ * this store. Tests that don't go through that reset call it directly.
  */
 
 export interface GatewayAclRow {
@@ -71,9 +72,9 @@ export function gatewayAclByChannelId(
 }
 
 /**
- * Clear the gateway ACL store. Tests call this in `beforeEach` (alongside the
- * assistant DB reset) for per-test isolation, the same way sibling in-memory
- * test stores reset themselves.
+ * Clear the gateway ACL store. Invoked by `resetDbForTesting()` so the shared DB
+ * reset gives every seeding test per-test isolation; tests that don't go through
+ * that reset call this directly in `beforeEach`.
  */
 export function resetGatewayAclStore(): void {
   rows.clear();

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -7,7 +7,7 @@
  * `gwContacts`/`gwContactChannels`) and warm the member-verdict cache so verdict
  * synthesis and the sync trust fallback resolve the intended trust. The assistant
  * row carries only identity/info columns (id, displayName, channel address/chat
- * id, principalId) — never the Phase-B-dropped ACL columns.
+ * id, principalId) — never the ACL columns, which are gateway-owned.
  */
 
 import { eq } from "drizzle-orm";
@@ -63,8 +63,8 @@ export function seedContactChannel(params: {
     reassignConflictingChannels: !!params.contactId,
   });
 
-  // principalId is an identity column that survives Phase B — keep stamping it
-  // on the assistant row so identity-keyed reads resolve it.
+  // principalId is an identity column (assistant-owned) — keep stamping it on
+  // the assistant row so identity-keyed reads resolve it.
   const db = getDb();
   if (params.principalId !== undefined) {
     db.update(contacts)


### PR DESCRIPTION
## Summary
- Clear the in-process gateway-ACL store from the shared DB reset so seeding tests get per-test isolation (fixes latent cross-test bleed)
- Trim phase-narration comments in the test helpers to live invariants

Self-review remediation for plan: drain-contacts-role.md