### PR TITLE
Add `assistant ps` command for daemon process tree

### DIFF
--- a/assistant/src/cli/commands/__tests__/ps.test.ts
+++ b/assistant/src/cli/commands/__tests__/ps.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the `assistant ps` CLI command.
+ *
+ * Validates:
+ *   - Calls the `ps` IPC method exactly once
+ *   - Renders the daemon process tree (parent + indented children + status)
+ *   - `--json` emits the raw route payload instead of the tree
+ *   - IPC failures surface via exitFromIpcResult (non-zero exit)
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let ipcCalls: Array<{ method: string }> = [];
+let mockResponse: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  statusCode?: number;
+} = { ok: true, result: { processes: [] } };
+
+let logLines: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string) => {
+    ipcCalls.push({ method });
+    return mockResponse;
+  },
+  exitFromIpcResult: (r: { error?: string }) => {
+    process.stderr.write((r.error ?? "error") + "\n");
+    process.exit(1);
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: (msg: string) => logLines.push(msg),
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerPsCommand } = await import("../ps.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runPsCommand(
+  args: string[] = [],
+): Promise<{ stdout: string; exitCode: number }> {
+  const stdoutChunks: string[] = [];
+  let capturedExitCode = 0;
+  let exitCalled = false;
+
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalExit = process.exit.bind(process);
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+    capturedExitCode = code ?? 0;
+    exitCalled = true;
+    throw new Error(`process.exit(${code})`);
+  }) as typeof process.exit;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+    registerPsCommand(program);
+    await program.parseAsync(["node", "assistant", "ps", ...args]);
+  } catch (err) {
+    if (err instanceof Error && !err.message.startsWith("process.exit(")) {
+      // Commander parse errors; ignore
+    }
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    (process as { exit: (code?: number) => never }).exit = originalExit;
+  }
+
+  const exitCode = exitCalled ? capturedExitCode : (process.exitCode ?? 0);
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ipcCalls = [];
+  logLines = [];
+  mockResponse = { ok: true, result: { processes: [] } };
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ps command — IPC wiring", () => {
+  test("calls the `ps` IPC method exactly once", async () => {
+    await runPsCommand();
+    expect(ipcCalls).toEqual([{ method: "ps" }]);
+  });
+});
+
+describe("ps command — tree rendering", () => {
+  test("renders parent, indented children, and status labels", async () => {
+    mockResponse = {
+      ok: true,
+      result: {
+        processes: [
+          {
+            name: "assistant",
+            status: "running",
+            children: [
+              { name: "qdrant", status: "running" },
+              { name: "embed-worker", status: "not_running" },
+            ],
+          },
+        ],
+      },
+    };
+
+    await runPsCommand();
+    const out = logLines.join("\n");
+
+    expect(out).toContain("assistant  [running]");
+    expect(out).toContain("  qdrant  [running]");
+    expect(out).toContain("  embed-worker  [not running]");
+  });
+
+  test("appends info text when present", async () => {
+    mockResponse = {
+      ok: true,
+      result: {
+        processes: [
+          { name: "qdrant", status: "unreachable", info: "probe timed out" },
+        ],
+      },
+    };
+
+    await runPsCommand();
+    expect(logLines.join("\n")).toContain(
+      "qdrant  [unreachable] — probe timed out",
+    );
+  });
+
+  test("prints a placeholder when no processes are reported", async () => {
+    mockResponse = { ok: true, result: { processes: [] } };
+    await runPsCommand();
+    expect(logLines.join("\n")).toContain("No processes reported.");
+  });
+});
+
+describe("ps command — JSON output", () => {
+  test("--json emits the raw route payload, not the tree", async () => {
+    const result = {
+      processes: [{ name: "assistant", status: "running" }],
+    };
+    mockResponse = { ok: true, result };
+
+    const { stdout } = await runPsCommand(["--json"]);
+
+    expect(JSON.parse(stdout)).toEqual(result);
+    // Tree renderer should not have run.
+    expect(logLines.join("\n")).not.toContain("[running]");
+  });
+});
+
+describe("ps command — failures", () => {
+  test("exits non-zero when the IPC call fails", async () => {
+    mockResponse = { ok: false, error: "boom", statusCode: 500 };
+    const { exitCode } = await runPsCommand();
+    expect(exitCode).toBe(1);
+  });
+});

--- a/assistant/src/cli/commands/ps.ts
+++ b/assistant/src/cli/commands/ps.ts
@@ -1,0 +1,89 @@
+/**
+ * CLI command: `assistant ps`
+ *
+ * Thin IPC wrapper over the daemon's `ps` route. Renders the daemon's own
+ * process tree (the assistant runtime and its supervised subsystems —
+ * qdrant, embed-worker) to the console. The route owns the live probing;
+ * the CLI just forwards the request and formats the response.
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { registerCommand } from "../lib/register-command.js";
+import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
+
+interface ProcessEntry {
+  name: string;
+  status: "running" | "not_running" | "unreachable";
+  children?: ProcessEntry[];
+  info?: string;
+}
+
+interface PsResponse {
+  processes: ProcessEntry[];
+}
+
+const STATUS_LABEL: Record<ProcessEntry["status"], string> = {
+  running: "running",
+  not_running: "not running",
+  unreachable: "unreachable",
+};
+
+/** Render one entry plus its children, indented to reflect tree depth. */
+function renderEntry(entry: ProcessEntry, depth: number): void {
+  const indent = "  ".repeat(depth);
+  const status = STATUS_LABEL[entry.status] ?? entry.status;
+  const info = entry.info ? ` — ${entry.info}` : "";
+  log.info(`${indent}${entry.name}  [${status}]${info}`);
+  for (const child of entry.children ?? []) {
+    renderEntry(child, depth + 1);
+  }
+}
+
+export function registerPsCommand(program: Command): void {
+  registerCommand(program, {
+    name: "ps",
+    transport: "ipc",
+    description:
+      "Show the assistant daemon's process tree and subsystem health",
+    build: (ps) => {
+      ps.option("--json", "Machine-readable JSON output").addHelpText(
+        "after",
+        `
+Reports the daemon's own process tree: the assistant runtime plus its
+supervised subsystems (qdrant vector store, embed-worker). Each subsystem
+status is probed live — qdrant via its readiness endpoint, embed-worker via
+PID-file liveness — so a status of "unreachable" means the probe itself
+failed rather than the process being confirmed down.
+
+Examples:
+  $ assistant ps
+  $ assistant ps --json`,
+      );
+
+      ps.action(async (_opts, cmd: Command) => {
+        const r = await cliIpcCall<PsResponse>("ps");
+        if (!r.ok) return exitFromIpcResult(r);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+          return;
+        }
+
+        const processes = r.result?.processes ?? [];
+        if (processes.length === 0) {
+          log.info("No processes reported.");
+          return;
+        }
+
+        log.info("");
+        for (const entry of processes) {
+          renderEntry(entry, 0);
+        }
+        log.info("");
+      });
+    },
+  });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -40,6 +40,7 @@ import { registerOAuthCommand } from "./commands/oauth/index.js";
 import { registerPendingCommand } from "./commands/pending.js";
 import { registerPlatformCommand } from "./commands/platform/index.js";
 import { registerPluginsCommand } from "./commands/plugins.js";
+import { registerPsCommand } from "./commands/ps.js";
 import { registerRoutesCommand } from "./commands/routes.js";
 import { registerSchedulesCommand } from "./commands/schedules.js";
 import { registerSequenceCommand } from "./commands/sequence.js";
@@ -137,6 +138,7 @@ Examples:
   if (isExternalPluginsEnabled(getConfigReadOnly())) {
     registerPluginsCommand(program);
   }
+  registerPsCommand(program);
   registerRoutesCommand(program);
   registerSchedulesCommand(program);
   registerSequenceCommand(program);

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -202,6 +202,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "platform callback-routes",
   "platform callback-routes register",
   "platform callback-routes list",
+  "ps",
   "routes",
   "routes list",
   "routes inspect",


### PR DESCRIPTION
## Why

The daemon already serves a `ps` route (`GET /v1/ps`) that reports its own process tree — the assistant runtime plus its supervised subsystems (qdrant vector store, embed-worker), each probed live (qdrant via its readiness endpoint, embed-worker via PID-file liveness). Because it lives in the shared `ROUTES` array, it's dual-exposed over both HTTP and IPC. But nothing on the CLI surfaced it, so there was no easy way to log the process tree to the console.

## What

- **New command `assistant ps`** (`assistant/src/cli/commands/ps.ts`): a thin `ipc`-transport wrapper that calls the `ps` IPC method and renders the process tree to the console. Indents children to reflect tree depth, shows each subsystem's status (`running` / `not running` / `unreachable`), and appends any `info` text. Supports `--json` for the raw route payload. Follows the `status`/`routes` command pattern — one IPC call per action, no daemon-internal imports (satisfies `cli/no-daemon-internals`).
- **Registered** in `assistant/src/cli/program.ts`.
- **Gateway risk registry** (`gateway/src/risk/command-registry/commands/assistant.ts`): added the `ps` command path (low-risk, read-only) per the CLI convention that command additions stay in sync with command-registry coverage.
- **Tests** (`assistant/src/cli/commands/__tests__/ps.test.ts`): IPC wiring, tree rendering, `info` text, empty-list placeholder, `--json` output, and the failure path.

## Example

```
$ assistant ps

assistant  [running]
  qdrant  [running]
  embed-worker  [not running]
```

## Testing

- `bun test src/cli/commands/__tests__/ps.test.ts` → 6 pass
- `bun test src/risk/command-registry.test.ts` (gateway) → 51 pass
- Targeted `tsc --noEmit` and `eslint` clean for all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZdVtmezMXKMVof8PaAVzc)_