### PR TITLE
Combo 11 Phase A: drain contacts.role reads to the gateway

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -90,6 +90,7 @@ import {
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 initAuthSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
@@ -131,6 +132,7 @@ function resetTables(): void {
     "contact_channels",
     "contacts",
   );
+  resetGatewayAclStore();
   deliveryChannels.resetAllRunDeliveryClaims();
   pendingInteractions.clear();
 }

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -74,17 +74,11 @@ mock.module("../ipc/gateway-client.js", () => ({
     params?: Record<string, unknown>,
   ) => {
     if (method === "mark_channel_revoked") {
-      const { getDb } = await import("../memory/db-connection.js");
-      const { contactChannels } = await import("../memory/schema.js");
-      const { eq } = await import("drizzle-orm");
+      const { revokeChannelById } = await import(
+        "./helpers/seed-contact-channel.js"
+      );
       const channelId = params?.contactChannelId as string | undefined;
-      if (channelId) {
-        getDb()
-          .update(contactChannels)
-          .set({ status: "revoked" })
-          .where(eq(contactChannels.id, channelId))
-          .run();
-      }
+      if (channelId) revokeChannelById(channelId);
     }
     return {
       ok: true,
@@ -105,40 +99,10 @@ mock.module("../ipc/gateway-client.js", () => ({
 // existence from the gateway. Derive the list from the local binding state so
 // the gateway-backed presence guard mirrors the DB the rest of the test sets up.
 const resolveGuardianList = async (input?: { channelTypes?: string[] }) => {
-  const { getDb } = await import("../memory/db-connection.js");
-  const { contacts, contactChannels } = await import("../memory/schema.js");
-  const { and, eq } = await import("drizzle-orm");
-  const channels = input?.channelTypes ?? [];
-  return channels
-    .map((channelType) => {
-      const row = getDb()
-        .select({ contact: contacts, channel: contactChannels })
-        .from(contacts)
-        .innerJoin(
-          contactChannels,
-          eq(contacts.id, contactChannels.contactId),
-        )
-        .where(
-          and(
-            eq(contacts.role, "guardian"),
-            eq(contactChannels.type, channelType),
-            eq(contactChannels.status, "active"),
-          ),
-        )
-        .get();
-      if (!row) return null;
-      return {
-        channelType,
-        contactId: row.contact.id,
-        principalId: row.contact.principalId ?? null,
-        displayName: row.contact.displayName ?? null,
-        address: row.channel.address,
-        externalChatId: row.channel.externalChatId ?? null,
-        status: "active",
-        verifiedAt: row.channel.verifiedAt ?? null,
-      };
-    })
-    .filter((g) => g !== null);
+  const { deriveGuardianDeliveries } = await import(
+    "./helpers/derive-guardian-delivery.js"
+  );
+  return deriveGuardianDeliveries({ channelTypes: input?.channelTypes ?? [] });
 };
 
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
@@ -179,7 +143,6 @@ import {
 } from "../memory/guardian-rate-limits.js";
 import {
   channelVerificationSessions,
-  contactChannels,
   conversations,
 } from "../memory/schema.js";
 import {
@@ -206,6 +169,8 @@ import {
 } from "../runtime/verification-templates.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
+import { revokeChannelsByType } from "./helpers/seed-contact-channel.js";
 
 initializeDb();
 
@@ -220,22 +185,18 @@ function resetTables(): void {
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
   db.run("DELETE FROM external_conversation_bindings");
+  resetGatewayAclStore();
   telegramDeliverCalls.length = 0;
   voiceCallInitCalls.length = 0;
   mockBotUsername = "test_bot";
 }
 
 /**
- * Revoke a guardian channel's local ACL state directly. The production revoke
- * is gateway-owned (relayed via mark_channel_revoked); this stamps the local
- * mirror so the guardian-resolution reads still under test see the downgrade.
+ * Stamp the local mirror of a gateway-owned guardian-channel revoke so the
+ * guardian-resolution reads still running locally observe the downgrade.
  */
 function revokeGuardianChannelLocally(channelType: string): void {
-  getDb()
-    .update(contactChannels)
-    .set({ status: "revoked" })
-    .where(eq(contactChannels.type, channelType))
-    .run();
+  revokeChannelsByType(channelType);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -37,6 +37,13 @@ mock.module("../prompts/user-reference.js", () => ({
   resolveGuardianName: () => "Your Guardian",
 }));
 
+// Role + the guardian name override derive from the gateway guardian id set.
+// Drive it deterministically per test.
+let guardianIds = new Set<string>();
+mock.module("../contacts/guardian-contact-reader.js", () => ({
+  getGuardianContactIds: async () => guardianIds,
+}));
+
 // IPC relay stub — each test sets the response/behavior.
 type IpcStub = (method: string, params?: Record<string, unknown>) => unknown;
 let ipcStub: IpcStub = () => undefined;
@@ -179,6 +186,7 @@ beforeEach(() => {
   localCalls.length = 0;
   debugLogs.length = 0;
   listContactsArgs.length = 0;
+  guardianIds = new Set();
 });
 
 describe("handleListContacts relay", () => {
@@ -203,13 +211,20 @@ describe("handleListContacts relay", () => {
     expect(ch.externalUserId).toBe(ch.address);
   });
 
-  test("applies guardian display-name override to relayed contacts", async () => {
+  test("trusts the gateway-relayed guardian role + applies the name override regardless of the id-set cache", async () => {
+    // Relayed read carries role "guardian" from the gateway. The guardian id
+    // set is empty/stale (rebind race) but must NOT downgrade the role; the
+    // name override keys off the relayed role.
+    guardianIds = new Set();
     ipcStub = () => ({
       ok: true,
-      contacts: [gatewayContact({ role: "guardian", displayName: "Real Name" })],
+      contacts: [
+        gatewayContact({ role: "guardian", displayName: "Real Name" }),
+      ],
     });
 
     const result = await handleListContacts({});
+    expect(result.contacts[0].role).toBe("guardian");
     expect(result.contacts[0].displayName).toBe("Your Guardian");
   });
 
@@ -343,13 +358,16 @@ describe("handleGetContact relay", () => {
     expect(contact.updatedAt).toBe(1700000000);
   });
 
-  test("applies guardian display-name override", async () => {
+  test("trusts the gateway-relayed guardian role + applies the name override regardless of the id-set cache", async () => {
+    // Empty/stale guardian id set must not downgrade a relayed guardian.
+    guardianIds = new Set();
     ipcStub = () => ({
       ok: true,
       contact: gatewayContact({ role: "guardian", displayName: "Real Name" }),
     });
 
     const result = await handleGetContact("gw-1");
+    expect(result.contact.role).toBe("guardian");
     expect(result.contact.displayName).toBe("Your Guardian");
   });
 

--- a/assistant/src/__tests__/db-test-helpers.ts
+++ b/assistant/src/__tests__/db-test-helpers.ts
@@ -20,6 +20,8 @@
  * from `src/memory/db-connection.ts` instead.
  */
 
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
+
 // Mirrors `src/memory/db-singleton.ts`. Duplicated by design — see the
 // "No source-module imports" section above.
 type DbSlotKey = "main" | "logs" | "memory" | "telemetry";
@@ -58,8 +60,13 @@ function dbSlots(): DbSlots {
  * reset, subsequent `getDb()`/`getLogsDb()`/`getMemoryDb()` calls return a
  * handle to the now-gone file. Idempotent: safe to call when no connection
  * has been opened.
+ *
+ * Also clears the in-process gateway-ACL test stand-in (a module-level Map),
+ * so tests that seed guardian/contact ACL rows get per-test isolation from the
+ * same reset that drops the DB singletons.
  */
 export function resetDbForTesting(): void {
+  resetGatewayAclStore();
   const slots = dbSlots();
   for (const key of ["main", "logs", "memory", "telemetry"] as const) {
     const s = slots[key];

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -32,40 +32,10 @@ mock.module("../config/loader.js", () => ({
 // by reseeding or clearing the local binding directly.
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async (input?: { channelTypes?: string[] }) => {
-    const { getDb } = await import("../memory/db-connection.js");
-    const { contacts, contactChannels } = await import("../memory/schema.js");
-    const { and, eq } = await import("drizzle-orm");
-    const channels = input?.channelTypes ?? [];
-    return channels
-      .map((channelType) => {
-        const row = getDb()
-          .select({ contact: contacts, channel: contactChannels })
-          .from(contacts)
-          .innerJoin(
-            contactChannels,
-            eq(contacts.id, contactChannels.contactId),
-          )
-          .where(
-            and(
-              eq(contacts.role, "guardian"),
-              eq(contactChannels.type, channelType),
-              eq(contactChannels.status, "active"),
-            ),
-          )
-          .get();
-        if (!row) return null;
-        return {
-          channelType,
-          contactId: row.contact.id,
-          principalId: row.contact.principalId ?? null,
-          displayName: row.contact.displayName ?? null,
-          address: row.channel.address,
-          externalChatId: row.channel.externalChatId ?? null,
-          status: "active",
-          verifiedAt: row.channel.verifiedAt ?? null,
-        };
-      })
-      .filter((g) => g !== null);
+    const { deriveGuardianDeliveries } = await import(
+      "./helpers/derive-guardian-delivery.js"
+    );
+    return deriveGuardianDeliveries({ channelTypes: input?.channelTypes ?? [] });
   },
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
@@ -117,6 +87,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { conversations } from "../memory/schema.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -145,6 +116,7 @@ function resetTables(): void {
   db.run("DELETE FROM conversations");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 
   // Seed the vellum guardian binding (gateway does this at startup in production)
   createGuardianBinding({
@@ -240,6 +212,7 @@ describe("guardian-dispatch", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
     createGuardianBinding({
       channel: "vellum",
       guardianExternalUserId: "local-actor-principal",
@@ -283,6 +256,7 @@ describe("guardian-dispatch", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
 
     const convId = "conv-dispatch-no-principal";
     ensureConversation(convId);

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -30,6 +30,7 @@ import {
   setAdapterProcessMessage,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -43,6 +44,7 @@ function resetTables(): void {
   db.run("DELETE FROM external_conversation_bindings");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/assistant/src/__tests__/helpers/channel-test-adapter.ts
+++ b/assistant/src/__tests__/helpers/channel-test-adapter.ts
@@ -62,16 +62,15 @@ mock.module("../../daemon/approval-generators.js", () => ({
 }));
 
 import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
-import { and, desc, eq } from "drizzle-orm";
 
+import { isChannelId } from "../../channels/types.js";
 import { findContactChannel } from "../../contacts/contact-store.js";
-import { getDb } from "../../memory/db-connection.js";
-import { contactChannels, contacts } from "../../memory/schema.js";
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
   MessageProcessor,
 } from "../../runtime/http-types.js";
+import { getCachedMemberAcl } from "../../runtime/member-verdict-cache.js";
 import {
   handleChannelDeliveryAck as _handleChannelDeliveryAck,
   handleListDeadLetters as _handleListDeadLetters,
@@ -82,6 +81,7 @@ import {
   handleDeleteConversation as _handleDeleteConversation,
 } from "../../runtime/routes/channel-inbound-routes.js";
 import { RouteError } from "../../runtime/routes/errors.js";
+import { deriveGuardianForChannel } from "./derive-guardian-delivery.js";
 
 /**
  * Wrap a transport-agnostic handler call, converting RouteError throws
@@ -147,27 +147,6 @@ function stampTrustVerdict(body: Record<string, unknown>): void {
   body.sourceMetadata = { ...(meta ?? {}), trustVerdict: verdict };
 }
 
-/**
- * Local mirror of the gateway's active-guardian-channel resolution, querying
- * the contact store directly (the production query now lives in the gateway).
- */
-function localGuardianForChannel(channelType: string) {
-  const row = getDb()
-    .select({ contact: contacts, channel: contactChannels })
-    .from(contacts)
-    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(
-        eq(contacts.role, "guardian"),
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.status, "active"),
-      ),
-    )
-    .orderBy(desc(contactChannels.verifiedAt))
-    .get();
-  return row ? { contact: row.contact, channel: row.channel } : null;
-}
-
 /** Local mirror of the gateway resolver, reading the daemon contact store. */
 export function resolveLocalTrustVerdict(input: {
   channelType: string;
@@ -182,28 +161,25 @@ export function resolveLocalTrustVerdict(input: {
         address: input.actorExternalId,
       })
     : null;
-  const guardian = localGuardianForChannel(input.channelType);
+  const guardian = deriveGuardianForChannel(input.channelType);
 
   const isGuardian =
     !!guardian &&
     !!canonicalSenderId &&
-    guardian.channel.address.toLowerCase() === canonicalSenderId.toLowerCase();
+    guardian.address.toLowerCase() === canonicalSenderId.toLowerCase();
 
-  // ACL columns are no longer on the slimmed ContactChannel type; read the raw
-  // row (columns still exist) so this local mirror sees status/policy/verified.
-  const memberRow = member
-    ? (getDb()
-        .select()
-        .from(contactChannels)
-        .where(eq(contactChannels.id, member.channel.id))
-        .get() ?? null)
-    : null;
+  // Mirror the gateway: read the member ACL from the warmed verdict cache (the
+  // source production resolves from) rather than the local ACL columns.
+  const memberAcl =
+    member && input.actorExternalId && isChannelId(input.channelType)
+      ? getCachedMemberAcl(input.channelType, input.actorExternalId)
+      : undefined;
 
   let trustClass: TrustClass;
   if (isGuardian) {
     trustClass = "guardian";
-  } else if (memberRow) {
-    const status = memberRow.status;
+  } else if (memberAcl) {
+    const status = memberAcl.status;
     if (status === "active") trustClass = "trusted_contact";
     else if (status === "unverified" || status === "pending")
       trustClass = "unverified_contact";
@@ -215,23 +191,21 @@ export function resolveLocalTrustVerdict(input: {
   const verdict: TrustVerdict = { trustClass, canonicalSenderId };
 
   if (guardian) {
-    verdict.guardianExternalUserId = guardian.channel.address;
-    verdict.guardianDeliveryChatId = guardian.channel.externalChatId;
-    if (guardian.contact.principalId)
-      verdict.guardianPrincipalId = guardian.contact.principalId;
-    verdict.guardianDisplayName = guardian.contact.displayName;
+    verdict.guardianExternalUserId = guardian.address;
+    verdict.guardianDeliveryChatId = guardian.externalChatId ?? null;
+    if (guardian.principalId)
+      verdict.guardianPrincipalId = guardian.principalId;
+    verdict.guardianDisplayName = guardian.displayName ?? undefined;
   }
 
-  if (member && memberRow) {
+  if (member && memberAcl) {
     verdict.contactId = member.channel.contactId;
     verdict.channelId = member.channel.id;
     verdict.type = member.channel.type;
     verdict.address = member.channel.address;
     verdict.externalChatId = member.channel.externalChatId;
-    verdict.status = memberRow.status;
-    verdict.policy = memberRow.policy;
-    verdict.verifiedAt = memberRow.verifiedAt;
-    verdict.verifiedVia = memberRow.verifiedVia;
+    verdict.status = memberAcl.status;
+    verdict.policy = memberAcl.policy;
     verdict.memberDisplayName = member.contact.displayName;
   }
 

--- a/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
+++ b/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
@@ -1,0 +1,66 @@
+/**
+ * Test-only resolver that mirrors the gateway's active-guardian-channel query.
+ *
+ * Production resolves the guardian binding + per-channel delivery endpoints from
+ * the gateway (`gateway/src/risk/guardian-delivery-resolver.ts`, reached via the
+ * `resolve_guardian_delivery` IPC route) — `role = 'guardian'` joined to active
+ * gateway contact channels, returning EVERY active row ordered by `verifiedAt`
+ * desc, optionally narrowed to `channelTypes` (empty array = unfiltered). Tests
+ * seed that gateway state via {@link seedContactChannel} / `createGuardianBinding`
+ * into the in-process gateway ACL store ({@link gatewayAclRows}); this resolver
+ * reads the SAME store so the gateway-derived delivery list reflects the seeded
+ * binding. No assistant ACL columns are read here — those are Phase-B-dropped.
+ */
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+import { gatewayAclRows } from "./gateway-acl-store.js";
+
+/**
+ * Resolve active guardian deliveries from the gateway ACL store, optionally
+ * filtered to a single channel (when `channelType` is given) or to a set of
+ * channel types (when `channelTypes` is given). Mirrors the gateway resolution:
+ * `role = 'guardian'` joined to active channels, returning ALL active rows
+ * ordered by verification recency. An empty `channelTypes` array means
+ * unfiltered (all types), matching the production resolver.
+ */
+export function deriveGuardianDeliveries(filter?: {
+  channelType?: string;
+  channelTypes?: string[];
+}): GuardianDelivery[] {
+  const channelTypes =
+    filter?.channelTypes ??
+    (filter?.channelType !== undefined ? [filter.channelType] : undefined);
+
+  return gatewayAclRows()
+    .filter((r) => {
+      if (r.role !== "guardian" || r.status !== "active") return false;
+      // Empty array => no filter (all types), matching production's
+      // `channelTypes.length > 0` predicate guard.
+      if (channelTypes && channelTypes.length > 0) {
+        return channelTypes.includes(r.channelType);
+      }
+      return true;
+    })
+    .sort((a, b) => (b.verifiedAt ?? 0) - (a.verifiedAt ?? 0))
+    .map((r) => ({
+      channelType: r.channelType,
+      contactId: r.contactId,
+      principalId: r.principalId ?? null,
+      displayName: r.displayName ?? null,
+      address: r.address,
+      externalChatId: r.externalChatId ?? null,
+      status: "active",
+      verifiedAt: r.verifiedAt ?? null,
+    }));
+}
+
+/**
+ * The single active guardian delivery for a channel type, mirroring the
+ * gateway's per-channel resolution (most-recently-verified wins).
+ */
+export function deriveGuardianForChannel(
+  channelType: string,
+): GuardianDelivery | null {
+  return deriveGuardianDeliveries({ channelType })[0] ?? null;
+}

--- a/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
+++ b/assistant/src/__tests__/helpers/derive-guardian-delivery.ts
@@ -9,7 +9,7 @@
  * seed that gateway state via {@link seedContactChannel} / `createGuardianBinding`
  * into the in-process gateway ACL store ({@link gatewayAclRows}); this resolver
  * reads the SAME store so the gateway-derived delivery list reflects the seeded
- * binding. No assistant ACL columns are read here — those are Phase-B-dropped.
+ * binding. No assistant ACL columns are read here — the ACL is gateway-owned.
  */
 
 import type { GuardianDelivery } from "@vellumai/gateway-client";

--- a/assistant/src/__tests__/helpers/gateway-acl-store.ts
+++ b/assistant/src/__tests__/helpers/gateway-acl-store.ts
@@ -1,0 +1,80 @@
+/**
+ * In-process stand-in for the gateway ACL DB (`gwContacts`/`gwContactChannels`),
+ * used by the trust/guardian test helpers.
+ *
+ * Production resolves the guardian binding + per-channel trust from the GATEWAY
+ * DB (see `gateway/src/risk/guardian-delivery-resolver.ts`). The gateway package
+ * is not a dependency of the assistant, so its `getGatewayDb()` can't be imported
+ * here; instead this module mirrors the gateway ACL rows the resolver reads
+ * (`role`, `status`, `verifiedAt`, delivery endpoints). The test seed helpers
+ * write here and the test guardian-delivery resolver reads here, so NO test code
+ * touches the assistant DB's ACL columns (which Phase B drops).
+ *
+ * Purely in-memory: no assistant DB / `src/` reach. Isolation is explicit — a
+ * test's `beforeEach` calls {@link resetGatewayAclStore} to clear the store,
+ * mirroring how sibling in-memory test stores reset themselves.
+ */
+
+export interface GatewayAclRow {
+  contactId: string;
+  channelId: string;
+  channelType: string;
+  address: string;
+  externalChatId: string | null;
+  principalId: string | null;
+  displayName: string | null;
+  /** Guardian iff role === "guardian"; mirrors gwContacts.role. */
+  role: string;
+  /** Mirrors gwContactChannels.status. */
+  status: string;
+  /** Mirrors gwContactChannels.policy (allow/deny). */
+  policy: string;
+  verifiedAt: number | null;
+}
+
+const rows = new Map<string, GatewayAclRow>();
+
+/** Upsert a gateway ACL row for a channel (keyed by assistant channel id). */
+export function upsertGatewayAcl(row: GatewayAclRow): void {
+  rows.set(row.channelId, row);
+}
+
+/** Patch the status of an existing gateway ACL row, if present. */
+export function setGatewayAclStatusByChannelId(
+  channelId: string,
+  status: string,
+): void {
+  const existing = rows.get(channelId);
+  if (existing) existing.status = status;
+}
+
+/** Patch the status of every gateway ACL row of a channel type. */
+export function setGatewayAclStatusByType(
+  channelType: string,
+  status: string,
+): void {
+  for (const row of rows.values()) {
+    if (row.channelType === channelType) row.status = status;
+  }
+}
+
+/** All gateway ACL rows currently in the store. */
+export function gatewayAclRows(): GatewayAclRow[] {
+  return [...rows.values()];
+}
+
+/** The gateway ACL row for a channel id, or `undefined` when absent. */
+export function gatewayAclByChannelId(
+  channelId: string,
+): GatewayAclRow | undefined {
+  return rows.get(channelId);
+}
+
+/**
+ * Clear the gateway ACL store. Tests call this in `beforeEach` (alongside the
+ * assistant DB reset) for per-test isolation, the same way sibling in-memory
+ * test stores reset themselves.
+ */
+export function resetGatewayAclStore(): void {
+  rows.clear();
+}

--- a/assistant/src/__tests__/helpers/gateway-acl-store.ts
+++ b/assistant/src/__tests__/helpers/gateway-acl-store.ts
@@ -8,11 +8,12 @@
  * here; instead this module mirrors the gateway ACL rows the resolver reads
  * (`role`, `status`, `verifiedAt`, delivery endpoints). The test seed helpers
  * write here and the test guardian-delivery resolver reads here, so NO test code
- * touches the assistant DB's ACL columns (which Phase B drops).
+ * touches the assistant DB's ACL columns — those columns are gateway-owned.
  *
- * Purely in-memory: no assistant DB / `src/` reach. Isolation is explicit — a
- * test's `beforeEach` calls {@link resetGatewayAclStore} to clear the store,
- * mirroring how sibling in-memory test stores reset themselves.
+ * Purely in-memory: no assistant DB / `src/` reach. Per-test isolation comes
+ * from the shared DB reset: `resetDbForTesting()` (db-test-helpers.ts) calls
+ * {@link resetGatewayAclStore}, so every test that resets the DB also clears
+ * this store. Tests that don't go through that reset call it directly.
  */
 
 export interface GatewayAclRow {
@@ -71,9 +72,9 @@ export function gatewayAclByChannelId(
 }
 
 /**
- * Clear the gateway ACL store. Tests call this in `beforeEach` (alongside the
- * assistant DB reset) for per-test isolation, the same way sibling in-memory
- * test stores reset themselves.
+ * Clear the gateway ACL store. Invoked by `resetDbForTesting()` so the shared DB
+ * reset gives every seeding test per-test isolation; tests that don't go through
+ * that reset call this directly in `beforeEach`.
  */
 export function resetGatewayAclStore(): void {
   rows.clear();

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -7,7 +7,7 @@
  * `gwContacts`/`gwContactChannels`) and warm the member-verdict cache so verdict
  * synthesis and the sync trust fallback resolve the intended trust. The assistant
  * row carries only identity/info columns (id, displayName, channel address/chat
- * id, principalId) — never the Phase-B-dropped ACL columns.
+ * id, principalId) — never the ACL columns, which are gateway-owned.
  */
 
 import { eq } from "drizzle-orm";
@@ -63,8 +63,8 @@ export function seedContactChannel(params: {
     reassignConflictingChannels: !!params.contactId,
   });
 
-  // principalId is an identity column that survives Phase B — keep stamping it
-  // on the assistant row so identity-keyed reads resolve it.
+  // principalId is an identity column (assistant-owned) — keep stamping it on
+  // the assistant row so identity-keyed reads resolve it.
   const db = getDb();
   if (params.principalId !== undefined) {
     db.update(contacts)

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -2,9 +2,12 @@
  * Test-only member seeding.
  *
  * Production identity upserts no longer write ACL columns (gateway-owned).
- * Tests that simulate gateway-resolved members stamp the ACL columns directly
- * and warm the member-verdict cache so verdict synthesis and the sync trust
- * fallback resolve the intended trust.
+ * Tests that simulate gateway-resolved members seed the ACL state into the
+ * in-process gateway ACL store ({@link upsertGatewayAcl}, the stand-in for
+ * `gwContacts`/`gwContactChannels`) and warm the member-verdict cache so verdict
+ * synthesis and the sync trust fallback resolve the intended trust. The assistant
+ * row carries only identity/info columns (id, displayName, channel address/chat
+ * id, principalId) — never the Phase-B-dropped ACL columns.
  */
 
 import { eq } from "drizzle-orm";
@@ -17,8 +20,14 @@ import type {
   ContactRole,
 } from "../../contacts/types.js";
 import { getDb } from "../../memory/db-connection.js";
-import { contactChannels, contacts } from "../../memory/schema.js";
+import { contacts } from "../../memory/schema.js";
 import { setMemberVerdict } from "../../runtime/member-verdict-cache.js";
+import {
+  gatewayAclByChannelId,
+  setGatewayAclStatusByChannelId,
+  setGatewayAclStatusByType,
+  upsertGatewayAcl,
+} from "./gateway-acl-store.js";
 
 export function seedContactChannel(params: {
   sourceChannel: string;
@@ -54,30 +63,41 @@ export function seedContactChannel(params: {
     reassignConflictingChannels: !!params.contactId,
   });
 
+  // principalId is an identity column that survives Phase B — keep stamping it
+  // on the assistant row so identity-keyed reads resolve it.
   const db = getDb();
-  if (params.role !== undefined || params.principalId !== undefined) {
-    const set: Record<string, unknown> = {};
-    if (params.role !== undefined) set.role = params.role;
-    if (params.principalId !== undefined) set.principalId = params.principalId;
-    db.update(contacts).set(set).where(eq(contacts.id, contact.id)).run();
+  if (params.principalId !== undefined) {
+    db.update(contacts)
+      .set({ principalId: params.principalId })
+      .where(eq(contacts.id, contact.id))
+      .run();
   }
 
   const channel = contact.channels.find(
     (ch) => ch.type === params.sourceChannel,
   )!;
-  const aclSet: Record<string, unknown> = { updatedAt: Date.now() };
-  if (params.status !== undefined) aclSet.status = params.status;
-  if (params.policy !== undefined) aclSet.policy = params.policy;
-  if (params.verifiedAt !== undefined) aclSet.verifiedAt = params.verifiedAt;
-  if (params.verifiedVia !== undefined) aclSet.verifiedVia = params.verifiedVia;
-  if (params.revokedReason !== undefined)
-    aclSet.revokedReason = params.revokedReason;
-  if (params.blockedReason !== undefined)
-    aclSet.blockedReason = params.blockedReason;
-  db.update(contactChannels)
-    .set(aclSet)
-    .where(eq(contactChannels.id, channel.id))
-    .run();
+
+  // Stamp the gateway-owned ACL row (role/status/verifiedAt + delivery
+  // endpoints) into the gateway ACL store — the source the guardian-delivery
+  // resolver reads, mirroring production. Re-seeding a channel's member ACL
+  // (e.g. a guardian's own active member row) without an explicit role keeps
+  // the existing gateway role, mirroring the gateway: an identity/member upsert
+  // never downgrades a guardian to a plain contact.
+  const status = params.status ?? "active";
+  const existing = gatewayAclByChannelId(channel.id);
+  upsertGatewayAcl({
+    contactId: contact.id,
+    channelId: channel.id,
+    channelType: channel.type,
+    address: channel.address,
+    externalChatId: channel.externalChatId ?? null,
+    principalId: params.principalId ?? existing?.principalId ?? null,
+    displayName: contact.displayName ?? null,
+    role: params.role ?? existing?.role ?? "contact",
+    status,
+    policy: params.policy ?? "allow",
+    verifiedAt: params.verifiedAt ?? existing?.verifiedAt ?? null,
+  });
 
   // Warm the verdict cache so the sync trust fallback resolves this member, as
   // a gateway verdict fetch would in production.
@@ -87,10 +107,25 @@ export function seedContactChannel(params: {
       canonicalSenderId: address,
       contactId: contact.id,
       channelId: channel.id,
-      status: (params.status ?? "active") as ChannelStatus,
+      status: status as ChannelStatus,
       policy: (params.policy ?? "allow") as ChannelPolicy,
     });
   }
 
   return { contactId: contact.id, channelId: channel.id };
+}
+
+/**
+ * Stamp the gateway-owned channel ACL downgrade. Production revoke is
+ * gateway-owned (relayed via `mark_channel_revoked`); tests whose
+ * guardian-resolution reads run against the gateway ACL store call these to
+ * mark channels `revoked` so those reads observe the downgrade.
+ */
+export function revokeChannelsByType(channelType: string): void {
+  setGatewayAclStatusByType(channelType, "revoked");
+}
+
+/** Stamp a gateway-owned channel revoke for a single channel id. */
+export function revokeChannelById(channelId: string): void {
+  setGatewayAclStatusByChannelId(channelId, "revoked");
 }

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -96,24 +96,20 @@ function richContactForId(contactId: string | undefined) {
   if (!contactId) return undefined;
   const contact = getContact(contactId);
   if (!contact) return undefined;
-  // ACL columns live on the still-present DB rows, not the slimmed interfaces;
-  // read them raw to build the gateway-rich response the production read parses.
-  const contactRole = (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contact.id) as { role: string } | undefined
-  )?.role;
+  // The gateway owns the ACL; tests seed it into the gateway ACL store. Source
+  // role/status/policy from there to build the gateway-rich response the
+  // production read parses (never the Phase-B-dropped assistant ACL columns).
   return {
     ok: true,
     contact: {
       id: contact.id,
       displayName: contact.displayName,
-      role: contactRole ?? "contact",
+      role: gatewayContactRole(contact.id) ?? "contact",
       interactionCount: contact.interactionCount,
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
       channels: contact.channels.map((c) => {
-        const acl = rawChannelAcl(c.id);
+        const acl = gatewayChannelAcl(c.id);
         return {
           id: c.id,
           contactId: c.contactId,
@@ -124,39 +120,35 @@ function richContactForId(contactId: string | undefined) {
           status: acl.status,
           policy: acl.policy,
           verifiedAt: acl.verifiedAt,
-          verifiedVia: acl.verifiedVia,
-          lastSeenAt: acl.lastSeenAt,
-          interactionCount: acl.interactionCount,
-          lastInteraction: acl.lastInteraction,
-          revokedReason: acl.revokedReason,
-          blockedReason: acl.blockedReason,
+          verifiedVia: null,
+          lastSeenAt: null,
+          interactionCount: 0,
+          lastInteraction: null,
+          revokedReason: null,
+          blockedReason: null,
         };
       }),
     },
   };
 }
 
-/** Read a channel's ACL columns straight off the still-present DB row. */
-function rawChannelAcl(channelId: string) {
-  return getSqlite()
-    .query(
-      `SELECT status, policy, verified_at AS verifiedAt, verified_via AS verifiedVia,
-              last_seen_at AS lastSeenAt, interaction_count AS interactionCount,
-              last_interaction AS lastInteraction, revoked_reason AS revokedReason,
-              blocked_reason AS blockedReason
-         FROM contact_channels WHERE id = ?`,
-    )
-    .get(channelId) as {
-    status: string;
-    policy: string;
-    verifiedAt: number | null;
-    verifiedVia: string | null;
-    lastSeenAt: number | null;
-    interactionCount: number;
-    lastInteraction: number | null;
-    revokedReason: string | null;
-    blockedReason: string | null;
+/** Read a channel's seeded ACL view from the gateway ACL store. */
+function gatewayChannelAcl(channelId: string): {
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+} {
+  const row = gatewayAclByChannelId(channelId);
+  return {
+    status: row?.status ?? "unverified",
+    policy: row?.policy ?? "allow",
+    verifiedAt: row?.verifiedAt ?? null,
   };
+}
+
+/** The seeded gateway role for any of a contact's channels. */
+function gatewayContactRole(contactId: string): string | undefined {
+  return gatewayAclRows().find((r) => r.contactId === contactId)?.role;
 }
 
 import {
@@ -164,13 +156,18 @@ import {
   getContact,
   upsertContact,
 } from "../contacts/contact-store.js";
-import { getDb, getSqlite } from "../memory/db-connection.js";
+import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import {
   handleChannelInbound,
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
+import {
+  gatewayAclByChannelId,
+  gatewayAclRows,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -194,6 +191,7 @@ function resetState(): void {
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
   gatewayIpcCalls.length = 0;

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -101,24 +101,20 @@ function richContactForId(contactId: string | undefined) {
   if (!contactId) return undefined;
   const contact = getContact(contactId);
   if (!contact) return undefined;
-  // ACL columns live on the still-present DB rows, not the slimmed interfaces;
-  // read them raw to build the gateway-rich response the production read parses.
-  const contactRole = (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contact.id) as { role: string } | undefined
-  )?.role;
+  // The gateway owns the ACL; tests seed it into the gateway ACL store. Source
+  // role/status/policy from there to build the gateway-rich response the
+  // production read parses (never the Phase-B-dropped assistant ACL columns).
   return {
     ok: true,
     contact: {
       id: contact.id,
       displayName: contact.displayName,
-      role: contactRole ?? "contact",
+      role: gatewayContactRole(contact.id) ?? "contact",
       interactionCount: contact.interactionCount,
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
       channels: contact.channels.map((c) => {
-        const acl = rawChannelAcl(c.id);
+        const acl = gatewayChannelAcl(c.id);
         return {
           id: c.id,
           contactId: c.contactId,
@@ -129,39 +125,35 @@ function richContactForId(contactId: string | undefined) {
           status: acl.status,
           policy: acl.policy,
           verifiedAt: acl.verifiedAt,
-          verifiedVia: acl.verifiedVia,
-          lastSeenAt: acl.lastSeenAt,
-          interactionCount: acl.interactionCount,
-          lastInteraction: acl.lastInteraction,
-          revokedReason: acl.revokedReason,
-          blockedReason: acl.blockedReason,
+          verifiedVia: null,
+          lastSeenAt: null,
+          interactionCount: 0,
+          lastInteraction: null,
+          revokedReason: null,
+          blockedReason: null,
         };
       }),
     },
   };
 }
 
-/** Read a channel's ACL columns straight off the still-present DB row. */
-function rawChannelAcl(channelId: string) {
-  return getSqlite()
-    .query(
-      `SELECT status, policy, verified_at AS verifiedAt, verified_via AS verifiedVia,
-              last_seen_at AS lastSeenAt, interaction_count AS interactionCount,
-              last_interaction AS lastInteraction, revoked_reason AS revokedReason,
-              blocked_reason AS blockedReason
-         FROM contact_channels WHERE id = ?`,
-    )
-    .get(channelId) as {
-    status: string;
-    policy: string;
-    verifiedAt: number | null;
-    verifiedVia: string | null;
-    lastSeenAt: number | null;
-    interactionCount: number;
-    lastInteraction: number | null;
-    revokedReason: string | null;
-    blockedReason: string | null;
+/** Read a channel's seeded ACL view from the gateway ACL store. */
+function gatewayChannelAcl(channelId: string): {
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+} {
+  const row = gatewayAclByChannelId(channelId);
+  return {
+    status: row?.status ?? "unverified",
+    policy: row?.policy ?? "allow",
+    verifiedAt: row?.verifiedAt ?? null,
   };
+}
+
+/** The seeded gateway role for any of a contact's channels. */
+function gatewayContactRole(contactId: string): string | undefined {
+  return gatewayAclRows().find((r) => r.contactId === contactId)?.role;
 }
 
 // Lets a test inject a side-effect into the gateway claim — runs after the
@@ -200,6 +192,11 @@ import {
   resolveMemberGateStatus,
 } from "../runtime/invite-redemption-service.js";
 import { hashVoiceCode } from "../util/voice-code.js";
+import {
+  gatewayAclByChannelId,
+  gatewayAclRows,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
@@ -208,6 +205,7 @@ function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");
   getSqlite().run("DELETE FROM contact_channels");
   getSqlite().run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 /** Create a throwaway contact and return its ID, for use as the invite's contactId. */
@@ -215,13 +213,9 @@ function createTargetContact(displayName = "Target Contact"): string {
   return upsertContact({ displayName, role: "contact" }).id;
 }
 
-/** Read a contact's local role column (dropped from the Contact interface). */
+/** Read a contact's seeded gateway role (gateway-owned, not a local column). */
 function localContactRole(contactId: string): string | undefined {
-  return (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contactId) as { role: string } | undefined
-  )?.role;
+  return gatewayContactRole(contactId);
 }
 
 describe("invite-redemption-service", () => {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -26,8 +26,6 @@ import {
   test,
 } from "bun:test";
 
-import { and, desc, eq } from "drizzle-orm";
-
 // ── Platform + logger mocks (must come before any source imports) ────
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -254,7 +252,7 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
 // setup keeps driving guardian resolution without per-test changes. Both the
 // async read and the sync cache peek (read by resolveActorTrust) share the same
 // DB-derived snapshot mirroring the gateway's active-guardian-channel query.
-function deriveGuardianDeliveries(
+function resolveGuardianDeliveries(
   channelTypes?: string[],
 ): Array<Record<string, unknown>> {
   if (mockGuardianDeliveryList) {
@@ -264,41 +262,14 @@ function deriveGuardianDeliveries(
         )
       : mockGuardianDeliveryList;
   }
-  const rows = getDb()
-    .select({ contact: contacts, channel: contactChannels })
-    .from(contacts)
-    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(eq(contacts.role, "guardian"), eq(contactChannels.status, "active")),
-    )
-    .orderBy(desc(contactChannels.verifiedAt))
-    .all();
-  if (rows.length === 0) return [];
-  const guardianId = rows[0].contact.id;
-  const list = rows
-    .filter((r) => r.contact.id === guardianId)
-    .map((r) => ({
-      channelType: r.channel.type,
-      contactId: r.contact.id,
-      principalId: r.contact.principalId ?? null,
-      displayName: r.contact.displayName ?? null,
-      address: r.channel.address,
-      externalChatId: r.channel.externalChatId ?? null,
-      status: r.channel.status,
-      verifiedAt: r.channel.verifiedAt ?? null,
-    }));
-  return channelTypes
-    ? list.filter((g) =>
-        channelTypes.includes(g.channelType),
-      )
-    : list;
+  return deriveGuardianDeliveries({ channelTypes });
 }
 
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async (input?: { channelTypes?: string[] }) =>
-    deriveGuardianDeliveries(input?.channelTypes),
+    resolveGuardianDeliveries(input?.channelTypes),
   peekCachedGuardianDelivery: (input?: { channelTypes?: string[] }) =>
-    deriveGuardianDeliveries(input?.channelTypes),
+    resolveGuardianDeliveries(input?.channelTypes),
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,
@@ -454,11 +425,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { createInvite } from "../memory/invite-store.js";
 import { resetTestTables } from "../memory/raw-query.js";
-import {
-  contactChannels,
-  contacts,
-  conversations,
-} from "../memory/schema.js";
+import { conversations } from "../memory/schema.js";
 import {
   createOutboundSession,
   getGuardianBinding,
@@ -466,6 +433,8 @@ import {
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { deriveGuardianDeliveries } from "./helpers/derive-guardian-delivery.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
@@ -548,6 +517,7 @@ function resetTables() {
     "contact_channels",
     "contacts",
   );
+  resetGatewayAclStore();
   ensuredConvIds = new Set();
 }
 
@@ -2984,6 +2954,7 @@ describe("relay-server", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
     try {
       ensureConversation("conv-invite-no-name");
       const session = createCallSession({
@@ -3028,6 +2999,7 @@ describe("relay-server", () => {
     const db = getDb();
     db.run("DELETE FROM contact_channels");
     db.run("DELETE FROM contacts");
+    resetGatewayAclStore();
     try {
       ensureConversation("conv-invite-uuid-name");
       const session = createCallSession({

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -73,6 +73,7 @@ import {
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -94,6 +95,7 @@ function resetState(): void {
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
 }
@@ -394,9 +396,13 @@ describe("trusted contact lifecycle notification signals", () => {
     // Clear the guardian contact's displayName to empty string so the
     // display name resolution returns a falsy value. createGuardianBinding
     // defaults displayName to the externalUserId, which would be a non-empty
-    // string and defeat the purpose of this test.
+    // string and defeat the purpose of this test. The role column is
+    // gateway-owned now, so target the guardian contact by its seeded
+    // (externalUserId-derived) display name instead.
     const db = getDb();
-    db.run("UPDATE contacts SET display_name = '' WHERE role = 'guardian'");
+    db.run(
+      "UPDATE contacts SET display_name = '' WHERE display_name = 'guardian-noname-111'",
+    );
 
     // Do NOT create a requester contact — display name should resolve to null
 

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -73,7 +73,7 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 }));
 
 import { findContactChannel } from "../contacts/contact-store.js";
-import { getDb, getSqlite } from "../memory/db-connection.js";
+import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   createOutboundSession,
@@ -84,6 +84,10 @@ import {
   seedContactChannel,
 } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import {
+  gatewayAclByChannelId,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -102,6 +106,7 @@ function resetState(): void {
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
   emitSignalCalls.length = 0;
   notifyGuardianCalls.length = 0;
   deliverReplyCalls.length = 0;
@@ -271,13 +276,8 @@ for (const config of CHANNEL_CONFIGS) {
       });
 
       expect(contactResult).not.toBeNull();
-      // Assert the gateway dual-write landed in the local ACL columns.
-      const acl = getSqlite()
-        .query("SELECT status, policy FROM contact_channels WHERE id = ?")
-        .get(contactResult!.channel.id) as {
-        status: string;
-        policy: string;
-      } | null;
+      // Assert the gateway-resolved ACL landed in the gateway ACL store.
+      const acl = gatewayAclByChannelId(contactResult!.channel.id);
       expect(acl!.status).toBe("active");
       expect(acl!.policy).toBe("allow");
       expect(contactResult!.channel.type).toBe(config.channel);

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -22,8 +22,6 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { and, desc, eq } from "drizzle-orm";
-
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel } from "../contacts/contact-store.js";
 import {
@@ -33,7 +31,6 @@ import {
 import type { ChannelStatus } from "../contacts/types.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { contactChannels, contacts } from "../memory/schema.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
 import {
   createOutboundSession,
@@ -44,6 +41,8 @@ import {
   setMemberVerdict,
 } from "../runtime/member-verdict-cache.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
+import { deriveGuardianForChannel } from "./helpers/derive-guardian-delivery.js";
+import { resetGatewayAclStore } from "./helpers/gateway-acl-store.js";
 
 await initializeDb();
 
@@ -57,6 +56,7 @@ function resetTables(): void {
   db.run("DELETE FROM channel_guardian_rate_limits");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 // Mirror a warmed gateway verdict so the sync resolveActorTrust fallback
@@ -77,28 +77,6 @@ function warmMemberVerdict(
     status,
     policy: "allow",
   });
-}
-
-/**
- * Read the local active guardian channel for a channel type, mirroring the
- * gateway's role/status resolution. Used by assertions that confirm the local
- * guardian binding state after verification flows.
- */
-function localGuardianForChannel(channelType: string) {
-  const row = getDb()
-    .select({ contact: contacts, channel: contactChannels })
-    .from(contacts)
-    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(
-        eq(contacts.role, "guardian"),
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.status, "active"),
-      ),
-    )
-    .orderBy(desc(contactChannels.verifiedAt))
-    .get();
-  return row ? { contact: row.contact, channel: row.channel } : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -413,9 +391,9 @@ describe("trusted contact verification → member activation", () => {
     }
 
     // The original guardian binding should remain intact
-    const guardianResult = localGuardianForChannel("telegram");
+    const guardianResult = deriveGuardianForChannel("telegram");
     expect(guardianResult).not.toBeNull();
-    expect(guardianResult!.channel.address).toBe("guardian-user-original");
+    expect(guardianResult!.address).toBe("guardian-user-original");
   });
 
   test("guardian inbound verification succeeds but does not create binding", async () => {
@@ -437,7 +415,7 @@ describe("trusted contact verification → member activation", () => {
       expect(result.verificationType).toBe("guardian");
     }
 
-    const guardianResult = localGuardianForChannel("telegram");
+    const guardianResult = deriveGuardianForChannel("telegram");
     expect(guardianResult).toBeNull();
   });
 });

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -59,24 +59,20 @@ function richContactForId(contactId: string | undefined) {
   if (!contactId) return undefined;
   const contact = getContact(contactId);
   if (!contact) return undefined;
-  // ACL columns live on the still-present DB rows, not the slimmed interfaces;
-  // read them raw to build the gateway-rich response the production read parses.
-  const contactRole = (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contact.id) as { role: string } | undefined
-  )?.role;
+  // The gateway owns the ACL; tests seed it into the gateway ACL store. Source
+  // role/status/policy from there to build the gateway-rich response the
+  // production read parses (never the Phase-B-dropped assistant ACL columns).
   return {
     ok: true,
     contact: {
       id: contact.id,
       displayName: contact.displayName,
-      role: contactRole ?? "contact",
+      role: gatewayContactRole(contact.id) ?? "contact",
       interactionCount: contact.interactionCount,
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
       channels: contact.channels.map((c) => {
-        const acl = rawChannelAcl(c.id);
+        const acl = gatewayChannelAcl(c.id);
         return {
           id: c.id,
           contactId: c.contactId,
@@ -87,48 +83,40 @@ function richContactForId(contactId: string | undefined) {
           status: acl.status,
           policy: acl.policy,
           verifiedAt: acl.verifiedAt,
-          verifiedVia: acl.verifiedVia,
-          lastSeenAt: acl.lastSeenAt,
-          interactionCount: acl.interactionCount,
-          lastInteraction: acl.lastInteraction,
-          revokedReason: acl.revokedReason,
-          blockedReason: acl.blockedReason,
+          verifiedVia: null,
+          lastSeenAt: null,
+          interactionCount: 0,
+          lastInteraction: null,
+          revokedReason: null,
+          blockedReason: null,
         };
       }),
     },
   };
 }
 
-/** Read a channel's ACL columns straight off the still-present DB row. */
-function rawChannelAcl(channelId: string) {
-  return getSqlite()
-    .query(
-      `SELECT status, policy, verified_at AS verifiedAt, verified_via AS verifiedVia,
-              last_seen_at AS lastSeenAt, interaction_count AS interactionCount,
-              last_interaction AS lastInteraction, revoked_reason AS revokedReason,
-              blocked_reason AS blockedReason
-         FROM contact_channels WHERE id = ?`,
-    )
-    .get(channelId) as {
-    status: string;
-    policy: string;
-    verifiedAt: number | null;
-    verifiedVia: string | null;
-    lastSeenAt: number | null;
-    interactionCount: number;
-    lastInteraction: number | null;
-    revokedReason: string | null;
-    blockedReason: string | null;
+/** Read a channel's seeded ACL view from the gateway ACL store. */
+function gatewayChannelAcl(channelId: string): {
+  status: string;
+  policy: string;
+  verifiedAt: number | null;
+} {
+  const row = gatewayAclByChannelId(channelId);
+  return {
+    status: row?.status ?? "unverified",
+    policy: row?.policy ?? "allow",
+    verifiedAt: row?.verifiedAt ?? null,
   };
 }
 
-/** Read a contact's local role column (dropped from the Contact interface). */
+/** The seeded gateway role for any of a contact's channels. */
+function gatewayContactRole(contactId: string): string | undefined {
+  return gatewayAclRows().find((r) => r.contactId === contactId)?.role;
+}
+
+/** Read a contact's seeded gateway role (gateway-owned, not a local column). */
 function localContactRole(contactId: string): string | undefined {
-  return (
-    getSqlite()
-      .query("SELECT role FROM contacts WHERE id = ?")
-      .get(contactId) as { role: string } | undefined
-  )?.role;
+  return gatewayContactRole(contactId);
 }
 
 function resetGatewayIpc() {
@@ -150,6 +138,11 @@ import { initializeDb } from "../memory/db-init.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
+import {
+  gatewayAclByChannelId,
+  gatewayAclRows,
+  resetGatewayAclStore,
+} from "./helpers/gateway-acl-store.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 
 await initializeDb();
@@ -158,6 +151,7 @@ function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");
   getSqlite().run("DELETE FROM contact_channels");
   getSqlite().run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 /** Create a throwaway contact and return its ID, for use as the invite's contactId. */

--- a/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
@@ -68,6 +68,14 @@ function seedGuardian(input: {
   );
 }
 
+/** Drop the legacy ACL columns the guardian read depends on. */
+function dropAclColumns(): void {
+  const sqlite = getSqlite();
+  sqlite.run("ALTER TABLE contacts DROP COLUMN role");
+  sqlite.run("ALTER TABLE contact_channels DROP COLUMN status");
+  sqlite.run("ALTER TABLE contact_channels DROP COLUMN verified_at");
+}
+
 function guardianUserFile(id: string): string | null {
   const row = getSqlite()
     .query<{ user_file: string | null }, [string]>(
@@ -322,5 +330,29 @@ describe("workspace migration 031-drop-user-md", () => {
   test("down() is a no-op (deletion is irreversible)", () => {
     dropUserMdMigration.down(workspaceDir());
     expect(existsSync(userMdPath())).toBe(false);
+  });
+
+  test("ACL columns absent — skips guardian cleanup cleanly and leaves USER.md untouched", () => {
+    // Mirror the later phase that drops the assistant-DB ACL columns. The
+    // migration must skip the guardian-dependent cleanup with no throw.
+    const content = customizedContent();
+    writeFileSync(userMdPath(), content, "utf-8");
+
+    dropAclColumns();
+    try {
+      expect(() => dropUserMdMigration.run(workspaceDir())).not.toThrow();
+    } finally {
+      // Restore schema so later runs (file load order independent) see the
+      // columns; beforeEach only clears rows, not schema.
+      const sqlite = getSqlite();
+      sqlite.run("ALTER TABLE contacts ADD COLUMN role TEXT");
+      sqlite.run("ALTER TABLE contact_channels ADD COLUMN status TEXT");
+      sqlite.run("ALTER TABLE contact_channels ADD COLUMN verified_at INTEGER");
+    }
+
+    // USER.md is left exactly as-is; no users/ scaffold is created.
+    expect(existsSync(userMdPath())).toBe(true);
+    expect(readFileSync(userMdPath(), "utf-8")).toBe(content);
+    expect(existsSync(join(workspaceDir(), "users"))).toBe(false);
   });
 });

--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -42,6 +42,10 @@ mock.module("../../util/logger.js", () => ({
 // the a2a.enabled flag. We use the real config system backed by initializeDb's
 // workspace directory.
 
+import {
+  gatewayAclByChannelId,
+  resetGatewayAclStore,
+} from "../../__tests__/helpers/gateway-acl-store.js";
 import { seedContactChannel } from "../../__tests__/helpers/seed-contact-channel.js";
 import {
   invalidateConfigCache,
@@ -81,13 +85,12 @@ const originalFetch = globalThis.fetch;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Read a channel's local ACL columns directly to assert the gateway dual-write. */
+/** Read a channel's gateway ACL row to assert the gateway-resolved trust. */
 function aclColumns(
   channelId: string,
 ): { status: string; policy: string } | null {
-  return getSqlite()
-    .query("SELECT status, policy FROM contact_channels WHERE id = ?")
-    .get(channelId) as { status: string; policy: string } | null;
+  const row = gatewayAclByChannelId(channelId);
+  return row ? { status: row.status, policy: row.policy } : null;
 }
 
 function resetTables(): void {
@@ -96,6 +99,7 @@ function resetTables(): void {
   sqlite.run("DELETE FROM assistant_contact_metadata");
   sqlite.run("DELETE FROM contact_channels");
   sqlite.run("DELETE FROM contacts");
+  resetGatewayAclStore();
 }
 
 function setConfigEnabled(enabled: boolean): void {

--- a/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
@@ -8,7 +8,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-let ipcResult: unknown = { ok: true, guardians: [] };
+let ipcResult: unknown = { ok: true, guardianIds: [] };
 let ipcError: Error | undefined;
 
 const ipcCallPersistentMock = mock(async () => {
@@ -23,7 +23,7 @@ mock.module("../../ipc/gateway-client.js", () => ({
   ipcCallPersistent: ipcCallPersistentMock,
 }));
 
-const { getGuardianContactIds, invalidateGuardianContactCache } = await import(
+const { getGuardianContactIds } = await import(
   "../guardian-contact-reader.js"
 );
 
@@ -32,16 +32,15 @@ const { emitContactChange } = await import("../contact-events.js");
 beforeEach(() => {
   ipcCallPersistentMock.mockClear();
   ipcError = undefined;
-  ipcResult = { ok: true, guardians: [] };
-  invalidateGuardianContactCache();
+  ipcResult = { ok: true, guardianIds: [] };
+  // Clear any cache carried over from a prior test by emitting a contact change
+  // (the in-file onContactChange subscription drops the cache).
+  emitContactChange();
 });
 
 describe("getGuardianContactIds", () => {
   test("returns the guardian id set from the gateway IPC", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+    ipcResult = { ok: true, guardianIds: ["g1"] };
 
     const ids = await getGuardianContactIds();
 
@@ -53,10 +52,7 @@ describe("getGuardianContactIds", () => {
   });
 
   test("caches within the TTL (second call does not re-invoke the IPC)", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+    ipcResult = { ok: true, guardianIds: ["g1"] };
 
     const first = await getGuardianContactIds();
     const second = await getGuardianContactIds();
@@ -79,33 +75,15 @@ describe("getGuardianContactIds", () => {
     await getGuardianContactIds();
 
     ipcError = undefined;
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+    ipcResult = { ok: true, guardianIds: ["g1"] };
     const ids = await getGuardianContactIds();
 
     expect([...ids]).toEqual(["g1"]);
     expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
   });
 
-  test("invalidate forces a re-fetch", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
-    await getGuardianContactIds();
-    invalidateGuardianContactCache();
-    await getGuardianContactIds();
-
-    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
-  });
-
-  test("a contact-change event clears the cache", async () => {
-    ipcResult = {
-      ok: true,
-      guardians: [{ id: "g1", displayName: "Guardian One" }],
-    };
+  test("a contact-change event clears the cache (forces a re-fetch)", async () => {
+    ipcResult = { ok: true, guardianIds: ["g1"] };
     await getGuardianContactIds();
     emitContactChange();
     await getGuardianContactIds();

--- a/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-contact-reader.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the daemon guardian-contact reader.
+ *
+ * `getGuardianContactIds` relays to the gateway IPC method
+ * `get_guardian_contact` via `ipcCallPersistent`, caches the result with a
+ * short TTL, and FAIL-SOFTS to an empty set (no throw) on IPC error.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let ipcResult: unknown = { ok: true, guardians: [] };
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(async () => {
+  if (ipcError) throw ipcError;
+  return ipcResult;
+});
+
+const actualGatewayClient = await import("../../ipc/gateway-client.js");
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+const { getGuardianContactIds, invalidateGuardianContactCache } = await import(
+  "../guardian-contact-reader.js"
+);
+
+const { emitContactChange } = await import("../contact-events.js");
+
+beforeEach(() => {
+  ipcCallPersistentMock.mockClear();
+  ipcError = undefined;
+  ipcResult = { ok: true, guardians: [] };
+  invalidateGuardianContactCache();
+});
+
+describe("getGuardianContactIds", () => {
+  test("returns the guardian id set from the gateway IPC", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+
+    const ids = await getGuardianContactIds();
+
+    expect([...ids]).toEqual(["g1"]);
+    expect(ipcCallPersistentMock).toHaveBeenCalledWith(
+      "get_guardian_contact",
+      {},
+    );
+  });
+
+  test("caches within the TTL (second call does not re-invoke the IPC)", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+
+    const first = await getGuardianContactIds();
+    const second = await getGuardianContactIds();
+
+    expect([...first]).toEqual(["g1"]);
+    expect([...second]).toEqual(["g1"]);
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fail-softs to an empty set on IPC error (no throw)", async () => {
+    ipcError = new Error("gateway down");
+
+    const ids = await getGuardianContactIds();
+
+    expect([...ids]).toEqual([]);
+  });
+
+  test("does not cache a failed read (retries on the next call)", async () => {
+    ipcError = new Error("gateway down");
+    await getGuardianContactIds();
+
+    ipcError = undefined;
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+    const ids = await getGuardianContactIds();
+
+    expect([...ids]).toEqual(["g1"]);
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("invalidate forces a re-fetch", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+    await getGuardianContactIds();
+    invalidateGuardianContactCache();
+    await getGuardianContactIds();
+
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a contact-change event clears the cache", async () => {
+    ipcResult = {
+      ok: true,
+      guardians: [{ id: "g1", displayName: "Guardian One" }],
+    };
+    await getGuardianContactIds();
+    emitContactChange();
+    await getGuardianContactIds();
+
+    expect(ipcCallPersistentMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -96,8 +96,8 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     id: row.id,
     displayName: row.displayName,
     notes: row.notes,
-    // Role is gateway-owned: the serve layer stamps the real role from the
-    // gateway guardian id set. This neutral default is never authoritative.
+    // gateway-owned; the serve layer stamps the real role from the gateway
+    // guardian id set.
     role: "contact",
     lastInteraction: null,
     interactionCount: 0,

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -96,7 +96,9 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     id: row.id,
     displayName: row.displayName,
     notes: row.notes,
-    role: row.role,
+    // Role is gateway-owned: the serve layer stamps the real role from the
+    // gateway guardian id set. This neutral default is never authoritative.
+    role: "contact",
     lastInteraction: null,
     interactionCount: 0,
     createdAt: row.createdAt,

--- a/assistant/src/contacts/guardian-contact-reader.ts
+++ b/assistant/src/contacts/guardian-contact-reader.ts
@@ -1,0 +1,55 @@
+/**
+ * Daemon-side reader for the guardian contact id(s), sourced from the gateway
+ * DB (source of truth) via the `get_guardian_contact` IPC.
+ *
+ * Lets contact-serve paths determine the guardian without reading the local
+ * `contacts.role` column. Result is cached with a short TTL.
+ *
+ * FAIL-SOFT: a cache miss or IPC error returns an empty set and logs a warning;
+ * this never throws (it runs on contact-serve paths).
+ */
+
+import { GetGuardianContactIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import { ipcCallPersistent } from "../ipc/gateway-client.js";
+import { getLogger } from "../util/logger.js";
+import { onContactChange } from "./contact-events.js";
+
+const log = getLogger("guardian-contact-reader");
+
+const CACHE_TTL_MS = 30_000;
+
+let cache: { ids: Set<string>; expiresAt: number } | null = null;
+
+/**
+ * Guardian contact ids from the gateway DB. Cached for {@link CACHE_TTL_MS};
+ * returns an empty set on IPC error (never throws).
+ */
+export async function getGuardianContactIds(): Promise<Set<string>> {
+  if (cache && cache.expiresAt > Date.now()) return cache.ids;
+
+  try {
+    const result = await ipcCallPersistent("get_guardian_contact", {});
+    const { guardians } = GetGuardianContactIpcResponseSchema.parse(result);
+    const ids = new Set(guardians.map((g) => g.id));
+    cache = { ids, expiresAt: Date.now() + CACHE_TTL_MS };
+    return ids;
+  } catch (err) {
+    log.warn(
+      { err },
+      "get_guardian_contact IPC failed; returning empty guardian set",
+    );
+    return new Set();
+  }
+}
+
+/**
+ * Drop the cached guardian set. Subscribed to `onContactChange` so contact
+ * mutations (rebind/revoke/upsert) refetch on the next read; also exported for
+ * any caller that wants to invalidate explicitly.
+ */
+export function invalidateGuardianContactCache(): void {
+  cache = null;
+}
+
+onContactChange(invalidateGuardianContactCache);

--- a/assistant/src/contacts/guardian-contact-reader.ts
+++ b/assistant/src/contacts/guardian-contact-reader.ts
@@ -30,8 +30,8 @@ export async function getGuardianContactIds(): Promise<Set<string>> {
 
   try {
     const result = await ipcCallPersistent("get_guardian_contact", {});
-    const { guardians } = GetGuardianContactIpcResponseSchema.parse(result);
-    const ids = new Set(guardians.map((g) => g.id));
+    const { guardianIds } = GetGuardianContactIpcResponseSchema.parse(result);
+    const ids = new Set(guardianIds);
     cache = { ids, expiresAt: Date.now() + CACHE_TTL_MS };
     return ids;
   } catch (err) {
@@ -45,10 +45,9 @@ export async function getGuardianContactIds(): Promise<Set<string>> {
 
 /**
  * Drop the cached guardian set. Subscribed to `onContactChange` so contact
- * mutations (rebind/revoke/upsert) refetch on the next read; also exported for
- * any caller that wants to invalidate explicitly.
+ * mutations (rebind/revoke/upsert) refetch on the next read.
  */
-export function invalidateGuardianContactCache(): void {
+function invalidateGuardianContactCache(): void {
   cache = null;
 }
 

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -4,11 +4,13 @@
  * `handleListContacts`, `handleGetContact`, and the `search_contacts`
  * no-filter case relay to the gateway rich read (`contacts_list_rich` /
  * `contacts_get_rich`), which is the source of truth for the ACL fields
- * (`role`/`status`/`policy`/`verifiedAt`/`interactionCount`/`lastInteraction`).
- * These tests assert the serialized response shape is gateway-sourced and
- * unchanged for the web client, that no read path falls back to the assistant
- * DB, and that a relay failure fails closed (surfaces an error) instead of
- * reading local ACL.
+ * (`status`/`policy`/`verifiedAt`/`interactionCount`/`lastInteraction`).
+ * Contact-level `role` is derived at the serve layer from the gateway guardian
+ * id set (never the local `contacts.role` column). These tests assert the
+ * serialized response shape is gateway-sourced and unchanged for the web
+ * client, that no read path falls back to the assistant DB, that role + the
+ * guardian name override derive from the gateway guardian id set, and that a
+ * relay failure fails closed (surfaces an error) instead of reading local ACL.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -58,12 +60,29 @@ mock.module("../../../contacts/contact-store.js", () => ({
   searchContacts: searchContactsMock,
 }));
 
+// Role + the guardian name override derive from the gateway guardian id set,
+// never the local `contacts.role` column. Drive the set deterministically.
+let guardianIds = new Set<string>();
+const getGuardianContactIdsMock = mock(async () => guardianIds);
+
+mock.module("../../../contacts/guardian-contact-reader.js", () => ({
+  getGuardianContactIds: getGuardianContactIdsMock,
+}));
+
+// Make the guardian display-name override observable without a persona file.
+const actualUserReference = await import("../../../prompts/user-reference.js");
+mock.module("../../../prompts/user-reference.js", () => ({
+  ...actualUserReference,
+  resolveGuardianName: (name?: string | null) => `guardian:${name}`,
+}));
+
 const { handleListContacts, handleGetContact, ROUTES } =
   await import("../contact-routes.js");
 
 // Daemon-native contact: INFO is hydrated locally; channel-level ACL fields
 // (status/policy/verification) are gateway-owned and absent on native reads.
-// Contact-level `role` is stored locally (NOT NULL) and always returned.
+// The fixture's `role` is ignored — the serve layer derives role from the
+// gateway guardian id set.
 const nativeContact = {
   id: "ct_2",
   displayName: "Bob",
@@ -133,9 +152,11 @@ describe("contacts read API relays from the gateway", () => {
     contactStoreReadGuard.mockClear();
     searchContactsResult = [];
     searchContactsMock.mockClear();
+    guardianIds = new Set(["ct_1"]);
+    getGuardianContactIdsMock.mockClear();
   });
 
-  test("list relays to contacts_list_rich and serializes the gateway ACL fields", async () => {
+  test("list relays to contacts_list_rich and trusts the gateway-sourced role", async () => {
     ipcResult = { ok: true, contacts: [gatewayContact] };
 
     const result = await handleListContacts({ limit: "50" });
@@ -147,8 +168,11 @@ describe("contacts read API relays from the gateway", () => {
     expect(result.contacts).toHaveLength(1);
 
     const [contact] = result.contacts;
-    // ACL fields are gateway-sourced and reach the web client unchanged.
+    // Role comes straight from the relayed payload; the name override keys off
+    // that role. The guardian id set is NOT consulted on relayed reads.
     expect((contact as { role?: string }).role).toBe("guardian");
+    expect(contact.displayName).toBe("guardian:Alice");
+    expect(getGuardianContactIdsMock).not.toHaveBeenCalled();
     expect(contact.interactionCount).toBe(7);
     expect(contact.lastInteraction).toBe(1900);
     const channel = contact.channels[0] as Record<string, unknown>;
@@ -160,6 +184,35 @@ describe("contacts read API relays from the gateway", () => {
     // Channel compat echoes address into externalUserId for older clients.
     expect(channel.externalUserId).toBe("+15550100");
 
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed list trusts the gateway role even when the guardian id set is empty/stale", async () => {
+    // Reproduces the rebind race: the gateway already returned role "guardian",
+    // but the 30s guardian-id cache is empty (or fail-softed). The relayed role
+    // must NOT be downgraded to "contact", and the name override must still run.
+    ipcResult = { ok: true, contacts: [gatewayContact] };
+    guardianIds = new Set();
+
+    const result = await handleListContacts({ limit: "50" });
+
+    const [contact] = result.contacts;
+    expect((contact as { role?: string }).role).toBe("guardian");
+    expect(contact.displayName).toBe("guardian:Alice");
+    // Relayed reads don't consult the guardian id set (they trust the role).
+    expect(getGuardianContactIdsMock).not.toHaveBeenCalled();
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed get trusts the gateway role even when the guardian id set is empty/stale", async () => {
+    ipcResult = { ok: true, contact: gatewayContact };
+    guardianIds = new Set();
+
+    const result = await handleGetContact("ct_1");
+
+    expect(result.contact.role).toBe("guardian");
+    expect(result.contact.displayName).toBe("guardian:Alice");
+    expect(getGuardianContactIdsMock).not.toHaveBeenCalled();
     expect(contactStoreReadGuard).not.toHaveBeenCalled();
   });
 
@@ -200,6 +253,7 @@ describe("contacts read API relays from the gateway", () => {
     ]);
     expect(result.ok).toBe(true);
     expect(result.contact.role).toBe("guardian");
+    expect(result.contact.displayName).toBe("guardian:Alice");
     expect(result.contact.interactionCount).toBe(7);
     const channel = result.contact.channels[0] as Record<string, unknown>;
     expect(channel.status).toBe("active");
@@ -265,6 +319,8 @@ describe("filtered/native contact reads stay daemon-native", () => {
     contactStoreReadGuard.mockClear();
     searchContactsResult = [];
     searchContactsMock.mockClear();
+    guardianIds = new Set();
+    getGuardianContactIdsMock.mockClear();
   });
 
   test("query-filtered list serves daemon-native INFO and validates against the response schema", async () => {
@@ -284,11 +340,36 @@ describe("filtered/native contact reads stay daemon-native", () => {
     expect(channel.interactionCount).toBe(4);
     expect(channel.lastSeenAt).toBe(4100);
     expect(channel.externalUserId).toBe("+15550200");
-    // Contact-level `role` is locally stored (NOT NULL) and always present.
+    // Non-guardian id derives role "contact" (no name override).
     expect((contact as { role: string }).role).toBe("contact");
+    expect(contact.displayName).toBe("Bob");
     // Channel-level ACL fields (status/policy) are gateway-owned and absent.
     expect("status" in channel).toBe(false);
     expect(() => listResponseSchema.parse(result)).not.toThrow();
+  });
+
+  test("daemon-native search stamps role guardian + the name override from the gateway id set", async () => {
+    searchContactsResult = [nativeContact];
+    guardianIds = new Set(["ct_2"]);
+
+    const result = await handleListContacts({ query: "Bob", limit: "10" });
+
+    expect(searchContactsMock).toHaveBeenCalled();
+    const [contact] = result.contacts;
+    expect((contact as { role: string }).role).toBe("guardian");
+    expect(contact.displayName).toBe("guardian:Bob");
+    expect(getGuardianContactIdsMock).toHaveBeenCalled();
+  });
+
+  test("fail-soft: an empty guardian id set yields role contact with no override", async () => {
+    searchContactsResult = [nativeContact];
+    guardianIds = new Set();
+
+    const result = await handleListContacts({ query: "Bob", limit: "10" });
+
+    const [contact] = result.contacts;
+    expect((contact as { role: string }).role).toBe("contact");
+    expect(contact.displayName).toBe("Bob");
   });
 
   test("POST search with a filter validates against the response schema", async () => {

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -21,6 +21,7 @@ import {
   mergeContacts,
   searchContacts,
 } from "../../contacts/contact-store.js";
+import { getGuardianContactIds } from "../../contacts/guardian-contact-reader.js";
 import type { ContactRole, ContactType } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
@@ -35,6 +36,9 @@ import { BadRequestError, NotFoundError, RouteError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("contact-routes");
+
+/** Sentinel for relayed-read calls that trust the gateway role (no derivation). */
+const EMPTY_GUARDIAN_IDS: ReadonlySet<string> = new Set<string>();
 
 /**
  * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
@@ -65,6 +69,26 @@ function withGuardianNameOverride<
   return contact;
 }
 
+/**
+ * Stamp `role` from the gateway guardian id set on DAEMON-NATIVE reads, whose
+ * `role` is the neutral `"contact"` default (search / contactType-filtered).
+ * Fail-soft: empty set → everyone is `"contact"`.
+ *
+ * NOT applied to gateway-relayed reads (`contacts_list_rich`/`_get_rich`),
+ * which already carry a gateway-sourced `role`. Re-deriving there would let a
+ * stale/empty 30s id-set cache DOWNGRADE a freshly-rebound guardian to
+ * `"contact"` during a rebind.
+ */
+function withGatewayRole<T extends { id: string; role: string }>(
+  contact: T,
+  guardianIds: ReadonlySet<string>,
+): T {
+  return {
+    ...contact,
+    role: guardianIds.has(contact.id) ? "guardian" : "contact",
+  };
+}
+
 /** Adds `externalUserId` (= `address`) to each channel for older macOS clients. */
 function withChannelCompat<T extends { channels: { address: string }[] }>(
   contact: T,
@@ -78,24 +102,36 @@ function withChannelCompat<T extends { channels: { address: string }[] }>(
   };
 }
 
-/** Compose both response transforms (guardian display name + channel compat).
- * Also coerces nullable gateway-sourced fields to their DB defaults so the
- * response satisfies the strict enum schema even in degraded mode (assistant
- * DB unreachable → gateway soft-fail join produces nulls).
+/** Compose the response transforms, then apply the guardian display-name
+ * override (keyed off the role that's correct for this path) and the channel
+ * compat field. Also coerces nullable gateway-sourced fields to their DB
+ * defaults so the response satisfies the strict enum schema even in degraded
+ * mode (assistant DB unreachable → gateway soft-fail join produces nulls).
+ *
+ * `deriveRole` controls where `role` comes from:
+ *   - `true`  (daemon-native reads): role is the neutral `"contact"` default,
+ *     so derive it from the gateway guardian id set.
+ *   - `false` (gateway-relayed reads): TRUST the gateway-sourced `role` already
+ *     on the `ContactRead`. Never re-derive — a stale/empty id-set cache must
+ *     not downgrade a relayed guardian to `"contact"`.
  */
 function prepareContactResponse<
   T extends {
+    id: string;
     role: string;
     displayName: string;
     contactType?: string | null;
     channels: { address: string }[];
   },
->(contact: T): T {
+>(contact: T, guardianIds: ReadonlySet<string>, deriveRole: boolean): T {
   const coerced =
     contact.contactType == null
       ? { ...contact, contactType: "human" as T["contactType"] }
       : contact;
-  return withChannelCompat(withGuardianNameOverride(coerced));
+  const withRole = deriveRole
+    ? withGatewayRole(coerced, guardianIds)
+    : coerced;
+  return withChannelCompat(withGuardianNameOverride(withRole));
 }
 
 const VALID_CONTACT_TYPES: readonly ContactType[] = ["human", "assistant"];
@@ -112,9 +148,11 @@ function isContactType(value: string): value is ContactType {
 // blockedReason) are gateway-owned and present ONLY on gateway-relayed reads
 // (`contacts_list_rich`/`contacts_get_rich`). Daemon-native filtered reads
 // (search / contactType) omit them, so they are `.optional()`. Contact-level
-// `role` is stored locally (NOT NULL, default "contact") and returned on all
-// paths. INFO telemetry (lastSeenAt/interactionCount/lastInteraction) is
-// locally hydrated on every read path and stays required.
+// `role` is gateway-sourced: relayed reads trust the role on the `ContactRead`,
+// while daemon-native reads derive it from the gateway guardian id set at the
+// serve layer (see prepareContactResponse). INFO telemetry
+// (lastSeenAt/interactionCount/lastInteraction) is locally hydrated on every
+// read path and stays required.
 const contactChannelSchema = z.object({
   id: z.string(),
   contactId: z.string(),
@@ -165,9 +203,13 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
       ...(role ? { role } : {}),
     });
     const { contacts } = ListContactsIpcResponseSchema.parse(result);
+    // Relayed reads carry a gateway-sourced role — trust it (deriveRole=false),
+    // so the guardian id set is not consulted here.
     return {
       ok: true,
-      contacts: contacts.map(prepareContactResponse),
+      contacts: contacts.map((c) =>
+        prepareContactResponse(c, EMPTY_GUARDIAN_IDS, false),
+      ),
     };
   } catch (err) {
     rethrowGatewayError(err);
@@ -204,9 +246,13 @@ export async function handleListContacts(queryParams: Record<string, string>) {
       contactType,
       limit,
     });
+    // Daemon-native read: role is the neutral default, so derive it.
+    const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map(prepareContactResponse),
+      contacts: contacts.map((c) =>
+        prepareContactResponse(c, guardianIds, true),
+      ),
     };
   }
 
@@ -219,9 +265,13 @@ export async function handleListContacts(queryParams: Record<string, string>) {
       "handleListContacts: contactType-filtered read served daemon-native (gateway-native contactType filtering is design-blocked, pending ACL classification)",
     );
     const contacts = listContacts(limit, contactType);
+    // Daemon-native read: role is the neutral default, so derive it.
+    const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map(prepareContactResponse),
+      contacts: contacts.map((c) =>
+        prepareContactResponse(c, guardianIds, true),
+      ),
     };
   }
 
@@ -237,9 +287,10 @@ export async function handleGetContact(contactId: string) {
     }
     const { contact, assistantMetadata } =
       GetContactIpcResponseSchema.parse(result);
+    // Relayed read: trust the gateway-sourced role (deriveRole=false).
     return {
       ok: true,
-      contact: prepareContactResponse(contact),
+      contact: prepareContactResponse(contact, EMPTY_GUARDIAN_IDS, false),
       assistantMetadata: assistantMetadata ?? undefined,
     };
   } catch (err) {
@@ -664,7 +715,11 @@ export const ROUTES: RouteDefinition[] = [
       log.debug(
         "search_contacts: search served daemon-native (gateway-native search is design-blocked)",
       );
-      return searchContacts(parsed).map(prepareContactResponse);
+      // Daemon-native read: role is the neutral default, so derive it.
+      const guardianIds = await getGuardianContactIds();
+      return searchContacts(parsed).map((c) =>
+        prepareContactResponse(c, guardianIds, true),
+      );
     },
   },
 
@@ -749,7 +804,7 @@ export const ROUTES: RouteDefinition[] = [
 // Transport-agnostic handlers (moved from HTTP-only)
 // ---------------------------------------------------------------------------
 
-function handleMergeContactsRoute(args: RouteHandlerArgs) {
+async function handleMergeContactsRoute(args: RouteHandlerArgs) {
   const { body } = args;
   const keepId = body?.keepId as string | undefined;
   const mergeId = body?.mergeId as string | undefined;
@@ -760,7 +815,12 @@ function handleMergeContactsRoute(args: RouteHandlerArgs) {
 
   try {
     const contact = mergeContacts(keepId, mergeId);
-    return { ok: true, contact: prepareContactResponse(contact) };
+    // Daemon-native read (assistant DB): role is the neutral default, derive it.
+    const guardianIds = await getGuardianContactIds();
+    return {
+      ok: true,
+      contact: prepareContactResponse(contact, guardianIds, true),
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new BadRequestError(message);

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -37,9 +37,6 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("contact-routes");
 
-/** Sentinel for relayed-read calls that trust the gateway role (no derivation). */
-const EMPTY_GUARDIAN_IDS: ReadonlySet<string> = new Set<string>();
-
 /**
  * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
  * adapters honor its statusCode/errorCode (4xx surfaces as 4xx, not a generic
@@ -108,12 +105,12 @@ function withChannelCompat<T extends { channels: { address: string }[] }>(
  * defaults so the response satisfies the strict enum schema even in degraded
  * mode (assistant DB unreachable → gateway soft-fail join produces nulls).
  *
- * `deriveRole` controls where `role` comes from:
- *   - `true`  (daemon-native reads): role is the neutral `"contact"` default,
- *     so derive it from the gateway guardian id set.
- *   - `false` (gateway-relayed reads): TRUST the gateway-sourced `role` already
+ * `guardianIds` controls where `role` comes from:
+ *   - omitted (gateway-relayed reads): TRUST the gateway-sourced `role` already
  *     on the `ContactRead`. Never re-derive — a stale/empty id-set cache must
  *     not downgrade a relayed guardian to `"contact"`.
+ *   - provided (daemon-native reads): role is the neutral `"contact"` default,
+ *     so derive it from the gateway guardian id set.
  */
 function prepareContactResponse<
   T extends {
@@ -123,12 +120,12 @@ function prepareContactResponse<
     contactType?: string | null;
     channels: { address: string }[];
   },
->(contact: T, guardianIds: ReadonlySet<string>, deriveRole: boolean): T {
+>(contact: T, guardianIds?: ReadonlySet<string>): T {
   const coerced =
     contact.contactType == null
       ? { ...contact, contactType: "human" as T["contactType"] }
       : contact;
-  const withRole = deriveRole
+  const withRole = guardianIds
     ? withGatewayRole(coerced, guardianIds)
     : coerced;
   return withChannelCompat(withGuardianNameOverride(withRole));
@@ -203,13 +200,11 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
       ...(role ? { role } : {}),
     });
     const { contacts } = ListContactsIpcResponseSchema.parse(result);
-    // Relayed reads carry a gateway-sourced role — trust it (deriveRole=false),
+    // Relayed reads carry a gateway-sourced role — trust it (omit guardianIds),
     // so the guardian id set is not consulted here.
     return {
       ok: true,
-      contacts: contacts.map((c) =>
-        prepareContactResponse(c, EMPTY_GUARDIAN_IDS, false),
-      ),
+      contacts: contacts.map((c) => prepareContactResponse(c)),
     };
   } catch (err) {
     rethrowGatewayError(err);
@@ -250,9 +245,7 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map((c) =>
-        prepareContactResponse(c, guardianIds, true),
-      ),
+      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
     };
   }
 
@@ -269,9 +262,7 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contacts: contacts.map((c) =>
-        prepareContactResponse(c, guardianIds, true),
-      ),
+      contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
     };
   }
 
@@ -287,10 +278,10 @@ export async function handleGetContact(contactId: string) {
     }
     const { contact, assistantMetadata } =
       GetContactIpcResponseSchema.parse(result);
-    // Relayed read: trust the gateway-sourced role (deriveRole=false).
+    // Relayed read: trust the gateway-sourced role (omit guardianIds).
     return {
       ok: true,
-      contact: prepareContactResponse(contact, EMPTY_GUARDIAN_IDS, false),
+      contact: prepareContactResponse(contact),
       assistantMetadata: assistantMetadata ?? undefined,
     };
   } catch (err) {
@@ -718,7 +709,7 @@ export const ROUTES: RouteDefinition[] = [
       // Daemon-native read: role is the neutral default, so derive it.
       const guardianIds = await getGuardianContactIds();
       return searchContacts(parsed).map((c) =>
-        prepareContactResponse(c, guardianIds, true),
+        prepareContactResponse(c, guardianIds),
       );
     },
   },
@@ -819,7 +810,7 @@ async function handleMergeContactsRoute(args: RouteHandlerArgs) {
     const guardianIds = await getGuardianContactIds();
     return {
       ok: true,
-      contact: prepareContactResponse(contact, guardianIds, true),
+      contact: prepareContactResponse(contact, guardianIds),
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -125,10 +125,9 @@ function tableColumns(db: Database, table: string): Set<string> {
 
 /**
  * The guardian read below depends on the legacy ACL columns
- * `contacts.role` and `contact_channels.status` / `verified_at`. The gateway
- * owns guardian ACL, and a later phase drops these columns from the assistant
- * DB. On schemas without them this one-time cleanup is a no-op: fresh installs
- * have no legacy USER.md to clean, and existing installs already ran it.
+ * `contacts.role` and `contact_channels.status` / `verified_at`. Guardian ACL
+ * is gateway-owned, so these columns may be absent from the assistant DB; this
+ * one-time cleanup is skipped when they are.
  */
 function aclColumnsPresent(db: Database): boolean {
   const contactCols = tableColumns(db, "contacts");

--- a/assistant/src/workspace/migrations/031-drop-user-md.ts
+++ b/assistant/src/workspace/migrations/031-drop-user-md.ts
@@ -115,6 +115,31 @@ function isValidSlug(slug: string): boolean {
   return basename(slug) === slug && slug !== "." && slug !== "..";
 }
 
+/** Names of the columns present on a table, via `PRAGMA table_info`. */
+function tableColumns(db: Database, table: string): Set<string> {
+  const rows = db
+    .query<{ name: string }, []>(`PRAGMA table_info(${table})`)
+    .all();
+  return new Set(rows.map((r) => r.name));
+}
+
+/**
+ * The guardian read below depends on the legacy ACL columns
+ * `contacts.role` and `contact_channels.status` / `verified_at`. The gateway
+ * owns guardian ACL, and a later phase drops these columns from the assistant
+ * DB. On schemas without them this one-time cleanup is a no-op: fresh installs
+ * have no legacy USER.md to clean, and existing installs already ran it.
+ */
+function aclColumnsPresent(db: Database): boolean {
+  const contactCols = tableColumns(db, "contacts");
+  const channelCols = tableColumns(db, "contact_channels");
+  return (
+    contactCols.has("role") &&
+    channelCols.has("status") &&
+    channelCols.has("verified_at")
+  );
+}
+
 /**
  * Strip LIKE metacharacters so the prefix match runs literally. SQLite has
  * no default LIKE escape character, so strip rather than escape. Inlined
@@ -201,6 +226,8 @@ export const dropUserMdMigration: WorkspaceMigration = {
     }
 
     try {
+      if (!aclColumnsPresent(db)) return; // ACL columns dropped — cleanup is a no-op.
+
       // Resolve the guardian contact from the local DB. Prefer the
       // vellum-channel binding (the canonical native guardian); fall back to
       // whichever guardian has the most recently verified active channel.

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -94,6 +94,10 @@ const upsertVerifiedChannelHandler = contactRoutes.find(
   (r) => r.method === "upsert_verified_channel",
 )!.handler;
 
+const getGuardianContactHandler = contactRoutes.find(
+  (r) => r.method === "get_guardian_contact",
+)!.handler;
+
 beforeAll(async () => {
   await initGatewayDb();
 });
@@ -346,6 +350,34 @@ describe("mark_channel_revoked IPC handler", () => {
     await expect(
       markChannelRevokedHandler({ contactChannelId: "nonexistent" }),
     ).rejects.toThrow(/not found/);
+  });
+});
+
+describe("get_guardian_contact IPC handler", () => {
+  test("returns the guardian contact id(s) from the gateway DB", async () => {
+    seedContact("g1", "guardian");
+    seedContact("c1", "contact");
+
+    const res = (await getGuardianContactHandler({})) as {
+      ok: boolean;
+      guardians: { id: string; displayName: string }[];
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.guardians).toEqual([{ id: "g1", displayName: "name-g1" }]);
+  });
+
+  test("excludes non-guardian contacts", async () => {
+    seedContact("c1", "contact");
+    seedContact("c2", "contact");
+
+    const res = (await getGuardianContactHandler({})) as {
+      ok: boolean;
+      guardians: { id: string }[];
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.guardians).toEqual([]);
   });
 });
 

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -360,11 +360,11 @@ describe("get_guardian_contact IPC handler", () => {
 
     const res = (await getGuardianContactHandler({})) as {
       ok: boolean;
-      guardians: { id: string; displayName: string }[];
+      guardianIds: string[];
     };
 
     expect(res.ok).toBe(true);
-    expect(res.guardians).toEqual([{ id: "g1", displayName: "name-g1" }]);
+    expect(res.guardianIds).toEqual(["g1"]);
   });
 
   test("excludes non-guardian contacts", async () => {
@@ -373,11 +373,11 @@ describe("get_guardian_contact IPC handler", () => {
 
     const res = (await getGuardianContactHandler({})) as {
       ok: boolean;
-      guardians: { id: string }[];
+      guardianIds: string[];
     };
 
     expect(res.ok).toBe(true);
-    expect(res.guardians).toEqual([]);
+    expect(res.guardianIds).toEqual([]);
   });
 });
 

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -63,15 +63,16 @@ export class ContactStore {
   }
 
   /**
-   * Guardian contacts (id + displayName) from the gateway DB (source of truth).
-   * Singular per workspace, but returns a set to be safe.
+   * Guardian contact ids from the gateway DB (source of truth). Singular per
+   * workspace, but returns a list to be safe.
    */
-  listGuardianContactIds(): { id: string; displayName: string }[] {
+  listGuardianContactIds(): string[] {
     return this.db
-      .select({ id: contacts.id, displayName: contacts.displayName })
+      .select({ id: contacts.id })
       .from(contacts)
       .where(eq(contacts.role, "guardian"))
-      .all();
+      .all()
+      .map((r) => r.id);
   }
 
   getContactByChannel(

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -62,6 +62,18 @@ export class ContactStore {
       .all();
   }
 
+  /**
+   * Guardian contacts (id + displayName) from the gateway DB (source of truth).
+   * Singular per workspace, but returns a set to be safe.
+   */
+  listGuardianContactIds(): { id: string; displayName: string }[] {
+    return this.db
+      .select({ id: contacts.id, displayName: contacts.displayName })
+      .from(contacts)
+      .where(eq(contacts.role, "guardian"))
+      .all();
+  }
+
   getContactByChannel(
     channelType: string,
     address: string,

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -9,6 +9,8 @@
 
 import {
   GetContactIpcParamsSchema,
+  GetGuardianContactIpcParamsSchema,
+  GetGuardianContactIpcResponseSchema,
   ListContactsIpcParamsSchema,
   MarkChannelRevokedIpcParamsSchema,
   MarkChannelRevokedIpcResponseSchema,
@@ -102,6 +104,17 @@ export const contactRoutes: IpcRoute[] = [
           ? { assistantMetadata: result.assistantMetadata }
           : {}),
       };
+    },
+  },
+  {
+    // Exposes the guardian contact id(s) from the gateway DB (source of truth)
+    // so the daemon can determine the guardian without reading the local
+    // contacts.role column.
+    method: "get_guardian_contact",
+    schema: GetGuardianContactIpcParamsSchema,
+    handler: () => {
+      const guardians = getStore().listGuardianContactIds();
+      return GetGuardianContactIpcResponseSchema.parse({ ok: true, guardians });
     },
   },
   {

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -113,8 +113,11 @@ export const contactRoutes: IpcRoute[] = [
     method: "get_guardian_contact",
     schema: GetGuardianContactIpcParamsSchema,
     handler: () => {
-      const guardians = getStore().listGuardianContactIds();
-      return GetGuardianContactIpcResponseSchema.parse({ ok: true, guardians });
+      const guardianIds = getStore().listGuardianContactIds();
+      return GetGuardianContactIpcResponseSchema.parse({
+        ok: true,
+        guardianIds,
+      });
     },
   },
   {

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -301,16 +301,9 @@ export type GetGuardianContactIpcParams = z.infer<
   typeof GetGuardianContactIpcParamsSchema
 >;
 
-export const GuardianContactSchema = z.object({
-  id: z.string(),
-  displayName: z.string(),
-});
-
-export type GuardianContact = z.infer<typeof GuardianContactSchema>;
-
 export const GetGuardianContactIpcResponseSchema = z.object({
   ok: z.boolean(),
-  guardians: z.array(GuardianContactSchema),
+  guardianIds: z.array(z.string()),
 });
 
 export type GetGuardianContactIpcResponse = z.infer<

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -291,3 +291,28 @@ export const GetContactIpcResponseSchema = z.object({
 export type GetContactIpcResponse = z.infer<
   typeof GetContactIpcResponseSchema
 >;
+
+export const GetGuardianContactIpcParamsSchema = z
+  .object({})
+  .strict()
+  .default({});
+
+export type GetGuardianContactIpcParams = z.infer<
+  typeof GetGuardianContactIpcParamsSchema
+>;
+
+export const GuardianContactSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+});
+
+export type GuardianContact = z.infer<typeof GuardianContactSchema>;
+
+export const GetGuardianContactIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  guardians: z.array(GuardianContactSchema),
+});
+
+export type GetGuardianContactIpcResponse = z.infer<
+  typeof GetGuardianContactIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
Phase A of dropping the assistant DB's 8 contact-ACL columns. The gateway DB is the source of truth for contact ACL; this drains the assistant's remaining reads of the local `contacts.role` column over to the gateway, and makes the stragglers (workspace migration 031 + the trust test suite) independent of the soon-dropped columns. **No schema change, no column dropped here** — that's Phase B (`drop-assistant-acl-columns.md`), which is now unblocked.

## What changed (4 PRs + 2 self-review fixes, squash-merged)
- **#36205** — new `get_guardian_contact` gateway IPC (returns guardian contact ids) + a cached, fail-soft daemon client (`getGuardianContactIds`, 30s TTL, invalidated on `onContactChange`).
- **#36210** — `parseContact` no longer reads `row.role`; every contact-serve path derives `role` + the guardian name override from the gateway guardian-id set. **Relayed `contacts_list_rich`/`get_rich` reads trust the gateway role; only daemon-native reads derive** (a stale/empty cache can't downgrade a relayed guardian). Wire `role` field unchanged → skills/CLI need no change.
- **#36204** — workspace migration 031 skips its guardian-dependent USER.md cleanup when the ACL columns are absent (PRAGMA guard), so it's safe post-drop. (Narrow skipped-version-upgrade window accepted.)
- **#36214** — reworked the assistant trust tests (~16 files) off the assistant ACL columns onto an in-process gateway-ACL stand-in mirroring `gateway/src/risk/guardian-delivery-resolver.ts`. `git grep` for the 8 ACL columns across assistant test code is now empty.
- **#36267 / #36270** (self-review remediation) — ids-only IPC (dropped unused `displayName`), collapsed `prepareContactResponse` param, un-exported cache invalidator, trimmed comments; wired `resetGatewayAclStore()` into the shared DB reset for per-test isolation.

## Verification
- Zero production reads of `contacts.role` (or the 6 channel ACL columns) from the assistant DB remain (verified by grep + self-review).
- All Codex review threads resolved; 4-pass self-review PASS with its 5 cleanup findings remediated.

## Next
Phase B (`drop-assistant-acl-columns.md`): migration 304 drops all 8 columns + schema removal + de-register m0006/m0008. Its prerequisite (this Phase A merged) is then satisfied.

Part of plan: drain-contacts-role.md