### PR TITLE
Fall back to plain text when cumulative Slack markdown exceeds the payload budget

### DIFF
--- a/assistant/src/messaging/providers/slack/render.test.ts
+++ b/assistant/src/messaging/providers/slack/render.test.ts
@@ -133,4 +133,14 @@ describe("renderSlackBlocks", () => {
     expect(blocks![49].type).toBe("context");
     expect(JSON.stringify(blocks![49])).toContain("omitted");
   });
+
+  test("falls back to plain text when cumulative markdown exceeds the payload budget", () => {
+    // Two ~7k prose runs split by a heading produce two markdown blocks summing
+    // to ~14k — over Slack's cumulative markdown-block budget — so the whole
+    // reply is delivered as plain text (no blocks) rather than a reject-prone
+    // payload.
+    const para = "word ".repeat(1400).trim();
+    const blocks = renderSlackBlocks(`${para}\n\n# Heading\n\n${para}`);
+    expect(blocks).toBeUndefined();
+  });
 });

--- a/assistant/src/messaging/providers/slack/render.ts
+++ b/assistant/src/messaging/providers/slack/render.ts
@@ -25,6 +25,15 @@ import { parseMarkdown } from "../../content/parse.js";
 const SLACK_BLOCK_LIMIT = 50;
 /** A `markdown` block's text is capped at 12,000 characters. */
 const SLACK_MARKDOWN_MAX_CHARS = 12_000;
+/**
+ * Slack also caps the *cumulative* `markdown`-block text across a single message
+ * payload, not just per block — an over-limit payload is rejected as
+ * `invalid_blocks`. The exact ceiling isn't documented in `@slack/types`; 12,000
+ * is conservative (it matches the documented per-block limit and stays under the
+ * observed cumulative threshold). Past it, the reply is delivered as plain text
+ * rather than risking rejection.
+ */
+const SLACK_MARKDOWN_PAYLOAD_MAX_CHARS = 12_000;
 /** A `header` block's plain_text is capped at 150 characters. */
 const SLACK_HEADER_MAX_CHARS = 150;
 /**
@@ -90,6 +99,17 @@ export function renderSlack(tree: Root, source: string): KnownBlock[] {
     }
   }
   flushRun();
+
+  // Slack caps cumulative `markdown`-block text per payload (see
+  // SLACK_MARKDOWN_PAYLOAD_MAX_CHARS). If the rendered markdown would exceed it,
+  // deliver the whole reply as plain text instead of a reject-prone payload —
+  // the same outcome as the `invalid_blocks` retry, but without the failed
+  // round trip. Returning an empty array makes the caller fall back to `text`.
+  const markdownChars = blocks.reduce(
+    (sum, block) => (block.type === "markdown" ? sum + block.text.length : sum),
+    0,
+  );
+  if (markdownChars > SLACK_MARKDOWN_PAYLOAD_MAX_CHARS) return [];
 
   return capBlocks(blocks);
 }


### PR DESCRIPTION
## What

Follow-up addressing the Codex P2 review on #36263 (now merged): the Slack renderer enforced only the **per-block** 12k `markdown` limit, but Slack also caps **cumulative** `markdown`-block text across a single payload (an over-limit payload is rejected as `invalid_blocks`). A long reply split into several `markdown` blocks could bust that cap.

`renderSlack` now sums the rendered `markdown`-block characters; if they exceed `SLACK_MARKDOWN_PAYLOAD_MAX_CHARS`, it returns no blocks so the reply is delivered as **plain text** — the same outcome as the existing `invalid_blocks` retry, but **proactively** (no failed round-trip). This is Codex's own suggested remedy ("switch overflow back to text delivery").

## Why this number

`12,000` is conservative: it matches Slack's documented **per-block** limit, and there's corroborating evidence of a cumulative ceiling in the same range (e.g. bolt-js #2509, "blocks too long" around ~13,200 chars). The exact cumulative number isn't in `@slack/types`; if a web check of the live docs confirms a higher ceiling, the constant can be raised — but conservative-low only means a rare >12k reply degrades to (full) plain text, never a hard failure.

## Safety / scope

- Pure rendering change in `providers/slack/render.ts`; no wire-contract change.
- Can't regress correctness — for any payload Slack would reject, the result is the same plain-text delivery the retry already produced, just without the wasted API call. Normal replies (well under 12k of markdown) are unaffected.
- Tests: +1 case (two ~7k prose runs split by a heading → over budget → plain text). 14 `render` tests green; `tsc` / `eslint` / `knip` clean.

Part of **LUM-2618**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_