### PR TITLE
feat(web): show referral credit ineligibility in billing referral panel

### DIFF
--- a/clients/web/src/domains/settings/components/referral-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/referral-panel.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for the ReferralPanel credit-eligibility messaging: when the user is
+ * not eligible to earn referral credits (`is_eligible_for_credits === false`),
+ * an info notice and invite-focused subtitle render while the stats and copy
+ * link stay put. When eligible, the panel is unchanged.
+ *
+ * Strategy: pre-populate the React Query cache so the panel's `useQuery`
+ * resolves synchronously — `renderToStaticMarkup` is single-pass, so a pending
+ * query would otherwise report `isLoading` and render the spinner.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { referralCodesMeRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { MyReferralCodeResponse } from "@/generated/api/types.gen";
+
+import { ReferralPanel } from "./referral-panel";
+
+const NOTICE_COPY = "not currently earning referral credits";
+
+function referralData(
+  isEligibleForCredits: boolean,
+): MyReferralCodeResponse {
+  return {
+    code: "ABC123",
+    referral_url: "https://vellum.ai/r/ABC123",
+    referred_count: 2,
+    total_earned_usd: "10.00",
+    earning_cap_usd: "50.00",
+    total_earned: "10.00",
+    earning_cap: "50.00",
+    credit_amount: "5.00",
+    referrer_credit_amount: "5.00",
+    is_eligible_for_credits: isEligibleForCredits,
+  };
+}
+
+function renderPanel(isEligibleForCredits: boolean): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    referralCodesMeRetrieveQueryKey(),
+    referralData(isEligibleForCredits),
+  );
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <ReferralPanel />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ReferralPanel credit eligibility", () => {
+  test("shows the ineligibility notice and invite-focused subtitle when not eligible", () => {
+    const html = renderPanel(false);
+    expect(html).toContain(NOTICE_COPY);
+    expect(html).toContain("Invite friends to Vellum.");
+    // Stats and copy link still render.
+    expect(html).toContain("Credits Earned");
+    expect(html).toContain("Friends Referred");
+    expect(html).toContain("referral-copy-button");
+  });
+
+  test("renders no notice and the default subtitle when eligible", () => {
+    const html = renderPanel(true);
+    expect(html).not.toContain(NOTICE_COPY);
+    expect(html).not.toContain("Invite friends to Vellum.");
+    expect(html).toContain("Share Vellum with friends");
+    expect(html).toContain("Credits Earned");
+    expect(html).toContain("referral-copy-button");
+  });
+});

--- a/clients/web/src/domains/settings/components/referral-panel.tsx
+++ b/clients/web/src/domains/settings/components/referral-panel.tsx
@@ -42,13 +42,17 @@ export function ReferralPanel() {
     });
   }, []);
 
-  const subtitle = data
-    ? `Share Vellum with friends - you'll each earn ${stripDecimals(
-        data.referrer_credit_amount,
-      )} credits when they sign up, up to ${stripDecimals(
-        data.earning_cap,
-      )} total.`
-    : "Share Vellum with friends and earn credits for every signup.";
+  const creditsGated = !!data && !data.is_eligible_for_credits;
+
+  const subtitle = creditsGated
+    ? "Invite friends to Vellum. You'll start earning referral credits once you've purchased credits or upgraded to Pro."
+    : data
+      ? `Share Vellum with friends - you'll each earn ${stripDecimals(
+          data.referrer_credit_amount,
+        )} credits when they sign up, up to ${stripDecimals(
+          data.earning_cap,
+        )} total.`
+      : "Share Vellum with friends and earn credits for every signup.";
 
   return (
     <Card padding="md" id={REFERRAL_PANEL_ANCHOR_ID}>
@@ -69,6 +73,14 @@ export function ReferralPanel() {
             {subtitle}
           </Typography>
         </div>
+
+        {creditsGated && (
+          <Notice tone="info">
+            You're not currently earning referral credits. Buy credits or
+            upgrade to Pro to start earning — your invite link still works in
+            the meantime.
+          </Notice>
+        )}
 
         {isLoading ? (
           <div className="flex items-center gap-2 text-body-medium-lighter text-[var(--content-tertiary)]">


### PR DESCRIPTION
## Summary
- Show invite-focused subtitle and an info Notice when the user is not eligible to earn referral credits (is_eligible_for_credits=false)
- Stats and Copy Share Link remain unchanged; panel unchanged when eligible
- Add test covering eligible vs ineligible rendering

Part of plan: referral-credit-gating.md (PR C of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->