### PR TITLE
feat(web): show referral credit ineligibility in earn-credits modal

### DIFF
--- a/clients/web/src/components/earn-credits-modal.test.tsx
+++ b/clients/web/src/components/earn-credits-modal.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for the Earn Credits modal's referral-credit gating.
+ *
+ * When the backend reports `is_eligible_for_credits: false`, the modal swaps
+ * in invite-focused copy that sets expectations: an invite-focused subtitle, a
+ * qualified "You earn credits" step, and an info Notice — while the share link
+ * stays visible and copyable. When the user is eligible, none of that gating
+ * copy renders and the modal looks exactly as it does today.
+ *
+ * The modal renders its content into a Radix portal, so we drive it with
+ * @testing-library/react (happy-dom is registered via the test preload) and
+ * assert on `document.body`. The React Query cache is pre-populated so the
+ * modal's `useQuery` resolves without a network round-trip.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render } from "@testing-library/react";
+
+import { referralCodesMeRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { MyReferralCodeResponse } from "@/generated/api/types.gen";
+
+import { EarnCreditsModal } from "./earn-credits-modal";
+
+const BASE_REFERRAL: MyReferralCodeResponse = {
+  code: "ABC123",
+  referral_url: "https://vellum.ai/r/ABC123",
+  referred_count: 0,
+  total_earned_usd: "0.00",
+  earning_cap_usd: "100.00",
+  total_earned: "0.00",
+  earning_cap: "100.00",
+  credit_amount: "10.00",
+  referrer_credit_amount: "10.00",
+  is_eligible_for_credits: true,
+};
+
+function renderModal(referral: MyReferralCodeResponse): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(referralCodesMeRetrieveQueryKey(), referral);
+  render(
+    <QueryClientProvider client={client}>
+      <EarnCreditsModal open onClose={() => {}} />
+    </QueryClientProvider>,
+  );
+  return document.body.textContent ?? "";
+}
+
+const INELIGIBLE_NOTICE = "You're not currently earning referral credits.";
+const INELIGIBLE_SUBTITLE =
+  "You'll start earning referral credits once you've purchased credits or upgraded to Pro.";
+const GATED_STEP =
+  "You earn credits — once you've purchased credits or upgraded to Pro";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("EarnCreditsModal referral credit gating", () => {
+  test("ineligible: renders the notice and invite-focused subtitle", () => {
+    const text = renderModal({
+      ...BASE_REFERRAL,
+      is_eligible_for_credits: false,
+    });
+    expect(text).toContain(INELIGIBLE_NOTICE);
+    expect(text).toContain(INELIGIBLE_SUBTITLE);
+    expect(text).toContain(GATED_STEP);
+    // Share link stays visible/copyable regardless of eligibility.
+    expect(
+      document.querySelector<HTMLInputElement>(
+        `input[value="${BASE_REFERRAL.referral_url}"]`,
+      ),
+    ).not.toBeNull();
+  });
+
+  test("eligible: renders neither the notice nor the gating copy", () => {
+    const text = renderModal({
+      ...BASE_REFERRAL,
+      is_eligible_for_credits: true,
+    });
+    expect(text).not.toContain(INELIGIBLE_NOTICE);
+    expect(text).not.toContain(INELIGIBLE_SUBTITLE);
+    expect(text).not.toContain(GATED_STEP);
+    expect(text).toContain("You earn credits");
+    expect(
+      document.querySelector<HTMLInputElement>(
+        `input[value="${BASE_REFERRAL.referral_url}"]`,
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/clients/web/src/components/earn-credits-modal.test.tsx
+++ b/clients/web/src/components/earn-credits-modal.test.tsx
@@ -37,7 +37,7 @@ const BASE_REFERRAL: MyReferralCodeResponse = {
 
 function renderModal(referral: MyReferralCodeResponse): string {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   });
   client.setQueryData(referralCodesMeRetrieveQueryKey(), referral);
   render(

--- a/clients/web/src/components/earn-credits-modal.tsx
+++ b/clients/web/src/components/earn-credits-modal.tsx
@@ -13,6 +13,7 @@ import { useCallback, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Button, Input, Modal } from "@vellumai/design-library";
+import { Notice } from "@vellumai/design-library/components/notice";
 
 import { referralCodesMeRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 
@@ -67,13 +68,17 @@ function EarnCreditsModalInner() {
     });
   }, []);
 
-  const subtitle = data
-    ? buildSubtitle(
-        data.referrer_credit_amount,
-        data.credit_amount,
-        data.earning_cap,
-      )
-    : "Refer friends to earn free credits.";
+  const creditsGated = !!data && !data.is_eligible_for_credits;
+
+  const subtitle = !data
+    ? "Refer friends to earn free credits."
+    : creditsGated
+      ? "Invite friends to Vellum. You'll start earning referral credits once you've purchased credits or upgraded to Pro."
+      : buildSubtitle(
+          data.referrer_credit_amount,
+          data.credit_amount,
+          data.earning_cap,
+        );
 
   const cap = data ? stripDecimals(data.earning_cap) : "";
   const title = showTerms ? "Referral Program Terms" : "Earn free credits";
@@ -139,11 +144,23 @@ function EarnCreditsModalInner() {
               />
               <HowItWorksStep
                 icon={<Gift className="h-4 w-4" />}
-                label="You earn credits"
+                label={
+                  creditsGated
+                    ? "You earn credits — once you've purchased credits or upgraded to Pro"
+                    : "You earn credits"
+                }
               />
             </div>
 
             <div style={{ borderTop: "1px solid var(--border-base)" }} />
+
+            {creditsGated && (
+              <Notice tone="info">
+                You're not currently earning referral credits. Buy credits or
+                upgrade to Pro to start earning — your invite link still works
+                in the meantime.
+              </Notice>
+            )}
 
             <div className="flex items-center gap-2">
               <Input


### PR DESCRIPTION
## Summary
- Show invite-focused subtitle, qualified "You earn credits" step, and an info Notice when the user is not eligible to earn referral credits (is_eligible_for_credits=false)
- Modal is unchanged when the user is eligible
- Add test covering eligible vs ineligible rendering

Part of plan: referral-credit-gating.md (PR B of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->