### PR TITLE
fix(web): gate referral credit messaging only on explicit ineligibility

### DIFF
--- a/clients/web/src/components/earn-credits-modal.tsx
+++ b/clients/web/src/components/earn-credits-modal.tsx
@@ -68,7 +68,7 @@ function EarnCreditsModalInner() {
     });
   }, []);
 
-  const creditsGated = !!data && !data.is_eligible_for_credits;
+  const creditsGated = data?.is_eligible_for_credits === false;
 
   const subtitle = !data
     ? "Refer friends to earn free credits."

--- a/clients/web/src/domains/settings/components/referral-panel.tsx
+++ b/clients/web/src/domains/settings/components/referral-panel.tsx
@@ -42,7 +42,7 @@ export function ReferralPanel() {
     });
   }, []);
 
-  const creditsGated = !!data && !data.is_eligible_for_credits;
+  const creditsGated = data?.is_eligible_for_credits === false;
 
   const subtitle = creditsGated
     ? "Invite friends to Vellum. You'll start earning referral credits once you've purchased credits or upgraded to Pro."


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for referral-credit-gating.md.

**Gap:** Inverted credit-gate default gated every user when is_eligible_for_credits was absent/falsy (older/cached backend, partial rollout) since there is no feature flag.
**Fix:** Derive creditsGated = data?.is_eligible_for_credits === false in both the earn-credits modal and the billing referral panel, so an absent/undefined field defaults to today's behavior (not gated). No behavior change when the field is present.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->