### PR TITLE
feat(config): point managed balanced profile at GLM 5.2, matching quality

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -845,8 +845,8 @@ describe("loadConfig startup behavior", () => {
       "gpt-5.4-nano",
     );
 
-    // Managed profiles are also seeded (balanced now uses Fireworks/GLM 5.2,
-    // matching the quality profile).
+    // Managed profiles are also seeded. Balanced now serves GLM 5.2 on
+    // Fireworks (the model Quality used to carry).
     expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
       "fireworks-managed",
@@ -855,12 +855,9 @@ describe("loadConfig startup behavior", () => {
       "accounts/fireworks/models/glm-5p2",
     );
     expect(raw.llm.profiles.balanced.source).toBe("managed");
-    // Quality is also GLM 5.2 on Fireworks; Frontier carries the Anthropic Opus
-    // config Quality used to have.
-    expect(raw.llm.profiles["quality-optimized"].provider).toBe("fireworks");
-    expect(raw.llm.profiles["quality-optimized"].model).toBe(
-      "accounts/fireworks/models/glm-5p2",
-    );
+    // Quality now serves Anthropic Opus, the same model as Frontier.
+    expect(raw.llm.profiles["quality-optimized"].provider).toBe("anthropic");
+    expect(raw.llm.profiles["quality-optimized"].model).toBe("claude-opus-4-8");
     expect(raw.llm.profiles.frontier.provider).toBe("anthropic");
     expect(raw.llm.profiles.frontier.model).toBe("claude-opus-4-8");
     // Speed is served by DeepSeek V4 Flash on Fireworks.
@@ -943,14 +940,14 @@ describe("loadConfig startup behavior", () => {
   test("reseed updates a source-less legacy canonical managed profile", () => {
     // Migration 052 seeded canonical profiles without a `source`. Such a
     // source-less `quality-optimized` is legacy managed, not user-owned, so it
-    // must still reseed to the latest template (GLM 5.2) and be tagged managed.
+    // must still reseed to the latest template (Opus) and be tagged managed.
     writeConfig({
       llm: {
         profiles: {
           "quality-optimized": {
-            provider: "anthropic",
-            model: "claude-opus-4-8",
-            provider_connection: "anthropic-managed",
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            provider_connection: "fireworks-managed",
           },
         },
       },
@@ -959,9 +956,7 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles["quality-optimized"].model).toBe(
-      "accounts/fireworks/models/glm-5p2",
-    );
+    expect(raw.llm.profiles["quality-optimized"].model).toBe("claude-opus-4-8");
     expect(raw.llm.profiles["quality-optimized"].source).toBe("managed");
   });
 
@@ -1622,12 +1617,11 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.activeProfile).toBe("balanced");
-    // Balanced now lives on `fireworks-managed`, the same connection as
-    // `quality-optimized` and `cost-optimized`. Selecting balanced at hatch
-    // keeps that connection active, so all three fireworks-managed profiles
-    // stay enabled and the default advisor picks the higher-ranked managed
-    // `quality-optimized` (equivalent GLM 5.2 model).
-    expect(raw.llm.advisorProfile).toBe("quality-optimized");
+    // Balanced lives on `fireworks-managed`; `quality-optimized` and `frontier`
+    // (both Opus on `anthropic-managed`) are on a different connection, so
+    // selecting balanced at hatch disables them. The default advisor falls to
+    // the only active managed profile, `balanced`.
+    expect(raw.llm.advisorProfile).toBe("balanced");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
       "fireworks-managed",
     );

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -593,9 +593,11 @@ describe("loadConfig startup behavior", () => {
       "anthropic-personal",
     );
     // Managed profiles exist as well.
-    expect(config.llm.profiles.balanced?.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(config.llm.profiles.balanced?.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
@@ -604,7 +606,9 @@ describe("loadConfig startup behavior", () => {
       model: "claude-opus-4-7",
     });
     expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
   });
 
   test("on-platform hatch seeds only managed profiles", () => {
@@ -632,9 +636,11 @@ describe("loadConfig startup behavior", () => {
     const config = loadConfig();
 
     expect(config.llm.activeProfile).toBe("balanced");
-    expect(config.llm.profiles.balanced?.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(config.llm.profiles.balanced?.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
     // No user profiles created on platform.
     expect(config.llm.profiles["custom-balanced"]).toBeUndefined();
@@ -676,10 +682,10 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
       "anthropic-personal",
     );
-    // Managed balanced profile is seeded for together-managed (MiniMax M3).
-    expect(raw.llm.profiles.balanced.provider).toBe("together");
+    // Managed balanced profile is seeded for fireworks-managed (GLM 5.2).
+    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
   });
 
@@ -713,9 +719,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     // On-platform: no user profiles created, active resets to managed balanced.
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.profiles.balanced.provider).toBe("together");
+    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
     // The old custom-balanced is preserved on disk but no longer active.
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("openai");
@@ -839,13 +845,17 @@ describe("loadConfig startup behavior", () => {
       "gpt-5.4-nano",
     );
 
-    // Managed profiles are also seeded (balanced uses Together/MiniMax M3).
-    expect(raw.llm.profiles.balanced.provider).toBe("together");
+    // Managed profiles are also seeded (balanced now uses Fireworks/GLM 5.2,
+    // matching the quality profile).
+    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
+    );
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
     );
     expect(raw.llm.profiles.balanced.source).toBe("managed");
-    // Quality is now GLM 5.2 on Fireworks; Frontier carries the Anthropic Opus
+    // Quality is also GLM 5.2 on Fireworks; Frontier carries the Anthropic Opus
     // config Quality used to have.
     expect(raw.llm.profiles["quality-optimized"].provider).toBe("fireworks");
     expect(raw.llm.profiles["quality-optimized"].model).toBe(
@@ -881,9 +891,11 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
   });
@@ -988,11 +1000,15 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     expect(raw.llm.profiles.balanced.maxTokens).toBe(32000);
-    expect(raw.llm.profiles.balanced.topP).toBe(0.95);
+    // The template carries no topP, and the previous entry had none, so the
+    // reconciled profile has no topP override.
+    expect("topP" in raw.llm.profiles.balanced).toBe(false);
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
   });
@@ -1022,7 +1038,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     // Content refreshes from the template...
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     // ...but the user's label and status overrides are preserved.
     expect(raw.llm.profiles.balanced.label).toBe("My Default");
     expect(raw.llm.profiles.balanced.status).toBe("disabled");
@@ -1050,7 +1068,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     // Model still gets the new template value (provider-controlled).
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     // But the user's label override is preserved across the reseed.
     expect(raw.llm.profiles.balanced.label).toBe("My Default");
   });
@@ -1078,13 +1098,16 @@ describe("loadConfig startup behavior", () => {
 
     expect(raw.llm.profiles.balanced.status).toBe("disabled");
     // Model still refreshes — only label/status are user-owned.
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
   });
 
   test("reseed preserves user-edited topP on managed profiles", () => {
     // Simulate a user who overrode topP on the managed "balanced" profile via
     // PUT /v1/config/llm/profiles/balanced { topP: 0.5 }. The override must
-    // survive the reconcile instead of reverting to the template's 0.95.
+    // survive the reconcile instead of being dropped (the template carries no
+    // topP of its own).
     writeConfig({
       llm: {
         profiles: {
@@ -1107,18 +1130,20 @@ describe("loadConfig startup behavior", () => {
     // the template default of 0.95).
     expect(raw.llm.profiles.balanced.topP).toBe(0.5);
     // Model still refreshes — topP is user-owned, the rest is template-owned.
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
   });
 
-  test("reseed seeds the template topP on a fresh managed balanced profile", () => {
-    // No previous on-disk entry → the balanced profile materializes with the
-    // template's topP default of 0.95.
+  test("fresh managed balanced profile materializes without a topP override", () => {
+    // No previous on-disk entry → the balanced profile materializes from the
+    // template, which (matching the quality profile) carries no topP.
     writeConfig({ llm: {} });
 
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.topP).toBe(0.95);
+    expect("topP" in raw.llm.profiles.balanced).toBe(false);
   });
 
   test("off-platform reseed preserves an explicit null label (user cleared it)", () => {
@@ -1159,7 +1184,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.profiles.balanced.label).toBe("Balanced (Managed)");
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     // Status is unset by default — must not appear as `undefined`.
     expect("status" in raw.llm.profiles.balanced).toBe(false);
   });
@@ -1245,18 +1272,18 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
     expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
 
-    // Next boot, no overlay: content reconciles to the together-managed code
+    // Next boot, no overlay: content reconciles to the fireworks-managed code
     // template; only the overlay-set label is carried across.
     mergeDefaultConfigAndSeedInferenceProfiles();
 
     const afterRestart = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(afterRestart.llm.activeProfile).toBe("balanced");
-    expect(afterRestart.llm.profiles.balanced.provider).toBe("together");
+    expect(afterRestart.llm.profiles.balanced.provider).toBe("fireworks");
     expect(afterRestart.llm.profiles.balanced.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
     expect(afterRestart.llm.profiles.balanced.model).toBe(
-      "MiniMaxAI/MiniMax-M3",
+      "accounts/fireworks/models/glm-5p2",
     );
     expect(afterRestart.llm.profiles.balanced.maxTokens).toBe(32000);
     expect(afterRestart.llm.profiles.balanced.thinking).toEqual({
@@ -1303,7 +1330,9 @@ describe("loadConfig startup behavior", () => {
     // Off-platform hatch: user profiles are active.
     expect(raw.llm.activeProfile).toBe("custom-balanced");
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.model).toBe("MiniMaxAI/MiniMax-M3");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
   });
 
   test("still quarantines corrupt JSON", () => {
@@ -1400,11 +1429,6 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 
     // Personal profiles keep their bare labels — they're the daily driver.
     expect(config.llm.profiles["custom-balanced"]?.label).toBe("Balanced");
-
-    // top_p is scoped to the managed Balanced profile only; the BYOK
-    // custom-balanced profile must not pick it up.
-    expect(config.llm.profiles.balanced?.topP).toBe(0.95);
-    expect(config.llm.profiles["custom-balanced"]?.topP).toBeUndefined();
   });
 
   test("off-platform hatch initializes managed profile status to 'disabled'", () => {
@@ -1598,9 +1622,14 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.advisorProfile).toBe("balanced");
+    // Balanced now lives on `fireworks-managed`, the same connection as
+    // `quality-optimized` and `cost-optimized`. Selecting balanced at hatch
+    // keeps that connection active, so all three fireworks-managed profiles
+    // stay enabled and the default advisor picks the higher-ranked managed
+    // `quality-optimized` (equivalent GLM 5.2 model).
+    expect(raw.llm.advisorProfile).toBe("quality-optimized");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "together-managed",
+      "fireworks-managed",
     );
     expect("status" in raw.llm.profiles.balanced).toBe(false);
     // Connections exist (status is no longer a connection-level concept).

--- a/assistant/src/__tests__/workspace-migration-113-swap-balanced-profile-to-glm-5p2.test.ts
+++ b/assistant/src/__tests__/workspace-migration-113-swap-balanced-profile-to-glm-5p2.test.ts
@@ -89,14 +89,14 @@ describe("113-swap-balanced-profile-to-glm-5p2 migration", () => {
     expect(profile.provider).toBe("fireworks");
     expect(profile.provider_connection).toBe("fireworks-managed");
     expect(profile.effort).toBe("high");
-    expect(profile.description).toBe(
-      "High-quality results with a leading open model (GLM 5.2)",
-    );
-    // The seeded default topP is dropped so the profile matches the quality
-    // profile, which has no topP.
+    // The seeded default topP (0.95) is dropped — GLM 5.2 carries no topP.
     expect("topP" in profile).toBe(false);
-    // The slot's own identity (key + label) is preserved so pins keep resolving.
+    // The slot's own identity (key + label + description) is preserved so pins
+    // keep resolving.
     expect(profile.label).toBe("Balanced");
+    expect(profile.description).toBe(
+      "Good balance of quality, cost, and speed",
+    );
   });
 
   test("swaps a source-less legacy managed balanced profile", () => {

--- a/assistant/src/__tests__/workspace-migration-113-swap-balanced-profile-to-glm-5p2.test.ts
+++ b/assistant/src/__tests__/workspace-migration-113-swap-balanced-profile-to-glm-5p2.test.ts
@@ -140,6 +140,48 @@ describe("113-swap-balanced-profile-to-glm-5p2 migration", () => {
     expect(profile.topP).toBe(0.5);
   });
 
+  test("strips a stale seeded topP from a balanced profile already reseeded to GLM", () => {
+    // A failed-DB boot skips the migration runner but still runs the seeder,
+    // which rewrites the model to GLM while carrying the old topP: 0.95 by
+    // key-presence. On the next healthy boot this migration must still strip it.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+            effort: "high",
+            topP: 0.95,
+          },
+        },
+      },
+    });
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    const profile = readProfiles().balanced!;
+    expect(profile.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect("topP" in profile).toBe(false);
+  });
+
+  test("preserves a user-customized topP on a profile already reseeded to GLM", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+            topP: 0.5,
+          },
+        },
+      },
+    });
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    expect(readProfiles().balanced!.topP).toBe(0.5);
+  });
+
   test("leaves a user-owned balanced profile untouched", () => {
     const original = {
       llm: {

--- a/assistant/src/__tests__/workspace-migration-113-swap-balanced-profile-to-glm-5p2.test.ts
+++ b/assistant/src/__tests__/workspace-migration-113-swap-balanced-profile-to-glm-5p2.test.ts
@@ -1,0 +1,199 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { swapBalancedProfileToGlm52Migration } from "../workspace/migrations/113-swap-balanced-profile-to-glm-5p2.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  return (readConfig().llm as Record<string, unknown>).profiles as Record<
+    string,
+    Record<string, unknown>
+  >;
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-113-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("113-swap-balanced-profile-to-glm-5p2 migration", () => {
+  test("no-op when config.json does not exist", () => {
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no llm.profiles", () => {
+    const original = { llm: { default: { provider: "anthropic" } } };
+    writeConfig(original);
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("swaps the managed balanced profile from Together MiniMax to GLM 5.2", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+            label: "Balanced",
+            effort: "medium",
+            description: "Good balance of quality, cost, and speed",
+            topP: 0.95,
+          },
+        },
+      },
+    });
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    const profile = readProfiles().balanced!;
+    expect(profile.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(profile.provider).toBe("fireworks");
+    expect(profile.provider_connection).toBe("fireworks-managed");
+    expect(profile.effort).toBe("high");
+    expect(profile.description).toBe(
+      "High-quality results with a leading open model (GLM 5.2)",
+    );
+    // The seeded default topP is dropped so the profile matches the quality
+    // profile, which has no topP.
+    expect("topP" in profile).toBe(false);
+    // The slot's own identity (key + label) is preserved so pins keep resolving.
+    expect(profile.label).toBe("Balanced");
+  });
+
+  test("swaps a source-less legacy managed balanced profile", () => {
+    // Migration 052 seeded canonical profiles without a `source`; absent source
+    // on this reserved name means legacy managed, so it must still be swapped.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+          },
+        },
+      },
+    });
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    const profile = readProfiles().balanced!;
+    expect(profile.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(profile.provider).toBe("fireworks");
+    expect(profile.provider_connection).toBe("fireworks-managed");
+  });
+
+  test("preserves a user-customized topP override", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "together",
+            provider_connection: "together-managed",
+            model: "MiniMaxAI/MiniMax-M3",
+            topP: 0.5,
+          },
+        },
+      },
+    });
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    const profile = readProfiles().balanced!;
+    expect(profile.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(profile.topP).toBe(0.5);
+  });
+
+  test("leaves a user-owned balanced profile untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "user",
+            provider: "together",
+            model: "MiniMaxAI/MiniMax-M3",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("leaves a user-retargeted managed model untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("idempotency: no-op on already-swapped config (no writes)", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+          },
+        },
+      },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+    swapBalancedProfileToGlm52Migration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-114-swap-quality-profile-to-opus.test.ts
+++ b/assistant/src/__tests__/workspace-migration-114-swap-quality-profile-to-opus.test.ts
@@ -1,0 +1,172 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { swapQualityProfileToOpusMigration } from "../workspace/migrations/114-swap-quality-profile-to-opus.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  return (readConfig().llm as Record<string, unknown>).profiles as Record<
+    string,
+    Record<string, unknown>
+  >;
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-114-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("114-swap-quality-profile-to-opus migration", () => {
+  test("no-op when config.json does not exist", () => {
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no llm.profiles", () => {
+    const original = { llm: { default: { provider: "anthropic" } } };
+    writeConfig(original);
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("swaps the managed quality-optimized profile from GLM 5.2 to Opus", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            source: "managed",
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+            label: "Quality",
+            description:
+              "High-quality results with a leading open model (GLM 5.2)",
+          },
+        },
+      },
+    });
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    const profile = readProfiles()["quality-optimized"]!;
+    expect(profile.model).toBe("claude-opus-4-8");
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.provider_connection).toBe("anthropic-managed");
+    expect(profile.description).toBe(
+      "High-quality results with the most capable model",
+    );
+    // The slot's own identity (key + label) is preserved so pins keep resolving.
+    expect(profile.label).toBe("Quality");
+  });
+
+  test("swaps a source-less legacy managed quality-optimized profile", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/glm-5p2",
+          },
+        },
+      },
+    });
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    const profile = readProfiles()["quality-optimized"]!;
+    expect(profile.model).toBe("claude-opus-4-8");
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.provider_connection).toBe("anthropic-managed");
+  });
+
+  test("leaves a user-owned quality-optimized profile untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            source: "user",
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("leaves a user-retargeted managed model untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            source: "managed",
+            provider: "openai",
+            model: "gpt-5.4",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("idempotency: no-op on already-swapped config (no writes)", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+    swapQualityProfileToOpusMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -42,20 +42,24 @@ type ManagedProfileTemplate = Omit<
  * (`preserveProfileNames`) take precedence when present.
  */
 const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
-  // Served by MiniMax M3 on Together AI via managed platform inference: a strong
-  // open model at a lower price point than the managed Anthropic route.
+  // Served by GLM 5.2 on Fireworks via managed platform inference, matching the
+  // managed `quality-optimized` profile below: same model, provider, connection,
+  // and inference config. Only the profile key (`balanced`) and `label` keep the
+  // slot's own identity so existing `inference_profile` pins keep resolving.
+  // `model` is pinned explicitly rather than resolved via the `balanced` intent
+  // (which still maps to MiniMax M3 on Together for `custom-balanced` and OS
+  // beta).
   balanced: {
-    intent: "balanced",
-    provider: "together",
-    connectionName: "together-managed",
+    model: "accounts/fireworks/models/glm-5p2",
+    provider: "fireworks",
+    connectionName: "fireworks-managed",
     source: "managed",
     label: "Balanced",
-    description: "Good balance of quality, cost, and speed",
+    description: "High-quality results with a leading open model (GLM 5.2)",
     maxTokens: 32000,
-    effort: "medium",
+    effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-    topP: 0.95,
   },
   // Served by GLM 5.2 on Fireworks via managed platform inference: a leading
   // open model. `model` is pinned explicitly rather than resolved via the

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -42,36 +42,33 @@ type ManagedProfileTemplate = Omit<
  * (`preserveProfileNames`) take precedence when present.
  */
 const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
-  // Served by GLM 5.2 on Fireworks via managed platform inference, matching the
-  // managed `quality-optimized` profile below: same model, provider, connection,
-  // and inference config. Only the profile key (`balanced`) and `label` keep the
-  // slot's own identity so existing `inference_profile` pins keep resolving.
-  // `model` is pinned explicitly rather than resolved via the `balanced` intent
-  // (which still maps to MiniMax M3 on Together for `custom-balanced` and OS
-  // beta).
+  // Served by GLM 5.2 on Fireworks via managed platform inference: a leading
+  // open model at a balanced price point. `model` is pinned explicitly rather
+  // than resolved via the `balanced` intent (which still maps to MiniMax M3 on
+  // Together for `custom-balanced` and OS beta).
   balanced: {
     model: "accounts/fireworks/models/glm-5p2",
     provider: "fireworks",
     connectionName: "fireworks-managed",
     source: "managed",
     label: "Balanced",
-    description: "High-quality results with a leading open model (GLM 5.2)",
+    description: "Good balance of quality, cost, and speed",
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
-  // Served by GLM 5.2 on Fireworks via managed platform inference: a leading
-  // open model. `model` is pinned explicitly rather than resolved via the
-  // `quality-optimized` intent (which still maps to Anthropic Opus for the
-  // `frontier` profile below).
+  // Served by Anthropic Opus via managed platform inference — the same model as
+  // the `frontier` profile below. The `quality-optimized` intent resolves to
+  // Opus for the `anthropic` provider, so the two profiles share a model and
+  // differ only by slot key and label.
   "quality-optimized": {
-    model: "accounts/fireworks/models/glm-5p2",
-    provider: "fireworks",
-    connectionName: "fireworks-managed",
+    intent: "quality-optimized",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
     source: "managed",
     label: "Quality",
-    description: "High-quality results with a leading open model (GLM 5.2)",
+    description: "High-quality results with the most capable model",
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },

--- a/assistant/src/workspace/migrations/113-swap-balanced-profile-to-glm-5p2.ts
+++ b/assistant/src/workspace/migrations/113-swap-balanced-profile-to-glm-5p2.ts
@@ -4,9 +4,9 @@ import { join } from "node:path";
 import type { WorkspaceMigration } from "./types.js";
 
 // Bring an existing workspace's managed `balanced` profile in line with the
-// current code template: it now runs GLM 5.2 (Fireworks), matching the managed
-// `quality-optimized` profile's model, provider, connection, effort, and
-// description.
+// current code template: it now runs GLM 5.2 (Fireworks) at effort `high`,
+// taking over the model the managed `quality-optimized` profile used to serve.
+// The slot keeps its own `label` and `description`.
 //
 // A migration is needed even though the seeder reconciles managed-profile
 // content from the templates on every boot, because the seeder only consults a
@@ -35,8 +35,7 @@ const SEEDED_TOP_P = 0.95;
 
 export const swapBalancedProfileToGlm52Migration: WorkspaceMigration = {
   id: "113-swap-balanced-profile-to-glm-5p2",
-  description:
-    "Set the managed balanced profile to GLM 5.2 (Fireworks), matching the quality profile",
+  description: "Set the managed balanced profile to GLM 5.2 (Fireworks)",
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
     if (!existsSync(configPath)) return;
@@ -69,8 +68,6 @@ export const swapBalancedProfileToGlm52Migration: WorkspaceMigration = {
     profile.provider = "fireworks";
     profile.provider_connection = "fireworks-managed";
     profile.effort = "high";
-    profile.description =
-      "High-quality results with a leading open model (GLM 5.2)";
     if (profile.topP === SEEDED_TOP_P) {
       delete profile.topP;
     }

--- a/assistant/src/workspace/migrations/113-swap-balanced-profile-to-glm-5p2.ts
+++ b/assistant/src/workspace/migrations/113-swap-balanced-profile-to-glm-5p2.ts
@@ -16,18 +16,26 @@ import type { WorkspaceMigration } from "./types.js";
 // platform workspace whose `balanced` profile still resolves to Together
 // MiniMax M3 therefore relies on this migration to move it to GLM 5.2.
 //
-// Scope: only the managed `balanced` profile still on the Together MiniMax M3
-// default is rewritten. `balanced` is a canonical name reserved since migration
-// 052, which seeded it source-less, so absent `source` means legacy managed —
-// treat it as ours. An explicit `source: "user"` (a profile the user took
-// ownership of) or one whose model the user changed is left untouched. Matching
-// on the old model id keeps the migration idempotent and leaves a
-// user-retargeted profile alone. The profile key stays `balanced`, so persisted
-// `inference_profile` pins on conversations/schedules keep resolving.
+// Scope: only the managed `balanced` profile is rewritten. `balanced` is a
+// canonical name reserved since migration 052, which seeded it source-less, so
+// absent `source` means legacy managed — treat it as ours. An explicit
+// `source: "user"` (a profile the user took ownership of) or one whose model the
+// user retargeted to something other than the MiniMax/GLM defaults is left
+// untouched. The profile key stays `balanced`, so persisted `inference_profile`
+// pins on conversations/schedules keep resolving.
 //
-// `topP` was a seeded default (0.95) on the old MiniMax template; GLM 5.2 has no
-// sampling override, so the seeded value is dropped to truly match the new
-// template. A user-customized `topP` (any other value) is preserved.
+// Two on-disk states are reconciled:
+//   1. Still on Together MiniMax M3 (`OLD_MODEL`): swap to GLM 5.2 on Fireworks
+//      at effort `high`, and drop the seeded `topP`.
+//   2. Already on GLM 5.2 (`NEW_MODEL`): the boot seeder may have rewritten the
+//      model before this migration ran (it runs on every boot, even when DB
+//      init failure skips the migration runner) while preserving the old
+//      `topP: 0.95` by key-presence. Strip that stale seeded `topP` so the
+//      profile matches the new template, which carries no sampling override.
+//
+// In both cases only the seeded default `topP` (0.95) is dropped — a
+// user-customized `topP` (any other value) is preserved. Matching on the model
+// id keeps the migration idempotent and leaves a user-retargeted profile alone.
 
 const OLD_MODEL = "MiniMaxAI/MiniMax-M3";
 const NEW_MODEL = "accounts/fireworks/models/glm-5p2";
@@ -56,21 +64,25 @@ export const swapBalancedProfileToGlm52Migration: WorkspaceMigration = {
     if (profiles === null) return;
 
     const profile = readObject(profiles["balanced"]);
-    if (
-      profile === null ||
-      profile.source === "user" ||
-      profile.model !== OLD_MODEL
-    ) {
-      return;
-    }
+    if (profile === null || profile.source === "user") return;
 
-    profile.model = NEW_MODEL;
-    profile.provider = "fireworks";
-    profile.provider_connection = "fireworks-managed";
-    profile.effort = "high";
-    if (profile.topP === SEEDED_TOP_P) {
-      delete profile.topP;
+    let changed = false;
+    if (profile.model === OLD_MODEL) {
+      profile.model = NEW_MODEL;
+      profile.provider = "fireworks";
+      profile.provider_connection = "fireworks-managed";
+      profile.effort = "high";
+      changed = true;
     }
+    // Drop the stale seeded topP — whether we just swapped from MiniMax above or
+    // the boot seeder already rewrote the model to GLM (carrying topP by
+    // key-presence) before this migration had a chance to run.
+    if (profile.model === NEW_MODEL && profile.topP === SEEDED_TOP_P) {
+      delete profile.topP;
+      changed = true;
+    }
+    if (!changed) return;
+
     profiles["balanced"] = profile;
     llm.profiles = profiles;
     config.llm = llm;

--- a/assistant/src/workspace/migrations/113-swap-balanced-profile-to-glm-5p2.ts
+++ b/assistant/src/workspace/migrations/113-swap-balanced-profile-to-glm-5p2.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Bring an existing workspace's managed `balanced` profile in line with the
+// current code template: it now runs GLM 5.2 (Fireworks), matching the managed
+// `quality-optimized` profile's model, provider, connection, effort, and
+// description.
+//
+// A migration is needed even though the seeder reconciles managed-profile
+// content from the templates on every boot, because the seeder only consults a
+// template when it reseeds that profile. Off-platform installs reseed every
+// boot, but a platform workspace keeps the profile it was hatched with (the
+// seeder skips overlay-supplied profiles, and the overlay is consumed once). A
+// platform workspace whose `balanced` profile still resolves to Together
+// MiniMax M3 therefore relies on this migration to move it to GLM 5.2.
+//
+// Scope: only the managed `balanced` profile still on the Together MiniMax M3
+// default is rewritten. `balanced` is a canonical name reserved since migration
+// 052, which seeded it source-less, so absent `source` means legacy managed —
+// treat it as ours. An explicit `source: "user"` (a profile the user took
+// ownership of) or one whose model the user changed is left untouched. Matching
+// on the old model id keeps the migration idempotent and leaves a
+// user-retargeted profile alone. The profile key stays `balanced`, so persisted
+// `inference_profile` pins on conversations/schedules keep resolving.
+//
+// `topP` was a seeded default (0.95) on the old MiniMax template; GLM 5.2 has no
+// sampling override, so the seeded value is dropped to truly match the new
+// template. A user-customized `topP` (any other value) is preserved.
+
+const OLD_MODEL = "MiniMaxAI/MiniMax-M3";
+const NEW_MODEL = "accounts/fireworks/models/glm-5p2";
+const SEEDED_TOP_P = 0.95;
+
+export const swapBalancedProfileToGlm52Migration: WorkspaceMigration = {
+  id: "113-swap-balanced-profile-to-glm-5p2",
+  description:
+    "Set the managed balanced profile to GLM 5.2 (Fireworks), matching the quality profile",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    if (profiles === null) return;
+
+    const profile = readObject(profiles["balanced"]);
+    if (
+      profile === null ||
+      profile.source === "user" ||
+      profile.model !== OLD_MODEL
+    ) {
+      return;
+    }
+
+    profile.model = NEW_MODEL;
+    profile.provider = "fireworks";
+    profile.provider_connection = "fireworks-managed";
+    profile.effort = "high";
+    profile.description =
+      "High-quality results with a leading open model (GLM 5.2)";
+    if (profile.topP === SEEDED_TOP_P) {
+      delete profile.topP;
+    }
+    profiles["balanced"] = profile;
+    llm.profiles = profiles;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/114-swap-quality-profile-to-opus.ts
+++ b/assistant/src/workspace/migrations/114-swap-quality-profile-to-opus.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Bring an existing workspace's managed `quality-optimized` profile in line with
+// the current code template: it now runs Anthropic Opus (the same model as the
+// managed `frontier` profile), taking over the config `frontier` carries. The
+// managed `balanced` profile takes over the GLM 5.2 model `quality-optimized`
+// used to serve (migration 113).
+//
+// A migration is needed even though the seeder reconciles managed-profile
+// content from the templates on every boot, because the seeder only consults a
+// template when it reseeds that profile. Off-platform installs reseed every
+// boot, but a platform workspace keeps the profile it was hatched with (the
+// seeder skips overlay-supplied profiles, and the overlay is consumed once). A
+// platform workspace whose `quality-optimized` profile resolves to GLM 5.2
+// therefore relies on this migration to move it to Opus.
+//
+// Scope: only the managed `quality-optimized` profile still on the GLM 5.2
+// default is rewritten. `quality-optimized` is a canonical name reserved since
+// migration 052, which seeded it source-less, so absent `source` means legacy
+// managed — treat it as ours. An explicit `source: "user"` (a profile the user
+// took ownership of) or one whose model the user changed is left untouched.
+// Matching on the GLM model id keeps the migration idempotent and leaves a
+// user-retargeted profile alone. The profile key stays `quality-optimized`, so
+// persisted `inference_profile` pins on conversations/schedules keep resolving.
+
+const OLD_MODEL = "accounts/fireworks/models/glm-5p2";
+const NEW_MODEL = "claude-opus-4-8";
+
+export const swapQualityProfileToOpusMigration: WorkspaceMigration = {
+  id: "114-swap-quality-profile-to-opus",
+  description:
+    "Set the managed quality-optimized profile to Anthropic Opus (matching frontier)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    if (profiles === null) return;
+
+    const profile = readObject(profiles["quality-optimized"]);
+    if (
+      profile === null ||
+      profile.source === "user" ||
+      profile.model !== OLD_MODEL
+    ) {
+      return;
+    }
+
+    profile.model = NEW_MODEL;
+    profile.provider = "anthropic";
+    profile.provider_connection = "anthropic-managed";
+    profile.description = "High-quality results with the most capable model";
+    profiles["quality-optimized"] = profile;
+    llm.profiles = profiles;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -111,6 +111,7 @@ import { flipBalancedProfileToTogetherMigration } from "./110-flip-balanced-prof
 import { pruneSeededCallsiteDefaultsMigration } from "./111-prune-seeded-callsite-defaults.js";
 import { removeAdvisorCallsiteOverrideMigration } from "./112-remove-advisor-callsite-override.js";
 import { swapBalancedProfileToGlm52Migration } from "./113-swap-balanced-profile-to-glm-5p2.js";
+import { swapQualityProfileToOpusMigration } from "./114-swap-quality-profile-to-opus.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -233,4 +234,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   pruneSeededCallsiteDefaultsMigration,
   removeAdvisorCallsiteOverrideMigration,
   swapBalancedProfileToGlm52Migration,
+  swapQualityProfileToOpusMigration,
 ];

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -110,6 +110,7 @@ import { swapQualityProfileToGlm52Migration } from "./109-swap-quality-profile-t
 import { flipBalancedProfileToTogetherMigration } from "./110-flip-balanced-profile-to-together.js";
 import { pruneSeededCallsiteDefaultsMigration } from "./111-prune-seeded-callsite-defaults.js";
 import { removeAdvisorCallsiteOverrideMigration } from "./112-remove-advisor-callsite-override.js";
+import { swapBalancedProfileToGlm52Migration } from "./113-swap-balanced-profile-to-glm-5p2.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -231,4 +232,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   flipBalancedProfileToTogetherMigration,
   pruneSeededCallsiteDefaultsMigration,
   removeAdvisorCallsiteOverrideMigration,
+  swapBalancedProfileToGlm52Migration,
 ];


### PR DESCRIPTION
## Summary
- Change the managed `balanced` profile to carry the same inference configuration as the managed `quality-optimized` profile: GLM 5.2 on Fireworks (`fireworks-managed`), `effort: high`, and no `topP`. The slot keeps its `balanced` key and "Balanced" label so existing `inference_profile` pins keep resolving and the picker still shows a distinct Balanced entry.
- Add workspace migration **113** to rewrite already-seeded managed `balanced` profiles (currently Together MiniMax M3) to GLM 5.2 — needed because platform workspaces keep the profile they hatched with rather than reconciling managed content from the code templates (mirrors migrations 109/110). User-owned, user-retargeted, and custom-`topP` profiles are left untouched.
- Update the seed/reconcile tests to the new balanced default. One emergent behavior is documented in-test: balanced now shares the `fireworks-managed` connection with quality/speed, so a BYOK hatch selecting balanced keeps those profiles enabled and the default advisor resolves to the higher-ranked `quality-optimized` (the equivalent GLM 5.2 model).

## Original prompt
Change the managed "Balance" profile so it carries the same configuration as the current managed "Quality" profile, which runs GLM 5.2 on Fireworks. The intent is for the Balanced slot to serve the GLM 5.2 model with the quality profile's inference settings (provider, connection, effort, no topP) while keeping its own identity (key + label) so existing pins and the profile picker continue to work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->