### PR TITLE
Referral credit gating — UI ineligibility messaging (clients/web)

### DIFF
--- a/clients/web/src/components/earn-credits-modal.test.tsx
+++ b/clients/web/src/components/earn-credits-modal.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for the Earn Credits modal's referral-credit gating.
+ *
+ * When the backend reports `is_eligible_for_credits: false`, the modal swaps
+ * in invite-focused copy that sets expectations: an invite-focused subtitle, a
+ * qualified "You earn credits" step, and an info Notice — while the share link
+ * stays visible and copyable. When the user is eligible, none of that gating
+ * copy renders and the modal looks exactly as it does today.
+ *
+ * The modal renders its content into a Radix portal, so we drive it with
+ * @testing-library/react (happy-dom is registered via the test preload) and
+ * assert on `document.body`. The React Query cache is pre-populated so the
+ * modal's `useQuery` resolves without a network round-trip.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render } from "@testing-library/react";
+
+import { referralCodesMeRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { MyReferralCodeResponse } from "@/generated/api/types.gen";
+
+import { EarnCreditsModal } from "./earn-credits-modal";
+
+const BASE_REFERRAL: MyReferralCodeResponse = {
+  code: "ABC123",
+  referral_url: "https://vellum.ai/r/ABC123",
+  referred_count: 0,
+  total_earned_usd: "0.00",
+  earning_cap_usd: "100.00",
+  total_earned: "0.00",
+  earning_cap: "100.00",
+  credit_amount: "10.00",
+  referrer_credit_amount: "10.00",
+  is_eligible_for_credits: true,
+};
+
+function renderModal(referral: MyReferralCodeResponse): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(referralCodesMeRetrieveQueryKey(), referral);
+  render(
+    <QueryClientProvider client={client}>
+      <EarnCreditsModal open onClose={() => {}} />
+    </QueryClientProvider>,
+  );
+  return document.body.textContent ?? "";
+}
+
+const INELIGIBLE_NOTICE = "You're not currently earning referral credits.";
+const INELIGIBLE_SUBTITLE =
+  "You'll start earning referral credits once you've purchased credits or upgraded to Pro.";
+const GATED_STEP =
+  "You earn credits — once you've purchased credits or upgraded to Pro";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("EarnCreditsModal referral credit gating", () => {
+  test("ineligible: renders the notice and invite-focused subtitle", () => {
+    const text = renderModal({
+      ...BASE_REFERRAL,
+      is_eligible_for_credits: false,
+    });
+    expect(text).toContain(INELIGIBLE_NOTICE);
+    expect(text).toContain(INELIGIBLE_SUBTITLE);
+    expect(text).toContain(GATED_STEP);
+    // Share link stays visible/copyable regardless of eligibility.
+    expect(
+      document.querySelector<HTMLInputElement>(
+        `input[value="${BASE_REFERRAL.referral_url}"]`,
+      ),
+    ).not.toBeNull();
+  });
+
+  test("eligible: renders neither the notice nor the gating copy", () => {
+    const text = renderModal({
+      ...BASE_REFERRAL,
+      is_eligible_for_credits: true,
+    });
+    expect(text).not.toContain(INELIGIBLE_NOTICE);
+    expect(text).not.toContain(INELIGIBLE_SUBTITLE);
+    expect(text).not.toContain(GATED_STEP);
+    expect(text).toContain("You earn credits");
+    expect(
+      document.querySelector<HTMLInputElement>(
+        `input[value="${BASE_REFERRAL.referral_url}"]`,
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/clients/web/src/components/earn-credits-modal.tsx
+++ b/clients/web/src/components/earn-credits-modal.tsx
@@ -68,7 +68,7 @@ function EarnCreditsModalInner() {
     });
   }, []);
 
-  const creditsGated = !!data && !data.is_eligible_for_credits;
+  const creditsGated = data?.is_eligible_for_credits === false;
 
   const subtitle = !data
     ? "Refer friends to earn free credits."

--- a/clients/web/src/components/earn-credits-modal.tsx
+++ b/clients/web/src/components/earn-credits-modal.tsx
@@ -13,6 +13,7 @@ import { useCallback, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Button, Input, Modal } from "@vellumai/design-library";
+import { Notice } from "@vellumai/design-library/components/notice";
 
 import { referralCodesMeRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 
@@ -67,13 +68,17 @@ function EarnCreditsModalInner() {
     });
   }, []);
 
-  const subtitle = data
-    ? buildSubtitle(
-        data.referrer_credit_amount,
-        data.credit_amount,
-        data.earning_cap,
-      )
-    : "Refer friends to earn free credits.";
+  const creditsGated = !!data && !data.is_eligible_for_credits;
+
+  const subtitle = !data
+    ? "Refer friends to earn free credits."
+    : creditsGated
+      ? "Invite friends to Vellum. You'll start earning referral credits once you've purchased credits or upgraded to Pro."
+      : buildSubtitle(
+          data.referrer_credit_amount,
+          data.credit_amount,
+          data.earning_cap,
+        );
 
   const cap = data ? stripDecimals(data.earning_cap) : "";
   const title = showTerms ? "Referral Program Terms" : "Earn free credits";
@@ -139,11 +144,23 @@ function EarnCreditsModalInner() {
               />
               <HowItWorksStep
                 icon={<Gift className="h-4 w-4" />}
-                label="You earn credits"
+                label={
+                  creditsGated
+                    ? "You earn credits — once you've purchased credits or upgraded to Pro"
+                    : "You earn credits"
+                }
               />
             </div>
 
             <div style={{ borderTop: "1px solid var(--border-base)" }} />
+
+            {creditsGated && (
+              <Notice tone="info">
+                You're not currently earning referral credits. Buy credits or
+                upgrade to Pro to start earning — your invite link still works
+                in the meantime.
+              </Notice>
+            )}
 
             <div className="flex items-center gap-2">
               <Input

--- a/clients/web/src/domains/settings/components/referral-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/referral-panel.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for the ReferralPanel credit-eligibility messaging: when the user is
+ * not eligible to earn referral credits (`is_eligible_for_credits === false`),
+ * an info notice and invite-focused subtitle render while the stats and copy
+ * link stay put. When eligible, the panel is unchanged.
+ *
+ * Strategy: pre-populate the React Query cache so the panel's `useQuery`
+ * resolves synchronously — `renderToStaticMarkup` is single-pass, so a pending
+ * query would otherwise report `isLoading` and render the spinner.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { referralCodesMeRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { MyReferralCodeResponse } from "@/generated/api/types.gen";
+
+import { ReferralPanel } from "./referral-panel";
+
+const NOTICE_COPY = "not currently earning referral credits";
+
+function referralData(
+  isEligibleForCredits: boolean,
+): MyReferralCodeResponse {
+  return {
+    code: "ABC123",
+    referral_url: "https://vellum.ai/r/ABC123",
+    referred_count: 2,
+    total_earned_usd: "10.00",
+    earning_cap_usd: "50.00",
+    total_earned: "10.00",
+    earning_cap: "50.00",
+    credit_amount: "5.00",
+    referrer_credit_amount: "5.00",
+    is_eligible_for_credits: isEligibleForCredits,
+  };
+}
+
+function renderPanel(isEligibleForCredits: boolean): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    referralCodesMeRetrieveQueryKey(),
+    referralData(isEligibleForCredits),
+  );
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <ReferralPanel />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ReferralPanel credit eligibility", () => {
+  test("shows the ineligibility notice and invite-focused subtitle when not eligible", () => {
+    const html = renderPanel(false);
+    expect(html).toContain(NOTICE_COPY);
+    expect(html).toContain("Invite friends to Vellum.");
+    // Stats and copy link still render.
+    expect(html).toContain("Credits Earned");
+    expect(html).toContain("Friends Referred");
+    expect(html).toContain("referral-copy-button");
+  });
+
+  test("renders no notice and the default subtitle when eligible", () => {
+    const html = renderPanel(true);
+    expect(html).not.toContain(NOTICE_COPY);
+    expect(html).not.toContain("Invite friends to Vellum.");
+    expect(html).toContain("Share Vellum with friends");
+    expect(html).toContain("Credits Earned");
+    expect(html).toContain("referral-copy-button");
+  });
+});

--- a/clients/web/src/domains/settings/components/referral-panel.tsx
+++ b/clients/web/src/domains/settings/components/referral-panel.tsx
@@ -42,7 +42,7 @@ export function ReferralPanel() {
     });
   }, []);
 
-  const creditsGated = !!data && !data.is_eligible_for_credits;
+  const creditsGated = data?.is_eligible_for_credits === false;
 
   const subtitle = creditsGated
     ? "Invite friends to Vellum. You'll start earning referral credits once you've purchased credits or upgraded to Pro."

--- a/clients/web/src/domains/settings/components/referral-panel.tsx
+++ b/clients/web/src/domains/settings/components/referral-panel.tsx
@@ -42,13 +42,17 @@ export function ReferralPanel() {
     });
   }, []);
 
-  const subtitle = data
-    ? `Share Vellum with friends - you'll each earn ${stripDecimals(
-        data.referrer_credit_amount,
-      )} credits when they sign up, up to ${stripDecimals(
-        data.earning_cap,
-      )} total.`
-    : "Share Vellum with friends and earn credits for every signup.";
+  const creditsGated = !!data && !data.is_eligible_for_credits;
+
+  const subtitle = creditsGated
+    ? "Invite friends to Vellum. You'll start earning referral credits once you've purchased credits or upgraded to Pro."
+    : data
+      ? `Share Vellum with friends - you'll each earn ${stripDecimals(
+          data.referrer_credit_amount,
+        )} credits when they sign up, up to ${stripDecimals(
+          data.earning_cap,
+        )} total.`
+      : "Share Vellum with friends and earn credits for every signup.";
 
   return (
     <Card padding="md" id={REFERRAL_PANEL_ANCHOR_ID}>
@@ -69,6 +73,14 @@ export function ReferralPanel() {
             {subtitle}
           </Typography>
         </div>
+
+        {creditsGated && (
+          <Notice tone="info">
+            You're not currently earning referral credits. Buy credits or
+            upgrade to Pro to start earning — your invite link still works in
+            the meantime.
+          </Notice>
+        )}
 
         {isLoading ? (
           <div className="flex items-center gap-2 text-body-medium-lighter text-[var(--content-tertiary)]">


### PR DESCRIPTION
## Summary
Surfaces "you won't earn referral credits until you're eligible" messaging in the two web referral surfaces (Earn Credits modal + billing Referral panel) when the platform reports `is_eligible_for_credits === false`. When eligible — or when the field is absent — the UI is unchanged from today. No feature flag; the backend simply reports eligibility.

## Self-review result
PASS — 1 gap found and fixed across 1 fix PR (round 1): the credit gate was changed to trigger only on an explicit `false`, so an absent/cached-backend eligibility field defaults to today's (not-gated) behavior, de-risking deploy ordering.

## PRs merged into feature branch
- #36275: feat(web): show referral credit ineligibility in earn-credits modal
- #36274: feat(web): show referral credit ineligibility in billing referral panel

### Fix PRs
- #36276: fix(web): gate referral credit messaging only on explicit ineligibility

## Notes
PR A from the plan (sync platform OpenAPI spec) was already complete on `main` (the `is_eligible_for_credits` property landed via #36174; the generated client is gitignored), so it was skipped — no empty PR opened.

Part of plan: referral-credit-gating.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->