### PR TITLE
combo11: drop the redundant contact ACL columns from the assistant DB…

### DIFF
--- a/assistant/src/__tests__/contact-store-interaction-info.test.ts
+++ b/assistant/src/__tests__/contact-store-interaction-info.test.ts
@@ -33,7 +33,7 @@ function resetContactTables(): void {
 function insertContact(id: string, displayName: string): void {
   const now = Date.now();
   getSqlite().run(
-    "INSERT INTO contacts (id, display_name, role, contact_type, user_file, created_at, updated_at) VALUES (?, ?, 'contact', 'human', ?, ?, ?)",
+    "INSERT INTO contacts (id, display_name, contact_type, user_file, created_at, updated_at) VALUES (?, ?, 'human', ?, ?, ?)",
     [id, displayName, `${id}.md`, now, now],
   );
 }

--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -1,4 +1,7 @@
+import { Database } from "bun:sqlite";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -11,9 +14,11 @@ import {
   generateUserFileSlug,
   upsertContact,
 } from "../contacts/contact-store.js";
-import { getDb, getSqlite } from "../memory/db-connection.js";
+import type { DrizzleDb } from "../memory/db-connection.js";
+import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { migrateNormalizeUserFileByPrincipal } from "../memory/migrations/220-normalize-user-file-by-principal.js";
+import * as schema from "../memory/schema.js";
 
 await initializeDb();
 
@@ -21,44 +26,27 @@ function resetContactTables(): void {
   const sqlite = getSqlite();
   sqlite.run("DELETE FROM contact_channels");
   sqlite.run("DELETE FROM contacts");
-  sqlite.run(
-    "DELETE FROM memory_checkpoints WHERE key = 'step:migrateNormalizeUserFileByPrincipal'",
-  );
 }
 
+/** Seed a contact row into the production DB (post-ACL-drop schema). */
 function insertContact(params: {
   id: string;
   displayName: string;
-  role: string;
-  principalId: string | null;
   userFile: string | null;
   createdAt: number;
 }): void {
   const sqlite = getSqlite();
   sqlite.run(
-    "INSERT INTO contacts (id, display_name, role, contact_type, principal_id, user_file, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO contacts (id, display_name, contact_type, user_file, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
     [
       params.id,
       params.displayName,
-      params.role,
       "human",
-      params.principalId,
       params.userFile,
       params.createdAt,
       params.createdAt,
     ],
   );
-}
-
-function fetchUserFilesByPrincipal(
-  principalId: string,
-): Array<{ id: string; user_file: string | null }> {
-  const sqlite = getSqlite();
-  return sqlite
-    .query(
-      "SELECT id, user_file FROM contacts WHERE principal_id = ? ORDER BY id",
-    )
-    .all(principalId) as Array<{ id: string; user_file: string | null }>;
 }
 
 describe("upsertContact user_file selection", () => {
@@ -143,8 +131,6 @@ describe("upsertContact user_file selection", () => {
     insertContact({
       id: "seed-null",
       displayName: "legacy",
-      role: "guardian",
-      principalId: "principal-null",
       userFile: null,
       createdAt: Date.now(),
     });
@@ -177,8 +163,6 @@ describe("generateUserFileSlug", () => {
     insertContact({
       id: "a",
       displayName: "Alice",
-      role: "contact",
-      principalId: null,
       userFile: "alice.md",
       createdAt: Date.now(),
     });
@@ -187,30 +171,75 @@ describe("generateUserFileSlug", () => {
 });
 
 describe("migrateNormalizeUserFileByPrincipal", () => {
+  // Migration 220 reads contacts.principal_id, which migration 305 later drops.
+  // Run it against an isolated DB seeded at the pre-drop schema so the historical
+  // migration's behavior stays under test after the column is gone in production.
+  let db: DrizzleDb;
+  let raw: Database;
+
   beforeEach(() => {
-    resetContactTables();
+    raw = new Database(":memory:");
+    raw.exec(/*sql*/ `
+      CREATE TABLE contacts (
+        id TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL,
+        principal_id TEXT,
+        user_file TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    db = drizzle(raw, { schema });
   });
+
+  function seedLegacy(params: {
+    id: string;
+    displayName: string;
+    principalId: string | null;
+    userFile: string | null;
+    createdAt: number;
+  }): void {
+    raw.run(
+      "INSERT INTO contacts (id, display_name, principal_id, user_file, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+      [
+        params.id,
+        params.displayName,
+        params.principalId,
+        params.userFile,
+        params.createdAt,
+        params.createdAt,
+      ],
+    );
+  }
+
+  function fetchUserFilesByPrincipal(
+    principalId: string,
+  ): Array<{ id: string; user_file: string | null }> {
+    return raw
+      .query(
+        "SELECT id, user_file FROM contacts WHERE principal_id = ? ORDER BY id",
+      )
+      .all(principalId) as Array<{ id: string; user_file: string | null }>;
+  }
 
   test("normalizes split user_file values across sibling contacts", () => {
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-x",
       userFile: "chris.md",
       createdAt: now - 1000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-x",
       userFile: "chris-2.md",
       createdAt: now,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-x");
     expect(rows).toHaveLength(2);
@@ -220,24 +249,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
 
   test("propagates a sibling's user_file to NULL rows", () => {
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-y",
       userFile: "chris.md",
       createdAt: now - 1000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-y",
       userFile: null,
       createdAt: now,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-y");
     expect(rows[0]?.user_file).toBe("chris.md");
@@ -248,24 +275,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     // Older contact has an auto-incremented name, newer has the clean one.
     // Heuristic should pick the clean one regardless of age.
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-z",
       userFile: "chris-3.md",
       createdAt: now - 2000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-z",
       userFile: "chris.md",
       createdAt: now,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-z");
     expect(rows[0]?.user_file).toBe("chris.md");
@@ -273,16 +298,15 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
   });
 
   test("leaves untouched when only one contact exists for a principal", () => {
-    insertContact({
+    seedLegacy({
       id: "solo",
       displayName: "Alone",
-      role: "contact",
       principalId: "principal-solo",
       userFile: "alone.md",
       createdAt: Date.now(),
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-solo");
     expect(rows).toHaveLength(1);
@@ -295,24 +319,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     // (starting at 2), so `dana-2024.md` must be treated as a normal filename
     // and not deprioritized in favor of an older sibling.
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "Dana 2024",
-      role: "guardian",
       principalId: "principal-dated",
       userFile: "dana-2024.md",
       createdAt: now,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "Dana",
-      role: "guardian",
       principalId: "principal-dated",
       userFile: "dana.md",
       createdAt: now - 1000,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-dated");
     // Neither candidate looks auto-incremented, so tiebreaker is oldest
@@ -324,24 +346,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
   test("excludes year-like 4-digit tails from the auto-increment class", () => {
     // `-2.md` is auto-increment; `-1999.md` (year) is not.
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "Bob 1999",
-      role: "guardian",
       principalId: "principal-mixed",
       userFile: "bob-1999.md",
       createdAt: now - 2000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "Bob",
-      role: "guardian",
       principalId: "principal-mixed",
       userFile: "bob-2.md",
       createdAt: now - 1000,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-mixed");
     // `bob-1999.md` is non-auto-incremented, `bob-2.md` is auto-incremented;
@@ -355,24 +375,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     // Those must still be recognized as auto-increments so siblings are
     // normalized to the clean base, not to the counter value.
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "Carol",
-      role: "guardian",
       principalId: "principal-big",
       userFile: "carol-1000.md",
       createdAt: now - 2000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "Carol",
-      role: "guardian",
       principalId: "principal-big",
       userFile: "carol.md",
       createdAt: now,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-big");
     // Despite `carol-1000.md` being older, it's auto-incremented, so
@@ -385,24 +403,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     // small counter), but the preceding `-2025-04` marks the whole tail as a
     // date. Must NOT be classified as auto-incremented.
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "Dana 2025 04 13",
-      role: "guardian",
       principalId: "principal-datefull",
       userFile: "dana-2025-04-13.md",
       createdAt: now - 2000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "Dana",
-      role: "guardian",
       principalId: "principal-datefull",
       userFile: "dana-2.md",
       createdAt: now - 1000,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-datefull");
     // `dana-2.md` is auto-incremented; `dana-2025-04-13.md` is a date-shaped
@@ -417,24 +433,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     // while ISO date components are always 2 digits (`-02`, `-04`), so
     // single-digit trailing segments mark the tail as a counter.
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "Dana 2025",
-      role: "guardian",
       principalId: "principal-yc",
       userFile: "dana-2025-2.md",
       createdAt: now - 2000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "Dana 2025",
-      role: "guardian",
       principalId: "principal-yc",
       userFile: "dana-2025.md",
       createdAt: now,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-yc");
     // Despite being older, `dana-2025-2.md` is auto-incremented, so
@@ -449,24 +463,22 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     // name — if `generateUserFileSlug`'s pure slug transform maps the name to
     // the filename, treat it as a base slug, not an auto-incremented counter.
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "Dana 2025 4",
-      role: "guardian",
       principalId: "principal-yb",
       userFile: "dana-2025-4.md",
       createdAt: now,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "Dana",
-      role: "guardian",
       principalId: "principal-yb",
       userFile: "dana-2.md",
       createdAt: now - 1000,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-yb");
     // `dana-2025-4.md` is a legitimate base slug (disambiguated by display
@@ -477,25 +489,23 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
 
   test("is idempotent", () => {
     const now = Date.now();
-    insertContact({
+    seedLegacy({
       id: "c1",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-i",
       userFile: "chris.md",
       createdAt: now - 1000,
     });
-    insertContact({
+    seedLegacy({
       id: "c2",
       displayName: "chris",
-      role: "guardian",
       principalId: "principal-i",
       userFile: "chris-2.md",
       createdAt: now,
     });
 
-    migrateNormalizeUserFileByPrincipal(getDb());
-    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(db);
+    migrateNormalizeUserFileByPrincipal(db);
 
     const rows = fetchUserFilesByPrincipal("principal-i");
     for (const row of rows) expect(row.user_file).toBe("chris.md");

--- a/assistant/src/__tests__/db-drop-contact-acl-columns-migration.test.ts
+++ b/assistant/src/__tests__/db-drop-contact-acl-columns-migration.test.ts
@@ -1,0 +1,151 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateDropContactAclColumns } from "../memory/migrations/305-drop-contact-acl-columns.js";
+import * as schema from "../memory/schema.js";
+
+const DROPPED_CONTACT_COLUMNS = ["role", "principal_id"] as const;
+const DROPPED_CHANNEL_COLUMNS = [
+  "status",
+  "policy",
+  "verified_at",
+  "verified_via",
+  "revoked_reason",
+  "blocked_reason",
+] as const;
+const KEPT_CHANNEL_COLUMNS = [
+  "invite_id",
+  "external_chat_id",
+  "type",
+  "address",
+  "is_primary",
+  "last_seen_at",
+  "interaction_count",
+  "last_interaction",
+] as const;
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+/** Seed the pre-migration contacts/contact_channels schema (with ACL columns). */
+function bootstrapLegacyTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE contacts (
+      id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      role TEXT NOT NULL DEFAULT 'contact',
+      principal_id TEXT,
+      user_file TEXT,
+      contact_type TEXT NOT NULL DEFAULT 'human'
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      external_chat_id TEXT,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      verified_at INTEGER,
+      verified_via TEXT,
+      invite_id TEXT,
+      revoked_reason TEXT,
+      blocked_reason TEXT,
+      last_seen_at INTEGER,
+      interaction_count INTEGER NOT NULL DEFAULT 0,
+      last_interaction INTEGER,
+      updated_at INTEGER,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX idx_contact_channels_type_ext_chat
+      ON contact_channels(type, external_chat_id)
+  `);
+}
+
+function columnNames(raw: Database, table: string): Set<string> {
+  const cols = raw.prepare(`PRAGMA table_info(${table})`).all() as {
+    name: string;
+  }[];
+  return new Set(cols.map((c) => c.name));
+}
+
+function indexNames(raw: Database, table: string): Set<string> {
+  const idx = raw.prepare(`PRAGMA index_list(${table})`).all() as {
+    name: string;
+  }[];
+  return new Set(idx.map((i) => i.name));
+}
+
+describe("migrateDropContactAclColumns", () => {
+  test("drops the 8 ACL columns and keeps INFO/identity/invite columns", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapLegacyTables(raw);
+
+    migrateDropContactAclColumns(db);
+
+    const contactCols = columnNames(raw, "contacts");
+    for (const col of DROPPED_CONTACT_COLUMNS) {
+      expect(contactCols.has(col)).toBe(false);
+    }
+    // Identity/INFO columns survive.
+    for (const col of ["id", "display_name", "notes", "user_file", "contact_type"]) {
+      expect(contactCols.has(col)).toBe(true);
+    }
+
+    const channelCols = columnNames(raw, "contact_channels");
+    for (const col of DROPPED_CHANNEL_COLUMNS) {
+      expect(channelCols.has(col)).toBe(false);
+    }
+    for (const col of KEPT_CHANNEL_COLUMNS) {
+      expect(channelCols.has(col)).toBe(true);
+    }
+  });
+
+  test("leaves the type/external_chat_id index intact", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapLegacyTables(raw);
+
+    migrateDropContactAclColumns(db);
+
+    expect(indexNames(raw, "contact_channels").has(
+      "idx_contact_channels_type_ext_chat",
+    )).toBe(true);
+  });
+
+  test("is idempotent — re-running on the dropped schema is a no-op", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapLegacyTables(raw);
+
+    migrateDropContactAclColumns(db);
+    const afterFirst = {
+      contacts: [...columnNames(raw, "contacts")].sort(),
+      channels: [...columnNames(raw, "contact_channels")].sort(),
+    };
+
+    expect(() => migrateDropContactAclColumns(db)).not.toThrow();
+
+    expect([...columnNames(raw, "contacts")].sort()).toEqual(
+      afterFirst.contacts,
+    );
+    expect([...columnNames(raw, "contact_channels")].sort()).toEqual(
+      afterFirst.channels,
+    );
+  });
+});

--- a/assistant/src/__tests__/helpers/seed-contact-channel.ts
+++ b/assistant/src/__tests__/helpers/seed-contact-channel.ts
@@ -7,10 +7,8 @@
  * `gwContacts`/`gwContactChannels`) and warm the member-verdict cache so verdict
  * synthesis and the sync trust fallback resolve the intended trust. The assistant
  * row carries only identity/info columns (id, displayName, channel address/chat
- * id, principalId) — never the ACL columns, which are gateway-owned.
+ * id) — never the ACL columns (incl. principalId), which are gateway-owned.
  */
-
-import { eq } from "drizzle-orm";
 
 import { isChannelId } from "../../channels/types.js";
 import { upsertContact } from "../../contacts/contact-store.js";
@@ -19,8 +17,6 @@ import type {
   ChannelStatus,
   ContactRole,
 } from "../../contacts/types.js";
-import { getDb } from "../../memory/db-connection.js";
-import { contacts } from "../../memory/schema.js";
 import { setMemberVerdict } from "../../runtime/member-verdict-cache.js";
 import {
   gatewayAclByChannelId,
@@ -62,16 +58,6 @@ export function seedContactChannel(params: {
     ],
     reassignConflictingChannels: !!params.contactId,
   });
-
-  // principalId is an identity column (assistant-owned) — keep stamping it on
-  // the assistant row so identity-keyed reads resolve it.
-  const db = getDb();
-  if (params.principalId !== undefined) {
-    db.update(contacts)
-      .set({ principalId: params.principalId })
-      .where(eq(contacts.id, contact.id))
-      .run();
-  }
 
   const channel = contact.channels.find(
     (ch) => ch.type === params.sourceChannel,

--- a/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
@@ -35,9 +35,38 @@ function resetContactTables(): void {
   sqlite.run("DELETE FROM contacts");
 }
 
+/** Whether a column exists on a table, via `PRAGMA table_info`. */
+function hasColumn(table: string, column: string): boolean {
+  const rows = getSqlite()
+    .query<{ name: string }, []>(`PRAGMA table_info(${table})`)
+    .all();
+  return rows.some((r) => r.name === column);
+}
+
+/**
+ * The guardian-cleanup path reads the legacy ACL columns `contacts.role` and
+ * `contact_channels.status` / `verified_at`, which migration 305 drops from the
+ * production schema. Re-add them (pre-drop shape) in the isolated test DB so the
+ * migration's `aclColumnsPresent` guard finds them and the cleanup path runs —
+ * exactly the historical schema the migration was written against.
+ */
+function ensureAclColumns(): void {
+  const sqlite = getSqlite();
+  if (!hasColumn("contacts", "role")) {
+    sqlite.run("ALTER TABLE contacts ADD COLUMN role TEXT");
+  }
+  if (!hasColumn("contact_channels", "status")) {
+    sqlite.run("ALTER TABLE contact_channels ADD COLUMN status TEXT");
+  }
+  if (!hasColumn("contact_channels", "verified_at")) {
+    sqlite.run("ALTER TABLE contact_channels ADD COLUMN verified_at INTEGER");
+  }
+}
+
 /**
  * Insert a guardian contact plus an active channel so the migration's
- * raw-SQL guardian read resolves it.
+ * raw-SQL guardian read resolves it. Requires the legacy ACL columns, so
+ * it ensures they are present first.
  */
 function seedGuardian(input: {
   id: string;
@@ -47,6 +76,7 @@ function seedGuardian(input: {
   address?: string;
   verifiedAt?: number;
 }): void {
+  ensureAclColumns();
   const now = Date.now();
   const sqlite = getSqlite();
   sqlite.run(
@@ -68,12 +98,18 @@ function seedGuardian(input: {
   );
 }
 
-/** Drop the legacy ACL columns the guardian read depends on. */
+/** Drop the legacy ACL columns the guardian read depends on, if present. */
 function dropAclColumns(): void {
   const sqlite = getSqlite();
-  sqlite.run("ALTER TABLE contacts DROP COLUMN role");
-  sqlite.run("ALTER TABLE contact_channels DROP COLUMN status");
-  sqlite.run("ALTER TABLE contact_channels DROP COLUMN verified_at");
+  if (hasColumn("contacts", "role")) {
+    sqlite.run("ALTER TABLE contacts DROP COLUMN role");
+  }
+  if (hasColumn("contact_channels", "status")) {
+    sqlite.run("ALTER TABLE contact_channels DROP COLUMN status");
+  }
+  if (hasColumn("contact_channels", "verified_at")) {
+    sqlite.run("ALTER TABLE contact_channels DROP COLUMN verified_at");
+  }
 }
 
 function guardianUserFile(id: string): string | null {
@@ -140,6 +176,11 @@ function customizedContent(): string {
 beforeEach(() => {
   resetContactTables();
   cleanupWorkspaceFiles();
+  // Most scenarios exercise the guardian-cleanup path, which the migration
+  // only enters when the legacy ACL columns are present. Migration 305 drops
+  // them from the production schema, so re-add them (pre-drop shape) by default;
+  // the dedicated "ACL columns absent" test drops them to cover the skip-path.
+  ensureAclColumns();
 });
 
 // ── Tests ─────────────────────────────────────────────────────────
@@ -333,8 +374,10 @@ describe("workspace migration 031-drop-user-md", () => {
   });
 
   test("ACL columns absent — skips guardian cleanup cleanly and leaves USER.md untouched", () => {
-    // Mirror the later phase that drops the assistant-DB ACL columns. The
-    // migration must skip the guardian-dependent cleanup with no throw.
+    // Mirror the post-drop assistant-DB schema (migration 305). The migration's
+    // `aclColumnsPresent` guard must skip the guardian-dependent cleanup with no
+    // throw. Guardian-seeding tests re-add the columns via `ensureAclColumns()`,
+    // so dropping them here only affects this scenario.
     const content = customizedContent();
     writeFileSync(userMdPath(), content, "utf-8");
 
@@ -342,12 +385,9 @@ describe("workspace migration 031-drop-user-md", () => {
     try {
       expect(() => dropUserMdMigration.run(workspaceDir())).not.toThrow();
     } finally {
-      // Restore schema so later runs (file load order independent) see the
-      // columns; beforeEach only clears rows, not schema.
-      const sqlite = getSqlite();
-      sqlite.run("ALTER TABLE contacts ADD COLUMN role TEXT");
-      sqlite.run("ALTER TABLE contact_channels ADD COLUMN status TEXT");
-      sqlite.run("ALTER TABLE contact_channels ADD COLUMN verified_at INTEGER");
+      // Restore schema so a later test that reads these columns directly is
+      // unaffected; beforeEach only clears rows, not schema.
+      ensureAclColumns();
     }
 
     // USER.md is left exactly as-is; no users/ scaffold is created.

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
@@ -128,26 +128,22 @@ describe("redeemA2AInvite", () => {
     expect(result.success).toBe(true);
   });
 
-  test("activeConnections counts a2a channel existence, not status", () => {
+  test("activeConnections counts a2a channel existence", () => {
     const result = redeemA2AInvite({ sender: SENDER });
     expect(result.success).toBe(true);
 
+    // Readiness is existence-based: the presence of the a2a channel is what
+    // counts. (Channel ACL status is gateway-owned and not stored locally.)
     expect(getA2AConfig().activeConnections).toBe(1);
-
-    // Readiness is existence-based: a non-active stored status still counts.
-    const sqlite = getSqlite();
-    sqlite.run("UPDATE contact_channels SET status = 'unverified'");
     invalidateConfigCache();
     expect(getA2AConfig().activeConnections).toBe(1);
   });
 
-  test("already-connected guard fires regardless of stored channel status", () => {
+  test("already-connected guard fires based on channel existence", () => {
     const first = redeemA2AInvite({ sender: SENDER });
     expect(first.success).toBe(true);
 
-    const sqlite = getSqlite();
-    sqlite.run("UPDATE contact_channels SET status = 'revoked'");
-
+    // The guard keys off the existing a2a channel, not any stored status.
     const second = redeemA2AInvite({ sender: SENDER });
     expect(second.alreadyConnected).toBe(true);
     expect(second.contactId).toBe(first.contactId);

--- a/assistant/src/memory/migrations/305-drop-contact-acl-columns.ts
+++ b/assistant/src/memory/migrations/305-drop-contact-acl-columns.ts
@@ -1,0 +1,49 @@
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const log = getLogger("migration-305");
+
+/**
+ * Drops the redundant contact ACL columns now owned by the gateway DB.
+ *
+ * Combo 11 Phase B: the gateway DB is the source of truth for contact ACL,
+ * making these assistant-DB columns redundant mirrors. Phase A already drained
+ * every production read off them.
+ *
+ * No DROP INDEX needed: the only contact_channels index
+ * (idx_contact_channels_type_ext_chat on (type, external_chat_id)) covers none
+ * of these columns.
+ *
+ * Idempotent: each drop is guarded on PRAGMA table_info.
+ */
+export function migrateDropContactAclColumns(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  dropColumnIfPresent(raw, "contacts", "role");
+  dropColumnIfPresent(raw, "contacts", "principal_id");
+  dropColumnIfPresent(raw, "contact_channels", "status");
+  dropColumnIfPresent(raw, "contact_channels", "policy");
+  dropColumnIfPresent(raw, "contact_channels", "verified_at");
+  dropColumnIfPresent(raw, "contact_channels", "verified_via");
+  dropColumnIfPresent(raw, "contact_channels", "revoked_reason");
+  dropColumnIfPresent(raw, "contact_channels", "blocked_reason");
+}
+
+function dropColumnIfPresent(
+  raw: Database,
+  table: string,
+  column: string,
+): void {
+  const cols = raw.prepare(`PRAGMA table_info(${table})`).all() as {
+    name: string;
+  }[];
+  if (!cols.some((c) => c.name === column)) {
+    log.info(`${table}.${column} already absent — skipping`);
+    return;
+  }
+
+  raw.run(`ALTER TABLE ${table} DROP COLUMN ${column}`);
+  log.info(`Dropped ${column} column from ${table}`);
+}

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -8,10 +8,6 @@ export const contacts = sqliteTable("contacts", {
   notes: text("notes"),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
-  role: text("role", { enum: ["guardian", "contact"] })
-    .notNull()
-    .default("contact"),
-  principalId: text("principal_id"), // internal auth principal (nullable)
   userFile: text("user_file"), // workspace-relative path to per-user persona file
   contactType: text("contact_type", { enum: ["human", "assistant"] })
     .notNull()
@@ -31,13 +27,7 @@ export const contactChannels = sqliteTable(
       .notNull()
       .default(false),
     externalChatId: text("external_chat_id"), // delivery/notification routing address (e.g., Telegram chat ID)
-    status: text("status").notNull().default("unverified"), // 'active' | 'pending' | 'revoked' | 'blocked' | 'unverified'
-    policy: text("policy").notNull().default("allow"), // 'allow' | 'deny' | 'escalate'
-    verifiedAt: integer("verified_at"), // epoch ms
-    verifiedVia: text("verified_via"), // 'challenge' | 'invite' | 'bootstrap' | etc.
     inviteId: text("invite_id"), // reference to invite that onboarded
-    revokedReason: text("revoked_reason"),
-    blockedReason: text("blocked_reason"),
     lastSeenAt: integer("last_seen_at"), // epoch ms
     interactionCount: integer("interaction_count").notNull().default(0),
     lastInteraction: integer("last_interaction"),

--- a/assistant/src/memory/steps.ts
+++ b/assistant/src/memory/steps.ts
@@ -412,6 +412,7 @@ import { createWatchdogEventsTable } from "./migrations/301-create-watchdog-even
 import { migrateCreateCompactionEvents } from "./migrations/302-create-compaction-events.js";
 import { migrateAddConversationCreationSeq } from "./migrations/303-add-conversation-creation-seq.js";
 import { migrateAddLlmUsageCronRunId } from "./migrations/304-add-llm-usage-cron-run-id.js";
+import { migrateDropContactAclColumns } from "./migrations/305-drop-contact-acl-columns.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1295,4 +1296,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateCreateCompactionEvents,
   migrateAddConversationCreationSeq,
   migrateAddLlmUsageCronRunId,
+  migrateDropContactAclColumns,
 ];


### PR DESCRIPTION
… (304) (#36279)

* combo11: drop redundant contact ACL columns from the assistant DB (migration 304)

* combo11: fix test seeds that referenced dropped contact ACL columns (workspace-migration-031, config-a2a-redeem)

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
