### PR TITLE
JARVIS-1229: overlay gateway ACL on daemon-forwarded filtered contact reads

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -100,6 +100,27 @@ let contactStoreListMock: ReturnType<typeof mock<ListFn>> = mock(async () => [])
 type GetFn = (contactId: string) => Promise<typeof DEFAULT_MOCK_CONTACT | null>;
 let contactStoreGetMock: ReturnType<typeof mock<GetFn>> = mock(async () => null);
 
+// getAclByContactIds returns the gateway ACL source of truth keyed by contact
+// id; the overlay path on filtered/search list reads uses it. Default: empty
+// map (no ACL to overlay) so the existing forward/passthrough tests are
+// unaffected.
+type ChannelAcl = {
+  id: string;
+  type: string;
+  address: string;
+  status: string | null;
+  policy: string | null;
+  verifiedAt: number | null;
+  verifiedVia: string | null;
+  revokedReason: string | null;
+  blockedReason: string | null;
+};
+type ContactAcl = { role: string; channels: Map<string, ChannelAcl> };
+type GetAclFn = (ids: string[]) => Promise<Map<string, ContactAcl>>;
+let contactStoreGetAclMock: ReturnType<typeof mock<GetAclFn>> = mock(
+  async () => new Map<string, ContactAcl>(),
+);
+
 type UpdateChannelFn = (channelId: string, params: {
   status?: string;
   policy?: string;
@@ -204,6 +225,9 @@ mock.module("../db/contact-store.js", () => ({
     async getContactWithInfo(contactId: string) {
       return contactStoreGetMock(contactId);
     }
+    async getAclByContactIds(ids: string[]) {
+      return contactStoreGetAclMock(ids);
+    }
     async updateChannelStatus(channelId: string, params: {
       status?: string;
       policy?: string;
@@ -289,6 +313,7 @@ afterEach(() => {
   }));
   contactStoreListMock = mock(async () => []);
   contactStoreGetMock = mock(async () => null);
+  contactStoreGetAclMock = mock(async () => new Map<string, ContactAcl>());
   contactStoreUpdateChannelMock = mock(() => null);
   contactStoreMergeMock = mock(async () => null);
   contactStoreGetContactMock = mock(() => ({ id: "ct_1" }));
@@ -853,6 +878,336 @@ describe("handleListContacts (gateway-native)", () => {
 
     const body = await res.json();
     expect(body.contacts[0].channels[0].externalUserId).toBe("@alice");
+  });
+});
+
+describe("handleListContacts ACL overlay (filtered/search path)", () => {
+  // A daemon contact as it comes back post-Combo-11: neutral role, channels
+  // with no/unverified ACL. The overlay must replace role + channel ACL from
+  // the gateway DB while leaving info/identity fields untouched.
+  function daemonContact(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "c1",
+      displayName: "Alice",
+      role: "contact",
+      notes: "friend from college",
+      contactType: "human",
+      interactionCount: 7,
+      lastInteraction: 555,
+      createdAt: 100,
+      updatedAt: 200,
+      channels: [
+        {
+          id: "ch1",
+          contactId: "c1",
+          type: "telegram",
+          address: "@alice",
+          isPrimary: true,
+          externalUserId: "@alice",
+          externalChatId: "12345",
+          inviteId: null,
+          status: "unverified",
+          policy: "allow",
+          verifiedAt: null,
+          verifiedVia: null,
+          revokedReason: null,
+          blockedReason: null,
+          lastSeenAt: null,
+          interactionCount: 3,
+          lastInteraction: 555,
+          createdAt: 100,
+          updatedAt: 200,
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  function daemonResponse(contacts: unknown[]) {
+    return new Response(JSON.stringify({ ok: true, contacts }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  test("overlays gateway role + channel ACL onto a filtered query", async () => {
+    fetchMock = mock(async () => daemonResponse([daemonContact()]));
+    contactStoreGetAclMock = mock(
+      async () =>
+        new Map<string, ContactAcl>([
+          [
+            "c1",
+            {
+              role: "guardian",
+              channels: new Map<string, ChannelAcl>([
+                [
+                  "ch1",
+                  {
+                    id: "ch1",
+                    type: "telegram",
+                    address: "@alice",
+                    status: "active",
+                    policy: "escalate",
+                    verifiedAt: 9999,
+                    verifiedVia: "manual",
+                    revokedReason: null,
+                    blockedReason: null,
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=alice"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contacts[0].role).toBe("guardian");
+    const ch = body.contacts[0].channels[0];
+    expect(ch.status).toBe("active");
+    expect(ch.policy).toBe("escalate");
+    expect(ch.verifiedAt).toBe(9999);
+    expect(ch.verifiedVia).toBe("manual");
+    expect(contactStoreGetAclMock).toHaveBeenCalledTimes(1);
+    expect(contactStoreGetAclMock.mock.calls[0][0]).toEqual(["c1"]);
+  });
+
+  test("channel matched by id: ACL replaced, info/identity preserved exactly", async () => {
+    fetchMock = mock(async () => daemonResponse([daemonContact()]));
+    contactStoreGetAclMock = mock(
+      async () =>
+        new Map<string, ContactAcl>([
+          [
+            "c1",
+            {
+              role: "guardian",
+              channels: new Map<string, ChannelAcl>([
+                [
+                  "ch1",
+                  {
+                    id: "ch1",
+                    type: "telegram",
+                    address: "@alice",
+                    status: "active",
+                    policy: "deny",
+                    verifiedAt: 1234,
+                    verifiedVia: "challenge",
+                    revokedReason: null,
+                    blockedReason: null,
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=alice"),
+    );
+    const body = await res.json();
+    const contact = body.contacts[0];
+    const ch = contact.channels[0];
+
+    // ACL replaced.
+    expect(ch.status).toBe("active");
+    expect(ch.policy).toBe("deny");
+    expect(ch.verifiedVia).toBe("challenge");
+    // Info/identity preserved.
+    expect(contact.displayName).toBe("Alice");
+    expect(contact.notes).toBe("friend from college");
+    expect(contact.contactType).toBe("human");
+    expect(contact.interactionCount).toBe(7);
+    expect(ch.address).toBe("@alice");
+    expect(ch.externalUserId).toBe("@alice");
+    expect(ch.externalChatId).toBe("12345");
+    expect(ch.isPrimary).toBe(true);
+    expect(ch.interactionCount).toBe(3);
+  });
+
+  test("channel matched by (type,address) when ids differ", async () => {
+    // Daemon channel id differs from the gateway's; fall back to (type,address).
+    fetchMock = mock(async () =>
+      daemonResponse([
+        daemonContact({
+          channels: [
+            {
+              ...daemonContact().channels[0],
+              id: "daemon-side-id",
+            },
+          ],
+        }),
+      ]),
+    );
+    contactStoreGetAclMock = mock(
+      async () =>
+        new Map<string, ContactAcl>([
+          [
+            "c1",
+            {
+              role: "contact",
+              channels: new Map<string, ChannelAcl>([
+                [
+                  "gateway-side-id",
+                  {
+                    id: "gateway-side-id",
+                    type: "telegram",
+                    address: "@alice",
+                    status: "active",
+                    policy: "allow",
+                    verifiedAt: 42,
+                    verifiedVia: "manual",
+                    revokedReason: null,
+                    blockedReason: null,
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=alice"),
+    );
+    const body = await res.json();
+    const ch = body.contacts[0].channels[0];
+    expect(ch.status).toBe("active");
+    expect(ch.verifiedAt).toBe(42);
+    // The daemon channel id is preserved (we only overlay ACL fields).
+    expect(ch.id).toBe("daemon-side-id");
+  });
+
+  test("soft-fail: ACL read throws → original daemon response unchanged", async () => {
+    const original = { ok: true, contacts: [daemonContact()] };
+    fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify(original), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    contactStoreGetAclMock = mock(async () => {
+      throw new Error("gateway DB unavailable");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=alice"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Unchanged: neutral role + unverified channel, exactly as the daemon sent.
+    expect(body).toEqual(original);
+    expect(body.contacts[0].role).toBe("contact");
+    expect(body.contacts[0].channels[0].status).toBe("unverified");
+  });
+
+  test("dual-write gap: present contact overlaid, missing one keeps daemon ACL; neither dropped", async () => {
+    const c2 = daemonContact({
+      id: "c2",
+      displayName: "Bob",
+      channels: [
+        {
+          ...daemonContact().channels[0],
+          id: "ch2",
+          contactId: "c2",
+          address: "@bob",
+        },
+      ],
+    });
+    fetchMock = mock(async () =>
+      daemonResponse([daemonContact(), c2]),
+    );
+    // Only c1 is in the gateway ACL map; c2 is the dual-write-gap survivor.
+    contactStoreGetAclMock = mock(
+      async () =>
+        new Map<string, ContactAcl>([
+          [
+            "c1",
+            {
+              role: "guardian",
+              channels: new Map<string, ChannelAcl>([
+                [
+                  "ch1",
+                  {
+                    id: "ch1",
+                    type: "telegram",
+                    address: "@alice",
+                    status: "active",
+                    policy: "allow",
+                    verifiedAt: 1,
+                    verifiedVia: "manual",
+                    revokedReason: null,
+                    blockedReason: null,
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=team"),
+    );
+    const body = await res.json();
+
+    // Neither contact dropped.
+    expect(body.contacts).toHaveLength(2);
+    // c1 overlaid.
+    const c1 = body.contacts.find((c: { id: string }) => c.id === "c1");
+    expect(c1.role).toBe("guardian");
+    expect(c1.channels[0].status).toBe("active");
+    // c2 keeps the daemon ACL (neutral).
+    const bob = body.contacts.find((c: { id: string }) => c.id === "c2");
+    expect(bob.role).toBe("contact");
+    expect(bob.channels[0].status).toBe("unverified");
+  });
+
+  test("regression guard: no-filter request stays gateway-native (no daemon forward)", async () => {
+    contactStoreListMock = mock(async () => [
+      { ...DEFAULT_MOCK_CONTACT, id: "c1", displayName: "Alice" },
+    ]);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+
+    expect(res.status).toBe(200);
+    // Native path: daemon forward and ACL overlay are NOT used.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(contactStoreGetAclMock).not.toHaveBeenCalled();
+    expect(contactStoreListMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("soft-fail: non-2xx daemon status returned unchanged", async () => {
+    fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ error: "boom" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=alice"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(contactStoreGetAclMock).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual({ error: "boom" });
   });
 });
 

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -882,9 +882,9 @@ describe("handleListContacts (gateway-native)", () => {
 });
 
 describe("handleListContacts ACL overlay (filtered/search path)", () => {
-  // A daemon contact as it comes back post-Combo-11: neutral role, channels
-  // with no/unverified ACL. The overlay must replace role + channel ACL from
-  // the gateway DB while leaving info/identity fields untouched.
+  // A daemon contact as it comes back from the search path: neutral role,
+  // channels with unverified ACL. The overlay must replace role + channel ACL
+  // from the gateway DB while leaving info/identity fields untouched.
   function daemonContact(overrides: Record<string, unknown> = {}) {
     return {
       id: "c1",
@@ -1208,6 +1208,61 @@ describe("handleListContacts ACL overlay (filtered/search path)", () => {
     expect(res.status).toBe(500);
     expect(contactStoreGetAclMock).not.toHaveBeenCalled();
     expect(await res.json()).toEqual({ error: "boom" });
+  });
+
+  test("drops stale content-length so the resized overlaid body isn't truncated", async () => {
+    // Daemon sends a content-length matching its NEUTRAL body. The overlay
+    // grows the body (role + ACL fields), so reusing that length would
+    // truncate the response. We must drop it and let the runtime recompute.
+    const neutralBody = JSON.stringify({ ok: true, contacts: [daemonContact()] });
+    fetchMock = mock(
+      async () =>
+        new Response(neutralBody, {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "content-length": String(Buffer.byteLength(neutralBody)),
+          },
+        }),
+    );
+    contactStoreGetAclMock = mock(
+      async () =>
+        new Map<string, ContactAcl>([
+          [
+            "c1",
+            {
+              role: "guardian",
+              channels: new Map<string, ChannelAcl>([
+                [
+                  "ch1",
+                  {
+                    id: "ch1",
+                    type: "telegram",
+                    address: "@alice",
+                    status: "active",
+                    policy: "escalate",
+                    verifiedAt: 9999,
+                    verifiedVia: "manual",
+                    revokedReason: null,
+                    blockedReason: null,
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=alice"),
+    );
+
+    // Stale content-length dropped; body fully intact (not truncated).
+    expect(res.headers.get("content-length")).toBeNull();
+    const body = await res.json();
+    expect(body.contacts[0].role).toBe("guardian");
+    expect(body.contacts[0].channels[0].verifiedVia).toBe("manual");
   });
 });
 

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -1085,6 +1085,61 @@ describe("handleListContacts ACL overlay (filtered/search path)", () => {
     expect(ch.id).toBe("daemon-side-id");
   });
 
+  test("(type,address) fallback is case-insensitive on address", async () => {
+    // Daemon and gateway disagree on channel id AND address casing. The
+    // logical key is (type, lower(address)), so the overlay must still match.
+    fetchMock = mock(async () =>
+      daemonResponse([
+        daemonContact({
+          channels: [
+            {
+              ...daemonContact().channels[0],
+              id: "daemon-side-id",
+              type: "email",
+              address: "Alice@Example.COM",
+            },
+          ],
+        }),
+      ]),
+    );
+    contactStoreGetAclMock = mock(
+      async () =>
+        new Map<string, ContactAcl>([
+          [
+            "c1",
+            {
+              role: "contact",
+              channels: new Map<string, ChannelAcl>([
+                [
+                  "gateway-side-id",
+                  {
+                    id: "gateway-side-id",
+                    type: "email",
+                    address: "alice@example.com",
+                    status: "blocked",
+                    policy: "deny",
+                    verifiedAt: null,
+                    verifiedVia: null,
+                    revokedReason: null,
+                    blockedReason: "spam",
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts?query=alice"),
+    );
+    const ch = (await res.json()).contacts[0].channels[0];
+    // Matched despite case + id mismatch: blocked ACL overlaid, not neutral.
+    expect(ch.status).toBe("blocked");
+    expect(ch.blockedReason).toBe("spam");
+  });
+
   test("soft-fail: ACL read throws → original daemon response unchanged", async () => {
     const original = { ok: true, contacts: [daemonContact()] };
     fetchMock = mock(

--- a/gateway/src/__tests__/contacts-info-joiner.test.ts
+++ b/gateway/src/__tests__/contacts-info-joiner.test.ts
@@ -440,3 +440,50 @@ describe("ContactStore.getContactWithInfo", () => {
     expect(result!.contactType).toBeNull();
   });
 });
+
+// ── ContactStore.getAclByContactIds ─────────────────────────────────────────
+
+describe("ContactStore.getAclByContactIds", () => {
+  test("empty input returns empty map (no query)", async () => {
+    const result = await new ContactStore().getAclByContactIds([]);
+    expect(result.size).toBe(0);
+  });
+
+  test("reads role + per-channel ACL from the gateway DB only", async () => {
+    seedGatewayContact({ id: "c1", role: "guardian" });
+    seedGatewayChannel({ id: "ch1", contactId: "c1", status: "active" });
+    seedGatewayChannel({ id: "ch2", contactId: "c1", status: "revoked" });
+    seedGatewayContact({ id: "c2", role: "contact" });
+    seedGatewayChannel({ id: "ch3", contactId: "c2", status: "blocked" });
+
+    const result = await new ContactStore().getAclByContactIds([
+      "c1",
+      "c2",
+      "c-missing",
+    ]);
+
+    expect(result.size).toBe(2);
+    expect(result.has("c-missing")).toBe(false);
+
+    const c1 = result.get("c1")!;
+    expect(c1.role).toBe("guardian");
+    expect(c1.channels.size).toBe(2);
+    expect(c1.channels.get("ch1")!.status).toBe("active");
+    expect(c1.channels.get("ch1")!.address).toBe("addr-ch1");
+    expect(c1.channels.get("ch2")!.status).toBe("revoked");
+
+    const c2 = result.get("c2")!;
+    expect(c2.role).toBe("contact");
+    expect(c2.channels.get("ch3")!.status).toBe("blocked");
+
+    // The assistant DB must NOT be consulted for ACL.
+    expect(fakeAssistantDb.queryCalls.length).toBe(0);
+  });
+
+  test("contact with no channels yields an empty channel map", async () => {
+    seedGatewayContact({ id: "c1", role: "contact" });
+
+    const result = await new ContactStore().getAclByContactIds(["c1"]);
+    expect(result.get("c1")!.channels.size).toBe(0);
+  });
+});

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -206,6 +206,60 @@ export class ContactStore {
     return joined[0] ?? null;
   }
 
+  /**
+   * Batched gateway-DB ACL read keyed by contact id. Reads ONLY the gateway DB
+   * (the ACL source of truth) — never the assistant DB. Used to overlay
+   * authoritative ACL onto daemon-forwarded (filtered/search) contact reads,
+   * which post-Combo-11 carry neutral ACL.
+   *
+   * Returns a map of contactId → { role, channels }, where `channels` is keyed
+   * by channel `id`. Empty input → empty map. Contacts/channels absent from the
+   * gateway are simply absent from the map (the caller leaves them untouched).
+   */
+  async getAclByContactIds(
+    ids: string[],
+  ): Promise<Map<string, ContactAcl>> {
+    const result = new Map<string, ContactAcl>();
+    if (ids.length === 0) return result;
+
+    const rows = this.db
+      .select({ contact: contacts, channel: contactChannels })
+      .from(contacts)
+      .leftJoin(contactChannels, eq(contactChannels.contactId, contacts.id))
+      .where(
+        sql`${contacts.id} IN (${sql.join(
+          ids.map((id) => sql`${id}`),
+          sql`, `,
+        )})`,
+      )
+      .all();
+
+    for (const row of rows) {
+      const id = row.contact.id;
+      let entry = result.get(id);
+      if (!entry) {
+        entry = { role: row.contact.role, channels: new Map() };
+        result.set(id, entry);
+      }
+      const ch = row.channel;
+      if (ch) {
+        entry.channels.set(ch.id, {
+          id: ch.id,
+          type: ch.type,
+          address: ch.address,
+          status: ch.status,
+          policy: ch.policy,
+          verifiedAt: ch.verifiedAt,
+          verifiedVia: ch.verifiedVia,
+          revokedReason: ch.revokedReason,
+          blockedReason: ch.blockedReason,
+        });
+      }
+    }
+
+    return result;
+  }
+
   // ── Rich reads (gateway ACL + assistant info, ContactRead contract) ──────
   //
   // listContactsRich / getContactRich assemble the shared ContactRead shape
@@ -1637,6 +1691,28 @@ export class ContactStore {
 // ---------------------------------------------------------------------------
 // Public response shapes
 // ---------------------------------------------------------------------------
+
+/**
+ * Authoritative per-channel ACL from the gateway DB, keyed by channel `id` in
+ * `ContactAcl.channels`. Used to overlay neutral ACL on daemon-forwarded reads.
+ */
+export interface ChannelAcl {
+  id: string;
+  type: string;
+  address: string;
+  status: string | null;
+  policy: string | null;
+  verifiedAt: number | null;
+  verifiedVia: string | null;
+  revokedReason: string | null;
+  blockedReason: string | null;
+}
+
+/** Contact-level role + channel ACL map (channel id → ChannelAcl). */
+export interface ContactAcl {
+  role: string;
+  channels: Map<string, ChannelAcl>;
+}
 
 export interface ContactChannelShape {
   id: string;

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -210,7 +210,7 @@ export class ContactStore {
    * Batched gateway-DB ACL read keyed by contact id. Reads ONLY the gateway DB
    * (the ACL source of truth) — never the assistant DB. Used to overlay
    * authoritative ACL onto daemon-forwarded (filtered/search) contact reads,
-   * which post-Combo-11 carry neutral ACL.
+   * which carry neutral ACL.
    *
    * Returns a map of contactId → { role, channels }, where `channels` is keyed
    * by channel `id`. Empty input → empty map. Contacts/channels absent from the

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -19,6 +19,8 @@ import {
   ContactStore,
   CannotRevokeBlockedError,
   MergeContactsError,
+  type ChannelAcl,
+  type ContactAcl,
   type ContactWithInfo,
 } from "../../db/contact-store.js";
 import { contacts } from "../../db/schema.js";
@@ -782,6 +784,94 @@ function validateSpeciesMetadata(
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// ACL overlay for daemon-forwarded (filtered/search) contact reads
+// ---------------------------------------------------------------------------
+//
+// Post-Combo-11 the assistant DB has no ACL columns, so the daemon's search /
+// contactType-filtered reads emit NEUTRAL ACL (role "contact", channels with
+// no status/policy/verified*/reason). The gateway DB is the ACL source of
+// truth, so we overlay it onto the forwarded body before returning.
+
+/** Copy the six ACL fields from a gateway ChannelAcl onto a daemon channel. */
+function applyChannelAcl(
+  channel: Record<string, unknown>,
+  acl: ChannelAcl,
+): void {
+  channel.status = acl.status;
+  channel.policy = acl.policy;
+  channel.verifiedAt = acl.verifiedAt;
+  channel.verifiedVia = acl.verifiedVia;
+  channel.revokedReason = acl.revokedReason;
+  channel.blockedReason = acl.blockedReason;
+}
+
+/**
+ * Overlay authoritative gateway ACL onto a parsed daemon contact-list body
+ * (in place). For each contact, replace contact-level `role` and per-channel
+ * ACL fields from the gateway map. Channels match by `id` first, then by
+ * `(type, address)`; an unmatched channel keeps the daemon's ACL. A contact
+ * absent from the gateway map (dual-write gap) is left untouched + warned.
+ *
+ * Pure aside from the warn log; mutates the passed contacts array's elements.
+ */
+function overlayAclOntoContacts(
+  contacts: Array<Record<string, unknown>>,
+  aclByContactId: Map<string, ContactAcl>,
+): void {
+  for (const contact of contacts) {
+    const id = contact.id;
+    if (typeof id !== "string") continue;
+    const acl = aclByContactId.get(id);
+    if (!acl) {
+      // Dual-write gap: present in the daemon read but absent from the gateway
+      // ACL source of truth. Leave the daemon's ACL; don't drop the contact.
+      log.warn(
+        { contactId: id },
+        "overlayAclOntoContacts: contact missing from gateway ACL (dual-write gap); leaving daemon ACL",
+      );
+      continue;
+    }
+
+    contact.role = acl.role;
+
+    const channels = contact.channels;
+    if (!Array.isArray(channels)) continue;
+
+    // Index gateway channels by (type,address) for the id-miss fallback.
+    const byTypeAddress = new Map<string, ChannelAcl>();
+    for (const ch of acl.channels.values()) {
+      byTypeAddress.set(`${ch.type} ${ch.address}`, ch);
+    }
+
+    for (const ch of channels) {
+      if (typeof ch !== "object" || ch === null) continue;
+      const channel = ch as Record<string, unknown>;
+      const chId = channel.id;
+      let match =
+        typeof chId === "string" ? acl.channels.get(chId) : undefined;
+      if (!match) {
+        const type = channel.type;
+        const address = channel.address;
+        if (typeof type === "string" && typeof address === "string") {
+          match = byTypeAddress.get(`${type} ${address}`);
+        }
+      }
+      if (match) applyChannelAcl(channel, match);
+    }
+  }
+}
+
+/** Locate the contacts array within the daemon `/v1/contacts` envelope. */
+function extractContactsArray(
+  body: unknown,
+): Array<Record<string, unknown>> | null {
+  if (typeof body !== "object" || body === null) return null;
+  const contacts = (body as Record<string, unknown>).contacts;
+  if (!Array.isArray(contacts)) return null;
+  return contacts as Array<Record<string, unknown>>;
+}
+
 export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
   async function forward(
     req: Request,
@@ -825,6 +915,61 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     });
   }
 
+  /**
+   * Forward the filtered/search contact list to the daemon, then overlay
+   * authoritative gateway-DB ACL onto the response body (role + per-channel
+   * status/policy/verified/reasons). The daemon owns filter/search + info;
+   * the gateway owns ACL (post-Combo-11 the daemon emits neutral ACL).
+   *
+   * SOFT-FAIL: if the upstream status isn't 2xx, the body isn't the expected
+   * JSON envelope, or the gateway ACL read throws — the ORIGINAL daemon bytes
+   * are returned unchanged (preserving status + headers). The overlay never
+   * turns a working (if stale) read into a 500.
+   */
+  async function forwardListWithAclOverlay(
+    req: Request,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const upstream = await forward(req, "/v1/contacts", upstreamSearch);
+
+    // Capture the body once; we both read it for overlay and replay it raw on
+    // any soft-fail. A Response body can only be consumed once.
+    const text = await upstream.text();
+    const rawResponse = () =>
+      new Response(text, {
+        status: upstream.status,
+        headers: upstream.headers,
+      });
+
+    if (upstream.status < 200 || upstream.status >= 300) {
+      return rawResponse();
+    }
+
+    try {
+      const body = JSON.parse(text) as unknown;
+      const contacts = extractContactsArray(body);
+      if (!contacts) return rawResponse();
+
+      const ids = contacts
+        .map((c) => c.id)
+        .filter((id): id is string => typeof id === "string");
+      const aclByContactId = await new ContactStore().getAclByContactIds(ids);
+
+      overlayAclOntoContacts(contacts, aclByContactId);
+
+      return new Response(JSON.stringify(body), {
+        status: upstream.status,
+        headers: upstream.headers,
+      });
+    } catch (err) {
+      log.warn(
+        { err },
+        "list_contacts: ACL overlay failed; returning daemon response unchanged",
+      );
+      return rawResponse();
+    }
+  }
+
   return {
     // ── Contact CRUD ──
     /**
@@ -859,11 +1004,12 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
         );
       }
 
-      // Search-style queries and contactType filter go through the daemon.
-      // contactType is an assistant-owned field — the gateway can't filter
-      // it without an assistant DB round-trip. The daemon handles it natively.
+      // Search-style queries and contactType filter go through the daemon
+      // (it owns filter/search + info/identity). The daemon emits NEUTRAL ACL
+      // post-Combo-11, so overlay authoritative gateway-DB ACL onto the
+      // forwarded body before returning.
       if (query || channelAddress || channelType || contactType) {
-        return forward(req, "/v1/contacts", url.search);
+        return forwardListWithAclOverlay(req, url.search);
       }
 
       try {

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -788,10 +788,10 @@ function validateSpeciesMetadata(
 // ACL overlay for daemon-forwarded (filtered/search) contact reads
 // ---------------------------------------------------------------------------
 //
-// Post-Combo-11 the assistant DB has no ACL columns, so the daemon's search /
-// contactType-filtered reads emit NEUTRAL ACL (role "contact", channels with
-// no status/policy/verified*/reason). The gateway DB is the ACL source of
-// truth, so we overlay it onto the forwarded body before returning.
+// The gateway DB is the ACL source of truth. The daemon's search /
+// contactType-filtered reads carry NEUTRAL ACL (role "contact", channels with
+// no status/policy/verified*/reason), so we overlay authoritative ACL onto the
+// forwarded body before returning.
 
 /** Copy the six ACL fields from a gateway ChannelAcl onto a daemon channel. */
 function applyChannelAcl(
@@ -919,7 +919,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
    * Forward the filtered/search contact list to the daemon, then overlay
    * authoritative gateway-DB ACL onto the response body (role + per-channel
    * status/policy/verified/reasons). The daemon owns filter/search + info;
-   * the gateway owns ACL (post-Combo-11 the daemon emits neutral ACL).
+   * the gateway owns ACL (the daemon emits neutral ACL).
    *
    * SOFT-FAIL: if the upstream status isn't 2xx, the body isn't the expected
    * JSON envelope, or the gateway ACL read throws — the ORIGINAL daemon bytes
@@ -1005,9 +1005,9 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       }
 
       // Search-style queries and contactType filter go through the daemon
-      // (it owns filter/search + info/identity). The daemon emits NEUTRAL ACL
-      // post-Combo-11, so overlay authoritative gateway-DB ACL onto the
-      // forwarded body before returning.
+      // (it owns filter/search + info/identity). The daemon emits NEUTRAL ACL,
+      // so overlay authoritative gateway-DB ACL onto the forwarded body before
+      // returning.
       if (query || channelAddress || channelType || contactType) {
         return forwardListWithAclOverlay(req, url.search);
       }

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -923,8 +923,13 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
    *
    * SOFT-FAIL: if the upstream status isn't 2xx, the body isn't the expected
    * JSON envelope, or the gateway ACL read throws — the ORIGINAL daemon bytes
-   * are returned unchanged (preserving status + headers). The overlay never
-   * turns a working (if stale) read into a 500.
+   * are returned unchanged (preserving status). The overlay never turns a
+   * working (if stale) read into a 500.
+   *
+   * Entity headers (content-length, content-encoding) are dropped on both
+   * paths: we always emit a freshly-serialized string body, so the runtime
+   * recomputes content-length — reusing the upstream length would truncate the
+   * (resized) overlaid body.
    */
   async function forwardListWithAclOverlay(
     req: Request,
@@ -935,20 +940,20 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     // Capture the body once; we both read it for overlay and replay it raw on
     // any soft-fail. A Response body can only be consumed once.
     const text = await upstream.text();
-    const rawResponse = () =>
-      new Response(text, {
-        status: upstream.status,
-        headers: upstream.headers,
-      });
+    const headers = new Headers(upstream.headers);
+    headers.delete("content-length");
+    headers.delete("content-encoding");
+    const respond = (payload: string) =>
+      new Response(payload, { status: upstream.status, headers });
 
     if (upstream.status < 200 || upstream.status >= 300) {
-      return rawResponse();
+      return respond(text);
     }
 
     try {
       const body = JSON.parse(text) as unknown;
       const contacts = extractContactsArray(body);
-      if (!contacts) return rawResponse();
+      if (!contacts) return respond(text);
 
       const ids = contacts
         .map((c) => c.id)
@@ -957,16 +962,13 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
 
       overlayAclOntoContacts(contacts, aclByContactId);
 
-      return new Response(JSON.stringify(body), {
-        status: upstream.status,
-        headers: upstream.headers,
-      });
+      return respond(JSON.stringify(body));
     } catch (err) {
       log.warn(
         { err },
         "list_contacts: ACL overlay failed; returning daemon response unchanged",
       );
-      return rawResponse();
+      return respond(text);
     }
   }
 

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -807,6 +807,15 @@ function applyChannelAcl(
 }
 
 /**
+ * Logical channel key: (type, lower(address)) — mirrors the case-insensitive
+ * key the gateway ACL uses (UNIQUE(type, address) collates NOCASE). The
+ * escaped NUL delimiter cannot appear in either field, so keys never collide.
+ */
+function channelKey(type: string, address: string): string {
+  return `${type}\u0000${address.toLowerCase()}`;
+}
+
+/**
  * Overlay authoritative gateway ACL onto a parsed daemon contact-list body
  * (in place). For each contact, replace contact-level `role` and per-channel
  * ACL fields from the gateway map. Channels match by `id` first, then by
@@ -838,10 +847,10 @@ function overlayAclOntoContacts(
     const channels = contact.channels;
     if (!Array.isArray(channels)) continue;
 
-    // Index gateway channels by (type,address) for the id-miss fallback.
+    // Index gateway channels by (type, lower(address)) for the id-miss fallback.
     const byTypeAddress = new Map<string, ChannelAcl>();
     for (const ch of acl.channels.values()) {
-      byTypeAddress.set(`${ch.type} ${ch.address}`, ch);
+      byTypeAddress.set(channelKey(ch.type, ch.address), ch);
     }
 
     for (const ch of channels) {
@@ -854,7 +863,7 @@ function overlayAclOntoContacts(
         const type = channel.type;
         const address = channel.address;
         if (typeof type === "string" && typeof address === "string") {
-          match = byTypeAddress.get(`${type} ${address}`);
+          match = byTypeAddress.get(channelKey(type, address));
         }
       }
       if (match) applyChannelAcl(channel, match);


### PR DESCRIPTION
## Summary
- Filtered/search contact-list reads (`query`/`channelAddress`/`channelType`/`contactType`) in `handleListContacts` forward to the daemon, which post-Combo-11 (migration 305, #36280) returns **neutral ACL** (`role:"contact"`, no channel status/policy/verified*). This overlays authoritative gateway-DB ACL onto the forwarded body so those views stop rendering verified contacts as unverified/un-roled. Display-only — trust/authz enforcement already reads the gateway DB directly and is untouched.
- New `ContactStore.getAclByContactIds(ids)` does a single batched gateway-DB read (role + channel ACL, keyed by channel id). The overlay replaces only the 6 channel ACL fields + contact `role`; all info/identity fields from the daemon are left intact. Channels match by id, falling back to `(type,address)`.
- **Soft-fail**: non-2xx upstream, non-JSON/unexpected envelope, or a thrown ACL read returns the original daemon bytes unchanged (status + headers preserved) — never converts a working (if stale) read into a 500. Dual-write-gap contacts (in daemon, absent from gateway) keep daemon ACL and are not dropped, with a warn.
- Tests (bun:test): overlay replaces ACL + preserves info/identity; soft-fail returns raw response; dual-write gap; (type,address) fallback; unfiltered native path unchanged. `bunx tsc --noEmit` clean.

## Original prompt
Following the merge of the Combo 11 assistant ACL column drop (#36280), we audited the open tickets in the contacts-ACL read-side Linear project and picked up **JARVIS-1229**: the gateway serves unfiltered contact lists natively with correct ACL, but forwards *filtered* queries to the daemon, whose ACL is now neutral post-drop. The fix is the ticket's lower-risk option 1 — overlay gateway-owned ACL onto the daemon-forwarded response rather than building gateway-native search. Gateway package only; display-only correctness fix.

Closes JARVIS-1229.