### PR TITLE
Show streaming thinking previews

### DIFF
--- a/clients/web/src/domains/chat/components/single-activity/single-activity.test.tsx
+++ b/clients/web/src/domains/chat/components/single-activity/single-activity.test.tsx
@@ -101,17 +101,33 @@ describe("SingleActivity — thinking variant", () => {
     expect(useViewerStore.getState().mainView).toBe("chat");
   });
 
-  test("while streaming, shows the three-dot loader + 'Thinking' (no brain)", () => {
+  test("while streaming, shows the three-dot loader + reasoning preview (no brain)", () => {
     const { getByTestId, getByText, queryByText, container } = render(
       <SingleActivity variant="thinking" content={CONTENT} isStreaming />,
     );
 
-    expect(getByText("Thinking")).toBeTruthy();
+    expect(getByText(CONTENT)).toBeTruthy();
     expect(queryByText("Thought process")).toBeNull();
     // The brain glyph is swapped for the three-dot indicator, so only the
     // trailing chevron remains as an svg.
     expect(getByTestId("thought-process-loading")).toBeTruthy();
     expect(container.querySelectorAll("svg").length).toBe(1);
+  });
+
+  test("while streaming, labels with the first sentence from the latest paragraph", () => {
+    const { getByText, queryByText } = render(
+      <SingleActivity
+        variant="thinking"
+        content={
+          "Earlier paragraph should not show. It has details.\n\nI should inspect the route first. Then write the fix."
+        }
+        isStreaming
+      />,
+    );
+
+    expect(getByText("I should inspect the route first.")).toBeTruthy();
+    expect(queryByText("Thinking")).toBeNull();
+    expect(queryByText("Earlier paragraph should not show.")).toBeNull();
   });
 
   test("stays clickable while streaming — opens the live reasoning in the drawer", () => {
@@ -128,11 +144,12 @@ describe("SingleActivity — thinking variant", () => {
   });
 
   test("renders while streaming even before any reasoning text arrives", () => {
-    const { getByTestId } = render(
+    const { getByTestId, getByText } = render(
       <SingleActivity variant="thinking" content="" isStreaming />,
     );
     expect(getByTestId("thought-process-link")).toBeTruthy();
     expect(getByTestId("thought-process-loading")).toBeTruthy();
+    expect(getByText("Thinking")).toBeTruthy();
   });
 
   test("renders nothing when content is empty and not streaming", () => {

--- a/clients/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/clients/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/domains/chat/components/web-search/web-search-step-row";
 import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
 import { SiteFavicon } from "@/domains/chat/components/web-search/site-favicon";
+import { useStreamingThinkingPreview } from "@/domains/chat/hooks/use-streaming-thinking-preview";
 import { sameThinkingTarget, useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { WebSearchResultItem } from "@/assistant/web-activity-types";
@@ -112,6 +113,10 @@ export function SingleActivity(props: SingleActivityProps) {
   // early return (empty, settled thinking) happens after them below.
   const toggleToolDetail = useViewerStore.use.toggleToolDetail();
   const activeDetail = useViewerStore.use.activeToolDetail();
+  const streamingThinkingPreview = useStreamingThinkingPreview(
+    props.variant === "thinking" ? props.content : "",
+    props.variant === "thinking" && props.isStreaming === true,
+  );
 
   // The web variant feeds a rotating carousel into the header info slot. Memoize
   // the element so it stays referentially stable (a fresh element each render
@@ -234,7 +239,9 @@ export function SingleActivity(props: SingleActivityProps) {
       ) : (
         <Brain className="size-4 shrink-0" aria-hidden />
       ),
-      label: isStreaming ? "Thinking" : "Thought process",
+      label: isStreaming
+        ? (streamingThinkingPreview ?? "Thinking")
+        : "Thought process",
       tone: "default",
       // Thinking payloads carry an empty `toolCallId`; the bare panel addresses
       // the whole group (no segment index), so match on its (message, group)
@@ -319,7 +326,9 @@ export function SingleActivity(props: SingleActivityProps) {
       >
         {view.icon}
       </span>
-      <span>{view.label}</span>
+      <span className="min-w-0 max-w-[min(520px,calc(100vw-8rem))] truncate">
+        {view.label}
+      </span>
       {view.riskLevel ? <RiskBadge level={view.riskLevel} /> : null}
       <ChevronRight
         className="size-3.5 shrink-0 text-[var(--content-tertiary)]"

--- a/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx
@@ -1,0 +1,152 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import {
+  STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS,
+  firstSentenceOfLatestThinkingParagraph,
+  useStreamingThinkingPreview,
+} from "@/domains/chat/hooks/use-streaming-thinking-preview";
+
+const START = 1_700_000_000_000;
+
+interface TimeoutHandle {
+  id: number;
+  fn: () => void;
+  ms: number;
+  cleared: boolean;
+}
+
+let timeouts: TimeoutHandle[] = [];
+let nextTimeoutId = 1;
+let originalSetTimeout: typeof globalThis.setTimeout;
+let originalClearTimeout: typeof globalThis.clearTimeout;
+
+beforeEach(() => {
+  timeouts = [];
+  nextTimeoutId = 1;
+  setSystemTime(new Date(START));
+  originalSetTimeout = globalThis.setTimeout;
+  originalClearTimeout = globalThis.clearTimeout;
+  globalThis.setTimeout = ((
+    fn: (...args: unknown[]) => void,
+    ms?: number,
+  ) => {
+    const handle: TimeoutHandle = {
+      id: nextTimeoutId++,
+      fn: () => fn(),
+      ms: ms ?? 0,
+      cleared: false,
+    };
+    timeouts.push(handle);
+    return handle.id as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+  globalThis.clearTimeout = ((id?: number) => {
+    const handle = timeouts.find((h) => h.id === id);
+    if (handle) handle.cleared = true;
+  }) as typeof globalThis.clearTimeout;
+});
+
+afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+  globalThis.clearTimeout = originalClearTimeout;
+  cleanup();
+  setSystemTime();
+});
+
+function pendingTimeouts() {
+  return timeouts.filter((h) => !h.cleared);
+}
+
+function firePendingTimers() {
+  for (const handle of pendingTimeouts()) {
+    handle.cleared = true;
+    act(() => {
+      handle.fn();
+    });
+  }
+}
+
+describe("firstSentenceOfLatestThinkingParagraph", () => {
+  test("returns the first sentence from the latest non-empty paragraph", () => {
+    expect(
+      firstSentenceOfLatestThinkingParagraph(
+        "Earlier paragraph should not show. It has details.\n\nI should inspect the route first. Then write the fix.",
+      ),
+    ).toBe("I should inspect the route first.");
+  });
+
+  test("returns an incomplete latest paragraph when no sentence terminator has streamed", () => {
+    expect(
+      firstSentenceOfLatestThinkingParagraph(
+        "Complete prior thought.\n\nStill forming the latest idea",
+      ),
+    ).toBe("Still forming the latest idea");
+  });
+
+  test("returns null for blank thinking text", () => {
+    expect(firstSentenceOfLatestThinkingParagraph("\n\n  ")).toBeNull();
+  });
+});
+
+describe("useStreamingThinkingPreview", () => {
+  test("throttles preview changes to at most once every five seconds", () => {
+    const { result, rerender } = renderHook(
+      ({ content }) => useStreamingThinkingPreview(content, true),
+      {
+        initialProps: {
+          content: "First visible thought",
+        },
+      },
+    );
+
+    expect(result.current).toBe("First visible thought");
+
+    setSystemTime(new Date(START + 1_000));
+    rerender({ content: "Second visible thought. More detail follows." });
+
+    expect(result.current).toBe("First visible thought");
+    expect(pendingTimeouts()).toHaveLength(1);
+    expect(pendingTimeouts()[0]!.ms).toBe(
+      STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS - 1_000,
+    );
+
+    setSystemTime(new Date(START + STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS));
+    firePendingTimers();
+
+    expect(result.current).toBe("Second visible thought.");
+  });
+
+  test("uses the latest pending preview when more tokens arrive before the throttle fires", () => {
+    const { result, rerender } = renderHook(
+      ({ content }) => useStreamingThinkingPreview(content, true),
+      {
+        initialProps: {
+          content: "First visible thought",
+        },
+      },
+    );
+
+    setSystemTime(new Date(START + 1_000));
+    rerender({ content: "Second visible thought." });
+    setSystemTime(new Date(START + 2_000));
+    rerender({
+      content:
+        "Second visible thought.\n\nNewest paragraph should win. Later sentence.",
+    });
+
+    expect(result.current).toBe("First visible thought");
+    expect(pendingTimeouts()).toHaveLength(1);
+
+    setSystemTime(new Date(START + STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS));
+    firePendingTimers();
+
+    expect(result.current).toBe("Newest paragraph should win.");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
+++ b/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+export const STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS = 5_000;
+
+export function firstSentenceOfLatestThinkingParagraph(
+  text: string,
+): string | null {
+  const latestParagraph = text
+    .split(/\n\s*\n/g)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (!latestParagraph) return null;
+
+  const normalized = latestParagraph.replace(/\s+/g, " ");
+  const firstSentence = normalized.match(/^.*?[.!?](?=\s|$)/)?.[0];
+  return (firstSentence ?? normalized).trim() || null;
+}
+
+export function useStreamingThinkingPreview(
+  content: string,
+  isStreaming: boolean,
+): string | null {
+  const nextPreview = useMemo(
+    () => firstSentenceOfLatestThinkingParagraph(content),
+    [content],
+  );
+  const [displayedPreview, setDisplayedPreview] = useState(nextPreview);
+  const updatedAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const now = Date.now();
+    if (!isStreaming) {
+      updatedAtRef.current = now;
+      setDisplayedPreview(nextPreview);
+      return;
+    }
+
+    updatedAtRef.current ??= now;
+
+    if (nextPreview === displayedPreview) return;
+
+    if (!nextPreview || !displayedPreview) {
+      updatedAtRef.current = now;
+      setDisplayedPreview(nextPreview);
+      return;
+    }
+
+    const elapsedMs = now - updatedAtRef.current;
+    if (elapsedMs >= STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS) {
+      updatedAtRef.current = now;
+      setDisplayedPreview(nextPreview);
+      return;
+    }
+
+    const waitMs = Math.max(
+      0,
+      STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS - elapsedMs,
+    );
+    const timeoutId = setTimeout(() => {
+      updatedAtRef.current = Date.now();
+      setDisplayedPreview(nextPreview);
+    }, waitMs);
+
+    return () => clearTimeout(timeoutId);
+  }, [displayedPreview, isStreaming, nextPreview]);
+
+  return isStreaming ? displayedPreview : null;
+}


### PR DESCRIPTION
## Summary
- Add a streaming thinking preview hook that extracts the first sentence from the latest thinking paragraph and coalesces updates to at most once every 5 seconds.
- Update the streaming thought-process chip to show that preview while preserving the fallback “Thinking” label before reasoning arrives.
- Add regression coverage for extraction, throttling, and chip rendering.

## Validation
- `bun test ./src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx ./src/domains/chat/components/single-activity/single-activity.test.tsx`
- `bunx eslint src/domains/chat/hooks/use-streaming-thinking-preview.ts src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx src/domains/chat/components/single-activity/single-activity.tsx src/domains/chat/components/single-activity/single-activity.test.tsx`
- `bunx tsc --noEmit`
- `npx react-doctor@latest --verbose --scope changed`

## Original prompt
Update the streaming thinking UI, not the initial post-send indicator, so it shows the first sentence of the latest paragraph of thinking tokens and updates at most every 5 seconds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->