### PR TITLE
[codex] Disable Fireworks reasoning when thinking is off

### DIFF
--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -481,7 +481,7 @@ describe("RetryProvider — callSite resolution", () => {
     expect("top_p" in config).toBe(false);
   });
 
-  test("strips effort/speed for providers that don't support them (e.g. fireworks)", async () => {
+  test("strips unsupported speed and thinking fields for Fireworks", async () => {
     setLlmConfig({
       default: {
         provider: "anthropic",
@@ -495,7 +495,8 @@ describe("RetryProvider — callSite resolution", () => {
     });
 
     let seen: SendMessageOptions | undefined;
-    // fireworks does not support speed or thinking — they must be stripped.
+    // Fireworks uses the OpenAI-compatible transport; speed and thinking stay
+    // out of the downstream config.
     const wrapped = new RetryProvider(
       makeProvider("fireworks", (options) => {
         seen = options;
@@ -511,6 +512,33 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.thinking).toBeUndefined();
     // Model still comes through.
     expect(config.model).toBe("claude-opus-4-7");
+  });
+
+  test("disabled thinking forces effort none before Fireworks strips thinking", async () => {
+    setLlmConfig({
+      default: {
+        provider: "fireworks",
+        model: "accounts/fireworks/models/glm-5p2",
+        effort: "high",
+        thinking: { enabled: false, streamThinking: false },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("fireworks", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.thinking).toBeUndefined();
+    expect(config.effort).toBe("none");
   });
 
   test("preserves thinking + level for Gemini provider", async () => {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -47,6 +47,15 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
   "together",
 ]);
 
+// For these providers, disabling reasoning is encoded through the same effort
+// knob their transports send on the wire. Non-"none" tiers can still vary by
+// model and are handled by the provider client.
+const DISABLED_THINKING_USES_EFFORT_PROVIDERS = new Set([
+  "openai",
+  "fireworks",
+  "together",
+]);
+
 /**
  * Providers that consume the `thinking` config. Anthropic uses it directly on
  * the wire; OpenRouter either forwards it to its Anthropic-compatible path or
@@ -345,6 +354,13 @@ function normalizeSendMessageOptions(
     } else {
       nextConfig.thinking = normalized;
     }
+  }
+
+  if (
+    isThinkingConfigDisabled(nextConfig.thinking) &&
+    DISABLED_THINKING_USES_EFFORT_PROVIDERS.has(providerName)
+  ) {
+    nextConfig.effort = "none";
   }
 
   // Claude Fable always reasons with adaptive thinking and rejects an explicit


### PR DESCRIPTION
## Summary
- Normalize disabled thinking to `effort: "none"` for providers whose disable signal is carried by the reasoning-effort knob (`openai`, `fireworks`, `together`)
- Add a Fireworks GLM 5.2 regression test covering disabled thinking plus inherited high effort
- Clarify the existing Fireworks strip test wording

## Root Cause
Fireworks consumes the OpenAI-compatible `reasoning_effort` parameter for GLM 5.2. Our provider normalizer stripped the generic `thinking: disabled` field before dispatching to Fireworks, but left the resolved `effort` value intact. Profiles with `thinking.enabled: false` and `effort: "high"` therefore still sent `reasoning_effort: "high"`.

## Validation
- `cd assistant && bun test src/providers/__tests__/retry-callsite.test.ts`
- `cd assistant && bun test src/__tests__/openai-provider.test.ts --grep "reasoning_effort|FireworksProvider reasoning_effort"`
- `cd assistant && bun test src/__tests__/agent-loop-callsite-precedence.test.ts`
- `cd assistant && bun run typecheck:fast`
- pre-push hook: assistant `tsc --noEmit` and eslint on changed files

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->