### PR TITLE
feat(config): remove the managed Frontier profile, repoint callsites to Quality

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -794,7 +794,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profileOrder).not.toContain("placeholder");
     expect(raw.llm.profileOrder).not.toContain("blend");
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.advisorProfile).toBe("frontier");
+    expect(raw.llm.advisorProfile).toBe("quality-optimized");
     expect(raw.llm.callSites.commitMessage.profile).toBeUndefined();
     expect(raw.llm.callSites.commitMessage.maxTokens).toBe(256);
   });
@@ -855,11 +855,9 @@ describe("loadConfig startup behavior", () => {
       "accounts/fireworks/models/glm-5p2",
     );
     expect(raw.llm.profiles.balanced.source).toBe("managed");
-    // Quality now serves Anthropic Opus, the same model as Frontier.
+    // Quality serves Anthropic Opus, the most capable managed profile.
     expect(raw.llm.profiles["quality-optimized"].provider).toBe("anthropic");
     expect(raw.llm.profiles["quality-optimized"].model).toBe("claude-opus-4-8");
-    expect(raw.llm.profiles.frontier.provider).toBe("anthropic");
-    expect(raw.llm.profiles.frontier.model).toBe("claude-opus-4-8");
     // Speed is served by DeepSeek V4 Flash on Fireworks.
     expect(raw.llm.profiles["cost-optimized"].provider).toBe("fireworks");
     expect(raw.llm.profiles["cost-optimized"].model).toBe(
@@ -897,46 +895,6 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.activeProfile).toBe("balanced");
   });
 
-  test("reseed leaves a user-owned profile that shares a managed name untouched", () => {
-    // A workspace that created its own profile named `frontier` before the name
-    // was reserved as managed must keep it: reseeding would change its
-    // provider/model and silently mark it managed.
-    const userFrontier = {
-      source: "user",
-      provider: "openai",
-      model: "gpt-5.4",
-      provider_connection: "openai-personal",
-      label: "My Frontier",
-    };
-    writeConfig({ llm: { profiles: { frontier: userFrontier } } });
-
-    mergeDefaultConfigAndSeedInferenceProfiles();
-    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-
-    expect(raw.llm.profiles.frontier).toEqual(userFrontier);
-    // The advisor default must not route to the user-owned `frontier`; it falls
-    // back to the always-managed Quality profile.
-    expect(raw.llm.advisorProfile).toBe("quality-optimized");
-  });
-
-  test("reseed leaves a source-less profile sharing a managed name untouched", () => {
-    // The settings UI saves custom profiles without a `source` field; such a
-    // profile keyed `frontier` must not be clobbered or marked managed.
-    const sourcelessFrontier = {
-      provider: "openai",
-      model: "gpt-5.4",
-      provider_connection: "openai-personal",
-      label: "My Frontier",
-    };
-    writeConfig({ llm: { profiles: { frontier: sourcelessFrontier } } });
-
-    mergeDefaultConfigAndSeedInferenceProfiles();
-    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-
-    expect(raw.llm.profiles.frontier).toEqual(sourcelessFrontier);
-    expect(raw.llm.advisorProfile).toBe("quality-optimized");
-  });
-
   test("reseed updates a source-less legacy canonical managed profile", () => {
     // Migration 052 seeded canonical profiles without a `source`. Such a
     // source-less `quality-optimized` is legacy managed, not user-owned, so it
@@ -960,14 +918,14 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["quality-optimized"].source).toBe("managed");
   });
 
-  test("seeds the managed Frontier profile as the default advisor profile", () => {
+  test("seeds the managed Quality profile as the default advisor profile", () => {
     writeConfig({ llm: { default: { provider: "anthropic" } } });
 
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.advisorProfile).toBe("frontier");
-    expect(raw.llm.profiles.frontier.source).toBe("managed");
+    expect(raw.llm.advisorProfile).toBe("quality-optimized");
+    expect(raw.llm.profiles["quality-optimized"].source).toBe("managed");
   });
 
   test("on-platform managed profiles reconcile to the code template on every boot", () => {
@@ -1445,7 +1403,6 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 
     expect(config.llm.profiles.balanced?.status).toBe("disabled");
     expect(config.llm.profiles["quality-optimized"]?.status).toBe("disabled");
-    expect(config.llm.profiles.frontier?.status).toBe("disabled");
     expect(config.llm.profiles["cost-optimized"]?.status).toBe("disabled");
   });
 
@@ -1469,7 +1426,6 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(
       config.llm.profiles["custom-quality-optimized"]?.provider_connection,
     ).toBe("anthropic-personal");
-    expect(config.llm.profiles.frontier?.status).toBe("disabled");
   });
 
   test("off-platform boot repairs a disabled managed advisor to a personal profile when no active managed replacement exists", () => {
@@ -1617,10 +1573,10 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.activeProfile).toBe("balanced");
-    // Balanced lives on `fireworks-managed`; `quality-optimized` and `frontier`
-    // (both Opus on `anthropic-managed`) are on a different connection, so
-    // selecting balanced at hatch disables them. The default advisor falls to
-    // the only active managed profile, `balanced`.
+    // Balanced lives on `fireworks-managed`; `quality-optimized` (Opus on
+    // `anthropic-managed`) is on a different connection, so selecting balanced at
+    // hatch disables it. The default advisor falls to the only active managed
+    // profile, `balanced`.
     expect(raw.llm.advisorProfile).toBe("balanced");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
       "fireworks-managed",

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -187,7 +187,7 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(after.llm.profiles["os-beta"]).toBeUndefined();
     expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
     expect(after.llm.activeProfile).toBe("balanced");
-    expect(after.llm.advisorProfile).toBe("frontier");
+    expect(after.llm.advisorProfile).toBe("quality-optimized");
   });
 
   test("flag off with no os-beta present is a no-op", () => {
@@ -268,7 +268,7 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
     expect(after.llm.profileOrder.includes("experiment")).toBe(false);
     expect(after.llm.activeProfile).toBe("balanced");
-    expect(after.llm.advisorProfile).toBe("frontier");
+    expect(after.llm.advisorProfile).toBe("quality-optimized");
     expect(
       (
         after.llm as unknown as Record<

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -58,10 +58,9 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
-  // Served by Anthropic Opus via managed platform inference — the same model as
-  // the `frontier` profile below. The `quality-optimized` intent resolves to
-  // Opus for the `anthropic` provider, so the two profiles share a model and
-  // differ only by slot key and label.
+  // Served by Anthropic Opus via managed platform inference — the most capable
+  // managed profile. The `quality-optimized` intent resolves to Opus for the
+  // `anthropic` provider.
   "quality-optimized": {
     intent: "quality-optimized",
     provider: "anthropic",
@@ -69,18 +68,6 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     source: "managed",
     label: "Quality",
     description: "High-quality results with the most capable model",
-    maxTokens: 32000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  frontier: {
-    intent: "quality-optimized",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
-    source: "managed",
-    label: "Frontier",
-    description: "Best results with the most capable model",
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
@@ -189,15 +176,6 @@ export const MANAGED_PROFILE_NAMES = new Set([
   OS_BETA_PROFILE_KEY,
 ]);
 
-// Managed names introduced after profile-ownership metadata existed, so any
-// pre-existing same-named entry must have been user-created. The seed loop
-// protects these from being clobbered: a user may already own a profile under
-// such a name (the settings UI saves custom profiles without a `source`), so an
-// entry that isn't explicitly `source: "managed"` is treated as theirs. The
-// original canonical names (`balanced`/`quality-optimized`/`cost-optimized`)
-// predate ownership metadata — migration 052 seeded them source-less — so they
-// are NOT listed here and always reseed, even when source is absent.
-const NEWLY_RESERVED_MANAGED_NAMES = new Set(["frontier"]);
 const MIX_MIN_ARMS = 2;
 
 export type SeedInferenceProfilesOptions = {
@@ -311,21 +289,6 @@ export function seedInferenceProfiles(
     if (preservedProfileNames.has(name)) continue;
 
     const previous = readObject(profiles[name]);
-    // Never clobber a custom profile that happens to share a *newly reserved*
-    // managed name (e.g. `frontier`): reseeding would change its provider/model
-    // and mark it managed. Treat anything not explicitly `source: "managed"` as
-    // the user's, since the settings UI saves custom profiles without a `source`
-    // and the source backfill below skips managed names. The original canonical
-    // names are excluded from this guard — they may be source-less *managed*
-    // entries from migration 052, so they must keep reseeding to receive
-    // template updates (see NEWLY_RESERVED_MANAGED_NAMES).
-    if (
-      NEWLY_RESERVED_MANAGED_NAMES.has(name) &&
-      previous &&
-      previous.source !== "managed"
-    ) {
-      continue;
-    }
     const effectiveTemplate: ManagedProfileTemplate = isByokMode
       ? { ...template, label: `${template.label} (Managed)` }
       : template;
@@ -602,7 +565,6 @@ function selectDefaultAdvisorProfile(
     "custom-cost-optimized",
   ]);
   const managed = firstActiveManagedProfile(profiles, [
-    "frontier",
     "quality-optimized",
     "balanced",
     "cost-optimized",

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -189,23 +189,12 @@ function disableProfile(
     typeof llm.advisorProfile === "string" &&
     removed.has(llm.advisorProfile)
   ) {
-    // Repoint the advisor at the managed Frontier profile (the strongest).
-    // `frontier` is seeded unconditionally every boot, so target it even if it
-    // has not been materialized yet this startup — this reconcile can run before
-    // the seeder in the boot sequence, and the later seeder won't rewrite an
-    // already-set `advisorProfile`. The exception is a user-owned profile named
-    // `frontier`: that is not ours to route to, so fall back to the
-    // always-managed Quality profile, then clear the pointer as a last resort.
-    const frontierEntry = readObject(profiles["frontier"]);
-    const frontierIsUserOwned =
-      frontierEntry !== null && frontierEntry.source !== "managed";
-    if (!frontierIsUserOwned) {
-      llm.advisorProfile = "frontier";
-    } else if (readObject(profiles["quality-optimized"]) !== null) {
-      llm.advisorProfile = "quality-optimized";
-    } else {
-      delete llm.advisorProfile;
-    }
+    // Repoint the advisor at the managed Quality profile (the strongest).
+    // `quality-optimized` is a canonical name seeded unconditionally every boot,
+    // so target it even if it has not been materialized yet this startup — this
+    // reconcile can run before the seeder in the boot sequence, and the later
+    // seeder won't rewrite an already-set `advisorProfile`.
+    llm.advisorProfile = "quality-optimized";
   }
 
   // Clear any call-site `profile` reference to a removed profile; other override

--- a/assistant/src/memory/migrations/306-rewrite-frontier-profile-pins.test.ts
+++ b/assistant/src/memory/migrations/306-rewrite-frontier-profile-pins.test.ts
@@ -1,0 +1,110 @@
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getWorkspaceConfigPath } from "../../util/platform.js";
+import * as schema from "../schema.js";
+import { migrateRewriteFrontierProfilePins } from "./306-rewrite-frontier-profile-pins.js";
+
+function writeWorkspaceConfig(config: Record<string, unknown>): void {
+  writeFileSync(getWorkspaceConfigPath(), JSON.stringify(config));
+}
+
+afterEach(() => {
+  const path = getWorkspaceConfigPath();
+  if (existsSync(path)) rmSync(path);
+});
+
+function createTestDb(withColumns = true) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY
+      ${withColumns ? ", inference_profile TEXT" : ""}
+    )
+  `);
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE cron_jobs (
+      id TEXT PRIMARY KEY
+      ${withColumns ? ", inference_profile TEXT" : ""}
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function pin(sqlite: Database, table: string, id: string): string | null {
+  return (
+    sqlite
+      .query(`SELECT inference_profile FROM ${table} WHERE id = ?`)
+      .get(id) as { inference_profile: string | null }
+  ).inference_profile;
+}
+
+describe("migration 306: rewrite frontier profile pins", () => {
+  test("rewrites frontier pins to quality-optimized on conversations and schedules", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'frontier'), ('c2', 'balanced'), ('c3', NULL)`,
+    );
+    sqlite.run(
+      `INSERT INTO cron_jobs (id, inference_profile) VALUES ('j1', 'frontier'), ('j2', 'quality-optimized')`,
+    );
+
+    migrateRewriteFrontierProfilePins(db);
+
+    expect(pin(sqlite, "conversations", "c1")).toBe("quality-optimized");
+    // Unrelated pins and NULLs are left untouched.
+    expect(pin(sqlite, "conversations", "c2")).toBe("balanced");
+    expect(pin(sqlite, "conversations", "c3")).toBeNull();
+    expect(pin(sqlite, "cron_jobs", "j1")).toBe("quality-optimized");
+    expect(pin(sqlite, "cron_jobs", "j2")).toBe("quality-optimized");
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'frontier')`,
+    );
+
+    migrateRewriteFrontierProfilePins(db);
+    expect(() => migrateRewriteFrontierProfilePins(db)).not.toThrow();
+    expect(pin(sqlite, "conversations", "c1")).toBe("quality-optimized");
+  });
+
+  test("skips a table that has no inference_profile column", () => {
+    const { db } = createTestDb(false);
+    expect(() => migrateRewriteFrontierProfilePins(db)).not.toThrow();
+  });
+
+  test("leaves pins alone when frontier is a user-owned profile", () => {
+    // The workspace migration keeps a user-owned profile of this name, so its
+    // pins still resolve and must not be switched to quality-optimized.
+    writeWorkspaceConfig({
+      llm: { profiles: { frontier: { source: "user" } } },
+    });
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'frontier')`,
+    );
+
+    migrateRewriteFrontierProfilePins(db);
+
+    expect(pin(sqlite, "conversations", "c1")).toBe("frontier");
+  });
+
+  test("rewrites pins when frontier is the managed profile in config", () => {
+    writeWorkspaceConfig({
+      llm: { profiles: { frontier: { source: "managed" } } },
+    });
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'frontier')`,
+    );
+
+    migrateRewriteFrontierProfilePins(db);
+
+    expect(pin(sqlite, "conversations", "c1")).toBe("quality-optimized");
+  });
+});

--- a/assistant/src/memory/migrations/306-rewrite-frontier-profile-pins.ts
+++ b/assistant/src/memory/migrations/306-rewrite-frontier-profile-pins.ts
@@ -1,0 +1,65 @@
+import { loadRawConfig } from "../../config/loader.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const OLD_PROFILE = "frontier";
+const NEW_PROFILE = "quality-optimized";
+
+// Active inference-profile pin columns: the per-conversation override and the
+// per-schedule override. Audit/telemetry tables (tool_invocations,
+// llm_usage_events, skill_loaded_events) also carry an `inference_profile`, but
+// those record what actually ran and must keep their historical value.
+const PIN_TABLES = ["conversations", "cron_jobs"] as const;
+
+/**
+ * Rewrite persisted `frontier` inference-profile pins to `quality-optimized`.
+ *
+ * The managed `frontier` profile folds into `quality-optimized` (both resolve to
+ * Anthropic Opus on `anthropic-managed`). The workspace-config migration removes
+ * the profile definition, but a profile key can also be pinned outside
+ * config.json — on a conversation (`conversations.inference_profile`) or a
+ * schedule (`cron_jobs.inference_profile`). Left unrewritten those pins dangle,
+ * and `resolveCallSiteConfig` treats an unresolvable override as a silent
+ * fall-through to the active/default profile — dropping the user's intended Opus
+ * route.
+ *
+ * Ownership guard: the companion workspace migration keeps a `frontier` profile
+ * the user owns (`source !== "managed"`) intact, so its pins still resolve and
+ * must not be touched. Memory migrations run before workspace migrations on boot,
+ * so the profile is still in config here either way; gate on its source rather
+ * than its presence. A managed `frontier` key (or no profile at all) means every
+ * pin is stale and safe to rewrite.
+ *
+ * Idempotent: the WHERE clause matches nothing once rewritten. The PRAGMA guard
+ * skips a table an install hasn't created the column on yet.
+ */
+export function migrateRewriteFrontierProfilePins(database: DrizzleDb): void {
+  if (isUserOwnedFrontierProfile()) return;
+
+  const raw = getSqliteFrom(database);
+
+  for (const table of PIN_TABLES) {
+    const cols = raw.prepare(`PRAGMA table_info(${table})`).all() as {
+      name: string;
+    }[];
+    if (!cols.some((c) => c.name === "inference_profile")) continue;
+
+    raw
+      .prepare(
+        `UPDATE ${table} SET inference_profile = ? WHERE inference_profile = ?`,
+      )
+      .run(NEW_PROFILE, OLD_PROFILE);
+  }
+}
+
+/** True when `frontier` exists in config as a user-owned profile. */
+function isUserOwnedFrontierProfile(): boolean {
+  const llm = asObject(loadRawConfig().llm);
+  const profile = asObject(asObject(llm?.profiles)?.[OLD_PROFILE]);
+  return profile !== null && profile.source !== "managed";
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}

--- a/assistant/src/memory/steps.ts
+++ b/assistant/src/memory/steps.ts
@@ -413,6 +413,7 @@ import { migrateCreateCompactionEvents } from "./migrations/302-create-compactio
 import { migrateAddConversationCreationSeq } from "./migrations/303-add-conversation-creation-seq.js";
 import { migrateAddLlmUsageCronRunId } from "./migrations/304-add-llm-usage-cron-run-id.js";
 import { migrateDropContactAclColumns } from "./migrations/305-drop-contact-acl-columns.js";
+import { migrateRewriteFrontierProfilePins } from "./migrations/306-rewrite-frontier-profile-pins.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1297,4 +1298,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateAddConversationCreationSeq,
   migrateAddLlmUsageCronRunId,
   migrateDropContactAclColumns,
+  migrateRewriteFrontierProfilePins,
 ];

--- a/assistant/src/workspace/migrations/115-drop-frontier-profile.ts
+++ b/assistant/src/workspace/migrations/115-drop-frontier-profile.ts
@@ -1,0 +1,129 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Reclaim the managed `frontier` inference profile. It ran Anthropic Opus on
+// `anthropic-managed` — the same model and config as the managed
+// `quality-optimized` profile, which the seeder reconciles from the templates
+// on every boot. The seeder never deletes a profile, so this migration deletes
+// the managed `frontier` object and repoints every reference to it — its
+// `profileOrder` entry, the `activeProfile` and `advisorProfile` selections,
+// call-site `profile` overrides, and mix-profile arms — onto `quality-optimized`,
+// which resolves to the same Opus route. A `frontier` profile that the user owns
+// (`source !== "managed"`) is left fully intact, references included.
+
+const FRONTIER = "frontier";
+const REPLACEMENT = "quality-optimized";
+
+export const dropFrontierProfileMigration: WorkspaceMigration = {
+  id: "115-drop-frontier-profile",
+  description:
+    "Remove the managed Frontier profile and repoint its references to Quality",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    const frontier = profiles !== null ? readObject(profiles[FRONTIER]) : null;
+
+    // A user-owned profile that happens to use this name keeps everything,
+    // references included — only the managed profile is reclaimed.
+    if (frontier !== null && frontier.source !== "managed") return;
+
+    let changed = false;
+
+    if (frontier !== null && profiles !== null) {
+      delete profiles[FRONTIER];
+      changed = true;
+    }
+
+    if (Array.isArray(llm.profileOrder)) {
+      const order = llm.profileOrder as unknown[];
+      const pruned = order.filter((name) => name !== FRONTIER);
+      if (pruned.length !== order.length) {
+        llm.profileOrder = pruned;
+        changed = true;
+      }
+    }
+
+    // Repoint call-site overrides — LLMSchema strips a profile name absent from
+    // `llm.profiles` at load, which would drop the equivalent Opus route.
+    const callSites = readObject(llm.callSites);
+    if (callSites !== null) {
+      for (const value of Object.values(callSites)) {
+        const site = readObject(value);
+        if (site !== null && site.profile === FRONTIER) {
+          site.profile = REPLACEMENT;
+          changed = true;
+        }
+      }
+    }
+
+    // Repoint mix-profile arms — LLMSchema.superRefine rejects a mix arm whose
+    // referenced profile is absent, failing config validation at load.
+    if (profiles !== null) {
+      for (const value of Object.values(profiles)) {
+        const entry = readObject(value);
+        if (entry === null || !Array.isArray(entry.mix)) continue;
+        for (const arm of entry.mix) {
+          const armObj = readObject(arm);
+          if (armObj !== null && armObj.profile === FRONTIER) {
+            armObj.profile = REPLACEMENT;
+            changed = true;
+          }
+        }
+      }
+    }
+
+    if (llm.activeProfile === FRONTIER) {
+      llm.activeProfile = REPLACEMENT;
+      changed = true;
+
+      // The replaced selection was an enabled profile, so `quality-optimized`
+      // must be usable: a disabled profile is skipped by the resolver and
+      // rejected by validation. Clearing the status sticks because the seeder
+      // preserves whatever status is on disk.
+      const quality =
+        profiles !== null ? readObject(profiles[REPLACEMENT]) : null;
+      if (quality !== null && quality.status === "disabled") {
+        delete quality.status;
+      }
+    }
+
+    // The advisor selection is the other top-level profile reference
+    // `LLMSchema.superRefine` validates against `llm.profiles`; an unresolvable
+    // value invalidates the config and is stripped at load.
+    if (llm.advisorProfile === FRONTIER) {
+      llm.advisorProfile = REPLACEMENT;
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -112,6 +112,7 @@ import { pruneSeededCallsiteDefaultsMigration } from "./111-prune-seeded-callsit
 import { removeAdvisorCallsiteOverrideMigration } from "./112-remove-advisor-callsite-override.js";
 import { swapBalancedProfileToGlm52Migration } from "./113-swap-balanced-profile-to-glm-5p2.js";
 import { swapQualityProfileToOpusMigration } from "./114-swap-quality-profile-to-opus.js";
+import { dropFrontierProfileMigration } from "./115-drop-frontier-profile.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -235,4 +236,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   removeAdvisorCallsiteOverrideMigration,
   swapBalancedProfileToGlm52Migration,
   swapQualityProfileToOpusMigration,
+  dropFrontierProfileMigration,
 ];


### PR DESCRIPTION
## Summary
- Remove the managed `frontier` inference profile, which was an exact duplicate of `quality-optimized` (both Anthropic Opus on `anthropic-managed`, differing only by label/description).
- Repoint every `frontier` reference to `quality-optimized`: the seed default-advisor priority list, the gated-profile disable fallback advisor, and — for existing workspaces — `profileOrder`, `activeProfile`, `advisorProfile`, callsite `profile` overrides, and mix arms via new workspace migration `115-drop-frontier-profile`.
- Drop the now-dead `NEWLY_RESERVED_MANAGED_NAMES` guard (it existed solely to protect a user-owned `frontier`). A user-owned profile named `frontier` is left fully intact by the migration.

## Original prompt
Confirmed that the managed Quality and Frontier profiles were configured identically (same model, settings; differing only in label), then asked to remove the managed Frontier profile and have any callsites that used it fall back to Quality (`quality-optimized`) instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->