### PR TITLE
fix(slack): guard empty assistant name in manifest URL builders

### DIFF
--- a/clients/web/src/domains/contacts/components/slack-setup-wizard.tsx
+++ b/clients/web/src/domains/contacts/components/slack-setup-wizard.tsx
@@ -64,9 +64,11 @@ const SLACK_MANIFEST_SCOPES = {
 } as const;
 
 function buildSlackManifestUrl(name: string): string {
+  // Slack requires display_information.name to be 1–35 characters.
+  const safeName = name.trim().slice(0, 35) || "My Assistant";
   const manifest = {
     display_information: {
-      name,
+      name: safeName,
       background_color: "#1a1a2e",
     },
     features: {
@@ -75,9 +77,9 @@ function buildSlackManifestUrl(name: string): string {
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false,
       },
-      bot_user: { display_name: name, always_online: true },
+      bot_user: { display_name: safeName, always_online: true },
       assistant_view: {
-        assistant_description: name,
+        assistant_description: safeName,
         suggested_prompts: [],
       },
     },

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -782,7 +782,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-26T19:27:06.000Z"
+      "updatedAt": "2026-06-26T19:38:39.000Z"
     },
     {
       "id": "start-the-day",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -644,7 +644,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-25T11:46:21.000Z"
+      "updatedAt": "2026-06-25T11:56:53.000Z"
     },
     {
       "id": "public-ingress",
@@ -782,7 +782,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-19T17:01:42.000Z"
+      "updatedAt": "2026-06-26T19:27:06.000Z"
     },
     {
       "id": "start-the-day",

--- a/skills/slack-app-setup/scripts/build-manifest-url.ts
+++ b/skills/slack-app-setup/scripts/build-manifest-url.ts
@@ -47,9 +47,12 @@ if (!name) {
   process.exit(1);
 }
 
+// Slack requires display_information.name to be 1–35 characters.
+const safeName = name.trim().slice(0, 35) || "My Assistant";
+
 const manifest = {
   display_information: {
-    name,
+    name: safeName,
     ...(desc ? { description: desc } : {}),
     background_color: "#1a1a2e",
   },
@@ -60,11 +63,11 @@ const manifest = {
       messages_tab_read_only_enabled: false,
     },
     bot_user: {
-      display_name: name,
+      display_name: safeName,
       always_online: true,
     },
     assistant_view: {
-      assistant_description: desc || name,
+      assistant_description: desc || safeName,
       suggested_prompts: [],
     },
   },

--- a/skills/slack-app-setup/scripts/build-manifest-url.ts
+++ b/skills/slack-app-setup/scripts/build-manifest-url.ts
@@ -37,7 +37,7 @@ if (stdinText.trim()) {
 const name = input.name ?? process.env.BOT_NAME;
 const desc = input.desc ?? process.env.BOT_DESC ?? "";
 
-if (!name) {
+if (name === undefined) {
   console.error(
     JSON.stringify({
       ok: false,


### PR DESCRIPTION
## Problem

When the assistant name is empty or whitespace-only, both Slack manifest URL builders emit `"name": ""` in `display_information`. Slack's manifest schema requires `display_information.name` to be **1–35 characters** (`minLength: 1`, `maxLength: 35`), so the generated "Create app from manifest" link 404s.

## Fix

Clamp the name to 1–35 characters and fall back to `"My Assistant"` when it's empty after trimming, then use that guarded value everywhere the name feeds the manifest:

```ts
const safeName = name.trim().slice(0, 35) || "My Assistant";
```

Applied to `display_information.name`, `bot_user.display_name`, and `assistant_view.assistant_description` in both builders.

## Files

- `clients/web/src/domains/contacts/components/slack-setup-wizard.tsx` — `buildSlackManifestUrl()` _(the bug report pointed at `clients/web/src/utils/slack-manifest.ts`, which doesn't exist; the function actually lives here)_
- `skills/slack-app-setup/scripts/build-manifest-url.ts` — top-level manifest builder

The two builders live in separate packages (`clients/web/` and the portable `skills/` catalog) that can't share code, so the guard is duplicated by necessity — same as the rest of the manifest logic.

## Verification

Ran the skill script across edge cases:

| Input name | Resulting manifest name |
|---|---|
| `"   "` (whitespace) | `"My Assistant"` |
| 50 `A`s | 35 `A`s (truncated) |
| `"My Bot"` (+ desc) | `"My Bot"` (unchanged, desc preserved) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfh2mkebWz3vHZPBiYXNix

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xfh2mkebWz3vHZPBiYXNix)_