### PR TITLE
feat(daemon): add synchronous readiness state for /readyz gating

### DIFF
--- a/assistant/src/daemon/__tests__/daemon-readiness.test.ts
+++ b/assistant/src/daemon/__tests__/daemon-readiness.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  isDbReady,
+  isStartupComplete,
+  resetReadinessForTest,
+  setDbReady,
+  setStartupComplete,
+} from "../daemon-readiness.js";
+
+describe("daemon-readiness", () => {
+  beforeEach(() => {
+    resetReadinessForTest();
+  });
+
+  afterEach(() => {
+    resetReadinessForTest();
+  });
+
+  test("defaults are false", () => {
+    expect(isDbReady()).toBe(false);
+    expect(isStartupComplete()).toBe(false);
+  });
+
+  test("setDbReady flips state both ways", () => {
+    setDbReady(true);
+    expect(isDbReady()).toBe(true);
+    setDbReady(false);
+    expect(isDbReady()).toBe(false);
+  });
+
+  test("setStartupComplete latches startup state", () => {
+    expect(isStartupComplete()).toBe(false);
+    setStartupComplete();
+    expect(isStartupComplete()).toBe(true);
+  });
+
+  test("setStartupComplete is monotonic", () => {
+    setStartupComplete();
+    setStartupComplete();
+    expect(isStartupComplete()).toBe(true);
+  });
+
+  test("resetReadinessForTest clears both latches", () => {
+    setDbReady(true);
+    setStartupComplete();
+    resetReadinessForTest();
+    expect(isDbReady()).toBe(false);
+    expect(isStartupComplete()).toBe(false);
+  });
+});

--- a/assistant/src/daemon/daemon-readiness.ts
+++ b/assistant/src/daemon/daemon-readiness.ts
@@ -1,0 +1,33 @@
+// Module-level readiness state for the daemon, readable synchronously from any
+// request handler with no `await`. The `/readyz` probe gates on these latches
+// to report whether the daemon can actually serve requests.
+//
+// CES is intentionally not latched here: it is read live
+// (`getCesClient()?.isReady()`) only when reported in a response body, and must
+// never gate readiness.
+
+let dbReady = false;
+let startupComplete = false;
+
+export function setDbReady(v: boolean): void {
+  dbReady = v;
+}
+
+export function isDbReady(): boolean {
+  return dbReady;
+}
+
+// One-way latch: once startup completes it stays complete for the process
+// lifetime.
+export function setStartupComplete(): void {
+  startupComplete = true;
+}
+
+export function isStartupComplete(): boolean {
+  return startupComplete;
+}
+
+export function resetReadinessForTest(): void {
+  dbReady = false;
+  startupComplete = false;
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -117,6 +117,7 @@ import {
   cleanupPidFileIfOwner,
   writePid,
 } from "./daemon-control.js";
+import { setDbReady, setStartupComplete } from "./daemon-readiness.js";
 import {
   evaluateDiskPressureNow,
   startDiskPressureGuard,
@@ -417,6 +418,7 @@ export async function runDaemon(): Promise<void> {
     try {
       await initializeDb();
       dbReady = true;
+      setDbReady(true);
       log.info("Daemon startup: DB initialized");
     } catch (err) {
       log.error(
@@ -1448,6 +1450,11 @@ export async function runDaemon(): Promise<void> {
         cleanupPidFile();
       },
     });
+
+    // The critical startup await-chain has completed and the daemon can serve
+    // requests, so latch readiness before logging "Daemon started". A failure
+    // in the startup catch below never reaches here.
+    setStartupComplete();
 
     log.info(
       {


### PR DESCRIPTION
## Summary
- Add daemon-readiness.ts module with synchronous db/startup latches
- Wire setDbReady/setStartupComplete into runDaemon lifecycle
- Unit tests for defaults, setters, monotonic startup latch

Part of plan: health-consolidation.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->