### PR TITLE
feat(daemon): include version in trivial /healthz; guarantee it never blocks

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -12,9 +12,26 @@ paths:
   /healthz:
     get:
       operationId: healthz_get
+      summary: Liveness probe
+      description:
+        Trivial liveness/startup probe. Returns { status, version } the instant the HTTP server is up, with zero
+        DB/CES/lifecycle access.
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  version:
+                    type: string
+                required:
+                  - status
+                  - version
+                additionalProperties: false
   /pages/{id}:
     get:
       operationId: pages__id__get

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -217,11 +217,35 @@ async function collectRoutesFromModules(): Promise<RouteEntry[]> {
 }
 
 /**
+ * Trivial liveness/startup probe response. `/healthz` is the k8s startup +
+ * liveness target and stays intentionally minimal: a static `{ status, version }`
+ * answered the instant the HTTP server is up, with zero DB/CES/lifecycle access.
+ */
+const trivialHealthSchema = z.object({
+  status: z.string(),
+  version: z.string(),
+});
+
+/**
  * Top-level routes outside the /v1/ namespace.
  * These are added to the spec separately.
  */
-const NON_V1_ROUTES: Array<{ method: string; path: string }> = [
-  { method: "GET", path: "/healthz" },
+const NON_V1_ROUTES: Array<{
+  method: string;
+  path: string;
+  summary?: string;
+  description?: string;
+  responseBody?: z.ZodType;
+}> = [
+  {
+    method: "GET",
+    path: "/healthz",
+    summary: "Liveness probe",
+    description:
+      "Trivial liveness/startup probe. Returns { status, version } the instant " +
+      "the HTTP server is up, with zero DB/CES/lifecycle access.",
+    responseBody: trivialHealthSchema,
+  },
   { method: "GET", path: "/readyz" },
   { method: "GET", path: "/pages/{id}" },
 ];
@@ -322,7 +346,13 @@ function buildSpec(
         path: r.path,
         method: r.method,
         endpoint: r.path,
-        entry: { method: r.method, endpoint: r.path },
+        entry: {
+          method: r.method,
+          endpoint: r.path,
+          ...(r.summary ? { summary: r.summary } : {}),
+          ...(r.description ? { description: r.description } : {}),
+          ...(r.responseBody ? { responseBody: r.responseBody } : {}),
+        },
       });
     }
   }

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -24,11 +24,13 @@ mock.module("../util/logger.js", () => ({
 
 import {
   handleDetailedHealth,
+  handleHealth,
   handleReadyz,
   ROUTES,
 } from "../runtime/routes/identity-routes.js";
 import { setCesClient } from "../security/secure-keys.js";
 import { getWorkspaceDir } from "../util/platform.js";
+import { APP_VERSION } from "../version.js";
 import {
   getHatchedSidecarPath,
   resolveHatchedAtReadOnly,
@@ -404,6 +406,45 @@ describe("identity routes — health endpoint", () => {
       expect(last).toBeDefined();
       expect(last.runId).toBe("newer-completed");
     });
+  });
+});
+
+describe("identity routes — trivial /healthz liveness probe", () => {
+  test("returns 200 with { status: 'ok', version } carrying APP_VERSION", async () => {
+    const res = handleHealth();
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ok");
+    expect(typeof body.version).toBe("string");
+    expect(body.version).not.toBe("");
+    expect(body.version).toBe(APP_VERSION);
+  });
+
+  test("never touches CES/lifecycle state — a throwing CES client is never consulted", async () => {
+    // If the trivial probe touched CES at all this would throw.
+    const explodingClient = {
+      isReady: () => {
+        throw new Error("handleHealth must not access CES");
+      },
+      close: () => {},
+    } as unknown as import("../credential-execution/client.js").CesClient;
+    setCesClient(explodingClient);
+
+    const res = handleHealth();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ status: "ok", version: APP_VERSION });
+
+    setCesClient(undefined);
+  });
+
+  test("answers with CES uninitialized", async () => {
+    setCesClient(undefined);
+    const res = handleHealth();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ status: "ok", version: APP_VERSION });
   });
 });
 

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -314,8 +314,16 @@ function getCpuInfo(): CpuInfo {
   };
 }
 
+/**
+ * Trivial liveness/startup probe (`GET /healthz`).
+ *
+ * This is the k8s startup + liveness probe target: it must answer the instant
+ * the HTTP server is up and must NEVER touch DB, CES, migrations, or any other
+ * lifecycle state. Keep it to a static `{ status, version }` payload — no
+ * syscalls, no disk/memory/cpu reads, no async work.
+ */
 export function handleHealth(): Response {
-  return Response.json({ status: "ok" });
+  return Response.json({ status: "ok", version: APP_VERSION });
 }
 
 function getDetailedHealth() {


### PR DESCRIPTION
## Summary
- /healthz now returns {status:"ok", version} with zero DB/CES/lifecycle access
- Regenerated assistant/openapi.yaml to document the version field
- /healthz stays excluded from the web daemon-spec transform — web SDK unchanged

Part of plan: health-consolidation.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->